### PR TITLE
fix(ci): ios export method app-store

### DIFF
--- a/apps/client/ios/ExportOptions.plist
+++ b/apps/client/ios/ExportOptions.plist
@@ -3,9 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>method</key>
-	<string>app-store-connect</string>
-	<key>destination</key>
-	<string>upload</string>
+	<string>app-store</string>
 	<key>signingStyle</key>
 	<string>manual</string>
 	<key>teamID</key>


### PR DESCRIPTION
Use app-store export method instead of app-store-connect to avoid authentication failure on CI runner. The separate xcrun altool step handles the upload.