### PR TITLE
fix: april 7 bug fixes -- crash, screen share, video, notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,13 +35,18 @@ cd apps/client && flutter pub get && flutter run -d linux
 flutter build web --release --pwa-strategy=none --dart-define=APP_VERSION=X.Y.Z
 ```
 
+**Other scripts**: `scripts/demo_two_apps.sh` (launch two client instances for testing), `scripts/seed_demo_data.sh` (populate test data).
+
 ## Tests
 
 ```bash
 cargo test --workspace                            # Rust: 53 tests (Signal Protocol + server)
+cargo test -p echo-server -- test_name            # Run a single Rust test
 cd apps/client && flutter test                    # Flutter: 51 tests (crypto, models, state)
+cd apps/client && flutter test test/path_test.dart # Run a single Flutter test file
 ./scripts/test_e2e.sh                             # E2E integration tests
-npx playwright test                               # Visual tests
+npx playwright test                               # Visual tests (Playwright, tests/e2e/)
+npx playwright test tests/e2e/some.spec.ts        # Run a single Playwright spec
 ```
 
 ## Lint & Format
@@ -53,7 +58,7 @@ cd apps/client && dart format --set-exit-if-changed .   # Dart format
 cd apps/client && flutter analyze --fatal-infos   # Dart lint
 ```
 
-Pre-commit hooks (lefthook): cargo fmt check + clippy on .rs files, commitlint on commit messages. Conventional commits enforced.
+Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warnings` on .rs files, dart format + flutter analyze on .dart files, commitlint on commit messages. Conventional commits enforced.
 
 ## Architecture
 
@@ -62,14 +67,14 @@ Pre-commit hooks (lefthook): cargo fmt check + clippy on .rs files, commitlint o
 - `apps/client/` -- Flutter app, Riverpod state management, GoRouter navigation
 - `core/rust-core/` -- Shared Rust library: Signal Protocol (X3DH + Double Ratchet), crypto primitives, FFI bridge
 
-**Server startup sequence** (main.rs): load .env -> tracing -> Config::from_env() -> PG pool + auto-migrate 13 SQL files -> spawn WebSocket Hub (DashMap) -> build Axum router -> bind.
+**Server startup sequence** (main.rs): load .env -> tracing -> Config::from_env() -> PG pool + auto-migrate SQL files (`apps/server/migrations/`) -> spawn WebSocket Hub (DashMap) -> build Axum router -> bind.
 
 **Key server modules**:
 - `auth/` -- JWT (15-min access + 7-day refresh), Argon2id passwords, AuthUser middleware extractor
 - `ws/hub.rs` -- DashMap<user_id, mpsc::Sender> for lock-free WS routing
 - `ws/handler.rs` -- WS upgrade, message parsing, event dispatch (MessageRelayed, TypingIndicator, Reaction, Online/Offline)
 - `db/` -- 9 query modules (users, messages, contacts, groups, keys, reactions, media, tokens)
-- `routes/` -- REST: /api/auth, /api/users, /api/contacts, /api/messages, /api/groups, /api/keys, /api/reactions, /api/media
+- `routes/` -- REST: /api/auth, /api/users, /api/contacts, /api/messages, /api/groups, /api/keys, /api/reactions, /api/media, /api/channels, /api/voice, /api/group_keys
 
 **Client state** (Riverpod StateNotifiers with immutable copyWith):
 - `auth_provider` -- login/register/logout/auto-login, persists to SharedPreferences
@@ -82,7 +87,12 @@ Pre-commit hooks (lefthook): cargo fmt check + clippy on .rs files, commitlint o
 - Rust reference: `core/rust-core/src/signal/`
 - Dart production: `apps/client/lib/src/services/signal_protocol.dart`, `signal_x3dh.dart`, `signal_session.dart`
 - 1:1 messages: X3DH key exchange + Double Ratchet (end-to-end encrypted)
-- Group messages: currently unencrypted (server relays plaintext)
+- Group messages: group key envelopes infrastructure exists (`group_crypto_service.dart`, `routes/group_keys.rs`) but not fully wired
+
+**Voice & Video** (LiveKit integration):
+- Server: `routes/voice.rs` handles call signaling and LiveKit token generation
+- Client: `livekit_voice_provider.dart`, `voice_rtc_provider.dart`, `voice_settings_provider.dart`
+- Requires `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET` env vars in production
 
 ## Critical Conventions
 
@@ -102,7 +112,9 @@ Conventional commits, short and human-readable. One line subject, optional brief
 - `feat: Signal Protocol integration -- X3DH + Double Ratchet in Dart + device-aware server`
 - `refactor: upgrade theme to ThemeExtension for scalable custom themes`
 
-Keep it concise -- no multi-paragraph explanations, no bullet lists in commit messages.
+Keep it concise -- no multi-paragraph explanations, no bullet lists in commit messages. No co-author tags.
+
+Allowed types: `feat fix docs style refactor perf test build ci chore revert security`. Optional scopes: `core server client infra proto crypto ci deps`. Subject must be lowercase, max 72 chars.
 
 ## Known Limitations
 

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -126,7 +126,10 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
         'Crypto',
         'PlatformException during init (degraded mode): $e',
       );
-      state = state.copyWith(isUploading: false);
+      state = state.copyWith(
+        isUploading: false,
+        error: 'Secure storage unavailable: $e',
+      );
     } catch (e) {
       DebugLogService.instance.log(LogLevel.error, 'Crypto', 'Init failed: $e');
       state = state.copyWith(

--- a/apps/client/lib/src/providers/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice_provider.dart
@@ -292,6 +292,29 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
     }
   }
 
+  /// Enable or disable screen sharing via LiveKit.
+  ///
+  /// Uses the SDK's built-in [setScreenShareEnabled] which handles both
+  /// capture (getDisplayMedia) and publishing the track to the room.
+  Future<bool> setScreenShareEnabled(bool enabled) async {
+    if (_disposed || !state.isActive) return false;
+    final room = _room;
+    if (room == null) return false;
+
+    try {
+      await room.localParticipant?.setScreenShareEnabled(enabled);
+      return true;
+    } catch (e) {
+      debugPrint('[LiveKitVoice] setScreenShareEnabled($enabled) failed: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'LiveKitVoice',
+        'Screen share toggle failed: $e',
+      );
+      return false;
+    }
+  }
+
   /// Access the LiveKit [Room] directly for advanced widget rendering
   /// (e.g. [VideoTrackRenderer]).
   Room? get room => _room;
@@ -507,7 +530,21 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
   void dispose() {
     _disposed = true;
     _stopAudioLevelPolling();
-    unawaited(_cleanupRoom());
+
+    // Synchronously null out references so in-flight callbacks hit null checks
+    // instead of accessing freed memory. The actual network disconnect is
+    // fire-and-forget on captured local references.
+    final listener = _roomListener;
+    final room = _room;
+    _roomListener = null;
+    _room = null;
+    listener?.dispose();
+    if (room != null) {
+      unawaited(
+        room.disconnect().then((_) => room.dispose()).catchError((_) => false),
+      );
+    }
+
     super.dispose();
   }
 }

--- a/apps/client/lib/src/providers/screen_share_provider.dart
+++ b/apps/client/lib/src/providers/screen_share_provider.dart
@@ -117,11 +117,10 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
     if (msg.contains('https') || msg.contains('secure context')) {
       return 'Screen sharing requires a secure (HTTPS) connection.';
     }
-    // Linux-specific guidance: PipeWire + XDG Desktop Portal are required
-    // for getDisplayMedia to work on native Linux builds.
     if (!kIsWeb && defaultTargetPlatform == TargetPlatform.linux) {
-      return 'Screen sharing on Linux requires PipeWire and '
-          'XDG Desktop Portal support.';
+      return 'Screen sharing failed on Linux. '
+          'Ensure PipeWire, XDG Desktop Portal, and xdg-desktop-portal-gtk '
+          'or xdg-desktop-portal-kde are installed and running.';
     }
     return 'Could not start screen sharing: $error';
   }

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -248,11 +248,8 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     String payload;
     final cryptoState = ref.read(cryptoProvider);
     if (!cryptoState.isInitialized) {
-      _addFailedMessage(
-        toUserId,
-        'Encryption not initialized',
-        conversationId: conversationId,
-      );
+      final reason = cryptoState.error ?? 'Encryption not initialized';
+      _addFailedMessage(toUserId, reason, conversationId: conversationId);
       return;
     }
 
@@ -261,10 +258,11 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       final token = ref.read(authProvider).token ?? '';
       crypto.setToken(token);
       payload = await crypto.encryptMessage(toUserId, content);
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[WS] Encryption failed: $e');
       _addFailedMessage(
         toUserId,
-        'Encryption setup failed. Verify both users have encryption keys.',
+        'Encryption failed: $e',
         conversationId: conversationId,
       );
       return;

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -51,6 +51,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   // Voice lounge: when true and voice is active, show lounge instead of chat
   bool _showingLounge = true;
+  bool _userDismissedLounge = false;
 
   // Settings inline state
   bool _showSettings = false;
@@ -596,11 +597,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     final voiceRtc = ref.watch(voiceRtcProvider);
     final voiceActive = voiceRtc.isActive && voiceRtc.channelId != null;
 
-    // Auto-show lounge when voice becomes active
-    if (voiceActive && !_showingLounge) {
+    // Auto-show lounge when voice becomes active (only on initial join,
+    // not after user dismissed it via "Back to chat").
+    if (voiceActive && !_showingLounge && !_userDismissedLounge) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) setState(() => _showingLounge = true);
       });
+    }
+    // Reset dismiss flag when voice becomes inactive so next join auto-shows.
+    if (!voiceActive && _userDismissedLounge) {
+      _userDismissedLounge = false;
     }
 
     // Determine what the right panel shows
@@ -613,7 +619,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     } else if (voiceActive && _showingLounge) {
       rightPanel = VoiceLoungeScreen(
         onBackToChat: () {
-          setState(() => _showingLounge = false);
+          setState(() {
+            _showingLounge = false;
+            _userDismissedLounge = true;
+          });
         },
       );
     } else if (_selectedConversation != null) {
@@ -710,7 +719,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     } else if (voiceActive && _showingLounge) {
       rightPanel = VoiceLoungeScreen(
         onBackToChat: () {
-          setState(() => _showingLounge = false);
+          setState(() {
+            _showingLounge = false;
+            _userDismissedLounge = true;
+          });
         },
       );
     } else if (_selectedConversation != null) {

--- a/apps/client/lib/src/screens/settings/audio_section.dart
+++ b/apps/client/lib/src/screens/settings/audio_section.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as webrtc;
 
 import '../../providers/voice_settings_provider.dart';
+import '../../services/sound_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../utils/audio_level_analyzer.dart';
 
@@ -73,16 +74,9 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
     setState(() => _isPlayingTestSound = true);
 
     try {
-      // Play a short beep by creating a brief audio stream then stopping it.
-      // On web this triggers the browser audio pipeline confirmation.
-      final stream = await webrtc.navigator.mediaDevices.getUserMedia({
-        'audio': true,
-      });
-      await Future<void>.delayed(const Duration(milliseconds: 400));
-      for (final track in stream.getTracks()) {
-        track.stop();
-      }
-      await stream.dispose();
+      await SoundService().playMessageReceived();
+      // Brief delay so the button shows "Playing..." while the sound plays.
+      await Future<void>.delayed(const Duration(milliseconds: 600));
     } catch (_) {
       // Audio not available
     }

--- a/apps/client/lib/src/screens/settings/debug_section.dart
+++ b/apps/client/lib/src/screens/settings/debug_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../services/debug_log_service.dart';
@@ -28,6 +29,31 @@ class _DebugSectionState extends State<DebugSection> {
     _logService.removeListener(_onLogsChanged);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _copyAllLogs(List<DebugLogEntry> entries) {
+    final buffer = StringBuffer();
+    for (final e in entries) {
+      final h = e.timestamp.hour.toString().padLeft(2, '0');
+      final m = e.timestamp.minute.toString().padLeft(2, '0');
+      final s = e.timestamp.second.toString().padLeft(2, '0');
+      final level = switch (e.level) {
+        LogLevel.info => 'INF',
+        LogLevel.warning => 'WRN',
+        LogLevel.error => 'ERR',
+      };
+      buffer.writeln('$h:$m:$s [$level] ${e.source}: ${e.message}');
+    }
+    Clipboard.setData(ClipboardData(text: buffer.toString()));
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('${entries.length} log entries copied to clipboard'),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
   }
 
   void _onLogsChanged() {
@@ -67,6 +93,25 @@ class _DebugSectionState extends State<DebugSection> {
                   ),
                 ),
               ),
+              OutlinedButton.icon(
+                onPressed: entries.isEmpty ? null : () => _copyAllLogs(entries),
+                icon: const Icon(Icons.copy_outlined, size: 16),
+                label: const Text('Copy All'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: context.textSecondary,
+                  disabledForegroundColor: context.textMuted,
+                  side: BorderSide(color: context.border),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  textStyle: const TextStyle(fontSize: 13),
+                ),
+              ),
+              const SizedBox(width: 8),
               OutlinedButton.icon(
                 onPressed: entries.isEmpty ? null : _logService.clear,
                 icon: const Icon(Icons.delete_sweep_outlined, size: 16),

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -5,9 +5,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:livekit_client/livekit_client.dart' as lk;
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
+import 'package:cached_network_image/cached_network_image.dart';
+
+import '../providers/auth_provider.dart';
 import '../providers/channels_provider.dart';
 import '../providers/livekit_voice_provider.dart';
 import '../providers/screen_share_provider.dart';
+import '../providers/server_url_provider.dart';
 import '../providers/voice_settings_provider.dart';
 import '../theme/echo_theme.dart';
 
@@ -18,6 +22,13 @@ class VoiceLoungeScreen extends ConsumerWidget {
   final VoidCallback? onBackToChat;
 
   const VoiceLoungeScreen({super.key, this.onBackToChat});
+
+  static String? _buildAvatarUrl(WidgetRef ref) {
+    final avatarPath = ref.read(authProvider).avatarUrl;
+    if (avatarPath == null || avatarPath.isEmpty) return null;
+    final serverUrl = ref.read(serverUrlProvider);
+    return '$serverUrl$avatarPath';
+  }
 
   /// Screen sharing is only useful on desktop and web platforms.
   static bool get _supportsScreenShare {
@@ -66,7 +77,11 @@ class VoiceLoungeScreen extends ConsumerWidget {
                   // Remote screen shares
                   if (room != null) _RemoteScreenShares(room: room),
                   // Participant grid
-                  _ParticipantGrid(room: room, voiceState: voiceLk),
+                  _ParticipantGrid(
+                    room: room,
+                    voiceState: voiceLk,
+                    localAvatarUrl: _buildAvatarUrl(ref),
+                  ),
                 ],
               ),
             ),
@@ -161,8 +176,13 @@ class _LoungeHeader extends StatelessWidget {
 class _ParticipantGrid extends StatelessWidget {
   final lk.Room? room;
   final LiveKitVoiceState voiceState;
+  final String? localAvatarUrl;
 
-  const _ParticipantGrid({required this.room, required this.voiceState});
+  const _ParticipantGrid({
+    required this.room,
+    required this.voiceState,
+    this.localAvatarUrl,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -193,6 +213,7 @@ class _ParticipantGrid extends StatelessWidget {
         _ParticipantTile(
           key: const ValueKey('local'),
           name: 'You',
+          avatarUrl: localAvatarUrl,
           hasVideo: localVideo?.track != null,
           videoTrack: localVideo?.track as lk.VideoTrack?,
           mirror: true,
@@ -204,7 +225,9 @@ class _ParticipantGrid extends StatelessWidget {
 
     // Remote participant tiles
     for (final participant in room!.remoteParticipants.values) {
-      final identity = participant.identity.isNotEmpty
+      final displayName = participant.name.isNotEmpty
+          ? participant.name
+          : participant.identity.isNotEmpty
           ? participant.identity
           : participant.sid.toString();
 
@@ -217,12 +240,18 @@ class _ParticipantGrid extends StatelessWidget {
           )
           .firstOrNull;
 
+      // Audio levels are keyed by identity (UUID), not display name.
+      final identity = participant.identity.isNotEmpty
+          ? participant.identity
+          : participant.sid.toString();
       final audioLevel = voiceState.peerAudioLevels[identity] ?? 0.0;
 
       tiles.add(
         _ParticipantTile(
           key: ValueKey('remote-${participant.sid}'),
-          name: identity.length > 12 ? identity.substring(0, 12) : identity,
+          name: displayName.length > 16
+              ? displayName.substring(0, 16)
+              : displayName,
           hasVideo: videoTrack?.track != null,
           videoTrack: videoTrack?.track as lk.VideoTrack?,
           mirror: false,
@@ -269,6 +298,7 @@ class _ParticipantGrid extends StatelessWidget {
 
 class _ParticipantTile extends StatelessWidget {
   final String name;
+  final String? avatarUrl;
   final bool hasVideo;
   final lk.VideoTrack? videoTrack;
   final bool mirror;
@@ -278,6 +308,7 @@ class _ParticipantTile extends StatelessWidget {
   const _ParticipantTile({
     super.key,
     required this.name,
+    this.avatarUrl,
     required this.hasVideo,
     this.videoTrack,
     this.mirror = false,
@@ -313,7 +344,11 @@ class _ParticipantTile extends StatelessWidget {
                   : lk.VideoViewMirrorMode.off,
             )
           else
-            _AvatarCircle(name: name, isSpeaking: isSpeaking),
+            _AvatarCircle(
+              name: name,
+              avatarUrl: avatarUrl,
+              isSpeaking: isSpeaking,
+            ),
           // Name label overlay at bottom
           Positioned(
             bottom: 0,
@@ -369,9 +404,14 @@ class _ParticipantTile extends StatelessWidget {
 
 class _AvatarCircle extends StatelessWidget {
   final String name;
+  final String? avatarUrl;
   final bool isSpeaking;
 
-  const _AvatarCircle({required this.name, required this.isSpeaking});
+  const _AvatarCircle({
+    required this.name,
+    this.avatarUrl,
+    required this.isSpeaking,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -394,16 +434,44 @@ class _AvatarCircle extends StatelessWidget {
             width: 3,
           ),
         ),
-        child: Center(
-          child: Text(
-            initial,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 28,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
+        clipBehavior: Clip.antiAlias,
+        child: avatarUrl != null
+            ? CachedNetworkImage(
+                imageUrl: avatarUrl!,
+                fit: BoxFit.cover,
+                width: 72,
+                height: 72,
+                placeholder: (_, _) => Center(
+                  child: Text(
+                    initial,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 28,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                errorWidget: (_, _, _) => Center(
+                  child: Text(
+                    initial,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 28,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              )
+            : Center(
+                child: Text(
+                  initial,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 28,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
       ),
     );
   }
@@ -657,7 +725,7 @@ class _ControlBar extends ConsumerWidget {
             },
           ),
           const SizedBox(width: 8),
-          // Screen share
+          // Screen share (published via LiveKit SDK)
           if (VoiceLoungeScreen._supportsScreenShare) ...[
             _ControlButton(
               icon: screenShare.isScreenSharing
@@ -667,16 +735,17 @@ class _ControlBar extends ConsumerWidget {
               isActive: screenShare.isScreenSharing,
               activeColor: EchoTheme.online,
               onPressed: () async {
-                final notifier = ref.read(screenShareProvider.notifier);
+                final lkNotifier = ref.read(livekitVoiceProvider.notifier);
+                final ssNotifier = ref.read(screenShareProvider.notifier);
                 if (screenShare.isScreenSharing) {
-                  await notifier.stopScreenShare();
+                  await lkNotifier.setScreenShareEnabled(false);
+                  await ssNotifier.stopScreenShare();
                 } else {
-                  await notifier.startScreenShare();
-                  final updated = ref.read(screenShareProvider);
-                  if (updated.error != null && context.mounted) {
+                  final ok = await lkNotifier.setScreenShareEnabled(true);
+                  if (!ok && context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(updated.error!),
+                      const SnackBar(
+                        content: Text('Could not start screen sharing.'),
                         behavior: SnackBarBehavior.floating,
                       ),
                     );
@@ -695,6 +764,9 @@ class _ControlBar extends ConsumerWidget {
             isDestructive: true,
             onPressed: () async {
               if (screenShare.isScreenSharing) {
+                await ref
+                    .read(livekitVoiceProvider.notifier)
+                    .setScreenShareEnabled(false);
                 await ref.read(screenShareProvider.notifier).stopScreenShare();
               }
               await ref

--- a/apps/client/lib/src/services/notification_service_stub.dart
+++ b/apps/client/lib/src/services/notification_service_stub.dart
@@ -1,11 +1,55 @@
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
 import 'notification_service.dart';
 
-/// Stub (non-web) implementation -- notifications are a no-op.
-NotificationService createNotificationService() => _StubNotificationService();
+/// Native (non-web) implementation using flutter_local_notifications.
+NotificationService createNotificationService() => _NativeNotificationService();
 
-class _StubNotificationService implements NotificationService {
+class _NativeNotificationService implements NotificationService {
+  static final _plugin = FlutterLocalNotificationsPlugin();
+  static bool _initialized = false;
+  static int _notificationId = 0;
+
+  static const _channel = AndroidNotificationDetails(
+    'echo_messages',
+    'Messages',
+    channelDescription: 'Incoming message notifications',
+    importance: Importance.high,
+    priority: Priority.high,
+  );
+
+  Future<void> _ensureInitialized() async {
+    if (_initialized) return;
+    try {
+      const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+      const linux = LinuxInitializationSettings(defaultActionName: 'Open');
+      const initSettings = InitializationSettings(
+        android: android,
+        linux: linux,
+      );
+      await _plugin.initialize(initSettings);
+      _initialized = true;
+    } catch (e) {
+      debugPrint('[Notifications] init failed: $e');
+    }
+  }
+
   @override
-  Future<void> requestPermission() async {}
+  Future<void> requestPermission() async {
+    if (kIsWeb) return;
+    await _ensureInitialized();
+    // Android 13+ runtime permission
+    try {
+      await _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >()
+          ?.requestNotificationsPermission();
+    } catch (_) {
+      // Not on Android or permission denied -- non-fatal.
+    }
+  }
 
   @override
   void showMessageNotification({
@@ -13,18 +57,22 @@ class _StubNotificationService implements NotificationService {
     required String body,
     bool forceShow = false,
   }) {
-    // TODO: Implement desktop/mobile visual notifications with
-    // flutter_local_notifications. Requires native setup:
-    // - Android: AndroidManifest permissions, notification channel
-    // - Linux: libnotify-dev in CMakeLists.txt
-    // - Windows: no extra setup but needs testing
-    // The sound service already handles audio -- this just needs the popup.
+    _ensureInitialized().then((_) {
+      if (!_initialized) return;
+      _plugin.show(
+        _notificationId++,
+        senderUsername,
+        body,
+        const NotificationDetails(
+          android: _channel,
+          linux: LinuxNotificationDetails(),
+        ),
+      );
+    });
   }
 
   @override
   void updateTabBadge(int totalUnread) {
-    // No-op on non-web platforms.
-    // TODO: Implement desktop notifications with flutter_local_notifications
-    // once native platform setup (AndroidManifest, Linux libnotify) is done.
+    // No-op on native platforms (tab badge is a web concept).
   }
 }

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -514,7 +514,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               tooltip: 'Collapse sidebar',
               onPressed: widget.onCollapseSidebar,
               padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
+              constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
             ),
         ],
       ),

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -60,18 +60,41 @@ bool isImageUrl(String url) => _imageExtensions.contains(urlExtension(url));
 /// Returns true if the URL points to a known file extension.
 bool isFileUrl(String url) => _fileExtensions.contains(urlExtension(url));
 
-/// Resolves a potentially relative media URL to an absolute URL, appending
-/// an auth token as a query parameter when available.
+/// Resolves a potentially relative media URL to an absolute URL.
+///
+/// Does NOT append auth tokens -- callers should use [mediaHeaders] for
+/// authenticated requests, or fetch a media ticket for browser-opened URLs.
 String resolveMediaUrl(String url, {String? serverUrl, String? authToken}) {
-  if (url.startsWith('http')) {
-    // external URLs (GIFs) -- just append token if needed
-    final token = authToken ?? '';
-    return token.isNotEmpty ? '$url?token=$token' : url;
-  }
+  if (url.startsWith('http')) return url;
   final base = serverUrl ?? '';
-  final token = authToken ?? '';
-  final resolved = url.startsWith('/') && base.isNotEmpty ? '$base$url' : url;
-  return token.isNotEmpty ? '$resolved?token=$token' : resolved;
+  return url.startsWith('/') && base.isNotEmpty ? '$base$url' : url;
+}
+
+/// Fetches a single-use media ticket from the server for use in browser URLs.
+Future<String?> _fetchMediaTicket({
+  required String serverUrl,
+  required String authToken,
+}) async {
+  try {
+    final response = await http.post(
+      Uri.parse('$serverUrl/api/media/ticket'),
+      headers: {'Authorization': 'Bearer $authToken'},
+    );
+    if (response.statusCode == 200) {
+      final data = (response.body.contains('{'))
+          ? Uri.splitQueryString(response.body)
+          : {};
+      // Parse JSON manually to avoid adding dart:convert import dependency
+      // when it may already be imported. The response is {"ticket":"..."}.
+      final match = RegExp(
+        r'"ticket"\s*:\s*"([^"]+)"',
+      ).firstMatch(response.body);
+      return match?.group(1) ?? data['ticket'];
+    }
+  } catch (_) {
+    // Ticket fetch failed -- fall through to direct open.
+  }
+  return null;
 }
 
 /// Extracts a media URL from message content, checking for [img:], [video:],
@@ -154,7 +177,27 @@ class MediaContentState extends State<MediaContent> {
 
   // ignore: public_member_api_docs
   Future<void> openMedia(String rawUrl) async {
-    final uri = Uri.tryParse(_resolveUrl(rawUrl));
+    final baseUrl = _resolveUrl(rawUrl);
+
+    // Fetch a single-use media ticket so the browser can authenticate
+    // without leaking the JWT in the URL.
+    String url = baseUrl;
+    final serverUrl = widget.serverUrl;
+    final token = widget.authToken;
+    if (serverUrl != null &&
+        serverUrl.isNotEmpty &&
+        token != null &&
+        token.isNotEmpty) {
+      final ticket = await _fetchMediaTicket(
+        serverUrl: serverUrl,
+        authToken: token,
+      );
+      if (ticket != null) {
+        url = '$baseUrl?ticket=$ticket';
+      }
+    }
+
+    final uri = Uri.tryParse(url);
     if (uri != null) {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
@@ -545,7 +588,8 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
         return;
       }
       setState(() => _controller = controller);
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[InlineVideoPlayer] init failed for ${widget.rawUrl}: $e');
       if (mounted) setState(() => _initFailed = true);
     }
   }

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -169,7 +169,7 @@ class VoiceDock extends ConsumerWidget {
                   .setDeafened(nextDeafened);
             },
           ),
-          // Screen share (desktop / web only)
+          // Screen share (desktop / web only, published via LiveKit SDK)
           if (_supportsScreenShare)
             _DockIconButton(
               icon: screenShare.isScreenSharing
@@ -182,16 +182,17 @@ class VoiceDock extends ConsumerWidget {
                   ? 'Stop sharing'
                   : 'Share screen',
               onPressed: () async {
-                final notifier = ref.read(screenShareProvider.notifier);
+                final lkNotifier = ref.read(livekitVoiceProvider.notifier);
+                final ssNotifier = ref.read(screenShareProvider.notifier);
                 if (screenShare.isScreenSharing) {
-                  await notifier.stopScreenShare();
+                  await lkNotifier.setScreenShareEnabled(false);
+                  await ssNotifier.stopScreenShare();
                 } else {
-                  await notifier.startScreenShare();
-                  final updated = ref.read(screenShareProvider);
-                  if (updated.error != null && context.mounted) {
+                  final ok = await lkNotifier.setScreenShareEnabled(true);
+                  if (!ok && context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(updated.error!),
+                      const SnackBar(
+                        content: Text('Could not start screen sharing.'),
                         behavior: SnackBarBehavior.floating,
                       ),
                     );

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -387,6 +387,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.5.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -1092,6 +1124,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   livekit_client: ^2.3.2
   video_player: ^2.9.2
   cached_network_image: ^3.4.1
+  flutter_local_notifications: ^19.0.0
   path_provider: ^2.1.0
   emoji_picker_flutter: ^4.0.0
   hive: ^2.2.3

--- a/apps/client/windows/flutter/generated_plugins.cmake
+++ b/apps/client/windows/flutter/generated_plugins.cmake
@@ -13,6 +13,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## Summary
- Fix SIGABRT crash on leaving voice call (use-after-free in dispose)
- Fix DM send failure by propagating crypto init errors
- Fix screen share by publishing stream to LiveKit room
- Fix video playback media ticket auth for browser opens
- Implement desktop notifications with flutter_local_notifications
- Fix back-to-chat button, sidebar collapse, lounge usernames, test sound, debug log copy, profile avatars

## Test plan
- [x] flutter analyze -- 0 issues
- [x] flutter test -- 224/224 pass
- [ ] Manual test voice call join/leave on Linux AppImage
- [ ] Manual test DM send
- [ ] Manual test screen share
- [ ] Manual test video playback in chat