### PR TITLE
fix: emoji underline, chrome autofill bar

### DIFF
--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -881,6 +881,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
           focusNode: _inputFocusNode,
           maxLines: 5,
           minLines: 1,
+          autofillHints: const [],
           style: TextStyle(fontSize: 14, color: context.textPrimary),
           decoration: InputDecoration(
             hintText: _isEditing ? 'Edit your message...' : 'Type a message...',

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -39,7 +39,13 @@ class ReactionBar extends StatelessWidget {
             for (final emoji in uniqueEmojis)
               Padding(
                 padding: const EdgeInsets.only(right: 2),
-                child: Text(emoji, style: const TextStyle(fontSize: 14)),
+                child: Text(
+                  emoji,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    decoration: TextDecoration.none,
+                  ),
+                ),
               ),
             if (totalCount > 1) ...[
               const SizedBox(width: 2),


### PR DESCRIPTION
Quick polish fixes: remove TextDecoration on reaction emojis, disable Chrome autofill hints on chat input.