### PR TITLE
fix: livekit subdomain, image dismiss, sidebar button

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice_provider.dart
@@ -492,11 +492,11 @@ class _LiveKitTokenResult {
 }
 
 /// Derive LiveKit WebSocket URL from the Echo server URL.
-/// https://echo-messenger.us → wss://echo-messenger.us:7881
+/// https://echo-messenger.us → wss://livekit.echo-messenger.us
 String _deriveLiveKitUrl(String serverUrl) {
   final uri = Uri.parse(serverUrl);
   final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
-  return '$scheme://${uri.host}:7881';
+  return '$scheme://livekit.${uri.host}';
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -508,16 +508,13 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
             constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
           ),
           if (widget.onCollapseSidebar != null)
-            Padding(
-              padding: const EdgeInsets.only(left: 4),
-              child: IconButton(
-                icon: const Icon(Icons.chevron_left, size: 16),
-                color: context.textMuted,
-                tooltip: 'Collapse sidebar',
-                onPressed: widget.onCollapseSidebar,
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
-              ),
+            IconButton(
+              icon: const Icon(Icons.chevron_left, size: 14),
+              color: context.textMuted,
+              tooltip: 'Collapse sidebar',
+              onPressed: widget.onCollapseSidebar,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
             ),
         ],
       ),

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -212,6 +212,7 @@ class MediaContentState extends State<MediaContent> {
     final headers = _headers();
     showDialog<void>(
       context: context,
+      barrierDismissible: true,
       barrierColor: Colors.black.withValues(alpha: 0.85),
       builder: (dialogContext) {
         final screenSize = MediaQuery.of(dialogContext).size;


### PR DESCRIPTION
LiveKit URL derives to livekit.echo-messenger.us subdomain. Image viewer dismissible on outside click. Sidebar collapse button sized smaller.