### PR TITLE
fix: disable chrome autofill on login and register fields

### DIFF
--- a/apps/client/lib/src/screens/login_screen.dart
+++ b/apps/client/lib/src/screens/login_screen.dart
@@ -112,6 +112,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
   Widget _buildUsernameField() {
     return TextFormField(
       controller: _usernameController,
+      autofillHints: const [],
       decoration: const InputDecoration(
         labelText: 'Username',
         border: OutlineInputBorder(),
@@ -130,6 +131,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     return TextFormField(
       controller: _passwordController,
       obscureText: true,
+      autofillHints: const [],
       decoration: const InputDecoration(
         labelText: 'Password',
         border: OutlineInputBorder(),

--- a/apps/client/lib/src/screens/register_screen.dart
+++ b/apps/client/lib/src/screens/register_screen.dart
@@ -188,6 +188,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
   Widget _buildUsernameField() {
     return TextFormField(
       controller: _usernameController,
+      autofillHints: const [],
       decoration: const InputDecoration(
         labelText: 'Username',
         border: OutlineInputBorder(),
@@ -201,6 +202,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
     return TextFormField(
       controller: _passwordController,
       obscureText: true,
+      autofillHints: const [],
       decoration: const InputDecoration(
         labelText: 'Password',
         border: OutlineInputBorder(),
@@ -258,6 +260,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
     return TextFormField(
       controller: _confirmController,
       obscureText: true,
+      autofillHints: const [],
       decoration: const InputDecoration(
         labelText: 'Confirm password',
         border: OutlineInputBorder(),


### PR DESCRIPTION
Adds autofillHints: const [] to all form fields on login and register screens to prevent Chrome mobile autofill bar.