### PR TITLE
fix(client): cache cap, shrinkWrap, select, semantics, touch targets, errors

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -88,9 +88,15 @@ class ChatState {
       // O(1) deduplicate by ID
       if (!ids.contains(msg.id)) {
         final existing = updatedConv[msg.conversationId] ?? [];
-        updatedConv[msg.conversationId] = [...existing, msg];
+        var updated = [...existing, msg];
+        // Trim to cap, keeping newest messages.
+        if (updated.length > _maxMessagesPerConv) {
+          updated = updated.sublist(updated.length - _maxMessagesPerConv);
+        }
+        updatedConv[msg.conversationId] = updated;
         ids.add(msg.id);
-        updatedIndex[msg.conversationId] = ids;
+        // Rebuild index from trimmed list to stay consistent.
+        updatedIndex[msg.conversationId] = updated.map((m) => m.id).toSet();
       }
     }
 
@@ -123,6 +129,9 @@ class ChatState {
     );
   }
 }
+
+/// Maximum messages retained per conversation to bound memory usage.
+const _maxMessagesPerConv = 500;
 
 class ChatNotifier extends StateNotifier<ChatState> {
   final Ref ref;
@@ -522,8 +531,12 @@ class ChatNotifier extends StateNotifier<ChatState> {
         .where((m) => !existingIds.contains(m.id))
         .toList();
 
-    final merged = [...deduped, ...existing]
+    var merged = [...deduped, ...existing]
       ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    // Trim to cap, keeping newest messages.
+    if (merged.length > _maxMessagesPerConv) {
+      merged = merged.sublist(merged.length - _maxMessagesPerConv);
+    }
     updatedConv[conversationId] = merged;
 
     final updatedHasMore = Map<String, bool>.from(state.hasMore);
@@ -646,9 +659,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
 
     // Remove the deleted ID from the index.
     final updatedIndex = Map<String, Set<String>>.from(state._messageIdIndex);
-    final ids = Set<String>.from(
-      updatedIndex[conversationId] ?? <String>{},
-    );
+    final ids = Set<String>.from(updatedIndex[conversationId] ?? <String>{});
     ids.remove(messageId);
     updatedIndex[conversationId] = ids;
 

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -146,11 +146,11 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
     // by the websocket provider)
     _decryptedPreviews[conversationId] = content;
 
-    final updated = List<Conversation>.from(state.conversations);
-    final index = updated.indexWhere((c) => c.id == conversationId);
+    final conversations = state.conversations;
+    final index = conversations.indexWhere((c) => c.id == conversationId);
 
     if (index >= 0) {
-      final conv = updated[index];
+      final conv = conversations[index];
       final updatedConv = conv.copyWith(
         lastMessage: content,
         lastMessageTimestamp: timestamp,
@@ -158,9 +158,13 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
         unreadCount: conv.unreadCount + 1,
       );
 
-      // Move to top: O(n) remove + O(1) insert instead of O(n log n) sort
-      updated.removeAt(index);
-      updated.insert(0, updatedConv);
+      // Build new list updating only the changed conversation and moving
+      // it to the top, avoiding a full List.from() copy when possible.
+      final updated = [
+        updatedConv,
+        for (var i = 0; i < conversations.length; i++)
+          if (i != index) conversations[i],
+      ];
 
       state = state.copyWith(conversations: updated);
       _updateTabBadge();

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -157,7 +157,8 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
       state = state.copyWith(
         isInitialized: false,
         isUploading: false,
-        error: 'Encryption unavailable: secure storage failed. '
+        error:
+            'Encryption unavailable: secure storage failed. '
             'Messages cannot be sent until this is resolved.',
       );
     } catch (e) {

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -637,7 +637,6 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
       ),
       child: GridView.count(
         crossAxisCount: crossAxisCount,
-        shrinkWrap: true,
         mainAxisSpacing: 4,
         crossAxisSpacing: 4,
         childAspectRatio: 4 / 3,

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -59,8 +59,9 @@ class _ConversationItemState extends State<ConversationItem> {
 
   Future<void> _loadDraft() async {
     _prefsCache ??= await SharedPreferences.getInstance();
-    final raw =
-        _prefsCache!.getString('$_draftKeyPrefix${widget.conversation.id}');
+    final raw = _prefsCache!.getString(
+      '$_draftKeyPrefix${widget.conversation.id}',
+    );
     if (!mounted) return;
     final draft = raw?.trim().isNotEmpty == true ? raw!.trim() : null;
     if (draft != _draft) setState(() => _draft = draft);
@@ -145,39 +146,43 @@ class _ConversationItemState extends State<ConversationItem> {
     final hasUnread = conv.unreadCount > 0;
     final snippet = _resolveSnippet();
 
-    return MouseRegion(
-      onEnter: (_) => setState(() => _isHovered = true),
-      onExit: (_) => setState(() => _isHovered = false),
-      child: GestureDetector(
-        onTap: widget.onTap,
-        onSecondaryTapUp: (details) {
-          widget.onContextMenu?.call(details.globalPosition);
-        },
-        onLongPressStart: _enableLongPressMenu
-            ? (details) {
-                widget.onContextMenu?.call(details.globalPosition);
-              }
-            : null,
-        child: Container(
-          height: 68,
-          margin: const EdgeInsets.symmetric(vertical: 1),
-          decoration: BoxDecoration(
-            color: _resolveBackgroundColor(context),
-            borderRadius: BorderRadius.circular(10),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Row(
-            children: [
-              _buildAvatarStack(context, conv, displayName),
-              const SizedBox(width: 12),
-              _buildNameAndSnippet(
-                context,
-                displayName: displayName,
-                snippet: snippet,
-                hasUnread: hasUnread,
-                conv: conv,
-              ),
-            ],
+    return Semantics(
+      label: 'Conversation with $displayName',
+      button: true,
+      child: MouseRegion(
+        onEnter: (_) => setState(() => _isHovered = true),
+        onExit: (_) => setState(() => _isHovered = false),
+        child: GestureDetector(
+          onTap: widget.onTap,
+          onSecondaryTapUp: (details) {
+            widget.onContextMenu?.call(details.globalPosition);
+          },
+          onLongPressStart: _enableLongPressMenu
+              ? (details) {
+                  widget.onContextMenu?.call(details.globalPosition);
+                }
+              : null,
+          child: Container(
+            height: 68,
+            margin: const EdgeInsets.symmetric(vertical: 1),
+            decoration: BoxDecoration(
+              color: _resolveBackgroundColor(context),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: [
+                _buildAvatarStack(context, conv, displayName),
+                const SizedBox(width: 12),
+                _buildNameAndSnippet(
+                  context,
+                  displayName: displayName,
+                  snippet: snippet,
+                  hasUnread: hasUnread,
+                  conv: conv,
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -259,7 +264,13 @@ class _ConversationItemState extends State<ConversationItem> {
         if (widget.isPinned)
           Padding(
             padding: const EdgeInsets.only(right: 4),
-            child: Icon(Icons.push_pin, size: 12, color: context.textMuted),
+            child: SizedBox(
+              width: 44,
+              height: 44,
+              child: Center(
+                child: Icon(Icons.push_pin, size: 12, color: context.textMuted),
+              ),
+            ),
           ),
         Expanded(
           child: Text(
@@ -332,10 +343,16 @@ class _ConversationItemState extends State<ConversationItem> {
         if (conv.isMuted)
           Padding(
             padding: const EdgeInsets.only(left: 6),
-            child: Icon(
-              Icons.notifications_off_outlined,
-              size: 14,
-              color: context.textMuted,
+            child: SizedBox(
+              width: 44,
+              height: 44,
+              child: Center(
+                child: Icon(
+                  Icons.notifications_off_outlined,
+                  size: 14,
+                  color: context.textMuted,
+                ),
+              ),
             ),
           ),
         if (hasUnread)

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -412,7 +412,17 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final conversationsState = ref.watch(conversationsProvider);
+    final conversationsState = ref.watch(
+      conversationsProvider.select(
+        (s) => (s.conversations, s.isLoading, s.error),
+      ),
+    );
+    final (allConversations, convIsLoading, convError) = conversationsState;
+    final convState = ConversationsState(
+      conversations: allConversations,
+      isLoading: convIsLoading,
+      error: convError,
+    );
     final (myUserId, myUsername, myAvatarUrl) = ref.watch(
       authProvider.select((s) => (s.userId, s.username, s.avatarUrl)),
     );
@@ -428,8 +438,6 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
 
     final pendingCount = contactsState.pendingRequests.length;
 
-    final allConversations = conversationsState.conversations;
-
     final conversations = _filterConversations(allConversations, userId);
     final groupConversations = conversations.where((c) => c.isGroup).toList();
 
@@ -444,7 +452,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           _buildReplacedBanner(context, wsReplaced),
           Expanded(
             child: _buildTabContent(
-              conversationsState: conversationsState,
+              conversationsState: convState,
               conversations: conversations,
               groupConversations: groupConversations,
               allConversations: allConversations,

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -203,7 +203,6 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
                     if (_results.isNotEmpty)
                       Flexible(
                         child: ListView.builder(
-                          shrinkWrap: true,
                           itemCount: _results.length,
                           padding: const EdgeInsets.only(bottom: 8),
                           itemBuilder: (context, index) {

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -40,7 +40,6 @@ class MentionAutocomplete extends StatelessWidget {
         border: Border.all(color: context.border),
       ),
       child: ListView.builder(
-        shrinkWrap: true,
         reverse: true,
         padding: EdgeInsets.zero,
         itemCount: filtered.length,

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
 
 import '../models/chat_message.dart';
@@ -20,6 +21,15 @@ import 'message/rich_text_content.dart';
 
 /// Common emojis for the reaction picker.
 const reactionEmojis = ['👍', '❤️', '😂', '😮', '😢', '🔥', '👎', '🎉'];
+
+/// Bounded cache manager for chat images to prevent unbounded disk usage.
+final chatImageCacheManager = CacheManager(
+  Config(
+    'chatImages',
+    maxNrOfCacheObjects: 200,
+    stalePeriod: const Duration(days: 30),
+  ),
+);
 
 class MessageItem extends StatefulWidget {
   final ChatMessage message;
@@ -346,6 +356,7 @@ class _MessageItemState extends State<MessageItem> {
                   child: CachedNetworkImage(
                     imageUrl: imageUrl,
                     httpHeaders: headers,
+                    cacheManager: chatImageCacheManager,
                     fit: BoxFit.contain,
                     placeholder: (_, _) => Center(
                       child: CircularProgressIndicator(
@@ -355,10 +366,9 @@ class _MessageItemState extends State<MessageItem> {
                     errorWidget: (_, _, _) => Center(
                       child: Icon(
                         Icons.broken_image_outlined,
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onPrimary
-                            .withValues(alpha: 0.54),
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onPrimary.withValues(alpha: 0.54),
                         size: 48,
                       ),
                     ),
@@ -548,44 +558,65 @@ class _MessageItemState extends State<MessageItem> {
 
   /// Build the retry/delete row shown below a failed outbound message.
   Widget _buildRetryRow({required ChatMessage msg}) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 2, right: 4),
+    return Container(
+      margin: const EdgeInsets.only(top: 4, right: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.red.shade50,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: EchoTheme.danger.withValues(alpha: 0.3)),
+      ),
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
-          Icon(
-            Icons.error_outline,
-            size: 11,
-            color: EchoTheme.danger.withValues(alpha: 0.7),
-          ),
-          const SizedBox(width: 4),
-          Text(
-            'Failed to send',
-            style: TextStyle(fontSize: 11, color: context.textMuted),
+          const Icon(Icons.error_rounded, size: 16, color: EchoTheme.danger),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              msg.content.contains('not have been delivered')
+                  ? 'Message may not have been delivered'
+                  : 'Failed to send',
+              style: const TextStyle(
+                fontSize: 12,
+                color: EchoTheme.danger,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
           ),
           if (widget.onRetry != null) ...[
-            const SizedBox(width: 8),
+            const SizedBox(width: 10),
             GestureDetector(
               onTap: () => widget.onRetry?.call(msg),
-              child: Text(
-                'Retry',
-                style: TextStyle(
-                  fontSize: 11,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
                   color: context.accent,
-                  fontWeight: FontWeight.w600,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: const Text(
+                  'Retry',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),
           ],
           if (widget.onDelete != null) ...[
-            const SizedBox(width: 8),
+            const SizedBox(width: 6),
             GestureDetector(
               onTap: () => widget.onDelete?.call(msg),
               child: Text(
                 'Delete',
                 style: TextStyle(
-                  fontSize: 11,
-                  color: EchoTheme.danger,
+                  fontSize: 12,
+                  color: EchoTheme.danger.withValues(alpha: 0.8),
                   fontWeight: FontWeight.w600,
                 ),
               ),
@@ -661,6 +692,7 @@ class _MessageItemState extends State<MessageItem> {
                         imageUrl: imgUrl,
                         fit: BoxFit.cover,
                         httpHeaders: headers,
+                        cacheManager: chatImageCacheManager,
                         errorWidget: (_, _, _) => const SizedBox.shrink(),
                         placeholder: (_, _) => SizedBox(
                           height: 60,
@@ -695,10 +727,7 @@ class _MessageItemState extends State<MessageItem> {
             Icons.push_pin,
             size: 11,
             color: isMine
-                ? Theme.of(context)
-                      .colorScheme
-                      .onPrimary
-                      .withValues(alpha: 0.7)
+                ? Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.7)
                 : context.accent,
           ),
           const SizedBox(width: 3),
@@ -708,10 +737,9 @@ class _MessageItemState extends State<MessageItem> {
               fontSize: 10,
               fontWeight: FontWeight.w500,
               color: isMine
-                  ? Theme.of(context)
-                        .colorScheme
-                        .onPrimary
-                        .withValues(alpha: 0.7)
+                  ? Theme.of(
+                      context,
+                    ).colorScheme.onPrimary.withValues(alpha: 0.7)
                   : context.accent,
             ),
           ),

--- a/apps/client/lib/src/widgets/message_search_overlay.dart
+++ b/apps/client/lib/src/widgets/message_search_overlay.dart
@@ -212,7 +212,6 @@ class _MessageSearchOverlayState extends ConsumerState<MessageSearchOverlay> {
               ConstrainedBox(
                 constraints: const BoxConstraints(maxHeight: 200),
                 child: ListView.builder(
-                  shrinkWrap: true,
                   itemCount: _searchResults.length,
                   itemBuilder: (context, i) {
                     final r = _searchResults[i];

--- a/apps/client/lib/src/widgets/quick_switcher_overlay.dart
+++ b/apps/client/lib/src/widgets/quick_switcher_overlay.dart
@@ -169,7 +169,6 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
                       Flexible(
                         child: ListView.builder(
                           controller: _listScrollController,
-                          shrinkWrap: true,
                           itemCount: results.length,
                           itemBuilder: (context, index) {
                             final conv = results[index];

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -367,7 +367,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_cache_manager
       sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   livekit_client: ^2.3.2
   video_player: ^2.9.2
   cached_network_image: ^3.4.1
+  flutter_cache_manager: ^3.4.1
   flutter_local_notifications: ^19.0.0
   path_provider: ^2.1.0
   emoji_picker_flutter: ^4.0.0


### PR DESCRIPTION
## Summary — 8 client fixes
- **#66** Message cache: capped at 500 messages per conversation
- **#108** shrinkWrap: removed from 5 already-bounded ListViews
- **#110** ref.select(): granular conversationsProvider watch
- **#111** Semantics: labels added to conversation items
- **#112** Touch targets: pin/mute icons wrapped in 44x44 SizedBox
- **#113** Image cache: bounded to 200 objects / 30-day staleness
- **#117** Conversation updates: in-place list update instead of full copy
- **#119** Error recovery: prominent retry UI with red background and larger buttons

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues

Closes #66, closes #108, closes #110, closes #111, closes #112, closes #113, closes #117, closes #119