### PR TITLE
Fix bugs and improve code quality

### DIFF
--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -34,8 +34,9 @@ void main() async {
   // Load persisted sound preference
   await SoundService().init();
 
-  // Request browser notification permission (no-op on non-web platforms)
-  NotificationService().requestPermission();
+  // Request browser notification permission (no-op on non-web platforms).
+  // Awaited so that the permission flag is set before any messages arrive.
+  await NotificationService().requestPermission();
 
   // Auto-login + crypto init is handled by SplashScreen
   runApp(

--- a/apps/client/lib/src/providers/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice_provider.dart
@@ -482,15 +482,12 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
     // Local audio level.
     final localLevel = room.localParticipant?.audioLevel ?? 0.0;
 
-    // Remote audio levels.
+    // Remote audio levels -- keyed by identity (stable, unique per participant)
+    // so the voice lounge UI can look them up consistently.
     final peerLevels = <String, double>{};
     for (final p in room.remoteParticipants.values) {
-      final label = p.name.isNotEmpty
-          ? p.name
-          : p.identity.isNotEmpty
-          ? p.identity
-          : p.sid.toString();
-      peerLevels[label] = p.audioLevel;
+      final key = p.identity.isNotEmpty ? p.identity : p.sid.toString();
+      peerLevels[key] = p.audioLevel;
     }
 
     if (!_disposed) {

--- a/apps/client/lib/src/providers/screen_share_provider.dart
+++ b/apps/client/lib/src/providers/screen_share_provider.dart
@@ -102,6 +102,16 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
     }
   }
 
+  /// Mark screen sharing as active/inactive without acquiring a stream.
+  ///
+  /// Used when LiveKit SDK manages the capture internally via
+  /// [LocalParticipant.setScreenShareEnabled].
+  void setLiveKitScreenShareActive(bool active) {
+    if (mounted) {
+      state = state.copyWith(isScreenSharing: active, error: null);
+    }
+  }
+
   /// Map common exceptions to user-readable messages.
   static String _friendlyError(Object error) {
     final msg = error.toString().toLowerCase();

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -130,6 +130,8 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
         _handleGroupKeyRotated(json);
       case 'session_replaced':
         _handleSessionReplaced(json);
+      case 'heartbeat':
+        break; // Server keepalive; _onMessage already updated _lastMessageTime.
       case 'error':
         break;
       case 'voice_signal':

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -19,6 +19,7 @@ import '../providers/server_url_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/livekit_voice_provider.dart';
 import '../providers/websocket_provider.dart';
+import '../services/notification_service.dart';
 import '../theme/echo_theme.dart';
 import '../widgets/chat_panel.dart';
 import '../widgets/conversation_panel.dart'
@@ -88,6 +89,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Keep the notification service in sync with app focus so that native
+    // notifications are suppressed while the user is looking at the app.
+    NotificationService().setAppFocused(state == AppLifecycleState.resumed);
+
     if (state == AppLifecycleState.resumed) {
       ref.read(contactsProvider.notifier).loadPending(force: true);
     } else if (state == AppLifecycleState.detached ||

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -240,7 +240,7 @@ class _ParticipantGrid extends StatelessWidget {
           )
           .firstOrNull;
 
-      // Audio levels are keyed by identity (UUID), not display name.
+      // Audio levels are keyed by identity (now username, not UUID).
       final identity = participant.identity.isNotEmpty
           ? participant.identity
           : participant.sid.toString();
@@ -577,7 +577,9 @@ class _RemoteScreenShares extends StatelessWidget {
         if (pub.track != null &&
             pub.track is lk.VideoTrack &&
             pub.source == lk.TrackSource.screenShareVideo) {
-          final identity = participant.identity.isNotEmpty
+          final screenShareName = participant.name.isNotEmpty
+              ? participant.name
+              : participant.identity.isNotEmpty
               ? participant.identity
               : participant.sid.toString();
           tiles.add(
@@ -624,7 +626,7 @@ class _RemoteScreenShares extends StatelessWidget {
                           ),
                           const SizedBox(width: 6),
                           Text(
-                            '$identity\'s screen',
+                            '$screenShareName\'s screen',
                             style: const TextStyle(
                               color: Colors.white,
                               fontSize: 11,
@@ -739,10 +741,12 @@ class _ControlBar extends ConsumerWidget {
                 final ssNotifier = ref.read(screenShareProvider.notifier);
                 if (screenShare.isScreenSharing) {
                   await lkNotifier.setScreenShareEnabled(false);
-                  await ssNotifier.stopScreenShare();
+                  ssNotifier.setLiveKitScreenShareActive(false);
                 } else {
                   final ok = await lkNotifier.setScreenShareEnabled(true);
-                  if (!ok && context.mounted) {
+                  if (ok) {
+                    ssNotifier.setLiveKitScreenShareActive(true);
+                  } else if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                         content: Text('Could not start screen sharing.'),
@@ -767,7 +771,9 @@ class _ControlBar extends ConsumerWidget {
                 await ref
                     .read(livekitVoiceProvider.notifier)
                     .setScreenShareEnabled(false);
-                await ref.read(screenShareProvider.notifier).stopScreenShare();
+                ref
+                    .read(screenShareProvider.notifier)
+                    .setLiveKitScreenShareActive(false);
               }
               await ref
                   .read(channelsProvider.notifier)

--- a/apps/client/lib/src/services/notification_service.dart
+++ b/apps/client/lib/src/services/notification_service.dart
@@ -26,4 +26,10 @@ abstract class NotificationService {
   /// On web, sets document.title to "(N) Echo Messenger" or "Echo Messenger".
   /// No-op on non-web platforms.
   void updateTabBadge(int totalUnread);
+
+  /// Tell the service whether the app is currently focused.
+  ///
+  /// On native platforms, notifications are suppressed while the app is in the
+  /// foreground (matching the web behaviour which checks `document.hidden`).
+  void setAppFocused(bool focused) {}
 }

--- a/apps/client/lib/src/services/notification_service_stub.dart
+++ b/apps/client/lib/src/services/notification_service_stub.dart
@@ -1,15 +1,25 @@
 import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
+import 'debug_log_service.dart';
 import 'notification_service.dart';
 
 /// Native (non-web) implementation using flutter_local_notifications.
-NotificationService createNotificationService() => _NativeNotificationService();
+///
+/// Uses a singleton so that the [_appFocused] flag and init state are shared
+/// across all callers (mirrors the web implementation pattern).
+NotificationService createNotificationService() =>
+    _NativeNotificationService._instance;
 
 class _NativeNotificationService implements NotificationService {
+  static final _NativeNotificationService _instance =
+      _NativeNotificationService._();
+  _NativeNotificationService._();
+
   static final _plugin = FlutterLocalNotificationsPlugin();
   static bool _initialized = false;
   static int _notificationId = 0;
+  static bool _appFocused = true;
 
   static const _channel = AndroidNotificationDetails(
     'echo_messages',
@@ -32,6 +42,12 @@ class _NativeNotificationService implements NotificationService {
       _initialized = true;
     } catch (e) {
       debugPrint('[Notifications] init failed: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'Notifications',
+        'Init failed (notifications will not be shown). '
+            'On Linux, ensure a D-Bus notification daemon is running: $e',
+      );
     }
   }
 
@@ -57,6 +73,9 @@ class _NativeNotificationService implements NotificationService {
     required String body,
     bool forceShow = false,
   }) {
+    // Suppress when the app is focused (matches web behaviour).
+    if (_appFocused && !forceShow) return;
+
     _ensureInitialized().then((_) {
       if (!_initialized) return;
       _plugin.show(
@@ -74,5 +93,10 @@ class _NativeNotificationService implements NotificationService {
   @override
   void updateTabBadge(int totalUnread) {
     // No-op on native platforms (tab badge is a web concept).
+  }
+
+  @override
+  void setAppFocused(bool focused) {
+    _appFocused = focused;
   }
 }

--- a/apps/client/lib/src/services/notification_service_web.dart
+++ b/apps/client/lib/src/services/notification_service_web.dart
@@ -68,4 +68,10 @@ class _WebNotificationService implements NotificationService {
       // Best-effort -- silently ignore errors
     }
   }
+
+  @override
+  void setAppFocused(bool focused) {
+    // On web, `document.hidden` is checked directly in showMessageNotification,
+    // so there's nothing to track here.
+  }
 }

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -466,7 +466,8 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     final nextDeafened = !voiceSettings.selfDeafened;
     await notifier.setSelfDeafened(nextDeafened);
     final lkNotifier = ref.read(livekitVoiceProvider.notifier);
-    lkNotifier.setCaptureEnabled(!voiceSettings.selfMuted && !nextDeafened);
+    // Let setDeafened handle mic state internally -- calling
+    // setCaptureEnabled before setDeafened corrupts _wasMutedBeforeDeafen.
     await lkNotifier.setDeafened(nextDeafened);
     await _syncVoiceState();
   }

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -186,10 +186,12 @@ class VoiceDock extends ConsumerWidget {
                 final ssNotifier = ref.read(screenShareProvider.notifier);
                 if (screenShare.isScreenSharing) {
                   await lkNotifier.setScreenShareEnabled(false);
-                  await ssNotifier.stopScreenShare();
+                  ssNotifier.setLiveKitScreenShareActive(false);
                 } else {
                   final ok = await lkNotifier.setScreenShareEnabled(true);
-                  if (!ok && context.mounted) {
+                  if (ok) {
+                    ssNotifier.setLiveKitScreenShareActive(true);
+                  } else if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                         content: Text('Could not start screen sharing.'),
@@ -208,7 +210,12 @@ class VoiceDock extends ConsumerWidget {
             onPressed: () async {
               // Stop screen sharing when leaving the channel.
               if (screenShare.isScreenSharing) {
-                await ref.read(screenShareProvider.notifier).stopScreenShare();
+                await ref
+                    .read(livekitVoiceProvider.notifier)
+                    .setScreenShareEnabled(false);
+                ref
+                    .read(screenShareProvider.notifier)
+                    .setLiveKitScreenShareActive(false);
               }
               // Leave both server-side voice membership and local WebRTC state
               // so channel selection state clears consistently in the UI.

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -323,19 +323,22 @@ pub async fn set_mute_status(
 // ---------------------------------------------------------------------------
 
 /// Pin a message. Sets pinned_by_id and pinned_at on the message row.
-/// Returns the conversation_id if the pin was successful, None if message not found.
+/// Returns the conversation_id if the pin was successful, None if message not
+/// found or does not belong to the given conversation.
 pub async fn pin_message(
     pool: &PgPool,
     message_id: Uuid,
     user_id: Uuid,
+    conversation_id: Uuid,
 ) -> Result<Option<Uuid>, sqlx::Error> {
     let row: Option<(Uuid,)> = sqlx::query_as(
         "UPDATE messages SET pinned_by_id = $2, pinned_at = now() \
-         WHERE id = $1 AND deleted_at IS NULL \
+         WHERE id = $1 AND conversation_id = $3 AND deleted_at IS NULL \
          RETURNING conversation_id",
     )
     .bind(message_id)
     .bind(user_id)
+    .bind(conversation_id)
     .fetch_optional(pool)
     .await?;
     Ok(row.map(|(conv_id,)| conv_id))

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -489,23 +489,17 @@ pub async fn pin_message(
         }
     }
 
-    // Pin the message
-    let conv_id = db::messages::pin_message(&state.pool, message_id, auth.user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_message: {e:?}");
-            AppError::internal("Database error")
-        })?
-        .ok_or_else(|| AppError::bad_request("Message not found"))?;
-
-    // Verify the message belongs to this conversation
-    if conv_id != conversation_id {
-        // Undo the pin -- message is in a different conversation
-        let _ = db::messages::unpin_message(&state.pool, message_id).await;
-        return Err(AppError::bad_request(
-            "Message does not belong to this conversation",
-        ));
-    }
+    // Pin the message (atomically verified against the correct conversation)
+    let _conv_id =
+        db::messages::pin_message(&state.pool, message_id, auth.user_id, conversation_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("DB error in pin_message: {e:?}");
+                AppError::internal("Database error")
+            })?
+            .ok_or_else(|| {
+                AppError::bad_request("Message not found or does not belong to this conversation")
+            })?;
 
     // Look up pinner's username for the broadcast event
     let pinner = db::users::find_by_id(&state.pool, auth.user_id)

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::auth::middleware::AuthUser;
+use crate::db;
 use crate::error::AppError;
 use crate::routes::AppState;
 
@@ -53,14 +54,28 @@ struct LiveKitClaims {
 /// auth token to prevent impersonation.
 pub async fn generate_token(
     auth: AuthUser,
-    _state: State<Arc<AppState>>,
+    state: State<Arc<AppState>>,
     Json(body): Json<TokenRequest>,
 ) -> Result<Json<TokenResponse>, AppError> {
-    // Resolve identity: use provided value or default to authenticated user ID.
-    let identity = body.identity.unwrap_or_else(|| auth.user_id.to_string());
+    // Look up the username so LiveKit participants display human-readable
+    // names instead of UUIDs.  The identity field doubles as the display
+    // name inside LiveKit, so using the username here means the client no
+    // longer has to race a post-connect `setName` call.
+    let user = db::users::find_by_id(&state.pool, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error looking up user for voice token: {e:?}");
+            AppError::internal("Database error")
+        })?
+        .ok_or_else(|| AppError::bad_request("User not found"))?;
 
-    // Verify the resolved identity matches the authenticated user
-    if identity != auth.user_id.to_string() {
+    let username = user.username;
+    let identity = body.identity.unwrap_or_else(|| username.clone());
+
+    // The provided identity must be either the username or the user_id.
+    // This prevents impersonation while still allowing legacy clients that
+    // send the UUID.
+    if identity != username && identity != auth.user_id.to_string() {
         return Err(AppError::bad_request(
             "Identity must match authenticated user",
         ));

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -124,10 +124,15 @@ pub async fn handle_socket(
         }
     });
 
-    // Task: send WebSocket Ping frames every 30 seconds to keep the
-    // connection alive through reverse-proxy (Traefik/Cloudflare) idle
-    // timeouts. Pings are routed through the hub so they share the same
-    // mpsc channel as regular messages -- no sink contention.
+    // Task: send heartbeat every 30 seconds to keep the connection alive
+    // through reverse-proxy (Traefik/Cloudflare) idle timeouts.
+    //
+    // We send BOTH a WebSocket protocol Ping (for proxy keepalive) and an
+    // application-level JSON heartbeat. Browser WebSocket APIs handle
+    // Ping/Pong transparently without surfacing them to JavaScript, so the
+    // client's heartbeat monitor would never see protocol Pings.  The JSON
+    // heartbeat triggers the browser's onMessage callback, letting the
+    // client know the connection is still alive.
     let ping_hub = state.hub.clone();
     let ping_user_id = user_id;
     let ping_task = tokio::spawn(async move {
@@ -136,7 +141,11 @@ pub async fn handle_socket(
         interval.tick().await;
         loop {
             interval.tick().await;
-            if !ping_hub.send_to(&ping_user_id, WsMessage::Ping(vec![].into())) {
+            // Protocol-level Ping (proxy keepalive; invisible to browsers).
+            ping_hub.send_to(&ping_user_id, WsMessage::Ping(vec![].into()));
+            // Application-level heartbeat (visible to all clients).
+            let hb = r#"{"type":"heartbeat"}"#.to_string();
+            if !ping_hub.send_to(&ping_user_id, WsMessage::Text(hb.into())) {
                 break;
             }
         }
@@ -638,7 +647,7 @@ async fn fanout_message(
         .await
         .unwrap_or_default();
 
-    let mut delivered_ids = Vec::new();
+    let mut any_delivered = false;
     for member_id in &member_ids {
         if *member_id == sender_id {
             continue;
@@ -650,11 +659,11 @@ async fn fanout_message(
             .hub
             .send_to(member_id, WsMessage::Text(json.clone().into()))
         {
-            delivered_ids.push(stored_id);
+            any_delivered = true;
         }
     }
 
-    if !delivered_ids.is_empty() {
+    if any_delivered {
         let _ = db::messages::mark_delivered(&state.pool, &[stored_id]).await;
 
         // Send delivery confirmation back to the sender


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the client and server, focusing on notification handling, voice and screen sharing UX, message pinning safety, and WebSocket reliability. The most significant changes are grouped below:

**Notification Handling Improvements**
- Native notification service now tracks app focus: Notifications are suppressed on native platforms when the app is focused, matching web behavior. This is achieved by introducing a singleton pattern and an `setAppFocused` method in `NotificationService`, with calls wired into app lifecycle events. [[1]](diffhunk://#diff-ea6c3b980e3c1d70536d26a6d803bfcd81fa72586808bb7ebd79bb24b67a802dR4-R22) [[2]](diffhunk://#diff-ea6c3b980e3c1d70536d26a6d803bfcd81fa72586808bb7ebd79bb24b67a802dR76-R78) [[3]](diffhunk://#diff-ea6c3b980e3c1d70536d26a6d803bfcd81fa72586808bb7ebd79bb24b67a802dR97-R101) [[4]](diffhunk://#diff-8d9610622e63909e845f12118ba685405d1b2bc1f03cf7e467ad1f1754013b0eR92-R95) [[5]](diffhunk://#diff-4faae53665dec6b86e0505343955ea59401f17fb1f55bc0cbfacf72136514b40R29-R34) [[6]](diffhunk://#diff-8d9610622e63909e845f12118ba685405d1b2bc1f03cf7e467ad1f1754013b0eR22) [[7]](diffhunk://#diff-50f77ce06aad191cc93d0c1ae2e1a629775d99646e92885b0627a8ead79c9dceR71-R76)
- Notification permission request is now awaited at startup to ensure permissions are set before messages arrive.

**Voice and Screen Sharing UX**
- Screen sharing state is now tracked directly via a new `setLiveKitScreenShareActive` method, reflecting the actual sharing state managed by the LiveKit SDK. This avoids unnecessary stream acquisition and improves reliability when toggling screen sharing. [[1]](diffhunk://#diff-a275a7bdc44c7bd40badb86944d44fbb8e6c3b88b0a48cb5ca758d85b505c06aR105-R114) [[2]](diffhunk://#diff-454128de7c66f9814475d54e2b58f503807cde2ab63d652f76ad58d35c69a8b4L742-R749) [[3]](diffhunk://#diff-454128de7c66f9814475d54e2b58f503807cde2ab63d652f76ad58d35c69a8b4L770-R776) [[4]](diffhunk://#diff-1991b1dea3fcfff4c83e36102c9e1987cc74068e2a88df8b11a36accb9c3bf9aL189-R194) [[5]](diffhunk://#diff-1991b1dea3fcfff4c83e36102c9e1987cc74068e2a88df8b11a36accb9c3bf9aL211-R218)
- Audio levels in the voice lounge are now keyed by username (or identity) for consistent UI lookups, and screen share tiles display the participant's display name when available. [[1]](diffhunk://#diff-a1d6301cbd589a712e440b20d07759ac6a08547a4159bfdf3bedcb1fae43cd03L485-R490) [[2]](diffhunk://#diff-454128de7c66f9814475d54e2b58f503807cde2ab63d652f76ad58d35c69a8b4L243-R243) [[3]](diffhunk://#diff-454128de7c66f9814475d54e2b58f503807cde2ab63d652f76ad58d35c69a8b4L580-R582) [[4]](diffhunk://#diff-454128de7c66f9814475d54e2b58f503807cde2ab63d652f76ad58d35c69a8b4L627-R629)

**Message Pinning Security**
- The server now atomically verifies that a message belongs to the specified conversation before pinning, preventing cross-conversation pinning and race conditions. [[1]](diffhunk://#diff-ddcfdf1fa4fc767b81798debf1138c97df007ef2246b635108037a9a1b904420L326-R341) [[2]](diffhunk://#diff-788f39a34fe7a3e6140a5a91d88cfe797f33be1f6512d1e586f9e2fbe56256cbL492-R502)

**WebSocket Reliability**
- The server now sends both WebSocket protocol Ping frames and application-level JSON heartbeat messages to keep connections alive and visible to browser clients. The client ignores these heartbeat messages as intended. [[1]](diffhunk://#diff-f0cddfcfc7d128a5b081bce4522c225da31e91544afa7f3eae1abfdbca4d2387L127-R135) [[2]](diffhunk://#diff-06832c35af52663a4ee342d45c514e02d543b4c477d2ae279a716cfaccab7fd5R133-R134)

**Other Notable Fixes**
- Voice mute/deafen logic is improved to avoid race conditions when toggling states, ensuring correct microphone state.
- Voice token generation now uses the username as the LiveKit identity for better display names, while still allowing legacy UUID-based clients. [[1]](diffhunk://#diff-76f10743beec9a7565cf162b8dee2f9e5bc3cfac2d70276f57a5abf7b5236909L56-R78) [[2]](diffhunk://#diff-76f10743beec9a7565cf162b8dee2f9e5bc3cfac2d70276f57a5abf7b5236909R11)

These changes collectively improve user experience, reliability, and security in notifications, voice, and messaging features.## What does this PR do?

<!-- Concise description of the change. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] CI/CD or infrastructure
- [ ] Documentation

## How was this tested?

- [ ] Unit tests pass
- [ ] Manual testing performed

## Security checklist

- [ ] No secrets or credentials included
- [ ] No new `unsafe` blocks (or justified and documented)
