### PR TITLE
feat: markdown, tests, theme factory, channel bar refactor

### DIFF
--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -29,54 +29,139 @@ class EchoTheme {
   static const activeBg = Color(0xFF27272A);
   static const divider = border;
 
-  static ThemeData get darkTheme {
-    final baseTextTheme = GoogleFonts.interTextTheme(
-      ThemeData.dark().textTheme,
-    );
-    final textTheme = baseTextTheme.copyWith(
+  // ---------------------------------------------------------------------------
+  // Shared factory methods for theme construction
+  // ---------------------------------------------------------------------------
+
+  static TextTheme _buildTextTheme({
+    required Brightness brightness,
+    required Color primaryColor,
+    required Color secondaryColor,
+    required Color mutedColor,
+  }) {
+    final base = brightness == Brightness.dark
+        ? ThemeData.dark().textTheme
+        : ThemeData.light().textTheme;
+    final baseTextTheme = GoogleFonts.interTextTheme(base);
+    return baseTextTheme.copyWith(
       headlineLarge: baseTextTheme.headlineLarge?.copyWith(
         fontSize: 24,
         fontWeight: FontWeight.w700,
         letterSpacing: -0.5,
-        color: textPrimary,
+        color: primaryColor,
       ),
       headlineMedium: baseTextTheme.headlineMedium?.copyWith(
         fontSize: 22,
         fontWeight: FontWeight.w700,
-        color: textPrimary,
+        color: primaryColor,
       ),
       titleLarge: baseTextTheme.titleLarge?.copyWith(
         fontSize: 16,
         fontWeight: FontWeight.w600,
-        color: textPrimary,
+        color: primaryColor,
       ),
       titleMedium: baseTextTheme.titleMedium?.copyWith(
         fontSize: 14,
         fontWeight: FontWeight.w600,
-        color: textPrimary,
+        color: primaryColor,
       ),
       bodyLarge: baseTextTheme.bodyLarge?.copyWith(
         fontSize: 15,
         fontWeight: FontWeight.w400,
         height: 1.47,
-        color: textPrimary,
+        color: primaryColor,
       ),
       bodyMedium: baseTextTheme.bodyMedium?.copyWith(
         fontSize: 13,
         fontWeight: FontWeight.w400,
-        color: textSecondary,
+        color: secondaryColor,
       ),
       bodySmall: baseTextTheme.bodySmall?.copyWith(
         fontSize: 12,
         fontWeight: FontWeight.w400,
-        color: textMuted,
+        color: mutedColor,
       ),
       labelLarge: baseTextTheme.labelLarge?.copyWith(
         fontSize: 11,
         fontWeight: FontWeight.w600,
         letterSpacing: 0.5,
-        color: textSecondary,
+        color: secondaryColor,
       ),
+    );
+  }
+
+  static FilledButtonThemeData _buildFilledButtonTheme(Color accentColor) {
+    return FilledButtonThemeData(
+      style: FilledButton.styleFrom(
+        backgroundColor: accentColor,
+        foregroundColor: Colors.white,
+        textStyle: GoogleFonts.inter(fontSize: 14, fontWeight: FontWeight.w600),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      ),
+    );
+  }
+
+  static TextButtonThemeData _buildTextButtonTheme(Color accentColor) {
+    return TextButtonThemeData(
+      style: TextButton.styleFrom(
+        foregroundColor: accentColor,
+        textStyle: GoogleFonts.inter(fontSize: 14, fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+
+  static OutlinedButtonThemeData _buildOutlinedButtonTheme(
+    Color foregroundColor,
+    Color borderColor,
+  ) {
+    return OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        foregroundColor: foregroundColor,
+        side: BorderSide(color: borderColor),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      ),
+    );
+  }
+
+  static InputDecorationTheme _buildInputTheme({
+    required Color fillColor,
+    required Color borderColor,
+    required Color focusBorderColor,
+    required Color hintColor,
+    required Color labelColor,
+  }) {
+    return InputDecorationTheme(
+      filled: true,
+      fillColor: fillColor,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: BorderSide(color: borderColor, width: 1),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: BorderSide(color: borderColor, width: 1),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: BorderSide(color: focusBorderColor, width: 1),
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      hintStyle: GoogleFonts.inter(color: hintColor, fontSize: 13),
+      labelStyle: GoogleFonts.inter(color: labelColor, fontSize: 13),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dark theme
+  // ---------------------------------------------------------------------------
+
+  static ThemeData get darkTheme {
+    final textTheme = _buildTextTheme(
+      brightness: Brightness.dark,
+      primaryColor: textPrimary,
+      secondaryColor: textSecondary,
+      mutedColor: textMuted,
     );
 
     return ThemeData(
@@ -112,60 +197,16 @@ class EchoTheme {
         thickness: 1,
         space: 1,
       ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
+      inputDecorationTheme: _buildInputTheme(
         fillColor: surface,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: border, width: 1),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: border, width: 1),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: accent, width: 1),
-        ),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 12,
-          vertical: 10,
-        ),
-        hintStyle: GoogleFonts.inter(color: textMuted, fontSize: 13),
-        labelStyle: GoogleFonts.inter(color: textSecondary, fontSize: 13),
+        borderColor: border,
+        focusBorderColor: accent,
+        hintColor: textMuted,
+        labelColor: textSecondary,
       ),
-      filledButtonTheme: FilledButtonThemeData(
-        style: FilledButton.styleFrom(
-          backgroundColor: accent,
-          foregroundColor: Colors.white,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-        ),
-      ),
-      textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-          foregroundColor: accent,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-      ),
-      outlinedButtonTheme: OutlinedButtonThemeData(
-        style: OutlinedButton.styleFrom(
-          foregroundColor: textPrimary,
-          side: const BorderSide(color: border),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-        ),
-      ),
+      filledButtonTheme: _buildFilledButtonTheme(accent),
+      textButtonTheme: _buildTextButtonTheme(accent),
+      outlinedButtonTheme: _buildOutlinedButtonTheme(textPrimary, border),
       iconTheme: const IconThemeData(color: textSecondary, size: 20),
       tooltipTheme: TooltipThemeData(
         decoration: BoxDecoration(
@@ -245,54 +286,16 @@ class EchoTheme {
   static const emberRecvBubble = Color(0xFF252019);
   static const emberBorder = Color(0xFF332D24);
 
+  // ---------------------------------------------------------------------------
+  // Light theme
+  // ---------------------------------------------------------------------------
+
   static ThemeData get lightTheme {
-    final baseTextTheme = GoogleFonts.interTextTheme(
-      ThemeData.light().textTheme,
-    );
-    final textTheme = baseTextTheme.copyWith(
-      headlineLarge: baseTextTheme.headlineLarge?.copyWith(
-        fontSize: 24,
-        fontWeight: FontWeight.w700,
-        letterSpacing: -0.5,
-        color: lightTextPrimary,
-      ),
-      headlineMedium: baseTextTheme.headlineMedium?.copyWith(
-        fontSize: 22,
-        fontWeight: FontWeight.w700,
-        color: lightTextPrimary,
-      ),
-      titleLarge: baseTextTheme.titleLarge?.copyWith(
-        fontSize: 16,
-        fontWeight: FontWeight.w600,
-        color: lightTextPrimary,
-      ),
-      titleMedium: baseTextTheme.titleMedium?.copyWith(
-        fontSize: 14,
-        fontWeight: FontWeight.w600,
-        color: lightTextPrimary,
-      ),
-      bodyLarge: baseTextTheme.bodyLarge?.copyWith(
-        fontSize: 15,
-        fontWeight: FontWeight.w400,
-        height: 1.47,
-        color: lightTextPrimary,
-      ),
-      bodyMedium: baseTextTheme.bodyMedium?.copyWith(
-        fontSize: 13,
-        fontWeight: FontWeight.w400,
-        color: lightTextSecondary,
-      ),
-      bodySmall: baseTextTheme.bodySmall?.copyWith(
-        fontSize: 12,
-        fontWeight: FontWeight.w400,
-        color: lightTextMuted,
-      ),
-      labelLarge: baseTextTheme.labelLarge?.copyWith(
-        fontSize: 11,
-        fontWeight: FontWeight.w600,
-        letterSpacing: 0.5,
-        color: lightTextSecondary,
-      ),
+    final textTheme = _buildTextTheme(
+      brightness: Brightness.light,
+      primaryColor: lightTextPrimary,
+      secondaryColor: lightTextSecondary,
+      mutedColor: lightTextMuted,
     );
 
     return ThemeData(
@@ -328,59 +331,18 @@ class EchoTheme {
         thickness: 1,
         space: 1,
       ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
+      inputDecorationTheme: _buildInputTheme(
         fillColor: lightSurface,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: lightBorder, width: 1),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: lightBorder, width: 1),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: accent, width: 1),
-        ),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 12,
-          vertical: 10,
-        ),
-        hintStyle: GoogleFonts.inter(color: lightTextMuted, fontSize: 13),
-        labelStyle: GoogleFonts.inter(color: lightTextSecondary, fontSize: 13),
+        borderColor: lightBorder,
+        focusBorderColor: accent,
+        hintColor: lightTextMuted,
+        labelColor: lightTextSecondary,
       ),
-      filledButtonTheme: FilledButtonThemeData(
-        style: FilledButton.styleFrom(
-          backgroundColor: accent,
-          foregroundColor: Colors.white,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-        ),
-      ),
-      textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-          foregroundColor: accent,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-      ),
-      outlinedButtonTheme: OutlinedButtonThemeData(
-        style: OutlinedButton.styleFrom(
-          foregroundColor: lightTextPrimary,
-          side: const BorderSide(color: lightBorder),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-        ),
+      filledButtonTheme: _buildFilledButtonTheme(accent),
+      textButtonTheme: _buildTextButtonTheme(accent),
+      outlinedButtonTheme: _buildOutlinedButtonTheme(
+        lightTextPrimary,
+        lightBorder,
       ),
       iconTheme: const IconThemeData(color: lightTextSecondary, size: 20),
       tooltipTheme: TooltipThemeData(
@@ -425,54 +387,16 @@ class EchoTheme {
     );
   }
 
+  // ---------------------------------------------------------------------------
+  // Graphite theme
+  // ---------------------------------------------------------------------------
+
   static ThemeData get graphiteTheme {
-    final baseTextTheme = GoogleFonts.interTextTheme(
-      ThemeData.dark().textTheme,
-    );
-    final textTheme = baseTextTheme.copyWith(
-      headlineLarge: baseTextTheme.headlineLarge?.copyWith(
-        fontSize: 24,
-        fontWeight: FontWeight.w700,
-        letterSpacing: -0.5,
-        color: graphiteTextPrimary,
-      ),
-      headlineMedium: baseTextTheme.headlineMedium?.copyWith(
-        fontSize: 22,
-        fontWeight: FontWeight.w700,
-        color: graphiteTextPrimary,
-      ),
-      titleLarge: baseTextTheme.titleLarge?.copyWith(
-        fontSize: 16,
-        fontWeight: FontWeight.w600,
-        color: graphiteTextPrimary,
-      ),
-      titleMedium: baseTextTheme.titleMedium?.copyWith(
-        fontSize: 14,
-        fontWeight: FontWeight.w600,
-        color: graphiteTextPrimary,
-      ),
-      bodyLarge: baseTextTheme.bodyLarge?.copyWith(
-        fontSize: 15,
-        fontWeight: FontWeight.w400,
-        height: 1.47,
-        color: graphiteTextPrimary,
-      ),
-      bodyMedium: baseTextTheme.bodyMedium?.copyWith(
-        fontSize: 13,
-        fontWeight: FontWeight.w400,
-        color: graphiteTextSecondary,
-      ),
-      bodySmall: baseTextTheme.bodySmall?.copyWith(
-        fontSize: 12,
-        fontWeight: FontWeight.w400,
-        color: graphiteTextMuted,
-      ),
-      labelLarge: baseTextTheme.labelLarge?.copyWith(
-        fontSize: 11,
-        fontWeight: FontWeight.w600,
-        letterSpacing: 0.5,
-        color: graphiteTextSecondary,
-      ),
+    final textTheme = _buildTextTheme(
+      brightness: Brightness.dark,
+      primaryColor: graphiteTextPrimary,
+      secondaryColor: graphiteTextSecondary,
+      mutedColor: graphiteTextMuted,
     );
 
     return ThemeData(
@@ -508,62 +432,18 @@ class EchoTheme {
         thickness: 1,
         space: 1,
       ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
+      inputDecorationTheme: _buildInputTheme(
         fillColor: graphiteSurface,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: graphiteBorder, width: 1),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: graphiteBorder, width: 1),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: graphiteAccent, width: 1),
-        ),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 12,
-          vertical: 10,
-        ),
-        hintStyle: GoogleFonts.inter(color: graphiteTextMuted, fontSize: 13),
-        labelStyle: GoogleFonts.inter(
-          color: graphiteTextSecondary,
-          fontSize: 13,
-        ),
+        borderColor: graphiteBorder,
+        focusBorderColor: graphiteAccent,
+        hintColor: graphiteTextMuted,
+        labelColor: graphiteTextSecondary,
       ),
-      filledButtonTheme: FilledButtonThemeData(
-        style: FilledButton.styleFrom(
-          backgroundColor: graphiteAccent,
-          foregroundColor: Colors.white,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-        ),
-      ),
-      textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-          foregroundColor: graphiteAccent,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-      ),
-      outlinedButtonTheme: OutlinedButtonThemeData(
-        style: OutlinedButton.styleFrom(
-          foregroundColor: graphiteTextPrimary,
-          side: const BorderSide(color: graphiteBorder),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-        ),
+      filledButtonTheme: _buildFilledButtonTheme(graphiteAccent),
+      textButtonTheme: _buildTextButtonTheme(graphiteAccent),
+      outlinedButtonTheme: _buildOutlinedButtonTheme(
+        graphiteTextPrimary,
+        graphiteBorder,
       ),
       iconTheme: const IconThemeData(color: graphiteTextSecondary, size: 20),
       tooltipTheme: TooltipThemeData(
@@ -601,54 +481,16 @@ class EchoTheme {
     );
   }
 
+  // ---------------------------------------------------------------------------
+  // Ember theme
+  // ---------------------------------------------------------------------------
+
   static ThemeData get emberTheme {
-    final baseTextTheme = GoogleFonts.interTextTheme(
-      ThemeData.dark().textTheme,
-    );
-    final textTheme = baseTextTheme.copyWith(
-      headlineLarge: baseTextTheme.headlineLarge?.copyWith(
-        fontSize: 24,
-        fontWeight: FontWeight.w700,
-        letterSpacing: -0.5,
-        color: emberTextPrimary,
-      ),
-      headlineMedium: baseTextTheme.headlineMedium?.copyWith(
-        fontSize: 22,
-        fontWeight: FontWeight.w700,
-        color: emberTextPrimary,
-      ),
-      titleLarge: baseTextTheme.titleLarge?.copyWith(
-        fontSize: 16,
-        fontWeight: FontWeight.w600,
-        color: emberTextPrimary,
-      ),
-      titleMedium: baseTextTheme.titleMedium?.copyWith(
-        fontSize: 14,
-        fontWeight: FontWeight.w600,
-        color: emberTextPrimary,
-      ),
-      bodyLarge: baseTextTheme.bodyLarge?.copyWith(
-        fontSize: 15,
-        fontWeight: FontWeight.w400,
-        height: 1.47,
-        color: emberTextPrimary,
-      ),
-      bodyMedium: baseTextTheme.bodyMedium?.copyWith(
-        fontSize: 13,
-        fontWeight: FontWeight.w400,
-        color: emberTextSecondary,
-      ),
-      bodySmall: baseTextTheme.bodySmall?.copyWith(
-        fontSize: 12,
-        fontWeight: FontWeight.w400,
-        color: emberTextMuted,
-      ),
-      labelLarge: baseTextTheme.labelLarge?.copyWith(
-        fontSize: 11,
-        fontWeight: FontWeight.w600,
-        letterSpacing: 0.5,
-        color: emberTextSecondary,
-      ),
+    final textTheme = _buildTextTheme(
+      brightness: Brightness.dark,
+      primaryColor: emberTextPrimary,
+      secondaryColor: emberTextSecondary,
+      mutedColor: emberTextMuted,
     );
 
     return ThemeData(
@@ -684,59 +526,18 @@ class EchoTheme {
         thickness: 1,
         space: 1,
       ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
+      inputDecorationTheme: _buildInputTheme(
         fillColor: emberSurface,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: emberBorder, width: 1),
-        ),
-        enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: emberBorder, width: 1),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(color: emberAccent, width: 1),
-        ),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 12,
-          vertical: 10,
-        ),
-        hintStyle: GoogleFonts.inter(color: emberTextMuted, fontSize: 13),
-        labelStyle: GoogleFonts.inter(color: emberTextSecondary, fontSize: 13),
+        borderColor: emberBorder,
+        focusBorderColor: emberAccent,
+        hintColor: emberTextMuted,
+        labelColor: emberTextSecondary,
       ),
-      filledButtonTheme: FilledButtonThemeData(
-        style: FilledButton.styleFrom(
-          backgroundColor: emberAccent,
-          foregroundColor: Colors.white,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-        ),
-      ),
-      textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-          foregroundColor: emberAccent,
-          textStyle: GoogleFonts.inter(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-      ),
-      outlinedButtonTheme: OutlinedButtonThemeData(
-        style: OutlinedButton.styleFrom(
-          foregroundColor: emberTextPrimary,
-          side: const BorderSide(color: emberBorder),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-        ),
+      filledButtonTheme: _buildFilledButtonTheme(emberAccent),
+      textButtonTheme: _buildTextButtonTheme(emberAccent),
+      outlinedButtonTheme: _buildOutlinedButtonTheme(
+        emberTextPrimary,
+        emberBorder,
       ),
       iconTheme: const IconThemeData(color: emberTextSecondary, size: 20),
       tooltipTheme: TooltipThemeData(

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -11,6 +11,7 @@ import '../theme/echo_theme.dart';
 class ChannelBar extends ConsumerStatefulWidget {
   final String conversationId;
   final String? selectedTextChannelId;
+  final String? activeVoiceChannelId;
   final bool hideVoiceDock;
   final ValueChanged<String?> onTextChannelChanged;
   final ValueChanged<String?> onVoiceChannelChanged;
@@ -19,6 +20,7 @@ class ChannelBar extends ConsumerStatefulWidget {
     super.key,
     required this.conversationId,
     this.selectedTextChannelId,
+    this.activeVoiceChannelId,
     this.hideVoiceDock = false,
     required this.onTextChannelChanged,
     required this.onVoiceChannelChanged,
@@ -29,8 +31,6 @@ class ChannelBar extends ConsumerStatefulWidget {
 }
 
 class _ChannelBarState extends ConsumerState<ChannelBar> {
-  // null = use inferred from voice sessions, '' = explicitly left (don't infer)
-  String? _activeVoiceChannelId;
   String? _lastAutoSelectedConversationId;
   bool _voiceCleanupInFlight = false;
   late final VoiceRtcNotifier _voiceRtcNotifier;
@@ -39,44 +39,6 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
   void initState() {
     super.initState();
     _voiceRtcNotifier = ref.read(voiceRtcProvider.notifier);
-  }
-
-  String _inferredActiveVoiceChannelId(
-    ChannelsState channelsState,
-    String myUserId,
-  ) {
-    final channels = channelsState.channelsFor(widget.conversationId);
-    return channels
-        .where((c) => c.isVoice)
-        .firstWhere(
-          (c) => channelsState
-              .voiceSessionsFor(c.id)
-              .any((m) => m.userId == myUserId),
-          orElse: () => const GroupChannel(
-            id: '',
-            conversationId: '',
-            name: '',
-            kind: 'voice',
-            position: 0,
-            createdAt: '',
-          ),
-        )
-        .id;
-  }
-
-  String? _effectiveActiveVoiceChannelId(
-    ChannelsState channelsState,
-    String myUserId,
-  ) {
-    final inferredActiveVoiceChannelId = _inferredActiveVoiceChannelId(
-      channelsState,
-      myUserId,
-    );
-    if (_activeVoiceChannelId == '') return null;
-    return _activeVoiceChannelId ??
-        (inferredActiveVoiceChannelId.isEmpty
-            ? null
-            : inferredActiveVoiceChannelId);
   }
 
   void _syncDerivedState(ChannelsState channelsState, String myUserId) {
@@ -90,14 +52,11 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
       widget.onTextChannelChanged(textChannels.first.id);
     }
 
-    final effectiveActiveVoiceChannelId = _effectiveActiveVoiceChannelId(
-      channelsState,
-      myUserId,
-    );
-    if (effectiveActiveVoiceChannelId == null || _voiceCleanupInFlight) return;
+    final activeVoice = widget.activeVoiceChannelId;
+    if (activeVoice == null || _voiceCleanupInFlight) return;
 
     final iAmInChannel = channelsState
-        .voiceSessionsFor(effectiveActiveVoiceChannelId)
+        .voiceSessionsFor(activeVoice)
         .any((p) => p.userId == myUserId);
     if (iAmInChannel) return;
 
@@ -105,11 +64,6 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     _voiceRtcNotifier.leaveChannel().whenComplete(() {
       _voiceCleanupInFlight = false;
       if (!mounted) return;
-      if (_activeVoiceChannelId != null) {
-        setState(() {
-          _activeVoiceChannelId = null;
-        });
-      }
       widget.onVoiceChannelChanged(null);
     });
   }
@@ -118,26 +72,23 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
   void didUpdateWidget(covariant ChannelBar oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.conversationId != oldWidget.conversationId) {
-      if (_activeVoiceChannelId != null) {
+      if (oldWidget.activeVoiceChannelId != null) {
         _voiceRtcNotifier.leaveChannel();
       }
-      setState(() {
-        _activeVoiceChannelId = null;
-      });
       _lastAutoSelectedConversationId = null;
     }
   }
 
   @override
   void dispose() {
-    if (_activeVoiceChannelId != null) {
+    if (widget.activeVoiceChannelId != null) {
       _voiceRtcNotifier.leaveChannel();
     }
     super.dispose();
   }
 
   Future<void> _syncVoiceState() async {
-    final channelId = _activeVoiceChannelId;
+    final channelId = widget.activeVoiceChannelId;
     if (channelId == null) return;
     final voiceSettings = ref.read(voiceSettingsProvider);
     await ref
@@ -197,7 +148,6 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     await rtcNotifier.leaveChannel();
 
     if (!mounted) return;
-    setState(() => _activeVoiceChannelId = '');
     widget.onVoiceChannelChanged(null);
   }
 
@@ -216,10 +166,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     final channels = channelsState.channelsFor(widget.conversationId);
     final textChannels = channels.where((c) => c.isText).toList();
     final voiceChannels = channels.where((c) => c.isVoice).toList();
-    final effectiveActiveVoiceChannelId = _effectiveActiveVoiceChannelId(
-      channelsState,
-      myUserId,
-    );
+    final activeVoice = widget.activeVoiceChannelId;
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -230,16 +177,16 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
           voiceChannels,
           channelsState,
           voiceSettings,
-          effectiveActiveVoiceChannelId,
+          activeVoice,
         ),
-        if (effectiveActiveVoiceChannelId != null && !widget.hideVoiceDock)
+        if (activeVoice != null && !widget.hideVoiceDock)
           _buildVoiceControlDock(
             channels,
             channelsState,
             voiceSettings,
             myUserId,
             voiceRtc,
-            effectiveActiveVoiceChannelId,
+            activeVoice,
           ),
       ],
     );
@@ -296,9 +243,9 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     GroupChannel channel,
     int participantCount,
     VoiceSettingsState voiceSettings,
-    String? effectiveActiveVoiceChannelId,
+    String? activeVoiceChannelId,
   ) {
-    final isActive = effectiveActiveVoiceChannelId == channel.id;
+    final isActive = activeVoiceChannelId == channel.id;
 
     return Material(
       color: Colors.transparent,
@@ -324,7 +271,6 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                 startMuted:
                     voiceSettings.selfMuted || voiceSettings.selfDeafened,
               );
-              setState(() => _activeVoiceChannelId = channel.id);
               widget.onVoiceChannelChanged(channel.id);
             }
           }
@@ -390,7 +336,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     List<GroupChannel> voiceChannels,
     ChannelsState channelsState,
     VoiceSettingsState voiceSettings,
-    String? effectiveActiveVoiceChannelId,
+    String? activeVoiceChannelId,
   ) {
     return Container(
       width: double.infinity,
@@ -419,7 +365,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                       channel,
                       channelsState.voiceSessionsFor(channel.id).length,
                       voiceSettings,
-                      effectiveActiveVoiceChannelId,
+                      activeVoiceChannelId,
                     ),
                   ),
                 ],
@@ -611,10 +557,10 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     VoiceSettingsState voiceSettings,
     String myUserId,
     VoiceRtcState voiceRtc,
-    String? effectiveActiveVoiceChannelId,
+    String? activeVoiceChannelId,
   ) {
     final activeVoiceChannel = channels
-        .where((c) => c.id == effectiveActiveVoiceChannelId)
+        .where((c) => c.id == activeVoiceChannelId)
         .firstOrNull;
     if (activeVoiceChannel == null) return const SizedBox.shrink();
 

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -871,6 +871,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
             ChannelBar(
               conversationId: conv.id,
               selectedTextChannelId: _selectedTextChannelId,
+              activeVoiceChannelId: _activeVoiceChannelId,
               hideVoiceDock: widget.hideVoiceDock,
               onTextChannelChanged: _onTextChannelChanged,
               onVoiceChannelChanged: (channelId) {

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -26,6 +26,19 @@ final _standaloneUrlRegex = RegExp(r'^https?://[^\s]+$', caseSensitive: false);
 /// Regex for detecting @mentions in message text.
 final _mentionRegex = RegExp(r'@(\w+)');
 
+/// Regex for detecting fenced code blocks: ```\n...\n``` (multiline).
+final _codeBlockRegex = RegExp(r'```\n?([\s\S]*?)```', multiLine: true);
+
+/// Regex for detecting inline code: `...` (single backtick, no nesting).
+final _inlineCodeRegex = RegExp(r'`([^`\n]+)`');
+
+/// Regex for detecting bold text: **...**
+final _boldRegex = RegExp(r'\*\*(.+?)\*\*');
+
+/// Regex for detecting italic text: *...*
+/// Negative lookahead/lookbehind to avoid matching ** (bold delimiters).
+final _italicRegex = RegExp(r'(?<!\*)\*([^*]+?)\*(?!\*)');
+
 /// Regex for detecting image markers: [img:URL]
 final _imgRegex = RegExp(r'^\[img:(.+)\]$');
 
@@ -617,14 +630,20 @@ class _MessageItemState extends State<MessageItem> {
     );
   }
 
-  /// Build spans for a plain text segment (no URLs), highlighting @mentions.
+  /// Base text style used throughout message rendering.
+  TextStyle _baseStyle({required Color textColor}) =>
+      TextStyle(fontSize: 15, color: textColor, height: 1.47);
+
+  /// Build spans for plain text that may contain @mentions.
+  /// Called for segments that have already been stripped of URLs, code, bold,
+  /// and italic markers.
   List<InlineSpan> _buildMentionSpans(String text, {required Color textColor}) {
     final mentionMatches = _mentionRegex.allMatches(text).toList();
     if (mentionMatches.isEmpty) {
       return [
         TextSpan(
           text: text,
-          style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
+          style: _baseStyle(textColor: textColor),
         ),
       ];
     }
@@ -636,7 +655,7 @@ class _MessageItemState extends State<MessageItem> {
         spans.add(
           TextSpan(
             text: text.substring(lastEnd, match.start),
-            style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
+            style: _baseStyle(textColor: textColor),
           ),
         );
       }
@@ -657,7 +676,7 @@ class _MessageItemState extends State<MessageItem> {
       spans.add(
         TextSpan(
           text: text.substring(lastEnd),
-          style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
+          style: _baseStyle(textColor: textColor),
         ),
       );
     }
@@ -674,6 +693,111 @@ class _MessageItemState extends State<MessageItem> {
       };
     _linkRecognizers.add(recognizer);
     return recognizer;
+  }
+
+  /// Build spans for a segment that may contain bold, italic, URLs, and
+  /// mentions (but NOT code -- code is stripped before this is called).
+  List<InlineSpan> _buildFormattedSpans(
+    String text, {
+    required Color textColor,
+  }) {
+    // Collect all matches for bold, italic, and URLs with a tag so we can
+    // process them in document order.
+    final entries = <({int start, int end, String tag, RegExpMatch match})>[];
+
+    for (final m in _boldRegex.allMatches(text)) {
+      entries.add((start: m.start, end: m.end, tag: 'bold', match: m));
+    }
+    for (final m in _italicRegex.allMatches(text)) {
+      entries.add((start: m.start, end: m.end, tag: 'italic', match: m));
+    }
+    for (final m in _urlRegex.allMatches(text)) {
+      entries.add((start: m.start, end: m.end, tag: 'url', match: m));
+    }
+
+    // Sort by start position; break ties by preferring longer matches.
+    entries.sort((a, b) {
+      final cmp = a.start.compareTo(b.start);
+      if (cmp != 0) return cmp;
+      return b.end.compareTo(a.end);
+    });
+
+    // Remove overlapping entries (first match wins).
+    final filtered = <({int start, int end, String tag, RegExpMatch match})>[];
+    int cursor = 0;
+    for (final e in entries) {
+      if (e.start < cursor) continue; // overlaps with a previous match
+      filtered.add(e);
+      cursor = e.end;
+    }
+
+    if (filtered.isEmpty) {
+      return _buildMentionSpans(text, textColor: textColor);
+    }
+
+    final spans = <InlineSpan>[];
+    int lastEnd = 0;
+
+    for (final e in filtered) {
+      // Gap before this match -- may contain mentions
+      if (e.start > lastEnd) {
+        spans.addAll(
+          _buildMentionSpans(
+            text.substring(lastEnd, e.start),
+            textColor: textColor,
+          ),
+        );
+      }
+
+      switch (e.tag) {
+        case 'bold':
+          final inner = e.match.group(1)!;
+          spans.add(
+            TextSpan(
+              text: inner,
+              style: _baseStyle(
+                textColor: textColor,
+              ).copyWith(fontWeight: FontWeight.bold),
+            ),
+          );
+        case 'italic':
+          final inner = e.match.group(1)!;
+          spans.add(
+            TextSpan(
+              text: inner,
+              style: _baseStyle(
+                textColor: textColor,
+              ).copyWith(fontStyle: FontStyle.italic),
+            ),
+          );
+        case 'url':
+          final url = e.match.group(0)!;
+          spans.add(
+            TextSpan(
+              text: url,
+              style: TextStyle(
+                fontSize: 15,
+                color: context.accentHover,
+                decoration: TextDecoration.underline,
+                decorationColor: context.accentHover,
+                height: 1.47,
+              ),
+              recognizer: _createLinkRecognizer(url),
+            ),
+          );
+      }
+
+      lastEnd = e.end;
+    }
+
+    // Remaining text after last match
+    if (lastEnd < text.length) {
+      spans.addAll(
+        _buildMentionSpans(text.substring(lastEnd), textColor: textColor),
+      );
+    }
+
+    return spans;
   }
 
   /// Build a friendly decryption failure message with a recovery action.
@@ -715,74 +839,173 @@ class _MessageItemState extends State<MessageItem> {
     );
   }
 
-  /// Build a RichText widget that renders URLs as tappable links and @mentions
-  /// with accent color + bold weight.
-  Widget _buildMessageText(String text, {required Color textColor}) {
-    // Dispose old recognizers on each rebuild
-    for (final r in _linkRecognizers) {
-      r.dispose();
-    }
-    _linkRecognizers.clear();
-    final urlMatches = _urlRegex.allMatches(text).toList();
-    final mentionMatches = _mentionRegex.allMatches(text).toList();
-
-    if (urlMatches.isEmpty && mentionMatches.isEmpty) {
-      return Text(
-        text,
-        style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
-      );
-    }
-
-    // If no URLs, just handle mentions.
-    if (urlMatches.isEmpty) {
-      return RichText(
-        text: TextSpan(
-          children: _buildMentionSpans(text, textColor: textColor),
-        ),
-      );
+  /// Build spans for a segment that may contain inline code, bold, italic,
+  /// URLs, and mentions (but NOT fenced code blocks).
+  List<InlineSpan> _buildInlineCodeAndFormatting(
+    String text, {
+    required Color textColor,
+  }) {
+    final inlineCodeMatches = _inlineCodeRegex.allMatches(text).toList();
+    if (inlineCodeMatches.isEmpty) {
+      return _buildFormattedSpans(text, textColor: textColor);
     }
 
     final spans = <InlineSpan>[];
     int lastEnd = 0;
 
-    for (final match in urlMatches) {
-      // Text before the URL -- may contain mentions
+    for (final match in inlineCodeMatches) {
+      // Gap before inline code -- process for bold/italic/URL/mention
       if (match.start > lastEnd) {
         spans.addAll(
-          _buildMentionSpans(
+          _buildFormattedSpans(
             text.substring(lastEnd, match.start),
             textColor: textColor,
           ),
         );
       }
 
-      // The URL itself
-      final url = match.group(0)!;
+      // Inline code span with monospace + subtle background
+      final code = match.group(1)!;
       spans.add(
-        TextSpan(
-          text: url,
-          style: TextStyle(
-            fontSize: 15,
-            color: context.accentHover,
-            decoration: TextDecoration.underline,
-            decorationColor: context.accentHover,
-            height: 1.47,
+        WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+            decoration: BoxDecoration(
+              color: context.textSecondary.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              code,
+              style: TextStyle(
+                fontSize: 14,
+                fontFamily: 'monospace',
+                color: textColor,
+                height: 1.47,
+              ),
+            ),
           ),
-          recognizer: _createLinkRecognizer(url),
         ),
       );
 
       lastEnd = match.end;
     }
 
-    // Remaining text after last URL -- may contain mentions
+    // Remaining text after last inline code
     if (lastEnd < text.length) {
       spans.addAll(
-        _buildMentionSpans(text.substring(lastEnd), textColor: textColor),
+        _buildFormattedSpans(text.substring(lastEnd), textColor: textColor),
       );
     }
 
-    return RichText(text: TextSpan(children: spans));
+    return spans;
+  }
+
+  /// Build a RichText widget that renders markdown formatting, URLs as tappable
+  /// links, and @mentions with accent color + bold weight.
+  ///
+  /// Precedence: code blocks > inline code > bold > italic > URLs > mentions.
+  Widget _buildMessageText(String text, {required Color textColor}) {
+    // Dispose old recognizers on each rebuild
+    for (final r in _linkRecognizers) {
+      r.dispose();
+    }
+    _linkRecognizers.clear();
+
+    // Check for fenced code blocks first (highest precedence).
+    final codeBlockMatches = _codeBlockRegex.allMatches(text).toList();
+
+    if (codeBlockMatches.isEmpty) {
+      // No code blocks -- check if any formatting exists at all.
+      final hasUrl = _urlRegex.hasMatch(text);
+      final hasMention = _mentionRegex.hasMatch(text);
+      final hasBold = _boldRegex.hasMatch(text);
+      final hasItalic = _italicRegex.hasMatch(text);
+      final hasInlineCode = _inlineCodeRegex.hasMatch(text);
+
+      if (!hasUrl && !hasMention && !hasBold && !hasItalic && !hasInlineCode) {
+        return Text(text, style: _baseStyle(textColor: textColor));
+      }
+
+      return RichText(
+        text: TextSpan(
+          children: _buildInlineCodeAndFormatting(text, textColor: textColor),
+        ),
+      );
+    }
+
+    // Has code blocks -- build a Column with interleaved text and code blocks.
+    final children = <Widget>[];
+    int lastEnd = 0;
+
+    for (final match in codeBlockMatches) {
+      // Text segment before the code block
+      if (match.start > lastEnd) {
+        final segment = text.substring(lastEnd, match.start);
+        if (segment.trim().isNotEmpty) {
+          children.add(
+            RichText(
+              text: TextSpan(
+                children: _buildInlineCodeAndFormatting(
+                  segment.trim(),
+                  textColor: textColor,
+                ),
+              ),
+            ),
+          );
+        }
+      }
+
+      // The code block itself
+      final code = match.group(1) ?? '';
+      children.add(
+        Container(
+          width: double.infinity,
+          margin: const EdgeInsets.symmetric(vertical: 4),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: context.textSecondary.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            code.trimRight(),
+            style: TextStyle(
+              fontSize: 13,
+              fontFamily: 'monospace',
+              color: textColor,
+              height: 1.5,
+            ),
+          ),
+        ),
+      );
+
+      lastEnd = match.end;
+    }
+
+    // Remaining text after the last code block
+    if (lastEnd < text.length) {
+      final segment = text.substring(lastEnd);
+      if (segment.trim().isNotEmpty) {
+        children.add(
+          RichText(
+            text: TextSpan(
+              children: _buildInlineCodeAndFormatting(
+                segment.trim(),
+                textColor: textColor,
+              ),
+            ),
+          ),
+        );
+      }
+    }
+
+    if (children.length == 1) return children.first;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: children,
+    );
   }
 
   Widget _buildReactionPill(List<Reaction> reactions, bool isMine) {

--- a/apps/client/test/providers/contacts_provider_test.dart
+++ b/apps/client/test/providers/contacts_provider_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:echo_app/src/providers/contacts_provider.dart';
+import 'package:echo_app/src/models/contact.dart';
+
+void main() {
+  group('ContactsState', () {
+    test('initial state has empty contacts and pending lists', () {
+      const state = ContactsState();
+      expect(state.contacts, isEmpty);
+      expect(state.pendingRequests, isEmpty);
+      expect(state.isLoading, isFalse);
+      expect(state.error, isNull);
+    });
+
+    test('copyWith preserves contacts, pending, and isLoading', () {
+      final state = ContactsState(
+        contacts: [
+          const Contact(
+            id: 'c1',
+            userId: 'u1',
+            username: 'alice',
+            status: 'accepted',
+          ),
+        ],
+        pendingRequests: [
+          const Contact(
+            id: 'c2',
+            userId: 'u2',
+            username: 'bob',
+            status: 'pending',
+          ),
+        ],
+        isLoading: true,
+      );
+      final copied = state.copyWith();
+      expect(copied.contacts, hasLength(1));
+      expect(copied.pendingRequests, hasLength(1));
+      expect(copied.isLoading, isTrue);
+    });
+
+    test('copyWith with no error argument clears error (by design)', () {
+      final state = ContactsState(error: 'old error');
+      // The copyWith uses direct assignment for error (not null-coalesce),
+      // so calling copyWith() without error clears it.
+      final copied = state.copyWith();
+      expect(copied.error, isNull);
+    });
+
+    test('copyWith updates contacts list', () {
+      const state = ContactsState();
+      final contacts = [
+        const Contact(
+          id: 'c1',
+          userId: 'u1',
+          username: 'alice',
+          status: 'accepted',
+        ),
+        const Contact(
+          id: 'c2',
+          userId: 'u2',
+          username: 'bob',
+          status: 'accepted',
+        ),
+      ];
+      final updated = state.copyWith(contacts: contacts);
+      expect(updated.contacts, hasLength(2));
+      expect(updated.contacts[0].username, 'alice');
+      expect(updated.contacts[1].username, 'bob');
+    });
+
+    test('copyWith updates pending requests', () {
+      const state = ContactsState();
+      final pending = [
+        const Contact(
+          id: 'c1',
+          userId: 'u1',
+          username: 'carol',
+          status: 'pending',
+        ),
+      ];
+      final updated = state.copyWith(pendingRequests: pending);
+      expect(updated.pendingRequests, hasLength(1));
+      expect(updated.pendingRequests.first.username, 'carol');
+    });
+
+    test('contact status tracking -- accepted, pending, blocked', () {
+      final contacts = [
+        const Contact(
+          id: 'c1',
+          userId: 'u1',
+          username: 'alice',
+          status: 'accepted',
+        ),
+        const Contact(
+          id: 'c2',
+          userId: 'u2',
+          username: 'bob',
+          status: 'pending',
+        ),
+        const Contact(
+          id: 'c3',
+          userId: 'u3',
+          username: 'carol',
+          status: 'blocked',
+        ),
+      ];
+
+      final accepted = contacts.where((c) => c.status == 'accepted').toList();
+      expect(accepted, hasLength(1));
+      expect(accepted.first.username, 'alice');
+
+      final pending = contacts.where((c) => c.status == 'pending').toList();
+      expect(pending, hasLength(1));
+      expect(pending.first.username, 'bob');
+
+      final blocked = contacts.where((c) => c.status == 'blocked').toList();
+      expect(blocked, hasLength(1));
+      expect(blocked.first.username, 'carol');
+    });
+
+    test('copyWith sets and clears error', () {
+      const state = ContactsState();
+      final withError = state.copyWith(error: 'Failed to load contacts');
+      expect(withError.error, 'Failed to load contacts');
+
+      final cleared = withError.copyWith(error: null);
+      expect(cleared.error, isNull);
+    });
+
+    test('copyWith sets loading state', () {
+      const state = ContactsState();
+      final loading = state.copyWith(isLoading: true);
+      expect(loading.isLoading, isTrue);
+      final done = loading.copyWith(isLoading: false);
+      expect(done.isLoading, isFalse);
+    });
+
+    test('contacts and pending lists are independent', () {
+      final state = ContactsState(
+        contacts: [
+          const Contact(
+            id: 'c1',
+            userId: 'u1',
+            username: 'alice',
+            status: 'accepted',
+          ),
+        ],
+        pendingRequests: [
+          const Contact(
+            id: 'c2',
+            userId: 'u2',
+            username: 'bob',
+            status: 'pending',
+          ),
+        ],
+      );
+
+      // Updating contacts does not affect pending
+      final updatedContacts = state.copyWith(contacts: []);
+      expect(updatedContacts.contacts, isEmpty);
+      expect(updatedContacts.pendingRequests, hasLength(1));
+
+      // Updating pending does not affect contacts
+      final updatedPending = state.copyWith(pendingRequests: []);
+      expect(updatedPending.contacts, hasLength(1));
+      expect(updatedPending.pendingRequests, isEmpty);
+    });
+  });
+
+  group('Contact model', () {
+    test('fromJson parses correctly', () {
+      final json = {
+        'id': 'contact-1',
+        'user_id': 'user-1',
+        'username': 'alice',
+        'display_name': 'Alice Wonderland',
+        'avatar_url': 'https://example.com/avatar.png',
+        'status': 'accepted',
+      };
+      final contact = Contact.fromJson(json);
+      expect(contact.id, 'contact-1');
+      expect(contact.userId, 'user-1');
+      expect(contact.username, 'alice');
+      expect(contact.displayName, 'Alice Wonderland');
+      expect(contact.avatarUrl, 'https://example.com/avatar.png');
+      expect(contact.status, 'accepted');
+    });
+
+    test('fromJson with null optional fields', () {
+      final json = {
+        'id': 'contact-2',
+        'user_id': 'user-2',
+        'username': 'bob',
+        'status': 'pending',
+      };
+      final contact = Contact.fromJson(json);
+      expect(contact.displayName, isNull);
+      expect(contact.avatarUrl, isNull);
+      expect(contact.status, 'pending');
+    });
+  });
+}

--- a/apps/client/test/providers/conversations_provider_test.dart
+++ b/apps/client/test/providers/conversations_provider_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:echo_app/src/providers/conversations_provider.dart';
+import 'package:echo_app/src/models/conversation.dart';
+
+void main() {
+  group('ConversationsState', () {
+    test('initial state has empty conversations and is not loading', () {
+      const state = ConversationsState();
+      expect(state.conversations, isEmpty);
+      expect(state.isLoading, isFalse);
+      expect(state.error, isNull);
+    });
+
+    test('copyWith preserves conversations and isLoading', () {
+      final state = ConversationsState(
+        conversations: [const Conversation(id: 'c1', isGroup: false)],
+        isLoading: true,
+      );
+      final copied = state.copyWith();
+      expect(copied.conversations, hasLength(1));
+      expect(copied.conversations.first.id, 'c1');
+      expect(copied.isLoading, isTrue);
+    });
+
+    test('copyWith with no error argument clears error (by design)', () {
+      final state = ConversationsState(error: 'old error');
+      // The copyWith uses direct assignment for error (not null-coalesce),
+      // so calling copyWith() without error clears it.
+      final copied = state.copyWith();
+      expect(copied.error, isNull);
+    });
+
+    test('copyWith overrides conversations', () {
+      const state = ConversationsState();
+      final updated = state.copyWith(
+        conversations: [
+          const Conversation(id: 'c1', isGroup: false),
+          const Conversation(id: 'c2', isGroup: true, name: 'Dev Team'),
+        ],
+      );
+      expect(updated.conversations, hasLength(2));
+      expect(updated.conversations[0].id, 'c1');
+      expect(updated.conversations[1].id, 'c2');
+    });
+
+    test('copyWith overrides isLoading', () {
+      const state = ConversationsState();
+      final loading = state.copyWith(isLoading: true);
+      expect(loading.isLoading, isTrue);
+      final notLoading = loading.copyWith(isLoading: false);
+      expect(notLoading.isLoading, isFalse);
+    });
+
+    test('copyWith sets and clears error', () {
+      const state = ConversationsState();
+      final withError = state.copyWith(error: 'Network error');
+      expect(withError.error, 'Network error');
+      // copyWith(error: null) clears the error because the field uses
+      // direct assignment (not null-coalesce)
+      final cleared = withError.copyWith(error: null);
+      expect(cleared.error, isNull);
+    });
+
+    test('adding a conversation updates the list', () {
+      const state = ConversationsState();
+      const conv = Conversation(
+        id: 'conv-1',
+        isGroup: false,
+        lastMessage: 'Hello',
+        lastMessageTimestamp: '2026-01-15T10:30:00Z',
+        lastMessageSender: 'alice',
+        unreadCount: 0,
+        members: [
+          ConversationMember(userId: 'u1', username: 'alice'),
+          ConversationMember(userId: 'u2', username: 'bob'),
+        ],
+      );
+      final updated = state.copyWith(conversations: [conv]);
+      expect(updated.conversations, hasLength(1));
+      expect(updated.conversations.first.id, 'conv-1');
+      expect(updated.conversations.first.lastMessage, 'Hello');
+    });
+
+    test('removing a conversation updates the list', () {
+      final state = ConversationsState(
+        conversations: [
+          const Conversation(id: 'c1', isGroup: false),
+          const Conversation(id: 'c2', isGroup: true, name: 'Group'),
+          const Conversation(id: 'c3', isGroup: false),
+        ],
+      );
+      final filtered = state.conversations.where((c) => c.id != 'c2').toList();
+      final updated = state.copyWith(conversations: filtered);
+      expect(updated.conversations, hasLength(2));
+      expect(updated.conversations.every((c) => c.id != 'c2'), isTrue);
+    });
+
+    test('unread count tracking via copyWith on Conversation', () {
+      const conv = Conversation(id: 'conv-1', isGroup: false, unreadCount: 0);
+      expect(conv.unreadCount, 0);
+
+      final withUnread = conv.copyWith(unreadCount: 5);
+      expect(withUnread.unreadCount, 5);
+
+      final reset = withUnread.copyWith(unreadCount: 0);
+      expect(reset.unreadCount, 0);
+    });
+
+    test('conversation unread count increments correctly', () {
+      const conv = Conversation(id: 'conv-1', isGroup: false, unreadCount: 2);
+
+      // Simulate receiving a new message (increment unread)
+      final bumped = conv.copyWith(unreadCount: conv.unreadCount + 1);
+      expect(bumped.unreadCount, 3);
+    });
+
+    test('conversation list can be sorted by timestamp', () {
+      final conversations = [
+        const Conversation(
+          id: 'c1',
+          isGroup: false,
+          lastMessageTimestamp: '2026-01-15T09:00:00Z',
+        ),
+        const Conversation(
+          id: 'c2',
+          isGroup: false,
+          lastMessageTimestamp: '2026-01-15T12:00:00Z',
+        ),
+        const Conversation(
+          id: 'c3',
+          isGroup: false,
+          lastMessageTimestamp: '2026-01-15T06:00:00Z',
+        ),
+      ];
+
+      // Sort by most recent first (same logic as provider)
+      conversations.sort((a, b) {
+        final aTime = a.lastMessageTimestamp ?? '';
+        final bTime = b.lastMessageTimestamp ?? '';
+        return bTime.compareTo(aTime);
+      });
+
+      expect(conversations[0].id, 'c2');
+      expect(conversations[1].id, 'c1');
+      expect(conversations[2].id, 'c3');
+    });
+
+    test('conversation mute state is preserved in copyWith', () {
+      const conv = Conversation(id: 'c1', isGroup: false, isMuted: false);
+      final muted = conv.copyWith(isMuted: true);
+      expect(muted.isMuted, isTrue);
+      final unmuted = muted.copyWith(isMuted: false);
+      expect(unmuted.isMuted, isFalse);
+    });
+  });
+}

--- a/apps/client/test/providers/websocket_provider_test.dart
+++ b/apps/client/test/providers/websocket_provider_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:echo_app/src/providers/websocket_provider.dart'
+    show WebSocketState;
+
+void main() {
+  group('WebSocketState', () {
+    test('initial state is not connected', () {
+      const state = WebSocketState();
+      expect(state.isConnected, isFalse);
+      expect(state.typingUsers, isEmpty);
+      expect(state.onlineUsers, isEmpty);
+    });
+
+    test('copyWith sets isConnected to true', () {
+      const state = WebSocketState();
+      final connected = state.copyWith(isConnected: true);
+      expect(connected.isConnected, isTrue);
+    });
+
+    test('copyWith preserves values when no arguments given', () {
+      final state = WebSocketState(
+        isConnected: true,
+        onlineUsers: {'u1', 'u2'},
+      );
+      final copied = state.copyWith();
+      expect(copied.isConnected, isTrue);
+      expect(copied.onlineUsers, containsAll(['u1', 'u2']));
+    });
+
+    test('disconnect resets isConnected to false', () {
+      const state = WebSocketState(isConnected: true);
+      final disconnected = state.copyWith(isConnected: false);
+      expect(disconnected.isConnected, isFalse);
+    });
+
+    test('isUserOnline returns true for online users', () {
+      final state = WebSocketState(onlineUsers: {'user-1', 'user-2'});
+      expect(state.isUserOnline('user-1'), isTrue);
+      expect(state.isUserOnline('user-2'), isTrue);
+      expect(state.isUserOnline('user-3'), isFalse);
+    });
+
+    test('typing indicators are tracked per conversation', () {
+      final now = DateTime.now();
+      final state = WebSocketState(
+        typingUsers: {
+          'conv-1:': {'alice': now},
+          'conv-2:': {'bob': now},
+        },
+      );
+
+      final typingInConv1 = state.typingIn('conv-1');
+      expect(typingInConv1, contains('alice'));
+      expect(typingInConv1, isNot(contains('bob')));
+
+      final typingInConv2 = state.typingIn('conv-2');
+      expect(typingInConv2, contains('bob'));
+      expect(typingInConv2, isNot(contains('alice')));
+    });
+
+    test('stale typing indicators are filtered out', () {
+      final staleTime = DateTime.now().subtract(const Duration(seconds: 10));
+      final freshTime = DateTime.now();
+
+      final state = WebSocketState(
+        typingUsers: {
+          'conv-1:': {'alice': staleTime, 'bob': freshTime},
+        },
+      );
+
+      final typing = state.typingIn('conv-1');
+      expect(typing, contains('bob'));
+      expect(typing, isNot(contains('alice')));
+    });
+
+    test('typingIn with channelId uses composite key', () {
+      final now = DateTime.now();
+      final state = WebSocketState(
+        typingUsers: {
+          'conv-1:chan-1': {'alice': now},
+          'conv-1:': {'bob': now},
+        },
+      );
+
+      final typingInChannel = state.typingIn('conv-1', channelId: 'chan-1');
+      expect(typingInChannel, contains('alice'));
+      expect(typingInChannel, isNot(contains('bob')));
+
+      final typingInGeneral = state.typingIn('conv-1');
+      expect(typingInGeneral, contains('bob'));
+      expect(typingInGeneral, isNot(contains('alice')));
+    });
+
+    test('typingIn returns empty list for unknown conversation', () {
+      const state = WebSocketState();
+      expect(state.typingIn('nonexistent'), isEmpty);
+    });
+
+    test('onlineUsers can be updated via copyWith', () {
+      const state = WebSocketState();
+      final withOnline = state.copyWith(onlineUsers: {'u1', 'u2', 'u3'});
+      expect(withOnline.onlineUsers, hasLength(3));
+      expect(withOnline.isUserOnline('u1'), isTrue);
+      expect(withOnline.isUserOnline('u3'), isTrue);
+    });
+
+    test('onlineUsers empty set means no users online', () {
+      final state = WebSocketState(onlineUsers: {'u1'});
+      final cleared = state.copyWith(onlineUsers: <String>{});
+      expect(cleared.onlineUsers, isEmpty);
+      expect(cleared.isUserOnline('u1'), isFalse);
+    });
+  });
+}

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:echo_app/src/models/channel.dart';
@@ -146,10 +147,15 @@ void main() {
       String? activeVoice;
 
       await tester.pumpApp(
-        ChannelBar(
-          conversationId: 'conv-1',
-          onTextChannelChanged: (_) {},
-          onVoiceChannelChanged: (channelId) => activeVoice = channelId,
+        StatefulBuilder(
+          builder: (context, setState) => ChannelBar(
+            conversationId: 'conv-1',
+            activeVoiceChannelId: activeVoice,
+            onTextChannelChanged: (_) {},
+            onVoiceChannelChanged: (channelId) {
+              setState(() => activeVoice = channelId);
+            },
+          ),
         ),
         overrides: [
           authOverride(loggedInAuthState),
@@ -187,10 +193,15 @@ void main() {
       String? activeVoice;
 
       await tester.pumpApp(
-        ChannelBar(
-          conversationId: 'conv-1',
-          onTextChannelChanged: (_) {},
-          onVoiceChannelChanged: (channelId) => activeVoice = channelId,
+        StatefulBuilder(
+          builder: (context, setState) => ChannelBar(
+            conversationId: 'conv-1',
+            activeVoiceChannelId: activeVoice,
+            onTextChannelChanged: (_) {},
+            onVoiceChannelChanged: (channelId) {
+              setState(() => activeVoice = channelId);
+            },
+          ),
         ),
         overrides: [
           authOverride(loggedInAuthState),

--- a/apps/client/test/widgets/chat_input_bar_test.dart
+++ b/apps/client/test/widgets/chat_input_bar_test.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/providers/voice_settings_provider.dart';
+import 'package:echo_app/src/services/crypto_service.dart';
+import 'package:echo_app/src/widgets/chat_input_bar.dart';
+
+import '../helpers/mock_providers.dart';
+import '../helpers/pump_app.dart';
+
+/// Override [chatProvider] with a specific [ChatState].
+Override chatOverride([ChatState state = const ChatState()]) {
+  return chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, state));
+}
+
+class _FakeChatNotifier extends ChatNotifier {
+  _FakeChatNotifier(super.ref, ChatState initial) {
+    state = initial;
+  }
+
+  @override
+  Future<void> loadHistoryWithUserId(
+    String conversationId,
+    String token,
+    String userId, {
+    String? channelId,
+    String? before,
+    CryptoService? crypto,
+    bool isGroup = false,
+  }) async {}
+
+  @override
+  void clearReplyTo() {
+    state = state.copyWith(clearReply: true);
+  }
+}
+
+/// Override [voiceSettingsProvider] with default state.
+Override voiceSettingsOverride() {
+  return voiceSettingsProvider.overrideWith(
+    (ref) => _FakeVoiceSettingsNotifier(),
+  );
+}
+
+class _FakeVoiceSettingsNotifier extends VoiceSettingsNotifier {
+  _FakeVoiceSettingsNotifier() {
+    state = const VoiceSettingsState();
+  }
+}
+
+/// Standard overrides for ChatInputBar tests.
+List<Override> _chatInputOverrides({ChatState chatState = const ChatState()}) {
+  return [
+    ...standardOverrides(),
+    chatOverride(chatState),
+    voiceSettingsOverride(),
+  ];
+}
+
+/// A 1:1 DM conversation that is encrypted (sending is allowed).
+const _dmConversation = Conversation(
+  id: 'conv-dm',
+  isGroup: false,
+  isEncrypted: true,
+  members: [
+    ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ConversationMember(userId: 'user-alice', username: 'alice'),
+  ],
+);
+
+/// A group conversation for mention testing.
+const _groupConversation = Conversation(
+  id: 'conv-group',
+  name: 'Dev Team',
+  isGroup: true,
+  members: [
+    ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ConversationMember(userId: 'user-alice', username: 'alice'),
+    ConversationMember(userId: 'user-bob', username: 'bob'),
+    ConversationMember(userId: 'user-carol', username: 'carol'),
+  ],
+);
+
+void main() {
+  group('ChatInputBar', () {
+    testWidgets('renders text field with hint', (tester) async {
+      await tester.pumpApp(
+        ChatInputBar(conversation: _dmConversation, onMessageSent: () {}),
+        overrides: _chatInputOverrides(),
+      );
+      await tester.pump();
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('Type a message...'), findsOneWidget);
+    });
+
+    testWidgets('send button is visually disabled when text is empty', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatInputBar(conversation: _dmConversation, onMessageSent: () {}),
+        overrides: _chatInputOverrides(),
+      );
+      await tester.pump();
+
+      // The send button is an Opacity widget. When the text field is empty,
+      // the send button should have reduced opacity (0.45).
+      final opacityWidgets = tester
+          .widgetList<Opacity>(find.byType(Opacity))
+          .where((o) => o.opacity < 1.0)
+          .toList();
+      expect(opacityWidgets, isNotEmpty);
+    });
+
+    testWidgets('send button becomes active when text is entered', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatInputBar(conversation: _dmConversation, onMessageSent: () {}),
+        overrides: _chatInputOverrides(),
+      );
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'Hello world');
+      await tester.pump();
+
+      // After entering text, the Opacity of the send button should be 1.0
+      final sendButtonOpacity = tester
+          .widgetList<Opacity>(find.byType(Opacity))
+          .where((o) => o.opacity == 1.0)
+          .toList();
+      expect(sendButtonOpacity, isNotEmpty);
+    });
+
+    testWidgets('reply preview shows when reply is active', (tester) async {
+      final replyMsg = ChatMessage(
+        id: 'msg-reply',
+        fromUserId: 'user-alice',
+        fromUsername: 'alice',
+        conversationId: 'conv-dm',
+        content: 'Hey, what do you think?',
+        timestamp: '2026-01-15T10:00:00Z',
+        isMine: false,
+      );
+      final chatState = ChatState(replyToMessage: replyMsg);
+
+      await tester.pumpApp(
+        ChatInputBar(conversation: _dmConversation, onMessageSent: () {}),
+        overrides: _chatInputOverrides(chatState: chatState),
+      );
+      await tester.pump();
+
+      expect(find.text('Replying to alice'), findsOneWidget);
+      expect(find.text('Hey, what do you think?'), findsOneWidget);
+      expect(find.byIcon(Icons.reply_outlined), findsOneWidget);
+    });
+
+    testWidgets('reply preview has close button', (tester) async {
+      final replyMsg = ChatMessage(
+        id: 'msg-reply',
+        fromUserId: 'user-alice',
+        fromUsername: 'alice',
+        conversationId: 'conv-dm',
+        content: 'Some message',
+        timestamp: '2026-01-15T10:00:00Z',
+        isMine: false,
+      );
+      final chatState = ChatState(replyToMessage: replyMsg);
+
+      await tester.pumpApp(
+        ChatInputBar(conversation: _dmConversation, onMessageSent: () {}),
+        overrides: _chatInputOverrides(chatState: chatState),
+      );
+      await tester.pump();
+
+      // Close icon exists in the reply bar
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('typing indicator shows when typingUsers is non-empty', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatInputBar(
+          conversation: _dmConversation,
+          typingUsers: const ['alice'],
+          onMessageSent: () {},
+        ),
+        overrides: _chatInputOverrides(),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('is typing...'), findsOneWidget);
+    });
+
+    testWidgets('group typing indicator shows multiple users', (tester) async {
+      await tester.pumpApp(
+        ChatInputBar(
+          conversation: _groupConversation,
+          typingUsers: const ['alice', 'bob'],
+          onMessageSent: () {},
+        ),
+        overrides: _chatInputOverrides(),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('are typing...'), findsOneWidget);
+    });
+
+    testWidgets('escape key clears reply when reply is active', (tester) async {
+      final replyMsg = ChatMessage(
+        id: 'msg-reply',
+        fromUserId: 'user-alice',
+        fromUsername: 'alice',
+        conversationId: 'conv-dm',
+        content: 'Some message to reply to',
+        timestamp: '2026-01-15T10:00:00Z',
+        isMine: false,
+      );
+      final chatState = ChatState(replyToMessage: replyMsg);
+
+      await tester.pumpApp(
+        ChatInputBar(conversation: _dmConversation, onMessageSent: () {}),
+        overrides: _chatInputOverrides(chatState: chatState),
+      );
+      await tester.pump();
+
+      // Verify reply preview is shown
+      expect(find.text('Replying to alice'), findsOneWidget);
+
+      // Focus the text field and press Escape
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+
+      // After Escape, the reply should be cleared
+      expect(find.text('Replying to alice'), findsNothing);
+    });
+
+    testWidgets('plus menu button is present', (tester) async {
+      await tester.pumpApp(
+        ChatInputBar(conversation: _dmConversation, onMessageSent: () {}),
+        overrides: _chatInputOverrides(),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+    });
+  });
+}

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/providers/channels_provider.dart';
+import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/providers/privacy_provider.dart';
+import 'package:echo_app/src/providers/theme_provider.dart';
+import 'package:echo_app/src/providers/voice_rtc_provider.dart';
+import 'package:echo_app/src/providers/voice_settings_provider.dart';
+import 'package:echo_app/src/services/crypto_service.dart';
+import 'package:echo_app/src/widgets/chat_panel.dart';
+
+import '../helpers/mock_providers.dart';
+import '../helpers/pump_app.dart';
+
+// ---------------------------------------------------------------------------
+// Fake notifiers for additional providers ChatPanel depends on
+// ---------------------------------------------------------------------------
+
+class _FakeChatNotifier extends ChatNotifier {
+  _FakeChatNotifier(super.ref, ChatState initial) {
+    state = initial;
+  }
+
+  @override
+  Future<void> loadHistoryWithUserId(
+    String conversationId,
+    String token,
+    String userId, {
+    String? channelId,
+    String? before,
+    CryptoService? crypto,
+    bool isGroup = false,
+  }) async {}
+
+  @override
+  void clearReplyTo() {
+    state = state.copyWith(clearReply: true);
+  }
+}
+
+class _FakeChannelsNotifier extends ChannelsNotifier {
+  _FakeChannelsNotifier(super.ref) {
+    state = const ChannelsState();
+  }
+
+  @override
+  Future<void> loadChannels(String conversationId) async {}
+}
+
+class _FakePrivacyNotifier extends PrivacyNotifier {
+  _FakePrivacyNotifier(super.ref) {
+    state = const PrivacyState();
+  }
+}
+
+class _FakeVoiceSettingsNotifier extends VoiceSettingsNotifier {
+  _FakeVoiceSettingsNotifier() {
+    state = const VoiceSettingsState();
+  }
+}
+
+class _FakeVoiceRtcNotifier extends VoiceRtcNotifier {
+  _FakeVoiceRtcNotifier(super.ref) {
+    state = VoiceRtcState.empty;
+  }
+
+  @override
+  Map<String, RTCVideoRenderer> get remoteAudioRenderers =>
+      const <String, RTCVideoRenderer>{};
+}
+
+/// Builds the full set of overrides needed for ChatPanel widget tests.
+List<Override> _chatPanelOverrides({ChatState chatState = const ChatState()}) {
+  return [
+    ...standardOverrides(),
+    chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, chatState)),
+    channelsProvider.overrideWith((ref) => _FakeChannelsNotifier(ref)),
+    privacyProvider.overrideWith((ref) => _FakePrivacyNotifier(ref)),
+    voiceSettingsProvider.overrideWith((ref) => _FakeVoiceSettingsNotifier()),
+    voiceRtcProvider.overrideWith((ref) => _FakeVoiceRtcNotifier(ref)),
+    themeProvider.overrideWith((ref) => _FakeThemeNotifier()),
+    messageLayoutProvider.overrideWith((ref) => _FakeMessageLayoutNotifier()),
+  ];
+}
+
+class _FakeThemeNotifier extends ThemeNotifier {
+  _FakeThemeNotifier() {
+    state = AppThemeSelection.dark;
+  }
+}
+
+class _FakeMessageLayoutNotifier extends MessageLayoutNotifier {
+  _FakeMessageLayoutNotifier() {
+    state = MessageLayout.bubbles;
+  }
+}
+
+/// A 1:1 DM conversation.
+const _dmConversation = Conversation(
+  id: 'conv-dm',
+  isGroup: false,
+  isEncrypted: true,
+  members: [
+    ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ConversationMember(userId: 'user-alice', username: 'alice'),
+  ],
+);
+
+/// A group conversation.
+const _groupConversation = Conversation(
+  id: 'conv-group',
+  name: 'Dev Team',
+  isGroup: true,
+  members: [
+    ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ConversationMember(userId: 'user-alice', username: 'alice'),
+    ConversationMember(userId: 'user-bob', username: 'bob'),
+  ],
+);
+
+void main() {
+  group('ChatPanel', () {
+    testWidgets('empty state placeholder renders when no conversation', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const ChatPanel(conversation: null),
+        overrides: _chatPanelOverrides(),
+      );
+      await tester.pump();
+
+      expect(find.text('Select a conversation'), findsOneWidget);
+      expect(
+        find.text('Pick someone from the left to start chatting'),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.chat_bubble_outline_rounded), findsOneWidget);
+    });
+
+    testWidgets('shows peer name in DM conversation header area', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatPanel(conversation: _dmConversation),
+        overrides: _chatPanelOverrides(),
+      );
+      await tester.pump();
+
+      // The header bar should show the peer's name
+      expect(find.text('alice'), findsWidgets);
+    });
+
+    testWidgets('shows group name in group conversation', (tester) async {
+      await tester.pumpApp(
+        ChatPanel(conversation: _groupConversation),
+        overrides: _chatPanelOverrides(),
+      );
+      await tester.pump();
+
+      expect(find.text('Dev Team'), findsWidgets);
+    });
+
+    testWidgets('empty message placeholder renders with no messages', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatPanel(conversation: _dmConversation),
+        overrides: _chatPanelOverrides(),
+      );
+      await tester.pump();
+
+      // The empty message placeholder shows "Start your conversation with alice"
+      expect(
+        find.textContaining('Start your conversation with'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('message list renders with messages', (tester) async {
+      final messages = [
+        ChatMessage(
+          id: 'msg-1',
+          fromUserId: 'user-alice',
+          fromUsername: 'alice',
+          conversationId: 'conv-dm',
+          content: 'Hello there!',
+          timestamp: '2026-01-15T10:00:00Z',
+          isMine: false,
+        ),
+        ChatMessage(
+          id: 'msg-2',
+          fromUserId: 'test-user-id',
+          fromUsername: 'testuser',
+          conversationId: 'conv-dm',
+          content: 'Hi alice!',
+          timestamp: '2026-01-15T10:01:00Z',
+          isMine: true,
+        ),
+      ];
+
+      final chatState = ChatState(
+        messagesByConversation: {'conv-dm': messages},
+      );
+
+      await tester.pumpApp(
+        ChatPanel(conversation: _dmConversation),
+        overrides: _chatPanelOverrides(chatState: chatState),
+      );
+      await tester.pump();
+
+      expect(find.text('Hello there!'), findsOneWidget);
+      expect(find.text('Hi alice!'), findsOneWidget);
+    });
+
+    testWidgets('loading indicator shows when loading history', (tester) async {
+      final chatState = ChatState(loadingHistory: {'conv-dm': true});
+
+      await tester.pumpApp(
+        ChatPanel(conversation: _dmConversation),
+        overrides: _chatPanelOverrides(chatState: chatState),
+      );
+      await tester.pump();
+
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('no loading indicator when not loading history', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatPanel(conversation: _dmConversation),
+        overrides: _chatPanelOverrides(),
+      );
+      await tester.pump();
+
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+    });
+
+    testWidgets('chat input bar is present in conversation view', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatPanel(conversation: _dmConversation),
+        overrides: _chatPanelOverrides(),
+      );
+      await tester.pump();
+
+      // The ChatInputBar contains a TextField
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('Type a message...'), findsOneWidget);
+    });
+
+    testWidgets('placeholder is not shown when conversation is provided', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChatPanel(conversation: _dmConversation),
+        overrides: _chatPanelOverrides(),
+      );
+      await tester.pump();
+
+      // The "Select a conversation" placeholder should NOT be shown
+      expect(find.text('Select a conversation'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Markdown rendering: **bold**, *italic*, `inline code`, ```code blocks``` in messages
- @Mention system verified working end-to-end
- 52 new tests across 5 files (107 → 159 total)
- Theme factory: extracted 5 shared builders, cut ~200 lines of duplication
- ChannelBar refactored to controlled widget (voice channel state lifted to parent)

## Test plan
- [x] flutter analyze -- no issues
- [x] flutter test -- 159/159 pass
- [x] dart format -- clean
- [x] Pre-commit hooks pass