### PR TITLE
fix: security hardening -- 6 pentest vulnerabilities

### DIFF
--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -99,6 +99,8 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
 
     disconnect();
     _reconnectAttempts = 0;
+    // Clear wasReplaced so a manual reconnect (e.g. page refresh) works.
+    state = state.copyWith(wasReplaced: false);
 
     // Attempt ticket-based connection, falling back to token-based for
     // backward compatibility with servers that don't support ws-ticket.
@@ -172,6 +174,9 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
   /// be cancelled in [disconnect] and [dispose].
   void _scheduleReconnect() {
     _reconnectTimer?.cancel();
+
+    // Do not reconnect if this session was replaced by another device/tab.
+    if (state.wasReplaced) return;
 
     if (!ref.read(authProvider).isLoggedIn) return;
 
@@ -468,6 +473,18 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     final json = jsonDecode(data) as Map<String, dynamic>;
     final myUserId = ref.read(authProvider).userId ?? '';
     handleServerMessage(json, myUserId);
+
+    // If the handler flagged session_replaced, disconnect cleanly and do NOT
+    // auto-reconnect -- the other session is the active one.
+    if (state.wasReplaced) {
+      _heartbeatTimer?.cancel();
+      _heartbeatTimer = null;
+      _reconnectTimer?.cancel();
+      _reconnectTimer = null;
+      _subscription?.cancel();
+      _channel?.sink.close();
+      _channel = null;
+    }
   }
 
   /// Remove stale typing indicators (older than 5 seconds).

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/chat_message.dart';
 import '../models/reaction.dart';
 import '../services/crypto_service.dart';
+import '../services/debug_log_service.dart';
 import '../services/group_crypto_service.dart';
 import '../services/notification_service.dart';
 import '../services/sound_service.dart';
@@ -26,21 +27,28 @@ class WebSocketState {
   /// Set of user IDs currently known to be online (from presence events).
   final Set<String> onlineUsers;
 
+  /// True when the server sent a `session_replaced` event, meaning another
+  /// device/tab took over this user's WebSocket session.
+  final bool wasReplaced;
+
   const WebSocketState({
     this.isConnected = false,
     this.typingUsers = const {},
     this.onlineUsers = const {},
+    this.wasReplaced = false,
   });
 
   WebSocketState copyWith({
     bool? isConnected,
     Map<String, Map<String, DateTime>>? typingUsers,
     Set<String>? onlineUsers,
+    bool? wasReplaced,
   }) {
     return WebSocketState(
       isConnected: isConnected ?? this.isConnected,
       typingUsers: typingUsers ?? this.typingUsers,
       onlineUsers: onlineUsers ?? this.onlineUsers,
+      wasReplaced: wasReplaced ?? this.wasReplaced,
     );
   }
 
@@ -120,6 +128,8 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
         _handleMention(json, myUserId);
       case 'group_key_rotated':
         _handleGroupKeyRotated(json);
+      case 'session_replaced':
+        _handleSessionReplaced(json);
       case 'error':
         break;
       case 'voice_signal':
@@ -129,6 +139,16 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
 
   void _handleVoiceSignal(Map<String, dynamic> json) {
     voiceSignalController.add(json);
+  }
+
+  void _handleSessionReplaced(Map<String, dynamic> json) {
+    final reason = json['reason'] as String? ?? 'Signed in on another device';
+    DebugLogService.instance.log(
+      LogLevel.warning,
+      'WebSocket',
+      'Session replaced by another connection: $reason',
+    );
+    state = state.copyWith(wasReplaced: true, isConnected: false);
   }
 
   void _refreshChannelsFromEvent(Map<String, dynamic> json) {

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -312,6 +312,36 @@ class CryptoService {
     final bobIdentityKeyBytes = base64Decode(data['identity_key'] as String);
     final bobSignedPrekeyBytes = base64Decode(data['signed_prekey'] as String);
 
+    // Verify the signed prekey signature to prevent MITM / malicious server
+    // substitution. The server returns `signing_key` and
+    // `signed_prekey_signature` alongside the prekey bundle.
+    final signingKeyB64 = data['signing_key'] as String?;
+    final signatureB64 = data['signed_prekey_signature'] as String?;
+    if (signingKeyB64 == null || signatureB64 == null) {
+      throw Exception(
+        'Prekey bundle for $peerUserId is missing signing_key or '
+        'signed_prekey_signature -- cannot verify prekey authenticity',
+      );
+    }
+
+    final signingKeyBytes = base64Decode(signingKeyB64);
+    final signatureBytes = base64Decode(signatureB64);
+
+    final signingPublicKey = SimplePublicKey(
+      signingKeyBytes,
+      type: KeyPairType.ed25519,
+    );
+    final isValid = await _ed25519.verify(
+      bobSignedPrekeyBytes,
+      signature: Signature(signatureBytes, publicKey: signingPublicKey),
+    );
+    if (!isValid) {
+      throw Exception(
+        'Signed prekey signature verification failed for $peerUserId '
+        '-- possible MITM attack',
+      );
+    }
+
     final bobIdentityKey = SimplePublicKey(
       bobIdentityKeyBytes,
       type: KeyPairType.x25519,

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -354,6 +354,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           _buildTabBar(),
           const SizedBox(height: 8),
           _buildPendingBanner(context, pendingCount),
+          _buildReplacedBanner(context, wsState),
           Expanded(
             child: _buildTabContent(
               conversationsState: conversationsState,
@@ -707,6 +708,52 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     );
   }
 
+  Widget _buildReplacedBanner(BuildContext context, WebSocketState wsState) {
+    if (!wsState.wasReplaced) return const SizedBox.shrink();
+    return Column(
+      children: [
+        GestureDetector(
+          onTap: () {
+            // Trigger a fresh connect (clears wasReplaced and reconnects)
+            ref.read(websocketProvider.notifier).connect();
+          },
+          child: Container(
+            height: 48,
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              color: context.surface,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: EchoTheme.warning, width: 1),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: [
+                const Icon(
+                  Icons.devices_other,
+                  size: 18,
+                  color: EchoTheme.warning,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    'Signed in on another device. Tap to reconnect.',
+                    style: TextStyle(
+                      color: context.textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+                const Icon(Icons.refresh, size: 18, color: EchoTheme.warning),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+      ],
+    );
+  }
+
   Widget _buildUserStatusBar(
     BuildContext context, {
     required String myUsername,
@@ -793,7 +840,11 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
             overflow: TextOverflow.ellipsis,
           ),
           Text(
-            wsState.isConnected ? 'Online' : 'Reconnecting...',
+            wsState.wasReplaced
+                ? 'Session replaced'
+                : wsState.isConnected
+                ? 'Online'
+                : 'Reconnecting...',
             style: TextStyle(
               color: wsState.isConnected ? EchoTheme.online : EchoTheme.warning,
               fontSize: 11,

--- a/apps/server/src/auth/jwt.rs
+++ b/apps/server/src/auth/jwt.rs
@@ -14,11 +14,15 @@ use crate::error::AppError;
 pub struct Claims {
     pub sub: String,
     pub exp: usize,
+    pub iat: usize,
+    pub iss: String,
+    pub aud: String,
 }
 
 /// Create a short-lived access token (15 minutes).
 pub fn create_token(user_id: Uuid, secret: &str) -> Result<String, AppError> {
-    let exp = chrono::Utc::now()
+    let now = chrono::Utc::now();
+    let exp = now
         .checked_add_signed(chrono::Duration::minutes(15))
         .expect("valid timestamp")
         .timestamp() as usize;
@@ -26,6 +30,9 @@ pub fn create_token(user_id: Uuid, secret: &str) -> Result<String, AppError> {
     let claims = Claims {
         sub: user_id.to_string(),
         exp,
+        iat: now.timestamp() as usize,
+        iss: "echo-messenger".to_string(),
+        aud: "echo-app".to_string(),
     };
 
     let token = encode(
@@ -39,10 +46,14 @@ pub fn create_token(user_id: Uuid, secret: &str) -> Result<String, AppError> {
 
 #[allow(dead_code)] // Used by AuthUser middleware extractor
 pub fn validate_token(token: &str, secret: &str) -> Result<Claims, AppError> {
+    let mut validation = Validation::default();
+    validation.set_issuer(&["echo-messenger"]);
+    validation.set_audience(&["echo-app"]);
+
     let token_data = decode::<Claims>(
         token,
         &DecodingKey::from_secret(secret.as_bytes()),
-        &Validation::default(),
+        &validation,
     )?;
 
     Ok(token_data.claims)

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -36,6 +36,7 @@ async fn main() {
         jwt_secret: config.jwt_secret,
         hub: hub.clone(),
         ticket_store: Mutex::new(HashMap::new()),
+        media_tickets: Mutex::new(HashMap::new()),
     });
 
     // Background task: clean up stale voice sessions every 60 seconds.

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -62,8 +62,27 @@ impl RateLimiter {
     }
 }
 
-/// Extract client IP from ConnectInfo or return a loopback fallback.
+/// Extract client IP from request headers or connection info.
+/// Priority: X-Forwarded-For (first IP) > X-Real-IP > ConnectInfo > localhost.
 fn extract_ip(req: &Request<Body>) -> IpAddr {
+    // Try X-Forwarded-For header first (first IP in comma-separated list)
+    if let Some(xff) = req.headers().get("x-forwarded-for")
+        && let Ok(value) = xff.to_str()
+        && let Some(first_ip) = value.split(',').next()
+        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
+    {
+        return ip;
+    }
+
+    // Fallback to X-Real-IP header
+    if let Some(xri) = req.headers().get("x-real-ip")
+        && let Ok(value) = xri.to_str()
+        && let Ok(ip) = value.trim().parse::<IpAddr>()
+    {
+        return ip;
+    }
+
+    // Fallback to ConnectInfo
     req.extensions()
         .get::<ConnectInfo<SocketAddr>>()
         .map(|ci| ci.0.ip())

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -1,13 +1,15 @@
 //! Media upload and download endpoints.
 
+use axum::Json;
 use axum::body::Body;
 use axum::extract::{Multipart, Path, Query, State};
 use axum::http::StatusCode;
 use axum::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use axum::response::{IntoResponse, Response};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::fs;
 use uuid::Uuid;
 
@@ -159,35 +161,91 @@ pub async fn upload(
     Ok((StatusCode::CREATED, axum::Json(body)))
 }
 
-/// Query param for media download -- allows `?token=JWT` for web clients
-/// where `<img>` elements can't set Authorization headers.
+// ---------------------------------------------------------------------------
+// POST /api/media/ticket
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct MediaTicketResponse {
+    pub ticket: String,
+}
+
+/// Issue a short-lived, single-use ticket for media downloads.
+/// Prevents JWT leakage in query strings, browser history, and referrer
+/// headers (same pattern as WebSocket tickets).
+pub async fn request_media_ticket(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+) -> Result<impl IntoResponse, AppError> {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use rand::RngCore;
+
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    let ticket = URL_SAFE_NO_PAD.encode(bytes);
+
+    const TICKET_TTL: Duration = Duration::from_secs(300); // 5 minutes
+    const MAX_TICKETS: usize = 100_000;
+
+    let mut store = state
+        .media_tickets
+        .lock()
+        .map_err(|_| AppError::internal("Internal state error"))?;
+
+    // Clean up expired tickets to bound memory
+    let now = Instant::now();
+    store.retain(|_, (_, ts)| now.duration_since(*ts) < TICKET_TTL);
+
+    if store.len() >= MAX_TICKETS {
+        return Err(AppError::bad_request(
+            "Too many pending media tickets, try again later",
+        ));
+    }
+
+    store.insert(ticket.clone(), (auth_user.user_id, now));
+    drop(store);
+
+    Ok(Json(MediaTicketResponse { ticket }))
+}
+
+/// Query param for media download -- accepts `?ticket=` (single-use media
+/// ticket) or legacy `?token=` (validated as media ticket, not JWT).
 #[derive(Debug, Deserialize)]
 pub struct MediaDownloadQuery {
+    pub ticket: Option<String>,
     pub token: Option<String>,
 }
 
 /// GET /api/media/:id
 ///
 /// Returns the file with correct Content-Type and Content-Disposition headers.
-/// Accepts auth via `Authorization: Bearer` header OR `?token=JWT` query param.
+/// Accepts auth via:
+///   1. `Authorization: Bearer <JWT>` header
+///   2. `?ticket=<media_ticket>` query param (single-use, consumed on use)
+///   3. `?token=<media_ticket>` query param (legacy compat, same as ticket)
 pub async fn download(
     State(state): State<Arc<AppState>>,
     Path(id): Path<Uuid>,
     Query(query): Query<MediaDownloadQuery>,
     headers: axum::http::HeaderMap,
 ) -> Result<Response, AppError> {
-    // Accept auth from header or query param (web <img> can't set headers)
-    let token_str = headers
+    // 1. Try Authorization header (JWT)
+    let user_id = if let Some(token_str) = headers
         .get("Authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
-        .map(String::from)
-        .or(query.token)
-        .ok_or_else(|| AppError::unauthorized("Missing authentication"))?;
-
-    let claims = jwt::validate_token(&token_str, &state.jwt_secret)?;
-    let user_id = Uuid::parse_str(&claims.sub)
-        .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?;
+    {
+        let claims = jwt::validate_token(token_str, &state.jwt_secret)?;
+        Uuid::parse_str(&claims.sub)
+            .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?
+    }
+    // 2. Try ?ticket= or legacy ?token= as media ticket
+    else if let Some(ticket_str) = query.ticket.or(query.token) {
+        validate_media_ticket(&state, &ticket_str)?
+    } else {
+        return Err(AppError::unauthorized("Missing authentication"));
+    };
     let row = db::media::get_media(&state.pool, id)
         .await?
         .ok_or_else(|| AppError {
@@ -244,4 +302,25 @@ pub async fn download(
         .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))?;
 
     Ok(response)
+}
+
+/// Validate a single-use media ticket. Removes the ticket from the store
+/// on success (single-use). Returns the associated `user_id`.
+fn validate_media_ticket(state: &AppState, ticket: &str) -> Result<Uuid, AppError> {
+    const TICKET_TTL: Duration = Duration::from_secs(300);
+
+    let mut store = state
+        .media_tickets
+        .lock()
+        .map_err(|_| AppError::internal("Internal state error"))?;
+
+    let (user_id, created_at) = store
+        .remove(ticket)
+        .ok_or_else(|| AppError::unauthorized("Invalid or expired media ticket"))?;
+
+    if Instant::now().duration_since(created_at) >= TICKET_TTL {
+        return Err(AppError::unauthorized("Invalid or expired media ticket"));
+    }
+
+    Ok(user_id)
 }

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -30,11 +30,15 @@ use crate::ws::hub::Hub;
 /// Map from ticket string to (user_id, created_at).
 pub type TicketStore = Mutex<HashMap<String, (Uuid, Instant)>>;
 
+/// Map from media ticket string to (user_id, created_at).
+pub type MediaTicketStore = Mutex<HashMap<String, (Uuid, Instant)>>;
+
 pub struct AppState {
     pub pool: PgPool,
     pub jwt_secret: String,
     pub hub: Hub,
     pub ticket_store: TicketStore,
+    pub media_tickets: MediaTicketStore,
 }
 
 pub fn create_router(state: Arc<AppState>) -> Router {
@@ -137,6 +141,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     let media_routes = Router::new()
         .route("/upload", post(media::upload))
+        .route("/ticket", post(media::request_media_ticket))
         .route("/{id}", get(media::download));
 
     let group_routes = Router::new()
@@ -248,9 +253,9 @@ pub async fn health() -> impl IntoResponse {
 }
 
 /// Returns ICE server configuration from environment variables.
-/// Public endpoint — no auth required (ICE config is not sensitive).
+/// Requires authentication to prevent unauthenticated access.
 /// Set TURN_URL, TURN_USERNAME, TURN_CREDENTIAL to configure TURN.
-pub async fn ice_config() -> impl IntoResponse {
+pub async fn ice_config(_auth: crate::auth::middleware::AuthUser) -> impl IntoResponse {
     let mut servers = vec![serde_json::json!({"urls": "stun:stun.l.google.com:19302"})];
 
     if let Ok(turn_url) = std::env::var("TURN_URL") {

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -20,7 +20,16 @@ impl Hub {
     }
 
     pub fn register(&self, user_id: Uuid, tx: WsTx) {
-        self.connections.insert(user_id, tx);
+        if let Some(old_tx) = self.connections.insert(user_id, tx) {
+            let msg = serde_json::json!({
+                "type": "session_replaced",
+                "reason": "Signed in on another device"
+            });
+            if let Ok(s) = serde_json::to_string(&msg) {
+                let _ = old_tx.send(WsMessage::Text(s.into()));
+            }
+            let _ = old_tx.send(WsMessage::Close(None));
+        }
     }
 
     pub fn unregister(&self, user_id: Uuid) {

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -42,6 +42,7 @@ pub async fn spawn_server() -> String {
         jwt_secret: TEST_JWT_SECRET.to_string(),
         hub,
         ticket_store: Mutex::new(HashMap::new()),
+        media_tickets: Mutex::new(HashMap::new()),
     });
 
     let app = routes::create_router(state);


### PR DESCRIPTION
## Summary — Sprint 9: Security Hardening

Addresses 6 vulnerabilities from the security pentest:

1. **ICE config auth restored** (VULN-01) — re-added AuthUser to prevent unauthenticated access
2. **Rate limiter fixed for reverse proxy** (VULN-06) — parses X-Forwarded-For/X-Real-IP instead of proxy IP
3. **JWT claims hardened** (VULN-08) — added iss, aud, iat fields with validation
4. **Media ticket system** (VULN-04) — replaces JWT-in-URL with 5-min single-use tickets
5. **Hub session replaced notification** (VULN-05) — old connection gets notified + closed before overwrite
6. **Client-side signed prekey verification** (VULN-03) — Ed25519 signature verified before X3DH handshake

Note: JWT format change means existing sessions will need re-login after deploy.

## Test plan
- [x] cargo clippy -- clean
- [x] flutter analyze -- no issues
- [x] flutter test -- 224/224 pass
- [x] Pre-commit hooks pass