### PR TITLE
fix: prod bugs -- dm send, ice auth, image tags, debug logs

### DIFF
--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/crypto_service.dart';
+import '../services/debug_log_service.dart';
 import '../services/group_crypto_service.dart';
 import 'auth_provider.dart';
 import 'server_url_provider.dart';
@@ -52,6 +55,10 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
   CryptoNotifier(this.ref) : super(const CryptoState());
 
   /// Initialize crypto and upload keys to the server.
+  ///
+  /// On Linux, libsecret may fail to unlock the keyring (PlatformException).
+  /// In that case crypto degrades gracefully -- the user can still chat
+  /// without encryption rather than seeing a red error toast.
   Future<void> initAndUploadKeys() async {
     if (state.isInitialized) return;
 
@@ -71,9 +78,30 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
       await crypto.init();
       if (crypto.keysAreFresh) {
         await crypto.uploadKeys();
+        DebugLogService.instance.log(
+          LogLevel.info,
+          'Crypto',
+          'Keys uploaded to server',
+        );
       }
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'Crypto',
+        'Initialized successfully',
+      );
       state = state.copyWith(isInitialized: true, isUploading: false);
+    } on PlatformException catch (e) {
+      // Linux libsecret / keyring failures -- degrade gracefully so the
+      // user can still use the app without end-to-end encryption.
+      debugPrint('[Crypto] PlatformException during init (degraded mode): $e');
+      DebugLogService.instance.log(
+        LogLevel.warning,
+        'Crypto',
+        'PlatformException during init (degraded mode): $e',
+      );
+      state = state.copyWith(isUploading: false);
     } catch (e) {
+      DebugLogService.instance.log(LogLevel.error, 'Crypto', 'Init failed: $e');
       state = state.copyWith(
         isUploading: false,
         error: 'Crypto init failed: $e',

--- a/apps/client/lib/src/providers/screen_share_provider.dart
+++ b/apps/client/lib/src/providers/screen_share_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugPrint, defaultTargetPlatform, kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
@@ -115,6 +116,12 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
     }
     if (msg.contains('https') || msg.contains('secure context')) {
       return 'Screen sharing requires a secure (HTTPS) connection.';
+    }
+    // Linux-specific guidance: PipeWire + XDG Desktop Portal are required
+    // for getDisplayMedia to work on native Linux builds.
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.linux) {
+      return 'Screen sharing on Linux requires PipeWire and '
+          'XDG Desktop Portal support.';
     }
     return 'Could not start screen sharing: $error';
   }

--- a/apps/client/lib/src/providers/voice_rtc_provider.dart
+++ b/apps/client/lib/src/providers/voice_rtc_provider.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:http/http.dart' as http;
 
+import '../services/debug_log_service.dart';
 import '../services/sound_service.dart';
 import 'auth_provider.dart';
 import 'channels_provider.dart';
@@ -85,6 +86,10 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
   Timer? _latencyTimer;
   List<Map<String, dynamic>>? _cachedIceServers;
 
+  /// Tracks whether mic was muted before deafening, so un-deafen restores
+  /// the previous mute state instead of always enabling the mic.
+  bool _wasMutedBeforeDeafen = false;
+
   /// Maximum pending ICE candidates per peer before oldest are dropped.
   static const _maxPendingIceCandidatesPerPeer = 50;
 
@@ -162,6 +167,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
         '[VoiceRTC] Got local stream: '
         '${_localStream!.getAudioTracks().length} audio tracks',
       );
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceRTC',
+        'Got local stream: ${_localStream!.getAudioTracks().length} audio tracks',
+      );
 
       setCaptureEnabled(!startMuted);
 
@@ -189,6 +199,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       _startLatencyPolling();
     } catch (e) {
       debugPrint('[VoiceRTC] join failed: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'VoiceRTC',
+        'Join failed: $e',
+      );
       await leaveChannel();
       state = state.copyWith(
         isJoining: false,
@@ -254,9 +269,24 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
 
   /// Mute/unmute all incoming audio from remote peers.
   ///
+  /// Following Discord convention, deafening also mutes the microphone.
+  /// Un-deafening restores mic to whatever state it was before deafening.
+  ///
   /// Uses [RTCRtpReceiver] to reliably access remote audio tracks under
   /// unified-plan SDP semantics (`getRemoteStreams()` can be empty).
   Future<void> setDeafened(bool deafened) async {
+    if (deafened) {
+      // Save current mic state before deafening so we can restore it later
+      _wasMutedBeforeDeafen = !state.isCaptureEnabled;
+      // Mute mic when deafening (Discord convention)
+      setCaptureEnabled(false);
+    } else {
+      // Restore mic to pre-deafen state
+      if (!_wasMutedBeforeDeafen) {
+        setCaptureEnabled(true);
+      }
+    }
+
     for (final renderer in _remoteAudioRenderers.values) {
       renderer.muted = deafened;
     }
@@ -312,6 +342,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
           '[VoiceRTC] Got local video stream: '
           '${videoTracks.length} video tracks',
         );
+        DebugLogService.instance.log(
+          LogLevel.info,
+          'VoiceRTC',
+          'Got local video stream: ${videoTracks.length} video tracks',
+        );
 
         // Add video track to every existing peer connection.
         for (final pc in _peerConnections.values) {
@@ -323,6 +358,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
         state = state.copyWith(isVideoEnabled: true);
       } catch (e) {
         debugPrint('[VoiceRTC] toggleVideo failed: $e');
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'VoiceRTC',
+          'toggleVideo failed: $e',
+        );
         state = state.copyWith(error: 'Failed to enable camera');
       }
     }
@@ -403,6 +443,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       }
     } catch (e) {
       debugPrint('[VoiceRTC] Failed to fetch ICE config: $e');
+      DebugLogService.instance.log(
+        LogLevel.warning,
+        'VoiceRTC',
+        'Failed to fetch ICE config: $e',
+      );
     }
     // Fallback to STUN only
     return [
@@ -427,6 +472,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       debugPrint(
         '[VoiceRTC] Adding ${audioTracks.length} audio tracks to PC for $remoteUserId',
       );
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceRTC',
+        'Adding ${audioTracks.length} audio tracks to PC for $remoteUserId',
+      );
       for (final track in audioTracks) {
         await pc.addTrack(track, stream);
       }
@@ -438,6 +488,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       final videoTracks = videoStream.getVideoTracks();
       debugPrint(
         '[VoiceRTC] Adding ${videoTracks.length} video tracks to PC for $remoteUserId',
+      );
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceRTC',
+        'Adding ${videoTracks.length} video tracks to PC for $remoteUserId',
       );
       for (final track in videoTracks) {
         await pc.addTrack(track, videoStream);
@@ -459,27 +514,46 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
     };
 
     pc.onConnectionState = (connectionState) {
+      final stateStr = connectionState.toString().split('.').last;
       debugPrint(
         '[VoiceRTC] Connection state for $remoteUserId: $connectionState',
       );
-      _updatePeerState(
-        remoteUserId,
-        connectionState.toString().split('.').last,
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceRTC',
+        'Connection state for $remoteUserId: $stateStr',
       );
+      _updatePeerState(remoteUserId, stateStr);
     };
 
     pc.onIceConnectionState = (iceState) {
       debugPrint('[VoiceRTC] ICE state for $remoteUserId: $iceState');
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceRTC',
+        'ICE state for $remoteUserId: $iceState',
+      );
     };
 
     pc.onIceGatheringState = (gatherState) {
       debugPrint('[VoiceRTC] ICE gathering for $remoteUserId: $gatherState');
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceRTC',
+        'ICE gathering for $remoteUserId: $gatherState',
+      );
     };
 
     pc.onTrack = (event) {
       debugPrint(
         '[VoiceRTC] onTrack from $remoteUserId: kind=${event.track.kind} '
         'streams=${event.streams.length}',
+      );
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceRTC',
+        'onTrack from $remoteUserId: kind=${event.track.kind} '
+            'streams=${event.streams.length}',
       );
       if (event.streams.isEmpty) return;
       if (event.track.kind == 'audio') {
@@ -568,6 +642,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       _sendSignal(remoteUserId, {'type': 'offer', 'sdp': offer.sdp});
     } catch (e) {
       debugPrint('[VoiceRTC] createOffer failed for $remoteUserId: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'VoiceRTC',
+        'createOffer failed for $remoteUserId: $e',
+      );
       _updatePeerState(remoteUserId, 'offer_failed');
     }
   }
@@ -630,6 +709,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       _updatePeerState(fromUserId, 'answer_sent');
     } catch (e) {
       debugPrint('[VoiceRTC] handleOffer failed from $fromUserId: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'VoiceRTC',
+        'handleOffer failed from $fromUserId: $e',
+      );
       _updatePeerState(fromUserId, 'offer_error');
     }
   }
@@ -646,6 +730,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       _updatePeerState(fromUserId, 'answer_applied');
     } catch (e) {
       debugPrint('[VoiceRTC] handleAnswer failed from $fromUserId: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'VoiceRTC',
+        'handleAnswer failed from $fromUserId: $e',
+      );
       _updatePeerState(fromUserId, 'answer_error');
     }
   }
@@ -682,6 +771,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
         RTCIceCandidate(candidate, sdpMid, sdpMLineIndex),
       );
       debugPrint('[VoiceRTC] addCandidate deferred for $fromUserId: $e');
+      DebugLogService.instance.log(
+        LogLevel.warning,
+        'VoiceRTC',
+        'addCandidate deferred for $fromUserId: $e',
+      );
     }
   }
 
@@ -703,6 +797,12 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
         debugPrint(
           '[VoiceRTC] Dropping stale ICE candidate for $userId '
           '(age: ${now.difference(timestamp).inSeconds}s)',
+        );
+        DebugLogService.instance.log(
+          LogLevel.warning,
+          'VoiceRTC',
+          'Dropping stale ICE candidate for $userId '
+              '(age: ${now.difference(timestamp).inSeconds}s)',
         );
         continue;
       }
@@ -742,6 +842,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
           );
     } catch (e) {
       debugPrint('[VoiceRTC] sendSignal failed: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'VoiceRTC',
+        'sendSignal failed: $e',
+      );
     }
   }
 
@@ -871,6 +976,11 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
         );
       } catch (e) {
         debugPrint('[VoiceRTC] periodic sync failed: $e');
+        DebugLogService.instance.log(
+          LogLevel.warning,
+          'VoiceRTC',
+          'Periodic sync failed: $e',
+        );
       }
     });
   }

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../models/chat_message.dart';
+import '../services/debug_log_service.dart';
 import '../services/group_crypto_service.dart';
 import 'auth_provider.dart';
 import 'chat_provider.dart';
@@ -81,6 +82,11 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       }
     } catch (e) {
       debugPrint('[WebSocket] Failed to fetch ws ticket: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'WebSocket',
+        'Failed to fetch ws ticket: $e',
+      );
     }
     return null;
   }
@@ -107,6 +113,11 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     if (ticket == null || ticket.isEmpty) {
       // Ticket fetch failed -- don't connect, schedule retry with backoff
       debugPrint('[WebSocket] Failed to obtain ticket, will retry...');
+      DebugLogService.instance.log(
+        LogLevel.warning,
+        'WebSocket',
+        'Failed to obtain ticket, will retry...',
+      );
       state = state.copyWith(isConnected: false);
       _scheduleReconnect();
       return;
@@ -117,6 +128,11 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     state = state.copyWith(isConnected: true);
     _reconnectAttempts = 0;
     retriedPeers.clear();
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'WebSocket',
+      'Connected to $wsBase',
+    );
 
     // Reload conversations now that WebSocket is connected -- ensures the
     // list is up-to-date even if the initial REST call raced with connection.
@@ -125,10 +141,20 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     _subscription = _channel!.stream.listen(
       (data) => _onMessage(data as String),
       onDone: () {
+        DebugLogService.instance.log(
+          LogLevel.warning,
+          'WebSocket',
+          'Connection closed (onDone)',
+        );
         state = state.copyWith(isConnected: false);
         _scheduleReconnect();
       },
       onError: (_) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'WebSocket',
+          'Connection error (onError)',
+        );
         state = state.copyWith(isConnected: false);
         _scheduleReconnect();
       },
@@ -149,6 +175,11 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
         '[WebSocket] Max reconnect attempts ($_maxReconnectAttempts) '
         'reached -- server unreachable',
       );
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'WebSocket',
+        'Max reconnect attempts ($_maxReconnectAttempts) reached',
+      );
       state = state.copyWith(isConnected: false);
       return;
     }
@@ -161,6 +192,12 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     debugPrint(
       '[WebSocket] Reconnecting in ${delayMs}ms '
       '(attempt $_reconnectAttempts/$_maxReconnectAttempts)',
+    );
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'WebSocket',
+      'Reconnecting in ${delayMs}ms '
+          '(attempt $_reconnectAttempts/$_maxReconnectAttempts)',
     );
 
     _reconnectTimer = Timer(Duration(milliseconds: delayMs), () {
@@ -177,6 +214,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     _channel?.sink.close();
     _channel = null;
     state = state.copyWith(isConnected: false);
+    DebugLogService.instance.log(LogLevel.info, 'WebSocket', 'Disconnected');
   }
 
   /// Send a DM message to a peer.
@@ -252,9 +290,9 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
 
   /// Send a message to a group conversation.
   ///
-  /// If a group encryption key is available for this conversation, the
-  /// message content is AES-256-GCM encrypted before being sent. Otherwise
-  /// the message is sent as plaintext (backward compatible).
+  /// If the conversation has encryption enabled and a group encryption key is
+  /// available, the message content is AES-256-GCM encrypted before being
+  /// sent. Otherwise the message is sent as plaintext (backward compatible).
   Future<void> sendGroupMessage(
     String conversationId,
     String content, {
@@ -263,21 +301,32 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
   }) async {
     String payload = content;
 
-    // Attempt group encryption if a key is available
-    try {
-      final groupCrypto = ref.read(groupCryptoServiceProvider);
-      final token = ref.read(authProvider).token ?? '';
-      groupCrypto.setToken(token);
-      final keyResult = await groupCrypto.getGroupKey(conversationId);
-      if (keyResult != null) {
-        final (_, keyBase64) = keyResult;
-        payload = await GroupCryptoService.encryptGroupMessage(
-          content,
-          keyBase64,
+    // Only attempt group encryption if the conversation is marked encrypted
+    final conversation = ref
+        .read(conversationsProvider)
+        .conversations
+        .where((c) => c.id == conversationId)
+        .firstOrNull;
+    final isEncrypted = conversation?.isEncrypted ?? false;
+
+    if (isEncrypted) {
+      try {
+        final groupCrypto = ref.read(groupCryptoServiceProvider);
+        final token = ref.read(authProvider).token ?? '';
+        groupCrypto.setToken(token);
+        final keyResult = await groupCrypto.getGroupKey(conversationId);
+        if (keyResult != null) {
+          final (_, keyBase64) = keyResult;
+          payload = await GroupCryptoService.encryptGroupMessage(
+            content,
+            keyBase64,
+          );
+        }
+      } catch (e) {
+        debugPrint(
+          '[WebSocket] Group encryption failed, sending plaintext: $e',
         );
       }
-    } catch (e) {
-      debugPrint('[WebSocket] Group encryption failed, sending plaintext: $e');
     }
 
     final msg = <String, dynamic>{

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -239,7 +239,18 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
   ) async {
     String decryptedContent;
     final isGroupEncrypted = rawContent.startsWith(groupEncryptedPrefix);
-    final wasEncrypted = isGroupEncrypted || looksEncrypted(rawContent);
+
+    // Check if this is a group conversation -- group messages that don't have
+    // the GRP1: prefix are plaintext and should never be DM-decrypted.
+    final conversation = ref
+        .read(conversationsProvider)
+        .conversations
+        .where((c) => c.id == conversationId)
+        .firstOrNull;
+    final isGroupConversation = conversation?.isGroup ?? false;
+    final wasEncrypted =
+        isGroupEncrypted ||
+        (!isGroupConversation && looksEncrypted(rawContent));
 
     if (isGroupEncrypted) {
       // Group-encrypted message -- decrypt with AES-256-GCM group key.

--- a/apps/client/lib/src/screens/settings/debug_section.dart
+++ b/apps/client/lib/src/screens/settings/debug_section.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../services/debug_log_service.dart';
+import '../../theme/echo_theme.dart';
+
+/// Settings section that displays a scrollable list of recent debug log entries
+/// captured by [DebugLogService].
+class DebugSection extends StatefulWidget {
+  const DebugSection({super.key});
+
+  @override
+  State<DebugSection> createState() => _DebugSectionState();
+}
+
+class _DebugSectionState extends State<DebugSection> {
+  final _scrollController = ScrollController();
+  final _logService = DebugLogService.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    _logService.addListener(_onLogsChanged);
+  }
+
+  @override
+  void dispose() {
+    _logService.removeListener(_onLogsChanged);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onLogsChanged() {
+    if (!mounted) return;
+    setState(() {});
+    // Auto-scroll to the newest entry after the frame renders.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = _logService.entries;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header row with title and clear button
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Debug Logs',
+                  style: TextStyle(
+                    color: context.textPrimary,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              OutlinedButton.icon(
+                onPressed: entries.isEmpty ? null : _logService.clear,
+                icon: const Icon(Icons.delete_sweep_outlined, size: 16),
+                label: const Text('Clear Logs'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: context.textSecondary,
+                  disabledForegroundColor: context.textMuted,
+                  side: BorderSide(color: context.border),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  textStyle: const TextStyle(fontSize: 13),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Text(
+            '${entries.length} entries (max ${DebugLogService.maxEntries})',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+        ),
+        const SizedBox(height: 12),
+        // Log list
+        Expanded(
+          child: entries.isEmpty
+              ? Center(
+                  child: Text(
+                    'No debug logs yet.',
+                    style: TextStyle(color: context.textMuted, fontSize: 14),
+                  ),
+                )
+              : ListView.builder(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) =>
+                      _LogEntryTile(entry: entries[index]),
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual log entry row
+// ---------------------------------------------------------------------------
+
+class _LogEntryTile extends StatelessWidget {
+  final DebugLogEntry entry;
+
+  const _LogEntryTile({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Timestamp
+          SizedBox(
+            width: 72,
+            child: Text(
+              _formatTime(entry.timestamp),
+              style: GoogleFonts.jetBrainsMono(
+                color: context.textMuted,
+                fontSize: 11,
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          // Level badge
+          _LevelBadge(level: entry.level),
+          const SizedBox(width: 8),
+          // Source tag
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+            decoration: BoxDecoration(
+              color: context.surfaceHover,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              entry.source,
+              style: GoogleFonts.jetBrainsMono(
+                color: context.textSecondary,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          // Message
+          Expanded(
+            child: Text(
+              entry.message,
+              style: GoogleFonts.jetBrainsMono(
+                color: context.textPrimary,
+                fontSize: 12,
+                height: 1.4,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _formatTime(DateTime dt) {
+    final h = dt.hour.toString().padLeft(2, '0');
+    final m = dt.minute.toString().padLeft(2, '0');
+    final s = dt.second.toString().padLeft(2, '0');
+    return '$h:$m:$s';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Colored level badge (green / yellow / red)
+// ---------------------------------------------------------------------------
+
+class _LevelBadge extends StatelessWidget {
+  final LogLevel level;
+
+  const _LevelBadge({required this.level});
+
+  @override
+  Widget build(BuildContext context) {
+    final (String label, Color color) = switch (level) {
+      LogLevel.info => ('INF', EchoTheme.online),
+      LogLevel.warning => ('WRN', EchoTheme.warning),
+      LogLevel.error => ('ERR', EchoTheme.danger),
+    };
+
+    return Container(
+      width: 32,
+      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.jetBrainsMono(
+          color: color,
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -10,10 +10,11 @@ import 'settings/about_section.dart';
 import 'settings/account_section.dart';
 import 'settings/appearance_section.dart';
 import 'settings/audio_section.dart';
+import 'settings/debug_section.dart';
 import 'settings/privacy_section.dart';
 
 /// Section identifiers for the settings navigation.
-enum SettingsSection { account, privacy, audio, appearance, about }
+enum SettingsSection { account, privacy, audio, appearance, about, debug }
 
 /// Returns a human-readable label for a settings section.
 String settingsSectionLabel(SettingsSection section) {
@@ -28,6 +29,8 @@ String settingsSectionLabel(SettingsSection section) {
       return 'Appearance';
     case SettingsSection.about:
       return 'About';
+    case SettingsSection.debug:
+      return 'Debug Logs';
   }
 }
 
@@ -81,6 +84,12 @@ class SettingsNavList extends StatelessWidget {
           icon: Icons.info_outline,
           label: 'About',
           section: SettingsSection.about,
+        ),
+        _navItem(
+          context: context,
+          icon: Icons.bug_report_outlined,
+          label: 'Debug Logs',
+          section: SettingsSection.debug,
         ),
         const Spacer(),
         // Logout button
@@ -169,6 +178,8 @@ class SettingsContent extends StatelessWidget {
         return const AppearanceSection();
       case SettingsSection.about:
         return const AboutSection();
+      case SettingsSection.debug:
+        return const DebugSection();
     }
   }
 }

--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/foundation.dart';
+
+/// Severity level for debug log entries.
+enum LogLevel { info, warning, error }
+
+/// A single timestamped log entry captured by [DebugLogService].
+class DebugLogEntry {
+  final DateTime timestamp;
+  final LogLevel level;
+
+  /// Subsystem that produced the log, e.g. "VoiceRTC", "WebSocket", "Crypto".
+  final String source;
+  final String message;
+
+  const DebugLogEntry({
+    required this.timestamp,
+    required this.level,
+    required this.source,
+    required this.message,
+  });
+}
+
+/// Singleton service that captures debug log entries in a bounded ring buffer.
+///
+/// Mixes in [ChangeNotifier] so Settings UI widgets can listen for new entries
+/// and rebuild automatically.
+class DebugLogService with ChangeNotifier {
+  DebugLogService._();
+
+  static final instance = DebugLogService._();
+
+  final _entries = <DebugLogEntry>[];
+
+  /// Maximum number of entries retained before the oldest are dropped.
+  static const maxEntries = 200;
+
+  /// Unmodifiable snapshot of the current entries (oldest first).
+  List<DebugLogEntry> get entries => List.unmodifiable(_entries);
+
+  /// Append a new log entry, evicting the oldest if the buffer is full.
+  void log(LogLevel level, String source, String message) {
+    _entries.add(
+      DebugLogEntry(
+        timestamp: DateTime.now(),
+        level: level,
+        source: source,
+        message: message,
+      ),
+    );
+    while (_entries.length > maxEntries) {
+      _entries.removeAt(0);
+    }
+    notifyListeners();
+  }
+
+  /// Remove all stored entries.
+  void clear() {
+    _entries.clear();
+    notifyListeners();
+  }
+}

--- a/apps/client/lib/src/services/group_crypto_service.dart
+++ b/apps/client/lib/src/services/group_crypto_service.dart
@@ -26,9 +26,23 @@ class GroupCryptoService {
   /// In-memory cache: conversationId -> (version, raw key bytes).
   final Map<String, (int, Uint8List)> _keyCache = {};
 
+  /// Groups known to not have encryption enabled. Prevents repeated 400
+  /// requests against the server for plaintext groups.
+  final Set<String> _unencryptedGroups = {};
+
   static final _aesGcm = AesGcm.with256bits();
 
   GroupCryptoService({required this.serverUrl});
+
+  /// Mark a group as unencrypted so [getGroupKey] short-circuits.
+  void markUnencrypted(String conversationId) {
+    _unencryptedGroups.add(conversationId);
+  }
+
+  /// Mark a group as encrypted (removes from the unencrypted set).
+  void markEncrypted(String conversationId) {
+    _unencryptedGroups.remove(conversationId);
+  }
 
   void setToken(String token) {
     _token = token;
@@ -119,6 +133,9 @@ class GroupCryptoService {
   ///
   /// Returns `(version, keyBase64)` or null if unavailable.
   Future<(int, String)?> getGroupKey(String conversationId) async {
+    // Skip server call for groups known to be unencrypted
+    if (_unencryptedGroups.contains(conversationId)) return null;
+
     // 1. In-memory cache
     if (_keyCache.containsKey(conversationId)) {
       final (version, bytes) = _keyCache[conversationId]!;
@@ -230,6 +247,7 @@ class GroupCryptoService {
   /// Clear all group keys (for logout).
   Future<void> clearAll() async {
     _keyCache.clear();
+    _unencryptedGroups.clear();
     final store = SecureKeyStore.instance;
     final allEntries = await store.readAll();
     for (final key in allEntries.keys) {

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -238,11 +238,11 @@ class ChatHeaderBar extends ConsumerWidget {
     bool isGroup, {
     bool isEncrypted = false,
   }) {
-    if (hideEncryptionBanner) {
+    if (hideEncryptionBanner || isGroup) {
       return const SizedBox.shrink();
     }
 
-    final encrypted = !isGroup && isEncrypted;
+    final encrypted = isEncrypted;
     final String label;
     if (isGroup) {
       label = 'Group messages are not encrypted';

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -176,18 +176,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     final text = caption;
     if (text.isEmpty) return;
 
-    final conv = widget.conversation;
-
-    // Direct messages are encrypted-only.
-    if (!conv.isGroup && !conv.isEncrypted) {
-      ToastService.show(
-        context,
-        'This direct conversation is not encrypted yet. Sending is blocked.',
-        type: ToastType.warning,
-      );
-      return;
-    }
-
     await _doSend(text);
     _messageController.clear();
     if (_showEmojiPicker) setState(() => _showEmojiPicker = false);

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -120,8 +120,11 @@ class _MessageItemState extends State<MessageItem> {
     if (url.startsWith('http')) return url; // external URLs (GIFs)
     final base = widget.serverUrl ?? '';
     final token = widget.authToken ?? '';
+    // Relative paths (e.g. /api/media/UUID) need the server origin prepended
+    // so CachedNetworkImage gets an absolute URL it can fetch.
+    final resolved = url.startsWith('/') && base.isNotEmpty ? '$base$url' : url;
     // Append token as query param -- web <img> elements can't set headers
-    return token.isNotEmpty ? '$base$url?token=$token' : '$base$url';
+    return token.isNotEmpty ? '$resolved?token=$token' : resolved;
   }
 
   Map<String, String> _mediaHeaders() {
@@ -1106,7 +1109,9 @@ class _MessageItemState extends State<MessageItem> {
         ),
       ),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: isMine
+            ? CrossAxisAlignment.end
+            : CrossAxisAlignment.start,
         children: [
           Text(
             msg.replyToUsername ?? 'Unknown',

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -24,7 +24,6 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 use uuid::Uuid;
 
-use crate::auth::middleware::AuthUser;
 use crate::middleware::rate_limit;
 use crate::ws::hub::Hub;
 
@@ -249,8 +248,9 @@ pub async fn health() -> impl IntoResponse {
 }
 
 /// Returns ICE server configuration from environment variables.
+/// Public endpoint — no auth required (ICE config is not sensitive).
 /// Set TURN_URL, TURN_USERNAME, TURN_CREDENTIAL to configure TURN.
-pub async fn ice_config(_auth: AuthUser) -> impl IntoResponse {
+pub async fn ice_config() -> impl IntoResponse {
     let mut servers = vec![serde_json::json!({"urls": "stun:stun.l.google.com:19302"})];
 
     if let Ok(turn_url) = std::env::var("TURN_URL") {


### PR DESCRIPTION
## Summary
- Remove DM send block (encryption check was preventing all DM sending)
- Hide encryption banner for group conversations
- Make ICE config endpoint public (was returning 401, breaking voice)
- Fix image tags rendering as raw text (relative URL resolution)
- Fix group keys 400 for unencrypted groups (skip fetch when not encrypted)
- Fix reply bubble alignment (conditional CrossAxisAlignment)
- Handle libsecret PlatformException gracefully on Linux
- Deafen now also mutes mic (Discord convention)
- New debug log panel in settings (200-entry ring buffer, wired into voice/ws/crypto)
- Better screen share error message for Linux