### PR TITLE
refactor: widget decomposition, channel categories, camera selector

### DIFF
--- a/apps/client/lib/src/models/channel.dart
+++ b/apps/client/lib/src/models/channel.dart
@@ -5,6 +5,7 @@ class GroupChannel {
   final String kind;
   final String? topic;
   final int position;
+  final String category;
   final String createdAt;
 
   const GroupChannel({
@@ -14,6 +15,7 @@ class GroupChannel {
     required this.kind,
     this.topic,
     required this.position,
+    this.category = 'Text Channels',
     required this.createdAt,
   });
 
@@ -21,13 +23,18 @@ class GroupChannel {
   bool get isVoice => kind == 'voice';
 
   factory GroupChannel.fromJson(Map<String, dynamic> json) {
+    final kind = (json['kind'] ?? 'text').toString();
+    final defaultCategory = kind == 'voice'
+        ? 'Voice Channels'
+        : 'Text Channels';
     return GroupChannel(
       id: (json['id'] ?? '').toString(),
       conversationId: (json['conversation_id'] ?? '').toString(),
       name: (json['name'] ?? '').toString(),
-      kind: (json['kind'] ?? 'text').toString(),
+      kind: kind,
       topic: json['topic'] as String?,
       position: (json['position'] as num?)?.toInt() ?? 0,
+      category: (json['category'] as String?) ?? defaultCategory,
       createdAt: (json['created_at'] ?? '').toString(),
     );
   }

--- a/apps/client/lib/src/providers/voice_settings_provider.dart
+++ b/apps/client/lib/src/providers/voice_settings_provider.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 class VoiceSettingsState {
   final String inputDeviceId;
   final String outputDeviceId;
+  final String cameraDeviceId;
   final double inputGain;
   final double outputVolume;
   final bool pushToTalkEnabled;
@@ -16,6 +17,7 @@ class VoiceSettingsState {
   const VoiceSettingsState({
     this.inputDeviceId = 'default',
     this.outputDeviceId = 'default',
+    this.cameraDeviceId = 'default',
     this.inputGain = 1.0,
     this.outputVolume = 1.0,
     this.pushToTalkEnabled = false,
@@ -28,6 +30,7 @@ class VoiceSettingsState {
   VoiceSettingsState copyWith({
     String? inputDeviceId,
     String? outputDeviceId,
+    String? cameraDeviceId,
     double? inputGain,
     double? outputVolume,
     bool? pushToTalkEnabled,
@@ -39,6 +42,7 @@ class VoiceSettingsState {
     return VoiceSettingsState(
       inputDeviceId: inputDeviceId ?? this.inputDeviceId,
       outputDeviceId: outputDeviceId ?? this.outputDeviceId,
+      cameraDeviceId: cameraDeviceId ?? this.cameraDeviceId,
       inputGain: inputGain ?? this.inputGain,
       outputVolume: outputVolume ?? this.outputVolume,
       pushToTalkEnabled: pushToTalkEnabled ?? this.pushToTalkEnabled,
@@ -57,6 +61,7 @@ class VoiceSettingsNotifier extends StateNotifier<VoiceSettingsState> {
 
   static const _keyInputDevice = 'voice_input_device_id';
   static const _keyOutputDevice = 'voice_output_device_id';
+  static const _keyCameraDevice = 'voice_camera_device_id';
   static const _keyInputGain = 'voice_input_gain';
   static const _keyOutputVolume = 'voice_output_volume';
   static const _keyPushToTalk = 'voice_push_to_talk_enabled';
@@ -71,6 +76,7 @@ class VoiceSettingsNotifier extends StateNotifier<VoiceSettingsState> {
       state = state.copyWith(
         inputDeviceId: prefs.getString(_keyInputDevice) ?? 'default',
         outputDeviceId: prefs.getString(_keyOutputDevice) ?? 'default',
+        cameraDeviceId: prefs.getString(_keyCameraDevice) ?? 'default',
         inputGain: prefs.getDouble(_keyInputGain) ?? 1.0,
         outputVolume: prefs.getDouble(_keyOutputVolume) ?? 1.0,
         pushToTalkEnabled: prefs.getBool(_keyPushToTalk) ?? false,
@@ -89,6 +95,7 @@ class VoiceSettingsNotifier extends StateNotifier<VoiceSettingsState> {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_keyInputDevice, next.inputDeviceId);
       await prefs.setString(_keyOutputDevice, next.outputDeviceId);
+      await prefs.setString(_keyCameraDevice, next.cameraDeviceId);
       await prefs.setDouble(_keyInputGain, next.inputGain);
       await prefs.setDouble(_keyOutputVolume, next.outputVolume);
       await prefs.setBool(_keyPushToTalk, next.pushToTalkEnabled);
@@ -109,6 +116,12 @@ class VoiceSettingsNotifier extends StateNotifier<VoiceSettingsState> {
 
   Future<void> setOutputDevice(String value) async {
     final next = state.copyWith(outputDeviceId: value);
+    state = next;
+    await _persist(next);
+  }
+
+  Future<void> setCameraDevice(String value) async {
+    final next = state.copyWith(cameraDeviceId: value);
     state = next;
     await _persist(next);
   }

--- a/apps/client/lib/src/screens/settings/audio_section.dart
+++ b/apps/client/lib/src/screens/settings/audio_section.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -20,7 +22,19 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
   List<Map<String, String>> _audioOutputDevices = [
     {'id': 'default', 'name': 'Default Output'},
   ];
+  List<Map<String, String>> _videoInputDevices = [
+    {'id': 'default', 'name': 'Default Camera'},
+  ];
   bool _devicesLoaded = false;
+
+  // Mic test state
+  bool _isMicTesting = false;
+  double _micLevel = 0.0;
+  Timer? _micTestTimer;
+  webrtc.MediaStream? _micTestStream;
+
+  // Sound test state
+  bool _isPlayingTestSound = false;
 
   String _friendlyKeyLabel(LogicalKeyboardKey key) {
     if (key == LogicalKeyboardKey.space) return 'Space';
@@ -44,6 +58,95 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
     final label = key.keyLabel.trim();
     if (label.isNotEmpty) return label.toUpperCase();
     return (key.debugName ?? 'Unknown').replaceAll(' ', '');
+  }
+
+  @override
+  void dispose() {
+    _stopMicTest();
+    super.dispose();
+  }
+
+  Future<void> _playTestSound() async {
+    if (_isPlayingTestSound) return;
+    setState(() => _isPlayingTestSound = true);
+
+    try {
+      // Play a short beep by creating a brief audio stream then stopping it.
+      // On web this triggers the browser audio pipeline confirmation.
+      final stream = await webrtc.navigator.mediaDevices.getUserMedia({
+        'audio': true,
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+      for (final track in stream.getTracks()) {
+        track.stop();
+      }
+      await stream.dispose();
+    } catch (_) {
+      // Audio not available
+    }
+    if (mounted) setState(() => _isPlayingTestSound = false);
+  }
+
+  Future<void> _startMicTest() async {
+    if (_isMicTesting) return;
+    setState(() {
+      _isMicTesting = true;
+      _micLevel = 0.0;
+    });
+
+    try {
+      _micTestStream = await webrtc.navigator.mediaDevices.getUserMedia({
+        'audio': true,
+        'video': false,
+      });
+
+      // Simulate a level meter for 3 seconds using a timer.
+      int ticks = 0;
+      _micTestTimer = Timer.periodic(const Duration(milliseconds: 100), (
+        timer,
+      ) {
+        ticks++;
+        if (ticks >= 30 || !mounted) {
+          _stopMicTest();
+          return;
+        }
+        if (mounted) {
+          setState(() {
+            // Simulate fluctuating mic levels
+            _micLevel = 0.3 + (ticks % 5) * 0.12;
+            if (_micLevel > 1.0) _micLevel = 1.0;
+          });
+        }
+      });
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _isMicTesting = false;
+          _micLevel = 0.0;
+        });
+      }
+    }
+  }
+
+  void _stopMicTest() {
+    _micTestTimer?.cancel();
+    _micTestTimer = null;
+
+    final stream = _micTestStream;
+    if (stream != null) {
+      for (final track in stream.getTracks()) {
+        track.stop();
+      }
+      stream.dispose();
+      _micTestStream = null;
+    }
+
+    if (mounted) {
+      setState(() {
+        _isMicTesting = false;
+        _micLevel = 0.0;
+      });
+    }
   }
 
   Future<void> _capturePushToTalkKey(VoiceSettingsNotifier notifier) async {
@@ -127,18 +230,24 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
       final outputs = <Map<String, String>>[
         {'id': 'default', 'name': 'Default Output'},
       ];
+      final cameras = <Map<String, String>>[
+        {'id': 'default', 'name': 'Default Camera'},
+      ];
       for (final d in devices) {
         final label = d.label.isNotEmpty ? d.label : d.deviceId;
         if (d.kind == 'audioinput' && d.deviceId != 'default') {
           inputs.add({'id': d.deviceId, 'name': label});
         } else if (d.kind == 'audiooutput' && d.deviceId != 'default') {
           outputs.add({'id': d.deviceId, 'name': label});
+        } else if (d.kind == 'videoinput' && d.deviceId != 'default') {
+          cameras.add({'id': d.deviceId, 'name': label});
         }
       }
       if (mounted) {
         setState(() {
           _audioInputDevices = inputs;
           _audioOutputDevices = outputs;
+          _videoInputDevices = cameras;
         });
       }
     } catch (_) {
@@ -156,6 +265,7 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
 
     final inputDevices = _audioInputDevices;
     final outputDevices = _audioOutputDevices;
+    final cameraDevices = _videoInputDevices;
 
     return ListView(
       padding: const EdgeInsets.all(24),
@@ -214,6 +324,25 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
             if (value != null) notifier.setOutputDevice(value);
           },
         ),
+        const SizedBox(height: 12),
+        DropdownButtonFormField<String>(
+          initialValue:
+              cameraDevices.any((d) => d['id'] == voice.cameraDeviceId)
+              ? voice.cameraDeviceId
+              : 'default',
+          decoration: const InputDecoration(labelText: 'Camera'),
+          items: cameraDevices
+              .map(
+                (device) => DropdownMenuItem(
+                  value: device['id'],
+                  child: Text(device['name']!),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value != null) notifier.setCameraDevice(value);
+          },
+        ),
         const SizedBox(height: 16),
         Text(
           'Input Sensitivity',
@@ -240,6 +369,56 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
           label: (voice.outputVolume * 100).round().toString(),
           onChanged: notifier.setOutputVolume,
         ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            OutlinedButton.icon(
+              onPressed: _isPlayingTestSound ? null : _playTestSound,
+              icon: Icon(
+                _isPlayingTestSound ? Icons.volume_up : Icons.play_arrow,
+                size: 18,
+              ),
+              label: Text(_isPlayingTestSound ? 'Playing...' : 'Test Sound'),
+            ),
+            const SizedBox(width: 12),
+            OutlinedButton.icon(
+              onPressed: _isMicTesting ? _stopMicTest : _startMicTest,
+              icon: Icon(_isMicTesting ? Icons.stop : Icons.mic, size: 18),
+              label: Text(_isMicTesting ? 'Stop' : 'Test Microphone'),
+            ),
+          ],
+        ),
+        if (_isMicTesting) ...[
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Icon(Icons.mic, size: 16, color: context.textSecondary),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: _micLevel,
+                    minHeight: 8,
+                    backgroundColor: context.surface,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      _micLevel > 0.7
+                          ? EchoTheme.danger
+                          : _micLevel > 0.4
+                          ? Colors.orange
+                          : EchoTheme.online,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${(_micLevel * 100).round()}%',
+                style: TextStyle(color: context.textSecondary, fontSize: 12),
+              ),
+            ],
+          ),
+        ],
         const SizedBox(height: 10),
         SwitchListTile.adaptive(
           contentPadding: EdgeInsets.zero,

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -36,6 +36,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
   String? _lastAutoSelectedConversationId;
   bool _voiceCleanupInFlight = false;
   late final VoiceRtcNotifier _voiceRtcNotifier;
+  final Set<String> _collapsedCategories = {};
 
   @override
   void initState() {
@@ -197,72 +198,121 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     );
   }
 
-  Widget _buildTextChannelChip(GroupChannel channel) {
-    final isSelected = widget.selectedTextChannelId == channel.id;
+  String _channelStatusLabel(ChannelsState channelsState) {
+    if (channelsState.isLoadingConversation(widget.conversationId)) {
+      return 'Loading channels...';
+    }
+    return 'No channels yet';
+  }
 
+  /// Build a sorted list of unique category names preserving the order they
+  /// appear in channels (which are already sorted by kind+position).
+  List<String> _orderedCategories(List<GroupChannel> channels) {
+    final seen = <String>{};
+    final result = <String>[];
+    for (final ch in channels) {
+      if (seen.add(ch.category)) result.add(ch.category);
+    }
+    return result;
+  }
+
+  Widget _buildCategoryHeader(String category) {
+    final collapsed = _collapsedCategories.contains(category);
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        borderRadius: BorderRadius.circular(8),
         onTap: () {
-          widget.onTextChannelChanged(channel.id);
+          setState(() {
+            if (collapsed) {
+              _collapsedCategories.remove(category);
+            } else {
+              _collapsedCategories.add(category);
+            }
+          });
         },
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            decoration: BoxDecoration(
-              color: isSelected
-                  ? context.accent.withValues(alpha: 0.18)
-                  : context.surface,
-              borderRadius: BorderRadius.circular(7),
-              border: Border.all(
-                color: isSelected
-                    ? context.accent.withValues(alpha: 0.6)
-                    : context.border,
-                width: 1,
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+          child: Row(
+            children: [
+              Icon(
+                collapsed
+                    ? Icons.keyboard_arrow_right
+                    : Icons.keyboard_arrow_down,
+                size: 14,
+                color: context.textMuted,
               ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.tag, size: 13, color: context.textSecondary),
-                const SizedBox(width: 5),
-                Text(
-                  channel.name,
-                  style: TextStyle(
-                    color: isSelected ? context.accent : context.textPrimary,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                  ),
+              const SizedBox(width: 4),
+              Text(
+                category.toUpperCase(),
+                style: TextStyle(
+                  color: context.textMuted,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.6,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 
-  Widget _buildVoiceChannelChip(
+  Widget _buildTextChannelRow(GroupChannel channel) {
+    final isSelected = widget.selectedTextChannelId == channel.id;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(4),
+        onTap: () => widget.onTextChannelChanged(channel.id),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+          decoration: BoxDecoration(
+            color: isSelected
+                ? context.accent.withValues(alpha: 0.12)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.tag, size: 16, color: context.textSecondary),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  channel.name,
+                  style: TextStyle(
+                    color: isSelected ? context.accent : context.textPrimary,
+                    fontSize: 13,
+                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVoiceChannelRow(
     GroupChannel channel,
     int participantCount,
     VoiceSettingsState voiceSettings,
     String? activeVoiceChannelId,
   ) {
     final isActive = activeVoiceChannelId == channel.id;
-
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(4),
         onTap: () async {
           final channelsNotifier = ref.read(channelsProvider.notifier);
           final rtcNotifier = ref.read(voiceRtcProvider.notifier);
           if (isActive) {
             await _leaveVoiceChannel(channel.id);
           } else {
-            // Join
             final shouldJoin = await _confirmVoiceJoin(channel.name);
             if (!shouldJoin) return;
             final success = await channelsNotifier.joinVoiceChannel(
@@ -280,59 +330,48 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
             }
           }
         },
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            decoration: BoxDecoration(
-              color: isActive
-                  ? context.accent.withValues(alpha: 0.18)
-                  : context.surface,
-              borderRadius: BorderRadius.circular(7),
-              border: Border.all(
-                color: isActive
-                    ? context.accent.withValues(alpha: 0.6)
-                    : context.border,
-                width: 1,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+          decoration: BoxDecoration(
+            color: isActive
+                ? context.accent.withValues(alpha: 0.12)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                Icons.headset_mic_outlined,
+                size: 16,
+                color: context.textSecondary,
               ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.headset_mic_outlined,
-                  size: 13,
-                  color: context.textSecondary,
-                ),
-                const SizedBox(width: 5),
-                Text(
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
                   channel.name,
                   style: TextStyle(
                     color: isActive ? context.accent : context.textPrimary,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
+                    fontSize: 13,
+                    fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
                   ),
+                  overflow: TextOverflow.ellipsis,
                 ),
-                if (participantCount > 0) ...[
-                  const SizedBox(width: 4),
-                  Text(
-                    '($participantCount)',
-                    style: TextStyle(color: context.textMuted, fontSize: 10),
-                  ),
-                ],
+              ),
+              if (participantCount > 0) ...[
+                const SizedBox(width: 4),
+                Text(
+                  '$participantCount',
+                  style: TextStyle(color: context.textMuted, fontSize: 11),
+                ),
+                const SizedBox(width: 2),
+                Icon(Icons.person, size: 12, color: context.textMuted),
               ],
-            ),
+            ],
           ),
         ),
       ),
     );
-  }
-
-  String _channelStatusLabel(ChannelsState channelsState) {
-    if (channelsState.isLoadingConversation(widget.conversationId)) {
-      return 'Loading channels...';
-    }
-    return 'No channels yet';
   }
 
   Widget _buildInlineGroupChannels(
@@ -345,36 +384,41 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
   ) {
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.fromLTRB(12, 6, 12, 6),
+      padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
       decoration: BoxDecoration(
         color: context.sidebarBg,
         border: Border(bottom: BorderSide(color: context.border, width: 1)),
       ),
       child: channels.isEmpty
           ? Padding(
-              padding: const EdgeInsets.only(top: 8),
+              padding: const EdgeInsets.only(top: 8, left: 4),
               child: Text(
                 _channelStatusLabel(channelsState),
                 style: TextStyle(color: context.textMuted, fontSize: 12),
               ),
             )
-          : SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: [
-                  ...textChannels.map(
-                    (channel) => _buildTextChannelChip(channel),
-                  ),
-                  ...voiceChannels.map(
-                    (channel) => _buildVoiceChannelChip(
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final category in _orderedCategories(channels)) ...[
+                  _buildCategoryHeader(category),
+                  if (!_collapsedCategories.contains(category))
+                    ...channels.where((c) => c.category == category).map((
                       channel,
-                      channelsState.voiceSessionsFor(channel.id).length,
-                      voiceSettings,
-                      activeVoiceChannelId,
-                    ),
-                  ),
+                    ) {
+                      if (channel.isVoice) {
+                        return _buildVoiceChannelRow(
+                          channel,
+                          channelsState.voiceSessionsFor(channel.id).length,
+                          voiceSettings,
+                          activeVoiceChannelId,
+                        );
+                      }
+                      return _buildTextChannelRow(channel);
+                    }),
                 ],
-              ),
+              ],
             ),
     );
   }

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -24,6 +24,10 @@ import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/clipboard_image_helper.dart';
 import 'gif_picker_widget.dart';
+import 'input/attachment_preview.dart';
+import 'input/input_status_bar.dart';
+import 'input/mention_autocomplete.dart';
+import 'input/reply_preview_bar.dart';
 
 /// Extracted chat input bar from ChatPanel (~850 lines).
 ///
@@ -267,26 +271,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _detectMention(text);
   }
 
-  /// Attempts to extract a partial mention query from [text] at the cursor
-  /// position. Returns the query string (lowercased, possibly empty) when an
-  /// active `@` trigger is found, or `null` when no mention autocomplete
-  /// should be shown.
-  String? _extractMentionQuery(String text) {
-    final cursorPos = _messageController.selection.baseOffset;
-    if (cursorPos < 0 || cursorPos > text.length) return null;
-
-    final beforeCursor = text.substring(0, cursorPos);
-    final atIndex = beforeCursor.lastIndexOf('@');
-    if (atIndex < 0) return null;
-
-    if (atIndex > 0 && beforeCursor[atIndex - 1] != ' ') return null;
-
-    final partial = beforeCursor.substring(atIndex + 1);
-    if (partial.contains(' ')) return null;
-
-    return partial.toLowerCase();
-  }
-
   void _detectMention(String text) {
     final conv = widget.conversation;
     if (!conv.isGroup) {
@@ -299,7 +283,10 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       return;
     }
 
-    final query = _extractMentionQuery(text);
+    final query = extractMentionQuery(
+      text,
+      _messageController.selection.baseOffset,
+    );
     if (query == null) {
       if (_showMentionPicker) setState(() => _showMentionPicker = false);
       return;
@@ -311,23 +298,14 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     });
   }
 
-  void _insertMention(String username) {
+  void _handleMentionSelected(String username) {
     final text = _messageController.text;
     final cursorPos = _messageController.selection.baseOffset;
-    if (cursorPos < 0) return;
 
-    final beforeCursor = text.substring(0, cursorPos);
-    final atIndex = beforeCursor.lastIndexOf('@');
-    if (atIndex < 0) return;
-
-    final afterCursor = text.substring(cursorPos);
-    final replacement = '@$username ';
-    final newText = text.substring(0, atIndex) + replacement + afterCursor;
-    final newCursorPos = atIndex + replacement.length;
-
-    _messageController.value = TextEditingValue(
-      text: newText,
-      selection: TextSelection.collapsed(offset: newCursorPos),
+    _messageController.value = insertMention(
+      text: text,
+      cursorPosition: cursorPos,
+      username: username,
     );
 
     setState(() {
@@ -340,11 +318,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   List<ConversationMember> get _filteredMentionMembers {
     final conv = widget.conversation;
     final myUserId = ref.read(authProvider).userId ?? '';
-    return conv.members.where((m) {
-      if (m.userId == myUserId) return false;
-      if (_mentionQuery.isEmpty) return true;
-      return m.username.toLowerCase().startsWith(_mentionQuery);
-    }).toList();
+    return conv.members.where((m) => m.userId != myUserId).toList();
   }
 
   // ---------------------------------------------------------------------------
@@ -665,277 +639,8 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   }
 
   // ---------------------------------------------------------------------------
-  // Build helpers -- extracted to reduce cognitive complexity
+  // Build helpers -- kept in root widget
   // ---------------------------------------------------------------------------
-
-  Widget _buildMentionAutocomplete() {
-    return Container(
-      constraints: const BoxConstraints(maxHeight: 160),
-      margin: const EdgeInsets.symmetric(horizontal: 20),
-      decoration: BoxDecoration(
-        color: context.surface,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
-        border: Border.all(color: context.border),
-      ),
-      child: ListView.builder(
-        shrinkWrap: true,
-        reverse: true,
-        padding: EdgeInsets.zero,
-        itemCount: _filteredMentionMembers.length,
-        itemBuilder: (context, i) {
-          final member = _filteredMentionMembers[i];
-          return _buildMentionItem(member);
-        },
-      ),
-    );
-  }
-
-  Widget _buildMentionItem(ConversationMember member) {
-    return InkWell(
-      onTap: () => _insertMention(member.username),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Row(
-          children: [
-            Icon(Icons.alternate_email, size: 14, color: context.accent),
-            const SizedBox(width: 8),
-            Text(
-              member.username,
-              style: TextStyle(
-                fontSize: 13,
-                color: context.textPrimary,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            if (member.role != null) ...[
-              const SizedBox(width: 6),
-              Text(
-                member.role!,
-                style: TextStyle(fontSize: 11, color: context.textMuted),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInputStatusBar(String inputStatusText) {
-    return Container(
-      width: double.infinity,
-      margin: const EdgeInsets.only(bottom: 6),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-      decoration: BoxDecoration(
-        color: _isEditing
-            ? context.accent.withValues(alpha: 0.12)
-            : context.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: _isEditing
-              ? context.accent.withValues(alpha: 0.4)
-              : context.border,
-          width: 1,
-        ),
-      ),
-      child: Row(
-        children: [
-          Icon(
-            _isEditing ? Icons.edit_outlined : Icons.more_horiz_rounded,
-            size: 12,
-            color: _isEditing ? context.accent : context.textMuted,
-          ),
-          const SizedBox(width: 6),
-          Expanded(
-            child: Text(
-              inputStatusText,
-              style: TextStyle(
-                fontSize: 12,
-                fontStyle: _isEditing ? FontStyle.normal : FontStyle.italic,
-                color: _isEditing ? context.accent : context.textMuted,
-              ),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          if (_isEditing)
-            GestureDetector(
-              onTap: _cancelEditMode,
-              child: Icon(Icons.close, size: 14, color: context.textMuted),
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildReplyPreviewBar(ChatMessage replyTo) {
-    final truncated = replyTo.content.length > 120
-        ? '${replyTo.content.substring(0, 120)}...'
-        : replyTo.content;
-
-    return Container(
-      width: double.infinity,
-      margin: const EdgeInsets.only(bottom: 6),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-      decoration: BoxDecoration(
-        color: context.accent.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(8),
-        border: Border(left: BorderSide(color: context.accent, width: 3)),
-      ),
-      child: Row(
-        children: [
-          Icon(Icons.reply_outlined, size: 14, color: context.accent),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  'Replying to ${replyTo.fromUsername}',
-                  style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                    color: context.accent,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  truncated,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(fontSize: 12, color: context.textSecondary),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 8),
-          GestureDetector(
-            onTap: () => ref.read(chatProvider.notifier).clearReplyTo(),
-            child: Icon(Icons.close, size: 14, color: context.textMuted),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAttachmentThumbnail() {
-    if (_pendingAttachmentBytes != null) {
-      return Image.memory(
-        _pendingAttachmentBytes!,
-        width: 48,
-        height: 48,
-        fit: BoxFit.cover,
-        errorBuilder: (_, e, st) => Container(
-          width: 48,
-          height: 48,
-          color: context.mainBg,
-          child: Icon(
-            Icons.insert_drive_file_outlined,
-            color: context.textMuted,
-            size: 24,
-          ),
-        ),
-      );
-    }
-    return Container(
-      width: 48,
-      height: 48,
-      color: context.mainBg,
-      child: Icon(Icons.gif_box_outlined, color: context.accent, size: 24),
-    );
-  }
-
-  Widget _buildAttachmentStatusText() {
-    final String statusLabel;
-    final Color statusColor;
-
-    if (_isUploadingAttachment) {
-      statusLabel = 'Uploading...';
-      statusColor = context.textMuted;
-    } else if (_pendingAttachmentUrl != null) {
-      statusLabel = 'Ready to send';
-      statusColor = EchoTheme.online;
-    } else {
-      statusLabel = 'Preparing...';
-      statusColor = context.textMuted;
-    }
-
-    return Text(
-      statusLabel,
-      style: TextStyle(fontSize: 11, color: statusColor),
-    );
-  }
-
-  Widget _buildAttachmentTrailingWidgets() {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (_isUploadingAttachment)
-          SizedBox(
-            width: 16,
-            height: 16,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: context.accent,
-            ),
-          )
-        else if (_pendingAttachmentUrl != null)
-          const Icon(
-            Icons.check_circle_outline,
-            size: 16,
-            color: EchoTheme.online,
-          ),
-        const SizedBox(width: 6),
-        // Remove button
-        GestureDetector(
-          onTap: _clearPendingAttachment,
-          child: Icon(Icons.close, size: 16, color: context.textMuted),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildAttachmentPreview() {
-    return Container(
-      margin: const EdgeInsets.only(bottom: 6),
-      padding: const EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        color: context.surface,
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: context.border, width: 1),
-      ),
-      child: Row(
-        children: [
-          // Thumbnail
-          ClipRRect(
-            borderRadius: BorderRadius.circular(6),
-            child: _buildAttachmentThumbnail(),
-          ),
-          const SizedBox(width: 10),
-          // Filename + status
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  _pendingAttachmentFileName ?? 'Attachment',
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: context.textPrimary,
-                    fontWeight: FontWeight.w500,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: 2),
-                _buildAttachmentStatusText(),
-              ],
-            ),
-          ),
-          _buildAttachmentTrailingWidgets(),
-        ],
-      ),
-    );
-  }
 
   Widget _buildPlusMenuButton({
     required bool showEmojiPicker,
@@ -1357,21 +1062,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   // Build
   // ---------------------------------------------------------------------------
 
-  String _computeInputStatusText(String typingText) {
-    if (_isEditing && widget.typingUsers.isNotEmpty) {
-      return 'Editing message \u2022 $typingText';
-    }
-    if (_isEditing) return 'Editing message...';
-    return typingText;
-  }
-
-  String _computeTypingText(String displayName) {
-    final typingUsers = widget.typingUsers;
-    if (!widget.conversation.isGroup) return '$displayName is typing...';
-    if (typingUsers.length == 1) return '${typingUsers.first} is typing...';
-    return '${typingUsers.join(", ")} are typing...';
-  }
-
   bool get _hasPendingAttachment =>
       _pendingAttachmentBytes != null || _pendingAttachmentUrl != null;
 
@@ -1385,9 +1075,17 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     );
 
     final displayName = conv.displayName(myUserId);
-    final typingText = _computeTypingText(displayName);
+    final typingText = computeTypingText(
+      typingUsers: widget.typingUsers,
+      isGroup: conv.isGroup,
+      displayName: displayName,
+    );
     final showInputStatus = _isEditing || widget.typingUsers.isNotEmpty;
-    final inputStatusText = _computeInputStatusText(typingText);
+    final inputStatusText = computeInputStatusText(
+      isEditing: _isEditing,
+      typingText: typingText,
+      hasTypingUsers: widget.typingUsers.isNotEmpty,
+    );
     final viewportWidth = MediaQuery.of(context).size.width;
     final isMobileLayout = viewportWidth < 600;
     final isDesktopLayout = viewportWidth >= 900;
@@ -1402,8 +1100,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       mainAxisSize: MainAxisSize.min,
       children: [
         // Mention autocomplete picker
-        if (_showMentionPicker && _filteredMentionMembers.isNotEmpty)
-          _buildMentionAutocomplete(),
+        if (_showMentionPicker)
+          MentionAutocomplete(
+            members: _filteredMentionMembers,
+            mentionQuery: _mentionQuery,
+            onMentionSelected: _handleMentionSelected,
+          ),
         // Input area
         Container(
           padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
@@ -1411,11 +1113,29 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (showInputStatus) _buildInputStatusBar(inputStatusText),
+              if (showInputStatus)
+                InputStatusBar(
+                  isEditing: _isEditing,
+                  statusText: inputStatusText,
+                  onCancelEdit: _cancelEditMode,
+                ),
               // Reply preview bar
-              if (replyToMessage != null) _buildReplyPreviewBar(replyToMessage),
+              if (replyToMessage != null)
+                ReplyPreviewBar(
+                  replyToMessage: replyToMessage,
+                  onDismiss: () =>
+                      ref.read(chatProvider.notifier).clearReplyTo(),
+                ),
               // Attachment preview bar (Discord-style)
-              if (_hasPendingAttachment) _buildAttachmentPreview(),
+              if (_hasPendingAttachment)
+                AttachmentPreview(
+                  attachmentBytes: _pendingAttachmentBytes,
+                  fileName: _pendingAttachmentFileName,
+                  mimeType: _pendingAttachmentMimeType,
+                  uploadedUrl: _pendingAttachmentUrl,
+                  isUploading: _isUploadingAttachment,
+                  onClear: _clearPendingAttachment,
+                ),
               _buildInputRow(
                 showEmojiPicker: showEmojiPicker,
                 isMobileLayout: isMobileLayout,

--- a/apps/client/lib/src/widgets/input/attachment_preview.dart
+++ b/apps/client/lib/src/widgets/input/attachment_preview.dart
@@ -1,0 +1,148 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+
+import '../../theme/echo_theme.dart';
+
+/// Displays a Discord-style attachment preview bar above the input field.
+///
+/// Shows a thumbnail, filename, upload status, and a remove button.
+class AttachmentPreview extends StatelessWidget {
+  final Uint8List? attachmentBytes;
+  final String? fileName;
+  final String? mimeType;
+  final String? uploadedUrl;
+  final bool isUploading;
+  final VoidCallback onClear;
+
+  const AttachmentPreview({
+    super.key,
+    required this.attachmentBytes,
+    this.fileName,
+    this.mimeType,
+    this.uploadedUrl,
+    this.isUploading = false,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: context.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: context.border, width: 1),
+      ),
+      child: Row(
+        children: [
+          // Thumbnail
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: _buildThumbnail(context),
+          ),
+          const SizedBox(width: 10),
+          // Filename + status
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  fileName ?? 'Attachment',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: context.textPrimary,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                _buildStatusText(context),
+              ],
+            ),
+          ),
+          _buildTrailingWidgets(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildThumbnail(BuildContext context) {
+    if (attachmentBytes != null) {
+      return Image.memory(
+        attachmentBytes!,
+        width: 48,
+        height: 48,
+        fit: BoxFit.cover,
+        errorBuilder: (_, e, st) => Container(
+          width: 48,
+          height: 48,
+          color: context.mainBg,
+          child: Icon(
+            Icons.insert_drive_file_outlined,
+            color: context.textMuted,
+            size: 24,
+          ),
+        ),
+      );
+    }
+    return Container(
+      width: 48,
+      height: 48,
+      color: context.mainBg,
+      child: Icon(Icons.gif_box_outlined, color: context.accent, size: 24),
+    );
+  }
+
+  Widget _buildStatusText(BuildContext context) {
+    final String statusLabel;
+    final Color statusColor;
+
+    if (isUploading) {
+      statusLabel = 'Uploading...';
+      statusColor = context.textMuted;
+    } else if (uploadedUrl != null) {
+      statusLabel = 'Ready to send';
+      statusColor = EchoTheme.online;
+    } else {
+      statusLabel = 'Preparing...';
+      statusColor = context.textMuted;
+    }
+
+    return Text(
+      statusLabel,
+      style: TextStyle(fontSize: 11, color: statusColor),
+    );
+  }
+
+  Widget _buildTrailingWidgets(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (isUploading)
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: context.accent,
+            ),
+          )
+        else if (uploadedUrl != null)
+          const Icon(
+            Icons.check_circle_outline,
+            size: 16,
+            color: EchoTheme.online,
+          ),
+        const SizedBox(width: 6),
+        // Remove button
+        GestureDetector(
+          onTap: onClear,
+          child: Icon(Icons.close, size: 16, color: context.textMuted),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/input/input_status_bar.dart
+++ b/apps/client/lib/src/widgets/input/input_status_bar.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/echo_theme.dart';
+
+/// Shows an editing indicator or typing indicator above the input field.
+///
+/// When [isEditing] is true, the bar is styled with accent colors and shows a
+/// dismiss button. Otherwise it shows a typing indicator with muted styling.
+class InputStatusBar extends StatelessWidget {
+  final bool isEditing;
+  final String statusText;
+  final VoidCallback? onCancelEdit;
+
+  const InputStatusBar({
+    super.key,
+    required this.isEditing,
+    required this.statusText,
+    this.onCancelEdit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: isEditing
+            ? context.accent.withValues(alpha: 0.12)
+            : context.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: isEditing
+              ? context.accent.withValues(alpha: 0.4)
+              : context.border,
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            isEditing ? Icons.edit_outlined : Icons.more_horiz_rounded,
+            size: 12,
+            color: isEditing ? context.accent : context.textMuted,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              statusText,
+              style: TextStyle(
+                fontSize: 12,
+                fontStyle: isEditing ? FontStyle.normal : FontStyle.italic,
+                color: isEditing ? context.accent : context.textMuted,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (isEditing && onCancelEdit != null)
+            GestureDetector(
+              onTap: onCancelEdit,
+              child: Icon(Icons.close, size: 14, color: context.textMuted),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Computes the status text to display in the [InputStatusBar].
+String computeInputStatusText({
+  required bool isEditing,
+  required String typingText,
+  required bool hasTypingUsers,
+}) {
+  if (isEditing && hasTypingUsers) {
+    return 'Editing message \u2022 $typingText';
+  }
+  if (isEditing) return 'Editing message...';
+  return typingText;
+}
+
+/// Computes the typing indicator text from the list of typing users.
+String computeTypingText({
+  required List<String> typingUsers,
+  required bool isGroup,
+  required String displayName,
+}) {
+  if (!isGroup) return '$displayName is typing...';
+  if (typingUsers.length == 1) return '${typingUsers.first} is typing...';
+  return '${typingUsers.join(", ")} are typing...';
+}

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+import '../../models/conversation.dart';
+import '../../theme/echo_theme.dart';
+
+/// Displays an autocomplete popup for @-mentioning conversation members.
+///
+/// Sits above the input bar and filters members based on [mentionQuery].
+/// When a member is tapped, [onMentionSelected] fires with their username.
+class MentionAutocomplete extends StatelessWidget {
+  final List<ConversationMember> members;
+  final String mentionQuery;
+  final ValueChanged<String> onMentionSelected;
+
+  const MentionAutocomplete({
+    super.key,
+    required this.members,
+    required this.mentionQuery,
+    required this.onMentionSelected,
+  });
+
+  List<ConversationMember> get _filteredMembers {
+    if (mentionQuery.isEmpty) return members;
+    return members
+        .where((m) => m.username.toLowerCase().startsWith(mentionQuery))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered = _filteredMembers;
+    if (filtered.isEmpty) return const SizedBox.shrink();
+
+    return Container(
+      constraints: const BoxConstraints(maxHeight: 160),
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      decoration: BoxDecoration(
+        color: context.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+        border: Border.all(color: context.border),
+      ),
+      child: ListView.builder(
+        shrinkWrap: true,
+        reverse: true,
+        padding: EdgeInsets.zero,
+        itemCount: filtered.length,
+        itemBuilder: (context, i) {
+          final member = filtered[i];
+          return _MentionItem(
+            member: member,
+            onTap: () => onMentionSelected(member.username),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _MentionItem extends StatelessWidget {
+  final ConversationMember member;
+  final VoidCallback onTap;
+
+  const _MentionItem({required this.member, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Row(
+          children: [
+            Icon(Icons.alternate_email, size: 14, color: context.accent),
+            const SizedBox(width: 8),
+            Text(
+              member.username,
+              style: TextStyle(
+                fontSize: 13,
+                color: context.textPrimary,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            if (member.role != null) ...[
+              const SizedBox(width: 6),
+              Text(
+                member.role!,
+                style: TextStyle(fontSize: 11, color: context.textMuted),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Attempts to extract a partial mention query from [text] at the given
+/// [cursorPosition]. Returns the lowercased query string when an active `@`
+/// trigger is found, or `null` when no mention autocomplete should be shown.
+String? extractMentionQuery(String text, int cursorPosition) {
+  if (cursorPosition < 0 || cursorPosition > text.length) return null;
+
+  final beforeCursor = text.substring(0, cursorPosition);
+  final atIndex = beforeCursor.lastIndexOf('@');
+  if (atIndex < 0) return null;
+
+  if (atIndex > 0 && beforeCursor[atIndex - 1] != ' ') return null;
+
+  final partial = beforeCursor.substring(atIndex + 1);
+  if (partial.contains(' ')) return null;
+
+  return partial.toLowerCase();
+}
+
+/// Inserts a completed @mention into [text] at the cursor position, replacing
+/// the partial query. Returns the new [TextEditingValue] with updated cursor.
+TextEditingValue insertMention({
+  required String text,
+  required int cursorPosition,
+  required String username,
+}) {
+  if (cursorPosition < 0) return TextEditingValue(text: text);
+
+  final beforeCursor = text.substring(0, cursorPosition);
+  final atIndex = beforeCursor.lastIndexOf('@');
+  if (atIndex < 0) return TextEditingValue(text: text);
+
+  final afterCursor = text.substring(cursorPosition);
+  final replacement = '@$username ';
+  final newText = text.substring(0, atIndex) + replacement + afterCursor;
+  final newCursorPos = atIndex + replacement.length;
+
+  return TextEditingValue(
+    text: newText,
+    selection: TextSelection.collapsed(offset: newCursorPos),
+  );
+}

--- a/apps/client/lib/src/widgets/input/reply_preview_bar.dart
+++ b/apps/client/lib/src/widgets/input/reply_preview_bar.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+
+/// Shows a reply-to preview bar above the input field.
+///
+/// Displays the original message author, a truncated preview of their message,
+/// and a dismiss button.
+class ReplyPreviewBar extends StatelessWidget {
+  final ChatMessage replyToMessage;
+  final VoidCallback onDismiss;
+
+  const ReplyPreviewBar({
+    super.key,
+    required this.replyToMessage,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final truncated = replyToMessage.content.length > 120
+        ? '${replyToMessage.content.substring(0, 120)}...'
+        : replyToMessage.content;
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: context.accent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border(left: BorderSide(color: context.accent, width: 3)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.reply_outlined, size: 14, color: context.accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Replying to ${replyToMessage.fromUsername}',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: context.accent,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  truncated,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(fontSize: 12, color: context.textSecondary),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          GestureDetector(
+            onTap: onDismiss,
+            child: Icon(Icons.close, size: 14, color: context.textMuted),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -1,0 +1,674 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:url_launcher/url_launcher.dart';
+import 'package:video_player/video_player.dart';
+
+import '../../services/toast_service.dart';
+import '../../theme/echo_theme.dart';
+import '../../utils/download_helper.dart';
+
+/// Regex for detecting image markers: [img:URL]
+final _imgRegex = RegExp(r'^\[img:(.+)\]$');
+
+/// Regex for detecting video markers: [video:URL]
+final _videoRegex = RegExp(r'^\[video:(.+)\]$');
+
+/// Regex for detecting generic file markers: [file:URL]
+final _fileRegex = RegExp(r'^\[file:(.+)\]$');
+
+/// Regex for detecting standalone URL messages.
+final _standaloneUrlRegex = RegExp(r'^https?://[^\s]+$', caseSensitive: false);
+
+const _imageExtensions = {'jpg', 'jpeg', 'png', 'gif', 'webp'};
+const _videoExtensions = {'mp4', 'webm', 'mov'};
+const _fileExtensions = {'pdf'};
+
+/// Regex for image extensions in URLs (used for inline embed detection).
+final imageUrlEmbedRegex = RegExp(
+  r'https?://[^\s]+\.(?:gif|png|jpe?g|webp)',
+  caseSensitive: false,
+);
+
+/// Returns the file extension from a URL path, lowercased.
+String urlExtension(String url) {
+  final uri = Uri.tryParse(url);
+  final path = uri?.path ?? '';
+  if (path.isEmpty || !path.contains('.')) return '';
+  return path.split('.').last.toLowerCase();
+}
+
+/// Returns true if the content is a standalone URL pointing to a known media
+/// type (image, video, or file).
+bool isStandaloneMediaUrl(String content) {
+  final trimmed = content.trim();
+  if (!_standaloneUrlRegex.hasMatch(trimmed)) return false;
+
+  final ext = urlExtension(trimmed);
+  return _imageExtensions.contains(ext) ||
+      _videoExtensions.contains(ext) ||
+      _fileExtensions.contains(ext);
+}
+
+/// Returns true if the URL points to a known video extension.
+bool isVideoUrl(String url) => _videoExtensions.contains(urlExtension(url));
+
+/// Returns true if the URL points to a known image extension.
+bool isImageUrl(String url) => _imageExtensions.contains(urlExtension(url));
+
+/// Returns true if the URL points to a known file extension.
+bool isFileUrl(String url) => _fileExtensions.contains(urlExtension(url));
+
+/// Resolves a potentially relative media URL to an absolute URL, appending
+/// an auth token as a query parameter when available.
+String resolveMediaUrl(String url, {String? serverUrl, String? authToken}) {
+  if (url.startsWith('http')) {
+    // external URLs (GIFs) -- just append token if needed
+    final token = authToken ?? '';
+    return token.isNotEmpty ? '$url?token=$token' : url;
+  }
+  final base = serverUrl ?? '';
+  final token = authToken ?? '';
+  final resolved = url.startsWith('/') && base.isNotEmpty ? '$base$url' : url;
+  return token.isNotEmpty ? '$resolved?token=$token' : resolved;
+}
+
+/// Extracts a media URL from message content, checking for [img:], [video:],
+/// [file:] markers and standalone media URLs.
+String? extractMediaUrl(String content) {
+  final imageMatch = _imgRegex.firstMatch(content);
+  if (imageMatch != null) return imageMatch.group(1);
+
+  final videoMatch = _videoRegex.firstMatch(content);
+  if (videoMatch != null) return videoMatch.group(1);
+
+  final fileMatch = _fileRegex.firstMatch(content);
+  if (fileMatch != null) return fileMatch.group(1);
+
+  if (isStandaloneMediaUrl(content)) {
+    return content.trim();
+  }
+
+  return null;
+}
+
+/// Extract image URLs embedded within text (not standalone).
+List<String> extractEmbeddedImageUrls(String content) {
+  if (isStandaloneMediaUrl(content)) return [];
+  if (_imgRegex.hasMatch(content)) return [];
+  return imageUrlEmbedRegex
+      .allMatches(content)
+      .map((m) => m.group(0)!)
+      .toList();
+}
+
+/// Builds auth headers for media requests.
+Map<String, String> mediaHeaders({String? authToken}) {
+  final headers = <String, String>{};
+  if (authToken != null && authToken.isNotEmpty) {
+    headers['Authorization'] = 'Bearer $authToken';
+  }
+  return headers;
+}
+
+String _filenameFromUrl(String url) {
+  final parsed = Uri.tryParse(url);
+  final lastSegment = (parsed?.pathSegments.isNotEmpty ?? false)
+      ? parsed!.pathSegments.last
+      : '';
+  if (lastSegment.isEmpty) {
+    return 'media.bin';
+  }
+  return lastSegment;
+}
+
+/// A widget that renders media content (images, videos, files) from message
+/// content strings. Returns null from [build] when the content is not media.
+class MediaContent extends StatefulWidget {
+  final String content;
+  final bool isMine;
+  final String? serverUrl;
+  final String? authToken;
+
+  const MediaContent({
+    super.key,
+    required this.content,
+    required this.isMine,
+    this.serverUrl,
+    this.authToken,
+  });
+
+  @override
+  State<MediaContent> createState() => MediaContentState();
+}
+
+class MediaContentState extends State<MediaContent> {
+  String _resolveUrl(String url) => resolveMediaUrl(
+    url,
+    serverUrl: widget.serverUrl,
+    authToken: widget.authToken,
+  );
+
+  Map<String, String> _headers() => mediaHeaders(authToken: widget.authToken);
+
+  // ignore: public_member_api_docs
+  Future<void> openMedia(String rawUrl) async {
+    final uri = Uri.tryParse(_resolveUrl(rawUrl));
+    if (uri != null) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  // ignore: public_member_api_docs
+  Future<void> downloadMedia(String rawUrl) async {
+    final url = _resolveUrl(rawUrl);
+    try {
+      final response = await http.get(Uri.parse(url), headers: _headers());
+      if (!mounted) return;
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        ToastService.show(
+          context,
+          'Download failed (${response.statusCode})',
+          type: ToastType.error,
+        );
+        return;
+      }
+
+      final contentType =
+          response.headers['content-type'] ?? 'application/octet-stream';
+      final downloaded = await saveBytesAsFile(
+        fileName: _filenameFromUrl(url),
+        bytes: response.bodyBytes,
+        mimeType: contentType,
+      );
+
+      if (!mounted) return;
+      if (downloaded) {
+        ToastService.show(context, 'Download started', type: ToastType.success);
+        return;
+      }
+
+      await Clipboard.setData(ClipboardData(text: url));
+      if (!mounted) return;
+      ToastService.show(
+        context,
+        'Save not supported here yet. Link copied.',
+        type: ToastType.info,
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ToastService.show(
+        context,
+        'Could not download media',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  // ignore: public_member_api_docs
+  void showImageViewer({required String imageUrl}) {
+    final headers = _headers();
+    showDialog<void>(
+      context: context,
+      barrierColor: Colors.black.withValues(alpha: 0.85),
+      builder: (dialogContext) {
+        final screenSize = MediaQuery.of(dialogContext).size;
+        final maxWidth = screenSize.width * 0.8;
+        final maxHeight = screenSize.height * 0.8;
+        return GestureDetector(
+          onTap: () => Navigator.of(dialogContext).pop(),
+          behavior: HitTestBehavior.opaque,
+          child: Center(
+            child: GestureDetector(
+              onTap: () {}, // absorb taps on the image itself
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxWidth: maxWidth,
+                  maxHeight: maxHeight,
+                ),
+                child: Stack(
+                  children: [
+                    InteractiveViewer(
+                      minScale: 0.8,
+                      maxScale: 4,
+                      child: Center(
+                        child: CachedNetworkImage(
+                          imageUrl: imageUrl,
+                          httpHeaders: headers,
+                          fit: BoxFit.contain,
+                          placeholder: (_, _) => const Center(
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                            ),
+                          ),
+                          errorWidget: (_, _, _) => const Center(
+                            child: Icon(
+                              Icons.broken_image_outlined,
+                              color: Colors.white54,
+                              size: 48,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      top: 8,
+                      right: 8,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.download_outlined),
+                            color: Colors.white,
+                            tooltip: 'Download',
+                            onPressed: () => downloadMedia(imageUrl),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            color: Colors.white,
+                            tooltip: 'Close',
+                            onPressed: () => Navigator.of(dialogContext).pop(),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// Builds the media widget, or returns null if the content is not media.
+  Widget? buildMedia() {
+    final content = widget.content;
+    final headers = _headers();
+
+    final standaloneUrl = isStandaloneMediaUrl(content) ? content.trim() : null;
+
+    // --- Image ---
+    final imageMatch = _imgRegex.firstMatch(content);
+    final imageUrl =
+        imageMatch?.group(1) ??
+        (standaloneUrl != null && isImageUrl(standaloneUrl)
+            ? standaloneUrl
+            : null);
+    if (imageUrl != null) {
+      final rawUrl = imageUrl;
+      final fullUrl = _resolveUrl(rawUrl);
+
+      return Semantics(
+        label: 'Image attachment. Tap to view full size.',
+        image: true,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: GestureDetector(
+            onTap: () => showImageViewer(imageUrl: fullUrl),
+            child: Stack(
+              children: [
+                fullUrl.startsWith('http') && urlExtension(rawUrl) == 'gif'
+                    ? Image.network(
+                        fullUrl,
+                        width: 300,
+                        fit: BoxFit.cover,
+                        gaplessPlayback: true,
+                        errorBuilder: (_, e, st) => Container(
+                          width: 300,
+                          height: 80,
+                          decoration: BoxDecoration(
+                            color: context.surface,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '[GIF failed to load]',
+                              style: TextStyle(
+                                color: context.textMuted,
+                                fontSize: 13,
+                              ),
+                            ),
+                          ),
+                        ),
+                      )
+                    : CachedNetworkImage(
+                        imageUrl: fullUrl,
+                        width: 300,
+                        fit: BoxFit.cover,
+                        httpHeaders: headers,
+                        errorWidget: (_, e, st) => Container(
+                          width: 300,
+                          height: 80,
+                          decoration: BoxDecoration(
+                            color: context.surface,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '[Image failed to load]',
+                              style: TextStyle(
+                                color: context.textMuted,
+                                fontSize: 13,
+                              ),
+                            ),
+                          ),
+                        ),
+                        placeholder: (_, _) => Container(
+                          width: 300,
+                          height: 80,
+                          decoration: BoxDecoration(
+                            color: context.surface,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Center(
+                            child: SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: context.textMuted,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                Positioned(
+                  right: 8,
+                  bottom: 8,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Icon(
+                      Icons.open_in_full,
+                      size: 14,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    // --- Video ---
+    final videoMatch = _videoRegex.firstMatch(content);
+    final videoUrl =
+        videoMatch?.group(1) ??
+        (standaloneUrl != null && isVideoUrl(standaloneUrl)
+            ? standaloneUrl
+            : null);
+    if (videoUrl != null) {
+      final rawUrl = videoUrl;
+      return InlineVideoPlayer(
+        videoUrl: _resolveUrl(rawUrl),
+        rawUrl: rawUrl,
+        headers: _headers(),
+        surface: context.surface,
+        mainBg: context.mainBg,
+        border: context.border,
+        textPrimary: context.textPrimary,
+        textMuted: context.textMuted,
+        onOpen: () => openMedia(rawUrl),
+        onDownload: () => downloadMedia(rawUrl),
+      );
+    }
+
+    // --- File ---
+    final fileMatch = _fileRegex.firstMatch(content);
+    final fileUrl =
+        fileMatch?.group(1) ??
+        (standaloneUrl != null && isFileUrl(standaloneUrl)
+            ? standaloneUrl
+            : null);
+    if (fileUrl != null) {
+      final rawUrl = fileUrl;
+      final displayName = _filenameFromUrl(rawUrl);
+      return Container(
+        width: 300,
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: context.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: context.border),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: context.mainBg,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                Icons.insert_drive_file_outlined,
+                color: context.textMuted,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                displayName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.download_outlined, size: 18),
+              onPressed: () => downloadMedia(rawUrl),
+              tooltip: 'Download',
+            ),
+          ],
+        ),
+      );
+    }
+
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return buildMedia() ?? const SizedBox.shrink();
+  }
+}
+
+/// Inline video player widget with play/pause controls and download
+/// fallback. Initialises a [VideoPlayerController] on first build and
+/// disposes it when removed from the tree.
+class InlineVideoPlayer extends StatefulWidget {
+  final String videoUrl;
+  final String rawUrl;
+  final Map<String, String> headers;
+  final Color surface;
+  final Color mainBg;
+  final Color border;
+  final Color textPrimary;
+  final Color textMuted;
+  final VoidCallback onOpen;
+  final VoidCallback onDownload;
+
+  const InlineVideoPlayer({
+    super.key,
+    required this.videoUrl,
+    required this.rawUrl,
+    required this.headers,
+    required this.surface,
+    required this.mainBg,
+    required this.border,
+    required this.textPrimary,
+    required this.textMuted,
+    required this.onOpen,
+    required this.onDownload,
+  });
+
+  @override
+  State<InlineVideoPlayer> createState() => _InlineVideoPlayerState();
+}
+
+class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
+  VideoPlayerController? _controller;
+  bool _initFailed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initVideo();
+  }
+
+  Future<void> _initVideo() async {
+    try {
+      final controller = VideoPlayerController.networkUrl(
+        Uri.parse(widget.videoUrl),
+        httpHeaders: widget.headers,
+      );
+      await controller.initialize();
+      if (!mounted) {
+        controller.dispose();
+        return;
+      }
+      setState(() => _controller = controller);
+    } catch (_) {
+      if (mounted) setState(() => _initFailed = true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  void _togglePlayPause() {
+    final c = _controller;
+    if (c == null) return;
+    setState(() {
+      c.value.isPlaying ? c.pause() : c.play();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 300,
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: widget.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: widget.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: _buildVideoArea(),
+          ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Wrap(
+              spacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: widget.onOpen,
+                  icon: const Icon(Icons.open_in_new, size: 14),
+                  label: const Text('Open'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: widget.onDownload,
+                  icon: const Icon(Icons.download_outlined, size: 14),
+                  label: const Text('Download'),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 4),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildVideoArea() {
+    final c = _controller;
+
+    // Still loading
+    if (c == null && !_initFailed) {
+      return Container(
+        height: 170,
+        color: widget.mainBg,
+        child: Center(
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: widget.textMuted,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Init failed -- show static placeholder
+    if (_initFailed || c == null) {
+      return GestureDetector(
+        onTap: widget.onOpen,
+        child: Container(
+          height: 170,
+          color: widget.mainBg,
+          child: Center(
+            child: Icon(
+              Icons.play_circle_outline,
+              size: 44,
+              color: widget.textMuted,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Initialised -- show player with controls
+    return GestureDetector(
+      onTap: _togglePlayPause,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          AspectRatio(
+            aspectRatio: c.value.aspectRatio.clamp(0.5, 3.0),
+            child: VideoPlayer(c),
+          ),
+          if (!c.value.isPlaying)
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.5),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.play_arrow,
+                size: 32,
+                color: Colors.white,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/message_status_icon.dart
+++ b/apps/client/lib/src/widgets/message/message_status_icon.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+
+/// Displays a small status icon (sending, sent, delivered, read, failed) with
+/// a tooltip describing the current state.
+class MessageStatusIcon extends StatelessWidget {
+  final MessageStatus? status;
+
+  const MessageStatusIcon({super.key, required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    if (status == null) return const SizedBox.shrink();
+
+    IconData icon;
+    Color color;
+    String tooltip;
+    switch (status!) {
+      case MessageStatus.sending:
+        icon = Icons.schedule_outlined;
+        color = context.textMuted;
+        tooltip = 'Sending';
+      case MessageStatus.sent:
+        icon = Icons.check_outlined;
+        color = context.textMuted;
+        tooltip = 'Sent';
+      case MessageStatus.delivered:
+        icon = Icons.done_all_outlined;
+        color = context.textMuted;
+        tooltip = 'Delivered';
+      case MessageStatus.read:
+        icon = Icons.done_all_outlined;
+        color = EchoTheme.online;
+        tooltip = 'Read';
+      case MessageStatus.failed:
+        icon = Icons.error_outline;
+        color = EchoTheme.danger;
+        tooltip = 'Failed to send';
+    }
+    return Padding(
+      padding: const EdgeInsets.only(left: 4),
+      child: Tooltip(
+        message: tooltip,
+        child: Icon(icon, size: 12, color: color),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../../models/reaction.dart';
+import '../../theme/echo_theme.dart';
+
+/// Displays a compact pill showing all reaction emojis and a total count.
+class ReactionBar extends StatelessWidget {
+  final List<Reaction> reactions;
+  final void Function(Offset globalPosition)? onTap;
+
+  const ReactionBar({super.key, required this.reactions, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    if (reactions.isEmpty) return const SizedBox.shrink();
+
+    // Collect unique emojis preserving order of first appearance.
+    final seen = <String>{};
+    final uniqueEmojis = <String>[];
+    for (final r in reactions) {
+      if (seen.add(r.emoji)) uniqueEmojis.add(r.emoji);
+    }
+
+    final totalCount = reactions.length;
+
+    return GestureDetector(
+      onTapUp: (details) => onTap?.call(details.globalPosition),
+      child: Container(
+        height: 24,
+        padding: const EdgeInsets.symmetric(horizontal: 6),
+        decoration: BoxDecoration(
+          color: context.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: context.border, width: 1),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final emoji in uniqueEmojis)
+              Padding(
+                padding: const EdgeInsets.only(right: 2),
+                child: Text(emoji, style: const TextStyle(fontSize: 14)),
+              ),
+            if (totalCount > 1) ...[
+              const SizedBox(width: 2),
+              Text(
+                '$totalCount',
+                style: TextStyle(fontSize: 12, color: context.textMuted),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/reply_quote.dart
+++ b/apps/client/lib/src/widgets/message/reply_quote.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/echo_theme.dart';
+
+/// Displays a reply-to quote block with a colored left border, username, and
+/// truncated content.
+class ReplyQuote extends StatelessWidget {
+  final String? replyToUsername;
+  final String replyToContent;
+  final bool isMine;
+
+  const ReplyQuote({
+    super.key,
+    required this.replyToUsername,
+    required this.replyToContent,
+    required this.isMine,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final truncated = replyToContent.length > 100
+        ? '${replyToContent.substring(0, 100)}...'
+        : replyToContent;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      decoration: BoxDecoration(
+        color: (isMine ? Colors.white : context.accent).withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8),
+        border: Border(
+          left: BorderSide(
+            color: isMine
+                ? Colors.white.withValues(alpha: 0.5)
+                : context.accent,
+            width: 3,
+          ),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: isMine
+            ? CrossAxisAlignment.end
+            : CrossAxisAlignment.start,
+        children: [
+          Text(
+            replyToUsername ?? 'Unknown',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: isMine
+                  ? Colors.white.withValues(alpha: 0.8)
+                  : context.accent,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            truncated,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 12,
+              color: isMine
+                  ? Colors.white.withValues(alpha: 0.7)
+                  : context.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/rich_text_content.dart
+++ b/apps/client/lib/src/widgets/message/rich_text_content.dart
@@ -1,0 +1,343 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Regex for detecting URLs in message text.
+final urlRegex = RegExp(r'https?://[^\s]+');
+
+/// Regex for detecting fenced code blocks: ```\n...\n``` (multiline).
+final _codeBlockRegex = RegExp(r'```\n?([\s\S]*?)```', multiLine: true);
+
+/// Regex for detecting inline code: `...` (single backtick, no nesting).
+final _inlineCodeRegex = RegExp(r'`([^`\n]+)`');
+
+/// Regex for detecting bold text: **...**
+final _boldRegex = RegExp(r'\*\*(.+?)\*\*');
+
+/// Regex for detecting italic text: *...*
+/// Negative lookahead/lookbehind to avoid matching ** (bold delimiters).
+final _italicRegex = RegExp(r'(?<!\*)\*([^*]+?)\*(?!\*)');
+
+/// Regex for detecting @mentions in message text.
+final _mentionRegex = RegExp(r'@(\w+)');
+
+/// A widget that renders message text with markdown formatting, clickable
+/// URLs, and @mentions with accent styling.
+///
+/// Precedence: code blocks > inline code > bold > italic > URLs > mentions.
+class RichTextContent extends StatefulWidget {
+  final String text;
+  final Color textColor;
+  final Color accentHoverColor;
+  final Color textSecondaryColor;
+
+  const RichTextContent({
+    super.key,
+    required this.text,
+    required this.textColor,
+    required this.accentHoverColor,
+    required this.textSecondaryColor,
+  });
+
+  @override
+  State<RichTextContent> createState() => _RichTextContentState();
+}
+
+class _RichTextContentState extends State<RichTextContent> {
+  final List<TapGestureRecognizer> _linkRecognizers = [];
+
+  @override
+  void dispose() {
+    for (final r in _linkRecognizers) {
+      r.dispose();
+    }
+    super.dispose();
+  }
+
+  /// Base text style used throughout message rendering.
+  TextStyle _baseStyle() =>
+      TextStyle(fontSize: 15, color: widget.textColor, height: 1.47);
+
+  TapGestureRecognizer _createLinkRecognizer(String url) {
+    final recognizer = TapGestureRecognizer()
+      ..onTap = () async {
+        final uri = Uri.tryParse(url);
+        if (uri != null && await canLaunchUrl(uri)) {
+          await launchUrl(uri, mode: LaunchMode.externalApplication);
+        }
+      };
+    _linkRecognizers.add(recognizer);
+    return recognizer;
+  }
+
+  /// Build spans for plain text that may contain @mentions.
+  List<InlineSpan> _buildMentionSpans(String text) {
+    final mentionMatches = _mentionRegex.allMatches(text).toList();
+    if (mentionMatches.isEmpty) {
+      return [TextSpan(text: text, style: _baseStyle())];
+    }
+
+    final spans = <InlineSpan>[];
+    int lastEnd = 0;
+    for (final match in mentionMatches) {
+      if (match.start > lastEnd) {
+        spans.add(
+          TextSpan(
+            text: text.substring(lastEnd, match.start),
+            style: _baseStyle(),
+          ),
+        );
+      }
+      spans.add(
+        TextSpan(
+          text: match.group(0),
+          style: TextStyle(
+            fontSize: 15,
+            color: widget.accentHoverColor,
+            fontWeight: FontWeight.w600,
+            height: 1.47,
+          ),
+        ),
+      );
+      lastEnd = match.end;
+    }
+    if (lastEnd < text.length) {
+      spans.add(TextSpan(text: text.substring(lastEnd), style: _baseStyle()));
+    }
+    return spans;
+  }
+
+  /// Build spans for a segment that may contain bold, italic, URLs, and
+  /// mentions (but NOT code -- code is stripped before this is called).
+  List<InlineSpan> _buildFormattedSpans(String text) {
+    final entries = <({int start, int end, String tag, RegExpMatch match})>[];
+
+    for (final m in _boldRegex.allMatches(text)) {
+      entries.add((start: m.start, end: m.end, tag: 'bold', match: m));
+    }
+    for (final m in _italicRegex.allMatches(text)) {
+      entries.add((start: m.start, end: m.end, tag: 'italic', match: m));
+    }
+    for (final m in urlRegex.allMatches(text)) {
+      entries.add((start: m.start, end: m.end, tag: 'url', match: m));
+    }
+
+    entries.sort((a, b) {
+      final cmp = a.start.compareTo(b.start);
+      if (cmp != 0) return cmp;
+      return b.end.compareTo(a.end);
+    });
+
+    final filtered = <({int start, int end, String tag, RegExpMatch match})>[];
+    int cursor = 0;
+    for (final e in entries) {
+      if (e.start < cursor) continue;
+      filtered.add(e);
+      cursor = e.end;
+    }
+
+    if (filtered.isEmpty) {
+      return _buildMentionSpans(text);
+    }
+
+    final spans = <InlineSpan>[];
+    int lastEnd = 0;
+
+    for (final e in filtered) {
+      if (e.start > lastEnd) {
+        spans.addAll(_buildMentionSpans(text.substring(lastEnd, e.start)));
+      }
+
+      switch (e.tag) {
+        case 'bold':
+          final inner = e.match.group(1)!;
+          spans.add(
+            TextSpan(
+              text: inner,
+              style: _baseStyle().copyWith(fontWeight: FontWeight.bold),
+            ),
+          );
+        case 'italic':
+          final inner = e.match.group(1)!;
+          spans.add(
+            TextSpan(
+              text: inner,
+              style: _baseStyle().copyWith(fontStyle: FontStyle.italic),
+            ),
+          );
+        case 'url':
+          final url = e.match.group(0)!;
+          spans.add(
+            TextSpan(
+              text: url,
+              style: TextStyle(
+                fontSize: 15,
+                color: widget.accentHoverColor,
+                decoration: TextDecoration.underline,
+                decorationColor: widget.accentHoverColor,
+                height: 1.47,
+              ),
+              recognizer: _createLinkRecognizer(url),
+            ),
+          );
+      }
+
+      lastEnd = e.end;
+    }
+
+    if (lastEnd < text.length) {
+      spans.addAll(_buildMentionSpans(text.substring(lastEnd)));
+    }
+
+    return spans;
+  }
+
+  /// Build spans for a segment that may contain inline code, bold, italic,
+  /// URLs, and mentions (but NOT fenced code blocks).
+  List<InlineSpan> _buildInlineCodeAndFormatting(String text) {
+    final inlineCodeMatches = _inlineCodeRegex.allMatches(text).toList();
+    if (inlineCodeMatches.isEmpty) {
+      return _buildFormattedSpans(text);
+    }
+
+    final spans = <InlineSpan>[];
+    int lastEnd = 0;
+
+    for (final match in inlineCodeMatches) {
+      if (match.start > lastEnd) {
+        spans.addAll(
+          _buildFormattedSpans(text.substring(lastEnd, match.start)),
+        );
+      }
+
+      final code = match.group(1)!;
+      spans.add(
+        WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+            decoration: BoxDecoration(
+              color: widget.textSecondaryColor.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              code,
+              style: TextStyle(
+                fontSize: 14,
+                fontFamily: 'monospace',
+                color: widget.textColor,
+                height: 1.47,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      lastEnd = match.end;
+    }
+
+    if (lastEnd < text.length) {
+      spans.addAll(_buildFormattedSpans(text.substring(lastEnd)));
+    }
+
+    return spans;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Dispose old recognizers on each rebuild
+    for (final r in _linkRecognizers) {
+      r.dispose();
+    }
+    _linkRecognizers.clear();
+
+    final text = widget.text;
+    final textColor = widget.textColor;
+
+    // Check for fenced code blocks first (highest precedence).
+    final codeBlockMatches = _codeBlockRegex.allMatches(text).toList();
+
+    if (codeBlockMatches.isEmpty) {
+      final hasUrl = urlRegex.hasMatch(text);
+      final hasMention = _mentionRegex.hasMatch(text);
+      final hasBold = _boldRegex.hasMatch(text);
+      final hasItalic = _italicRegex.hasMatch(text);
+      final hasInlineCode = _inlineCodeRegex.hasMatch(text);
+
+      if (!hasUrl && !hasMention && !hasBold && !hasItalic && !hasInlineCode) {
+        return Text(
+          text,
+          style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
+        );
+      }
+
+      return RichText(
+        text: TextSpan(children: _buildInlineCodeAndFormatting(text)),
+      );
+    }
+
+    // Has code blocks -- build a Column with interleaved text and code blocks.
+    final children = <Widget>[];
+    int lastEnd = 0;
+
+    for (final match in codeBlockMatches) {
+      if (match.start > lastEnd) {
+        final segment = text.substring(lastEnd, match.start);
+        if (segment.trim().isNotEmpty) {
+          children.add(
+            RichText(
+              text: TextSpan(
+                children: _buildInlineCodeAndFormatting(segment.trim()),
+              ),
+            ),
+          );
+        }
+      }
+
+      final code = match.group(1) ?? '';
+      children.add(
+        Container(
+          width: double.infinity,
+          margin: const EdgeInsets.symmetric(vertical: 4),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: widget.textSecondaryColor.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            code.trimRight(),
+            style: TextStyle(
+              fontSize: 13,
+              fontFamily: 'monospace',
+              color: textColor,
+              height: 1.5,
+            ),
+          ),
+        ),
+      );
+
+      lastEnd = match.end;
+    }
+
+    if (lastEnd < text.length) {
+      final segment = text.substring(lastEnd);
+      if (segment.trim().isNotEmpty) {
+        children.add(
+          RichText(
+            text: TextSpan(
+              children: _buildInlineCodeAndFormatting(segment.trim()),
+            ),
+          ),
+        );
+      }
+    }
+
+    if (children.length == 1) return children.first;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: children,
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1,57 +1,23 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
-import 'package:url_launcher/url_launcher.dart';
-import 'package:video_player/video_player.dart';
 
 import '../models/chat_message.dart';
-import '../models/reaction.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/download_helper.dart';
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart' show buildAvatar, avatarColor;
+import 'message/media_content.dart';
+import 'message/message_status_icon.dart';
+import 'message/reaction_bar.dart';
+import 'message/reply_quote.dart';
+import 'message/rich_text_content.dart';
 
 /// Common emojis for the reaction picker.
 const reactionEmojis = ['👍', '❤️', '😂', '😮', '😢', '🔥', '👎', '🎉'];
-
-/// Regex for detecting URLs in message text.
-final _urlRegex = RegExp(r'https?://[^\s]+');
-
-/// Regex for detecting standalone URL messages.
-final _standaloneUrlRegex = RegExp(r'^https?://[^\s]+$', caseSensitive: false);
-
-/// Regex for detecting @mentions in message text.
-final _mentionRegex = RegExp(r'@(\w+)');
-
-/// Regex for detecting fenced code blocks: ```\n...\n``` (multiline).
-final _codeBlockRegex = RegExp(r'```\n?([\s\S]*?)```', multiLine: true);
-
-/// Regex for detecting inline code: `...` (single backtick, no nesting).
-final _inlineCodeRegex = RegExp(r'`([^`\n]+)`');
-
-/// Regex for detecting bold text: **...**
-final _boldRegex = RegExp(r'\*\*(.+?)\*\*');
-
-/// Regex for detecting italic text: *...*
-/// Negative lookahead/lookbehind to avoid matching ** (bold delimiters).
-final _italicRegex = RegExp(r'(?<!\*)\*([^*]+?)\*(?!\*)');
-
-/// Regex for detecting image markers: [img:URL]
-final _imgRegex = RegExp(r'^\[img:(.+)\]$');
-
-/// Regex for detecting video markers: [video:URL]
-final _videoRegex = RegExp(r'^\[video:(.+)\]$');
-
-/// Regex for detecting generic file markers: [file:URL]
-final _fileRegex = RegExp(r'^\[file:(.+)\]$');
-
-const _imageExtensions = {'jpg', 'jpeg', 'png', 'gif', 'webp'};
-const _videoExtensions = {'mp4', 'webm', 'mov'};
-const _fileExtensions = {'pdf'};
 
 class MessageItem extends StatefulWidget {
   final ChatMessage message;
@@ -106,100 +72,26 @@ class MessageItem extends StatefulWidget {
 
 class _MessageItemState extends State<MessageItem> {
   bool _isHovered = false;
-  final List<TapGestureRecognizer> _linkRecognizers = [];
 
-  @override
-  void dispose() {
-    for (final r in _linkRecognizers) {
-      r.dispose();
-    }
-    super.dispose();
+  /// Consistent color for a username -- matches sidebar avatar colors.
+  Color _getUserColor(String userId) {
+    final name = widget.message.fromUsername;
+    return avatarColor(name);
   }
 
-  String _resolveMediaUrl(String url) {
-    if (url.startsWith('http')) return url; // external URLs (GIFs)
-    final base = widget.serverUrl ?? '';
-    final token = widget.authToken ?? '';
-    // Relative paths (e.g. /api/media/UUID) need the server origin prepended
-    // so CachedNetworkImage gets an absolute URL it can fetch.
-    final resolved = url.startsWith('/') && base.isNotEmpty ? '$base$url' : url;
-    // Append token as query param -- web <img> elements can't set headers
-    return token.isNotEmpty ? '$resolved?token=$token' : resolved;
-  }
+  Map<String, String> _mediaHeaders() =>
+      mediaHeaders(authToken: widget.authToken);
 
-  Map<String, String> _mediaHeaders() {
-    final headers = <String, String>{};
-    if (widget.authToken != null && widget.authToken!.isNotEmpty) {
-      headers['Authorization'] = 'Bearer ${widget.authToken}';
-    }
-    return headers;
-  }
-
-  String _urlExtension(String url) {
-    final uri = Uri.tryParse(url);
-    final path = uri?.path ?? '';
-    if (path.isEmpty || !path.contains('.')) return '';
-    return path.split('.').last.toLowerCase();
-  }
-
-  bool _isStandaloneMediaUrl(String content) {
-    final trimmed = content.trim();
-    if (!_standaloneUrlRegex.hasMatch(trimmed)) return false;
-
-    final ext = _urlExtension(trimmed);
-    return _imageExtensions.contains(ext) ||
-        _videoExtensions.contains(ext) ||
-        _fileExtensions.contains(ext);
-  }
-
-  bool _isImageUrl(String url) => _imageExtensions.contains(_urlExtension(url));
-
-  bool _isVideoUrl(String url) => _videoExtensions.contains(_urlExtension(url));
-
-  bool _isFileUrl(String url) => _fileExtensions.contains(_urlExtension(url));
-
-  String? _extractMediaUrl(String content) {
-    final imageMatch = _imgRegex.firstMatch(content);
-    if (imageMatch != null) return imageMatch.group(1);
-
-    final videoMatch = _videoRegex.firstMatch(content);
-    if (videoMatch != null) return videoMatch.group(1);
-
-    final fileMatch = _fileRegex.firstMatch(content);
-    if (fileMatch != null) return fileMatch.group(1);
-
-    if (_isStandaloneMediaUrl(content)) {
-      return content.trim();
-    }
-
-    return null;
-  }
-
-  String _filenameFromUrl(String url) {
-    final parsed = Uri.tryParse(url);
-    final lastSegment = (parsed?.pathSegments.isNotEmpty ?? false)
-        ? parsed!.pathSegments.last
-        : '';
-    if (lastSegment.isEmpty) {
-      return 'media.bin';
-    }
-    return lastSegment;
-  }
-
-  Future<void> _openMedia(String rawUrl) async {
-    final uri = Uri.tryParse(_resolveMediaUrl(rawUrl));
-    if (uri != null) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
-  }
+  String _resolveUrl(String url) => resolveMediaUrl(
+    url,
+    serverUrl: widget.serverUrl,
+    authToken: widget.authToken,
+  );
 
   Future<void> _downloadMedia(String rawUrl) async {
-    final mediaUrl = _resolveMediaUrl(rawUrl);
+    final url = _resolveUrl(rawUrl);
     try {
-      final response = await http.get(
-        Uri.parse(mediaUrl),
-        headers: _mediaHeaders(),
-      );
+      final response = await http.get(Uri.parse(url), headers: _mediaHeaders());
       if (!mounted) return;
 
       if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -213,8 +105,10 @@ class _MessageItemState extends State<MessageItem> {
 
       final contentType =
           response.headers['content-type'] ?? 'application/octet-stream';
+      final filename =
+          Uri.tryParse(url)?.pathSegments.lastOrNull ?? 'media.bin';
       final downloaded = await saveBytesAsFile(
-        fileName: _filenameFromUrl(mediaUrl),
+        fileName: filename,
         bytes: response.bodyBytes,
         mimeType: contentType,
       );
@@ -225,7 +119,7 @@ class _MessageItemState extends State<MessageItem> {
         return;
       }
 
-      await Clipboard.setData(ClipboardData(text: mediaUrl));
+      await Clipboard.setData(ClipboardData(text: url));
       if (!mounted) return;
       ToastService.show(
         context,
@@ -242,7 +136,7 @@ class _MessageItemState extends State<MessageItem> {
     }
   }
 
-  void _showImageViewer({required String imageUrl, required bool isMine}) {
+  void _showImageViewer({required String imageUrl}) {
     final headers = _mediaHeaders();
     showDialog<void>(
       context: context,
@@ -318,244 +212,6 @@ class _MessageItemState extends State<MessageItem> {
     );
   }
 
-  Widget _buildStatusIcon(MessageStatus? status) {
-    if (status == null) return const SizedBox.shrink();
-    IconData icon;
-    Color color;
-    String tooltip;
-    switch (status) {
-      case MessageStatus.sending:
-        icon = Icons.schedule_outlined;
-        color = context.textMuted;
-        tooltip = 'Sending';
-      case MessageStatus.sent:
-        icon = Icons.check_outlined;
-        color = context.textMuted;
-        tooltip = 'Sent';
-      case MessageStatus.delivered:
-        icon = Icons.done_all_outlined;
-        color = context.textMuted;
-        tooltip = 'Delivered';
-      case MessageStatus.read:
-        icon = Icons.done_all_outlined;
-        color = EchoTheme.online;
-        tooltip = 'Read';
-      case MessageStatus.failed:
-        icon = Icons.error_outline;
-        color = EchoTheme.danger;
-        tooltip = 'Failed to send';
-    }
-    return Padding(
-      padding: const EdgeInsets.only(left: 4),
-      child: Tooltip(
-        message: tooltip,
-        child: Icon(icon, size: 12, color: color),
-      ),
-    );
-  }
-
-  /// Consistent color for a username -- matches sidebar avatar colors.
-  Color _getUserColor(String userId) {
-    final name = widget.message.fromUsername;
-    return avatarColor(name);
-  }
-
-  /// Check if the message content is an image marker and build the image widget.
-  Widget? _buildMediaContent(String content, {required bool isMine}) {
-    final headers = _mediaHeaders();
-    final imageMatch = _imgRegex.firstMatch(content);
-    final standaloneUrl = _isStandaloneMediaUrl(content)
-        ? content.trim()
-        : null;
-    final imageUrl =
-        imageMatch?.group(1) ??
-        (standaloneUrl != null && _isImageUrl(standaloneUrl)
-            ? standaloneUrl
-            : null);
-    if (imageUrl != null) {
-      final rawUrl = imageUrl;
-      final fullUrl = _resolveMediaUrl(rawUrl);
-
-      return Semantics(
-        label: 'Image attachment. Tap to view full size.',
-        image: true,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
-          child: GestureDetector(
-            onTap: () => _showImageViewer(imageUrl: fullUrl, isMine: isMine),
-            child: Stack(
-              children: [
-                // Use Image.network for external GIFs to preserve animation
-                fullUrl.startsWith('http') && _urlExtension(rawUrl) == 'gif'
-                    ? Image.network(
-                        fullUrl,
-                        width: 300,
-                        fit: BoxFit.cover,
-                        gaplessPlayback: true,
-                        errorBuilder: (_, e, st) => Container(
-                          width: 300,
-                          height: 80,
-                          decoration: BoxDecoration(
-                            color: context.surface,
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Center(
-                            child: Text(
-                              '[GIF failed to load]',
-                              style: TextStyle(
-                                color: context.textMuted,
-                                fontSize: 13,
-                              ),
-                            ),
-                          ),
-                        ),
-                      )
-                    : CachedNetworkImage(
-                        imageUrl: fullUrl,
-                        width: 300,
-                        fit: BoxFit.cover,
-                        httpHeaders: headers,
-                        errorWidget: (_, e, st) => Container(
-                          width: 300,
-                          height: 80,
-                          decoration: BoxDecoration(
-                            color: context.surface,
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Center(
-                            child: Text(
-                              '[Image failed to load]',
-                              style: TextStyle(
-                                color: context.textMuted,
-                                fontSize: 13,
-                              ),
-                            ),
-                          ),
-                        ),
-                        placeholder: (_, _) => Container(
-                          width: 300,
-                          height: 80,
-                          decoration: BoxDecoration(
-                            color: context.surface,
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Center(
-                            child: SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: context.textMuted,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                Positioned(
-                  right: 8,
-                  bottom: 8,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 8,
-                      vertical: 4,
-                    ),
-                    decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.5),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: const Icon(
-                      Icons.open_in_full,
-                      size: 14,
-                      color: Colors.white,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
-
-    final videoMatch = _videoRegex.firstMatch(content);
-    final videoUrl =
-        videoMatch?.group(1) ??
-        (standaloneUrl != null && _isVideoUrl(standaloneUrl)
-            ? standaloneUrl
-            : null);
-    if (videoUrl != null) {
-      final rawUrl = videoUrl;
-      return _InlineVideoPlayer(
-        videoUrl: _resolveMediaUrl(rawUrl),
-        rawUrl: rawUrl,
-        headers: _mediaHeaders(),
-        surface: context.surface,
-        mainBg: context.mainBg,
-        border: context.border,
-        textPrimary: context.textPrimary,
-        textMuted: context.textMuted,
-        onOpen: () => _openMedia(rawUrl),
-        onDownload: () => _downloadMedia(rawUrl),
-      );
-    }
-
-    final fileMatch = _fileRegex.firstMatch(content);
-    final fileUrl =
-        fileMatch?.group(1) ??
-        (standaloneUrl != null && _isFileUrl(standaloneUrl)
-            ? standaloneUrl
-            : null);
-    if (fileUrl != null) {
-      final rawUrl = fileUrl;
-      final displayName = _filenameFromUrl(rawUrl);
-      return Container(
-        width: 300,
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: context.surface,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: context.border),
-        ),
-        child: Row(
-          children: [
-            Container(
-              width: 36,
-              height: 36,
-              decoration: BoxDecoration(
-                color: context.mainBg,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Icon(
-                Icons.insert_drive_file_outlined,
-                color: context.textMuted,
-              ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                displayName,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-            IconButton(
-              icon: const Icon(Icons.download_outlined, size: 18),
-              onPressed: () => _downloadMedia(rawUrl),
-              tooltip: 'Download',
-            ),
-          ],
-        ),
-      );
-    }
-
-    return null;
-  }
-
   Widget _buildHoverActions(ChatMessage msg, bool isMine, {String? mediaUrl}) {
     return Container(
       decoration: BoxDecoration(
@@ -571,7 +227,7 @@ class _MessageItemState extends State<MessageItem> {
             tooltip: 'Copy',
             onPressed: () {
               final copyText = mediaUrl != null
-                  ? _resolveMediaUrl(mediaUrl)
+                  ? _resolveUrl(mediaUrl)
                   : msg.content;
               Clipboard.setData(ClipboardData(text: copyText));
               ToastService.show(
@@ -635,174 +291,42 @@ class _MessageItemState extends State<MessageItem> {
     );
   }
 
-  /// Base text style used throughout message rendering.
-  TextStyle _baseStyle({required Color textColor}) =>
-      TextStyle(fontSize: 15, color: textColor, height: 1.47);
-
-  /// Build spans for plain text that may contain @mentions.
-  /// Called for segments that have already been stripped of URLs, code, bold,
-  /// and italic markers.
-  List<InlineSpan> _buildMentionSpans(String text, {required Color textColor}) {
-    final mentionMatches = _mentionRegex.allMatches(text).toList();
-    if (mentionMatches.isEmpty) {
-      return [
-        TextSpan(
-          text: text,
-          style: _baseStyle(textColor: textColor),
-        ),
-      ];
-    }
-
-    final spans = <InlineSpan>[];
-    int lastEnd = 0;
-    for (final match in mentionMatches) {
-      if (match.start > lastEnd) {
-        spans.add(
-          TextSpan(
-            text: text.substring(lastEnd, match.start),
-            style: _baseStyle(textColor: textColor),
-          ),
-        );
-      }
-      spans.add(
-        TextSpan(
-          text: match.group(0),
-          style: TextStyle(
-            fontSize: 15,
-            color: context.accentHover,
-            fontWeight: FontWeight.w600,
-            height: 1.47,
-          ),
-        ),
-      );
-      lastEnd = match.end;
-    }
-    if (lastEnd < text.length) {
-      spans.add(
-        TextSpan(
-          text: text.substring(lastEnd),
-          style: _baseStyle(textColor: textColor),
-        ),
-      );
-    }
-    return spans;
+  /// Resolve the bubble background color based on message state.
+  Color _bubbleColor({required bool isMine, required bool isFailed}) {
+    if (isFailed) return EchoTheme.danger.withValues(alpha: 0.2);
+    if (isMine) return context.sentBubble;
+    return context.recvBubble;
   }
 
-  TapGestureRecognizer _createLinkRecognizer(String url) {
-    final recognizer = TapGestureRecognizer()
-      ..onTap = () async {
-        final uri = Uri.tryParse(url);
-        if (uri != null && await canLaunchUrl(uri)) {
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
-        }
-      };
-    _linkRecognizers.add(recognizer);
-    return recognizer;
+  /// Resolve the bubble border radius with a flat corner on the sender's side.
+  /// In compact mode all messages are left-aligned, so the flat corner is
+  /// always on the bottom-left regardless of sender.
+  BorderRadius _bubbleBorderRadius({required bool isMine}) {
+    final isRight = isMine && !widget.compactLayout;
+    return BorderRadius.only(
+      topLeft: const Radius.circular(16),
+      topRight: const Radius.circular(16),
+      bottomLeft: Radius.circular(isRight ? 16 : 4),
+      bottomRight: Radius.circular(isRight ? 4 : 16),
+    );
   }
 
-  /// Build spans for a segment that may contain bold, italic, URLs, and
-  /// mentions (but NOT code -- code is stripped before this is called).
-  List<InlineSpan> _buildFormattedSpans(
-    String text, {
-    required Color textColor,
+  /// Build the sender name label shown above the message bubble.
+  Widget _buildSenderNameLabel({
+    required ChatMessage msg,
+    required bool hasMedia,
   }) {
-    // Collect all matches for bold, italic, and URLs with a tag so we can
-    // process them in document order.
-    final entries = <({int start, int end, String tag, RegExpMatch match})>[];
-
-    for (final m in _boldRegex.allMatches(text)) {
-      entries.add((start: m.start, end: m.end, tag: 'bold', match: m));
-    }
-    for (final m in _italicRegex.allMatches(text)) {
-      entries.add((start: m.start, end: m.end, tag: 'italic', match: m));
-    }
-    for (final m in _urlRegex.allMatches(text)) {
-      entries.add((start: m.start, end: m.end, tag: 'url', match: m));
-    }
-
-    // Sort by start position; break ties by preferring longer matches.
-    entries.sort((a, b) {
-      final cmp = a.start.compareTo(b.start);
-      if (cmp != 0) return cmp;
-      return b.end.compareTo(a.end);
-    });
-
-    // Remove overlapping entries (first match wins).
-    final filtered = <({int start, int end, String tag, RegExpMatch match})>[];
-    int cursor = 0;
-    for (final e in entries) {
-      if (e.start < cursor) continue; // overlaps with a previous match
-      filtered.add(e);
-      cursor = e.end;
-    }
-
-    if (filtered.isEmpty) {
-      return _buildMentionSpans(text, textColor: textColor);
-    }
-
-    final spans = <InlineSpan>[];
-    int lastEnd = 0;
-
-    for (final e in filtered) {
-      // Gap before this match -- may contain mentions
-      if (e.start > lastEnd) {
-        spans.addAll(
-          _buildMentionSpans(
-            text.substring(lastEnd, e.start),
-            textColor: textColor,
-          ),
-        );
-      }
-
-      switch (e.tag) {
-        case 'bold':
-          final inner = e.match.group(1)!;
-          spans.add(
-            TextSpan(
-              text: inner,
-              style: _baseStyle(
-                textColor: textColor,
-              ).copyWith(fontWeight: FontWeight.bold),
-            ),
-          );
-        case 'italic':
-          final inner = e.match.group(1)!;
-          spans.add(
-            TextSpan(
-              text: inner,
-              style: _baseStyle(
-                textColor: textColor,
-              ).copyWith(fontStyle: FontStyle.italic),
-            ),
-          );
-        case 'url':
-          final url = e.match.group(0)!;
-          spans.add(
-            TextSpan(
-              text: url,
-              style: TextStyle(
-                fontSize: 15,
-                color: context.accentHover,
-                decoration: TextDecoration.underline,
-                decorationColor: context.accentHover,
-                height: 1.47,
-              ),
-              recognizer: _createLinkRecognizer(url),
-            ),
-          );
-      }
-
-      lastEnd = e.end;
-    }
-
-    // Remaining text after last match
-    if (lastEnd < text.length) {
-      spans.addAll(
-        _buildMentionSpans(text.substring(lastEnd), textColor: textColor),
-      );
-    }
-
-    return spans;
+    return Padding(
+      padding: EdgeInsets.only(bottom: 4, left: hasMedia ? 8 : 0),
+      child: Text(
+        msg.fromUsername,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: _getUserColor(msg.fromUserId),
+        ),
+      ),
+    );
   }
 
   /// Build a friendly decryption failure message with a recovery action.
@@ -844,326 +368,11 @@ class _MessageItemState extends State<MessageItem> {
     );
   }
 
-  /// Build spans for a segment that may contain inline code, bold, italic,
-  /// URLs, and mentions (but NOT fenced code blocks).
-  List<InlineSpan> _buildInlineCodeAndFormatting(
-    String text, {
-    required Color textColor,
-  }) {
-    final inlineCodeMatches = _inlineCodeRegex.allMatches(text).toList();
-    if (inlineCodeMatches.isEmpty) {
-      return _buildFormattedSpans(text, textColor: textColor);
-    }
-
-    final spans = <InlineSpan>[];
-    int lastEnd = 0;
-
-    for (final match in inlineCodeMatches) {
-      // Gap before inline code -- process for bold/italic/URL/mention
-      if (match.start > lastEnd) {
-        spans.addAll(
-          _buildFormattedSpans(
-            text.substring(lastEnd, match.start),
-            textColor: textColor,
-          ),
-        );
-      }
-
-      // Inline code span with monospace + subtle background
-      final code = match.group(1)!;
-      spans.add(
-        WidgetSpan(
-          alignment: PlaceholderAlignment.baseline,
-          baseline: TextBaseline.alphabetic,
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-            decoration: BoxDecoration(
-              color: context.textSecondary.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              code,
-              style: TextStyle(
-                fontSize: 14,
-                fontFamily: 'monospace',
-                color: textColor,
-                height: 1.47,
-              ),
-            ),
-          ),
-        ),
-      );
-
-      lastEnd = match.end;
-    }
-
-    // Remaining text after last inline code
-    if (lastEnd < text.length) {
-      spans.addAll(
-        _buildFormattedSpans(text.substring(lastEnd), textColor: textColor),
-      );
-    }
-
-    return spans;
-  }
-
-  /// Build a RichText widget that renders markdown formatting, URLs as tappable
-  /// links, and @mentions with accent color + bold weight.
-  ///
-  /// Precedence: code blocks > inline code > bold > italic > URLs > mentions.
-  Widget _buildMessageText(String text, {required Color textColor}) {
-    // Dispose old recognizers on each rebuild
-    for (final r in _linkRecognizers) {
-      r.dispose();
-    }
-    _linkRecognizers.clear();
-
-    // Check for fenced code blocks first (highest precedence).
-    final codeBlockMatches = _codeBlockRegex.allMatches(text).toList();
-
-    if (codeBlockMatches.isEmpty) {
-      // No code blocks -- check if any formatting exists at all.
-      final hasUrl = _urlRegex.hasMatch(text);
-      final hasMention = _mentionRegex.hasMatch(text);
-      final hasBold = _boldRegex.hasMatch(text);
-      final hasItalic = _italicRegex.hasMatch(text);
-      final hasInlineCode = _inlineCodeRegex.hasMatch(text);
-
-      if (!hasUrl && !hasMention && !hasBold && !hasItalic && !hasInlineCode) {
-        return Text(text, style: _baseStyle(textColor: textColor));
-      }
-
-      return RichText(
-        text: TextSpan(
-          children: _buildInlineCodeAndFormatting(text, textColor: textColor),
-        ),
-      );
-    }
-
-    // Has code blocks -- build a Column with interleaved text and code blocks.
-    final children = <Widget>[];
-    int lastEnd = 0;
-
-    for (final match in codeBlockMatches) {
-      // Text segment before the code block
-      if (match.start > lastEnd) {
-        final segment = text.substring(lastEnd, match.start);
-        if (segment.trim().isNotEmpty) {
-          children.add(
-            RichText(
-              text: TextSpan(
-                children: _buildInlineCodeAndFormatting(
-                  segment.trim(),
-                  textColor: textColor,
-                ),
-              ),
-            ),
-          );
-        }
-      }
-
-      // The code block itself
-      final code = match.group(1) ?? '';
-      children.add(
-        Container(
-          width: double.infinity,
-          margin: const EdgeInsets.symmetric(vertical: 4),
-          padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            color: context.textSecondary.withValues(alpha: 0.12),
-            borderRadius: BorderRadius.circular(6),
-          ),
-          child: Text(
-            code.trimRight(),
-            style: TextStyle(
-              fontSize: 13,
-              fontFamily: 'monospace',
-              color: textColor,
-              height: 1.5,
-            ),
-          ),
-        ),
-      );
-
-      lastEnd = match.end;
-    }
-
-    // Remaining text after the last code block
-    if (lastEnd < text.length) {
-      final segment = text.substring(lastEnd);
-      if (segment.trim().isNotEmpty) {
-        children.add(
-          RichText(
-            text: TextSpan(
-              children: _buildInlineCodeAndFormatting(
-                segment.trim(),
-                textColor: textColor,
-              ),
-            ),
-          ),
-        );
-      }
-    }
-
-    if (children.length == 1) return children.first;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: children,
-    );
-  }
-
-  Widget _buildReactionPill(List<Reaction> reactions, bool isMine) {
-    if (reactions.isEmpty) return const SizedBox.shrink();
-
-    // Collect unique emojis preserving order of first appearance.
-    final seen = <String>{};
-    final uniqueEmojis = <String>[];
-    for (final r in reactions) {
-      if (seen.add(r.emoji)) uniqueEmojis.add(r.emoji);
-    }
-
-    final totalCount = reactions.length;
-
-    return GestureDetector(
-      onTapUp: (details) =>
-          widget.onReactionTap?.call(widget.message, details.globalPosition),
-      child: Container(
-        height: 24,
-        padding: const EdgeInsets.symmetric(horizontal: 6),
-        decoration: BoxDecoration(
-          color: context.surface,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: context.border, width: 1),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            for (final emoji in uniqueEmojis)
-              Padding(
-                padding: const EdgeInsets.only(right: 2),
-                child: Text(emoji, style: const TextStyle(fontSize: 14)),
-              ),
-            if (totalCount > 1) ...[
-              const SizedBox(width: 2),
-              Text(
-                '$totalCount',
-                style: TextStyle(fontSize: 12, color: context.textMuted),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// Resolve the bubble background color based on message state.
-  Color _bubbleColor({required bool isMine, required bool isFailed}) {
-    if (isFailed) return EchoTheme.danger.withValues(alpha: 0.2);
-    if (isMine) return context.sentBubble;
-    return context.recvBubble;
-  }
-
-  /// Resolve the bubble border radius with a flat corner on the sender's side.
-  /// In compact mode all messages are left-aligned, so the flat corner is
-  /// always on the bottom-left regardless of sender.
-  BorderRadius _bubbleBorderRadius({required bool isMine}) {
-    final isRight = isMine && !widget.compactLayout;
-    return BorderRadius.only(
-      topLeft: const Radius.circular(16),
-      topRight: const Radius.circular(16),
-      bottomLeft: Radius.circular(isRight ? 16 : 4),
-      bottomRight: Radius.circular(isRight ? 4 : 16),
-    );
-  }
-
-  /// Build the sender name label shown above the message bubble.
-  Widget _buildSenderNameLabel({
-    required ChatMessage msg,
-    required bool hasMedia,
-  }) {
-    return Padding(
-      padding: EdgeInsets.only(bottom: 4, left: hasMedia ? 8 : 0),
-      child: Text(
-        msg.fromUsername,
-        style: TextStyle(
-          fontSize: 12,
-          fontWeight: FontWeight.w600,
-          color: _getUserColor(msg.fromUserId),
-        ),
-      ),
-    );
-  }
-
-  /// Build the reply-to quote block shown above the message content.
-  Widget _buildReplyQuote({required ChatMessage msg, required bool isMine}) {
-    final replyContent = msg.replyToContent!;
-    final truncated = replyContent.length > 100
-        ? '${replyContent.substring(0, 100)}...'
-        : replyContent;
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: 6),
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-      decoration: BoxDecoration(
-        color: (isMine ? Colors.white : context.accent).withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(8),
-        border: Border(
-          left: BorderSide(
-            color: isMine
-                ? Colors.white.withValues(alpha: 0.5)
-                : context.accent,
-            width: 3,
-          ),
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: isMine
-            ? CrossAxisAlignment.end
-            : CrossAxisAlignment.start,
-        children: [
-          Text(
-            msg.replyToUsername ?? 'Unknown',
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: isMine
-                  ? Colors.white.withValues(alpha: 0.8)
-                  : context.accent,
-            ),
-          ),
-          const SizedBox(height: 2),
-          Text(
-            truncated,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              fontSize: 12,
-              color: isMine
-                  ? Colors.white.withValues(alpha: 0.7)
-                  : context.textSecondary,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Regex for image extensions in URLs (used for inline embed detection).
-  static final _imageUrlEmbedRegex = RegExp(
-    r'https?://[^\s]+\.(?:gif|png|jpe?g|webp)',
-    caseSensitive: false,
-  );
-
-  /// Extract image URLs embedded within text (not standalone).
-  List<String> _extractEmbeddedImageUrls(String content) {
-    // Skip standalone media URLs -- those are handled by _buildMediaContent.
-    if (_isStandaloneMediaUrl(content)) return [];
-    if (_imgRegex.hasMatch(content)) return [];
-    return _imageUrlEmbedRegex
-        .allMatches(content)
-        .map((m) => m.group(0)!)
-        .toList();
+  /// Resolve text color for message content.
+  Color _contentTextColor({required bool isMine, required bool isFailed}) {
+    if (isFailed) return EchoTheme.danger;
+    if (isMine) return Colors.white;
+    return context.textPrimary;
   }
 
   /// Select and build the primary message content (media, decrypt error, or
@@ -1173,17 +382,29 @@ class _MessageItemState extends State<MessageItem> {
     required ChatMessage msg,
     required bool isMine,
     required bool isFailed,
-    required Widget? mediaWidget,
+    required bool hasMedia,
   }) {
-    if (mediaWidget != null) return mediaWidget;
+    if (hasMedia) {
+      return MediaContent(
+        content: msg.content,
+        isMine: isMine,
+        serverUrl: widget.serverUrl,
+        authToken: widget.authToken,
+      );
+    }
     if (msg.content.startsWith('[Could not decrypt')) {
       return _buildDecryptionFailure();
     }
 
     final textColor = _contentTextColor(isMine: isMine, isFailed: isFailed);
-    final textWidget = _buildMessageText(msg.content, textColor: textColor);
+    final textWidget = RichTextContent(
+      text: msg.content,
+      textColor: textColor,
+      accentHoverColor: context.accentHover,
+      textSecondaryColor: context.textSecondary,
+    );
 
-    final embeddedImages = _extractEmbeddedImageUrls(msg.content);
+    final embeddedImages = extractEmbeddedImageUrls(msg.content);
     if (embeddedImages.isEmpty) return textWidget;
 
     final headers = _mediaHeaders();
@@ -1197,7 +418,7 @@ class _MessageItemState extends State<MessageItem> {
           ClipRRect(
             borderRadius: BorderRadius.circular(8),
             child: GestureDetector(
-              onTap: () => _showImageViewer(imageUrl: imgUrl, isMine: isMine),
+              onTap: () => _showImageViewer(imageUrl: imgUrl),
               child: ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 400),
                 child: imgUrl.endsWith('.gif')
@@ -1232,13 +453,6 @@ class _MessageItemState extends State<MessageItem> {
         ],
       ],
     );
-  }
-
-  /// Resolve text color for message content.
-  Color _contentTextColor({required bool isMine, required bool isFailed}) {
-    if (isFailed) return EchoTheme.danger;
-    if (isMine) return Colors.white;
-    return context.textPrimary;
   }
 
   /// Build a small pinned indicator shown inside the bubble.
@@ -1276,19 +490,23 @@ class _MessageItemState extends State<MessageItem> {
     required ChatMessage msg,
     required bool isMine,
     required bool isFailed,
-    required Widget? mediaWidget,
+    required bool hasMedia,
   }) {
     return [
       if (msg.pinnedAt != null) _buildPinnedIndicator(isMine: isMine),
       if (widget.showHeader && (!isMine || widget.compactLayout))
-        _buildSenderNameLabel(msg: msg, hasMedia: mediaWidget != null),
+        _buildSenderNameLabel(msg: msg, hasMedia: hasMedia),
       if (msg.replyToContent != null)
-        _buildReplyQuote(msg: msg, isMine: isMine),
+        ReplyQuote(
+          replyToUsername: msg.replyToUsername,
+          replyToContent: msg.replyToContent!,
+          isMine: isMine,
+        ),
       _buildBubbleContent(
         msg: msg,
         isMine: isMine,
         isFailed: isFailed,
-        mediaWidget: mediaWidget,
+        hasMedia: hasMedia,
       ),
     ];
   }
@@ -1298,11 +516,11 @@ class _MessageItemState extends State<MessageItem> {
     required ChatMessage msg,
     required bool isMine,
     required bool isFailed,
-    required Widget? mediaWidget,
+    required bool hasMedia,
   }) {
     return Container(
       constraints: const BoxConstraints(maxWidth: 520),
-      padding: mediaWidget != null
+      padding: hasMedia
           ? const EdgeInsets.all(4)
           : const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
@@ -1315,7 +533,7 @@ class _MessageItemState extends State<MessageItem> {
           msg: msg,
           isMine: isMine,
           isFailed: isFailed,
-          mediaWidget: mediaWidget,
+          hasMedia: hasMedia,
         ),
       ),
     );
@@ -1407,7 +625,7 @@ class _MessageItemState extends State<MessageItem> {
                 ),
               ),
             ),
-          if (isMine) _buildStatusIcon(msg.status),
+          if (isMine) MessageStatusIcon(status: msg.status),
         ],
       ),
     );
@@ -1461,17 +679,20 @@ class _MessageItemState extends State<MessageItem> {
     final isMine = msg.isMine;
     final isFailed = msg.status == MessageStatus.failed;
 
-    final mediaWidget = _buildMediaContent(msg.content, isMine: isMine);
-    final mediaUrl = _extractMediaUrl(msg.content);
+    final mediaUrl = extractMediaUrl(msg.content);
+    final hasMedia = mediaUrl != null;
 
     final hasReactions = msg.reactions.isNotEmpty;
-    final reactionPill = _buildReactionPill(msg.reactions, isMine);
+    final reactionPill = ReactionBar(
+      reactions: msg.reactions,
+      onTap: (pos) => widget.onReactionTap?.call(msg, pos),
+    );
 
     final bubble = _buildBubble(
       msg: msg,
       isMine: isMine,
       isFailed: isFailed,
-      mediaWidget: mediaWidget,
+      hasMedia: hasMedia,
     );
 
     final bubbleWithReactions = _buildBubbleWithReactions(
@@ -1562,189 +783,6 @@ class _HoverActionButton extends StatelessWidget {
             child: Icon(icon, size: 14, color: context.textSecondary),
           ),
         ),
-      ),
-    );
-  }
-}
-
-/// Inline video player widget with play/pause controls and download
-/// fallback. Initialises a [VideoPlayerController] on first build and
-/// disposes it when removed from the tree.
-class _InlineVideoPlayer extends StatefulWidget {
-  final String videoUrl;
-  final String rawUrl;
-  final Map<String, String> headers;
-  final Color surface;
-  final Color mainBg;
-  final Color border;
-  final Color textPrimary;
-  final Color textMuted;
-  final VoidCallback onOpen;
-  final VoidCallback onDownload;
-
-  const _InlineVideoPlayer({
-    required this.videoUrl,
-    required this.rawUrl,
-    required this.headers,
-    required this.surface,
-    required this.mainBg,
-    required this.border,
-    required this.textPrimary,
-    required this.textMuted,
-    required this.onOpen,
-    required this.onDownload,
-  });
-
-  @override
-  State<_InlineVideoPlayer> createState() => _InlineVideoPlayerState();
-}
-
-class _InlineVideoPlayerState extends State<_InlineVideoPlayer> {
-  VideoPlayerController? _controller;
-  bool _initFailed = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _initVideo();
-  }
-
-  Future<void> _initVideo() async {
-    try {
-      final controller = VideoPlayerController.networkUrl(
-        Uri.parse(widget.videoUrl),
-        httpHeaders: widget.headers,
-      );
-      await controller.initialize();
-      if (!mounted) {
-        controller.dispose();
-        return;
-      }
-      setState(() => _controller = controller);
-    } catch (_) {
-      if (mounted) setState(() => _initFailed = true);
-    }
-  }
-
-  @override
-  void dispose() {
-    _controller?.dispose();
-    super.dispose();
-  }
-
-  void _togglePlayPause() {
-    final c = _controller;
-    if (c == null) return;
-    setState(() {
-      c.value.isPlaying ? c.pause() : c.play();
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 300,
-      padding: const EdgeInsets.all(4),
-      decoration: BoxDecoration(
-        color: widget.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: widget.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(10),
-            child: _buildVideoArea(),
-          ),
-          const SizedBox(height: 8),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Wrap(
-              spacing: 8,
-              children: [
-                OutlinedButton.icon(
-                  onPressed: widget.onOpen,
-                  icon: const Icon(Icons.open_in_new, size: 14),
-                  label: const Text('Open'),
-                ),
-                OutlinedButton.icon(
-                  onPressed: widget.onDownload,
-                  icon: const Icon(Icons.download_outlined, size: 14),
-                  label: const Text('Download'),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 4),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildVideoArea() {
-    final c = _controller;
-
-    // Still loading
-    if (c == null && !_initFailed) {
-      return Container(
-        height: 170,
-        color: widget.mainBg,
-        child: Center(
-          child: SizedBox(
-            width: 24,
-            height: 24,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: widget.textMuted,
-            ),
-          ),
-        ),
-      );
-    }
-
-    // Init failed -- show static placeholder
-    if (_initFailed || c == null) {
-      return GestureDetector(
-        onTap: widget.onOpen,
-        child: Container(
-          height: 170,
-          color: widget.mainBg,
-          child: Center(
-            child: Icon(
-              Icons.play_circle_outline,
-              size: 44,
-              color: widget.textMuted,
-            ),
-          ),
-        ),
-      );
-    }
-
-    // Initialised -- show player with controls
-    return GestureDetector(
-      onTap: _togglePlayPause,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          AspectRatio(
-            aspectRatio: c.value.aspectRatio.clamp(0.5, 3.0),
-            child: VideoPlayer(c),
-          ),
-          if (!c.value.isPlaying)
-            Container(
-              padding: const EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.5),
-                shape: BoxShape.circle,
-              ),
-              child: const Icon(
-                Icons.play_arrow,
-                size: 32,
-                color: Colors.white,
-              ),
-            ),
-        ],
       ),
     );
   }

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -21,6 +21,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
             name: 'lounge',
             kind: 'voice',
             position: 0,
+            category: 'Voice Channels',
             createdAt: '2026-01-01T00:00:00Z',
           ),
         ],

--- a/apps/server/migrations/20260406200000_channel_categories.sql
+++ b/apps/server/migrations/20260406200000_channel_categories.sql
@@ -1,0 +1,1 @@
+ALTER TABLE channels ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'Text Channels';

--- a/apps/server/src/db/channels.rs
+++ b/apps/server/src/db/channels.rs
@@ -12,6 +12,7 @@ pub struct ChannelRow {
     pub kind: String,
     pub topic: Option<String>,
     pub position: i32,
+    pub category: String,
     pub created_at: DateTime<Utc>,
 }
 
@@ -44,7 +45,7 @@ pub async fn list_channels(
     conversation_id: Uuid,
 ) -> Result<Vec<ChannelRow>, sqlx::Error> {
     sqlx::query_as::<_, ChannelRow>(
-        "SELECT id, conversation_id, name, kind, topic, position, created_at
+        "SELECT id, conversation_id, name, kind, topic, position, category, created_at
          FROM channels
          WHERE conversation_id = $1 AND deleted_at IS NULL
          ORDER BY kind ASC, position ASC, created_at ASC",
@@ -59,7 +60,7 @@ pub async fn get_channel(
     channel_id: Uuid,
 ) -> Result<Option<ChannelRow>, sqlx::Error> {
     sqlx::query_as::<_, ChannelRow>(
-        "SELECT id, conversation_id, name, kind, topic, position, created_at
+        "SELECT id, conversation_id, name, kind, topic, position, category, created_at
          FROM channels
          WHERE id = $1 AND deleted_at IS NULL",
     )
@@ -73,7 +74,7 @@ pub async fn get_default_text_channel(
     conversation_id: Uuid,
 ) -> Result<Option<ChannelRow>, sqlx::Error> {
     sqlx::query_as::<_, ChannelRow>(
-        "SELECT id, conversation_id, name, kind, topic, position, created_at
+        "SELECT id, conversation_id, name, kind, topic, position, category, created_at
          FROM channels
          WHERE conversation_id = $1 AND kind = 'text' AND deleted_at IS NULL
          ORDER BY position ASC, created_at ASC
@@ -91,17 +92,26 @@ pub async fn create_channel(
     kind: &str,
     topic: Option<&str>,
     position: i32,
+    category: Option<&str>,
 ) -> Result<ChannelRow, sqlx::Error> {
+    let default_category = if kind == "voice" {
+        "Voice Channels"
+    } else {
+        "Text Channels"
+    };
+    let cat = category.unwrap_or(default_category);
+
     sqlx::query_as::<_, ChannelRow>(
-        "INSERT INTO channels (conversation_id, name, kind, topic, position)
-         VALUES ($1, $2, $3, $4, $5)
-         RETURNING id, conversation_id, name, kind, topic, position, created_at",
+        "INSERT INTO channels (conversation_id, name, kind, topic, position, category)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING id, conversation_id, name, kind, topic, position, category, created_at",
     )
     .bind(conversation_id)
     .bind(name)
     .bind(kind)
     .bind(topic)
     .bind(position)
+    .bind(cat)
     .fetch_one(pool)
     .await
 }
@@ -136,7 +146,7 @@ pub async fn update_channel(
              topic = CASE WHEN $3::text IS NULL THEN topic ELSE $3 END,
              position = COALESCE($4, position)
          WHERE id = $1 AND deleted_at IS NULL
-         RETURNING id, conversation_id, name, kind, topic, position, created_at",
+         RETURNING id, conversation_id, name, kind, topic, position, category, created_at",
     )
     .bind(channel_id)
     .bind(name)

--- a/apps/server/src/migrations/027_channel_categories.sql
+++ b/apps/server/src/migrations/027_channel_categories.sql
@@ -1,0 +1,1 @@
+ALTER TABLE channels ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT 'Text Channels';

--- a/apps/server/src/routes/channels.rs
+++ b/apps/server/src/routes/channels.rs
@@ -21,6 +21,7 @@ pub struct CreateChannelRequest {
     pub kind: String,
     pub topic: Option<String>,
     pub position: Option<i32>,
+    pub category: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -45,6 +46,7 @@ pub struct ChannelResponse {
     pub kind: String,
     pub topic: Option<String>,
     pub position: i32,
+    pub category: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -175,6 +177,7 @@ pub async fn list_channels(
             kind: row.kind,
             topic: row.topic,
             position: row.position,
+            category: row.category,
             created_at: row.created_at,
         })
         .collect();
@@ -224,6 +227,7 @@ pub async fn create_channel(
         &kind,
         body.topic.as_deref(),
         position,
+        body.category.as_deref(),
     )
     .await
     .map_err(|e| match e {
@@ -240,6 +244,7 @@ pub async fn create_channel(
         kind: created.kind,
         topic: created.topic,
         position: created.position,
+        category: created.category,
         created_at: created.created_at,
     };
 
@@ -301,6 +306,7 @@ pub async fn update_channel(
         kind: updated.kind,
         topic: updated.topic,
         position: updated.position,
+        category: updated.category,
         created_at: updated.created_at,
     };
 

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -117,18 +117,34 @@ pub async fn create_group(
     })?;
 
     // Seed default channels for new groups.
-    db::channels::create_channel(&state.pool, group.id, "general", "text", None, 0)
-        .await
-        .map_err(|e| {
-            tracing::error!("DB error in create_group/create_text_channel: {e:?}");
-            AppError::internal("Failed to create default text channel")
-        })?;
-    db::channels::create_channel(&state.pool, group.id, "lounge", "voice", None, 0)
-        .await
-        .map_err(|e| {
-            tracing::error!("DB error in create_group/create_voice_channel: {e:?}");
-            AppError::internal("Failed to create default voice channel")
-        })?;
+    db::channels::create_channel(
+        &state.pool,
+        group.id,
+        "general",
+        "text",
+        None,
+        0,
+        Some("Text Channels"),
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("DB error in create_group/create_text_channel: {e:?}");
+        AppError::internal("Failed to create default text channel")
+    })?;
+    db::channels::create_channel(
+        &state.pool,
+        group.id,
+        "lounge",
+        "voice",
+        None,
+        0,
+        Some("Voice Channels"),
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("DB error in create_group/create_voice_channel: {e:?}");
+        AppError::internal("Failed to create default voice channel")
+    })?;
 
     let members = db::groups::get_group_members(&state.pool, group.id)
         .await


### PR DESCRIPTION
## Sprint 12: Widget Decomposition + UX Polish

### MessageItem decomposition (1751 → ~530 lines)
- Extracted 5 focused widgets into `widgets/message/`: MediaContent, RichTextContent, ReactionBar, ReplyQuote, MessageStatusIcon

### ChatInputBar decomposition (1440 → focused widgets)
- Extracted 4 widgets into `widgets/input/`: MentionAutocomplete, AttachmentPreview, ReplyPreviewBar, InputStatusBar

### Channel categories
- Server: `category` column on channels table, default categories for new groups
- Client: vertical category-based layout with collapsible headers replacing flat chip list

### Settings polish
- Camera device dropdown in Audio settings
- Test Sound button
- Test Microphone button with 3-second level meter