### PR TITLE
feat(crypto): multi-device encryption sync

### DIFF
--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -58,9 +58,13 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
   ///
   /// Returns the ticket string on success, or null on failure. If the
   /// request returns 401, attempts to refresh the access token once and
-  /// retries.
+  /// retries. Includes device_id in the request body for multi-device support.
   Future<String?> _fetchWsTicket() async {
     final serverUrl = ref.read(serverUrlProvider);
+    // Include device_id in the ticket request for multi-device routing.
+    // The crypto service may not be initialized yet on first connect.
+    final crypto = ref.read(cryptoServiceProvider);
+    final deviceId = crypto.isInitialized ? crypto.deviceId : 0;
     try {
       final response = await ref
           .read(authProvider.notifier)
@@ -71,6 +75,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
                 'Content-Type': 'application/json',
                 'Authorization': 'Bearer $token',
               },
+              body: jsonEncode({'device_id': deviceId}),
             ),
           );
 
@@ -246,7 +251,6 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     String? conversationId,
     String? replyToId,
   }) async {
-    String payload;
     final cryptoState = ref.read(cryptoProvider);
     if (!cryptoState.isInitialized) {
       final reason = cryptoState.error ?? 'Encryption not initialized';
@@ -264,27 +268,55 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       await ref.read(cryptoProvider.notifier).retryKeyUpload();
     }
 
+    Map<String, String>? deviceContents;
+    String fallbackPayload;
     try {
       final crypto = ref.read(cryptoServiceProvider);
       final token = ref.read(authProvider).token ?? '';
       crypto.setToken(token);
-      payload = await crypto.encryptMessage(toUserId, content);
+
+      // Multi-device: encrypt per-device for the recipient
+      deviceContents = await crypto.encryptForAllDevices(toUserId, content);
+
+      // Also encrypt for sender's own other devices (self-delivery)
+      final myUserId = ref.read(authProvider).userId;
+      if (myUserId != null && myUserId.isNotEmpty) {
+        final selfContents = await crypto.encryptForOwnDevices(
+          myUserId,
+          content,
+        );
+        deviceContents.addAll(selfContents);
+      }
+
+      // Use first ciphertext as the fallback for legacy storage
+      fallbackPayload = deviceContents.values.firstOrNull ?? '';
     } catch (e) {
-      debugPrint('[WS] Encryption failed: $e');
-      _addFailedMessage(
-        toUserId,
-        _friendlyEncryptionError(e),
-        conversationId: conversationId,
-        originalContent: content,
-      );
-      return;
+      debugPrint('[WS] Multi-device encryption failed: $e');
+      // Fall back to single-device encrypt
+      try {
+        final crypto = ref.read(cryptoServiceProvider);
+        fallbackPayload = await crypto.encryptMessage(toUserId, content);
+        deviceContents = null;
+      } catch (e2) {
+        debugPrint('[WS] Fallback encryption also failed: $e2');
+        _addFailedMessage(
+          toUserId,
+          _friendlyEncryptionError(e2),
+          conversationId: conversationId,
+          originalContent: content,
+        );
+        return;
+      }
     }
 
     final msg = <String, dynamic>{
       'type': 'send_message',
       'to_user_id': toUserId,
-      'content': payload,
+      'content': fallbackPayload,
     };
+    if (deviceContents != null && deviceContents.isNotEmpty) {
+      msg['device_contents'] = deviceContents;
+    }
     if (conversationId != null && conversationId.isNotEmpty) {
       msg['conversation_id'] = conversationId;
     }

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -165,6 +165,8 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
         _handleMention(json, myUserId);
       case 'group_key_rotated':
         _handleGroupKeyRotated(json);
+      case 'self_message':
+        _handleSelfMessage(json, myUserId);
       case 'session_replaced':
         _handleSessionReplaced(json);
       case 'heartbeat':
@@ -267,6 +269,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
   void _handleNewMessage(Map<String, dynamic> json, String myUserId) {
     final rawContent = json['content'] as String;
     final fromUserId = json['from_user_id'] as String;
+    final fromDeviceId = json['from_device_id'] as int?;
     final conversationId = json['conversation_id'] as String;
     final timestamp = json['timestamp'] as String;
     final senderUsername = json['from_username'] as String;
@@ -291,6 +294,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
         conversationId,
         timestamp,
         senderUsername,
+        fromDeviceId: fromDeviceId,
       );
     } else {
       // Crypto not ready yet — show a placeholder and queue for decryption.
@@ -336,8 +340,9 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
     String myUserId,
     String conversationId,
     String timestamp,
-    String senderUsername,
-  ) async {
+    String senderUsername, {
+    int? fromDeviceId,
+  }) async {
     String decryptedContent;
     final isGroupEncrypted = rawContent.startsWith(groupEncryptedPrefix);
 
@@ -379,7 +384,11 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
       decryptedContent = rawContent;
     } else {
       try {
-        decryptedContent = await crypto.decryptMessage(fromUserId, rawContent);
+        decryptedContent = await crypto.decryptMessage(
+          fromUserId,
+          rawContent,
+          fromDeviceId: fromDeviceId,
+        );
       } catch (e) {
         // Do NOT invalidate the session here. Invalidating and re-creating a
         // new X3DH outgoing session would put Alice and Bob out of sync,
@@ -424,6 +433,57 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
     if (fromUserId != myUserId) {
       _notifyIfAllowed(conversationId, senderUsername, decryptedContent);
     }
+  }
+
+  /// Handle a `self_message` event: an outgoing message sent from another
+  /// device of the current user. Decrypt and display as a sent message.
+  void _handleSelfMessage(Map<String, dynamic> json, String myUserId) {
+    final rawContent = json['content'] as String? ?? '';
+    final fromDeviceId = json['from_device_id'] as int?;
+    final conversationId = json['conversation_id'] as String? ?? '';
+    final timestamp = json['timestamp'] as String? ?? '';
+    final messageId = json['message_id'] as String? ?? '';
+    final cryptoState = ref.read(cryptoProvider);
+
+    if (!cryptoState.isInitialized || rawContent.isEmpty) return;
+
+    final crypto = ref.read(cryptoServiceProvider);
+    final token = ref.read(authProvider).token ?? '';
+    crypto.setToken(token);
+
+    () async {
+      try {
+        final decrypted = await crypto.decryptMessage(
+          myUserId,
+          rawContent,
+          fromDeviceId: fromDeviceId,
+        );
+        final msg = ChatMessage(
+          id: messageId,
+          conversationId: conversationId,
+          fromUserId: myUserId,
+          fromUsername: 'Me',
+          content: decrypted,
+          timestamp: timestamp,
+          isMine: true,
+          isEncrypted: true,
+        );
+        ref.read(chatProvider.notifier).addMessage(msg);
+        if (!messageId.startsWith('pending_')) {
+          MessageCache.cacheMessages(conversationId, [msg]);
+        }
+        ref
+            .read(conversationsProvider.notifier)
+            .onNewMessage(
+              conversationId: conversationId,
+              content: decrypted,
+              timestamp: timestamp,
+              senderUsername: 'Me',
+            );
+      } catch (e) {
+        debugPrint('[WebSocket] Self-message decryption failed: $e');
+      }
+    }();
   }
 
   /// Show a notification + play sound if the conversation is not muted.

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -436,54 +436,41 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
   }
 
   /// Handle a `self_message` event: an outgoing message sent from another
-  /// device of the current user. Decrypt and display as a sent message.
+  /// device of the current user. Repackage as a new_message from self and
+  /// reuse the standard decrypt-and-deliver pipeline.
   void _handleSelfMessage(Map<String, dynamic> json, String myUserId) {
     final rawContent = json['content'] as String? ?? '';
     final fromDeviceId = json['from_device_id'] as int?;
     final conversationId = json['conversation_id'] as String? ?? '';
     final timestamp = json['timestamp'] as String? ?? '';
-    final messageId = json['message_id'] as String? ?? '';
-    final cryptoState = ref.read(cryptoProvider);
 
-    if (!cryptoState.isInitialized || rawContent.isEmpty) return;
+    if (rawContent.isEmpty) return;
+
+    // Repackage as a new_message so _decryptAndDeliverWithPreview handles it.
+    final syntheticJson = <String, dynamic>{
+      ...json,
+      'from_user_id': myUserId,
+      'from_username': 'Me',
+    };
+
+    final cryptoState = ref.read(cryptoProvider);
+    if (!cryptoState.isInitialized) return;
 
     final crypto = ref.read(cryptoServiceProvider);
     final token = ref.read(authProvider).token ?? '';
     crypto.setToken(token);
 
-    () async {
-      try {
-        final decrypted = await crypto.decryptMessage(
-          myUserId,
-          rawContent,
-          fromDeviceId: fromDeviceId,
-        );
-        final msg = ChatMessage(
-          id: messageId,
-          conversationId: conversationId,
-          fromUserId: myUserId,
-          fromUsername: 'Me',
-          content: decrypted,
-          timestamp: timestamp,
-          isMine: true,
-          isEncrypted: true,
-        );
-        ref.read(chatProvider.notifier).addMessage(msg);
-        if (!messageId.startsWith('pending_')) {
-          MessageCache.cacheMessages(conversationId, [msg]);
-        }
-        ref
-            .read(conversationsProvider.notifier)
-            .onNewMessage(
-              conversationId: conversationId,
-              content: decrypted,
-              timestamp: timestamp,
-              senderUsername: 'Me',
-            );
-      } catch (e) {
-        debugPrint('[WebSocket] Self-message decryption failed: $e');
-      }
-    }();
+    _decryptAndDeliverWithPreview(
+      crypto,
+      syntheticJson,
+      rawContent,
+      myUserId,
+      myUserId,
+      conversationId,
+      timestamp,
+      'Me',
+      fromDeviceId: fromDeviceId,
+    );
   }
 
   /// Show a notification + play sound if the conversation is not muted.

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -758,6 +758,38 @@ class CryptoService {
   static const _initialMsgMagicV1 = [0xEC, 0x01];
   static const _initialMsgMagicV2 = [0xEC, 0x02];
 
+  /// Build the initial message wire format with X3DH key exchange header.
+  /// Returns the session wire bytes unchanged if no X3DH result is pending.
+  Future<Uint8List> _buildInitialWire(Uint8List sessionWire) async {
+    if (_lastX3dhResult == null) return sessionWire;
+
+    final idPub = (await _identityKeyPair!.extractPublicKey()).bytes;
+    final ephPub = _lastX3dhResult!.ephemeralPublic.bytes;
+
+    Uint8List wire;
+    if (_lastOtpKeyId != null) {
+      wire = Uint8List(2 + 32 + 32 + 4 + sessionWire.length);
+      wire[0] = _initialMsgMagicV2[0];
+      wire[1] = _initialMsgMagicV2[1];
+      wire.setRange(2, 34, Uint8List.fromList(idPub));
+      wire.setRange(34, 66, Uint8List.fromList(ephPub));
+      final bd = ByteData.sublistView(wire);
+      bd.setInt32(66, _lastOtpKeyId!, Endian.little);
+      wire.setRange(70, wire.length, sessionWire);
+    } else {
+      wire = Uint8List(2 + 32 + 32 + sessionWire.length);
+      wire[0] = _initialMsgMagicV1[0];
+      wire[1] = _initialMsgMagicV1[1];
+      wire.setRange(2, 34, Uint8List.fromList(idPub));
+      wire.setRange(34, 66, Uint8List.fromList(ephPub));
+      wire.setRange(66, wire.length, sessionWire);
+    }
+
+    _lastX3dhResult = null;
+    _lastOtpKeyId = null;
+    return wire;
+  }
+
   /// Encrypt a plaintext message for a specific peer.
   ///
   /// For the first message (new session), includes X3DH key exchange data
@@ -784,37 +816,7 @@ class CryptoService {
     }
 
     final wire = await session.encrypt(plaintextBytes);
-
-    Uint8List finalWire;
-    if (isNewSession && _lastX3dhResult != null) {
-      final idPub = (await _identityKeyPair!.extractPublicKey()).bytes;
-      final ephPub = _lastX3dhResult!.ephemeralPublic.bytes;
-
-      if (_lastOtpKeyId != null) {
-        // V2 format: includes OTP key ID so Bob can look up the right private key
-        finalWire = Uint8List(2 + 32 + 32 + 4 + wire.length);
-        finalWire[0] = _initialMsgMagicV2[0];
-        finalWire[1] = _initialMsgMagicV2[1];
-        finalWire.setRange(2, 34, Uint8List.fromList(idPub));
-        finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
-        final bd = ByteData.sublistView(finalWire);
-        bd.setInt32(66, _lastOtpKeyId!, Endian.little);
-        finalWire.setRange(70, finalWire.length, wire);
-      } else {
-        // V1 format: no OTP used (3-DH)
-        finalWire = Uint8List(2 + 32 + 32 + wire.length);
-        finalWire[0] = _initialMsgMagicV1[0];
-        finalWire[1] = _initialMsgMagicV1[1];
-        finalWire.setRange(2, 34, Uint8List.fromList(idPub));
-        finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
-        finalWire.setRange(66, finalWire.length, wire);
-      }
-
-      _lastX3dhResult = null;
-      _lastOtpKeyId = null;
-    } else {
-      finalWire = wire;
-    }
+    final finalWire = await _buildInitialWire(wire);
 
     await _saveSession(peerUserId, session);
     return base64Encode(finalWire);
@@ -1341,40 +1343,12 @@ class CryptoService {
           );
           final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
 
-          final isNewSession = _lastX3dhResult != null;
-          if (!isNewSession) {
+          if (_lastX3dhResult == null) {
             await _saveSession(sessionKey, session);
           }
 
           final wire = await session.encrypt(plaintextBytes);
-
-          Uint8List finalWire;
-          if (isNewSession && _lastX3dhResult != null) {
-            final idPub = (await _identityKeyPair!.extractPublicKey()).bytes;
-            final ephPub = _lastX3dhResult!.ephemeralPublic.bytes;
-
-            if (_lastOtpKeyId != null) {
-              finalWire = Uint8List(2 + 32 + 32 + 4 + wire.length);
-              finalWire[0] = _initialMsgMagicV2[0];
-              finalWire[1] = _initialMsgMagicV2[1];
-              finalWire.setRange(2, 34, Uint8List.fromList(idPub));
-              finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
-              final bd = ByteData.sublistView(finalWire);
-              bd.setInt32(66, _lastOtpKeyId!, Endian.little);
-              finalWire.setRange(70, finalWire.length, wire);
-            } else {
-              finalWire = Uint8List(2 + 32 + 32 + wire.length);
-              finalWire[0] = _initialMsgMagicV1[0];
-              finalWire[1] = _initialMsgMagicV1[1];
-              finalWire.setRange(2, 34, Uint8List.fromList(idPub));
-              finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
-              finalWire.setRange(66, finalWire.length, wire);
-            }
-            _lastX3dhResult = null;
-            _lastOtpKeyId = null;
-          } else {
-            finalWire = wire;
-          }
+          final finalWire = await _buildInitialWire(wire);
 
           await _saveSession(sessionKey, session);
           return base64Encode(finalWire);
@@ -1387,33 +1361,6 @@ class CryptoService {
       }
     }
     return results;
-  }
-
-  /// Encrypt a message for the sender's OWN other devices (self-delivery).
-  ///
-  /// Returns a map of `{deviceId: base64Ciphertext}` for each of the sender's
-  /// other devices (excluding the current device).
-  Future<Map<String, String>> encryptForSelfDevices(String plaintext) async {
-    if (_identityKeyPair == null) await init();
-
-    // Fetch own user ID from the auth token claims (or use a cached value)
-    // For now, we fetch our own device list from the server
-    try {
-      final response = await http.get(
-        // We need the current user's ID — it's embedded in the token but
-        // easier to just use the fact that crypto_provider knows it.
-        // This method is called from websocket_provider which has access.
-        // For now, return empty — self-device delivery will be wired when
-        // the caller provides the userId.
-        Uri.parse('$serverUrl/api/keys/bundles/_self'),
-        headers: {'Authorization': 'Bearer $_token'},
-      );
-      // This endpoint doesn't exist yet for "_self" — handle gracefully
-      if (response.statusCode != 200) return {};
-    } catch (_) {
-      return {};
-    }
-    return {};
   }
 
   /// Encrypt for the sender's own other devices given the sender's user ID.
@@ -1440,33 +1387,7 @@ class CryptoService {
               await _saveSession(sessionKey, session);
             }
             final wire = await session.encrypt(plaintextBytes);
-
-            Uint8List finalWire;
-            if (_lastX3dhResult != null) {
-              final idPub = (await _identityKeyPair!.extractPublicKey()).bytes;
-              final ephPub = _lastX3dhResult!.ephemeralPublic.bytes;
-              if (_lastOtpKeyId != null) {
-                finalWire = Uint8List(2 + 32 + 32 + 4 + wire.length);
-                finalWire[0] = _initialMsgMagicV2[0];
-                finalWire[1] = _initialMsgMagicV2[1];
-                finalWire.setRange(2, 34, Uint8List.fromList(idPub));
-                finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
-                final bd = ByteData.sublistView(finalWire);
-                bd.setInt32(66, _lastOtpKeyId!, Endian.little);
-                finalWire.setRange(70, finalWire.length, wire);
-              } else {
-                finalWire = Uint8List(2 + 32 + 32 + wire.length);
-                finalWire[0] = _initialMsgMagicV1[0];
-                finalWire[1] = _initialMsgMagicV1[1];
-                finalWire.setRange(2, 34, Uint8List.fromList(idPub));
-                finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
-                finalWire.setRange(66, finalWire.length, wire);
-              }
-              _lastX3dhResult = null;
-              _lastOtpKeyId = null;
-            } else {
-              finalWire = wire;
-            }
+            final finalWire = await _buildInitialWire(wire);
 
             await _saveSession(sessionKey, session);
             return base64Encode(finalWire);

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -84,6 +84,11 @@ class CryptoService {
   /// Prevents interleaved async ops from corrupting session chain state.
   final Map<String, Completer<void>> _sessionLocks = {};
 
+  /// Cache of per-user device bundles with TTL for multi-device encryption.
+  /// Key: userId, Value: (bundles, fetchedAt)
+  final Map<String, (List<Map<String, dynamic>>, DateTime)> _bundleCache = {};
+  static const _bundleCacheTtl = Duration(minutes: 5);
+
   final _x25519 = X25519();
   final _ed25519 = Ed25519();
 
@@ -419,6 +424,9 @@ class CryptoService {
   final Set<String> _corruptedSessions = {};
 
   /// Load persisted Signal sessions from secure storage.
+  ///
+  /// Handles both legacy format (`echo_signal_session_<userId>`) and
+  /// multi-device format (`echo_signal_session_<userId>:<deviceId>`).
   Future<void> _loadSessions(SecureKeyStore store) async {
     _sessions.clear();
     _corruptedSessions.clear();
@@ -816,16 +824,40 @@ class CryptoService {
   ///
   /// If this is an initial message (contains X3DH key exchange prefix),
   /// establishes the session as Bob (responder) before decrypting.
-  Future<String> decryptMessage(String peerUserId, String ciphertextB64) =>
-      _withSessionLock(
-        peerUserId,
-        () => _decryptMessageImpl(peerUserId, ciphertextB64),
-      );
+  ///
+  /// [fromDeviceId] is the sender's device ID (from `from_device_id` in the
+  /// server message). When provided, sessions are keyed per-device.
+  Future<String> decryptMessage(
+    String peerUserId,
+    String ciphertextB64, {
+    int? fromDeviceId,
+  }) {
+    final sessionKey = _sessionKeyFor(peerUserId, fromDeviceId);
+    return _withSessionLock(
+      sessionKey,
+      () => _decryptMessageImpl(peerUserId, ciphertextB64, fromDeviceId),
+    );
+  }
+
+  /// Resolve the session map key: prefer `userId:deviceId` when device is
+  /// known, fall back to `userId` for legacy sessions.
+  String _sessionKeyFor(String peerUserId, int? deviceId) {
+    if (deviceId != null) {
+      final key = '$peerUserId:$deviceId';
+      if (_sessions.containsKey(key)) return key;
+      // Fall back to legacy key if device-specific doesn't exist yet
+      if (_sessions.containsKey(peerUserId)) return peerUserId;
+      return key; // Will create with device-specific key
+    }
+    return peerUserId;
+  }
 
   Future<String> _decryptMessageImpl(
     String peerUserId,
     String ciphertextB64,
+    int? fromDeviceId,
   ) async {
+    final sessionKey = _sessionKeyFor(peerUserId, fromDeviceId);
     final fullWire = Uint8List.fromList(base64Decode(ciphertextB64));
 
     // Check for initial message magic prefix (V1 or V2)
@@ -840,11 +872,17 @@ class CryptoService {
     if (isV1 || isV2) {
       // Always accept an initial X3DH message — the peer may have reset their
       // keys.  Drop any stale session so we establish a fresh one.
-      if (_sessions.containsKey(peerUserId)) {
+      if (_sessions.containsKey(sessionKey)) {
         debugPrint(
-          '[Crypto] Replacing stale session for $peerUserId '
+          '[Crypto] Replacing stale session for $sessionKey '
           '(received new X3DH initial message)',
         );
+        _sessions.remove(sessionKey);
+        final store = SecureKeyStore.instance;
+        await store.delete('$_sessionPrefix$sessionKey');
+      }
+      // Also remove legacy key if we're now using device-specific
+      if (fromDeviceId != null && _sessions.containsKey(peerUserId)) {
         _sessions.remove(peerUserId);
         final store = SecureKeyStore.instance;
         await store.delete('$_sessionPrefix$peerUserId');
@@ -926,8 +964,8 @@ class CryptoService {
 
       // Decrypt the actual message
       final plainBytes = await session.decrypt(sessionWire);
-      _sessions[peerUserId] = session;
-      await _saveSession(peerUserId, session);
+      _sessions[sessionKey] = session;
+      await _saveSession(sessionKey, session);
 
       // Consume the OTP -- delete after successful use (one-time)
       if (bobOtp != null && isV2) {
@@ -947,17 +985,17 @@ class CryptoService {
     // getOrCreateSession() here: creating a brand-new X3DH session for a
     // non-initial message would produce an incompatible session that can't
     // decrypt the message and would pollute state.
-    final session = _sessions[peerUserId];
+    final session = _sessions[sessionKey];
     if (session == null) {
       throw Exception(
-        'No session for $peerUserId — cannot decrypt normal message. '
+        'No session for $sessionKey — cannot decrypt normal message. '
         'Awaiting new X3DH initial message from peer.',
       );
     }
     // Write-ahead: save before mutation so crash recovery replays correctly
-    await _saveSession(peerUserId, session);
+    await _saveSession(sessionKey, session);
     final plainBytes = await session.decrypt(fullWire);
-    await _saveSession(peerUserId, session);
+    await _saveSession(sessionKey, session);
     return utf8.decode(plainBytes);
   }
 
@@ -1150,6 +1188,306 @@ class CryptoService {
     final store = SecureKeyStore.instance;
     await store.delete('$_otpPrivatePrefix$keyId');
     debugPrint('[Crypto] Consumed and deleted OTP key_id=$keyId');
+  }
+
+  // -----------------------------------------------------------------------
+  // Multi-device encryption
+  // -----------------------------------------------------------------------
+
+  /// Fetch all device bundles for a peer, with a 5-minute cache.
+  Future<List<Map<String, dynamic>>> _fetchAllBundles(String userId) async {
+    final cached = _bundleCache[userId];
+    if (cached != null &&
+        DateTime.now().difference(cached.$2) < _bundleCacheTtl) {
+      return cached.$1;
+    }
+
+    final response = await http.get(
+      Uri.parse('$serverUrl/api/keys/bundles/$userId'),
+      headers: {'Authorization': 'Bearer $_token'},
+    );
+
+    if (response.statusCode == 401) {
+      throw Exception('Auth expired fetching bundles for $userId');
+    }
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch bundles for $userId: ${response.body}');
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final bundles = (data['bundles'] as List).cast<Map<String, dynamic>>();
+    _bundleCache[userId] = (bundles, DateTime.now());
+    return bundles;
+  }
+
+  /// Get or create a Signal session for a specific device of a peer.
+  ///
+  /// Uses device-specific session key (`userId:deviceId`).
+  Future<SignalSession> _getOrCreateSessionForDevice(
+    String peerUserId,
+    int deviceId,
+    Map<String, dynamic> bundleData,
+  ) async {
+    final sessionKey = '$peerUserId:$deviceId';
+    if (_sessions.containsKey(sessionKey)) {
+      return _sessions[sessionKey]!;
+    }
+    // Fall back to legacy session if it exists (pre-multi-device)
+    if (_sessions.containsKey(peerUserId)) {
+      return _sessions[peerUserId]!;
+    }
+
+    if (_identityKeyPair == null) await init();
+
+    final bobIdentityKeyBytes = base64Decode(
+      bundleData['identity_key'] as String,
+    );
+    final bobSignedPrekeyBytes = base64Decode(
+      bundleData['signed_prekey'] as String,
+    );
+
+    // Verify signed prekey signature
+    final signingKeyB64 = bundleData['signing_key'] as String?;
+    final signatureB64 = bundleData['signed_prekey_signature'] as String?;
+    if (signingKeyB64 != null && signatureB64 != null) {
+      final signingKeyBytes = base64Decode(signingKeyB64);
+      final signatureBytes = base64Decode(signatureB64);
+      final signingPublicKey = SimplePublicKey(
+        signingKeyBytes,
+        type: KeyPairType.ed25519,
+      );
+      final isValid = await _ed25519.verify(
+        bobSignedPrekeyBytes,
+        signature: Signature(signatureBytes, publicKey: signingPublicKey),
+      );
+      if (!isValid) {
+        throw Exception(
+          'Signed prekey signature verification failed for $peerUserId '
+          'device $deviceId -- possible MITM attack',
+        );
+      }
+    }
+
+    final bobIdentityKey = SimplePublicKey(
+      bobIdentityKeyBytes,
+      type: KeyPairType.x25519,
+    );
+    final bobSignedPrekey = SimplePublicKey(
+      bobSignedPrekeyBytes,
+      type: KeyPairType.x25519,
+    );
+
+    // Extract one-time prekey if available
+    SimplePublicKey? bobOneTimePrekey;
+    int? otpKeyId;
+    final otpData = bundleData['one_time_prekey'] as Map<String, dynamic>?;
+    if (otpData != null) {
+      final otpPubB64 = otpData['public_key'] as String?;
+      otpKeyId = otpData['key_id'] as int?;
+      if (otpPubB64 != null) {
+        bobOneTimePrekey = SimplePublicKey(
+          base64Decode(otpPubB64),
+          type: KeyPairType.x25519,
+        );
+      }
+    }
+
+    final x3dhResult = await X3DH.initiate(
+      aliceIdentity: _identityKeyPair!,
+      bobIdentityKey: bobIdentityKey,
+      bobSignedPrekey: bobSignedPrekey,
+      bobOneTimePrekey: bobOneTimePrekey,
+    );
+
+    _lastOtpKeyId = otpKeyId;
+    _lastX3dhResult = x3dhResult;
+
+    final session = await SignalSession.initAlice(
+      x3dhResult.sharedSecret,
+      bobSignedPrekey,
+    );
+
+    _sessions[sessionKey] = session;
+    await _saveSession(sessionKey, session);
+    return session;
+  }
+
+  /// Encrypt a message for ALL devices of a peer.
+  ///
+  /// Returns a map of `{deviceId: base64Ciphertext}` for each device.
+  /// This enables multi-device delivery where each device gets its own
+  /// ciphertext encrypted with a device-specific session.
+  Future<Map<String, String>> encryptForAllDevices(
+    String peerUserId,
+    String plaintext,
+  ) async {
+    final bundles = await _fetchAllBundles(peerUserId);
+    if (bundles.isEmpty) {
+      // Fall back to legacy single-device encrypt
+      final ct = await encryptMessage(peerUserId, plaintext);
+      return {'0': ct};
+    }
+
+    final results = <String, String>{};
+    for (final bundle in bundles) {
+      final deviceId = bundle['device_id'] as int;
+      try {
+        final sessionKey = '$peerUserId:$deviceId';
+        final ct = await _withSessionLock(sessionKey, () async {
+          final session = await _getOrCreateSessionForDevice(
+            peerUserId,
+            deviceId,
+            bundle,
+          );
+          final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
+
+          final isNewSession = _lastX3dhResult != null;
+          if (!isNewSession) {
+            await _saveSession(sessionKey, session);
+          }
+
+          final wire = await session.encrypt(plaintextBytes);
+
+          Uint8List finalWire;
+          if (isNewSession && _lastX3dhResult != null) {
+            final idPub = (await _identityKeyPair!.extractPublicKey()).bytes;
+            final ephPub = _lastX3dhResult!.ephemeralPublic.bytes;
+
+            if (_lastOtpKeyId != null) {
+              finalWire = Uint8List(2 + 32 + 32 + 4 + wire.length);
+              finalWire[0] = _initialMsgMagicV2[0];
+              finalWire[1] = _initialMsgMagicV2[1];
+              finalWire.setRange(2, 34, Uint8List.fromList(idPub));
+              finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
+              final bd = ByteData.sublistView(finalWire);
+              bd.setInt32(66, _lastOtpKeyId!, Endian.little);
+              finalWire.setRange(70, finalWire.length, wire);
+            } else {
+              finalWire = Uint8List(2 + 32 + 32 + wire.length);
+              finalWire[0] = _initialMsgMagicV1[0];
+              finalWire[1] = _initialMsgMagicV1[1];
+              finalWire.setRange(2, 34, Uint8List.fromList(idPub));
+              finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
+              finalWire.setRange(66, finalWire.length, wire);
+            }
+            _lastX3dhResult = null;
+            _lastOtpKeyId = null;
+          } else {
+            finalWire = wire;
+          }
+
+          await _saveSession(sessionKey, session);
+          return base64Encode(finalWire);
+        });
+        results[deviceId.toString()] = ct;
+      } catch (e) {
+        debugPrint(
+          '[Crypto] Failed to encrypt for $peerUserId device $deviceId: $e',
+        );
+      }
+    }
+    return results;
+  }
+
+  /// Encrypt a message for the sender's OWN other devices (self-delivery).
+  ///
+  /// Returns a map of `{deviceId: base64Ciphertext}` for each of the sender's
+  /// other devices (excluding the current device).
+  Future<Map<String, String>> encryptForSelfDevices(String plaintext) async {
+    if (_identityKeyPair == null) await init();
+
+    // Fetch own user ID from the auth token claims (or use a cached value)
+    // For now, we fetch our own device list from the server
+    try {
+      final response = await http.get(
+        // We need the current user's ID — it's embedded in the token but
+        // easier to just use the fact that crypto_provider knows it.
+        // This method is called from websocket_provider which has access.
+        // For now, return empty — self-device delivery will be wired when
+        // the caller provides the userId.
+        Uri.parse('$serverUrl/api/keys/bundles/_self'),
+        headers: {'Authorization': 'Bearer $_token'},
+      );
+      // This endpoint doesn't exist yet for "_self" — handle gracefully
+      if (response.statusCode != 200) return {};
+    } catch (_) {
+      return {};
+    }
+    return {};
+  }
+
+  /// Encrypt for the sender's own other devices given the sender's user ID.
+  Future<Map<String, String>> encryptForOwnDevices(
+    String myUserId,
+    String plaintext,
+  ) async {
+    try {
+      final bundles = await _fetchAllBundles(myUserId);
+      final results = <String, String>{};
+      for (final bundle in bundles) {
+        final deviceId = bundle['device_id'] as int;
+        if (deviceId == _deviceId) continue; // Skip current device
+        try {
+          final sessionKey = '$myUserId:$deviceId';
+          final ct = await _withSessionLock(sessionKey, () async {
+            final session = await _getOrCreateSessionForDevice(
+              myUserId,
+              deviceId,
+              bundle,
+            );
+            final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
+            if (_lastX3dhResult == null) {
+              await _saveSession(sessionKey, session);
+            }
+            final wire = await session.encrypt(plaintextBytes);
+
+            Uint8List finalWire;
+            if (_lastX3dhResult != null) {
+              final idPub = (await _identityKeyPair!.extractPublicKey()).bytes;
+              final ephPub = _lastX3dhResult!.ephemeralPublic.bytes;
+              if (_lastOtpKeyId != null) {
+                finalWire = Uint8List(2 + 32 + 32 + 4 + wire.length);
+                finalWire[0] = _initialMsgMagicV2[0];
+                finalWire[1] = _initialMsgMagicV2[1];
+                finalWire.setRange(2, 34, Uint8List.fromList(idPub));
+                finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
+                final bd = ByteData.sublistView(finalWire);
+                bd.setInt32(66, _lastOtpKeyId!, Endian.little);
+                finalWire.setRange(70, finalWire.length, wire);
+              } else {
+                finalWire = Uint8List(2 + 32 + 32 + wire.length);
+                finalWire[0] = _initialMsgMagicV1[0];
+                finalWire[1] = _initialMsgMagicV1[1];
+                finalWire.setRange(2, 34, Uint8List.fromList(idPub));
+                finalWire.setRange(34, 66, Uint8List.fromList(ephPub));
+                finalWire.setRange(66, finalWire.length, wire);
+              }
+              _lastX3dhResult = null;
+              _lastOtpKeyId = null;
+            } else {
+              finalWire = wire;
+            }
+
+            await _saveSession(sessionKey, session);
+            return base64Encode(finalWire);
+          });
+          results[deviceId.toString()] = ct;
+        } catch (e) {
+          debugPrint(
+            '[Crypto] Failed to encrypt for self device $deviceId: $e',
+          );
+        }
+      }
+      return results;
+    } catch (e) {
+      debugPrint('[Crypto] Self-device encryption failed: $e');
+      return {};
+    }
+  }
+
+  /// Invalidate the device bundle cache for a specific user.
+  void invalidateBundleCache(String userId) {
+    _bundleCache.remove(userId);
   }
 
   // -----------------------------------------------------------------------

--- a/apps/server/migrations/20260411100000_multi_device_messages.sql
+++ b/apps/server/migrations/20260411100000_multi_device_messages.sql
@@ -1,0 +1,9 @@
+-- Per-device ciphertexts for multi-device encrypted messaging.
+-- When a sender encrypts for multiple recipient devices, each device's
+-- ciphertext is stored here alongside the canonical message row.
+CREATE TABLE IF NOT EXISTS message_device_contents (
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    device_id  INT  NOT NULL,
+    content    TEXT NOT NULL,
+    PRIMARY KEY (message_id, device_id)
+);

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -433,3 +433,55 @@ pub async fn get_pinned_messages(
     .fetch_all(pool)
     .await
 }
+
+// ---------------------------------------------------------------------------
+// Multi-device per-device ciphertext storage
+// ---------------------------------------------------------------------------
+
+/// Store per-device ciphertexts for a message (multi-device encrypted delivery).
+pub async fn store_device_contents(
+    pool: &PgPool,
+    message_id: Uuid,
+    entries: &[(i32, &str)],
+) -> Result<(), sqlx::Error> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    // Build a batch insert: INSERT INTO ... VALUES ($1,$2,$3), ($1,$4,$5), ...
+    let mut query = String::from(
+        "INSERT INTO message_device_contents (message_id, device_id, content) VALUES ",
+    );
+    let mut param_idx = 2; // $1 = message_id
+    for (i, _) in entries.iter().enumerate() {
+        if i > 0 {
+            query.push_str(", ");
+        }
+        query.push_str(&format!("($1, ${}, ${})", param_idx, param_idx + 1));
+        param_idx += 2;
+    }
+    query.push_str(" ON CONFLICT (message_id, device_id) DO NOTHING");
+
+    let mut q = sqlx::query(&query).bind(message_id);
+    for (device_id, content) in entries {
+        q = q.bind(device_id).bind(*content);
+    }
+    q.execute(pool).await?;
+    Ok(())
+}
+
+/// Fetch the per-device ciphertext for a specific device.
+pub async fn get_device_content(
+    pool: &PgPool,
+    message_id: Uuid,
+    device_id: i32,
+) -> Result<Option<String>, sqlx::Error> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT content FROM message_device_contents \
+         WHERE message_id = $1 AND device_id = $2",
+    )
+    .bind(message_id)
+    .bind(device_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(c,)| c))
+}

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -231,14 +231,24 @@ pub async fn logout(
 // POST /api/auth/ws-ticket
 // ---------------------------------------------------------------------------
 
+/// Optional device_id in ws-ticket request body.
+#[derive(Debug, Deserialize, Default)]
+pub struct WsTicketRequest {
+    #[serde(default)]
+    pub device_id: i32,
+}
+
 pub async fn ws_ticket(
     State(state): State<Arc<AppState>>,
     auth_user: AuthUser,
+    body: Option<Json<WsTicketRequest>>,
 ) -> Result<impl IntoResponse, AppError> {
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use rand::RngCore;
     use std::time::{Duration, Instant};
+
+    let device_id = body.map(|b| b.device_id).unwrap_or(0);
 
     let mut bytes = [0u8; 32];
     rand::rng().fill_bytes(&mut bytes);
@@ -251,7 +261,7 @@ pub async fn ws_ticket(
     let now = Instant::now();
     state
         .ticket_store
-        .retain(|_, (_, ts)| now.duration_since(*ts) < TICKET_TTL);
+        .retain(|_, (_, _, ts)| now.duration_since(*ts) < TICKET_TTL);
 
     // Cap total tickets to prevent memory exhaustion
     if state.ticket_store.len() >= MAX_TICKETS {
@@ -262,7 +272,7 @@ pub async fn ws_ticket(
 
     state
         .ticket_store
-        .insert(ticket.clone(), (auth_user.user_id, now));
+        .insert(ticket.clone(), (auth_user.user_id, device_id, now));
 
     Ok(Json(WsTicketResponse { ticket }))
 }

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -252,6 +252,51 @@ pub async fn get_devices(
     }))
 }
 
+/// Response for a single device bundle within the all-bundles response.
+#[derive(Debug, Serialize)]
+pub struct DeviceBundleResponse {
+    pub device_id: i32,
+    pub identity_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signing_key: Option<String>,
+    pub signed_prekey: String,
+    pub signed_prekey_signature: String,
+    pub signed_prekey_id: i32,
+    pub one_time_prekey: Option<OneTimePreKeyResponse>,
+}
+
+/// GET /api/keys/bundles/:user_id -- Fetch ALL device bundles for a user.
+///
+/// Returns bundles for every registered device in a single request,
+/// enabling multi-device encryption without N+1 round trips.
+pub async fn get_all_bundles(
+    State(state): State<Arc<AppState>>,
+    _auth_user: AuthUser,
+    Path(user_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let device_ids = db::keys::get_user_devices(&state.pool, user_id).await?;
+    let mut bundles = Vec::new();
+
+    for device_id in device_ids {
+        if let Some(bundle) = db::keys::get_prekey_bundle(&state.pool, user_id, device_id).await? {
+            bundles.push(DeviceBundleResponse {
+                device_id,
+                identity_key: BASE64.encode(&bundle.identity_key),
+                signing_key: bundle.signing_key.as_ref().map(|sk| BASE64.encode(sk)),
+                signed_prekey: BASE64.encode(&bundle.signed_prekey),
+                signed_prekey_signature: BASE64.encode(&bundle.signed_prekey_signature),
+                signed_prekey_id: bundle.signed_prekey_id,
+                one_time_prekey: bundle.one_time_prekey.map(|otk| OneTimePreKeyResponse {
+                    key_id: otk.key_id,
+                    public_key: BASE64.encode(&otk.public_key),
+                }),
+            });
+        }
+    }
+
+    Ok(Json(serde_json::json!({ "bundles": bundles })))
+}
+
 /// Query parameters for the OTP count endpoint.
 #[derive(Debug, Deserialize)]
 pub struct OtpCountQuery {

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -30,9 +30,9 @@ use uuid::Uuid;
 use crate::middleware::rate_limit;
 use crate::ws::hub::Hub;
 
-/// Map from ticket string to (user_id, created_at).
+/// Map from ticket string to (user_id, device_id, created_at).
 /// Uses DashMap for lock-free concurrent access in async context.
-pub type TicketStore = DashMap<String, (Uuid, Instant)>;
+pub type TicketStore = DashMap<String, (Uuid, i32, Instant)>;
 
 /// Map from media ticket string to (user_id, created_at).
 pub type MediaTicketStore = DashMap<String, (Uuid, Instant)>;
@@ -146,6 +146,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/bundle/{user_id}/{device_id}",
             get(keys::get_device_bundle),
         )
+        .route("/bundles/{user_id}", get(keys::get_all_bundles))
         .route("/devices/{user_id}", get(keys::get_devices))
         .route("/otp-count", get(keys::get_otp_count));
 

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -306,7 +306,7 @@ pub async fn delete_account(
         })?;
 
     // Disconnect from WebSocket hub if online
-    state.hub.unregister(auth.user_id);
+    state.hub.unregister_all(auth.user_id);
 
     // Delete user row (CASCADE handles related tables)
     let deleted = db::users::delete_user(&state.pool, auth.user_id)

--- a/apps/server/src/routes/ws.rs
+++ b/apps/server/src/routes/ws.rs
@@ -32,9 +32,9 @@ pub async fn ws_upgrade(
     let now = Instant::now();
     state
         .ticket_store
-        .retain(|_, (_, ts)| now.duration_since(*ts) < TICKET_TTL);
+        .retain(|_, (_, _, ts)| now.duration_since(*ts) < TICKET_TTL);
 
-    let (_, (user_id, created_at)) = state
+    let (_, (user_id, device_id, created_at)) = state
         .ticket_store
         .remove(&params.ticket)
         .ok_or_else(|| AppError::unauthorized("Invalid or expired WebSocket ticket"))?;
@@ -54,7 +54,14 @@ pub async fn ws_upgrade(
         })?
         .ok_or_else(|| AppError::unauthorized("User not found"))?;
 
-    tracing::info!("WebSocket connecting: {} ({})", user.username, user_id);
+    tracing::info!(
+        "WebSocket connecting: {} ({}) device={}",
+        user.username,
+        user_id,
+        device_id
+    );
 
-    Ok(ws.on_upgrade(move |socket| handler::handle_socket(socket, user_id, user.username, state)))
+    Ok(ws.on_upgrade(move |socket| {
+        handler::handle_socket(socket, user_id, device_id, user.username, state)
+    }))
 }

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -4,6 +4,7 @@ use axum::extract::ws::{Message as WsMessage, WebSocket};
 use chrono::{DateTime, Utc};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -26,6 +27,10 @@ enum ClientMessage {
         to_user_id: Option<Uuid>,
         content: String,
         reply_to_id: Option<Uuid>,
+        /// Per-device ciphertexts: device_id (as string) -> base64 ciphertext.
+        /// When present, enables multi-device delivery.
+        #[serde(default)]
+        device_contents: Option<HashMap<String, String>>,
     },
     #[serde(rename = "typing")]
     Typing {
@@ -47,13 +52,15 @@ enum ClientMessage {
     CallStarted { conversation_id: Uuid },
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 #[serde(tag = "type")]
 enum ServerMessage {
     #[serde(rename = "new_message")]
     NewMessage {
         message_id: Uuid,
         from_user_id: Uuid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        from_device_id: Option<i32>,
         from_username: String,
         conversation_id: Uuid,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -66,6 +73,19 @@ enum ServerMessage {
         reply_to_content: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         reply_to_username: Option<String>,
+    },
+    /// Sent to the sender's OTHER devices so they see outgoing messages.
+    #[serde(rename = "self_message")]
+    SelfMessage {
+        message_id: Uuid,
+        from_device_id: i32,
+        conversation_id: Uuid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel_id: Option<Uuid>,
+        content: String,
+        timestamp: DateTime<Utc>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reply_to_id: Option<Uuid>,
     },
     #[serde(rename = "message_sent")]
     MessageSent {
@@ -119,14 +139,15 @@ enum ServerMessage {
 pub async fn handle_socket(
     socket: WebSocket,
     user_id: Uuid,
+    device_id: i32,
     username: String,
     state: Arc<AppState>,
 ) {
     let (mut sender, mut receiver) = socket.split();
     let (tx, mut rx) = mpsc::unbounded_channel::<WsMessage>();
 
-    // Register in hub
-    state.hub.register(user_id, tx);
+    // Register in hub (multi-device: keyed by user_id + device_id)
+    state.hub.register(user_id, device_id, tx);
 
     // Broadcast online presence to contacts
     broadcast_presence(&state, user_id, &username, "online").await;
@@ -151,6 +172,7 @@ pub async fn handle_socket(
     // client know the connection is still alive.
     let ping_hub = state.hub.clone();
     let ping_user_id = user_id;
+    let ping_device_id = device_id;
     let ping_task = tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(30));
         // The first tick fires immediately; skip it.
@@ -158,10 +180,14 @@ pub async fn handle_socket(
         loop {
             interval.tick().await;
             // Protocol-level Ping (proxy keepalive; invisible to browsers).
-            ping_hub.send_to(&ping_user_id, WsMessage::Ping(vec![].into()));
+            ping_hub.send_to_device(
+                &ping_user_id,
+                ping_device_id,
+                WsMessage::Ping(vec![].into()),
+            );
             // Application-level heartbeat (visible to all clients).
             let hb = r#"{"type":"heartbeat"}"#.to_string();
-            if !ping_hub.send_to(&ping_user_id, WsMessage::Text(hb.into())) {
+            if !ping_hub.send_to_device(&ping_user_id, ping_device_id, WsMessage::Text(hb.into())) {
                 break;
             }
         }
@@ -169,10 +195,10 @@ pub async fn handle_socket(
 
     deliver_undelivered_messages(&state, user_id).await;
 
-    run_receive_loop(&mut receiver, user_id, &username, &state).await;
+    run_receive_loop(&mut receiver, user_id, device_id, &username, &state).await;
 
     // Cleanup
-    state.hub.unregister(user_id);
+    state.hub.unregister(user_id, device_id);
     send_task.abort();
     ping_task.abort();
 
@@ -198,6 +224,7 @@ async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid) {
         let server_msg = ServerMessage::NewMessage {
             message_id: msg.id,
             from_user_id: msg.sender_id,
+            from_device_id: None, // Offline delivery doesn't track sender device
             from_username: msg.sender_username.clone(),
             conversation_id: msg.conversation_id,
             channel_id: msg.channel_id,
@@ -208,7 +235,9 @@ async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid) {
             reply_to_username: msg.reply_to_username.clone(),
         };
         if let Ok(json) = serde_json::to_string(&server_msg) {
-            let _ = state.hub.send_to(&user_id, WsMessage::Text(json.into()));
+            let _ = state
+                .hub
+                .send_to_user(&user_id, WsMessage::Text(json.into()));
         }
     }
 
@@ -242,6 +271,7 @@ async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid) {
 async fn run_receive_loop(
     receiver: &mut futures_util::stream::SplitStream<WebSocket>,
     user_id: Uuid,
+    device_id: i32,
     username: &str,
     state: &AppState,
 ) {
@@ -272,7 +302,7 @@ async fn run_receive_loop(
                     continue;
                 }
                 tokens -= 1.0;
-                handle_text_message(&text, user_id, username, state).await;
+                handle_text_message(&text, user_id, device_id, username, state).await;
             }
             WsMessage::Close(_) => break,
             _ => {}
@@ -312,7 +342,13 @@ async fn cleanup_user_voice_sessions(state: &AppState, user_id: Uuid) {
 /// content is 10 KB, and the JSON envelope adds minimal overhead).
 const MAX_WS_FRAME_BYTES: usize = 65_536;
 
-async fn handle_text_message(text: &str, sender_id: Uuid, sender_username: &str, state: &AppState) {
+async fn handle_text_message(
+    text: &str,
+    sender_id: Uuid,
+    sender_device_id: i32,
+    sender_username: &str,
+    state: &AppState,
+) {
     if text.len() > MAX_WS_FRAME_BYTES {
         send_error(
             state,
@@ -341,16 +377,19 @@ async fn handle_text_message(text: &str, sender_id: Uuid, sender_username: &str,
             to_user_id,
             content,
             reply_to_id,
+            device_contents,
         } => {
             handle_send_message(
                 state,
                 sender_id,
+                sender_device_id,
                 sender_username,
                 conversation_id,
                 channel_id,
                 to_user_id,
                 content,
                 reply_to_id,
+                device_contents,
             )
             .await;
         }
@@ -454,12 +493,14 @@ async fn handle_broadcast_event<F>(
 async fn handle_send_message(
     state: &AppState,
     sender_id: Uuid,
+    sender_device_id: i32,
     sender_username: &str,
     conversation_id: Option<Uuid>,
     channel_id: Option<Uuid>,
     to_user_id: Option<Uuid>,
     content: String,
     reply_to_id: Option<Uuid>,
+    device_contents: Option<HashMap<String, String>>,
 ) {
     // Validate message content length
     const MAX_MESSAGE_LENGTH: usize = 10_000;
@@ -521,7 +562,7 @@ async fn handle_send_message(
 
     let (reply_content, reply_username) = lookup_reply_context(&state.pool, reply_to_id).await;
 
-    // Store message
+    // Store message (use first device content as the canonical content for DB storage)
     let stored = match db::messages::store_message(
         &state.pool,
         conv_id,
@@ -539,7 +580,21 @@ async fn handle_send_message(
         }
     };
 
-    // Send confirmation to sender
+    // Store per-device ciphertexts if present
+    if let Some(ref dc) = device_contents {
+        let entries: Vec<(i32, &str)> = dc
+            .iter()
+            .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, v.as_str())))
+            .collect();
+        if !entries.is_empty()
+            && let Err(e) =
+                db::messages::store_device_contents(&state.pool, stored.id, &entries).await
+        {
+            tracing::error!("Failed to store device contents: {e:?}");
+        }
+    }
+
+    // Send confirmation to sender's device
     let confirm = ServerMessage::MessageSent {
         message_id: stored.id,
         conversation_id: conv_id,
@@ -547,12 +602,42 @@ async fn handle_send_message(
         timestamp: stored.created_at,
     };
     if let Ok(json) = serde_json::to_string(&confirm) {
-        state.hub.send_to(&sender_id, WsMessage::Text(json.into()));
+        state
+            .hub
+            .send_to_device(&sender_id, sender_device_id, WsMessage::Text(json.into()));
+    }
+
+    // Self-device delivery: notify sender's OTHER devices about outgoing message
+    if let Some(ref dc) = device_contents {
+        for (device_id_str, ciphertext) in dc {
+            if let Ok(did) = device_id_str.parse::<i32>() {
+                if did == sender_device_id {
+                    continue; // Don't send to the originating device
+                }
+                // Attempt delivery — Hub returns false if device isn't registered
+                // for this user (i.e. it's a recipient device, not a self device).
+                let self_msg = ServerMessage::SelfMessage {
+                    message_id: stored.id,
+                    from_device_id: sender_device_id,
+                    conversation_id: conv_id,
+                    channel_id: stored.channel_id,
+                    content: ciphertext.clone(),
+                    timestamp: stored.created_at,
+                    reply_to_id,
+                };
+                if let Ok(json) = serde_json::to_string(&self_msg) {
+                    state
+                        .hub
+                        .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
+                }
+            }
+        }
     }
 
     let deliver = ServerMessage::NewMessage {
         message_id: stored.id,
         from_user_id: sender_id,
+        from_device_id: Some(sender_device_id),
         from_username: sender_username.to_string(),
         conversation_id: conv_id,
         channel_id: stored.channel_id,
@@ -566,10 +651,12 @@ async fn handle_send_message(
     fanout_message(
         state,
         sender_id,
+        sender_device_id,
         conv_id,
         &deliver,
         stored.id,
         conv_security.is_encrypted,
+        device_contents,
     )
     .await;
 }
@@ -725,14 +812,17 @@ async fn lookup_reply_context(
 }
 
 /// Fan out a message to all conversation members (except sender), with block filtering
-/// and delivery tracking.
+/// and delivery tracking. Supports per-device ciphertext delivery for multi-device.
+#[allow(clippy::too_many_arguments)]
 async fn fanout_message(
     state: &AppState,
     sender_id: Uuid,
+    sender_device_id: i32,
     conv_id: Uuid,
     message: &ServerMessage,
     stored_id: Uuid,
     is_encrypted: bool,
+    device_contents: Option<HashMap<String, String>>,
 ) {
     let member_ids = match db::groups::get_conversation_member_ids(&state.pool, conv_id).await {
         Ok(ids) => ids,
@@ -742,11 +832,6 @@ async fn fanout_message(
         }
     };
 
-    let json = match serde_json::to_string(message) {
-        Ok(j) => j,
-        Err(_) => return,
-    };
-
     // Batch check which members have blocked the sender (single query instead of N+1)
     let blockers: Vec<Uuid> = db::contacts::get_blockers_of(&state.pool, &member_ids, sender_id)
         .await
@@ -754,6 +839,40 @@ async fn fanout_message(
 
     let mut any_delivered = false;
     let mut offline_user_ids = Vec::new();
+
+    // Extract common fields from the message for per-device rewriting
+    let (msg_id, from_uid, from_did, from_name, conv, ch, ts, rto_id, rto_content, rto_user) =
+        match message {
+            ServerMessage::NewMessage {
+                message_id,
+                from_user_id,
+                from_device_id,
+                from_username,
+                conversation_id,
+                channel_id,
+                timestamp,
+                reply_to_id,
+                reply_to_content,
+                reply_to_username,
+                ..
+            } => (
+                *message_id,
+                *from_user_id,
+                *from_device_id,
+                from_username.clone(),
+                *conversation_id,
+                *channel_id,
+                *timestamp,
+                *reply_to_id,
+                reply_to_content.clone(),
+                reply_to_username.clone(),
+            ),
+            _ => unreachable!("fanout_message always receives NewMessage"),
+        };
+
+    // Legacy fallback JSON (used when no device_contents or for non-DM group messages)
+    let legacy_json = serde_json::to_string(message).ok();
+
     for member_id in &member_ids {
         if *member_id == sender_id {
             continue;
@@ -761,13 +880,49 @@ async fn fanout_message(
         if blockers.contains(member_id) {
             continue;
         }
-        if state
-            .hub
-            .send_to(member_id, WsMessage::Text(json.clone().into()))
-        {
-            any_delivered = true;
-        } else {
-            offline_user_ids.push(*member_id);
+
+        // For multi-device: try per-device delivery if device_contents is available.
+        if let Some(ref dc) = device_contents {
+            let mut member_delivered = false;
+            for (device_id_str, ciphertext) in dc {
+                if let Ok(did) = device_id_str.parse::<i32>() {
+                    let per_device_msg = ServerMessage::NewMessage {
+                        message_id: msg_id,
+                        from_user_id: from_uid,
+                        from_device_id: from_did,
+                        from_username: from_name.clone(),
+                        conversation_id: conv,
+                        channel_id: ch,
+                        content: ciphertext.clone(),
+                        timestamp: ts,
+                        reply_to_id: rto_id,
+                        reply_to_content: rto_content.clone(),
+                        reply_to_username: rto_user.clone(),
+                    };
+                    if let Ok(json) = serde_json::to_string(&per_device_msg)
+                        && state
+                            .hub
+                            .send_to_device(member_id, did, WsMessage::Text(json.into()))
+                    {
+                        member_delivered = true;
+                    }
+                }
+            }
+            if member_delivered {
+                any_delivered = true;
+            } else {
+                offline_user_ids.push(*member_id);
+            }
+        } else if let Some(ref json) = legacy_json {
+            // Legacy single-content delivery to all user devices
+            if state
+                .hub
+                .send_to_user(member_id, WsMessage::Text(json.clone().into()))
+            {
+                any_delivered = true;
+            } else {
+                offline_user_ids.push(*member_id);
+            }
         }
     }
 
@@ -780,9 +935,11 @@ async fn fanout_message(
             conversation_id: conv_id,
         };
         if let Ok(delivered_json) = serde_json::to_string(&delivered_event) {
-            state
-                .hub
-                .send_to(&sender_id, WsMessage::Text(delivered_json.into()));
+            state.hub.send_to_device(
+                &sender_id,
+                sender_device_id,
+                WsMessage::Text(delivered_json.into()),
+            );
         }
     }
 

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -1,4 +1,7 @@
 //! WebSocket connection hub for routing messages to online users.
+//!
+//! Supports multiple simultaneous connections per user (multi-device).
+//! Each connection is keyed by `(user_id, device_id)`.
 
 use axum::extract::ws::Message as WsMessage;
 use dashmap::DashMap;
@@ -9,7 +12,8 @@ pub type WsTx = mpsc::UnboundedSender<WsMessage>;
 
 #[derive(Debug, Default, Clone)]
 pub struct Hub {
-    connections: DashMap<Uuid, WsTx>,
+    /// user_id -> (device_id -> sender channel)
+    connections: DashMap<Uuid, DashMap<i32, WsTx>>,
 }
 
 impl Hub {
@@ -19,20 +23,29 @@ impl Hub {
         }
     }
 
-    pub fn register(&self, user_id: Uuid, tx: WsTx) {
-        if let Some(old_tx) = self.connections.insert(user_id, tx) {
-            let msg = serde_json::json!({
-                "type": "session_replaced",
-                "reason": "Signed in on another device"
-            });
-            if let Ok(s) = serde_json::to_string(&msg) {
-                let _ = old_tx.send(WsMessage::Text(s.into()));
+    /// Register a device connection. Multiple devices per user are supported.
+    pub fn register(&self, user_id: Uuid, device_id: i32, tx: WsTx) {
+        self.connections
+            .entry(user_id)
+            .or_default()
+            .insert(device_id, tx);
+    }
+
+    /// Unregister a specific device. Cleans up the user entry if no devices remain.
+    pub fn unregister(&self, user_id: Uuid, device_id: i32) {
+        if let Some(devices) = self.connections.get(&user_id) {
+            devices.remove(&device_id);
+            if devices.is_empty() {
+                drop(devices);
+                // Re-check after dropping the ref to avoid race
+                self.connections
+                    .remove_if(&user_id, |_, devs| devs.is_empty());
             }
-            let _ = old_tx.send(WsMessage::Close(None));
         }
     }
 
-    pub fn unregister(&self, user_id: Uuid) {
+    /// Unregister ALL devices for a user (e.g., account deletion).
+    pub fn unregister_all(&self, user_id: Uuid) {
         self.connections.remove(&user_id);
     }
 
@@ -40,12 +53,54 @@ impl Hub {
         self.connections.iter().map(|entry| *entry.key()).collect()
     }
 
-    pub fn send_to(&self, user_id: &Uuid, msg: WsMessage) -> bool {
-        if let Some(tx) = self.connections.get(user_id) {
-            tx.send(msg).is_ok()
+    /// Send a message to ALL connected devices of a user.
+    pub fn send_to_user(&self, user_id: &Uuid, msg: WsMessage) -> bool {
+        if let Some(devices) = self.connections.get(user_id) {
+            let mut any_sent = false;
+            for entry in devices.iter() {
+                if entry.value().send(msg.clone()).is_ok() {
+                    any_sent = true;
+                }
+            }
+            any_sent
         } else {
             false
         }
+    }
+
+    /// Send a message to a specific device of a user.
+    pub fn send_to_device(&self, user_id: &Uuid, device_id: i32, msg: WsMessage) -> bool {
+        if let Some(devices) = self.connections.get(user_id)
+            && let Some(tx) = devices.get(&device_id)
+        {
+            return tx.send(msg).is_ok();
+        }
+        false
+    }
+
+    /// Send a message to all devices of a user EXCEPT the specified device.
+    pub fn send_to_other_devices(
+        &self,
+        user_id: &Uuid,
+        exclude_device_id: i32,
+        msg: WsMessage,
+    ) -> bool {
+        if let Some(devices) = self.connections.get(user_id) {
+            let mut any_sent = false;
+            for entry in devices.iter() {
+                if *entry.key() != exclude_device_id && entry.value().send(msg.clone()).is_ok() {
+                    any_sent = true;
+                }
+            }
+            any_sent
+        } else {
+            false
+        }
+    }
+
+    /// Backward-compatible: send to user (all devices). Alias for `send_to_user`.
+    pub fn send_to(&self, user_id: &Uuid, msg: WsMessage) -> bool {
+        self.send_to_user(user_id, msg)
     }
 
     /// Broadcast a JSON event to all members of a conversation, optionally excluding one user.
@@ -54,7 +109,7 @@ impl Hub {
             if Some(*member_id) == exclude {
                 continue;
             }
-            self.send_to(member_id, WsMessage::Text(json.to_string().into()));
+            self.send_to_user(member_id, WsMessage::Text(json.to_string().into()));
         }
     }
 }
@@ -69,7 +124,7 @@ mod tests {
         let user_id = Uuid::new_v4();
         let (tx, mut rx) = mpsc::unbounded_channel();
 
-        hub.register(user_id, tx);
+        hub.register(user_id, 1, tx);
         let sent = hub.send_to(&user_id, WsMessage::Text("hello".into()));
         assert!(sent);
 
@@ -86,8 +141,8 @@ mod tests {
         let user_id = Uuid::new_v4();
         let (tx, _rx) = mpsc::unbounded_channel();
 
-        hub.register(user_id, tx);
-        hub.unregister(user_id);
+        hub.register(user_id, 1, tx);
+        hub.unregister(user_id, 1);
 
         let sent = hub.send_to(&user_id, WsMessage::Text("hello".into()));
         assert!(!sent);
@@ -100,5 +155,101 @@ mod tests {
 
         let sent = hub.send_to(&user_id, WsMessage::Text("hello".into()));
         assert!(!sent);
+    }
+
+    #[tokio::test]
+    async fn test_multi_device_delivery() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+
+        hub.register(user_id, 1, tx1);
+        hub.register(user_id, 2, tx2);
+
+        let sent = hub.send_to_user(&user_id, WsMessage::Text("hello".into()));
+        assert!(sent);
+
+        let msg1 = rx1.recv().await.unwrap();
+        let msg2 = rx2.recv().await.unwrap();
+        match (msg1, msg2) {
+            (WsMessage::Text(t1), WsMessage::Text(t2)) => {
+                assert_eq!(t1.as_str(), "hello");
+                assert_eq!(t2.as_str(), "hello");
+            }
+            _ => panic!("Expected Text messages"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_to_specific_device() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+
+        hub.register(user_id, 1, tx1);
+        hub.register(user_id, 2, tx2);
+
+        let sent = hub.send_to_device(&user_id, 2, WsMessage::Text("device2".into()));
+        assert!(sent);
+
+        // Device 2 should receive it
+        let msg = rx2.recv().await.unwrap();
+        match msg {
+            WsMessage::Text(t) => assert_eq!(t.as_str(), "device2"),
+            _ => panic!("Expected Text message"),
+        }
+
+        // Device 1 should NOT have a message
+        assert!(rx1.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_send_to_other_devices() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        let (tx3, mut rx3) = mpsc::unbounded_channel();
+
+        hub.register(user_id, 1, tx1);
+        hub.register(user_id, 2, tx2);
+        hub.register(user_id, 3, tx3);
+
+        let sent = hub.send_to_other_devices(&user_id, 1, WsMessage::Text("from_device_1".into()));
+        assert!(sent);
+
+        // Device 1 should NOT receive
+        assert!(rx1.try_recv().is_err());
+        // Devices 2 and 3 should receive
+        match rx2.recv().await.unwrap() {
+            WsMessage::Text(t) => assert_eq!(t.as_str(), "from_device_1"),
+            _ => panic!("Expected Text"),
+        }
+        match rx3.recv().await.unwrap() {
+            WsMessage::Text(t) => assert_eq!(t.as_str(), "from_device_1"),
+            _ => panic!("Expected Text"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_unregister_one_device_keeps_others() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx1, _rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+
+        hub.register(user_id, 1, tx1);
+        hub.register(user_id, 2, tx2);
+        hub.unregister(user_id, 1);
+
+        let sent = hub.send_to_user(&user_id, WsMessage::Text("still here".into()));
+        assert!(sent);
+
+        match rx2.recv().await.unwrap() {
+            WsMessage::Text(t) => assert_eq!(t.as_str(), "still here"),
+            _ => panic!("Expected Text"),
+        }
     }
 }

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -78,26 +78,6 @@ impl Hub {
         false
     }
 
-    /// Send a message to all devices of a user EXCEPT the specified device.
-    pub fn send_to_other_devices(
-        &self,
-        user_id: &Uuid,
-        exclude_device_id: i32,
-        msg: WsMessage,
-    ) -> bool {
-        if let Some(devices) = self.connections.get(user_id) {
-            let mut any_sent = false;
-            for entry in devices.iter() {
-                if *entry.key() != exclude_device_id && entry.value().send(msg.clone()).is_ok() {
-                    any_sent = true;
-                }
-            }
-            any_sent
-        } else {
-            false
-        }
-    }
-
     /// Backward-compatible: send to user (all devices). Alias for `send_to_user`.
     pub fn send_to(&self, user_id: &Uuid, msg: WsMessage) -> bool {
         self.send_to_user(user_id, msg)
@@ -203,34 +183,6 @@ mod tests {
 
         // Device 1 should NOT have a message
         assert!(rx1.try_recv().is_err());
-    }
-
-    #[tokio::test]
-    async fn test_send_to_other_devices() {
-        let hub = Hub::new();
-        let user_id = Uuid::new_v4();
-        let (tx1, mut rx1) = mpsc::unbounded_channel();
-        let (tx2, mut rx2) = mpsc::unbounded_channel();
-        let (tx3, mut rx3) = mpsc::unbounded_channel();
-
-        hub.register(user_id, 1, tx1);
-        hub.register(user_id, 2, tx2);
-        hub.register(user_id, 3, tx3);
-
-        let sent = hub.send_to_other_devices(&user_id, 1, WsMessage::Text("from_device_1".into()));
-        assert!(sent);
-
-        // Device 1 should NOT receive
-        assert!(rx1.try_recv().is_err());
-        // Devices 2 and 3 should receive
-        match rx2.recv().await.unwrap() {
-            WsMessage::Text(t) => assert_eq!(t.as_str(), "from_device_1"),
-            _ => panic!("Expected Text"),
-        }
-        match rx3.recv().await.unwrap() {
-            WsMessage::Text(t) => assert_eq!(t.as_str(), "from_device_1"),
-            _ => panic!("Expected Text"),
-        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Hub supports multiple simultaneous WS connections per user (keyed by user_id + device_id), removing session eviction
- Sender encrypts per-device via new `GET /api/keys/bundles/:user_id` endpoint, server routes device-specific ciphertexts to each connection
- Self-device delivery via `self_message` WS event lets sender's other devices see outgoing messages
- New `message_device_contents` DB table stores per-device ciphertexts alongside canonical message
- Client sessions keyed by `userId:deviceId` with fallback to legacy `userId` format
- Full backward compatibility: old clients send single `content`, new clients send `device_contents` map

## Test plan
- [x] `cargo test --workspace --lib` — 58 tests pass (6 new hub multi-device tests)
- [x] `flutter test` — 241 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `flutter analyze --fatal-infos` — 0 issues
- [ ] Manual: launch two client instances as same user via `scripts/demo_two_apps.sh`, verify both stay connected
- [ ] Manual: send DM from Device A, verify Device B receives and decrypts
- [ ] Manual: verify sender's other device sees outgoing messages via self_message