### PR TITLE
test(server): rate limiter, WS ticket, and refresh token theft tests

### DIFF
--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -148,6 +148,119 @@ pub fn ticket_limiter() -> RateLimiter {
     RateLimiter::new(10, 60)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_allows_within_limit() {
+        let limiter = RateLimiter::new(3, 60);
+        let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        assert!(limiter.check(ip));
+        assert!(limiter.check(ip));
+        assert!(limiter.check(ip));
+    }
+
+    #[test]
+    fn test_blocks_over_limit() {
+        let limiter = RateLimiter::new(2, 60);
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        assert!(limiter.check(ip)); // 1
+        assert!(limiter.check(ip)); // 2
+        assert!(!limiter.check(ip)); // 3 -> blocked
+        assert!(!limiter.check(ip)); // still blocked
+    }
+
+    #[test]
+    fn test_different_ips_independent() {
+        let limiter = RateLimiter::new(1, 60);
+        let ip_a = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
+        let ip_b = IpAddr::V4(Ipv4Addr::new(2, 2, 2, 2));
+        assert!(limiter.check(ip_a));
+        assert!(!limiter.check(ip_a)); // blocked
+        assert!(limiter.check(ip_b)); // different IP, allowed
+    }
+
+    #[test]
+    fn test_login_limiter_config() {
+        let limiter = login_limiter();
+        assert_eq!(limiter.max_requests, 5);
+        assert_eq!(limiter.window_secs, 60);
+    }
+
+    #[test]
+    fn test_register_limiter_config() {
+        let limiter = register_limiter();
+        assert_eq!(limiter.max_requests, 3);
+        assert_eq!(limiter.window_secs, 60);
+    }
+
+    #[test]
+    fn test_is_private_ipv4() {
+        assert!(is_private(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(is_private(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(is_private(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
+        assert!(is_private(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)))); // link-local
+        assert!(!is_private(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+    }
+
+    #[test]
+    fn test_is_private_ipv6_ula() {
+        // ULA: fc00::/7
+        assert!(is_private(IpAddr::V6(Ipv6Addr::new(
+            0xfc00, 0, 0, 0, 0, 0, 0, 1
+        ))));
+        assert!(is_private(IpAddr::V6(Ipv6Addr::new(
+            0xfd12, 0x3456, 0, 0, 0, 0, 0, 1
+        ))));
+        // Link-local: fe80::/10
+        assert!(is_private(IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0, 0, 0, 0, 0, 0, 1
+        ))));
+        // Public IPv6
+        assert!(!is_private(IpAddr::V6(Ipv6Addr::new(
+            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1
+        ))));
+    }
+
+    #[test]
+    fn test_xff_private_ip_rejected() {
+        let mut req = Request::new(Body::empty());
+        req.headers_mut().insert(
+            "x-forwarded-for",
+            "1.2.3.4, 192.168.1.1".parse().unwrap(),
+        );
+        // Last IP is private -> should fall through to ConnectInfo/localhost
+        let ip = extract_ip(&req);
+        assert!(ip.is_loopback(), "private XFF IP should be rejected");
+    }
+
+    #[test]
+    fn test_xff_public_ip_accepted() {
+        let mut req = Request::new(Body::empty());
+        req.headers_mut().insert(
+            "x-forwarded-for",
+            "spoofed, 203.0.113.50".parse().unwrap(),
+        );
+        let ip = extract_ip(&req);
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
+    }
+
+    #[test]
+    fn test_x_real_ip_preferred() {
+        let mut req = Request::new(Body::empty());
+        req.headers_mut()
+            .insert("x-real-ip", "1.2.3.4".parse().unwrap());
+        req.headers_mut().insert(
+            "x-forwarded-for",
+            "5.6.7.8".parse().unwrap(),
+        );
+        let ip = extract_ip(&req);
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+    }
+}
+
 /// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
 fn is_private(ip: IpAddr) -> bool {
     match ip {

--- a/apps/server/src/routes/ws.rs
+++ b/apps/server/src/routes/ws.rs
@@ -69,3 +69,77 @@ pub async fn ws_upgrade(
         handler::handle_socket(socket, user_id, device_id, user.username, state)
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashmap::DashMap;
+    use uuid::Uuid;
+
+    type TestTicketStore = DashMap<String, (Uuid, i32, Instant)>;
+
+    #[test]
+    fn test_ticket_single_use() {
+        let store: TestTicketStore = DashMap::new();
+        let uid = Uuid::new_v4();
+        let ticket = "test-ticket-123".to_string();
+        store.insert(ticket.clone(), (uid, 1, Instant::now()));
+
+        // First use succeeds
+        let now = Instant::now();
+        let first = store.remove_if(&ticket, |_, (_, _, created_at)| {
+            now.duration_since(*created_at) < TICKET_TTL
+        });
+        assert!(first.is_some(), "first use should succeed");
+
+        // Second use fails (ticket consumed)
+        let second = store.remove_if(&ticket, |_, (_, _, created_at)| {
+            now.duration_since(*created_at) < TICKET_TTL
+        });
+        assert!(second.is_none(), "replay should fail");
+    }
+
+    #[test]
+    fn test_ticket_expired() {
+        let store: TestTicketStore = DashMap::new();
+        let uid = Uuid::new_v4();
+        let ticket = "expired-ticket".to_string();
+        // Insert with a timestamp 60 seconds in the past
+        let old = Instant::now() - Duration::from_secs(60);
+        store.insert(ticket.clone(), (uid, 1, old));
+
+        let now = Instant::now();
+        let result = store.remove_if(&ticket, |_, (_, _, created_at)| {
+            now.duration_since(*created_at) < TICKET_TTL
+        });
+        assert!(result.is_none(), "expired ticket should be rejected");
+        // Ticket still in store (not removed because condition was false)
+        assert!(store.contains_key(&ticket));
+    }
+
+    #[test]
+    fn test_ticket_invalid() {
+        let store: TestTicketStore = DashMap::new();
+        let result = store.remove_if("nonexistent", |_, (_, _, created_at)| {
+            Instant::now().duration_since(*created_at) < TICKET_TTL
+        });
+        assert!(result.is_none(), "invalid ticket should be rejected");
+    }
+
+    #[test]
+    fn test_ticket_returns_correct_user() {
+        let store: TestTicketStore = DashMap::new();
+        let uid = Uuid::new_v4();
+        let device_id = 42;
+        store.insert("my-ticket".to_string(), (uid, device_id, Instant::now()));
+
+        let now = Instant::now();
+        let (_, (returned_uid, returned_did, _)) = store
+            .remove_if("my-ticket", |_, (_, _, created_at)| {
+                now.duration_since(*created_at) < TICKET_TTL
+            })
+            .unwrap();
+        assert_eq!(returned_uid, uid);
+        assert_eq!(returned_did, device_id);
+    }
+}

--- a/apps/server/tests/api_auth.rs
+++ b/apps/server/tests/api_auth.rs
@@ -69,3 +69,77 @@ async fn protected_route_without_token_returns_401() {
 
     assert_eq!(resp.status().as_u16(), 401);
 }
+
+#[tokio::test]
+async fn refresh_token_returns_new_tokens() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("refresh");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_body: serde_json::Value = client
+        .post(format!("{base}/api/auth/login"))
+        .json(&serde_json::json!({ "username": username, "password": "password123" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let refresh_token = login_body["refresh_token"].as_str().unwrap();
+
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": refresh_token }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["access_token"].as_str().is_some());
+    assert!(body["refresh_token"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn refresh_token_revoked_returns_401() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("revoked");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_body: serde_json::Value = client
+        .post(format!("{base}/api/auth/login"))
+        .json(&serde_json::json!({ "username": username, "password": "password123" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let refresh_token = login_body["refresh_token"].as_str().unwrap();
+
+    // First refresh — consumes (revokes) the original token
+    let resp1 = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": refresh_token }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp1.status().as_u16(), 200);
+
+    // Replay the SAME old token — should fail (theft detection)
+    let resp2 = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": refresh_token }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status().as_u16(),
+        401,
+        "replaying a revoked refresh token should return 401"
+    );
+}


### PR DESCRIPTION
## Summary
- **#69** Rate limiter: 10 unit tests (limit enforcement, IP independence, private IP rejection, XFF parsing, X-Real-IP priority)
- **#70** WS ticket: 4 unit tests (single-use enforcement, expiry rejection, invalid ticket, correct user return)
- **#68** Refresh token: 2 integration tests (token refresh flow, theft detection via replay)

## Test plan
- [x] `cargo test --workspace --lib` — 72 unit tests pass (14 new)
- [x] Integration tests compile (require DATABASE_URL to run)

Closes #68, closes #69, closes #70