### PR TITLE
fix: bug bash -- 27 fixes across messaging, voice, ui, media

### DIFF
--- a/apps/client/lib/src/models/conversation.dart
+++ b/apps/client/lib/src/models/conversation.dart
@@ -2,6 +2,7 @@ class Conversation {
   final String id;
   final String? name;
   final String? description;
+  final String? iconUrl;
   final bool isGroup;
   final bool isEncrypted;
   final String? lastMessage;
@@ -15,6 +16,7 @@ class Conversation {
     required this.id,
     this.name,
     this.description,
+    this.iconUrl,
     required this.isGroup,
     this.isEncrypted = false,
     this.lastMessage,
@@ -65,6 +67,7 @@ class Conversation {
       id: json['conversation_id'] as String? ?? json['id'] as String,
       name: (json['title'] ?? json['name']) as String?,
       description: json['description'] as String?,
+      iconUrl: json['icon_url'] as String?,
       isGroup: isGroupValue,
       isEncrypted: json['is_encrypted'] as bool? ?? false,
       lastMessage: lastMsg,
@@ -88,6 +91,7 @@ class Conversation {
     String? id,
     String? name,
     String? description,
+    String? iconUrl,
     bool? isGroup,
     bool? isEncrypted,
     String? lastMessage,
@@ -101,6 +105,7 @@ class Conversation {
       id: id ?? this.id,
       name: name ?? this.name,
       description: description ?? this.description,
+      iconUrl: iconUrl ?? this.iconUrl,
       isGroup: isGroup ?? this.isGroup,
       isEncrypted: isEncrypted ?? this.isEncrypted,
       lastMessage: lastMessage ?? this.lastMessage,
@@ -119,6 +124,7 @@ class Conversation {
             id == other.id &&
             name == other.name &&
             description == other.description &&
+            iconUrl == other.iconUrl &&
             isGroup == other.isGroup &&
             isEncrypted == other.isEncrypted &&
             lastMessage == other.lastMessage &&
@@ -134,6 +140,7 @@ class Conversation {
     id,
     name,
     description,
+    iconUrl,
     isGroup,
     isEncrypted,
     lastMessage,

--- a/apps/client/lib/src/providers/voice_rtc_provider.dart
+++ b/apps/client/lib/src/providers/voice_rtc_provider.dart
@@ -22,6 +22,9 @@ class VoiceRtcState {
   final bool isDeafened;
   final bool isVideoEnabled;
   final Map<String, String> peerConnectionStates;
+
+  /// Round-trip latency in seconds per peer, extracted from RTCStats.
+  final Map<String, double> peerLatencies;
   final String? error;
 
   const VoiceRtcState({
@@ -33,6 +36,7 @@ class VoiceRtcState {
     this.isDeafened = false,
     this.isVideoEnabled = false,
     this.peerConnectionStates = const {},
+    this.peerLatencies = const {},
     this.error,
   });
 
@@ -45,6 +49,7 @@ class VoiceRtcState {
     bool? isDeafened,
     bool? isVideoEnabled,
     Map<String, String>? peerConnectionStates,
+    Map<String, double>? peerLatencies,
     String? error,
   }) {
     return VoiceRtcState(
@@ -56,6 +61,7 @@ class VoiceRtcState {
       isDeafened: isDeafened ?? this.isDeafened,
       isVideoEnabled: isVideoEnabled ?? this.isVideoEnabled,
       peerConnectionStates: peerConnectionStates ?? this.peerConnectionStates,
+      peerLatencies: peerLatencies ?? this.peerLatencies,
       error: error,
     );
   }
@@ -76,6 +82,7 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       {};
   Set<String> _currentParticipants = const {};
   Timer? _participantSyncTimer;
+  Timer? _latencyTimer;
   List<Map<String, dynamic>>? _cachedIceServers;
 
   /// Maximum pending ICE candidates per peer before oldest are dropped.
@@ -179,6 +186,7 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
 
       // Start periodic participant sync to reconcile stale peer state.
       _startPeriodicParticipantSync(conversationId, channelId);
+      _startLatencyPolling();
     } catch (e) {
       debugPrint('[VoiceRTC] join failed: $e');
       await leaveChannel();
@@ -196,6 +204,7 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
     }
     _participantSyncTimer?.cancel();
     _participantSyncTimer = null;
+    _stopLatencyPolling();
 
     for (final userId in _peerConnections.keys.toList()) {
       final pc = _peerConnections[userId];
@@ -753,6 +762,51 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
     state = state.copyWith(peerConnectionStates: updated);
   }
 
+  // ---------------------------------------------------------------------------
+  // Latency polling -- extracts currentRoundTripTime from RTCStats every 5s
+  // ---------------------------------------------------------------------------
+
+  void _startLatencyPolling() {
+    _latencyTimer?.cancel();
+    _latencyTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      if (_disposed) {
+        _latencyTimer?.cancel();
+        _latencyTimer = null;
+        return;
+      }
+      _pollPeerLatencies();
+    });
+  }
+
+  void _stopLatencyPolling() {
+    _latencyTimer?.cancel();
+    _latencyTimer = null;
+  }
+
+  Future<void> _pollPeerLatencies() async {
+    final latencies = <String, double>{};
+    for (final entry in _peerConnections.entries) {
+      try {
+        final stats = await entry.value.getStats();
+        for (final report in stats) {
+          // Look for the nominated candidate-pair stat.
+          if (report.type == 'candidate-pair') {
+            final rtt = report.values['currentRoundTripTime'];
+            if (rtt is double && rtt > 0) {
+              latencies[entry.key] = rtt;
+              break;
+            }
+          }
+        }
+      } catch (_) {
+        // getStats can fail if the peer connection is closing.
+      }
+    }
+    if (!_disposed && latencies.isNotEmpty) {
+      state = state.copyWith(peerLatencies: latencies);
+    }
+  }
+
   /// Periodically fetch voice participants from the server and reconcile
   /// with local peer state. Catches stale peers that may have disconnected
   /// without sending a proper leave event.
@@ -825,6 +879,7 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
   void dispose() {
     _disposed = true;
     _participantSyncTimer?.cancel();
+    _latencyTimer?.cancel();
     _signalSubscription?.cancel();
     unawaited(leaveChannel());
     super.dispose();

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -181,34 +181,15 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
 
   /// Send a DM message to a peer.
   ///
-  /// Direct messages are encrypted-only. If a legacy conversation is not
-  /// marked encrypted yet, sending is blocked.
+  /// Direct messages are encrypted via the Signal Protocol. Encryption is
+  /// attempted regardless of the conversation's isEncrypted flag to avoid
+  /// blocking on newly created conversations where the flag may lag.
   Future<void> sendMessage(
     String toUserId,
     String content, {
     String? conversationId,
     String? replyToId,
   }) async {
-    // Check if encryption is enabled for this conversation.
-    final isEncrypted =
-        conversationId != null &&
-        ref
-                .read(conversationsProvider)
-                .conversations
-                .where((c) => c.id == conversationId)
-                .firstOrNull
-                ?.isEncrypted ==
-            true;
-
-    if (!isEncrypted) {
-      _addFailedMessage(
-        toUserId,
-        'This direct conversation is not encrypted. Sending is blocked.',
-        conversationId: conversationId ?? '',
-      );
-      return;
-    }
-
     String payload;
     final cryptoState = ref.read(cryptoProvider);
     if (!cryptoState.isInitialized) {
@@ -239,7 +220,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       'to_user_id': toUserId,
       'content': payload,
     };
-    if (conversationId.isNotEmpty) {
+    if (conversationId != null && conversationId.isNotEmpty) {
       msg['conversation_id'] = conversationId;
     }
     if (replyToId != null && replyToId.isNotEmpty) {

--- a/apps/client/lib/src/router/app_router.dart
+++ b/apps/client/lib/src/router/app_router.dart
@@ -19,6 +19,11 @@ const _routeHome = '/home';
 const _routeLogin = '/login';
 const _routeSplash = '/splash';
 
+/// Stores a deep link path that was requested before the user was
+/// authenticated. After login or splash auto-login, the app navigates
+/// here instead of /home.
+String? pendingDeepLink;
+
 /// Shared fade transition used by all routes.
 CustomTransitionPage<void> _fadePage({
   required LocalKey key,
@@ -66,7 +71,14 @@ final routerProvider = Provider<GoRouter>((ref) {
       // Let the splash screen handle its own navigation
       if (isSplash) return null;
 
-      if (!isLoggedIn && !isAuthRoute) return _routeLogin;
+      if (!isLoggedIn && !isAuthRoute) {
+        // Save the intended path so we can navigate there after login
+        final intended = state.matchedLocation;
+        if (intended != _routeHome && intended != _routeLogin) {
+          pendingDeepLink = state.uri.toString();
+        }
+        return _routeLogin;
+      }
       if (isLoggedIn && isAuthRoute) return _routeHome;
       return null;
     },

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
 
 import '../models/conversation.dart';
 import '../services/toast_service.dart';
@@ -460,6 +462,65 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     }
   }
 
+  Future<void> _uploadGroupAvatar() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return;
+
+    final file = result.files.first;
+    if (file.bytes == null) return;
+
+    final serverUrl = ref.read(serverUrlProvider);
+    final token = ref.read(authProvider).token;
+    if (token == null) return;
+
+    final uri = Uri.parse(
+      '$serverUrl/api/groups/${widget.conversationId}/avatar',
+    );
+    final request = http.MultipartRequest('PUT', uri)
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(
+        http.MultipartFile.fromBytes(
+          'avatar',
+          file.bytes!,
+          filename: file.name,
+          contentType: MediaType('image', 'png'),
+        ),
+      );
+
+    try {
+      final streamedResponse = await request.send();
+      // Drain the response body to close the stream.
+      await streamedResponse.stream.bytesToString();
+      if (!mounted) return;
+
+      if (streamedResponse.statusCode == 200) {
+        await ref.read(conversationsProvider.notifier).loadConversations();
+        await _loadGroupInfo(force: true);
+        if (mounted) {
+          ToastService.show(
+            context,
+            'Group avatar updated',
+            type: ToastType.success,
+          );
+        }
+      } else {
+        ToastService.show(
+          context,
+          'Failed to upload avatar (${streamedResponse.statusCode})',
+          type: ToastType.error,
+        );
+      }
+    } catch (e) {
+      debugPrint('[GroupInfo] _uploadGroupAvatar failed: $e');
+      if (mounted) {
+        ToastService.show(context, 'Upload error: $e', type: ToastType.error);
+      }
+    }
+  }
+
   Future<void> _showAddChannelDialog() async {
     final nameController = TextEditingController();
     String selectedKind = 'text';
@@ -584,12 +645,56 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     );
   }
 
-  Widget _buildGroupAvatar() {
-    return Center(
-      child: CircleAvatar(
+  Widget _buildGroupAvatar({required bool isOwnerOrAdmin, String? iconUrl}) {
+    final serverUrl = ref.read(serverUrlProvider);
+    final token = ref.read(authProvider).token;
+    final hasIcon = iconUrl != null && iconUrl.isNotEmpty;
+
+    Widget avatar;
+    if (hasIcon) {
+      final fullUrl = token != null && token.isNotEmpty
+          ? '$serverUrl$iconUrl?token=$token'
+          : '$serverUrl$iconUrl';
+      avatar = CircleAvatar(
+        radius: 40,
+        backgroundColor: Theme.of(context).colorScheme.tertiary,
+        backgroundImage: NetworkImage(fullUrl),
+        onBackgroundImageError: (_, _) {},
+        child: null,
+      );
+    } else {
+      avatar = CircleAvatar(
         radius: 40,
         backgroundColor: Theme.of(context).colorScheme.tertiary,
         child: const Icon(Icons.group_outlined, size: 40),
+      );
+    }
+
+    return Center(
+      child: GestureDetector(
+        onTap: isOwnerOrAdmin ? _uploadGroupAvatar : null,
+        child: Stack(
+          children: [
+            avatar,
+            if (isOwnerOrAdmin)
+              Positioned(
+                bottom: 0,
+                right: 0,
+                child: Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.camera_alt_outlined,
+                    size: 16,
+                    color: Theme.of(context).colorScheme.onPrimary,
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }
@@ -1015,7 +1120,10 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
           child: ListView(
             children: [
               const SizedBox(height: 24),
-              _buildGroupAvatar(),
+              _buildGroupAvatar(
+                isOwnerOrAdmin: isOwnerOrAdmin,
+                iconUrl: conv.iconUrl,
+              ),
               const SizedBox(height: 16),
               _buildGroupNameSection(
                 displayName: displayName,

--- a/apps/client/lib/src/screens/login_screen.dart
+++ b/apps/client/lib/src/screens/login_screen.dart
@@ -17,7 +17,11 @@ class LoginScreen extends ConsumerStatefulWidget {
   ConsumerState<LoginScreen> createState() => _LoginScreenState();
 }
 
-class _LoginScreenState extends ConsumerState<LoginScreen> {
+class _LoginScreenState extends ConsumerState<LoginScreen>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   final _formKey = GlobalKey<FormState>();
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
@@ -44,6 +48,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final authState = ref.watch(authProvider);
     final serverUrl = ref.watch(serverUrlProvider);
 

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../providers/auth_provider.dart';
 import '../providers/crypto_provider.dart';
 import '../providers/update_provider.dart';
+import '../router/app_router.dart' show pendingDeepLink;
 import '../theme/echo_theme.dart';
 import '../widgets/echo_logo_icon.dart';
 
@@ -85,7 +86,13 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     if (!mounted) return;
 
     final isLoggedIn = ref.read(authProvider).isLoggedIn;
-    context.go(isLoggedIn ? '/home' : '/login');
+    if (isLoggedIn && pendingDeepLink != null) {
+      final destination = pendingDeepLink!;
+      pendingDeepLink = null;
+      context.go(destination);
+    } else {
+      context.go(isLoggedIn ? '/home' : '/login');
+    }
   }
 
   @override

--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
 /// Shared avatar builder used across conversation panel widgets.
@@ -7,14 +8,9 @@ Widget buildAvatar({
   required double radius,
   Color? bgColor,
   Widget? fallbackIcon,
+  String? authToken,
 }) {
-  if (imageUrl != null && imageUrl.isNotEmpty) {
-    return CircleAvatar(
-      radius: radius,
-      backgroundImage: NetworkImage(imageUrl),
-    );
-  }
-  return CircleAvatar(
+  final fallback = CircleAvatar(
     radius: radius,
     backgroundColor: bgColor ?? avatarColor(name),
     child:
@@ -28,6 +24,25 @@ Widget buildAvatar({
           ),
         ),
   );
+
+  if (imageUrl != null && imageUrl.isNotEmpty) {
+    final effectiveUrl = (authToken != null && authToken.isNotEmpty)
+        ? '$imageUrl${imageUrl.contains('?') ? '&' : '?'}token=$authToken'
+        : imageUrl;
+    return ClipOval(
+      child: SizedBox(
+        width: radius * 2,
+        height: radius * 2,
+        child: CachedNetworkImage(
+          imageUrl: effectiveUrl,
+          fit: BoxFit.cover,
+          placeholder: (_, _) => fallback,
+          errorWidget: (_, _, _) => fallback,
+        ),
+      ),
+    );
+  }
+  return fallback;
 }
 
 /// Deterministic color from a name string.

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -609,12 +609,24 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     );
   }
 
+  /// Format peer latency as a compact string, e.g. "42ms".
+  String _formatLatency(VoiceRtcState voiceRtc) {
+    final latencies = voiceRtc.peerLatencies;
+    if (latencies.isEmpty) return '';
+    // Show average RTT across all peers.
+    final avgMs =
+        (latencies.values.reduce((a, b) => a + b) / latencies.length * 1000)
+            .round();
+    return '${avgMs}ms';
+  }
+
   Widget _buildCompactVoiceDock({
     required GroupChannel activeVoiceChannel,
     required VoiceRtcState voiceRtc,
     required VoiceSettingsState voiceSettings,
     required bool iAmConnected,
   }) {
+    final latencyLabel = _formatLatency(voiceRtc);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -626,7 +638,8 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
             Expanded(
               child: Text(
                 'Connected to ${activeVoiceChannel.name} '
-                '${voiceRtc.peerConnectionStates.length} peer(s)',
+                '${voiceRtc.peerConnectionStates.length} peer(s)'
+                '${latencyLabel.isNotEmpty ? ' \u00b7 $latencyLabel' : ''}',
                 style: TextStyle(
                   color: context.textPrimary,
                   fontSize: 12,
@@ -667,6 +680,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     required VoiceSettingsState voiceSettings,
     required bool iAmConnected,
   }) {
+    final latencyLabel = _formatLatency(voiceRtc);
     return Row(
       children: [
         Icon(Icons.graphic_eq, size: 16, color: context.accent),
@@ -674,7 +688,8 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
         Expanded(
           child: Text(
             'Connected to ${activeVoiceChannel.name} '
-            '${voiceRtc.peerConnectionStates.length} peer(s)',
+            '${voiceRtc.peerConnectionStates.length} peer(s)'
+            '${latencyLabel.isNotEmpty ? ' \u00b7 $latencyLabel' : ''}',
             style: TextStyle(
               color: context.textPrimary,
               fontSize: 12,

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -48,7 +48,8 @@ class ChatPanel extends ConsumerStatefulWidget {
   ConsumerState<ChatPanel> createState() => _ChatPanelState();
 }
 
-class _ChatPanelState extends ConsumerState<ChatPanel> {
+class _ChatPanelState extends ConsumerState<ChatPanel>
+    with WidgetsBindingObserver {
   final _scrollController = ScrollController();
   final _chatInputBarKey = GlobalKey<ChatInputBarState>();
 
@@ -57,6 +58,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   String? _activeVoiceChannelId;
   String? _loadedHistoryKey;
   String? _loadedChannelsConversationId;
+  String? _autoScrollConversationKey;
 
   bool _showSearch = false;
   String? _highlightedMessageId;
@@ -69,6 +71,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
@@ -79,6 +82,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
       _selectedTextChannelId = null;
       _activeVoiceChannelId = null;
       _loadedHistoryKey = null;
+      _autoScrollConversationKey = null;
       _showSearch = false;
       _highlightedMessageId = null;
       _highlightTimer?.cancel();
@@ -88,11 +92,20 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _dismissReactionPicker();
     _highlightTimer?.cancel();
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed && widget.conversation != null) {
+      _markAsRead();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -106,7 +119,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     }
   }
 
-  void _scrollToBottom({bool animated = true, int settleRetries = 2}) {
+  void _scrollToBottom({bool animated = true, int settleRetries = 3}) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!_scrollController.hasClients) return;
 
@@ -117,7 +130,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
 
       Future<void> settleIfNeeded() async {
         if (settleRetries <= 0 || !_scrollController.hasClients) return;
-        await Future<void>.delayed(const Duration(milliseconds: 80));
+        await Future<void>.delayed(const Duration(milliseconds: 100));
         _scrollToBottom(animated: false, settleRetries: settleRetries - 1);
       }
 
@@ -879,6 +892,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     String? selectedChannelId,
     bool includeUnchanneled,
   ) {
+    final key = '${conv.id}:${selectedChannelId ?? ""}';
+    if (_autoScrollConversationKey == key) return;
+    _autoScrollConversationKey = key;
+
     ref.listen<ChatState>(chatProvider, (prev, next) {
       int visibleCount(ChatState s) {
         if (!conv.isGroup) return s.messagesForConversation(conv.id).length;
@@ -894,7 +911,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
       final prevCount = prev == null ? 0 : visibleCount(prev);
       final nextCount = visibleCount(next);
       if (nextCount > prevCount && _isNearBottom()) {
-        _scrollToBottom(settleRetries: 2);
+        _scrollToBottom(settleRetries: 3);
       }
     });
   }

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -477,7 +477,8 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   Widget _buildHeaderActions(BuildContext context, int pendingCount) {
     return Flexible(
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: MainAxisSize.max,
+        mainAxisAlignment: MainAxisAlignment.end,
         children: [
           _buildNewChatButton(context, pendingCount),
           IconButton(
@@ -496,7 +497,8 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
           ),
-          if (widget.onCollapseSidebar != null)
+          if (widget.onCollapseSidebar != null) ...[
+            const Spacer(),
             IconButton(
               icon: const Icon(Icons.chevron_left, size: 18),
               color: context.textMuted,
@@ -505,6 +507,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               padding: EdgeInsets.zero,
               constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
             ),
+          ],
         ],
       ),
     );

--- a/apps/client/lib/src/widgets/gif_picker_widget.dart
+++ b/apps/client/lib/src/widgets/gif_picker_widget.dart
@@ -192,12 +192,25 @@ class _GifPickerWidgetState extends State<GifPickerWidget> {
         ),
       );
     }
+    final screenWidth = MediaQuery.of(context).size.width;
+    final int crossAxisCount;
+    final double spacing;
+    if (screenWidth > 1200) {
+      crossAxisCount = 5;
+      spacing = 4;
+    } else if (screenWidth >= 600) {
+      crossAxisCount = 4;
+      spacing = 4;
+    } else {
+      crossAxisCount = 2;
+      spacing = 6;
+    }
     return GridView.builder(
       padding: const EdgeInsets.all(8),
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 3,
-        crossAxisSpacing: 6,
-        mainAxisSpacing: 6,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
+        crossAxisSpacing: spacing,
+        mainAxisSpacing: spacing,
       ),
       itemCount: _results.length,
       itemBuilder: (ctx, i) {

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -78,7 +78,7 @@ class MembersPanel extends ConsumerWidget {
               },
             ),
           ),
-          // Leave / Delete group buttons
+          // Leave group button (non-owners only)
           Container(
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
             decoration: BoxDecoration(

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
 import 'package:url_launcher/url_launcher.dart';
+import 'package:video_player/video_player.dart';
 
 import '../models/chat_message.dart';
 import '../models/reaction.dart';
@@ -242,58 +243,75 @@ class _MessageItemState extends State<MessageItem> {
     final headers = _mediaHeaders();
     showDialog<void>(
       context: context,
-      builder: (dialogContext) => Dialog(
-        backgroundColor: Colors.black.withValues(alpha: 0.85),
-        insetPadding: const EdgeInsets.all(20),
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: InteractiveViewer(
-                minScale: 0.8,
-                maxScale: 4,
-                child: Center(
-                  child: CachedNetworkImage(
-                    imageUrl: imageUrl,
-                    httpHeaders: headers,
-                    fit: BoxFit.contain,
-                    placeholder: (_, _) => const Center(
-                      child: CircularProgressIndicator(color: Colors.white),
-                    ),
-                    errorWidget: (_, _, _) => const Center(
-                      child: Icon(
-                        Icons.broken_image_outlined,
-                        color: Colors.white54,
-                        size: 48,
+      barrierColor: Colors.black.withValues(alpha: 0.85),
+      builder: (dialogContext) {
+        final screenSize = MediaQuery.of(dialogContext).size;
+        final maxWidth = screenSize.width * 0.8;
+        final maxHeight = screenSize.height * 0.8;
+        return GestureDetector(
+          onTap: () => Navigator.of(dialogContext).pop(),
+          behavior: HitTestBehavior.opaque,
+          child: Center(
+            child: GestureDetector(
+              onTap: () {}, // absorb taps on the image itself
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxWidth: maxWidth,
+                  maxHeight: maxHeight,
+                ),
+                child: Stack(
+                  children: [
+                    InteractiveViewer(
+                      minScale: 0.8,
+                      maxScale: 4,
+                      child: Center(
+                        child: CachedNetworkImage(
+                          imageUrl: imageUrl,
+                          httpHeaders: headers,
+                          fit: BoxFit.contain,
+                          placeholder: (_, _) => const Center(
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                            ),
+                          ),
+                          errorWidget: (_, _, _) => const Center(
+                            child: Icon(
+                              Icons.broken_image_outlined,
+                              color: Colors.white54,
+                              size: 48,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
+                    Positioned(
+                      top: 8,
+                      right: 8,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.download_outlined),
+                            color: Colors.white,
+                            tooltip: 'Download',
+                            onPressed: () => _downloadMedia(imageUrl),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            color: Colors.white,
+                            tooltip: 'Close',
+                            onPressed: () => Navigator.of(dialogContext).pop(),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
-            Positioned(
-              top: 8,
-              right: 8,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.download_outlined),
-                    color: Colors.white,
-                    tooltip: 'Download',
-                    onPressed: () => _downloadMedia(imageUrl),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    color: Colors.white,
-                    tooltip: 'Close',
-                    onPressed: () => Navigator.of(dialogContext).pop(),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 
@@ -455,58 +473,17 @@ class _MessageItemState extends State<MessageItem> {
             : null);
     if (videoUrl != null) {
       final rawUrl = videoUrl;
-      return Container(
-        width: 300,
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: context.surface,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: context.border),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Container(
-              height: 140,
-              decoration: BoxDecoration(
-                color: context.mainBg,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Center(
-                child: Icon(
-                  Icons.play_circle_outline,
-                  size: 44,
-                  color: context.textMuted,
-                ),
-              ),
-            ),
-            const SizedBox(height: 10),
-            Text(
-              'Video attachment',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 8,
-              children: [
-                OutlinedButton.icon(
-                  onPressed: () => _openMedia(rawUrl),
-                  icon: const Icon(Icons.open_in_new, size: 14),
-                  label: const Text('Open'),
-                ),
-                OutlinedButton.icon(
-                  onPressed: () => _downloadMedia(rawUrl),
-                  icon: const Icon(Icons.download_outlined, size: 14),
-                  label: const Text('Download'),
-                ),
-              ],
-            ),
-          ],
-        ),
+      return _InlineVideoPlayer(
+        videoUrl: _resolveMediaUrl(rawUrl),
+        rawUrl: rawUrl,
+        headers: _mediaHeaders(),
+        surface: context.surface,
+        mainBg: context.mainBg,
+        border: context.border,
+        textPrimary: context.textPrimary,
+        textMuted: context.textMuted,
+        onOpen: () => _openMedia(rawUrl),
+        onDownload: () => _downloadMedia(rawUrl),
       );
     }
 
@@ -1076,12 +1053,15 @@ class _MessageItemState extends State<MessageItem> {
   }
 
   /// Resolve the bubble border radius with a flat corner on the sender's side.
+  /// In compact mode all messages are left-aligned, so the flat corner is
+  /// always on the bottom-left regardless of sender.
   BorderRadius _bubbleBorderRadius({required bool isMine}) {
+    final isRight = isMine && !widget.compactLayout;
     return BorderRadius.only(
       topLeft: const Radius.circular(16),
       topRight: const Radius.circular(16),
-      bottomLeft: Radius.circular(isMine ? 16 : 4),
-      bottomRight: Radius.circular(isMine ? 4 : 16),
+      bottomLeft: Radius.circular(isRight ? 16 : 4),
+      bottomRight: Radius.circular(isRight ? 4 : 16),
     );
   }
 
@@ -1155,8 +1135,26 @@ class _MessageItemState extends State<MessageItem> {
     );
   }
 
+  /// Regex for image extensions in URLs (used for inline embed detection).
+  static final _imageUrlEmbedRegex = RegExp(
+    r'https?://[^\s]+\.(?:gif|png|jpe?g|webp)',
+    caseSensitive: false,
+  );
+
+  /// Extract image URLs embedded within text (not standalone).
+  List<String> _extractEmbeddedImageUrls(String content) {
+    // Skip standalone media URLs -- those are handled by _buildMediaContent.
+    if (_isStandaloneMediaUrl(content)) return [];
+    if (_imgRegex.hasMatch(content)) return [];
+    return _imageUrlEmbedRegex
+        .allMatches(content)
+        .map((m) => m.group(0)!)
+        .toList();
+  }
+
   /// Select and build the primary message content (media, decrypt error, or
-  /// rich text).
+  /// rich text). When the text contains embedded image URLs mixed with
+  /// regular text, image previews are appended below the text.
   Widget _buildBubbleContent({
     required ChatMessage msg,
     required bool isMine,
@@ -1167,9 +1165,58 @@ class _MessageItemState extends State<MessageItem> {
     if (msg.content.startsWith('[Could not decrypt')) {
       return _buildDecryptionFailure();
     }
-    return _buildMessageText(
-      msg.content,
-      textColor: _contentTextColor(isMine: isMine, isFailed: isFailed),
+
+    final textColor = _contentTextColor(isMine: isMine, isFailed: isFailed);
+    final textWidget = _buildMessageText(msg.content, textColor: textColor);
+
+    final embeddedImages = _extractEmbeddedImageUrls(msg.content);
+    if (embeddedImages.isEmpty) return textWidget;
+
+    final headers = _mediaHeaders();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        textWidget,
+        for (final imgUrl in embeddedImages) ...[
+          const SizedBox(height: 6),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: GestureDetector(
+              onTap: () => _showImageViewer(imageUrl: imgUrl, isMine: isMine),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 400),
+                child: imgUrl.endsWith('.gif')
+                    ? Image.network(
+                        imgUrl,
+                        fit: BoxFit.cover,
+                        gaplessPlayback: true,
+                        errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                      )
+                    : CachedNetworkImage(
+                        imageUrl: imgUrl,
+                        fit: BoxFit.cover,
+                        httpHeaders: headers,
+                        errorWidget: (_, _, _) => const SizedBox.shrink(),
+                        placeholder: (_, _) => SizedBox(
+                          height: 60,
+                          child: Center(
+                            child: SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: context.textMuted,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 
@@ -1501,6 +1548,189 @@ class _HoverActionButton extends StatelessWidget {
             child: Icon(icon, size: 14, color: context.textSecondary),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Inline video player widget with play/pause controls and download
+/// fallback. Initialises a [VideoPlayerController] on first build and
+/// disposes it when removed from the tree.
+class _InlineVideoPlayer extends StatefulWidget {
+  final String videoUrl;
+  final String rawUrl;
+  final Map<String, String> headers;
+  final Color surface;
+  final Color mainBg;
+  final Color border;
+  final Color textPrimary;
+  final Color textMuted;
+  final VoidCallback onOpen;
+  final VoidCallback onDownload;
+
+  const _InlineVideoPlayer({
+    required this.videoUrl,
+    required this.rawUrl,
+    required this.headers,
+    required this.surface,
+    required this.mainBg,
+    required this.border,
+    required this.textPrimary,
+    required this.textMuted,
+    required this.onOpen,
+    required this.onDownload,
+  });
+
+  @override
+  State<_InlineVideoPlayer> createState() => _InlineVideoPlayerState();
+}
+
+class _InlineVideoPlayerState extends State<_InlineVideoPlayer> {
+  VideoPlayerController? _controller;
+  bool _initFailed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initVideo();
+  }
+
+  Future<void> _initVideo() async {
+    try {
+      final controller = VideoPlayerController.networkUrl(
+        Uri.parse(widget.videoUrl),
+        httpHeaders: widget.headers,
+      );
+      await controller.initialize();
+      if (!mounted) {
+        controller.dispose();
+        return;
+      }
+      setState(() => _controller = controller);
+    } catch (_) {
+      if (mounted) setState(() => _initFailed = true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  void _togglePlayPause() {
+    final c = _controller;
+    if (c == null) return;
+    setState(() {
+      c.value.isPlaying ? c.pause() : c.play();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 300,
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: widget.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: widget.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: _buildVideoArea(),
+          ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Wrap(
+              spacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: widget.onOpen,
+                  icon: const Icon(Icons.open_in_new, size: 14),
+                  label: const Text('Open'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: widget.onDownload,
+                  icon: const Icon(Icons.download_outlined, size: 14),
+                  label: const Text('Download'),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 4),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildVideoArea() {
+    final c = _controller;
+
+    // Still loading
+    if (c == null && !_initFailed) {
+      return Container(
+        height: 170,
+        color: widget.mainBg,
+        child: Center(
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: widget.textMuted,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Init failed -- show static placeholder
+    if (_initFailed || c == null) {
+      return GestureDetector(
+        onTap: widget.onOpen,
+        child: Container(
+          height: 170,
+          color: widget.mainBg,
+          child: Center(
+            child: Icon(
+              Icons.play_circle_outline,
+              size: 44,
+              color: widget.textMuted,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Initialised -- show player with controls
+    return GestureDetector(
+      onTap: _togglePlayPause,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          AspectRatio(
+            aspectRatio: c.value.aspectRatio.clamp(0.5, 3.0),
+            child: VideoPlayer(c),
+          ),
+          if (!c.value.isPlaying)
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.5),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.play_arrow,
+                size: 32,
+                color: Colors.white,
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.0"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   dart_style:
     dependency: transitive
     description:
@@ -466,6 +474,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: "direct main"
     description:
@@ -1068,6 +1084,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.5"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: af0e5b8a7a4876fb37e7cc8cb2a011e82bb3ecfa45844ef672e32cb14a1f259e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   audioplayers: ^6.1.0
   web: ^1.1.0
   flutter_webrtc: ^0.12.0
+  video_player: ^2.9.2
   cached_network_image: ^3.4.1
   path_provider: ^2.1.0
   emoji_picker_flutter: ^4.0.0

--- a/apps/client/test/widgets/message_item_test.dart
+++ b/apps/client/test/widgets/message_item_test.dart
@@ -325,10 +325,11 @@ void main() {
             serverUrl: 'http://localhost:8080',
           ),
         );
-        await tester.pump();
+        // Allow video init future to settle (fails in test -> shows fallback).
+        await tester.pumpAndSettle();
 
         expect(find.text('[video:/api/media/clip.mp4]'), findsNothing);
-        expect(find.text('Video attachment'), findsOneWidget);
+        // Fallback shows play icon when video init fails in test env.
         expect(find.byIcon(Icons.play_circle_outline), findsOneWidget);
       });
     });

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -11,6 +11,7 @@ pub struct GroupInfo {
     pub title: Option<String>,
     pub kind: String,
     pub description: Option<String>,
+    pub icon_url: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -35,8 +36,9 @@ pub async fn create_group_with_visibility(
     let mut tx = pool.begin().await?;
 
     let group: GroupInfo = sqlx::query_as(
-        "INSERT INTO conversations (kind, title, is_public, description) VALUES ('group', $1, $2, $3) \
-         RETURNING id, title, kind, description, created_at",
+        "INSERT INTO conversations (kind, title, is_public, description) \
+         VALUES ('group', $1, $2, $3) \
+         RETURNING id, title, kind, description, icon_url, created_at",
     )
     .bind(name)
     .bind(is_public)
@@ -171,7 +173,8 @@ pub async fn join_public_group(
 /// Get group info by conversation ID.
 pub async fn get_group(pool: &PgPool, group_id: Uuid) -> Result<Option<GroupInfo>, sqlx::Error> {
     sqlx::query_as::<_, GroupInfo>(
-        "SELECT id, title, kind, description, created_at FROM conversations WHERE id = $1 AND kind = 'group'",
+        "SELECT id, title, kind, description, icon_url, created_at \
+         FROM conversations WHERE id = $1 AND kind = 'group'",
     )
     .bind(group_id)
     .fetch_optional(pool)
@@ -412,6 +415,33 @@ pub async fn force_delete_conversation(
         .execute(pool)
         .await?;
     Ok(())
+}
+
+/// Update the icon_url (group avatar) for a conversation.
+pub async fn update_group_icon_url(
+    pool: &PgPool,
+    group_id: Uuid,
+    icon_url: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE conversations SET icon_url = $1 WHERE id = $2")
+        .bind(icon_url)
+        .bind(group_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Get the icon_url for a conversation. Returns None if unset.
+pub async fn get_group_icon_url(
+    pool: &PgPool,
+    group_id: Uuid,
+) -> Result<Option<String>, sqlx::Error> {
+    let row: Option<(Option<String>,)> =
+        sqlx::query_as("SELECT icon_url FROM conversations WHERE id = $1")
+            .bind(group_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.and_then(|(url,)| url))
 }
 
 /// Unban a user from a group.

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -1,11 +1,15 @@
 //! Group management REST endpoints.
 
 use axum::Json;
-use axum::extract::{Path, Query, State};
+use axum::body::Body;
+use axum::extract::{Multipart, Path, Query, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::sync::Arc;
+use tokio::fs;
 use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
@@ -47,6 +51,7 @@ pub struct GroupResponse {
     pub title: Option<String>,
     pub kind: String,
     pub description: Option<String>,
+    pub icon_url: Option<String>,
     pub members: Vec<GroupMemberResponse>,
 }
 
@@ -137,6 +142,7 @@ pub async fn create_group(
         title: group.title,
         kind: group.kind,
         description: group.description,
+        icon_url: group.icon_url,
         members: members
             .into_iter()
             .map(|m| GroupMemberResponse {
@@ -189,6 +195,7 @@ pub async fn get_group(
         title: group.title,
         kind: group.kind,
         description: group.description,
+        icon_url: group.icon_url,
         members: members
             .into_iter()
             .map(|m| GroupMemberResponse {
@@ -612,4 +619,172 @@ pub async fn unban_member(
     }
 
     Ok(Json(serde_json::json!({ "status": "unbanned" })))
+}
+
+// ---------------------------------------------------------------------------
+// Group avatar upload/download
+// ---------------------------------------------------------------------------
+
+/// Maximum group avatar size: 2 MB.
+const MAX_GROUP_AVATAR_SIZE: usize = 2 * 1024 * 1024;
+
+/// Allowed group avatar MIME types.
+const ALLOWED_GROUP_AVATAR_TYPES: &[&str] = &["image/jpeg", "image/png", "image/webp"];
+
+fn avatar_extension_for_mime(mime: &str) -> &str {
+    match mime {
+        "image/jpeg" => "jpg",
+        "image/png" => "png",
+        "image/webp" => "webp",
+        _ => "bin",
+    }
+}
+
+fn avatar_mime_for_extension(ext: &str) -> &str {
+    match ext {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "webp" => "image/webp",
+        _ => "application/octet-stream",
+    }
+}
+
+/// PUT /api/groups/:id/avatar -- Upload a group avatar (owner/admin only).
+///
+/// Accepts multipart form data with an `avatar` field. Saves to
+/// `./uploads/avatars/group_{id}.{ext}` and sets `icon_url` on the
+/// conversation row.
+pub async fn upload_group_avatar(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(group_id): Path<Uuid>,
+    mut multipart: Multipart,
+) -> Result<impl IntoResponse, AppError> {
+    // Verify caller is owner or admin
+    let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in upload_group_avatar/get_role: {e:?}");
+            AppError::internal("Database error")
+        })?
+        .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
+
+    let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
+    if !caller_role_enum.is_admin_or_above() {
+        return Err(AppError::unauthorized(
+            "Only the group owner or admin can change the avatar",
+        ));
+    }
+
+    fs::create_dir_all("./uploads/avatars")
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to create avatars directory: {e}")))?;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| AppError::bad_request(format!("Invalid multipart data: {e}")))?
+    {
+        let field_name = field.name().unwrap_or_default().to_string();
+        if field_name != "avatar" {
+            continue;
+        }
+
+        let mime_type = field
+            .content_type()
+            .unwrap_or("application/octet-stream")
+            .to_string();
+
+        if !ALLOWED_GROUP_AVATAR_TYPES.contains(&mime_type.as_str()) {
+            return Err(AppError::bad_request(format!(
+                "Avatar type '{mime_type}' is not allowed. \
+                 Allowed: {}",
+                ALLOWED_GROUP_AVATAR_TYPES.join(", ")
+            )));
+        }
+
+        let data = field
+            .bytes()
+            .await
+            .map_err(|e| AppError::bad_request(format!("Failed to read avatar data: {e}")))?;
+
+        if data.len() > MAX_GROUP_AVATAR_SIZE {
+            return Err(AppError::bad_request(format!(
+                "Avatar too large. Maximum size is {} bytes",
+                MAX_GROUP_AVATAR_SIZE
+            )));
+        }
+
+        let ext = avatar_extension_for_mime(&mime_type);
+        let disk_filename = format!("group_{group_id}.{ext}");
+        let disk_path = format!("./uploads/avatars/{disk_filename}");
+
+        // Remove old avatar files for this group (different extensions)
+        for old_ext in &["jpg", "png", "webp"] {
+            let old = format!("./uploads/avatars/group_{group_id}.{old_ext}");
+            let _ = fs::remove_file(&old).await;
+        }
+
+        fs::write(&disk_path, &data)
+            .await
+            .map_err(|e| AppError::internal(format!("Failed to save avatar: {e}")))?;
+
+        let icon_url = format!("/api/groups/{group_id}/avatar");
+        db::groups::update_group_icon_url(&state.pool, group_id, &icon_url)
+            .await
+            .map_err(|e| {
+                tracing::error!("DB error in upload_group_avatar/set_icon: {e:?}");
+                AppError::internal("Failed to update group avatar")
+            })?;
+
+        return Ok((StatusCode::OK, Json(json!({ "avatar_url": icon_url }))));
+    }
+
+    Err(AppError::bad_request(
+        "Missing 'avatar' field in multipart form data",
+    ))
+}
+
+/// GET /api/groups/:id/avatar -- Serve the group avatar image.
+pub async fn get_group_avatar(
+    _auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(group_id): Path<Uuid>,
+) -> Result<Response, AppError> {
+    let icon_url = db::groups::get_group_icon_url(&state.pool, group_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in get_group_avatar/icon_url: {e:?}");
+            AppError::internal("Database error")
+        })?
+        .ok_or_else(|| AppError {
+            status: StatusCode::NOT_FOUND,
+            message: "No avatar set for this group".to_string(),
+        })?;
+
+    let expected = format!("/api/groups/{group_id}/avatar");
+    if icon_url != expected {
+        return Err(AppError {
+            status: StatusCode::NOT_FOUND,
+            message: "No avatar set for this group".to_string(),
+        });
+    }
+
+    for ext in &["jpg", "png", "webp"] {
+        let disk_path = format!("./uploads/avatars/group_{group_id}.{ext}");
+        if let Ok(data) = fs::read(&disk_path).await {
+            let mime = avatar_mime_for_extension(ext);
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, mime)
+                .body(Body::from(data))
+                .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))?;
+            return Ok(response);
+        }
+    }
+
+    Err(AppError {
+        status: StatusCode::NOT_FOUND,
+        message: "Avatar file not found on disk".to_string(),
+    })
 }

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -56,6 +56,7 @@ pub struct ConversationListItem {
     pub conversation_id: Uuid,
     pub kind: String,
     pub title: Option<String>,
+    pub icon_url: Option<String>,
     pub is_encrypted: bool,
     pub is_muted: bool,
     pub members: Vec<MemberInfo>,
@@ -84,6 +85,7 @@ struct ConversationFullRow {
     conversation_id: Uuid,
     kind: String,
     title: Option<String>,
+    icon_url: Option<String>,
     is_encrypted: bool,
     is_muted: bool,
     members_json: Option<serde_json::Value>,
@@ -102,6 +104,7 @@ pub async fn list_conversations(
             c.id AS conversation_id, \
             c.kind, \
             c.title, \
+            c.icon_url, \
             c.is_encrypted, \
             cm.is_muted, \
             (SELECT json_agg(json_build_object( \
@@ -160,6 +163,7 @@ pub async fn list_conversations(
             conversation_id: row.conversation_id,
             kind: row.kind,
             title: row.title,
+            icon_url: row.icon_url,
             is_encrypted: row.is_encrypted,
             is_muted: row.is_muted,
             members,

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -188,7 +188,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/{id}/join", post(groups::join_group))
         .route("/{id}/leave", post(groups::leave_group))
         .route("/{id}/ban/{user_id}", post(groups::ban_member))
-        .route("/{id}/unban/{user_id}", post(groups::unban_member));
+        .route("/{id}/unban/{user_id}", post(groups::unban_member))
+        .route(
+            "/{id}/avatar",
+            put(groups::upload_group_avatar).get(groups::get_group_avatar),
+        );
 
     let user_routes = Router::new()
         .route("/me", delete(users::delete_account))


### PR DESCRIPTION
## Summary -- 27 bug fixes

### P0 Critical
- DM encryption block removed (was preventing all DM sending)
- Message scroll-to-bottom fixed (deduplicated listeners, increased retries)
- Join links now work (deep link preserved through splash/auth flow)
- Copy/paste fixed on Linux/web (removed platform-specific early returns)
- Read receipts privacy: local marking always happens, only sending is toggled
- Login username preserved on failed password
- Avatar loading: auth tokens + CachedNetworkImage + error fallback

### P1 Voice
- Voice leave button now deselects channel UI
- RTCStats ping display (polled every 5s, shown in channel bar)
- Mobile responsive voice dock (full width, stacked layout <600px)

### P2 UI/UX
- Compact mode bubble alignment fixed (flat corner on correct side)
- Sidebar collapse button properly spaced (Spacer + MainAxisSize.max)
- Emoji picker: RECENT tab default, 12 columns on desktop, hidden on mobile
- GIF grid responsive (5 cols desktop, 4 tablet, 2 mobile)
- Fullscreen image popup constrained to 80% screen, tap-outside dismiss
- Members panel: clarified no delete button (correct behavior)

### P3 Features
- Group avatar upload (server PUT endpoint + client picker UI)
- Video player embedded in chat (video_player package)
- Inline image URL embeds (detect image URLs in text, render preview)

## Test plan
- [x] flutter analyze -- no issues
- [x] flutter test -- 169/169 pass
- [x] cargo clippy -- clean
- [x] All pre-commit hooks pass