### PR TITLE
feat: message pinning and notification improvements

### DIFF
--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'src/app.dart';
 import 'src/providers/server_url_provider.dart';
 import 'src/services/notification_service.dart';
+import 'src/services/sound_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,6 +25,9 @@ void main() async {
       await container.read(serverUrlProvider.notifier).setUrl(serverParam);
     }
   }
+
+  // Load persisted sound preference
+  await SoundService().init();
 
   // Request browser notification permission (no-op on non-web platforms)
   NotificationService().requestPermission();

--- a/apps/client/lib/src/models/chat_message.dart
+++ b/apps/client/lib/src/models/chat_message.dart
@@ -1,5 +1,9 @@
 import 'reaction.dart';
 
+/// Sentinel value used in [ChatMessage.copyWith] to distinguish between
+/// "not provided" and "explicitly set to null" for nullable fields.
+const _sentinel = Object();
+
 enum MessageStatus { sending, sent, delivered, read, failed }
 
 bool _listEquals<T>(List<T> a, List<T> b) {
@@ -27,6 +31,8 @@ class ChatMessage {
   final String? replyToId;
   final String? replyToContent;
   final String? replyToUsername;
+  final String? pinnedById;
+  final DateTime? pinnedAt;
 
   const ChatMessage({
     required this.id,
@@ -44,6 +50,8 @@ class ChatMessage {
     this.replyToId,
     this.replyToContent,
     this.replyToUsername,
+    this.pinnedById,
+    this.pinnedAt,
   });
 
   factory ChatMessage.fromServerJson(
@@ -71,6 +79,9 @@ class ChatMessage {
                 DateTime.now().toIso8601String())
             .toString();
 
+    final pinnedByIdRaw = json['pinned_by_id'] as String?;
+    final pinnedAtRaw = json['pinned_at'] as String?;
+
     return ChatMessage(
       id: id,
       fromUserId: fromUserId,
@@ -86,6 +97,8 @@ class ChatMessage {
       replyToId: json['reply_to_id'] as String?,
       replyToContent: json['reply_to_content'] as String?,
       replyToUsername: json['reply_to_username'] as String?,
+      pinnedById: pinnedByIdRaw,
+      pinnedAt: pinnedAtRaw != null ? DateTime.tryParse(pinnedAtRaw) : null,
     );
   }
 
@@ -105,6 +118,8 @@ class ChatMessage {
     String? replyToId,
     String? replyToContent,
     String? replyToUsername,
+    Object? pinnedById = _sentinel,
+    Object? pinnedAt = _sentinel,
   }) {
     return ChatMessage(
       id: id ?? this.id,
@@ -122,6 +137,10 @@ class ChatMessage {
       replyToId: replyToId ?? this.replyToId,
       replyToContent: replyToContent ?? this.replyToContent,
       replyToUsername: replyToUsername ?? this.replyToUsername,
+      pinnedById: pinnedById == _sentinel
+          ? this.pinnedById
+          : pinnedById as String?,
+      pinnedAt: pinnedAt == _sentinel ? this.pinnedAt : pinnedAt as DateTime?,
     );
   }
 
@@ -143,7 +162,9 @@ class ChatMessage {
             isEncrypted == other.isEncrypted &&
             replyToId == other.replyToId &&
             replyToContent == other.replyToContent &&
-            replyToUsername == other.replyToUsername;
+            replyToUsername == other.replyToUsername &&
+            pinnedById == other.pinnedById &&
+            pinnedAt == other.pinnedAt;
   }
 
   @override
@@ -163,5 +184,7 @@ class ChatMessage {
     replyToId,
     replyToContent,
     replyToUsername,
+    pinnedById,
+    pinnedAt,
   );
 }

--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -553,6 +553,34 @@ class ChatNotifier extends StateNotifier<ChatState> {
     );
   }
 
+  /// Update a message's pin state in local state.
+  void updateMessagePin(
+    String conversationId,
+    String messageId,
+    String? pinnedById,
+    DateTime? pinnedAt,
+  ) {
+    final updatedConv = Map<String, List<ChatMessage>>.from(
+      state.messagesByConversation,
+    );
+    final messages = updatedConv[conversationId];
+    if (messages == null) return;
+
+    updatedConv[conversationId] = messages.map((msg) {
+      if (msg.id == messageId) {
+        return msg.copyWith(pinnedById: pinnedById, pinnedAt: pinnedAt);
+      }
+      return msg;
+    }).toList();
+
+    state = ChatState(
+      messagesByConversation: updatedConv,
+      loadingHistory: state.loadingHistory,
+      hasMore: state.hasMore,
+      replyToMessage: state.replyToMessage,
+    );
+  }
+
   void clear() {
     state = const ChatState();
   }

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 
 import '../models/conversation.dart';
+import '../services/notification_service.dart';
 import '../utils/crypto_utils.dart';
 import 'auth_provider.dart';
 import 'privacy_provider.dart';
@@ -67,6 +68,15 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
     'Authorization': 'Bearer $token',
   };
 
+  /// Compute total unread count and update the browser tab badge.
+  void _updateTabBadge() {
+    final total = state.conversations.fold<int>(
+      0,
+      (sum, c) => sum + c.unreadCount,
+    );
+    NotificationService().updateTabBadge(total);
+  }
+
   /// Make an authenticated request with automatic 401 refresh-and-retry.
   Future<http.Response> _authenticatedRequest(
     Future<http.Response> Function(String token) requestFn,
@@ -113,6 +123,7 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
         });
 
         state = state.copyWith(conversations: conversations, isLoading: false);
+        _updateTabBadge();
       } else {
         state = state.copyWith(
           isLoading: false,
@@ -152,6 +163,7 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
       updated.insert(0, updatedConv);
 
       state = state.copyWith(conversations: updated);
+      _updateTabBadge();
     } else {
       // New conversation we don't have locally -- reload from server
       loadConversations();
@@ -194,6 +206,7 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
     if (index >= 0) {
       updated[index] = updated[index].copyWith(unreadCount: 0);
       state = state.copyWith(conversations: updated);
+      _updateTabBadge();
     }
   }
 

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -99,6 +99,10 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
         _handleMessageDeleted(json);
       case 'message_edited':
         _handleMessageEdited(json);
+      case 'message_pinned':
+        _handleMessagePinned(json);
+      case 'message_unpinned':
+        _handleMessageUnpinned(json);
       case 'presence':
         _handlePresence(json);
       case 'presence_list':
@@ -367,6 +371,27 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
           conversationId: conversationId,
           newContent: newContent,
         );
+  }
+
+  void _handleMessagePinned(Map<String, dynamic> json) {
+    final conversationId = json['conversation_id'] as String;
+    final messageId = json['message_id'] as String;
+    final pinnedById = json['pinned_by_id'] as String?;
+    final pinnedAtRaw = json['pinned_at'] as String?;
+    final pinnedAt = pinnedAtRaw != null
+        ? DateTime.tryParse(pinnedAtRaw)
+        : DateTime.now();
+    ref
+        .read(chatProvider.notifier)
+        .updateMessagePin(conversationId, messageId, pinnedById, pinnedAt);
+  }
+
+  void _handleMessageUnpinned(Map<String, dynamic> json) {
+    final conversationId = json['conversation_id'] as String;
+    final messageId = json['message_id'] as String;
+    ref
+        .read(chatProvider.notifier)
+        .updateMessagePin(conversationId, messageId, null, null);
   }
 
   void _handleMention(Map<String, dynamic> json, String myUserId) {

--- a/apps/client/lib/src/services/notification_service.dart
+++ b/apps/client/lib/src/services/notification_service.dart
@@ -19,4 +19,9 @@ abstract class NotificationService {
     required String senderUsername,
     required String body,
   });
+
+  /// Update the browser tab title badge with total unread count.
+  /// On web, sets document.title to "(N) Echo Messenger" or "Echo Messenger".
+  /// No-op on non-web platforms.
+  void updateTabBadge(int totalUnread);
 }

--- a/apps/client/lib/src/services/notification_service_stub.dart
+++ b/apps/client/lib/src/services/notification_service_stub.dart
@@ -11,5 +11,19 @@ class _StubNotificationService implements NotificationService {
   void showMessageNotification({
     required String senderUsername,
     required String body,
-  }) {}
+  }) {
+    // TODO: Implement desktop/mobile visual notifications with
+    // flutter_local_notifications. Requires native setup:
+    // - Android: AndroidManifest permissions, notification channel
+    // - Linux: libnotify-dev in CMakeLists.txt
+    // - Windows: no extra setup but needs testing
+    // The sound service already handles audio -- this just needs the popup.
+  }
+
+  @override
+  void updateTabBadge(int totalUnread) {
+    // No-op on non-web platforms.
+    // TODO: Implement desktop notifications with flutter_local_notifications
+    // once native platform setup (AndroidManifest, Linux libnotify) is done.
+  }
 }

--- a/apps/client/lib/src/services/notification_service_web.dart
+++ b/apps/client/lib/src/services/notification_service_web.dart
@@ -45,4 +45,17 @@ class _WebNotificationService implements NotificationService {
       // Best-effort -- silently ignore errors
     }
   }
+
+  @override
+  void updateTabBadge(int totalUnread) {
+    try {
+      if (totalUnread > 0) {
+        web.document.title = '($totalUnread) Echo Messenger';
+      } else {
+        web.document.title = 'Echo Messenger';
+      }
+    } catch (_) {
+      // Best-effort -- silently ignore errors
+    }
+  }
 }

--- a/apps/client/lib/src/services/sound_service.dart
+++ b/apps/client/lib/src/services/sound_service.dart
@@ -1,5 +1,6 @@
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Simple service for playing UI sound effects.
 ///
@@ -9,16 +10,50 @@ class SoundService {
   factory SoundService() => _instance;
   SoundService._();
 
+  static const _prefKey = 'sound_enabled';
+
   final AudioPlayer _sentPlayer = AudioPlayer();
   final AudioPlayer _receivedPlayer = AudioPlayer();
   final AudioPlayer _voiceJoinPlayer = AudioPlayer();
   final AudioPlayer _voiceLeavePlayer = AudioPlayer();
 
-  bool enabled = true;
+  bool _enabled = true;
+  bool _initialized = false;
+
+  /// Whether sound effects are currently enabled.
+  bool get enabled => _enabled;
+
+  /// Toggle sound effects on or off and persist the preference.
+  set enabled(bool value) {
+    _enabled = value;
+    _persist(value);
+  }
+
+  /// Load the persisted sound preference from SharedPreferences.
+  /// Should be called once during app initialization.
+  Future<void> init() async {
+    if (_initialized) return;
+    _initialized = true;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      _enabled = prefs.getBool(_prefKey) ?? true;
+    } catch (e) {
+      debugPrint('[Sound] Failed to load preference: $e');
+    }
+  }
+
+  Future<void> _persist(bool value) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_prefKey, value);
+    } catch (e) {
+      debugPrint('[Sound] Failed to save preference: $e');
+    }
+  }
 
   /// Play a short "whoosh" sound when the user sends a message.
   Future<void> playMessageSent() async {
-    if (!enabled) return;
+    if (!_enabled) return;
     try {
       await _sentPlayer.play(AssetSource('sounds/sent.mp3'), volume: 0.4);
     } catch (e) {
@@ -28,7 +63,7 @@ class SoundService {
 
   /// Play a short "ding" sound when a new message is received.
   Future<void> playMessageReceived() async {
-    if (!enabled) return;
+    if (!_enabled) return;
     try {
       await _receivedPlayer.play(
         AssetSource('sounds/received.mp3'),
@@ -41,7 +76,7 @@ class SoundService {
 
   /// Play ascending chime when joining a voice channel.
   Future<void> playVoiceJoin() async {
-    if (!enabled) return;
+    if (!_enabled) return;
     try {
       await _voiceJoinPlayer.play(
         AssetSource('sounds/voice_join.mp3'),
@@ -54,7 +89,7 @@ class SoundService {
 
   /// Play descending chime when leaving a voice channel.
   Future<void> playVoiceLeave() async {
-    if (!enabled) return;
+    if (!_enabled) return;
     try {
       await _voiceLeavePlayer.play(
         AssetSource('sounds/voice_leave.mp3'),

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -1,13 +1,20 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 
+import '../models/chat_message.dart';
 import '../models/conversation.dart';
 import '../providers/auth_provider.dart';
+import '../providers/chat_provider.dart';
 import '../providers/crypto_provider.dart';
+import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import '../utils/time_utils.dart';
 import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
 
 class ChatHeaderBar extends ConsumerWidget {
@@ -158,6 +165,13 @@ class ChatHeaderBar extends ConsumerWidget {
     WidgetRef ref,
     Conversation conv,
   ) {
+    // Count pinned messages from local state.
+    final chatState = ref.watch(chatProvider);
+    final pinnedCount = chatState
+        .messagesForConversation(conv.id)
+        .where((m) => m.pinnedAt != null)
+        .length;
+
     return [
       if (!conv.isGroup)
         const Tooltip(
@@ -173,6 +187,22 @@ class ChatHeaderBar extends ConsumerWidget {
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
         ),
+      IconButton(
+        icon: Badge(
+          isLabelVisible: pinnedCount > 0,
+          label: Text(
+            '$pinnedCount',
+            style: const TextStyle(fontSize: 9, color: Colors.white),
+          ),
+          backgroundColor: context.accent,
+          child: const Icon(Icons.push_pin_outlined, size: 20),
+        ),
+        color: context.textSecondary,
+        tooltip: 'Pinned messages',
+        onPressed: () => _showPinnedMessagesDialog(context, ref, conv),
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+      ),
       IconButton(
         icon: Icon(showSearch ? Icons.search_off : Icons.search, size: 20),
         color: showSearch ? context.accent : context.textSecondary,
@@ -261,6 +291,24 @@ class ChatHeaderBar extends ConsumerWidget {
     );
   }
 
+  void _showPinnedMessagesDialog(
+    BuildContext context,
+    WidgetRef ref,
+    Conversation conv,
+  ) {
+    final serverUrl = ref.read(serverUrlProvider);
+    final myUserId = this.myUserId;
+
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => _PinnedMessagesDialog(
+        conversationId: conv.id,
+        serverUrl: serverUrl,
+        myUserId: myUserId,
+      ),
+    );
+  }
+
   Future<void> _resetPeerKeys(
     BuildContext context,
     WidgetRef ref,
@@ -330,5 +378,245 @@ class ChatHeaderBar extends ConsumerWidget {
         );
       }
     }
+  }
+}
+
+/// Dialog that fetches and displays pinned messages for a conversation.
+class _PinnedMessagesDialog extends ConsumerStatefulWidget {
+  final String conversationId;
+  final String serverUrl;
+  final String myUserId;
+
+  const _PinnedMessagesDialog({
+    required this.conversationId,
+    required this.serverUrl,
+    required this.myUserId,
+  });
+
+  @override
+  ConsumerState<_PinnedMessagesDialog> createState() =>
+      _PinnedMessagesDialogState();
+}
+
+class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
+  List<ChatMessage>? _pinnedMessages;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPinnedMessages();
+  }
+
+  Future<void> _fetchPinnedMessages() async {
+    try {
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.get(
+              Uri.parse(
+                '${widget.serverUrl}/api/conversations'
+                '/${widget.conversationId}/pinned',
+              ),
+              headers: {
+                'Authorization': 'Bearer $token',
+                'Content-Type': 'application/json',
+              },
+            ),
+          );
+
+      if (!mounted) return;
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        final decoded = jsonDecode(response.body);
+        final list = decoded is List
+            ? decoded
+            : (decoded['messages'] as List? ?? []);
+        final messages = list
+            .map(
+              (e) => ChatMessage.fromServerJson(
+                e as Map<String, dynamic>,
+                widget.myUserId,
+              ),
+            )
+            .toList();
+        setState(() {
+          _pinnedMessages = messages;
+          _isLoading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load pinned messages';
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Failed to load pinned messages';
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _unpinMessage(ChatMessage message) async {
+    try {
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.delete(
+              Uri.parse(
+                '${widget.serverUrl}/api/conversations'
+                '/${widget.conversationId}'
+                '/messages/${message.id}/pin',
+              ),
+              headers: {'Authorization': 'Bearer $token'},
+            ),
+          );
+
+      if (!mounted) return;
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        ref
+            .read(chatProvider.notifier)
+            .updateMessagePin(widget.conversationId, message.id, null, null);
+        setState(() {
+          _pinnedMessages?.removeWhere((m) => m.id == message.id);
+        });
+        ToastService.show(context, 'Message unpinned', type: ToastType.success);
+      } else {
+        ToastService.show(
+          context,
+          'Failed to unpin message',
+          type: ToastType.error,
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ToastService.show(
+        context,
+        'Failed to unpin message',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: context.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: context.border),
+      ),
+      title: Row(
+        children: [
+          Icon(Icons.push_pin, size: 18, color: context.accent),
+          const SizedBox(width: 8),
+          Text(
+            'Pinned Messages',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+      content: SizedBox(width: 420, height: 380, child: _buildContent(context)),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Text(
+          _error!,
+          style: TextStyle(color: context.textMuted, fontSize: 14),
+        ),
+      );
+    }
+    final messages = _pinnedMessages ?? [];
+    if (messages.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.push_pin_outlined, size: 40, color: context.textMuted),
+            const SizedBox(height: 12),
+            Text(
+              'No pinned messages',
+              style: TextStyle(color: context.textMuted, fontSize: 14),
+            ),
+          ],
+        ),
+      );
+    }
+    return ListView.separated(
+      itemCount: messages.length,
+      separatorBuilder: (_, _) => Divider(color: context.border, height: 1),
+      itemBuilder: (_, index) {
+        final msg = messages[index];
+        final preview = msg.content.length > 120
+            ? '${msg.content.substring(0, 120)}...'
+            : msg.content;
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      msg.fromUsername,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: context.accent,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      preview,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: context.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      formatMessageTimestamp(msg.timestamp),
+                      style: TextStyle(fontSize: 11, color: context.textMuted),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.push_pin_outlined, size: 16),
+                color: context.textMuted,
+                tooltip: 'Unpin',
+                onPressed: () => _unpinMessage(msg),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 }

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -18,6 +18,7 @@ import '../providers/theme_provider.dart';
 import '../providers/voice_rtc_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../screens/user_profile_screen.dart';
+import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import 'channel_bar.dart';
 import 'chat_header_bar.dart';
@@ -445,6 +446,118 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   }
 
   // ---------------------------------------------------------------------------
+  // Pin / Unpin
+  // ---------------------------------------------------------------------------
+
+  Future<void> _pinMessage(ChatMessage message) async {
+    final conv = widget.conversation;
+    if (conv == null) return;
+    final myUserId = ref.read(authProvider).userId ?? '';
+    final serverUrl = ref.read(serverUrlProvider);
+
+    // Optimistically update local state
+    ref
+        .read(chatProvider.notifier)
+        .updateMessagePin(conv.id, message.id, myUserId, DateTime.now());
+
+    try {
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.post(
+              Uri.parse(
+                '$serverUrl/api/conversations/${conv.id}'
+                '/messages/${message.id}/pin',
+              ),
+              headers: {'Authorization': 'Bearer $token'},
+            ),
+          );
+      if (!mounted) return;
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        ToastService.show(context, 'Message pinned', type: ToastType.success);
+      } else {
+        // Revert on failure
+        ref
+            .read(chatProvider.notifier)
+            .updateMessagePin(conv.id, message.id, null, null);
+        ToastService.show(
+          context,
+          'Failed to pin message',
+          type: ToastType.error,
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ref
+          .read(chatProvider.notifier)
+          .updateMessagePin(conv.id, message.id, null, null);
+      ToastService.show(
+        context,
+        'Failed to pin message',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  Future<void> _unpinMessage(ChatMessage message) async {
+    final conv = widget.conversation;
+    if (conv == null) return;
+    final serverUrl = ref.read(serverUrlProvider);
+
+    // Save previous state for revert
+    final prevPinnedById = message.pinnedById;
+    final prevPinnedAt = message.pinnedAt;
+
+    // Optimistically clear pin
+    ref
+        .read(chatProvider.notifier)
+        .updateMessagePin(conv.id, message.id, null, null);
+
+    try {
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.delete(
+              Uri.parse(
+                '$serverUrl/api/conversations/${conv.id}'
+                '/messages/${message.id}/pin',
+              ),
+              headers: {'Authorization': 'Bearer $token'},
+            ),
+          );
+      if (!mounted) return;
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        ToastService.show(context, 'Message unpinned', type: ToastType.success);
+      } else {
+        // Revert on failure
+        ref
+            .read(chatProvider.notifier)
+            .updateMessagePin(
+              conv.id,
+              message.id,
+              prevPinnedById,
+              prevPinnedAt,
+            );
+        ToastService.show(
+          context,
+          'Failed to unpin message',
+          type: ToastType.error,
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ref
+          .read(chatProvider.notifier)
+          .updateMessagePin(conv.id, message.id, prevPinnedById, prevPinnedAt);
+      ToastService.show(
+        context,
+        'Failed to unpin message',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Message list helpers
   // ---------------------------------------------------------------------------
 
@@ -685,6 +798,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
               ref.read(chatProvider.notifier).setReplyTo(msg);
               _chatInputBarKey.currentState?.requestInputFocus();
             },
+            onPin: (msg) => _pinMessage(msg),
+            onUnpin: (msg) => _unpinMessage(msg),
             onAvatarTap: (userId) {
               UserProfileScreen.show(context, ref, userId);
             },

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -394,6 +394,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     WebSocketState wsState,
     int pendingCount,
   ) {
+    final conversationsState = ref.watch(conversationsProvider);
+    final totalUnread = conversationsState.conversations.fold<int>(
+      0,
+      (sum, c) => sum + c.unreadCount,
+    );
+
     return Container(
       height: 56,
       padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -402,7 +408,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       ),
       child: Row(
         children: [
-          const EchoLogoIcon(size: 24),
+          _buildLogoWithBadge(totalUnread),
           const SizedBox(width: 10),
           Text(
             'Echo',
@@ -419,6 +425,41 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           _buildHeaderActions(context, pendingCount),
         ],
       ),
+    );
+  }
+
+  Widget _buildLogoWithBadge(int totalUnread) {
+    if (totalUnread <= 0) {
+      return const EchoLogoIcon(size: 24);
+    }
+    final label = totalUnread > 99 ? '99+' : '$totalUnread';
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        const EchoLogoIcon(size: 24),
+        Positioned(
+          top: -6,
+          right: -10,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+            constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
+            decoration: BoxDecoration(
+              color: EchoTheme.danger,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Center(
+              child: Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 9,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -64,6 +64,8 @@ class MessageItem extends StatefulWidget {
   final void Function(ChatMessage message)? onEdit;
   final void Function(ChatMessage message)? onReply;
   final void Function(String userId)? onAvatarTap;
+  final void Function(ChatMessage message)? onPin;
+  final void Function(ChatMessage message)? onUnpin;
 
   /// Server URL for resolving relative image paths.
   final String? serverUrl;
@@ -89,6 +91,8 @@ class MessageItem extends StatefulWidget {
     this.onEdit,
     this.onReply,
     this.onAvatarTap,
+    this.onPin,
+    this.onUnpin,
     this.serverUrl,
     this.authToken,
     this.senderAvatarUrl,
@@ -613,6 +617,18 @@ class _MessageItemState extends State<MessageItem> {
               widget.onReactionTap?.call(msg, pos);
             },
           ),
+          if (msg.pinnedAt == null && widget.onPin != null)
+            _HoverActionButton(
+              icon: Icons.push_pin_outlined,
+              tooltip: 'Pin',
+              onPressed: () => widget.onPin?.call(msg),
+            ),
+          if (msg.pinnedAt != null && widget.onUnpin != null)
+            _HoverActionButton(
+              icon: Icons.push_pin,
+              tooltip: 'Unpin',
+              onPressed: () => widget.onUnpin?.call(msg),
+            ),
           if (isMine && widget.onEdit != null)
             _HoverActionButton(
               icon: Icons.edit_outlined,
@@ -1164,6 +1180,36 @@ class _MessageItemState extends State<MessageItem> {
     return context.textPrimary;
   }
 
+  /// Build a small pinned indicator shown inside the bubble.
+  Widget _buildPinnedIndicator({required bool isMine}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.push_pin,
+            size: 11,
+            color: isMine
+                ? Colors.white.withValues(alpha: 0.7)
+                : context.accent,
+          ),
+          const SizedBox(width: 3),
+          Text(
+            'Pinned',
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w500,
+              color: isMine
+                  ? Colors.white.withValues(alpha: 0.7)
+                  : context.accent,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   /// Assemble the children of the bubble Column.
   List<Widget> _bubbleChildren({
     required ChatMessage msg,
@@ -1172,6 +1218,7 @@ class _MessageItemState extends State<MessageItem> {
     required Widget? mediaWidget,
   }) {
     return [
+      if (msg.pinnedAt != null) _buildPinnedIndicator(isMine: isMine),
       if (widget.showHeader && (!isMine || widget.compactLayout))
         _buildSenderNameLabel(msg: msg, hasMedia: mediaWidget != null),
       if (msg.replyToContent != null)
@@ -1281,6 +1328,11 @@ class _MessageItemState extends State<MessageItem> {
             const Padding(
               padding: EdgeInsets.only(left: 3),
               child: Icon(Icons.lock, size: 10, color: EchoTheme.online),
+            ),
+          if (msg.pinnedAt != null)
+            Padding(
+              padding: const EdgeInsets.only(left: 4),
+              child: Icon(Icons.push_pin, size: 10, color: context.accent),
             ),
           if (msg.editedAt != null)
             Padding(

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -317,3 +317,79 @@ pub async fn set_mute_status(
     .await?;
     Ok(result.rows_affected() > 0)
 }
+
+// ---------------------------------------------------------------------------
+// Message pinning
+// ---------------------------------------------------------------------------
+
+/// Pin a message. Sets pinned_by_id and pinned_at on the message row.
+/// Returns the conversation_id if the pin was successful, None if message not found.
+pub async fn pin_message(
+    pool: &PgPool,
+    message_id: Uuid,
+    user_id: Uuid,
+) -> Result<Option<Uuid>, sqlx::Error> {
+    let row: Option<(Uuid,)> = sqlx::query_as(
+        "UPDATE messages SET pinned_by_id = $2, pinned_at = now() \
+         WHERE id = $1 AND deleted_at IS NULL \
+         RETURNING conversation_id",
+    )
+    .bind(message_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(conv_id,)| conv_id))
+}
+
+/// Unpin a message. Clears pinned_by_id and pinned_at.
+/// Returns the conversation_id if the unpin was successful, None if message not found or
+/// not pinned.
+pub async fn unpin_message(pool: &PgPool, message_id: Uuid) -> Result<Option<Uuid>, sqlx::Error> {
+    let row: Option<(Uuid,)> = sqlx::query_as(
+        "UPDATE messages SET pinned_by_id = NULL, pinned_at = NULL \
+         WHERE id = $1 AND pinned_at IS NOT NULL AND deleted_at IS NULL \
+         RETURNING conversation_id",
+    )
+    .bind(message_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(conv_id,)| conv_id))
+}
+
+#[derive(Debug, sqlx::FromRow, serde::Serialize)]
+pub struct PinnedMessageRow {
+    pub id: Uuid,
+    pub conversation_id: Uuid,
+    pub sender_id: Uuid,
+    pub sender_username: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub pinned_by_id: Option<Uuid>,
+    pub pinned_by_username: Option<String>,
+    pub pinned_at: Option<DateTime<Utc>>,
+}
+
+/// Get all pinned messages for a conversation, ordered by pinned_at DESC.
+pub async fn get_pinned_messages(
+    pool: &PgPool,
+    conversation_id: Uuid,
+) -> Result<Vec<PinnedMessageRow>, sqlx::Error> {
+    sqlx::query_as::<_, PinnedMessageRow>(
+        "SELECT m.id, m.conversation_id, m.sender_id, \
+                u.username AS sender_username, \
+                m.content, m.created_at, \
+                m.pinned_by_id, \
+                pu.username AS pinned_by_username, \
+                m.pinned_at \
+         FROM messages m \
+         JOIN users u ON u.id = m.sender_id \
+         LEFT JOIN users pu ON pu.id = m.pinned_by_id \
+         WHERE m.conversation_id = $1 \
+           AND m.pinned_at IS NOT NULL \
+           AND m.deleted_at IS NULL \
+         ORDER BY m.pinned_at DESC",
+    )
+    .bind(conversation_id)
+    .fetch_all(pool)
+    .await
+}

--- a/apps/server/src/migrations/024_message_pinning.sql
+++ b/apps/server/src/migrations/024_message_pinning.sql
@@ -1,0 +1,4 @@
+-- Message pinning support
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS pinned_by_id UUID REFERENCES users(id) ON DELETE SET NULL;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS pinned_at TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_messages_pinned ON messages (conversation_id, pinned_at) WHERE pinned_at IS NOT NULL;

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::auth::middleware::AuthUser;
 use crate::db;
 use crate::error::AppError;
-use crate::types::ConversationKind;
+use crate::types::{ConversationKind, Role};
 
 use super::AppState;
 
@@ -437,4 +437,211 @@ pub async fn toggle_mute(
         "conversation_id": conversation_id,
         "is_muted": body.is_muted,
     })))
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/conversations/:conversation_id/messages/:message_id/pin
+// ---------------------------------------------------------------------------
+
+pub async fn pin_message(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path((conversation_id, message_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    // Verify membership
+    let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in pin_message/is_member: {e:?}");
+            AppError::internal("Database error")
+        })?;
+    if !is_member {
+        return Err(AppError::unauthorized("Not a member of this conversation"));
+    }
+
+    // For groups, only admins/owners can pin
+    let kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in pin_message/get_kind: {e:?}");
+            AppError::internal("Database error")
+        })?
+        .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
+
+    if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group) {
+        let role_str = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("DB error in pin_message/get_role: {e:?}");
+                AppError::internal("Database error")
+            })?
+            .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
+
+        let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
+        if !role.is_admin_or_above() {
+            return Err(AppError::unauthorized(
+                "Only admins and owners can pin messages in groups",
+            ));
+        }
+    }
+
+    // Pin the message
+    let conv_id = db::messages::pin_message(&state.pool, message_id, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in pin_message: {e:?}");
+            AppError::internal("Database error")
+        })?
+        .ok_or_else(|| AppError::bad_request("Message not found"))?;
+
+    // Verify the message belongs to this conversation
+    if conv_id != conversation_id {
+        // Undo the pin -- message is in a different conversation
+        let _ = db::messages::unpin_message(&state.pool, message_id).await;
+        return Err(AppError::bad_request(
+            "Message does not belong to this conversation",
+        ));
+    }
+
+    // Look up pinner's username for the broadcast event
+    let pinner = db::users::find_by_id(&state.pool, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in pin_message/find_user: {e:?}");
+            AppError::internal("Database error")
+        })?;
+    let pinned_by_username = pinner
+        .map(|u| u.username)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Broadcast to conversation members via WebSocket
+    let member_ids = db::groups::get_conversation_member_ids(&state.pool, conversation_id)
+        .await
+        .unwrap_or_default();
+
+    let event = serde_json::json!({
+        "type": "message_pinned",
+        "message_id": message_id,
+        "conversation_id": conversation_id,
+        "pinned_by_id": auth.user_id,
+        "pinned_by_username": pinned_by_username,
+        "pinned_at": chrono::Utc::now(),
+    });
+    if let Ok(json) = serde_json::to_string(&event) {
+        state.hub.broadcast_json(&member_ids, &json, None);
+    }
+
+    Ok(Json(serde_json::json!({
+        "message_id": message_id,
+        "conversation_id": conversation_id,
+        "pinned_by_id": auth.user_id,
+    })))
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/conversations/:conversation_id/messages/:message_id/pin
+// ---------------------------------------------------------------------------
+
+pub async fn unpin_message(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path((conversation_id, message_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    // Verify membership
+    let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in unpin_message/is_member: {e:?}");
+            AppError::internal("Database error")
+        })?;
+    if !is_member {
+        return Err(AppError::unauthorized("Not a member of this conversation"));
+    }
+
+    // For groups, only admins/owners can unpin
+    let kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in unpin_message/get_kind: {e:?}");
+            AppError::internal("Database error")
+        })?
+        .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
+
+    if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group) {
+        let role_str = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("DB error in unpin_message/get_role: {e:?}");
+                AppError::internal("Database error")
+            })?
+            .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
+
+        let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
+        if !role.is_admin_or_above() {
+            return Err(AppError::unauthorized(
+                "Only admins and owners can unpin messages in groups",
+            ));
+        }
+    }
+
+    // Unpin the message
+    let conv_id = db::messages::unpin_message(&state.pool, message_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in unpin_message: {e:?}");
+            AppError::internal("Database error")
+        })?
+        .ok_or_else(|| AppError::bad_request("Message not found or not pinned"))?;
+
+    if conv_id != conversation_id {
+        return Err(AppError::bad_request(
+            "Message does not belong to this conversation",
+        ));
+    }
+
+    // Broadcast to conversation members via WebSocket
+    let member_ids = db::groups::get_conversation_member_ids(&state.pool, conversation_id)
+        .await
+        .unwrap_or_default();
+
+    let event = serde_json::json!({
+        "type": "message_unpinned",
+        "message_id": message_id,
+        "conversation_id": conversation_id,
+    });
+    if let Ok(json) = serde_json::to_string(&event) {
+        state.hub.broadcast_json(&member_ids, &json, None);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/conversations/:conversation_id/pinned
+// ---------------------------------------------------------------------------
+
+pub async fn get_pinned_messages(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(conversation_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    // Verify membership
+    let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in get_pinned_messages/is_member: {e:?}");
+            AppError::internal("Database error")
+        })?;
+    if !is_member {
+        return Err(AppError::unauthorized("Not a member of this conversation"));
+    }
+
+    let pinned = db::messages::get_pinned_messages(&state.pool, conversation_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in get_pinned_messages: {e:?}");
+            AppError::internal("Database error")
+        })?;
+
+    Ok(Json(pinned))
 }

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -107,6 +107,14 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             put(messages::toggle_mute),
         )
         .route(
+            "/conversations/{conversation_id}/pinned",
+            get(messages::get_pinned_messages),
+        )
+        .route(
+            "/conversations/{conversation_id}/messages/{message_id}/pin",
+            post(messages::pin_message).delete(messages::unpin_message),
+        )
+        .route(
             "/messages/{id}",
             get(messages::get_messages)
                 .delete(messages::delete_message)


### PR DESCRIPTION
## Summary
- Full-stack message pinning: migration, DB queries, REST endpoints, WS broadcast, client UI with pin/unpin actions, pinned messages dialog
- Web tab badge showing unread count in browser title
- Sound preference persisted to SharedPreferences
- Total unread badge on Echo logo in sidebar

## Test plan
- [x] flutter analyze -- no issues
- [x] flutter test -- 159/159 pass
- [x] cargo clippy -- clean
- [x] cargo test --lib -- all pass
- [x] Pre-commit hooks pass