### PR TITLE
fix: avatar 401s and linux secure storage resilience

### DIFF
--- a/apps/client/lib/src/services/secure_key_store.dart
+++ b/apps/client/lib/src/services/secure_key_store.dart
@@ -48,21 +48,39 @@ class SecureKeyStore {
 
   /// Write a key-value pair.
   Future<void> write(String key, String value) async {
-    await _storage.write(key: key, value: value);
+    try {
+      await _storage.write(key: key, value: value);
+    } catch (e) {
+      debugPrint('[SecureKeyStore] write($key) failed: $e');
+    }
   }
 
   /// Delete a single key.
   Future<void> delete(String key) async {
-    await _storage.delete(key: key);
+    try {
+      await _storage.delete(key: key);
+    } catch (e) {
+      debugPrint('[SecureKeyStore] delete($key) failed: $e');
+    }
   }
 
   /// Read all key-value pairs. Used for iterating session keys.
   Future<Map<String, String>> readAll() async {
-    return await _storage.readAll();
+    try {
+      return await _storage.readAll();
+    } catch (e) {
+      debugPrint('[SecureKeyStore] readAll failed: $e');
+      return {};
+    }
   }
 
   /// Check if a key exists.
   Future<bool> containsKey(String key) async {
-    return await _storage.containsKey(key: key);
+    try {
+      return await _storage.containsKey(key: key);
+    } catch (e) {
+      debugPrint('[SecureKeyStore] containsKey($key) failed: $e');
+      return false;
+    }
   }
 }

--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -26,15 +26,12 @@ Widget buildAvatar({
   );
 
   if (imageUrl != null && imageUrl.isNotEmpty) {
-    final effectiveUrl = (authToken != null && authToken.isNotEmpty)
-        ? '$imageUrl${imageUrl.contains('?') ? '&' : '?'}token=$authToken'
-        : imageUrl;
     return ClipOval(
       child: SizedBox(
         width: radius * 2,
         height: radius * 2,
         child: CachedNetworkImage(
-          imageUrl: effectiveUrl,
+          imageUrl: imageUrl,
           fit: BoxFit.cover,
           placeholder: (_, _) => fallback,
           errorWidget: (_, _, _) => fallback,

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -746,8 +746,8 @@ pub async fn upload_group_avatar(
 }
 
 /// GET /api/groups/:id/avatar -- Serve the group avatar image.
+/// Public endpoint — no auth required.
 pub async fn get_group_avatar(
-    _auth: AuthUser,
     State(state): State<Arc<AppState>>,
     Path(group_id): Path<Uuid>,
 ) -> Result<Response, AppError> {

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -289,9 +289,9 @@ pub async fn upload_avatar(
 /// GET /api/users/:id/avatar
 ///
 /// Serves the avatar image with the correct Content-Type header.
+/// Public endpoint — no auth required (avatars are profile pictures).
 /// Returns 404 if no avatar is set.
 pub async fn get_avatar(
-    _auth: AuthUser,
     State(state): State<Arc<AppState>>,
     Path(user_id): Path<Uuid>,
 ) -> Result<Response, AppError> {


### PR DESCRIPTION
## Summary
- Make user and group avatar GET endpoints public (remove AuthUser requirement) -- fixes 401s on avatar loading since img tags can't send auth headers
- Add try-catch to all SecureKeyStore methods (write, delete, readAll, containsKey) -- prevents crashes on Linux when libsecret is unavailable
- Remove unnecessary auth token append from avatar_utils since endpoints are now public