### PR TITLE
fix(server): media ACL info leak, CSP tightening, prekey transaction

### DIFF
--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
+use sqlx::postgres::PgConnection;
 use uuid::Uuid;
 
 #[derive(Debug, serde::Serialize)]
@@ -22,7 +23,7 @@ pub struct OneTimePreKeyRow {
 
 /// Store or replace a user's identity key for a specific device.
 pub async fn store_identity_key(
-    pool: &PgPool,
+    db: impl sqlx::PgExecutor<'_>,
     user_id: Uuid,
     device_id: i32,
     identity_key: &[u8],
@@ -38,14 +39,14 @@ pub async fn store_identity_key(
     .bind(device_id)
     .bind(identity_key)
     .bind(signing_key)
-    .execute(pool)
+    .execute(db)
     .await?;
     Ok(())
 }
 
 /// Store or replace a user's signed prekey for a specific device.
 pub async fn store_signed_prekey(
-    pool: &PgPool,
+    db: impl sqlx::PgExecutor<'_>,
     user_id: Uuid,
     device_id: i32,
     key_id: i32,
@@ -63,7 +64,7 @@ pub async fn store_signed_prekey(
     .bind(key_id)
     .bind(public_key)
     .bind(signature)
-    .execute(pool)
+    .execute(db)
     .await?;
     Ok(())
 }
@@ -75,7 +76,7 @@ pub async fn store_signed_prekey(
 /// the most recently generated OTP, so the server must store the matching
 /// public key.  Also resets `used = false` so the key is consumable again.
 pub async fn store_one_time_prekeys(
-    pool: &PgPool,
+    conn: &mut PgConnection,
     user_id: Uuid,
     device_id: i32,
     prekeys: &[(i32, Vec<u8>)],
@@ -92,7 +93,7 @@ pub async fn store_one_time_prekeys(
         .bind(device_id)
         .bind(key_id)
         .bind(public_key)
-        .execute(pool)
+        .execute(&mut *conn)
         .await?;
     }
     Ok(())

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -103,8 +103,14 @@ pub async fn upload_bundle(
         })
         .collect::<Result<Vec<_>, AppError>>()?;
 
+    // Wrap all key stores in a transaction to prevent partial uploads.
+    let mut tx = state.pool.begin().await.map_err(|e| {
+        tracing::error!("Failed to begin key upload transaction: {e:?}");
+        AppError::internal("Database error")
+    })?;
+
     db::keys::store_identity_key(
-        &state.pool,
+        &mut *tx,
         auth_user.user_id,
         device_id,
         &identity_key,
@@ -112,7 +118,7 @@ pub async fn upload_bundle(
     )
     .await?;
     db::keys::store_signed_prekey(
-        &state.pool,
+        &mut *tx,
         auth_user.user_id,
         device_id,
         body.signed_prekey_id,
@@ -123,13 +129,18 @@ pub async fn upload_bundle(
 
     if !one_time_prekeys.is_empty() {
         db::keys::store_one_time_prekeys(
-            &state.pool,
+            &mut *tx,
             auth_user.user_id,
             device_id,
             &one_time_prekeys,
         )
         .await?;
     }
+
+    tx.commit().await.map_err(|e| {
+        tracing::error!("Failed to commit key upload transaction: {e:?}");
+        AppError::internal("Database error")
+    })?;
 
     tracing::info!(
         "PreKey bundle uploaded for user {} device {} ({} OTPs)",

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -310,9 +310,10 @@ pub async fn download(
         })?;
 
     if !allowed {
+        // Return 404 (not 403) to avoid revealing whether the file exists.
         return Err(AppError {
-            status: StatusCode::FORBIDDEN,
-            message: "You do not have access to this media".to_string(),
+            status: StatusCode::NOT_FOUND,
+            message: "Media not found".to_string(),
         });
     }
 

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -284,7 +284,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
                  img-src 'self' https: data: blob:; \
                  font-src 'self' https://fonts.gstatic.com; \
                  style-src 'self' 'unsafe-inline'; \
-                 script-src 'self' 'unsafe-inline' 'unsafe-eval'; \
+                 script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; \
                  media-src 'self' blob:; \
                  worker-src 'self' blob:",
             ),


### PR DESCRIPTION
## Summary
- **#98** Media ACL: return 404 instead of 403 to prevent file existence disclosure
- **#72** CSP: replace `unsafe-eval` with `wasm-unsafe-eval` (allows WASM but blocks arbitrary eval)
- **#92** Prekey upload: wrap identity key + signed prekey + OTP stores in a single DB transaction

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` — 58 unit tests pass

Closes #98, closes #72, closes #92