### PR TITLE
fix(server): 11 quick fixes — push errors, SSRF, fanout, queries, enum

### DIFF
--- a/apps/server/migrations/20260411300000_username_search_index.sql
+++ b/apps/server/migrations/20260411300000_username_search_index.sql
@@ -1,0 +1,2 @@
+-- Add a functional index for case-insensitive username search.
+CREATE INDEX IF NOT EXISTS idx_users_username_lower ON users(LOWER(username));

--- a/apps/server/src/db/contacts.rs
+++ b/apps/server/src/db/contacts.rs
@@ -30,8 +30,7 @@ pub async fn create_contact_request(
 
     // Check if either party has blocked the other -- return a generic error
     // (same as "user not found") to avoid leaking block status.
-    let blocked = is_blocked(pool, target_id, requester_id).await?
-        || is_blocked(pool, requester_id, target_id).await?;
+    let blocked = is_either_blocked(pool, requester_id, target_id).await?;
     if blocked {
         return Err(sqlx::Error::RowNotFound);
     }
@@ -177,6 +176,26 @@ pub async fn list_blocked_users(
     .bind(blocker_id)
     .fetch_all(pool)
     .await
+}
+
+/// Check if either user has blocked the other (bidirectional check in a single query).
+pub async fn is_either_blocked(
+    pool: &PgPool,
+    user_a: Uuid,
+    user_b: Uuid,
+) -> Result<bool, sqlx::Error> {
+    let row: (bool,) = sqlx::query_as(
+        "SELECT EXISTS(\
+            SELECT 1 FROM blocked_users \
+            WHERE (blocker_id = $1 AND blocked_id = $2) \
+               OR (blocker_id = $2 AND blocked_id = $1)\
+        )",
+    )
+    .bind(user_a)
+    .bind(user_b)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
 }
 
 /// Check if `blocker_id` has blocked `blocked_id`.

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -81,21 +81,33 @@ pub async fn store_one_time_prekeys(
     device_id: i32,
     prekeys: &[(i32, Vec<u8>)],
 ) -> Result<(), sqlx::Error> {
-    for (key_id, public_key) in prekeys {
-        sqlx::query(
-            "INSERT INTO one_time_prekeys (user_id, device_id, key_id, public_key) \
-             VALUES ($1, $2, $3, $4) \
-             ON CONFLICT (user_id, device_id, key_id) \
-             DO UPDATE SET public_key = EXCLUDED.public_key, \
-                           used = false",
-        )
-        .bind(user_id)
-        .bind(device_id)
-        .bind(key_id)
-        .bind(public_key)
-        .execute(&mut *conn)
-        .await?;
+    if prekeys.is_empty() {
+        return Ok(());
     }
+
+    // Build a single batch INSERT: VALUES ($1,$2,$3,$4), ($1,$2,$5,$6), ...
+    let mut query = String::from(
+        "INSERT INTO one_time_prekeys (user_id, device_id, key_id, public_key) VALUES ",
+    );
+    // $1 = user_id, $2 = device_id, then pairs of (key_id, public_key)
+    let mut param_idx = 3_u32; // first two params are user_id and device_id
+    for (i, _) in prekeys.iter().enumerate() {
+        if i > 0 {
+            query.push_str(", ");
+        }
+        query.push_str(&format!("($1, $2, ${}, ${})", param_idx, param_idx + 1));
+        param_idx += 2;
+    }
+    query.push_str(
+        " ON CONFLICT (user_id, device_id, key_id) \
+         DO UPDATE SET public_key = EXCLUDED.public_key, used = false",
+    );
+
+    let mut q = sqlx::query(&query).bind(user_id).bind(device_id);
+    for (key_id, public_key) in prekeys {
+        q = q.bind(key_id).bind(public_key);
+    }
+    q.execute(&mut *conn).await?;
     Ok(())
 }
 

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -44,14 +44,17 @@ pub async fn find_or_create_dm_conversation(
 ) -> Result<Uuid, sqlx::Error> {
     let mut tx = pool.begin().await?;
 
-    // Find existing DM conversation where both users are members and only 2 members total
+    // Find existing DM conversation where both users are members and no third member exists
     let existing: Option<(Uuid,)> = sqlx::query_as(
         "SELECT cm1.conversation_id \
          FROM conversation_members cm1 \
          JOIN conversation_members cm2 ON cm1.conversation_id = cm2.conversation_id \
          WHERE cm1.user_id = $1 AND cm2.user_id = $2 \
-           AND (SELECT COUNT(*) FROM conversation_members cm3 \
-                WHERE cm3.conversation_id = cm1.conversation_id) = 2 \
+           AND NOT EXISTS ( \
+               SELECT 1 FROM conversation_members cm3 \
+               WHERE cm3.conversation_id = cm1.conversation_id \
+                 AND cm3.user_id != $1 AND cm3.user_id != $2 \
+           ) \
          LIMIT 1",
     )
     .bind(user_a)
@@ -120,56 +123,30 @@ pub async fn get_messages(
     before: Option<DateTime<Utc>>,
     limit: i64,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
-    match before {
-        Some(cursor) => {
-            sqlx::query_as::<_, MessageWithSender>(
-                "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
-                        u.username AS sender_username, \
-                        m.content, m.created_at, m.edited_at, m.reply_to_id, \
-                        rm.content AS reply_to_content, \
-                        ru.username AS reply_to_username \
-                 FROM messages m \
-                 JOIN users u ON u.id = m.sender_id \
-                 LEFT JOIN messages rm ON rm.id = m.reply_to_id \
-                 LEFT JOIN users ru ON ru.id = rm.sender_id \
-                 WHERE m.conversation_id = $1 \
-                   AND ($2::uuid IS NULL OR m.channel_id = $2) \
-                   AND m.created_at < $3 \
-                   AND m.deleted_at IS NULL \
-                 ORDER BY m.created_at DESC \
-                 LIMIT $4",
-            )
-            .bind(conversation_id)
-            .bind(channel_id)
-            .bind(cursor)
-            .bind(limit)
-            .fetch_all(pool)
-            .await
-        }
-        None => {
-            sqlx::query_as::<_, MessageWithSender>(
-                "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
-                        u.username AS sender_username, \
-                        m.content, m.created_at, m.edited_at, m.reply_to_id, \
-                        rm.content AS reply_to_content, \
-                        ru.username AS reply_to_username \
-                 FROM messages m \
-                 JOIN users u ON u.id = m.sender_id \
-                 LEFT JOIN messages rm ON rm.id = m.reply_to_id \
-                 LEFT JOIN users ru ON ru.id = rm.sender_id \
-                 WHERE m.conversation_id = $1 \
-                   AND ($2::uuid IS NULL OR m.channel_id = $2) \
-                   AND m.deleted_at IS NULL \
-                 ORDER BY m.created_at DESC \
-                 LIMIT $3",
-            )
-            .bind(conversation_id)
-            .bind(channel_id)
-            .bind(limit)
-            .fetch_all(pool)
-            .await
-        }
-    }
+    // Single query handles both cursor and non-cursor cases via optional $3 param.
+    sqlx::query_as::<_, MessageWithSender>(
+        "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
+                u.username AS sender_username, \
+                m.content, m.created_at, m.edited_at, m.reply_to_id, \
+                rm.content AS reply_to_content, \
+                ru.username AS reply_to_username \
+         FROM messages m \
+         JOIN users u ON u.id = m.sender_id \
+         LEFT JOIN messages rm ON rm.id = m.reply_to_id \
+         LEFT JOIN users ru ON ru.id = rm.sender_id \
+         WHERE m.conversation_id = $1 \
+           AND ($2::uuid IS NULL OR m.channel_id = $2) \
+           AND ($3::timestamptz IS NULL OR m.created_at < $3) \
+           AND m.deleted_at IS NULL \
+         ORDER BY m.created_at DESC \
+         LIMIT $4",
+    )
+    .bind(conversation_id)
+    .bind(channel_id)
+    .bind(before)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
 }
 
 pub async fn get_undelivered(
@@ -309,6 +286,21 @@ pub async fn search_messages_global(
     .bind(query)
     .bind(limit)
     .fetch_all(pool)
+    .await
+}
+
+/// Look up reply context (content and username) for a given reply_to message ID.
+pub async fn lookup_reply_context(
+    pool: &PgPool,
+    reply_to_id: Uuid,
+) -> Result<Option<(String, String)>, sqlx::Error> {
+    sqlx::query_as::<_, (String, String)>(
+        "SELECT m.content, u.username \
+         FROM messages m JOIN users u ON u.id = m.sender_id \
+         WHERE m.id = $1",
+    )
+    .bind(reply_to_id)
+    .fetch_optional(pool)
     .await
 }
 

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -148,6 +148,21 @@ pub fn ticket_limiter() -> RateLimiter {
     RateLimiter::new(10, 60)
 }
 
+/// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
+fn is_private(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        IpAddr::V6(v6) => {
+            // ULA: fc00::/7 (first byte 0xFC or 0xFD)
+            let first_segment = v6.segments()[0];
+            let is_ula = (first_segment & 0xfe00) == 0xfc00;
+            // Link-local: fe80::/10
+            let is_link_local = (first_segment & 0xffc0) == 0xfe80;
+            is_ula || is_link_local
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,10 +242,8 @@ mod tests {
     #[test]
     fn test_xff_private_ip_rejected() {
         let mut req = Request::new(Body::empty());
-        req.headers_mut().insert(
-            "x-forwarded-for",
-            "1.2.3.4, 192.168.1.1".parse().unwrap(),
-        );
+        req.headers_mut()
+            .insert("x-forwarded-for", "1.2.3.4, 192.168.1.1".parse().unwrap());
         // Last IP is private -> should fall through to ConnectInfo/localhost
         let ip = extract_ip(&req);
         assert!(ip.is_loopback(), "private XFF IP should be rejected");
@@ -239,10 +252,8 @@ mod tests {
     #[test]
     fn test_xff_public_ip_accepted() {
         let mut req = Request::new(Body::empty());
-        req.headers_mut().insert(
-            "x-forwarded-for",
-            "spoofed, 203.0.113.50".parse().unwrap(),
-        );
+        req.headers_mut()
+            .insert("x-forwarded-for", "spoofed, 203.0.113.50".parse().unwrap());
         let ip = extract_ip(&req);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
     }
@@ -252,26 +263,9 @@ mod tests {
         let mut req = Request::new(Body::empty());
         req.headers_mut()
             .insert("x-real-ip", "1.2.3.4".parse().unwrap());
-        req.headers_mut().insert(
-            "x-forwarded-for",
-            "5.6.7.8".parse().unwrap(),
-        );
+        req.headers_mut()
+            .insert("x-forwarded-for", "5.6.7.8".parse().unwrap());
         let ip = extract_ip(&req);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
-    }
-}
-
-/// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
-fn is_private(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
-        IpAddr::V6(v6) => {
-            // ULA: fc00::/7 (first byte 0xFC or 0xFD)
-            let first_segment = v6.segments()[0];
-            let is_ula = (first_segment & 0xfe00) == 0xfc00;
-            // Link-local: fe80::/10
-            let is_link_local = (first_segment & 0xffc0) == 0xfe80;
-            is_ula || is_link_local
-        }
     }
 }

--- a/apps/server/src/routes/channels.rs
+++ b/apps/server/src/routes/channels.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use crate::auth::middleware::AuthUser;
 use crate::db;
 use crate::error::AppError;
-use crate::types::{ConversationKind, Role};
+use crate::types::{ChannelKind, ConversationKind, Role};
 
 use super::AppState;
 
@@ -64,7 +64,7 @@ pub struct VoiceSessionResponse {
 }
 
 fn is_valid_channel_kind(kind: &str) -> bool {
-    matches!(kind, "text" | "voice")
+    ChannelKind::from_str_opt(kind).is_some()
 }
 
 fn normalize_channel_name(name: &str) -> String {
@@ -368,7 +368,7 @@ pub async fn list_voice_sessions(
     ensure_group_member(&state, group_id, auth.user_id).await?;
     let channel = ensure_channel_in_group(&state, group_id, channel_id).await?;
 
-    if channel.kind != "voice" {
+    if ChannelKind::from_str_opt(&channel.kind) != Some(ChannelKind::Voice) {
         return Err(AppError::bad_request("Channel is not a voice channel"));
     }
 
@@ -406,7 +406,7 @@ pub async fn join_voice_channel(
     ensure_group_member(&state, group_id, auth.user_id).await?;
     let channel = ensure_channel_in_group(&state, group_id, channel_id).await?;
 
-    if channel.kind != "voice" {
+    if ChannelKind::from_str_opt(&channel.kind) != Some(ChannelKind::Voice) {
         return Err(AppError::bad_request("Channel is not a voice channel"));
     }
 
@@ -462,7 +462,7 @@ pub async fn leave_voice_channel(
     ensure_group_member(&state, group_id, auth.user_id).await?;
     let channel = ensure_channel_in_group(&state, group_id, channel_id).await?;
 
-    if channel.kind != "voice" {
+    if ChannelKind::from_str_opt(&channel.kind) != Some(ChannelKind::Voice) {
         return Err(AppError::bad_request("Channel is not a voice channel"));
     }
 
@@ -502,7 +502,7 @@ pub async fn update_voice_state(
     ensure_group_member(&state, group_id, auth.user_id).await?;
     let channel = ensure_channel_in_group(&state, group_id, channel_id).await?;
 
-    if channel.kind != "voice" {
+    if ChannelKind::from_str_opt(&channel.kind) != Some(ChannelKind::Voice) {
         return Err(AppError::bad_request("Channel is not a voice channel"));
     }
 

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -128,13 +128,8 @@ pub async fn upload_bundle(
     .await?;
 
     if !one_time_prekeys.is_empty() {
-        db::keys::store_one_time_prekeys(
-            &mut *tx,
-            auth_user.user_id,
-            device_id,
-            &one_time_prekeys,
-        )
-        .await?;
+        db::keys::store_one_time_prekeys(&mut tx, auth_user.user_id, device_id, &one_time_prekeys)
+            .await?;
     }
 
     tx.commit().await.map_err(|e| {

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -71,7 +71,7 @@ pub async fn fetch_preview(
     // Fetch the page with a short timeout
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
-        .redirect(reqwest::redirect::Policy::limited(3))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|_| AppError::internal("Failed to create HTTP client"))?;
 

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -114,13 +114,13 @@ pub async fn generate_token(
     if let Some(ref cid) = conversation_id_str {
         let conv_uuid = uuid::Uuid::parse_str(cid)
             .map_err(|_| AppError::bad_request("Invalid conversation_id or channel_id"))?;
-        let members = db::groups::get_conversation_member_ids(&state.pool, conv_uuid)
+        let is_member = db::groups::is_member(&state.pool, conv_uuid, auth.user_id)
             .await
             .map_err(|e| {
                 tracing::error!("DB error checking voice token membership: {e:?}");
                 AppError::internal("Database error")
             })?;
-        if !members.contains(&auth.user_id) {
+        if !is_member {
             return Err(AppError::bad_request("Not a member of this conversation"));
         }
     }
@@ -182,7 +182,13 @@ mod tests {
             );
         }
         // Invalid names
-        for name in ["room name", "room/../../etc", "room\n", "<script>", "room;DROP"] {
+        for name in [
+            "room name",
+            "room/../../etc",
+            "room\n",
+            "<script>",
+            "room;DROP",
+        ] {
             assert!(
                 !name
                     .chars()

--- a/apps/server/src/types.rs
+++ b/apps/server/src/types.rs
@@ -60,3 +60,28 @@ impl ConversationKind {
         }
     }
 }
+
+/// Channel kinds used in group conversations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChannelKind {
+    Text,
+    Voice,
+}
+
+impl ChannelKind {
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "text" => Some(Self::Text),
+            "voice" => Some(Self::Voice),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Voice => "voice",
+        }
+    }
+}

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -11,8 +11,6 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use uuid::Uuid;
 
-use sqlx;
-
 use crate::db;
 use crate::routes::AppState;
 use crate::types::ConversationKind;
@@ -794,15 +792,7 @@ async fn lookup_reply_context(
     reply_to_id: Option<Uuid>,
 ) -> (Option<String>, Option<String>) {
     if let Some(rid) = reply_to_id {
-        match sqlx::query_as::<_, (String, String)>(
-            "SELECT m.content, u.username \
-             FROM messages m JOIN users u ON u.id = m.sender_id \
-             WHERE m.id = $1",
-        )
-        .bind(rid)
-        .fetch_optional(pool)
-        .await
-        {
+        match db::messages::lookup_reply_context(pool, rid).await {
             Ok(Some((c, u))) => (Some(c), Some(u)),
             _ => (None, None),
         }
@@ -876,6 +866,31 @@ async fn fanout_message(
     // Legacy fallback JSON (used when no device_contents or for non-DM group messages)
     let legacy_json = serde_json::to_string(message).ok();
 
+    // Pre-serialize per-device JSON messages once (keyed by device_id) to avoid
+    // re-serializing the same message for every member in the fanout loop.
+    let per_device_json: Option<Vec<(i32, String)>> = device_contents.as_ref().map(|dc| {
+        dc.iter()
+            .filter_map(|(device_id_str, ciphertext)| {
+                let did = device_id_str.parse::<i32>().ok()?;
+                let per_device_msg = ServerMessage::NewMessage {
+                    message_id: msg_id,
+                    from_user_id: from_uid,
+                    from_device_id: from_did,
+                    from_username: from_name.clone(),
+                    conversation_id: conv,
+                    channel_id: ch,
+                    content: ciphertext.clone(),
+                    timestamp: ts,
+                    reply_to_id: rto_id,
+                    reply_to_content: rto_content.clone(),
+                    reply_to_username: rto_user.clone(),
+                };
+                let json = serde_json::to_string(&per_device_msg).ok()?;
+                Some((did, json))
+            })
+            .collect()
+    });
+
     for member_id in &member_ids {
         if *member_id == sender_id {
             continue;
@@ -885,30 +900,14 @@ async fn fanout_message(
         }
 
         // For multi-device: try per-device delivery if device_contents is available.
-        if let Some(ref dc) = device_contents {
+        if let Some(ref device_jsons) = per_device_json {
             let mut member_delivered = false;
-            for (device_id_str, ciphertext) in dc {
-                if let Ok(did) = device_id_str.parse::<i32>() {
-                    let per_device_msg = ServerMessage::NewMessage {
-                        message_id: msg_id,
-                        from_user_id: from_uid,
-                        from_device_id: from_did,
-                        from_username: from_name.clone(),
-                        conversation_id: conv,
-                        channel_id: ch,
-                        content: ciphertext.clone(),
-                        timestamp: ts,
-                        reply_to_id: rto_id,
-                        reply_to_content: rto_content.clone(),
-                        reply_to_username: rto_user.clone(),
-                    };
-                    if let Ok(json) = serde_json::to_string(&per_device_msg)
-                        && state
-                            .hub
-                            .send_to_device(member_id, did, WsMessage::Text(json.into()))
-                    {
-                        member_delivered = true;
-                    }
+            for (did, json) in device_jsons {
+                if state
+                    .hub
+                    .send_to_device(member_id, *did, WsMessage::Text(json.clone().into()))
+                {
+                    member_delivered = true;
                 }
             }
             if member_delivered {
@@ -959,7 +958,7 @@ async fn fanout_message(
         let pool = state.pool.clone();
         let sender_name = sender_name.to_string();
         let content = content.to_string();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             crate::push::notify_offline_users(
                 &pool,
                 &offline_user_ids,
@@ -970,6 +969,14 @@ async fn fanout_message(
                 stored_id,
             )
             .await;
+        });
+        tokio::spawn(async move {
+            match handle.await {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::error!("Push notification task failed for conv {conv_id}: {e}");
+                }
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary — 11 server fixes
- **#62** Push notification errors now logged instead of silently dropped
- **#63** SSRF: disabled HTTP redirects in link preview client
- **#65** Fanout: pre-serialize JSON once instead of per-member×per-device
- **#78** DM lookup: NOT EXISTS replaces COUNT(*) correlated subquery
- **#79** OTP prekeys: single batch INSERT replaces N individual INSERTs
- **#81** Block check: single query replaces 2 sequential queries
- **#85** Reply context SQL moved from WS handler to db/messages.rs
- **#96** Added LOWER(username) index migration
- **#97** Channel kind: enum replaces raw string comparisons
- **#99** Voice token: EXISTS check replaces full member list fetch
- **#101** Consolidated duplicate get_messages SQL into single function

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace --lib` — 72 unit tests pass

Closes #62, closes #63, closes #65, closes #78, closes #79, closes #81, closes #85, closes #96, closes #97, closes #99, closes #101