### PR TITLE
fix(server): CTE query, typing cache, device limit, extract helpers

### DIFF
--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -174,10 +174,10 @@ pub async fn get_prekey_bundle(
     }))
 }
 
-/// Return all device_ids registered for a given user.
+/// Return device_ids registered for a given user (capped at 10).
 pub async fn get_user_devices(pool: &PgPool, user_id: Uuid) -> Result<Vec<i32>, sqlx::Error> {
     let rows: Vec<(i32,)> = sqlx::query_as(
-        "SELECT device_id FROM identity_keys WHERE user_id = $1 ORDER BY device_id DESC",
+        "SELECT device_id FROM identity_keys WHERE user_id = $1 ORDER BY device_id DESC LIMIT 10",
     )
     .bind(user_id)
     .fetch_all(pool)

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -97,45 +97,75 @@ pub async fn list_conversations(
     auth: AuthUser,
     State(state): State<Arc<AppState>>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Single query with subqueries for members, last message, and unread count.
-    // This replaces the previous 3N+1 query pattern.
+    // CTE-based query: compute members, last message, and unread counts once
+    // instead of per-row correlated subqueries (was O(N^2), now O(N)).
     let rows = sqlx::query_as::<_, ConversationFullRow>(
-        "SELECT \
+        "WITH user_convs AS ( \
+            SELECT cm.conversation_id, cm.is_muted \
+            FROM conversation_members cm \
+            WHERE cm.user_id = $1 \
+        ), \
+        members_cte AS ( \
+            SELECT cm2.conversation_id, \
+                   json_agg(json_build_object( \
+                       'user_id', u.id, 'username', u.username, \
+                       'role', cm2.role, 'avatar_url', u.avatar_url \
+                   )) AS members_json \
+            FROM conversation_members cm2 \
+            JOIN users u ON cm2.user_id = u.id \
+            WHERE cm2.conversation_id IN (SELECT conversation_id FROM user_convs) \
+            GROUP BY cm2.conversation_id \
+        ), \
+        last_msg_cte AS ( \
+            SELECT DISTINCT ON (m.conversation_id) \
+                   m.conversation_id, \
+                   m.content, m.created_at, u2.username AS sender_username \
+            FROM messages m \
+            JOIN users u2 ON m.sender_id = u2.id \
+            WHERE m.conversation_id IN (SELECT conversation_id FROM user_convs) \
+              AND m.deleted_at IS NULL \
+            ORDER BY m.conversation_id, m.created_at DESC \
+        ), \
+        read_cte AS ( \
+            SELECT rr.conversation_id, rr.last_read_at \
+            FROM read_receipts rr \
+            WHERE rr.user_id = $1 \
+              AND rr.conversation_id IN (SELECT conversation_id FROM user_convs) \
+        ), \
+        unread_cte AS ( \
+            SELECT m2.conversation_id, COUNT(*) AS unread_count \
+            FROM messages m2 \
+            JOIN user_convs uc ON uc.conversation_id = m2.conversation_id \
+            LEFT JOIN read_cte rc ON rc.conversation_id = m2.conversation_id \
+            WHERE m2.sender_id != $1 \
+              AND m2.deleted_at IS NULL \
+              AND m2.created_at > COALESCE(rc.last_read_at, '1970-01-01'::timestamptz) \
+            GROUP BY m2.conversation_id \
+        ) \
+        SELECT \
             c.id AS conversation_id, \
             c.kind, \
             c.title, \
             c.icon_url, \
             c.is_encrypted, \
-            cm.is_muted, \
-            (SELECT json_agg(json_build_object( \
-                'user_id', u.id, 'username', u.username, 'role', cm2.role, 'avatar_url', u.avatar_url \
-            )) FROM conversation_members cm2 \
-            JOIN users u ON cm2.user_id = u.id \
-            WHERE cm2.conversation_id = c.id) AS members_json, \
-            (SELECT row_to_json(sub) FROM ( \
-                SELECT m.content, m.created_at, u2.username AS sender_username \
-                FROM messages m \
-                JOIN users u2 ON m.sender_id = u2.id \
-                WHERE m.conversation_id = c.id AND m.deleted_at IS NULL \
-                ORDER BY m.created_at DESC LIMIT 1 \
-            ) sub) AS last_message_json, \
-            (SELECT COUNT(*) FROM messages m2 \
-                WHERE m2.conversation_id = c.id \
-                AND m2.sender_id != $1 \
-                AND m2.deleted_at IS NULL \
-                AND m2.created_at > COALESCE( \
-                    (SELECT last_read_at FROM read_receipts \
-                     WHERE conversation_id = c.id AND user_id = $1), \
-                    '1970-01-01'::timestamptz \
-                ) \
-            ) AS unread_count \
-         FROM conversations c \
-         JOIN conversation_members cm ON cm.conversation_id = c.id \
-         WHERE cm.user_id = $1 \
-         ORDER BY ( \
-            SELECT MAX(m3.created_at) FROM messages m3 \
-            WHERE m3.conversation_id = c.id \
-         ) DESC NULLS LAST",
+            uc.is_muted, \
+            mc.members_json, \
+            CASE WHEN lm.conversation_id IS NOT NULL \
+                 THEN json_build_object( \
+                     'content', lm.content, \
+                     'created_at', lm.created_at, \
+                     'sender_username', lm.sender_username \
+                 ) \
+                 ELSE NULL \
+            END AS last_message_json, \
+            COALESCE(urc.unread_count, 0) AS unread_count \
+        FROM conversations c \
+        JOIN user_convs uc ON uc.conversation_id = c.id \
+        LEFT JOIN members_cte mc ON mc.conversation_id = c.id \
+        LEFT JOIN last_msg_cte lm ON lm.conversation_id = c.id \
+        LEFT JOIN unread_cte urc ON urc.conversation_id = c.id \
+        ORDER BY lm.created_at DESC NULLS LAST \
+        LIMIT 50",
     )
     .bind(auth.user_id)
     .fetch_all(&state.pool)

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -2,10 +2,12 @@
 
 use axum::extract::ws::{Message as WsMessage, WebSocket};
 use chrono::{DateTime, Utc};
+use dashmap::DashMap;
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
@@ -14,6 +16,14 @@ use uuid::Uuid;
 use crate::db;
 use crate::routes::AppState;
 use crate::types::ConversationKind;
+
+/// In-memory cache for conversation membership checks used by the typing
+/// indicator path.  Keyed by (user_id, conversation_id), stores the
+/// tokio::time::Instant when membership was last verified.  Entries older
+/// than `MEMBERSHIP_CACHE_TTL` are treated as expired and re-verified
+/// against the database.
+static MEMBERSHIP_CACHE: LazyLock<DashMap<(Uuid, Uuid), Instant>> = LazyLock::new(DashMap::new);
+const MEMBERSHIP_CACHE_TTL: Duration = Duration::from_secs(60);
 
 #[derive(Deserialize)]
 #[serde(tag = "type")]
@@ -560,77 +570,21 @@ async fn handle_send_message(
 
     let (reply_content, reply_username) = lookup_reply_context(&state.pool, reply_to_id).await;
 
-    // Store message (use first device content as the canonical content for DB storage)
-    let stored = match db::messages::store_message(
-        &state.pool,
+    // Store message, send confirmation, and deliver to sender's other devices.
+    let Some(stored) = store_and_confirm(
+        state,
+        sender_id,
+        sender_device_id,
         conv_id,
         resolved_channel_id,
-        sender_id,
         &content,
         reply_to_id,
+        &device_contents,
     )
     .await
-    {
-        Ok(row) => row,
-        Err(_) => {
-            send_error(state, sender_id, "Failed to store message");
-            return;
-        }
+    else {
+        return;
     };
-
-    // Store per-device ciphertexts if present
-    if let Some(ref dc) = device_contents {
-        let entries: Vec<(i32, &str)> = dc
-            .iter()
-            .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, v.as_str())))
-            .collect();
-        if !entries.is_empty()
-            && let Err(e) =
-                db::messages::store_device_contents(&state.pool, stored.id, &entries).await
-        {
-            tracing::error!("Failed to store device contents: {e:?}");
-        }
-    }
-
-    // Send confirmation to sender's device
-    let confirm = ServerMessage::MessageSent {
-        message_id: stored.id,
-        conversation_id: conv_id,
-        channel_id: stored.channel_id,
-        timestamp: stored.created_at,
-    };
-    if let Ok(json) = serde_json::to_string(&confirm) {
-        state
-            .hub
-            .send_to_device(&sender_id, sender_device_id, WsMessage::Text(json.into()));
-    }
-
-    // Self-device delivery: notify sender's OTHER devices about outgoing message
-    if let Some(ref dc) = device_contents {
-        for (device_id_str, ciphertext) in dc {
-            if let Ok(did) = device_id_str.parse::<i32>() {
-                if did == sender_device_id {
-                    continue; // Don't send to the originating device
-                }
-                // Attempt delivery — Hub returns false if device isn't registered
-                // for this user (i.e. it's a recipient device, not a self device).
-                let self_msg = ServerMessage::SelfMessage {
-                    message_id: stored.id,
-                    from_device_id: sender_device_id,
-                    conversation_id: conv_id,
-                    channel_id: stored.channel_id,
-                    content: ciphertext.clone(),
-                    timestamp: stored.created_at,
-                    reply_to_id,
-                };
-                if let Ok(json) = serde_json::to_string(&self_msg) {
-                    state
-                        .hub
-                        .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
-                }
-            }
-        }
-    }
 
     let deliver = ServerMessage::NewMessage {
         message_id: stored.id,
@@ -657,6 +611,94 @@ async fn handle_send_message(
         device_contents,
     )
     .await;
+}
+
+/// Persist the message to the database, store per-device ciphertexts, send
+/// a `message_sent` confirmation to the originating device, and relay the
+/// message to the sender's other devices.  Returns the stored message row
+/// on success, or `None` after sending an error to the client.
+#[allow(clippy::too_many_arguments)]
+async fn store_and_confirm(
+    state: &AppState,
+    sender_id: Uuid,
+    sender_device_id: i32,
+    conv_id: Uuid,
+    resolved_channel_id: Option<Uuid>,
+    content: &str,
+    reply_to_id: Option<Uuid>,
+    device_contents: &Option<HashMap<String, String>>,
+) -> Option<db::messages::MessageRow> {
+    // Store message in DB
+    let stored = match db::messages::store_message(
+        &state.pool,
+        conv_id,
+        resolved_channel_id,
+        sender_id,
+        content,
+        reply_to_id,
+    )
+    .await
+    {
+        Ok(row) => row,
+        Err(_) => {
+            send_error(state, sender_id, "Failed to store message");
+            return None;
+        }
+    };
+
+    // Store per-device ciphertexts if present
+    if let Some(dc) = device_contents {
+        let entries: Vec<(i32, &str)> = dc
+            .iter()
+            .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, v.as_str())))
+            .collect();
+        if !entries.is_empty()
+            && let Err(e) =
+                db::messages::store_device_contents(&state.pool, stored.id, &entries).await
+        {
+            tracing::error!("Failed to store device contents: {e:?}");
+        }
+    }
+
+    // Send confirmation to sender's device
+    let confirm = ServerMessage::MessageSent {
+        message_id: stored.id,
+        conversation_id: conv_id,
+        channel_id: stored.channel_id,
+        timestamp: stored.created_at,
+    };
+    if let Ok(json) = serde_json::to_string(&confirm) {
+        state
+            .hub
+            .send_to_device(&sender_id, sender_device_id, WsMessage::Text(json.into()));
+    }
+
+    // Self-device delivery: notify sender's OTHER devices about outgoing message
+    if let Some(dc) = device_contents {
+        for (device_id_str, ciphertext) in dc {
+            if let Ok(did) = device_id_str.parse::<i32>() {
+                if did == sender_device_id {
+                    continue; // Don't send to the originating device
+                }
+                let self_msg = ServerMessage::SelfMessage {
+                    message_id: stored.id,
+                    from_device_id: sender_device_id,
+                    conversation_id: conv_id,
+                    channel_id: stored.channel_id,
+                    content: ciphertext.clone(),
+                    timestamp: stored.created_at,
+                    reply_to_id,
+                };
+                if let Ok(json) = serde_json::to_string(&self_msg) {
+                    state
+                        .hub
+                        .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
+                }
+            }
+        }
+    }
+
+    Some(stored)
 }
 
 /// Resolve the target conversation from either an explicit conversation_id or a to_user_id.
@@ -981,6 +1023,39 @@ async fn fanout_message(
     }
 }
 
+/// Check conversation membership using the in-memory cache.
+/// Returns true if the user is a verified member. Cache entries expire
+/// after `MEMBERSHIP_CACHE_TTL` (60 seconds).
+async fn check_membership_cached(
+    pool: &sqlx::PgPool,
+    conversation_id: Uuid,
+    user_id: Uuid,
+) -> bool {
+    let cache_key = (user_id, conversation_id);
+
+    // Fast path: check cache
+    if let Some(entry) = MEMBERSHIP_CACHE.get(&cache_key) {
+        if entry.value().elapsed() < MEMBERSHIP_CACHE_TTL {
+            return true;
+        }
+    }
+
+    // Slow path: hit database
+    let is_member = match db::groups::is_member(pool, conversation_id, user_id).await {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+
+    if is_member {
+        MEMBERSHIP_CACHE.insert(cache_key, Instant::now());
+    } else {
+        // Evict stale positive entry if membership was revoked
+        MEMBERSHIP_CACHE.remove(&cache_key);
+    }
+
+    is_member
+}
+
 async fn handle_typing(
     state: &AppState,
     sender_id: Uuid,
@@ -988,12 +1063,8 @@ async fn handle_typing(
     conversation_id: Uuid,
     channel_id: Option<Uuid>,
 ) {
-    // Verify membership
-    let is_member = match db::groups::is_member(&state.pool, conversation_id, sender_id).await {
-        Ok(m) => m,
-        Err(_) => return,
-    };
-    if !is_member {
+    // Verify membership via cache (avoids DB hit on every keystroke)
+    if !check_membership_cached(&state.pool, conversation_id, sender_id).await {
         return;
     }
 


### PR DESCRIPTION
## Summary — 4 server fixes
- **#67** list_conversations: CTE-based query replaces O(N^2) correlated subqueries + LIMIT 50
- **#77** Typing events: in-memory membership cache with 60s TTL eliminates DB hit per keystroke
- **#80** Device bundle fetch: LIMIT 10 on device queries
- **#82** handle_send_message: extracted store_and_confirm() helper, function now reads as orchestrator

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace --lib` — 72 unit tests pass

Closes #67, closes #77, closes #80, closes #82