### PR TITLE
feat: crypto redesign -- group envelopes, otp, safety numbers

### DIFF
--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -19,9 +19,11 @@ final cryptoServiceProvider = Provider<CryptoService>((ref) {
 /// Provider for the GroupCryptoService singleton.
 ///
 /// Handles AES-256-GCM group encryption: key generation, encrypt/decrypt,
-/// and key distribution via the server.
+/// and per-member envelope-based key distribution via the server.
 final groupCryptoServiceProvider = Provider<GroupCryptoService>((ref) {
-  return GroupCryptoService(serverUrl: ref.watch(serverUrlProvider));
+  final service = GroupCryptoService(serverUrl: ref.watch(serverUrlProvider));
+  service.setCryptoService(ref.watch(cryptoServiceProvider));
+  return service;
 });
 
 /// State for tracking crypto initialization.
@@ -198,14 +200,21 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
   // Group encryption key management
   // -----------------------------------------------------------------------
 
-  /// Generate a new group key, upload it to the server, and cache it.
+  /// Generate a new group key, encrypt it for each member, and upload
+  /// per-member envelopes to the server.
+  ///
+  /// [members] is a list of `{'user_id': String, 'identity_key': String?}`
+  /// maps. Members without an identity key are skipped.
   ///
   /// Returns the new key version, or null on failure.
-  Future<int?> rotateGroupKey(String conversationId) async {
+  Future<int?> rotateGroupKey(
+    String conversationId,
+    List<Map<String, dynamic>> members,
+  ) async {
     final groupCrypto = ref.read(groupCryptoServiceProvider);
     final token = ref.read(authProvider).token ?? '';
     groupCrypto.setToken(token);
-    return groupCrypto.rotateGroupKey(conversationId);
+    return groupCrypto.rotateGroupKey(conversationId, members);
   }
 
   /// Fetch the latest group key from the server and cache it locally.

--- a/apps/client/lib/src/screens/safety_number_screen.dart
+++ b/apps/client/lib/src/screens/safety_number_screen.dart
@@ -1,0 +1,367 @@
+/// Screen for displaying and verifying safety numbers between two peers.
+///
+/// Shows the 60-digit safety number derived from both users' identity keys,
+/// formatted in groups of 5 for easy comparison. Includes a QR code
+/// representation and a verification toggle that persists locally.
+library;
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../providers/crypto_provider.dart';
+import '../services/safety_number_service.dart';
+import '../services/secure_key_store.dart';
+import '../services/toast_service.dart';
+import '../theme/echo_theme.dart';
+
+/// Displays and manages safety number verification for a DM conversation.
+///
+/// On desktop (>=900px) opens as a dialog; on smaller screens pushes a
+/// full-screen route.
+class SafetyNumberScreen extends ConsumerStatefulWidget {
+  final String peerUserId;
+  final String peerUsername;
+  final String myUsername;
+
+  const SafetyNumberScreen({
+    super.key,
+    required this.peerUserId,
+    required this.peerUsername,
+    required this.myUsername,
+  });
+
+  /// Open the safety number screen as a dialog on desktop or full-screen
+  /// route on mobile.
+  static void show(
+    BuildContext context,
+    WidgetRef ref, {
+    required String peerUserId,
+    required String peerUsername,
+    required String myUsername,
+  }) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= 900) {
+      showDialog(
+        context: context,
+        builder: (_) => Dialog(
+          backgroundColor: context.surface,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+            side: BorderSide(color: context.border),
+          ),
+          child: SizedBox(
+            width: 440,
+            height: 580,
+            child: SafetyNumberScreen(
+              peerUserId: peerUserId,
+              peerUsername: peerUsername,
+              myUsername: myUsername,
+            ),
+          ),
+        ),
+      );
+    } else {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => SafetyNumberScreen(
+            peerUserId: peerUserId,
+            peerUsername: peerUsername,
+            myUsername: myUsername,
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  ConsumerState<SafetyNumberScreen> createState() => _SafetyNumberScreenState();
+}
+
+class _SafetyNumberScreenState extends ConsumerState<SafetyNumberScreen> {
+  String? _safetyNumber;
+  bool _isLoading = true;
+  String? _error;
+  bool _isVerified = false;
+
+  static const _verifiedPrefix = 'echo_safety_verified_';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSafetyNumber();
+  }
+
+  Future<void> _loadSafetyNumber() async {
+    try {
+      final store = SecureKeyStore.instance;
+
+      // Load my identity public key
+      final myPubB64 = await store.read('echo_identity_pub_key');
+      if (myPubB64 == null) {
+        setState(() {
+          _error = 'Identity key not found. Encryption may not be initialized.';
+          _isLoading = false;
+        });
+        return;
+      }
+      final myPub = Uint8List.fromList(base64Decode(myPubB64));
+
+      // Load peer identity public key from cached prekey bundle
+      final peerPubB64 = await store.read(
+        'echo_peer_identity_${widget.peerUserId}',
+      );
+      if (peerPubB64 == null) {
+        // Try to fetch from server via crypto service
+        final crypto = ref.read(cryptoServiceProvider);
+        final fetched = await crypto.fetchPeerIdentityKey(widget.peerUserId);
+        if (fetched == null) {
+          setState(() {
+            _error =
+                'Peer identity key not available. '
+                'Start a conversation first to exchange keys.';
+            _isLoading = false;
+          });
+          return;
+        }
+        _safetyNumber = await SafetyNumberService.generate(myPub, fetched);
+      } else {
+        final peerPub = Uint8List.fromList(base64Decode(peerPubB64));
+        _safetyNumber = await SafetyNumberService.generate(myPub, peerPub);
+      }
+
+      // Load verification state
+      final prefs = await SharedPreferences.getInstance();
+      _isVerified =
+          prefs.getBool('$_verifiedPrefix${widget.peerUserId}') ?? false;
+
+      setState(() => _isLoading = false);
+    } catch (e) {
+      setState(() {
+        _error = 'Failed to generate safety number: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _toggleVerified() async {
+    final newState = !_isVerified;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('$_verifiedPrefix${widget.peerUserId}', newState);
+    setState(() => _isVerified = newState);
+
+    if (!mounted) return;
+    ToastService.show(
+      context,
+      newState ? 'Marked as verified' : 'Verification removed',
+      type: newState ? ToastType.success : ToastType.info,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDialog = MediaQuery.of(context).size.width >= 900;
+
+    return Scaffold(
+      backgroundColor: isDialog ? Colors.transparent : context.mainBg,
+      appBar: isDialog
+          ? null
+          : AppBar(
+              backgroundColor: context.chatBg,
+              title: const Text('Safety Number'),
+              foregroundColor: context.textPrimary,
+            ),
+      body: _buildBody(context, isDialog),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, bool isDialog) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.warning_amber_rounded,
+                size: 48,
+                color: context.textMuted,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: context.textSecondary, fontSize: 14),
+              ),
+              if (isDialog) ...[
+                const SizedBox(height: 24),
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Close'),
+                ),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+
+    final formatted = SafetyNumberService.formatForDisplay(_safetyNumber!);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        children: [
+          if (isDialog)
+            Row(
+              children: [
+                Icon(
+                  Icons.verified_user_outlined,
+                  size: 20,
+                  color: context.accent,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Safety Number',
+                  style: TextStyle(
+                    color: context.textPrimary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const Spacer(),
+                IconButton(
+                  icon: Icon(Icons.close, size: 18, color: context.textMuted),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
+          const SizedBox(height: 8),
+          Text(
+            'Verify that the safety number below matches on both '
+            '${widget.myUsername}\'s and ${widget.peerUsername}\'s devices.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: context.textSecondary, fontSize: 13),
+          ),
+          const SizedBox(height: 24),
+
+          // QR code
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: QrImageView(
+              data: _safetyNumber!,
+              version: QrVersions.auto,
+              size: 160,
+              backgroundColor: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // Safety number digits
+          GestureDetector(
+            onTap: () {
+              Clipboard.setData(ClipboardData(text: _safetyNumber!));
+              ToastService.show(
+                context,
+                'Safety number copied',
+                type: ToastType.success,
+              );
+            },
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: context.surface,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: context.border),
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    formatted,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: context.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
+                      fontFamily: 'monospace',
+                      letterSpacing: 2,
+                      height: 1.6,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.copy, size: 12, color: context.textMuted),
+                      const SizedBox(width: 4),
+                      Text(
+                        'Tap to copy',
+                        style: TextStyle(
+                          color: context.textMuted,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // Verification button
+          SizedBox(
+            width: double.infinity,
+            child: _isVerified
+                ? OutlinedButton.icon(
+                    onPressed: _toggleVerified,
+                    icon: const Icon(Icons.check_circle, size: 18),
+                    label: const Text('Verified'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: EchoTheme.online,
+                      side: const BorderSide(color: EchoTheme.online),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  )
+                : FilledButton.icon(
+                    onPressed: _toggleVerified,
+                    icon: const Icon(Icons.verified_user_outlined, size: 18),
+                    label: const Text('Mark as Verified'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: context.accent,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'If the numbers match, tap to mark this conversation as verified. '
+            'If they change later, the session may have been re-established.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: context.textMuted, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -28,6 +28,18 @@ class CryptoService {
   static const _signedPrekeyPref = 'echo_signed_prekey';
   static const _signedPrekeyPubPref = 'echo_signed_prekey_pub';
   static const _sessionPrefix = 'echo_signal_session_';
+  static const _peerIdentityPrefix = 'echo_peer_identity_';
+  static const _otpPrivatePrefix = 'echo_otp_private_';
+  static const _signedPrekeyCreatedAtPref = 'echo_signed_prekey_created_at';
+  static const _signedPrekeyPreviousPref = 'echo_signed_prekey_previous';
+  static const _signedPrekeyPreviousPubPref = 'echo_signed_prekey_previous_pub';
+
+  /// Duration after which the signed prekey should be rotated.
+  static const _signedPrekeyMaxAge = Duration(days: 7);
+
+  /// Grace period to keep the old signed prekey for peers that have not yet
+  /// fetched the new one.
+  static const _signedPrekeyGracePeriod = Duration(days: 14);
 
   /// All crypto key names that should live in secure storage.
   static const _allCryptoKeys = [
@@ -37,6 +49,9 @@ class CryptoService {
     _signingPubKeyPref,
     _signedPrekeyPref,
     _signedPrekeyPubPref,
+    _signedPrekeyCreatedAtPref,
+    _signedPrekeyPreviousPref,
+    _signedPrekeyPreviousPubPref,
   ];
 
   final String serverUrl;
@@ -47,6 +62,7 @@ class CryptoService {
   SimpleKeyPair? _signingKeyPair;
   final Map<String, SignalSession> _sessions = {};
   X3dhInitResult? _lastX3dhResult;
+  int? _lastOtpKeyId;
   bool _keysAreFresh = false;
 
   final _x25519 = X25519();
@@ -162,6 +178,9 @@ class CryptoService {
 
         // Load persisted sessions
         await _loadSessions(store);
+
+        // Check if signed prekey needs rotation
+        await _rotateSignedPrekeyIfNeeded(store);
       } else {
         // Generate all keys fresh
         _identityKeyPair = await _x25519.newKeyPair();
@@ -176,12 +195,124 @@ class CryptoService {
         await store.write(_identityPubKeyPref, base64Encode(publicKey.bytes));
         await _saveSigningKey(store);
         await _saveSignedPrekey(store);
+        await store.write(
+          _signedPrekeyCreatedAtPref,
+          DateTime.now().toIso8601String(),
+        );
 
         _keysAreFresh = true;
       }
     } catch (e) {
       rethrow;
     }
+  }
+
+  /// Rotate the signed prekey if it is older than [_signedPrekeyMaxAge].
+  ///
+  /// The old key pair is kept as a "previous" signed prekey for a grace period
+  /// so that peers who fetched the old bundle can still complete X3DH.
+  Future<void> _rotateSignedPrekeyIfNeeded(SecureKeyStore store) async {
+    final createdAtStr = await store.read(_signedPrekeyCreatedAtPref);
+    if (createdAtStr == null) {
+      // No timestamp -- store current time and skip rotation this cycle.
+      await store.write(
+        _signedPrekeyCreatedAtPref,
+        DateTime.now().toIso8601String(),
+      );
+      return;
+    }
+
+    final createdAt = DateTime.tryParse(createdAtStr);
+    if (createdAt == null) return;
+
+    final age = DateTime.now().difference(createdAt);
+    if (age < _signedPrekeyMaxAge) return;
+
+    debugPrint('[Crypto] Signed prekey is ${age.inDays} days old -- rotating');
+
+    // Move current signed prekey to "previous" slot
+    final currentPriv = await store.read(_signedPrekeyPref);
+    final currentPub = await store.read(_signedPrekeyPubPref);
+    if (currentPriv != null && currentPub != null) {
+      await store.write(_signedPrekeyPreviousPref, currentPriv);
+      await store.write(_signedPrekeyPreviousPubPref, currentPub);
+    }
+
+    // Generate new signed prekey
+    _signedPrekeyPair = await _x25519.newKeyPair();
+    await _saveSignedPrekey(store);
+    await store.write(
+      _signedPrekeyCreatedAtPref,
+      DateTime.now().toIso8601String(),
+    );
+
+    _keysAreFresh = true;
+
+    // Clean up previous prekey if it has exceeded the grace period
+    await _cleanupPreviousPrekey(store);
+  }
+
+  /// Remove the previous signed prekey if it is older than the grace period.
+  Future<void> _cleanupPreviousPrekey(SecureKeyStore store) async {
+    final prevPriv = await store.read(_signedPrekeyPreviousPref);
+    if (prevPriv == null) return;
+
+    // The previous prekey was created when the current one replaced it.
+    // We use the current prekey creation time minus max age as an estimate
+    // for when the previous key was active. For simplicity, keep it for
+    // one full grace period from now -- it will be cleaned up on the next
+    // rotation cycle after that.
+    final createdAtStr = await store.read(_signedPrekeyCreatedAtPref);
+    if (createdAtStr == null) return;
+
+    final createdAt = DateTime.tryParse(createdAtStr);
+    if (createdAt == null) return;
+
+    // If the current prekey is already older than the grace period minus
+    // the max age, the previous one has definitely expired.
+    final currentAge = DateTime.now().difference(createdAt);
+    if (currentAge >= _signedPrekeyGracePeriod) {
+      await store.delete(_signedPrekeyPreviousPref);
+      await store.delete(_signedPrekeyPreviousPubPref);
+      debugPrint('[Crypto] Cleaned up expired previous signed prekey');
+    }
+  }
+
+  /// Fetch and cache a peer's identity public key from the server.
+  ///
+  /// Returns the key bytes, or null if unavailable.
+  Future<Uint8List?> fetchPeerIdentityKey(String peerUserId) async {
+    // Check cache first
+    final store = SecureKeyStore.instance;
+    final cached = await store.read('$_peerIdentityPrefix$peerUserId');
+    if (cached != null) return Uint8List.fromList(base64Decode(cached));
+
+    // Fetch from server
+    try {
+      final response = await http.get(
+        Uri.parse('$serverUrl/api/keys/bundle/$peerUserId'),
+        headers: {'Authorization': 'Bearer $_token'},
+      );
+      if (response.statusCode != 200) return null;
+
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final identityKeyB64 = data['identity_key'] as String?;
+      if (identityKeyB64 == null) return null;
+
+      // Cache for future use
+      await store.write('$_peerIdentityPrefix$peerUserId', identityKeyB64);
+      return Uint8List.fromList(base64Decode(identityKeyB64));
+    } catch (e) {
+      debugPrint('[Crypto] Failed to fetch peer identity key: $e');
+      return null;
+    }
+  }
+
+  /// Get the local identity public key bytes.
+  Future<Uint8List?> getIdentityPublicKey() async {
+    if (_identityKeyPair == null) return null;
+    final pub = await _identityKeyPair!.extractPublicKey();
+    return Uint8List.fromList(pub.bytes);
   }
 
   Future<void> _saveSigningKey(SecureKeyStore store) async {
@@ -253,12 +384,23 @@ class CryptoService {
     final signingPub = await _signingKeyPair!.extractPublicKey();
     final signingPubB64 = base64Encode(signingPub.bytes);
 
-    // Generate one-time prekeys
+    // Generate one-time prekeys and persist private keys
+    final store = SecureKeyStore.instance;
     final otps = <Map<String, dynamic>>[];
     for (var i = 0; i < 10; i++) {
       final otpPair = await _x25519.newKeyPair();
       final otpPub = await otpPair.extractPublicKey();
-      otps.add({'key_id': i, 'public_key': base64Encode(otpPub.bytes)});
+      final otpPrivBytes = await (otpPair as SimpleKeyPairData)
+          .extractPrivateKeyBytes();
+
+      // Persist OTP key pair keyed by key_id for lookup during decryption
+      final pubB64 = base64Encode(otpPub.bytes);
+      await store.write(
+        '$_otpPrivatePrefix$i',
+        jsonEncode({'private': base64Encode(otpPrivBytes), 'public': pubB64}),
+      );
+
+      otps.add({'key_id': i, 'public_key': pubB64});
     }
 
     final body = jsonEncode({
@@ -351,17 +493,38 @@ class CryptoService {
       type: KeyPairType.x25519,
     );
 
-    // NOTE: One-time prekeys are not used because OTP private keys are not
-    // persisted on the client. Both Alice and Bob must use 3-DH only so the
-    // shared secrets match. OTPs are still uploaded/stored server-side for
-    // future use once private-key persistence is implemented.
+    // Cache peer identity key for safety number generation
+    final peerStore = SecureKeyStore.instance;
+    await peerStore.write(
+      '$_peerIdentityPrefix$peerUserId',
+      data['identity_key'] as String,
+    );
 
-    // Perform X3DH as Alice (initiator) -- 3-DH only (no one-time prekey)
+    // Extract one-time prekey if the server provided one (4-DH)
+    SimplePublicKey? bobOneTimePrekey;
+    int? otpKeyId;
+    final otpData = data['one_time_prekey'] as Map<String, dynamic>?;
+    if (otpData != null) {
+      final otpPubB64 = otpData['public_key'] as String?;
+      otpKeyId = otpData['key_id'] as int?;
+      if (otpPubB64 != null) {
+        bobOneTimePrekey = SimplePublicKey(
+          base64Decode(otpPubB64),
+          type: KeyPairType.x25519,
+        );
+      }
+    }
+
+    // Perform X3DH as Alice (initiator) -- 4-DH with OTP if available
     final x3dhResult = await X3DH.initiate(
       aliceIdentity: _identityKeyPair!,
       bobIdentityKey: bobIdentityKey,
       bobSignedPrekey: bobSignedPrekey,
+      bobOneTimePrekey: bobOneTimePrekey,
     );
+
+    // Track which OTP key ID was used so we can include it in the wire format
+    _lastOtpKeyId = otpKeyId;
 
     // Initialize Double Ratchet as Alice.
     // Bob's signed prekey serves as his initial ratchet public key.
@@ -378,8 +541,10 @@ class CryptoService {
   }
 
   // Magic byte prefix for initial messages that include X3DH key exchange data.
-  // Format: [0xEC, 0x01] || alice_identity_pub (32) || alice_ephemeral_pub (32) || session_wire
-  static const _initialMsgMagic = [0xEC, 0x01];
+  // V1: [0xEC, 0x01] || identity(32) || ephemeral(32) || session_wire (no OTP)
+  // V2: [0xEC, 0x02] || identity(32) || ephemeral(32) || otp_key_id(4 LE) || session_wire (with OTP)
+  static const _initialMsgMagicV1 = [0xEC, 0x01];
+  static const _initialMsgMagicV2 = [0xEC, 0x02];
 
   /// Encrypt a plaintext message for a specific peer.
   ///
@@ -394,16 +559,31 @@ class CryptoService {
 
     Uint8List finalWire;
     if (isNewSession && _lastX3dhResult != null) {
-      // First message: prepend magic + identity + ephemeral keys
       final idPub = (await _identityKeyPair!.extractPublicKey()).bytes;
       final ephPub = _lastX3dhResult!.ephemeralPublic.bytes;
-      finalWire = Uint8List(2 + 32 + 32 + wire.length);
-      finalWire[0] = _initialMsgMagic[0];
-      finalWire[1] = _initialMsgMagic[1];
-      finalWire.setRange(2, 34, Uint8List.fromList(idPub));
-      finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
-      finalWire.setRange(66, finalWire.length, wire);
-      _lastX3dhResult = null; // Clear after use
+
+      if (_lastOtpKeyId != null) {
+        // V2 format: includes OTP key ID so Bob can look up the right private key
+        finalWire = Uint8List(2 + 32 + 32 + 4 + wire.length);
+        finalWire[0] = _initialMsgMagicV2[0];
+        finalWire[1] = _initialMsgMagicV2[1];
+        finalWire.setRange(2, 34, Uint8List.fromList(idPub));
+        finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
+        final bd = ByteData.sublistView(finalWire);
+        bd.setInt32(66, _lastOtpKeyId!, Endian.little);
+        finalWire.setRange(70, finalWire.length, wire);
+      } else {
+        // V1 format: no OTP used (3-DH)
+        finalWire = Uint8List(2 + 32 + 32 + wire.length);
+        finalWire[0] = _initialMsgMagicV1[0];
+        finalWire[1] = _initialMsgMagicV1[1];
+        finalWire.setRange(2, 34, Uint8List.fromList(idPub));
+        finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
+        finalWire.setRange(66, finalWire.length, wire);
+      }
+
+      _lastX3dhResult = null;
+      _lastOtpKeyId = null;
     } else {
       finalWire = wire;
     }
@@ -419,41 +599,99 @@ class CryptoService {
   Future<String> decryptMessage(String peerUserId, String ciphertextB64) async {
     final fullWire = Uint8List.fromList(base64Decode(ciphertextB64));
 
-    // Check for initial message magic prefix
-    if (fullWire.length > 66 &&
-        fullWire[0] == _initialMsgMagic[0] &&
-        fullWire[1] == _initialMsgMagic[1] &&
-        !_sessions.containsKey(peerUserId)) {
+    // Check for initial message magic prefix (V1 or V2)
+    final isV1 =
+        fullWire.length > 66 &&
+        fullWire[0] == _initialMsgMagicV1[0] &&
+        fullWire[1] == _initialMsgMagicV1[1];
+    final isV2 =
+        fullWire.length > 70 &&
+        fullWire[0] == _initialMsgMagicV2[0] &&
+        fullWire[1] == _initialMsgMagicV2[1];
+    if ((isV1 || isV2) && !_sessions.containsKey(peerUserId)) {
       // This is an initial message -- establish session as Bob
+      final aliceIdentityBytes = fullWire.sublist(2, 34);
       final aliceIdentityPub = SimplePublicKey(
-        fullWire.sublist(2, 34),
+        aliceIdentityBytes,
         type: KeyPairType.x25519,
       );
       final aliceEphemeralPub = SimplePublicKey(
         fullWire.sublist(34, 66),
         type: KeyPairType.x25519,
       );
-      final sessionWire = fullWire.sublist(66);
+
+      // V2 includes a 4-byte OTP key ID after the ephemeral key
+      SimpleKeyPair? bobOtp;
+      final Uint8List sessionWire;
+      if (isV2) {
+        final bd = ByteData.sublistView(fullWire);
+        final otpKeyId = bd.getInt32(66, Endian.little);
+        sessionWire = fullWire.sublist(70);
+        // Look up the OTP key pair by key ID
+        bobOtp = await _loadOtpPrivateKey(otpKeyId);
+        if (bobOtp != null) {
+          debugPrint('[Crypto] Using OTP key_id=$otpKeyId for 4-DH');
+        } else {
+          debugPrint(
+            '[Crypto] OTP key_id=$otpKeyId not found -- 3-DH fallback',
+          );
+        }
+      } else {
+        sessionWire = fullWire.sublist(66);
+      }
+
+      // Cache peer identity key for safety number generation
+      final peerStore = SecureKeyStore.instance;
+      await peerStore.write(
+        '$_peerIdentityPrefix$peerUserId',
+        base64Encode(aliceIdentityBytes),
+      );
 
       // Compute X3DH as Bob (responder)
       if (_signedPrekeyPair == null) await init();
-      final sharedSecret = await X3DH.respond(
-        bobIdentity: _identityKeyPair!,
-        bobSignedPrekey: _signedPrekeyPair!,
-        aliceIdentityKey: aliceIdentityPub,
-        aliceEphemeralKey: aliceEphemeralPub,
-      );
+
+      // Try current signed prekey first, then fall back to previous
+      // in case the peer fetched the old bundle before rotation.
+      Uint8List sharedSecret;
+      SimpleKeyPair prekeyToUse;
+      try {
+        sharedSecret = await X3DH.respond(
+          bobIdentity: _identityKeyPair!,
+          bobSignedPrekey: _signedPrekeyPair!,
+          bobOneTimePrekey: bobOtp,
+          aliceIdentityKey: aliceIdentityPub,
+          aliceEphemeralKey: aliceEphemeralPub,
+        );
+        prekeyToUse = _signedPrekeyPair!;
+      } catch (_) {
+        // Try previous signed prekey
+        final prevPrekey = await _loadPreviousSignedPrekey();
+        if (prevPrekey == null) rethrow;
+        sharedSecret = await X3DH.respond(
+          bobIdentity: _identityKeyPair!,
+          bobSignedPrekey: prevPrekey,
+          bobOneTimePrekey: bobOtp,
+          aliceIdentityKey: aliceIdentityPub,
+          aliceEphemeralKey: aliceEphemeralPub,
+        );
+        prekeyToUse = prevPrekey;
+      }
 
       // Initialize Double Ratchet as Bob
-      final session = await SignalSession.initBob(
-        sharedSecret,
-        _signedPrekeyPair!,
-      );
+      final session = await SignalSession.initBob(sharedSecret, prekeyToUse);
 
       // Decrypt the actual message
       final plainBytes = await session.decrypt(sessionWire);
       _sessions[peerUserId] = session;
       await _saveSession(peerUserId, session);
+
+      // Consume the OTP -- delete after successful use (one-time)
+      if (bobOtp != null && isV2) {
+        final bd2 = ByteData.sublistView(fullWire);
+        final consumedId = bd2.getInt32(66, Endian.little);
+        await _deleteOtpPrivateKey(consumedId);
+      }
+
       return utf8.decode(plainBytes);
     }
 
@@ -503,7 +741,7 @@ class CryptoService {
     }
     final allEntries = await store.readAll();
     for (final key in allEntries.keys) {
-      if (key.startsWith(_sessionPrefix)) {
+      if (key.startsWith(_sessionPrefix) || key.startsWith(_otpPrivatePrefix)) {
         await store.delete(key);
       }
     }
@@ -513,6 +751,25 @@ class CryptoService {
     _signedPrekeyPair = null;
     await init(); // Generates new keys, sets _keysAreFresh = true
     await uploadKeys();
+  }
+
+  /// Load the previous signed prekey pair from secure storage.
+  ///
+  /// Returns null if no previous prekey is stored.
+  Future<SimpleKeyPair?> _loadPreviousSignedPrekey() async {
+    final store = SecureKeyStore.instance;
+    final prevPriv = await store.read(_signedPrekeyPreviousPref);
+    final prevPub = await store.read(_signedPrekeyPreviousPubPref);
+    if (prevPriv == null || prevPub == null) return null;
+
+    return SimpleKeyPairData(
+      base64Decode(prevPriv),
+      publicKey: SimplePublicKey(
+        base64Decode(prevPub),
+        type: KeyPairType.x25519,
+      ),
+      type: KeyPairType.x25519,
+    );
   }
 
   /// Clear all stored keys (for logout).
@@ -527,9 +784,142 @@ class CryptoService {
     }
     final allEntries = await store.readAll();
     for (final key in allEntries.keys) {
-      if (key.startsWith(_sessionPrefix)) {
+      if (key.startsWith(_sessionPrefix) ||
+          key.startsWith(_peerIdentityPrefix) ||
+          key.startsWith(_otpPrivatePrefix)) {
         await store.delete(key);
       }
     }
+  }
+
+  // -----------------------------------------------------------------------
+  // OTP private key persistence
+  // -----------------------------------------------------------------------
+
+  /// Load a one-time prekey private key by key_id from secure storage.
+  Future<SimpleKeyPair?> _loadOtpPrivateKey(int keyId) async {
+    final store = SecureKeyStore.instance;
+    final raw = await store.read('$_otpPrivatePrefix$keyId');
+    if (raw == null) return null;
+
+    try {
+      final data = jsonDecode(raw) as Map<String, dynamic>;
+      final privBytes = base64Decode(data['private'] as String);
+      final pubBytes = base64Decode(data['public'] as String);
+      return SimpleKeyPairData(
+        privBytes,
+        publicKey: SimplePublicKey(pubBytes, type: KeyPairType.x25519),
+        type: KeyPairType.x25519,
+      );
+    } catch (e) {
+      debugPrint('[Crypto] Failed to load OTP key_id=$keyId: $e');
+      return null;
+    }
+  }
+
+  /// Delete a consumed one-time prekey from secure storage.
+  Future<void> _deleteOtpPrivateKey(int keyId) async {
+    final store = SecureKeyStore.instance;
+    await store.delete('$_otpPrivatePrefix$keyId');
+    debugPrint('[Crypto] Consumed and deleted OTP key_id=$keyId');
+  }
+
+  // -----------------------------------------------------------------------
+  // Group key wrapping: encrypt/decrypt a symmetric key for a specific user
+  // -----------------------------------------------------------------------
+
+  static final _aesGcm = AesGcm.with256bits();
+  static final _hkdf = Hkdf(hmac: Hmac.sha256(), outputLength: 32);
+
+  /// Encrypt [plaintext] for a specific recipient using their X25519 identity
+  /// public key. Uses ECDH + HKDF + AES-256-GCM.
+  ///
+  /// Returns base64(ephemeral_pub(32) || nonce(12) || ciphertext || tag(16)).
+  Future<String> encryptForUser(
+    Uint8List plaintext,
+    Uint8List recipientPublicKeyBytes,
+  ) async {
+    if (_identityKeyPair == null) await init();
+
+    // Generate ephemeral key pair for this encryption
+    final ephemeral = await _x25519.newKeyPair();
+    final ephPub = await ephemeral.extractPublicKey();
+
+    // ECDH with recipient's identity public key
+    final recipientPub = SimplePublicKey(
+      recipientPublicKeyBytes,
+      type: KeyPairType.x25519,
+    );
+    final shared = await _x25519.sharedSecretKey(
+      keyPair: ephemeral,
+      remotePublicKey: recipientPub,
+    );
+    final sharedBytes = await shared.extractBytes();
+
+    // Derive AES key via HKDF
+    final derived = await _hkdf.deriveKey(
+      secretKey: SecretKeyData(sharedBytes),
+      nonce: Uint8List(32),
+      info: 'EchoGroupKeyWrap'.codeUnits,
+    );
+    final aesKey = SecretKey(await derived.extractBytes());
+
+    // Encrypt
+    final box = await _aesGcm.encrypt(plaintext, secretKey: aesKey);
+
+    // Wire: ephemeral_pub(32) || nonce(12) || ciphertext || tag(16)
+    final nonce = Uint8List.fromList(box.nonce);
+    final ct = Uint8List.fromList(box.cipherText);
+    final mac = Uint8List.fromList(box.mac.bytes);
+    final wire = Uint8List(32 + 12 + ct.length + 16);
+    wire.setRange(0, 32, Uint8List.fromList(ephPub.bytes));
+    wire.setRange(32, 44, nonce);
+    wire.setRange(44, 44 + ct.length, ct);
+    wire.setRange(44 + ct.length, wire.length, mac);
+
+    return base64Encode(wire);
+  }
+
+  /// Decrypt data that was encrypted with [encryptForUser] using our identity
+  /// private key.
+  ///
+  /// [ciphertextB64] is base64(ephemeral_pub(32) || nonce(12) || ct || tag(16)).
+  Future<Uint8List> decryptFromUser(String ciphertextB64) async {
+    if (_identityKeyPair == null) await init();
+
+    final wire = Uint8List.fromList(base64Decode(ciphertextB64));
+    if (wire.length < 32 + 12 + 16) {
+      throw FormatException(
+        'encryptForUser ciphertext too short: ${wire.length} bytes',
+      );
+    }
+
+    final ephPub = SimplePublicKey(
+      wire.sublist(0, 32),
+      type: KeyPairType.x25519,
+    );
+    final nonce = wire.sublist(32, 44);
+    final ct = wire.sublist(44, wire.length - 16);
+    final mac = Mac(wire.sublist(wire.length - 16));
+
+    // ECDH with the ephemeral key
+    final shared = await _x25519.sharedSecretKey(
+      keyPair: _identityKeyPair!,
+      remotePublicKey: ephPub,
+    );
+    final sharedBytes = await shared.extractBytes();
+
+    // Derive AES key via HKDF (same parameters as encrypt)
+    final derived = await _hkdf.deriveKey(
+      secretKey: SecretKeyData(sharedBytes),
+      nonce: Uint8List(32),
+      info: 'EchoGroupKeyWrap'.codeUnits,
+    );
+    final aesKey = SecretKey(await derived.extractBytes());
+
+    // Decrypt
+    final box = SecretBox(ct, nonce: nonce, mac: mac);
+    final plaintext = await _aesGcm.decrypt(box, secretKey: aesKey);
+    return Uint8List.fromList(plaintext);
   }
 }

--- a/apps/client/lib/src/services/group_crypto_service.dart
+++ b/apps/client/lib/src/services/group_crypto_service.dart
@@ -1,6 +1,11 @@
-/// AES-256-GCM group encryption service.
+/// AES-256-GCM group encryption service with per-member key distribution.
 ///
-/// Each group conversation has a symmetric key that all members share.
+/// Each group conversation has a symmetric AES key shared by all members.
+/// Instead of uploading the raw key to the server, the key is encrypted
+/// individually for each member using their X25519 identity public key
+/// (ECDH + HKDF + AES-GCM wrapping). The server only ever sees per-member
+/// encrypted envelopes and cannot recover the plaintext group key.
+///
 /// Messages are encrypted with a random 12-byte nonce; the wire format is
 /// `nonce(12) || ciphertext || tag(16)`, base64-encoded for transport.
 ///
@@ -13,6 +18,7 @@ import 'package:cryptography/cryptography.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
+import 'crypto_service.dart';
 import 'secure_key_store.dart';
 
 /// Prefix used to mark group-encrypted payloads so we can distinguish them
@@ -22,6 +28,10 @@ const groupEncryptedPrefix = 'GRP1:';
 class GroupCryptoService {
   final String serverUrl;
   String _token = '';
+
+  /// Reference to the CryptoService for identity key operations and
+  /// per-user encryption/decryption (ECDH key wrapping).
+  CryptoService? _cryptoService;
 
   /// In-memory cache: conversationId -> (version, raw key bytes).
   final Map<String, (int, Uint8List)> _keyCache = {};
@@ -33,6 +43,11 @@ class GroupCryptoService {
   static final _aesGcm = AesGcm.with256bits();
 
   GroupCryptoService({required this.serverUrl});
+
+  /// Set the CryptoService instance for identity key operations.
+  void setCryptoService(CryptoService service) {
+    _cryptoService = service;
+  }
 
   /// Mark a group as unencrypted so [getGroupKey] short-circuits.
   void markUnencrypted(String conversationId) {
@@ -172,6 +187,9 @@ class GroupCryptoService {
 
   /// Fetch the latest group key from the server and cache it.
   ///
+  /// The server returns a per-member encrypted envelope. We decrypt it using
+  /// our identity private key to recover the raw AES group key.
+  ///
   /// Returns `(version, keyBase64)` or null on failure.
   Future<(int, String)?> fetchGroupKey(String conversationId) async {
     try {
@@ -192,23 +210,82 @@ class GroupCryptoService {
       final encryptedKey = data['encrypted_key'] as String;
       final version = data['key_version'] as int;
 
-      await _cacheKey(conversationId, version, encryptedKey);
-      return (version, encryptedKey);
+      // Try to decrypt the envelope using our identity key.
+      // If _cryptoService is available, the encrypted_key is a per-member
+      // envelope that must be unwrapped. If not, assume legacy plaintext key.
+      String rawKeyB64;
+      if (_cryptoService != null && encryptedKey != '__envelope__') {
+        try {
+          final rawKeyBytes = await _cryptoService!.decryptFromUser(
+            encryptedKey,
+          );
+          rawKeyB64 = base64Encode(rawKeyBytes);
+        } catch (e) {
+          // Fallback: treat as legacy plaintext key (migration path)
+          debugPrint(
+            '[GroupCrypto] Envelope decrypt failed, trying as legacy: $e',
+          );
+          rawKeyB64 = encryptedKey;
+        }
+      } else {
+        rawKeyB64 = encryptedKey;
+      }
+
+      await _cacheKey(conversationId, version, rawKeyB64);
+      return (version, rawKeyB64);
     } catch (e) {
       debugPrint('[GroupCrypto] fetchGroupKey error: $e');
       return null;
     }
   }
 
-  /// Generate a new group key and upload it to the server.
+  /// Generate a new group key and upload per-member encrypted envelopes.
+  ///
+  /// For each group member, the raw AES key is encrypted using their identity
+  /// public key via ECDH + HKDF + AES-GCM (CryptoService.encryptForUser).
+  /// The server never sees the plaintext key.
   ///
   /// Returns the new version number, or null on failure.
-  Future<int?> rotateGroupKey(String conversationId) async {
+  Future<int?> rotateGroupKey(
+    String conversationId,
+    List<Map<String, dynamic>> members,
+  ) async {
+    if (_cryptoService == null) {
+      debugPrint('[GroupCrypto] Cannot rotate key: no CryptoService set');
+      return null;
+    }
+
     // Determine next version
     final current = await getGroupKey(conversationId);
     final nextVersion = current != null ? current.$1 + 1 : 1;
 
     final newKey = generateGroupKey();
+    final newKeyBytes = Uint8List.fromList(base64Decode(newKey));
+
+    // Build per-member envelopes
+    final envelopes = <Map<String, dynamic>>[];
+    for (final member in members) {
+      final userId = member['user_id'] as String;
+      final identityKeyB64 = member['identity_key'] as String?;
+
+      if (identityKeyB64 == null) {
+        debugPrint('[GroupCrypto] Skipping member $userId: no identity key');
+        continue;
+      }
+
+      final identityKeyBytes = base64Decode(identityKeyB64);
+      final encryptedEnvelope = await _cryptoService!.encryptForUser(
+        newKeyBytes,
+        Uint8List.fromList(identityKeyBytes),
+      );
+
+      envelopes.add({'user_id': userId, 'encrypted_key': encryptedEnvelope});
+    }
+
+    if (envelopes.isEmpty) {
+      debugPrint('[GroupCrypto] No valid envelopes to upload');
+      return null;
+    }
 
     try {
       final response = await http.post(
@@ -217,7 +294,7 @@ class GroupCryptoService {
           'Authorization': 'Bearer $_token',
           'Content-Type': 'application/json',
         },
-        body: jsonEncode({'encrypted_key': newKey, 'key_version': nextVersion}),
+        body: jsonEncode({'key_version': nextVersion, 'envelopes': envelopes}),
       );
 
       if (response.statusCode != 201) {

--- a/apps/client/lib/src/services/safety_number_service.dart
+++ b/apps/client/lib/src/services/safety_number_service.dart
@@ -1,0 +1,88 @@
+/// Safety number generation for key verification between two peers.
+///
+/// Produces a deterministic 60-digit safety number from two identity public
+/// keys. Both parties compute the same number regardless of who initiates,
+/// because the keys are sorted before hashing.
+///
+/// Follows a similar approach to Signal's safety numbers: each key contributes
+/// 30 digits derived from SHA-512 hashes, giving a collision-resistant
+/// fingerprint that users can compare out-of-band.
+library;
+
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+
+class SafetyNumberService {
+  static final _sha512 = Sha512();
+
+  /// Generate a 60-digit safety number from two identity public keys.
+  ///
+  /// Each key produces 30 digits. The lexicographically lower key always
+  /// comes first so both parties compute the same number.
+  static Future<String> generate(
+    Uint8List myIdentityKey,
+    Uint8List peerIdentityKey,
+  ) async {
+    // Sort keys so both parties compute the same number.
+    final comparison = _compareBytes(myIdentityKey, peerIdentityKey);
+    final first = comparison < 0 ? myIdentityKey : peerIdentityKey;
+    final second = comparison < 0 ? peerIdentityKey : myIdentityKey;
+
+    // Hash each key with SHA-512 using both keys as context.
+    // hash1 = SHA-512(first || second || first)
+    // hash2 = SHA-512(second || first || second)
+    final input1 = Uint8List(first.length + second.length + first.length);
+    input1.setRange(0, first.length, first);
+    input1.setRange(first.length, first.length + second.length, second);
+    input1.setRange(first.length + second.length, input1.length, first);
+
+    final input2 = Uint8List(second.length + first.length + second.length);
+    input2.setRange(0, second.length, second);
+    input2.setRange(second.length, second.length + first.length, first);
+    input2.setRange(second.length + first.length, input2.length, second);
+
+    final hash1 = await _sha512.hash(input1);
+    final hash2 = await _sha512.hash(input2);
+
+    final digits1 = _bytesToDigits(Uint8List.fromList(hash1.bytes), 30);
+    final digits2 = _bytesToDigits(Uint8List.fromList(hash2.bytes), 30);
+
+    return digits1 + digits2;
+  }
+
+  /// Format a 60-digit safety number as groups of 5 for readability.
+  ///
+  /// Example: "12345 67890 12345 67890 ..."
+  static String formatForDisplay(String safetyNumber) {
+    final buffer = StringBuffer();
+    for (var i = 0; i < safetyNumber.length; i += 5) {
+      if (i > 0) buffer.write(' ');
+      buffer.write(safetyNumber.substring(i, min(i + 5, safetyNumber.length)));
+    }
+    return buffer.toString();
+  }
+
+  /// Convert the first [digitCount] digits from hash bytes.
+  ///
+  /// Each byte mod 100 produces 2 digits. We take [digitCount / 2] bytes
+  /// and convert each to a zero-padded 2-digit decimal string.
+  static String _bytesToDigits(Uint8List hashBytes, int digitCount) {
+    final buffer = StringBuffer();
+    final bytesNeeded = digitCount ~/ 2;
+    for (var i = 0; i < bytesNeeded && i < hashBytes.length; i++) {
+      buffer.write((hashBytes[i] % 100).toString().padLeft(2, '0'));
+    }
+    return buffer.toString();
+  }
+
+  /// Lexicographic byte comparison.
+  static int _compareBytes(Uint8List a, Uint8List b) {
+    final len = min(a.length, b.length);
+    for (var i = 0; i < len; i++) {
+      if (a[i] != b[i]) return a[i] - b[i];
+    }
+    return a.length - b.length;
+  }
+}

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -11,6 +11,7 @@ import '../providers/chat_provider.dart';
 import '../providers/crypto_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
+import '../screens/safety_number_screen.dart';
 import '../screens/user_profile_screen.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
@@ -174,9 +175,13 @@ class ChatHeaderBar extends ConsumerWidget {
 
     return [
       if (!conv.isGroup)
-        const Tooltip(
-          message: 'End-to-end encrypted',
-          child: Icon(Icons.lock_outlined, size: 20, color: EchoTheme.online),
+        IconButton(
+          icon: const Icon(Icons.lock_outlined, size: 20),
+          color: EchoTheme.online,
+          tooltip: 'Verify safety number',
+          onPressed: () => _openSafetyNumber(context, ref, conv),
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
         ),
       if (!conv.isGroup && conv.isEncrypted)
         IconButton(
@@ -288,6 +293,26 @@ class ChatHeaderBar extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+
+  void _openSafetyNumber(
+    BuildContext context,
+    WidgetRef ref,
+    Conversation conv,
+  ) {
+    final peer = conv.members.where((m) => m.userId != myUserId).firstOrNull;
+    if (peer == null) return;
+
+    final authState = ref.read(authProvider);
+    final myName = authState.username ?? 'You';
+
+    SafetyNumberScreen.show(
+      context,
+      ref,
+      peerUserId: peer.userId,
+      peerUsername: peer.username,
+      myUsername: myName,
     );
   }
 

--- a/apps/server/migrations/20260406100000_group_key_envelopes.sql
+++ b/apps/server/migrations/20260406100000_group_key_envelopes.sql
@@ -1,0 +1,17 @@
+-- Per-member encrypted group key distribution.
+-- Instead of storing a single plaintext key per version, each member gets
+-- the group key encrypted specifically for them using their identity public key.
+-- The server never sees the raw AES group key.
+
+CREATE TABLE IF NOT EXISTS group_key_envelopes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    key_version INT NOT NULL,
+    recipient_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    encrypted_key TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(conversation_id, key_version, recipient_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_key_envelopes_recipient
+    ON group_key_envelopes(conversation_id, recipient_user_id, key_version DESC);

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -248,3 +248,84 @@ pub async fn get_group_key(
     .fetch_optional(pool)
     .await
 }
+
+// -------------------------------------------------------------------------
+// Per-member encrypted group key envelopes
+// -------------------------------------------------------------------------
+
+/// Row returned by group_key_envelopes queries.
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct GroupKeyEnvelopeRow {
+    pub id: Uuid,
+    pub conversation_id: Uuid,
+    pub key_version: i32,
+    pub recipient_user_id: Uuid,
+    pub encrypted_key: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Store an encrypted group key envelope for a specific recipient.
+pub async fn store_group_key_envelope(
+    pool: &PgPool,
+    conversation_id: Uuid,
+    key_version: i32,
+    recipient_user_id: Uuid,
+    encrypted_key: &str,
+) -> Result<GroupKeyEnvelopeRow, sqlx::Error> {
+    sqlx::query_as::<_, GroupKeyEnvelopeRow>(
+        "INSERT INTO group_key_envelopes \
+             (conversation_id, key_version, recipient_user_id, encrypted_key) \
+         VALUES ($1, $2, $3, $4) \
+         ON CONFLICT (conversation_id, key_version, recipient_user_id) \
+         DO UPDATE SET encrypted_key = $4 \
+         RETURNING id, conversation_id, key_version, recipient_user_id, \
+                   encrypted_key, created_at",
+    )
+    .bind(conversation_id)
+    .bind(key_version)
+    .bind(recipient_user_id)
+    .bind(encrypted_key)
+    .fetch_one(pool)
+    .await
+}
+
+/// Get the latest group key envelope for a specific user in a conversation.
+pub async fn get_my_group_key_envelope(
+    pool: &PgPool,
+    conversation_id: Uuid,
+    user_id: Uuid,
+) -> Result<Option<GroupKeyEnvelopeRow>, sqlx::Error> {
+    sqlx::query_as::<_, GroupKeyEnvelopeRow>(
+        "SELECT id, conversation_id, key_version, recipient_user_id, \
+                encrypted_key, created_at \
+         FROM group_key_envelopes \
+         WHERE conversation_id = $1 AND recipient_user_id = $2 \
+         ORDER BY key_version DESC \
+         LIMIT 1",
+    )
+    .bind(conversation_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Get a specific version of a group key envelope for a user.
+pub async fn get_my_group_key_envelope_version(
+    pool: &PgPool,
+    conversation_id: Uuid,
+    user_id: Uuid,
+    key_version: i32,
+) -> Result<Option<GroupKeyEnvelopeRow>, sqlx::Error> {
+    sqlx::query_as::<_, GroupKeyEnvelopeRow>(
+        "SELECT id, conversation_id, key_version, recipient_user_id, \
+                encrypted_key, created_at \
+         FROM group_key_envelopes \
+         WHERE conversation_id = $1 AND recipient_user_id = $2 \
+               AND key_version = $3",
+    )
+    .bind(conversation_id)
+    .bind(user_id)
+    .bind(key_version)
+    .fetch_optional(pool)
+    .await
+}

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -158,6 +158,10 @@ async fn delete_group_dependents(pool: &PgPool, gid: uuid::Uuid) {
         .bind(gid)
         .execute(pool)
         .await;
+    let _ = sqlx::query("DELETE FROM group_key_envelopes WHERE conversation_id = $1")
+        .bind(gid)
+        .execute(pool)
+        .await;
     let _ = sqlx::query("DELETE FROM group_keys WHERE conversation_id = $1")
         .bind(gid)
         .execute(pool)

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -20,11 +20,18 @@ use super::AppState;
 // -------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
-pub struct UploadGroupKeyRequest {
-    /// Base64-encoded encrypted group key material.
+pub struct KeyEnvelope {
+    pub user_id: Uuid,
     pub encrypted_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UploadGroupKeyRequest {
     /// The version number for this key (must be higher than any existing).
     pub key_version: i32,
+    /// Per-member encrypted envelopes. Each contains the group AES key
+    /// encrypted specifically for that member using their identity public key.
+    pub envelopes: Vec<KeyEnvelope>,
 }
 
 #[derive(Debug, Serialize)]
@@ -50,8 +57,29 @@ impl GroupKeyResponse {
     }
 }
 
+#[derive(Debug, Serialize)]
+pub struct GroupKeyEnvelopeResponse {
+    pub id: Uuid,
+    pub conversation_id: Uuid,
+    pub key_version: i32,
+    pub encrypted_key: String,
+    pub created_at: String,
+}
+
+impl GroupKeyEnvelopeResponse {
+    fn from_row(row: db::keys::GroupKeyEnvelopeRow) -> Self {
+        Self {
+            id: row.id,
+            conversation_id: row.conversation_id,
+            key_version: row.key_version,
+            encrypted_key: row.encrypted_key,
+            created_at: row.created_at.to_rfc3339(),
+        }
+    }
+}
+
 // -------------------------------------------------------------------------
-// POST /api/groups/:id/keys -- Upload a new group key (owner/admin only)
+// POST /api/groups/:id/keys -- Upload group key envelopes (owner/admin only)
 // -------------------------------------------------------------------------
 
 pub async fn upload_group_key(
@@ -76,8 +104,8 @@ pub async fn upload_group_key(
         ));
     }
 
-    if body.encrypted_key.is_empty() {
-        return Err(AppError::bad_request("encrypted_key cannot be empty"));
+    if body.envelopes.is_empty() {
+        return Err(AppError::bad_request("envelopes array cannot be empty"));
     }
     if body.key_version < 1 {
         return Err(AppError::bad_request(
@@ -85,11 +113,21 @@ pub async fn upload_group_key(
         ));
     }
 
+    for envelope in &body.envelopes {
+        if envelope.encrypted_key.is_empty() {
+            return Err(AppError::bad_request(
+                "encrypted_key cannot be empty in envelope",
+            ));
+        }
+    }
+
+    // Store a sentinel row in group_keys for version tracking (encrypted_key
+    // is a placeholder -- the real per-member keys live in group_key_envelopes).
     let row = db::keys::store_group_key(
         &state.pool,
         group_id,
         body.key_version,
-        &body.encrypted_key,
+        "__envelope__",
         auth.user_id,
     )
     .await
@@ -102,6 +140,25 @@ pub async fn upload_group_key(
             AppError::internal("Failed to store group key")
         }
     })?;
+
+    // Store per-member envelopes
+    for envelope in &body.envelopes {
+        db::keys::store_group_key_envelope(
+            &state.pool,
+            group_id,
+            body.key_version,
+            envelope.user_id,
+            &envelope.encrypted_key,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "DB error storing envelope for user {}: {e:?}",
+                envelope.user_id
+            );
+            AppError::internal("Failed to store group key envelope")
+        })?;
+    }
 
     // Broadcast key_rotated event to all group members
     let member_ids = db::groups::get_conversation_member_ids(&state.pool, group_id)
@@ -129,7 +186,7 @@ pub async fn upload_group_key(
 }
 
 // -------------------------------------------------------------------------
-// GET /api/groups/:id/keys/latest -- Get latest group key
+// GET /api/groups/:id/keys/latest -- Get latest group key envelope for me
 // -------------------------------------------------------------------------
 
 pub async fn get_latest_group_key(
@@ -148,6 +205,19 @@ pub async fn get_latest_group_key(
         return Err(AppError::unauthorized("Not a member of this group"));
     }
 
+    // Try envelope-based lookup first (new E2E scheme)
+    let envelope = db::keys::get_my_group_key_envelope(&state.pool, group_id, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in get_latest_group_key/envelope: {e:?}");
+            AppError::internal("Database error")
+        })?;
+
+    if let Some(env) = envelope {
+        return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
+    }
+
+    // Fallback: legacy group_keys table (for groups that haven't rotated yet)
     let row = db::keys::get_latest_group_key(&state.pool, group_id)
         .await
         .map_err(|e| {
@@ -156,7 +226,7 @@ pub async fn get_latest_group_key(
         })?
         .ok_or_else(|| AppError::bad_request("No group key found for this conversation"))?;
 
-    Ok(Json(GroupKeyResponse::from_row(row)))
+    Ok(Json(GroupKeyResponse::from_row(row)).into_response())
 }
 
 // -------------------------------------------------------------------------
@@ -179,6 +249,20 @@ pub async fn get_group_key_version(
         return Err(AppError::unauthorized("Not a member of this group"));
     }
 
+    // Try envelope-based lookup first
+    let envelope =
+        db::keys::get_my_group_key_envelope_version(&state.pool, group_id, auth.user_id, version)
+            .await
+            .map_err(|e| {
+                tracing::error!("DB error in get_group_key_version/envelope: {e:?}");
+                AppError::internal("Database error")
+            })?;
+
+    if let Some(env) = envelope {
+        return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
+    }
+
+    // Fallback: legacy group_keys table
     let row = db::keys::get_group_key(&state.pool, group_id, version)
         .await
         .map_err(|e| {
@@ -187,5 +271,5 @@ pub async fn get_group_key_version(
         })?
         .ok_or_else(|| AppError::bad_request("Group key version not found"))?;
 
-    Ok(Json(GroupKeyResponse::from_row(row)))
+    Ok(Json(GroupKeyResponse::from_row(row)).into_response())
 }


### PR DESCRIPTION
## Summary — Sprint 11: Crypto Redesign

### Group Encryption (server never sees keys)
- New `group_key_envelopes` table: per-member encrypted keys via ECDH + AES-GCM wrapping
- Server stores only encrypted envelopes, not raw AES keys
- Legacy plaintext key fallback for migration compatibility
- Key rotation generates new envelopes for all members

### One-Time Prekey Persistence (full 4-DH X3DH)
- OTP private keys persisted in SecureKeyStore
- V2 wire format: includes OTP key ID for 4-DH handshake
- OTP consumed and deleted after single use
- Backward compatible with V1 (3-DH) messages

### Safety Numbers
- 60-digit safety number from SHA-512 of identity keys
- Verification screen with QR code (qr_flutter) + formatted digits
- Lock icon in DM header opens verification
- Verification state persisted

### Signed Prekey Rotation
- Auto-rotates every 7 days on app init
- 14-day grace period for old prekey
- Previous prekey stored for decryption fallback

## Test plan
- [x] 31 crypto tests pass (Signal Protocol + group)
- [x] 224 total tests pass
- [x] cargo clippy clean
- [x] flutter analyze clean