### PR TITLE
feat(ci): ios build pipeline with TestFlight upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,8 +325,9 @@ jobs:
             --export-options-plist=ios/ExportOptions.plist
       - name: Rename IPA
         run: |
-          cp apps/client/build/ios/ipa/*.ipa \
-             echo-ios-${{ needs.version.outputs.version }}.ipa
+          IPA_FILE=$(find apps/client/build/ios -name "*.ipa" -type f | head -1)
+          echo "Found IPA: $IPA_FILE"
+          cp "$IPA_FILE" echo-ios-${{ needs.version.outputs.version }}.ipa
       - name: Upload to TestFlight
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}


### PR DESCRIPTION
## Summary
- Add `build-ios` job to release pipeline — builds signed IPA on macOS runner, uploads to TestFlight via App Store Connect API
- Manual code signing with base64 secrets (mirrors existing Android pattern)
- Bump iOS deployment target from 13.0 to 16.0
- Add Podfile, ExportOptions.plist, Runner.entitlements
- Fix iOS local notification initialization (DarwinInitializationSettings)

## Test plan
- [ ] Release pipeline `build-ios` job completes on macOS runner
- [ ] IPA is signed and renamed correctly
- [ ] TestFlight upload succeeds
- [ ] Build appears in TestFlight
- [ ] IPA included in GitHub Release artifacts