### PR TITLE
fix(client): 9 quick fixes — dedup, prefs, catches, theme, dialogs

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -19,6 +19,9 @@ class ChatState {
   /// Messages keyed by conversation ID.
   final Map<String, List<ChatMessage>> messagesByConversation;
 
+  /// O(1) dedup index: message IDs per conversation.
+  final Map<String, Set<String>> _messageIdIndex;
+
   /// Whether history is currently loading for a conversation.
   /// Key format: conversationId:channelId (channelId empty for full conversation).
   final Map<String, bool> loadingHistory;
@@ -32,10 +35,11 @@ class ChatState {
 
   const ChatState({
     this.messagesByConversation = const {},
+    Map<String, Set<String>> messageIdIndex = const {},
     this.loadingHistory = const {},
     this.hasMore = const {},
     this.replyToMessage,
-  });
+  }) : _messageIdIndex = messageIdIndex;
 
   /// Get messages for a conversation ID.
   List<ChatMessage> messagesForConversation(String conversationId) {
@@ -76,16 +80,23 @@ class ChatState {
     final updatedConv = Map<String, List<ChatMessage>>.from(
       messagesByConversation,
     );
+    final updatedIndex = Map<String, Set<String>>.from(_messageIdIndex);
     if (msg.conversationId.isNotEmpty) {
-      final existing = updatedConv[msg.conversationId] ?? [];
-      // Deduplicate by ID
-      if (!existing.any((m) => m.id == msg.id)) {
+      final ids = Set<String>.from(
+        updatedIndex[msg.conversationId] ?? <String>{},
+      );
+      // O(1) deduplicate by ID
+      if (!ids.contains(msg.id)) {
+        final existing = updatedConv[msg.conversationId] ?? [];
         updatedConv[msg.conversationId] = [...existing, msg];
+        ids.add(msg.id);
+        updatedIndex[msg.conversationId] = ids;
       }
     }
 
     return ChatState(
       messagesByConversation: updatedConv,
+      messageIdIndex: updatedIndex,
       loadingHistory: loadingHistory,
       hasMore: hasMore,
       replyToMessage: replyToMessage,
@@ -94,6 +105,7 @@ class ChatState {
 
   ChatState copyWith({
     Map<String, List<ChatMessage>>? messagesByConversation,
+    Map<String, Set<String>>? messageIdIndex,
     Map<String, bool>? loadingHistory,
     Map<String, bool>? hasMore,
     ChatMessage? replyToMessage,
@@ -102,6 +114,7 @@ class ChatState {
     return ChatState(
       messagesByConversation:
           messagesByConversation ?? this.messagesByConversation,
+      messageIdIndex: messageIdIndex ?? _messageIdIndex,
       loadingHistory: loadingHistory ?? this.loadingHistory,
       hasMore: hasMore ?? this.hasMore,
       replyToMessage: clearReply
@@ -228,12 +241,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
       state.messagesByConversation,
     );
     updatedConv[conversationId] = updatedList;
-    state = ChatState(
-      messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(messagesByConversation: updatedConv);
   }
 
   void confirmSent(
@@ -266,11 +274,14 @@ class ChatNotifier extends StateNotifier<ChatState> {
       );
     }
 
-    state = ChatState(
+    // Rebuild the index for this conversation since a pending ID was replaced.
+    final updatedIndex = Map<String, Set<String>>.from(state._messageIdIndex);
+    updatedIndex[conversationId] = (updatedConv[conversationId] ?? [])
+        .map((m) => m.id)
+        .toSet();
+    state = state.copyWith(
       messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
+      messageIdIndex: updatedIndex,
     );
 
     // Cache the confirmed message
@@ -493,12 +504,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
   void _setLoadingHistory(String historyKey, bool loading) {
     final updatedLoading = Map<String, bool>.from(state.loadingHistory);
     updatedLoading[historyKey] = loading;
-    state = ChatState(
-      messagesByConversation: state.messagesByConversation,
-      loadingHistory: updatedLoading,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(loadingHistory: updatedLoading);
   }
 
   void _mergeMessages(
@@ -516,18 +522,22 @@ class ChatNotifier extends StateNotifier<ChatState> {
         .where((m) => !existingIds.contains(m.id))
         .toList();
 
-    updatedConv[conversationId] = [...deduped, ...existing]
+    final merged = [...deduped, ...existing]
       ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    updatedConv[conversationId] = merged;
 
     final updatedHasMore = Map<String, bool>.from(state.hasMore);
     updatedHasMore['$conversationId:${channelId ?? ''}'] =
         newMessages.length >= 50;
 
-    state = ChatState(
+    // Rebuild index for this conversation after merge.
+    final updatedIndex = Map<String, Set<String>>.from(state._messageIdIndex);
+    updatedIndex[conversationId] = merged.map((m) => m.id).toSet();
+
+    state = state.copyWith(
       messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
+      messageIdIndex: updatedIndex,
       hasMore: updatedHasMore,
-      replyToMessage: state.replyToMessage,
     );
   }
 
@@ -552,12 +562,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
       return msg;
     }).toList();
 
-    state = ChatState(
-      messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(messagesByConversation: updatedConv);
   }
 
   /// Remove a reaction from a message.
@@ -582,12 +587,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
       return msg;
     }).toList();
 
-    state = ChatState(
-      messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(messagesByConversation: updatedConv);
   }
 
   /// Update message status (sent, delivered).
@@ -609,12 +609,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
       return msg;
     }).toList();
 
-    state = ChatState(
-      messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(messagesByConversation: updatedConv);
   }
 
   /// Mark all of my sent/delivered messages in a conversation as read.
@@ -634,12 +629,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
       return msg;
     }).toList();
 
-    state = ChatState(
-      messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(messagesByConversation: updatedConv);
   }
 
   /// Delete a message from local state.
@@ -654,11 +644,17 @@ class ChatNotifier extends StateNotifier<ChatState> {
         .where((msg) => msg.id != messageId)
         .toList();
 
-    state = ChatState(
+    // Remove the deleted ID from the index.
+    final updatedIndex = Map<String, Set<String>>.from(state._messageIdIndex);
+    final ids = Set<String>.from(
+      updatedIndex[conversationId] ?? <String>{},
+    );
+    ids.remove(messageId);
+    updatedIndex[conversationId] = ids;
+
+    state = state.copyWith(
       messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
+      messageIdIndex: updatedIndex,
     );
   }
 
@@ -685,12 +681,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
       return msg;
     }).toList();
 
-    state = ChatState(
-      messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(messagesByConversation: updatedConv);
   }
 
   /// Update a message's pin state in local state.
@@ -713,15 +704,15 @@ class ChatNotifier extends StateNotifier<ChatState> {
       return msg;
     }).toList();
 
-    state = ChatState(
-      messagesByConversation: updatedConv,
-      loadingHistory: state.loadingHistory,
-      hasMore: state.hasMore,
-      replyToMessage: state.replyToMessage,
-    );
+    state = state.copyWith(messagesByConversation: updatedConv);
   }
 
   void clear() {
+    // Cancel all pending send-timeout timers to prevent orphaned callbacks.
+    for (final timer in _sendTimeouts.values) {
+      timer.cancel();
+    }
+    _sendTimeouts.clear();
     state = const ChatState();
   }
 }

--- a/apps/client/lib/src/providers/screen_share_provider.dart
+++ b/apps/client/lib/src/providers/screen_share_provider.dart
@@ -93,9 +93,10 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
           track.stop();
         }
         await stream.dispose();
-      } catch (_) {
+      } catch (e) {
         // Platform may throw "No active stream to cancel" if the capture
         // was already released (e.g. getDisplayMedia failed on Linux).
+        debugPrint('[ScreenShare] Error disposing stream: $e');
       }
     }
 
@@ -103,8 +104,9 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
       try {
         renderer.srcObject = null;
         await renderer.dispose();
-      } catch (_) {
+      } catch (e) {
         // Renderer may already be disposed.
+        debugPrint('[ScreenShare] Error disposing renderer: $e');
       }
     }
 

--- a/apps/client/lib/src/providers/update_provider.dart
+++ b/apps/client/lib/src/providers/update_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -109,7 +110,8 @@ class UpdateNotifier extends StateNotifier<UpdateState> {
       }
 
       await _fetchLatestRelease(prefs);
-    } catch (_) {
+    } catch (e) {
+      debugPrint('[UpdateProvider] Error checking for updates: $e');
       state = state.copyWith(status: UpdateStatus.idle);
     }
   }

--- a/apps/client/lib/src/providers/voice_rtc_provider.dart
+++ b/apps/client/lib/src/providers/voice_rtc_provider.dart
@@ -242,7 +242,9 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       }
       try {
         await pc.close();
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('[VoiceRTC] Error closing peer connection: $e');
+      }
       await _disposeRemoteRenderer(userId);
       await _disposeRemoteVideoRenderer(userId);
     }
@@ -416,7 +418,9 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       if (pc != null) {
         try {
           await pc.close();
-        } catch (_) {}
+        } catch (e) {
+          debugPrint('[VoiceRTC] Error closing stale peer connection: $e');
+        }
       }
       await _disposeRemoteRenderer(userId);
       await _disposeRemoteVideoRenderer(userId);
@@ -822,7 +826,8 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       }
       try {
         await pc.addCandidate(candidate);
-      } catch (_) {
+      } catch (e) {
+        debugPrint('[VoiceRTC] Error adding ICE candidate: $e');
         remaining.add(entry);
       }
     }
@@ -942,7 +947,9 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
             }
           }
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('[VoiceRTC] Error polling peer audio levels: $e');
+      }
     }
 
     // Local audio level from outbound stats
@@ -962,7 +969,9 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
           }
         }
         if (localLevel > 0) break;
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('[VoiceRTC] Error polling local audio level: $e');
+      }
     }
 
     if (!_disposed) {
@@ -988,8 +997,9 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
             }
           }
         }
-      } catch (_) {
+      } catch (e) {
         // getStats can fail if the peer connection is closing.
+        debugPrint('[VoiceRTC] Error polling peer latencies: $e');
       }
     }
     if (!_disposed && latencies.isNotEmpty) {

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -489,7 +489,9 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
               body: jsonEncode({'emoji': emoji}),
             ),
           );
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('[WebSocket] sendReaction error: $e');
+    }
   }
 
   /// Remove a reaction via REST.
@@ -508,7 +510,9 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
               headers: {'Authorization': 'Bearer $token'},
             ),
           );
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('[WebSocket] removeReaction error: $e');
+    }
   }
 
   /// Send a read receipt via WebSocket.

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -309,21 +309,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   void _showDiscoverGroupsDialog() {
     showDialog(
       context: context,
-      builder: (dialogContext) => Dialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        child: SizedBox(
-          width: 480,
-          height: 640,
-          child: ClipRRect(
+      builder: (dialogContext) {
+        final size = MediaQuery.of(dialogContext).size;
+        return Dialog(
+          backgroundColor: context.surface,
+          shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
-            child: const DiscoverGroupsScreen(),
+            side: BorderSide(color: context.border),
           ),
-        ),
-      ),
+          child: SizedBox(
+            width: (size.width * 0.4).clamp(320, 560).toDouble(),
+            height: (size.height * 0.7).clamp(400, 720).toDouble(),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: const DiscoverGroupsScreen(),
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -347,47 +350,53 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   void _showContactsDialog() {
     showDialog(
       context: context,
-      builder: (dialogContext) => Dialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        child: SizedBox(
-          width: 480,
-          height: 600,
-          child: ClipRRect(
+      builder: (dialogContext) {
+        final size = MediaQuery.of(dialogContext).size;
+        return Dialog(
+          backgroundColor: context.surface,
+          shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
-            child: ContactsScreen(
-              onStartConversation: (conv) {
-                Navigator.pop(dialogContext);
-                _selectConversation(conv);
-              },
+            side: BorderSide(color: context.border),
+          ),
+          child: SizedBox(
+            width: (size.width * 0.4).clamp(320, 560).toDouble(),
+            height: (size.height * 0.65).clamp(400, 680).toDouble(),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: ContactsScreen(
+                onStartConversation: (conv) {
+                  Navigator.pop(dialogContext);
+                  _selectConversation(conv);
+                },
+              ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 
   void _showCreateGroupDialog() {
     showDialog(
       context: context,
-      builder: (dialogContext) => Dialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        child: SizedBox(
-          width: 480,
-          height: 600,
-          child: ClipRRect(
+      builder: (dialogContext) {
+        final size = MediaQuery.of(dialogContext).size;
+        return Dialog(
+          backgroundColor: context.surface,
+          shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
-            child: const CreateGroupScreen(),
+            side: BorderSide(color: context.border),
           ),
-        ),
-      ),
+          child: SizedBox(
+            width: (size.width * 0.4).clamp(320, 560).toDouble(),
+            height: (size.height * 0.65).clamp(400, 680).toDouble(),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: const CreateGroupScreen(),
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -13,7 +13,7 @@ class EchoTheme {
   static const accentLight = Color(0x1A6366F1);
   static const textPrimary = Color(0xFFEDEDEF);
   static const textSecondary = Color(0xFF8B8B8E);
-  static const textMuted = Color(0xFF6B6B6F);
+  static const textMuted = Color(0xFF9090A0);
   static const sentBubble = Color(0xFF6366F1);
   static const recvBubble = Color(0xFF1C1C1E);
   static const border = Color(0xFF27272A);

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -40,6 +40,9 @@ class _ConversationItemState extends State<ConversationItem> {
 
   static const _draftKeyPrefix = 'chat_draft_';
 
+  /// Cached SharedPreferences instance to avoid async getInstance() per render.
+  static SharedPreferences? _prefsCache;
+
   @override
   void initState() {
     super.initState();
@@ -55,8 +58,9 @@ class _ConversationItemState extends State<ConversationItem> {
   }
 
   Future<void> _loadDraft() async {
-    final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString('$_draftKeyPrefix${widget.conversation.id}');
+    _prefsCache ??= await SharedPreferences.getInstance();
+    final raw =
+        _prefsCache!.getString('$_draftKeyPrefix${widget.conversation.id}');
     if (!mounted) return;
     final draft = raw?.trim().isNotEmpty == true ? raw!.trim() : null;
     if (draft != _draft) setState(() => _draft = draft);

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1103,6 +1103,8 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       child: ListView.builder(
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        // Use fixed itemExtent when no section headers/dividers for faster layout.
+        itemExtent: extraItems == 0 ? 70 : null,
         itemCount: sorted.length + extraItems,
         itemBuilder: (context, index) {
           if (pinnedCount > 0) {

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -320,7 +320,7 @@ class _MessageItemState extends State<MessageItem> {
     showDialog<void>(
       context: context,
       barrierDismissible: true,
-      barrierColor: Colors.black.withValues(alpha: 0.9),
+      barrierColor: Theme.of(context).shadowColor.withValues(alpha: 0.9),
       builder: (dialogContext) {
         return Stack(
           children: [
@@ -347,13 +347,18 @@ class _MessageItemState extends State<MessageItem> {
                     imageUrl: imageUrl,
                     httpHeaders: headers,
                     fit: BoxFit.contain,
-                    placeholder: (_, _) => const Center(
-                      child: CircularProgressIndicator(color: Colors.white),
+                    placeholder: (_, _) => Center(
+                      child: CircularProgressIndicator(
+                        color: Theme.of(context).colorScheme.onPrimary,
+                      ),
                     ),
-                    errorWidget: (_, _, _) => const Center(
+                    errorWidget: (_, _, _) => Center(
                       child: Icon(
                         Icons.broken_image_outlined,
-                        color: Colors.white54,
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onPrimary
+                            .withValues(alpha: 0.54),
                         size: 48,
                       ),
                     ),
@@ -370,13 +375,13 @@ class _MessageItemState extends State<MessageItem> {
                 children: [
                   IconButton(
                     icon: const Icon(Icons.download_outlined),
-                    color: Colors.white,
+                    color: Theme.of(context).colorScheme.onPrimary,
                     tooltip: 'Download',
                     onPressed: () => _downloadMedia(imageUrl),
                   ),
                   IconButton(
                     icon: const Icon(Icons.close),
-                    color: Colors.white,
+                    color: Theme.of(context).colorScheme.onPrimary,
                     tooltip: 'Close',
                     onPressed: () => Navigator.of(dialogContext).pop(),
                   ),
@@ -594,7 +599,7 @@ class _MessageItemState extends State<MessageItem> {
   /// Resolve text color for message content.
   Color _contentTextColor({required bool isMine, required bool isFailed}) {
     if (isFailed) return EchoTheme.danger;
-    if (isMine) return Colors.white;
+    if (isMine) return Theme.of(context).colorScheme.onPrimary;
     return context.textPrimary;
   }
 
@@ -690,7 +695,10 @@ class _MessageItemState extends State<MessageItem> {
             Icons.push_pin,
             size: 11,
             color: isMine
-                ? Colors.white.withValues(alpha: 0.7)
+                ? Theme.of(context)
+                      .colorScheme
+                      .onPrimary
+                      .withValues(alpha: 0.7)
                 : context.accent,
           ),
           const SizedBox(width: 3),
@@ -700,7 +708,10 @@ class _MessageItemState extends State<MessageItem> {
               fontSize: 10,
               fontWeight: FontWeight.w500,
               color: isMine
-                  ? Colors.white.withValues(alpha: 0.7)
+                  ? Theme.of(context)
+                        .colorScheme
+                        .onPrimary
+                        .withValues(alpha: 0.7)
                   : context.accent,
             ),
           ),

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -148,6 +148,21 @@ pub fn ticket_limiter() -> RateLimiter {
     RateLimiter::new(10, 60)
 }
 
+/// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
+fn is_private(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        IpAddr::V6(v6) => {
+            // ULA: fc00::/7 (first byte 0xFC or 0xFD)
+            let first_segment = v6.segments()[0];
+            let is_ula = (first_segment & 0xfe00) == 0xfc00;
+            // Link-local: fe80::/10
+            let is_link_local = (first_segment & 0xffc0) == 0xfe80;
+            is_ula || is_link_local
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,10 +242,8 @@ mod tests {
     #[test]
     fn test_xff_private_ip_rejected() {
         let mut req = Request::new(Body::empty());
-        req.headers_mut().insert(
-            "x-forwarded-for",
-            "1.2.3.4, 192.168.1.1".parse().unwrap(),
-        );
+        req.headers_mut()
+            .insert("x-forwarded-for", "1.2.3.4, 192.168.1.1".parse().unwrap());
         // Last IP is private -> should fall through to ConnectInfo/localhost
         let ip = extract_ip(&req);
         assert!(ip.is_loopback(), "private XFF IP should be rejected");
@@ -239,10 +252,8 @@ mod tests {
     #[test]
     fn test_xff_public_ip_accepted() {
         let mut req = Request::new(Body::empty());
-        req.headers_mut().insert(
-            "x-forwarded-for",
-            "spoofed, 203.0.113.50".parse().unwrap(),
-        );
+        req.headers_mut()
+            .insert("x-forwarded-for", "spoofed, 203.0.113.50".parse().unwrap());
         let ip = extract_ip(&req);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
     }
@@ -252,26 +263,9 @@ mod tests {
         let mut req = Request::new(Body::empty());
         req.headers_mut()
             .insert("x-real-ip", "1.2.3.4".parse().unwrap());
-        req.headers_mut().insert(
-            "x-forwarded-for",
-            "5.6.7.8".parse().unwrap(),
-        );
+        req.headers_mut()
+            .insert("x-forwarded-for", "5.6.7.8".parse().unwrap());
         let ip = extract_ip(&req);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
-    }
-}
-
-/// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
-fn is_private(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
-        IpAddr::V6(v6) => {
-            // ULA: fc00::/7 (first byte 0xFC or 0xFD)
-            let first_segment = v6.segments()[0];
-            let is_ula = (first_segment & 0xfe00) == 0xfc00;
-            // Link-local: fe80::/10
-            let is_link_local = (first_segment & 0xffc0) == 0xfe80;
-            is_ula || is_link_local
-        }
     }
 }

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -128,13 +128,8 @@ pub async fn upload_bundle(
     .await?;
 
     if !one_time_prekeys.is_empty() {
-        db::keys::store_one_time_prekeys(
-            &mut *tx,
-            auth_user.user_id,
-            device_id,
-            &one_time_prekeys,
-        )
-        .await?;
+        db::keys::store_one_time_prekeys(&mut tx, auth_user.user_id, device_id, &one_time_prekeys)
+            .await?;
     }
 
     tx.commit().await.map_err(|e| {


### PR DESCRIPTION
## Summary — 9 client fixes
- **#93** Message dedup: O(1) Set lookup replaces O(N) linear scan
- **#95** SharedPreferences: cached instance instead of per-render getInstance()
- **#107** Colors.white/black: 8 hardcodes replaced with theme tokens in message_item.dart
- **#109** Silent catches: 11 empty catch blocks now log errors across 4 providers
- **#116** OverlayEntry: verified already cleaned up in dispose() (no change needed)
- **#118** Dialog dimensions: responsive sizing with clamp() instead of hardcoded 480x640
- **#120** ListView itemExtent: added 70px hint for conversation list
- **#121** Dark mode contrast: textMuted lightened from 0xFF6B6B6F to 0xFF9090A0
- **#122** Timer cleanup: cancel all pending timers on logout/clear

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues found

Closes #93, closes #95, closes #107, closes #109, closes #116, closes #118, closes #120, closes #121, closes #122