### PR TITLE
fix(client): 12 sonar quickwins — const, string constants, ternaries

### DIFF
--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -623,10 +623,10 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
                 color: EchoTheme.danger,
               ),
               const SizedBox(width: 8),
-              Expanded(
+              const Expanded(
                 child: Text(
                   'Failed to load profile. Check your connection.',
-                  style: const TextStyle(color: EchoTheme.danger, fontSize: 13),
+                  style: TextStyle(color: EchoTheme.danger, fontSize: 13),
                 ),
               ),
               TextButton(onPressed: _loadProfile, child: const Text('Retry')),

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -18,6 +18,8 @@ import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
 import '../widgets/vertex_mesh_background.dart';
 
+const _kScreenshareLocal = 'screenshare-local';
+
 /// Resolve a LiveKit participant's display name, preferring name > identity > sid.
 String _participantDisplayName(lk.Participant participant) {
   if (participant.name.isNotEmpty) return participant.name;
@@ -95,7 +97,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       if (pub == null || !voiceLk.isVideoEnabled) return (null, false);
       return (pub.track as lk.VideoTrack?, true);
     }
-    if (tileKey == 'screenshare-local') {
+    if (tileKey == _kScreenshareLocal) {
       final pub = room.localParticipant?.videoTrackPublications
           .where(
             (p) =>
@@ -213,8 +215,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         children: [
           if (screenShare.isScreenSharing)
             GestureDetector(
-              onTap: () =>
-                  setState(() => _focusedTileKey = 'screenshare-local'),
+              onTap: () => setState(() => _focusedTileKey = _kScreenshareLocal),
               child: _ScreenShareViewer(ref: ref),
             ),
           if (screenShare.isScreenSharing) const SizedBox(height: 16),
@@ -252,8 +253,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
           if (screenShare.isScreenSharing) ...[
             const SizedBox(height: 8),
             GestureDetector(
-              onTap: () =>
-                  setState(() => _focusedTileKey = 'screenshare-local'),
+              onTap: () => setState(() => _focusedTileKey = _kScreenshareLocal),
               child: SizedBox(height: 120, child: _ScreenShareViewer(ref: ref)),
             ),
           ],

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -418,10 +418,10 @@ class ChatHeaderBar extends ConsumerWidget {
             color: EchoTheme.warning,
           ),
           const SizedBox(width: 8),
-          Expanded(
+          const Expanded(
             child: Text(
               label,
-              style: const TextStyle(fontSize: 11, color: EchoTheme.warning),
+              style: TextStyle(fontSize: 11, color: EchoTheme.warning),
             ),
           ),
           GestureDetector(

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -33,6 +33,9 @@ import 'input/reply_preview_bar.dart';
 import 'media_picker_panel.dart';
 import 'mobile_media_picker_panel.dart';
 
+const _kOctetStream = 'octet-stream';
+const _kImageGif = 'image/gif';
+
 /// Extracted chat input bar from ChatPanel (~850 lines).
 ///
 /// Manages:
@@ -411,7 +414,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         return 'jpg';
       case 'image/png':
         return 'png';
-      case 'image/gif':
+      case _kImageGif:
         return 'gif';
       case 'image/webp':
         return 'webp';
@@ -520,7 +523,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       final parts = mimeType.split('/');
       final mediaType = parts.length == 2
           ? MediaType(parts[0], parts[1])
-          : MediaType('application', 'octet-stream');
+          : MediaType('application', _kOctetStream);
 
       request.files.add(
         http.MultipartFile.fromBytes(
@@ -650,7 +653,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         'mp4': ['video', 'mp4'],
         'pdf': ['application', 'pdf'],
       };
-      final mime = mimeTypes[ext] ?? ['application', 'octet-stream'];
+      final mime = mimeTypes[ext] ?? ['application', _kOctetStream];
 
       _setPendingAttachment(
         bytes: file.bytes!,
@@ -841,7 +844,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         'mp4': ['video', 'mp4'],
         'mov': ['video', 'quicktime'],
       };
-      final mime = mimeTypes[ext] ?? ['application', 'octet-stream'];
+      final mime = mimeTypes[ext] ?? ['application', _kOctetStream];
       _setPendingAttachment(
         bytes: file.bytes!,
         fileName: file.name,
@@ -1098,17 +1101,16 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                 required currentLength,
                 required isFocused,
                 required maxLength,
-              }) => currentLength > 3200
-              ? Text(
+              }) {
+                if (currentLength <= 3200) return null;
+                final counterColor = currentLength > 3900
+                    ? EchoTheme.danger
+                    : context.textMuted;
+                return Text(
                   '$currentLength/$maxLength',
-                  style: TextStyle(
-                    color: currentLength > 3900
-                        ? EchoTheme.danger
-                        : context.textMuted,
-                    fontSize: 11,
-                  ),
-                )
-              : null,
+                  style: TextStyle(color: counterColor, fontSize: 11),
+                );
+              },
           autofillHints: const [],
           style: TextStyle(fontSize: 14, color: context.textPrimary),
           decoration: InputDecoration(
@@ -1262,7 +1264,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
           _pendingAttachmentUrl = gifUrl;
           _pendingAttachmentExt = 'gif';
           _pendingAttachmentFileName = 'gif';
-          _pendingAttachmentMimeType = 'image/gif';
+          _pendingAttachmentMimeType = _kImageGif;
           _pendingAttachmentBytes = null; // no local bytes for GIFs
           _isUploadingAttachment = false;
         });
@@ -1398,7 +1400,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                       _pendingAttachmentUrl = gifUrl;
                       _pendingAttachmentExt = 'gif';
                       _pendingAttachmentFileName = 'gif';
-                      _pendingAttachmentMimeType = 'image/gif';
+                      _pendingAttachmentMimeType = _kImageGif;
                       _pendingAttachmentBytes = null;
                       _isUploadingAttachment = false;
                     });

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -302,6 +302,7 @@ class _ConversationItemState extends State<ConversationItem> {
     Conversation conv,
   ) {
     final showDraft = _draft != null && !hasUnread;
+    final snippetWeight = hasUnread ? FontWeight.w500 : FontWeight.normal;
     return Row(
       children: [
         Expanded(
@@ -311,7 +312,7 @@ class _ConversationItemState extends State<ConversationItem> {
                   overflow: TextOverflow.ellipsis,
                   text: TextSpan(
                     children: [
-                      TextSpan(
+                      const TextSpan(
                         text: 'Draft: ',
                         style: TextStyle(
                           fontSize: 13,
@@ -336,7 +337,7 @@ class _ConversationItemState extends State<ConversationItem> {
                   style: TextStyle(
                     fontSize: 13,
                     color: context.textMuted,
-                    fontWeight: hasUnread ? FontWeight.w500 : FontWeight.normal,
+                    fontWeight: snippetWeight,
                   ),
                 ),
         ),

--- a/apps/client/lib/src/widgets/mobile_media_picker_panel.dart
+++ b/apps/client/lib/src/widgets/mobile_media_picker_panel.dart
@@ -88,9 +88,9 @@ class _MobileMediaPickerPanelState extends State<MobileMediaPickerPanel>
                     ),
                     dividerColor: Colors.transparent,
                     labelPadding: const EdgeInsets.symmetric(horizontal: 16),
-                    tabs: [
-                      const Tab(height: 34, text: 'Emoji'),
-                      const Tab(height: 34, text: 'GIFs'),
+                    tabs: const [
+                      Tab(height: 34, text: 'Emoji'),
+                      Tab(height: 34, text: 'GIFs'),
                     ],
                   ),
                 ),

--- a/apps/client/lib/src/widgets/vertex_mesh_background.dart
+++ b/apps/client/lib/src/widgets/vertex_mesh_background.dart
@@ -48,13 +48,15 @@ class _VertexMeshBackgroundState extends State<VertexMeshBackground>
   void _initVertices(Size size) {
     _vertices.clear();
     for (int i = 0; i < widget.vertexCount; i++) {
-      _vertices.add(_Vertex(
-        x: _rng.nextDouble() * size.width,
-        y: _rng.nextDouble() * size.height,
-        vx: (_rng.nextDouble() - 0.5) * 0.4,
-        vy: (_rng.nextDouble() - 0.5) * 0.4,
-        radius: 1.5 + _rng.nextDouble() * 1.5,
-      ));
+      _vertices.add(
+        _Vertex(
+          x: _rng.nextDouble() * size.width,
+          y: _rng.nextDouble() * size.height,
+          vx: (_rng.nextDouble() - 0.5) * 0.4,
+          vy: (_rng.nextDouble() - 0.5) * 0.4,
+          radius: 1.5 + _rng.nextDouble() * 1.5,
+        ),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary — 12 SonarCloud fixes

**S7112 — const constructors (6):**
- conversation_item.dart, chat_header_bar.dart, account_section.dart

**S1192 — duplicated string literals (3):**
- `"octet-stream"` and `"image/gif"` in chat_input_bar.dart
- `"screenshare-local"` in voice_lounge_screen.dart

**S3358 — nested ternaries (2):**
- chat_input_bar.dart buildCounter, conversation_item.dart snippet weight

**S7123 — const for @immutable (1):**
- mobile_media_picker_panel.dart tab list

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `dart format` — clean