### PR TITLE
fix: null check crash on voice join failure

### DIFF
--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -277,7 +277,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                 startMuted:
                     voiceSettings.selfMuted || voiceSettings.selfDeafened,
               );
-              widget.onVoiceChannelChanged(channel.id);
+              if (mounted) widget.onVoiceChannelChanged(channel.id);
             }
           }
         },

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -1063,7 +1063,9 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
               hideVoiceDock: widget.hideVoiceDock,
               onTextChannelChanged: _onTextChannelChanged,
               onVoiceChannelChanged: (channelId) {
-                setState(() => _activeVoiceChannelId = channelId);
+                if (mounted) {
+                  setState(() => _activeVoiceChannelId = channelId);
+                }
               },
             ),
 


### PR DESCRIPTION
Added mounted checks before setState in voice channel callbacks to prevent crash when widget is disposed during async voice join.