### PR TITLE
fix(server): rate limit spoofing, CORS PATCH, unreachable panic, MIME validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +665,7 @@ dependencies = [
  "dotenvy",
  "ed25519-dalek",
  "futures-util",
+ "infer",
  "jsonwebtoken",
  "rand 0.9.3",
  "reqwest",
@@ -1380,6 +1392,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -51,6 +51,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # HTTP client (link previews)
 reqwest = { version = "0.12", features = ["json"] }
 
+# File type detection (magic bytes)
+infer = "0.19"
+
 [dev-dependencies]
 tokio-tungstenite = "0.26"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -80,11 +80,15 @@ fn extract_ip(req: &Request<Body>) -> IpAddr {
     }
 
     // Fallback to X-Forwarded-For -- use the LAST IP (appended by our proxy),
-    // not the first (attacker-controlled).
+    // not the first (attacker-controlled).  Reject private/loopback IPs to
+    // prevent spoofing bypass.
     if let Some(xff) = req.headers().get("x-forwarded-for")
         && let Ok(value) = xff.to_str()
         && let Some(last_ip) = value.rsplit(',').next()
         && let Ok(ip) = last_ip.trim().parse::<IpAddr>()
+        && !ip.is_loopback()
+        && !ip.is_unspecified()
+        && !is_private(ip)
     {
         return ip;
     }
@@ -142,4 +146,12 @@ pub fn refresh_limiter() -> RateLimiter {
 /// WebSocket ticket rate limiter: 10 tickets per 60 seconds per IP.
 pub fn ticket_limiter() -> RateLimiter {
     RateLimiter::new(10, 60)
+}
+
+/// Check whether an IP is in a private/reserved range (RFC 1918, link-local).
+fn is_private(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        IpAddr::V6(_) => false, // IPv6 ULA (fc00::/7) is not spoofable via XFF in practice
+    }
 }

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -133,7 +133,7 @@ pub async fn upload(
 
         let original_filename = field.file_name().unwrap_or("upload").to_string();
 
-        let mime_type = field
+        let mut mime_type = field
             .content_type()
             .unwrap_or("application/octet-stream")
             .to_string();
@@ -156,6 +156,18 @@ pub async fn upload(
                 "File too large. Maximum size is {} bytes",
                 MAX_FILE_SIZE
             )));
+        }
+
+        // Validate actual file type via magic bytes — don't trust client MIME header
+        if let Some(inferred) = infer::get(&data) {
+            let inferred_mime = inferred.mime_type();
+            if !ALLOWED_MIME_TYPES.contains(&inferred_mime) {
+                return Err(AppError::bad_request(format!(
+                    "Detected file type '{inferred_mime}' is not allowed"
+                )));
+            }
+            // Use the inferred MIME instead of the client-supplied one
+            mime_type = inferred_mime.to_string();
         }
 
         file_data = Some((original_filename, mime_type, data));

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -53,6 +53,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         Method::GET,
         Method::POST,
         Method::PUT,
+        Method::PATCH,
         Method::DELETE,
         Method::OPTIONS,
     ];

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -867,7 +867,10 @@ async fn fanout_message(
                 reply_to_content.clone(),
                 reply_to_username.clone(),
             ),
-            _ => unreachable!("fanout_message always receives NewMessage"),
+            _ => {
+                tracing::error!("fanout_message called with non-NewMessage variant");
+                return;
+            }
         };
 
     // Legacy fallback JSON (used when no device_contents or for non-DM group messages)


### PR DESCRIPTION
## Summary
- **#58** Rate limit bypass: reject private/loopback IPs from X-Forwarded-For to prevent spoofing
- **#64** CORS missing PATCH: add Method::PATCH to allowed_methods (was blocking profile updates)
- **#86** unreachable!() on live path: replace with error log + early return (prevents server panic)
- **#71** File upload MIME trust: add `infer` crate for magic-byte validation, override client MIME

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` — 57 unit tests pass
- [x] Clippy + rustfmt clean

Closes #58, closes #64, closes #86, closes #71