### PR TITLE
security + perf: fix rand advisory, add criterion benchmarks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cargo-audit
-      # RUSTSEC-2023-0071 is a transitive rsa advisory via jsonwebtoken.
-      # No upstream patch is available yet; rationale is tracked in deny.toml.
-      - run: cargo audit --ignore RUSTSEC-2023-0071
+      # RUSTSEC-2023-0071: transitive rsa advisory via jsonwebtoken (no upstream patch).
+      # RUSTSEC-2026-0097: rand 0.8.5 unsound advisory, pinned by sqlx 0.8.6 transitively.
+      - run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097
   deny:
     name: License + Ban Check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,15 +494,15 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "hkdf",
- "rand 0.8.5",
+ "rand_core 0.6.4",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "uuid",
  "x25519-dalek",
@@ -528,7 +528,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tower",
@@ -2186,7 +2186,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -2275,7 +2275,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2359,7 +2359,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uuid",
  "whoami",
@@ -2398,7 +2398,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uuid",
  "whoami",
@@ -2424,7 +2424,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "url",
  "uuid",
@@ -2520,31 +2520,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2684,27 +2664,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.26.2",
 ]
 
@@ -2850,25 +2818,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "native-tls",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -2878,9 +2827,10 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.3",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
  "utf-8",
 ]
 
@@ -2897,7 +2847,7 @@ dependencies = [
  "log",
  "rand 0.9.3",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
  "utf-8",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +297,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +332,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "concurrent-queue"
@@ -354,6 +424,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +492,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -491,6 +622,7 @@ dependencies = [
  "aes-gcm",
  "base64",
  "chrono",
+ "criterion",
  "ed25519-dalek",
  "futures-util",
  "hkdf",
@@ -517,6 +649,7 @@ dependencies = [
  "axum-extra",
  "base64",
  "chrono",
+ "criterion",
  "dashmap",
  "dotenvy",
  "ed25519-dalek",
@@ -857,6 +990,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +1073,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1258,6 +1408,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1697,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +1863,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +2026,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2061,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2010,6 +2246,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2589,6 +2834,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3106,6 +3371,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -53,3 +53,8 @@ reqwest = { version = "0.12", features = ["json"] }
 
 [dev-dependencies]
 tokio-tungstenite = "0.26"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "hub"
+harness = false

--- a/apps/server/benches/hub.rs
+++ b/apps/server/benches/hub.rs
@@ -1,0 +1,163 @@
+use axum::extract::ws::Message as WsMessage;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use echo_server::ws::hub::Hub;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+fn bench_hub_register(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hub_register");
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    group.bench_function("single_device", |b| {
+        b.iter(|| {
+            let hub = Hub::new();
+            let (tx, _rx) = mpsc::channel(16);
+            hub.register(Uuid::new_v4(), 1, tx);
+        });
+    });
+
+    // Register N users, then add one more
+    for n in [100, 1000, 10000] {
+        group.bench_with_input(BenchmarkId::new("with_existing_users", n), &n, |b, &n| {
+            let hub = Hub::new();
+            let _rxs: Vec<_> = (0..n)
+                .map(|_| {
+                    let (tx, rx) = mpsc::channel(16);
+                    hub.register(Uuid::new_v4(), 1, tx);
+                    rx
+                })
+                .collect();
+
+            b.iter(|| {
+                let (tx, _rx) = mpsc::channel(16);
+                hub.register(Uuid::new_v4(), 1, tx);
+            });
+        });
+    }
+
+    group.finish();
+    drop(rt);
+}
+
+fn bench_hub_send(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hub_send");
+    let _rt = tokio::runtime::Runtime::new().unwrap();
+
+    // send_to_user with 1 device
+    group.bench_function("send_to_user_1_device", |b| {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(4096);
+        hub.register(user_id, 1, tx);
+
+        b.iter(|| {
+            hub.send_to_user(&user_id, WsMessage::Text("test".into()));
+        });
+    });
+
+    // send_to_user with 5 devices
+    group.bench_function("send_to_user_5_devices", |b| {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let _rxs: Vec<_> = (0..5)
+            .map(|i| {
+                let (tx, rx) = mpsc::channel(4096);
+                hub.register(user_id, i, tx);
+                rx
+            })
+            .collect();
+
+        b.iter(|| {
+            hub.send_to_user(&user_id, WsMessage::Text("test".into()));
+        });
+    });
+
+    // send_to_device (specific device lookup)
+    group.bench_function("send_to_device", |b| {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(4096);
+        hub.register(user_id, 1, tx);
+
+        b.iter(|| {
+            hub.send_to_device(&user_id, 1, WsMessage::Text("test".into()));
+        });
+    });
+
+    // send to offline user (miss path)
+    group.bench_function("send_to_offline", |b| {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+
+        b.iter(|| {
+            hub.send_to_user(&user_id, WsMessage::Text("test".into()));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_hub_broadcast(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hub_broadcast");
+    let _rt = tokio::runtime::Runtime::new().unwrap();
+
+    for member_count in [10, 50, 100, 500] {
+        group.bench_with_input(
+            BenchmarkId::new("broadcast_json", member_count),
+            &member_count,
+            |b, &n| {
+                let hub = Hub::new();
+                let member_ids: Vec<Uuid> = (0..n).map(|_| Uuid::new_v4()).collect();
+                let _rxs: Vec<_> = member_ids
+                    .iter()
+                    .map(|uid| {
+                        let (tx, rx) = mpsc::channel(4096);
+                        hub.register(*uid, 1, tx);
+                        rx
+                    })
+                    .collect();
+
+                let json = r#"{"type":"message","content":"hello"}"#;
+                let exclude = Some(member_ids[0]);
+
+                b.iter(|| {
+                    hub.broadcast_json(&member_ids, json, exclude);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_hub_concurrent_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hub_lookup");
+    let _rt = tokio::runtime::Runtime::new().unwrap();
+
+    // Measure DashMap lookup speed with many entries
+    for n in [100, 1000, 10000] {
+        group.bench_with_input(BenchmarkId::new("get_online_ids", n), &n, |b, &n| {
+            let hub = Hub::new();
+            let _rxs: Vec<_> = (0..n)
+                .map(|_| {
+                    let (tx, rx) = mpsc::channel(16);
+                    hub.register(Uuid::new_v4(), 1, tx);
+                    rx
+                })
+                .collect();
+
+            b.iter(|| hub.get_online_user_ids());
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_hub_register,
+    bench_hub_send,
+    bench_hub_broadcast,
+    bench_hub_concurrent_lookup,
+);
+criterion_main!(benches);

--- a/core/rust-core/Cargo.toml
+++ b/core/rust-core/Cargo.toml
@@ -17,7 +17,7 @@ tracing.workspace = true
 chrono.workspace = true
 
 # Networking
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 futures-util = "0.3"
 reqwest = { version = "0.12", features = ["json"] }
 
@@ -25,7 +25,7 @@ reqwest = { version = "0.12", features = ["json"] }
 rusqlite = { version = "0.32", features = ["bundled-sqlcipher"] }
 
 # Crypto utilities
-rand = "0.8"
+rand_core = { version = "0.6", features = ["getrandom"] }
 base64 = "0.22"
 
 # Crypto - Signal Protocol primitives

--- a/core/rust-core/Cargo.toml
+++ b/core/rust-core/Cargo.toml
@@ -34,3 +34,10 @@ ed25519-dalek = { version = "2", features = ["serde"] }
 aes-gcm = "0.10"
 hkdf = "0.12"
 sha2 = "0.10"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "crypto"
+harness = false

--- a/core/rust-core/benches/crypto.rs
+++ b/core/rust-core/benches/crypto.rs
@@ -1,0 +1,268 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use echo_core::crypto::{encrypt, keys, session};
+use echo_core::signal::keys::{EphemeralKeyPair, IdentityKeyPair, PreKeyBundle};
+use echo_core::signal::ratchet::RatchetState;
+use echo_core::signal::session as signal_session;
+use echo_core::signal::x3dh;
+use rand_core::OsRng;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+// ---------------------------------------------------------------------------
+// AES-256-GCM
+// ---------------------------------------------------------------------------
+
+fn bench_aes_gcm(c: &mut Criterion) {
+    let key = [42u8; 32];
+    let mut group = c.benchmark_group("aes_gcm");
+
+    for size in [64, 256, 1024, 4096, 10240] {
+        let plaintext = vec![0xABu8; size];
+        let encrypted = encrypt::encrypt(&key, &plaintext).unwrap();
+
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("encrypt", size), &plaintext, |b, pt| {
+            b.iter(|| encrypt::encrypt(&key, pt).unwrap());
+        });
+
+        group.bench_with_input(BenchmarkId::new("decrypt", size), &encrypted, |b, ct| {
+            b.iter(|| encrypt::decrypt(&key, ct).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// X3DH key exchange (crypto module -- simplified)
+// ---------------------------------------------------------------------------
+
+fn bench_x3dh_crypto(c: &mut Criterion) {
+    let mut group = c.benchmark_group("x3dh_crypto");
+
+    let alice_identity = StaticSecret::random_from_rng(OsRng);
+    let alice_identity_pub = PublicKey::from(&alice_identity);
+
+    let bob_identity = StaticSecret::random_from_rng(OsRng);
+    let bob_identity_pub = PublicKey::from(&bob_identity);
+
+    let bob_spk = StaticSecret::random_from_rng(OsRng);
+    let bob_spk_pub = PublicKey::from(&bob_spk);
+
+    let bob_otp = StaticSecret::random_from_rng(OsRng);
+    let bob_otp_pub = PublicKey::from(&bob_otp);
+
+    group.bench_function("initiate_with_otp", |b| {
+        b.iter(|| {
+            session::x3dh_initiate(
+                &alice_identity,
+                &bob_identity_pub,
+                &bob_spk_pub,
+                Some(&bob_otp_pub),
+            )
+            .unwrap()
+        });
+    });
+
+    group.bench_function("initiate_without_otp", |b| {
+        b.iter(|| {
+            session::x3dh_initiate(&alice_identity, &bob_identity_pub, &bob_spk_pub, None).unwrap()
+        });
+    });
+
+    // Pre-compute an initiation result for respond benchmark
+    let init_result = session::x3dh_initiate(
+        &alice_identity,
+        &bob_identity_pub,
+        &bob_spk_pub,
+        Some(&bob_otp_pub),
+    )
+    .unwrap();
+    let their_ephemeral =
+        PublicKey::from(<[u8; 32]>::try_from(init_result.ephemeral_public.as_slice()).unwrap());
+
+    group.bench_function("respond_with_otp", |b| {
+        b.iter(|| {
+            session::x3dh_respond(
+                &bob_identity,
+                &bob_spk,
+                Some(&bob_otp),
+                &alice_identity_pub,
+                &their_ephemeral,
+            )
+            .unwrap()
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// X3DH key exchange (signal module -- full with signatures)
+// ---------------------------------------------------------------------------
+
+fn bench_x3dh_signal(c: &mut Criterion) {
+    let mut group = c.benchmark_group("x3dh_signal");
+
+    let alice_identity = IdentityKeyPair::generate();
+    let bob_identity = IdentityKeyPair::generate();
+
+    let bob_spk_private = StaticSecret::random_from_rng(OsRng);
+    let bob_spk_public = PublicKey::from(&bob_spk_private);
+    let spk_sig = bob_identity.sign(bob_spk_public.as_bytes());
+
+    let bob_otp_private = StaticSecret::random_from_rng(OsRng);
+    let bob_otp_public = PublicKey::from(&bob_otp_private);
+
+    let bundle = PreKeyBundle {
+        identity_key: bob_identity.public,
+        signed_prekey: bob_spk_public,
+        signed_prekey_signature: spk_sig,
+        one_time_prekey: Some(bob_otp_public),
+    };
+    let bob_verifying = bob_identity.verifying_key();
+
+    group.bench_function("initiate_full", |b| {
+        b.iter(|| x3dh::initiate(&alice_identity, &bundle, &bob_verifying).unwrap());
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Double Ratchet
+// ---------------------------------------------------------------------------
+
+fn bench_ratchet(c: &mut Criterion) {
+    let mut group = c.benchmark_group("double_ratchet");
+
+    let shared_secret = [42u8; 32];
+    let bob_priv = StaticSecret::random_from_rng(OsRng);
+    let bob_pub = PublicKey::from(&bob_priv);
+
+    // Benchmark single-direction encrypt (no DH ratchet steps after init)
+    group.bench_function("encrypt_no_dh", |b| {
+        let mut alice = RatchetState::init_alice(&shared_secret, &bob_pub).unwrap();
+        b.iter(|| alice.encrypt(b"Hello, world!").unwrap());
+    });
+
+    // Benchmark decrypt (receiving sequential messages, no DH ratchet)
+    group.bench_function("decrypt_no_dh", |b| {
+        b.iter_custom(|iters| {
+            let mut alice = RatchetState::init_alice(&shared_secret, &bob_pub).unwrap();
+            let bob_priv_clone = StaticSecret::from(bob_priv.to_bytes());
+            let mut bob = RatchetState::init_bob(&shared_secret, bob_priv_clone).unwrap();
+
+            // Pre-generate messages
+            let msgs: Vec<_> = (0..iters)
+                .map(|_| alice.encrypt(b"Hello, world!").unwrap())
+                .collect();
+
+            let start = std::time::Instant::now();
+            for (ct, hdr) in &msgs {
+                bob.decrypt(hdr, ct).unwrap();
+            }
+            start.elapsed()
+        });
+    });
+
+    // Benchmark ping-pong (every message triggers DH ratchet)
+    group.bench_function("encrypt_decrypt_ping_pong", |b| {
+        b.iter_custom(|iters| {
+            let mut alice = RatchetState::init_alice(&shared_secret, &bob_pub).unwrap();
+            let bob_priv_clone = StaticSecret::from(bob_priv.to_bytes());
+            let mut bob = RatchetState::init_bob(&shared_secret, bob_priv_clone).unwrap();
+
+            let start = std::time::Instant::now();
+            for _ in 0..iters {
+                let (ct, hdr) = alice.encrypt(b"ping").unwrap();
+                bob.decrypt(&hdr, &ct).unwrap();
+                let (ct, hdr) = bob.encrypt(b"pong").unwrap();
+                alice.decrypt(&hdr, &ct).unwrap();
+            }
+            start.elapsed()
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Key generation
+// ---------------------------------------------------------------------------
+
+fn bench_keygen(c: &mut Criterion) {
+    let mut group = c.benchmark_group("keygen");
+
+    group.bench_function("identity_keypair", |b| {
+        b.iter(IdentityKeyPair::generate);
+    });
+
+    group.bench_function("ephemeral_keypair", |b| {
+        b.iter(EphemeralKeyPair::generate);
+    });
+
+    group.bench_function("crypto_identity_keypair", |b| {
+        b.iter(keys::IdentityKeyPair::generate);
+    });
+
+    let identity = keys::IdentityKeyPair::generate();
+    group.bench_function("signed_prekey", |b| {
+        b.iter(|| keys::generate_signed_prekey(&identity, 1));
+    });
+
+    group.bench_function("one_time_prekeys_10", |b| {
+        b.iter(|| keys::generate_one_time_prekeys(0, 10));
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Full session lifecycle
+// ---------------------------------------------------------------------------
+
+fn bench_session_lifecycle(c: &mut Criterion) {
+    let mut group = c.benchmark_group("session_lifecycle");
+
+    group.bench_function("create_and_accept", |b| {
+        b.iter(|| {
+            let alice_id = IdentityKeyPair::generate();
+            let bob_id = IdentityKeyPair::generate();
+
+            let bob_spk_priv = StaticSecret::random_from_rng(OsRng);
+            let bob_spk_pub = PublicKey::from(&bob_spk_priv);
+            let spk_sig = bob_id.sign(bob_spk_pub.as_bytes());
+
+            let bundle = PreKeyBundle {
+                identity_key: bob_id.public,
+                signed_prekey: bob_spk_pub,
+                signed_prekey_signature: spk_sig,
+                one_time_prekey: None,
+            };
+
+            let bob_verifying = bob_id.verifying_key();
+            let (mut alice_session, initial_msg) =
+                signal_session::create_session(&alice_id, "bob", &bundle, &bob_verifying).unwrap();
+            let mut bob_session =
+                signal_session::accept_session(&bob_id, &bob_spk_priv, None, "alice", &initial_msg)
+                    .unwrap();
+
+            let wire = signal_session::encrypt_message(&mut alice_session, b"Hello Bob!").unwrap();
+            signal_session::decrypt_message(&mut bob_session, &wire).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_aes_gcm,
+    bench_x3dh_crypto,
+    bench_x3dh_signal,
+    bench_ratchet,
+    bench_keygen,
+    bench_session_lifecycle,
+);
+criterion_main!(benches);

--- a/core/rust-core/src/crypto/encrypt.rs
+++ b/core/rust-core/src/crypto/encrypt.rs
@@ -2,7 +2,7 @@
 
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
-use rand::RngCore;
+use rand_core::RngCore;
 
 use crate::error::CoreError;
 
@@ -14,7 +14,7 @@ pub fn encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, CoreError> {
     let cipher = Aes256Gcm::new(cipher_key);
 
     let mut nonce_bytes = [0u8; 12];
-    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+    rand_core::OsRng.fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
 
     let ciphertext = cipher

--- a/core/rust-core/src/crypto/keys.rs
+++ b/core/rust-core/src/crypto/keys.rs
@@ -1,7 +1,7 @@
 //! Key generation and PreKey bundle management.
 
 use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 use x25519_dalek::{PublicKey, StaticSecret};
 
 /// Long-term Ed25519 identity key pair used for signing.
@@ -28,7 +28,7 @@ impl IdentityKeyPair {
     /// Generate a new random Ed25519 identity key pair.
     pub fn generate() -> Self {
         let mut secret_bytes = [0u8; 32];
-        rand::RngCore::fill_bytes(&mut OsRng, &mut secret_bytes);
+        rand_core::RngCore::fill_bytes(&mut OsRng, &mut secret_bytes);
         let signing_key = SigningKey::from_bytes(&secret_bytes);
         let verifying_key = signing_key.verifying_key();
         Self {

--- a/core/rust-core/src/crypto/session.rs
+++ b/core/rust-core/src/crypto/session.rs
@@ -1,7 +1,7 @@
 //! Simplified X3DH key agreement for session establishment.
 
 use hkdf::Hkdf;
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
 

--- a/core/rust-core/src/signal/keys.rs
+++ b/core/rust-core/src/signal/keys.rs
@@ -4,7 +4,7 @@
 //! and prekey bundles used in X3DH key agreement.
 
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::error::CoreError;
@@ -43,7 +43,7 @@ impl IdentityKeyPair {
         let public = PublicKey::from(&private);
 
         let mut signing_bytes = [0u8; 32];
-        rand::RngCore::fill_bytes(&mut OsRng, &mut signing_bytes);
+        rand_core::RngCore::fill_bytes(&mut OsRng, &mut signing_bytes);
         let signing_key = SigningKey::from_bytes(&signing_bytes);
 
         Self {

--- a/core/rust-core/src/signal/ratchet.rs
+++ b/core/rust-core/src/signal/ratchet.rs
@@ -12,8 +12,7 @@ use std::collections::HashMap;
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use hkdf::Hkdf;
-use rand::RngCore;
-use rand::rngs::OsRng;
+use rand_core::{OsRng, RngCore};
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
 

--- a/core/rust-core/src/signal/session.rs
+++ b/core/rust-core/src/signal/session.rs
@@ -233,7 +233,7 @@ pub fn deserialize_session(data: &[u8]) -> Result<Session, CoreError> {
 mod tests {
     use super::super::keys::IdentityKeyPair;
     use super::*;
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
     use x25519_dalek::StaticSecret;
 
     /// Set up Alice and Bob identities, Bob's prekey bundle, and all secrets.

--- a/core/rust-core/src/signal/x3dh.rs
+++ b/core/rust-core/src/signal/x3dh.rs
@@ -123,7 +123,7 @@ pub fn respond(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
 
     /// Helper: create Bob's prekey bundle and return all his secrets.
     fn bob_setup() -> (

--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,12 @@ all-features = true
 
 [advisories]
 version = 2
-ignore = []
+ignore = [
+    # rand 0.8.5 unsound advisory. sqlx 0.8.6 pins rand 0.8.5 transitively
+    # via sqlx-postgres and sqlx-mysql. No sqlx 0.9 available yet.
+    # Advisory conditions (custom logger + rand::rng() reseed) don't apply to sqlx usage.
+    "RUSTSEC-2026-0097",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary
- Fix RUSTSEC-2026-0097 CI failure by replacing `rand 0.8` with `rand_core 0.6` in echo-core and upgrading tokio-tungstenite 0.24 to 0.26
- Add RUSTSEC-2026-0097 to deny.toml ignore for sqlx transitive deps
- Add Criterion benchmark suites for crypto operations (AES-GCM, X3DH, Double Ratchet, keygen) and hub operations (register, send, broadcast)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` -- 57 unit tests pass
- [x] `cargo deny check` -- advisories ok
- [x] `cargo bench --bench crypto -- --test` -- all benchmarks compile and run
- [x] `cargo bench --bench hub -- --test` -- all benchmarks compile and run