### PR TITLE
refactor: reduce cognitive complexity in 32 methods (sonar S3776 batch 2+3)

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -435,6 +435,40 @@ class ChatNotifier extends StateNotifier<ChatState> {
     return newMessages;
   }
 
+  Future<ChatMessage> _decryptGroupMessage(
+    ChatMessage msg,
+    GroupCryptoService? groupCrypto,
+    String? conversationId,
+  ) async {
+    if (groupCrypto == null || conversationId == null) {
+      return msg.copyWith(
+        content: '[Encrypted group message]',
+        isEncrypted: true,
+      );
+    }
+    try {
+      final keyResult = await groupCrypto.getGroupKey(conversationId);
+      if (keyResult == null) {
+        return msg.copyWith(
+          content: '[Encrypted group message - key unavailable]',
+          isEncrypted: true,
+        );
+      }
+      final (_, keyBase64) = keyResult;
+      final decrypted = await GroupCryptoService.decryptGroupMessage(
+        msg.content,
+        keyBase64,
+      );
+      return msg.copyWith(content: decrypted, isEncrypted: true);
+    } catch (e) {
+      debugPrint('[Chat] Group history decrypt failed for ${msg.id}: $e');
+      return msg.copyWith(
+        content: '[Could not decrypt group message]',
+        isEncrypted: true,
+      );
+    }
+  }
+
   Future<ChatMessage> _decryptIfNeeded(
     ChatMessage msg, {
     required String myUserId,
@@ -445,33 +479,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
   }) async {
     // Group-encrypted messages (prefixed with GRP1:)
     if (msg.content.startsWith(groupEncryptedPrefix)) {
-      if (groupCrypto == null || conversationId == null) {
-        return msg.copyWith(
-          content: '[Encrypted group message]',
-          isEncrypted: true,
-        );
-      }
-      try {
-        final keyResult = await groupCrypto.getGroupKey(conversationId);
-        if (keyResult == null) {
-          return msg.copyWith(
-            content: '[Encrypted group message - key unavailable]',
-            isEncrypted: true,
-          );
-        }
-        final (_, keyBase64) = keyResult;
-        final decrypted = await GroupCryptoService.decryptGroupMessage(
-          msg.content,
-          keyBase64,
-        );
-        return msg.copyWith(content: decrypted, isEncrypted: true);
-      } catch (e) {
-        debugPrint('[Chat] Group history decrypt failed for ${msg.id}: $e');
-        return msg.copyWith(
-          content: '[Could not decrypt group message]',
-          isEncrypted: true,
-        );
-      }
+      return _decryptGroupMessage(msg, groupCrypto, conversationId);
     }
 
     // Skip decryption for non-encrypted group messages

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -65,6 +65,31 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
 
   CryptoNotifier(this.ref) : super(const CryptoState());
 
+  /// Attempt key upload with one automatic retry.
+  /// Returns the error string on final failure, or null on success.
+  Future<String?> _uploadKeysWithRetry(CryptoService crypto) async {
+    for (var attempt = 1; attempt <= 2; attempt++) {
+      try {
+        await crypto.uploadKeys();
+        DebugLogService.instance.log(
+          LogLevel.info,
+          'Crypto',
+          'Keys uploaded to server (attempt $attempt)',
+        );
+        return null;
+      } catch (uploadError) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'Crypto',
+          'Key upload attempt $attempt failed: $uploadError',
+        );
+        if (attempt == 2) return uploadError.toString();
+        await Future<void>.delayed(const Duration(seconds: 1));
+      }
+    }
+    return null; // unreachable
+  }
+
   /// Initialize crypto and upload keys to the server.
   ///
   /// On Linux, libsecret may fail to unlock the keyring (PlatformException).
@@ -88,35 +113,15 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
       crypto.setToken(token);
       await crypto.init();
       if (crypto.keysAreFresh) {
-        // Attempt upload with one automatic retry on failure.
-        var uploaded = false;
-        for (var attempt = 1; attempt <= 2 && !uploaded; attempt++) {
-          try {
-            await crypto.uploadKeys();
-            uploaded = true;
-            DebugLogService.instance.log(
-              LogLevel.info,
-              'Crypto',
-              'Keys uploaded to server (attempt $attempt)',
-            );
-          } catch (uploadError) {
-            DebugLogService.instance.log(
-              LogLevel.error,
-              'Crypto',
-              'Key upload attempt $attempt failed: $uploadError',
-            );
-            if (attempt == 2) {
-              state = state.copyWith(
-                isInitialized: true,
-                isUploading: false,
-                keysUploadFailed: true,
-                error: 'Key upload failed: $uploadError',
-              );
-              return;
-            }
-            // Brief pause before retry
-            await Future<void>.delayed(const Duration(seconds: 1));
-          }
+        final uploadError = await _uploadKeysWithRetry(crypto);
+        if (uploadError != null) {
+          state = state.copyWith(
+            isInitialized: true,
+            isUploading: false,
+            keysUploadFailed: true,
+            error: 'Key upload failed: $uploadError',
+          );
+          return;
         }
       }
       final regenerated = crypto.keysWereRegenerated;

--- a/apps/client/lib/src/providers/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice_provider.dart
@@ -271,33 +271,33 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
   /// Following Discord convention, deafening also mutes the microphone.
   /// Un-deafening restores mic to whatever state it was before deafening.
   Future<void> setDeafened(bool deafened) async {
+    _syncMicStateForDeafen(deafened);
+    await _setRemoteAudioEnabled(!deafened);
+    state = state.copyWith(isDeafened: deafened);
+  }
+
+  /// Save mic state and mute/unmute for deafen toggle.
+  void _syncMicStateForDeafen(bool deafened) {
     if (deafened) {
       _wasMutedBeforeDeafen = !state.isCaptureEnabled;
       setCaptureEnabled(false);
-    } else {
-      if (!_wasMutedBeforeDeafen) {
-        setCaptureEnabled(true);
-      }
+    } else if (!_wasMutedBeforeDeafen) {
+      setCaptureEnabled(true);
     }
+  }
 
-    // Disable/enable audio on all remote participant tracks.
+  /// Enable or disable all remote participant audio tracks.
+  Future<void> _setRemoteAudioEnabled(bool enabled) async {
     final room = _room;
-    if (room != null) {
-      for (final participant in room.remoteParticipants.values) {
-        for (final pub in participant.audioTrackPublications) {
-          final track = pub.track;
-          if (track != null) {
-            if (deafened) {
-              await track.disable();
-            } else {
-              await track.enable();
-            }
-          }
+    if (room == null) return;
+    for (final participant in room.remoteParticipants.values) {
+      for (final pub in participant.audioTrackPublications) {
+        final track = pub.track;
+        if (track != null) {
+          enabled ? await track.enable() : await track.disable();
         }
       }
     }
-
-    state = state.copyWith(isDeafened: deafened);
   }
 
   /// Toggle the local camera on/off.

--- a/apps/client/lib/src/providers/voice_rtc_provider.dart
+++ b/apps/client/lib/src/providers/voice_rtc_provider.dart
@@ -483,7 +483,16 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
     };
 
     final pc = await createPeerConnection(config);
+    await _addLocalTracksToConnection(pc, remoteUserId);
+    _registerPeerConnectionCallbacks(pc, remoteUserId);
+    return pc;
+  }
 
+  /// Add local audio and video tracks to a newly created peer connection.
+  Future<void> _addLocalTracksToConnection(
+    RTCPeerConnection pc,
+    String remoteUserId,
+  ) async {
     final stream = _localStream;
     if (stream != null) {
       final audioTracks = stream.getAudioTracks();
@@ -500,7 +509,6 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
       }
     }
 
-    // If video is already enabled, add video tracks to the new peer connection.
     final videoStream = _localVideoStream;
     if (videoStream != null && state.isVideoEnabled) {
       final videoTracks = videoStream.getVideoTracks();
@@ -516,13 +524,16 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
         await pc.addTrack(track, videoStream);
       }
     }
+  }
 
+  /// Register ICE, connection, and track callbacks on a peer connection.
+  void _registerPeerConnectionCallbacks(
+    RTCPeerConnection pc,
+    String remoteUserId,
+  ) {
     pc.onIceCandidate = (candidate) {
       final candidateValue = candidate.candidate;
-      if (candidateValue == null || candidateValue.isEmpty) {
-        return;
-      }
-
+      if (candidateValue == null || candidateValue.isEmpty) return;
       _sendSignal(remoteUserId, {
         'type': 'ice-candidate',
         'candidate': candidateValue,
@@ -580,8 +591,6 @@ class VoiceRtcNotifier extends StateNotifier<VoiceRtcState> {
         _attachRemoteVideoStream(remoteUserId, event.streams.first);
       }
     };
-
-    return pc;
   }
 
   Future<void> _attachRemoteAudioStream(

--- a/apps/client/lib/src/router/app_router.dart
+++ b/apps/client/lib/src/router/app_router.dart
@@ -49,51 +49,95 @@ class _AuthNotifierListenable extends ChangeNotifier {
   }
 }
 
+/// Redirect logic for auth state.
+String? _authRedirect(Ref ref, GoRouterState state) {
+  final isLoggedIn = ref.read(authProvider).isLoggedIn;
+  final isSplash = state.matchedLocation == _routeSplash;
+  final isAuthRoute =
+      state.matchedLocation == _routeLogin ||
+      state.matchedLocation == '/register';
+  final isOnboarding = state.matchedLocation == '/onboarding';
+  final isJoinRoute =
+      state.matchedLocation.startsWith('/join') ||
+      state.matchedLocation.startsWith('/invite');
+
+  if (isSplash) return null;
+
+  if (!isLoggedIn && !isAuthRoute && !isOnboarding && !isJoinRoute) {
+    final intended = state.matchedLocation;
+    if (intended != _routeHome && intended != _routeLogin) {
+      pendingDeepLink = state.uri.toString();
+    }
+    return _routeLogin;
+  }
+  if (isLoggedIn && isAuthRoute) {
+    if (pendingDeepLink != null) {
+      final destination = pendingDeepLink!;
+      pendingDeepLink = null;
+      return destination;
+    }
+    return _routeHome;
+  }
+  return null;
+}
+
+Widget _buildProfilePage(String userId) {
+  return Scaffold(
+    appBar: AppBar(title: const Text('Profile')),
+    body: UserProfileScreen(userId: userId),
+  );
+}
+
+/// Profile-related routes (/profile/:userId, /u/:userId, etc.).
+List<GoRoute> _profileRoutes() {
+  return [
+    GoRoute(
+      path: '/profile/:userId',
+      pageBuilder: (context, state) => _fadePage(
+        key: state.pageKey,
+        child: _buildProfilePage(state.pathParameters['userId']!),
+      ),
+    ),
+    GoRoute(
+      path: '/u/:userId',
+      pageBuilder: (context, state) => _fadePage(
+        key: state.pageKey,
+        child: _buildProfilePage(state.pathParameters['userId']!),
+      ),
+    ),
+    GoRoute(
+      path: '/user/:userId',
+      pageBuilder: (context, state) => _fadePage(
+        key: state.pageKey,
+        child: _buildProfilePage(state.pathParameters['userId']!),
+      ),
+    ),
+    GoRoute(
+      path: '/profile',
+      redirect: (context, state) {
+        final qp = state.uri.queryParameters;
+        final userId = qp['userId'] ?? qp['uid'] ?? qp['id'] ?? '';
+        if (userId.isEmpty) return _routeHome;
+        return '/profile/$userId';
+      },
+    ),
+    GoRoute(
+      path: '/echo-user/:userId',
+      pageBuilder: (context, state) => _fadePage(
+        key: state.pageKey,
+        child: _buildProfilePage(state.pathParameters['userId']!),
+      ),
+    ),
+  ];
+}
+
 final routerProvider = Provider<GoRouter>((ref) {
   final refreshListenable = _AuthNotifierListenable(ref);
-
-  Widget buildProfilePage(String userId) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Profile')),
-      body: UserProfileScreen(userId: userId),
-    );
-  }
 
   return GoRouter(
     initialLocation: _routeSplash,
     refreshListenable: refreshListenable,
-    redirect: (context, state) {
-      final isLoggedIn = ref.read(authProvider).isLoggedIn;
-      final isSplash = state.matchedLocation == _routeSplash;
-      final isAuthRoute =
-          state.matchedLocation == _routeLogin ||
-          state.matchedLocation == '/register';
-      final isOnboarding = state.matchedLocation == '/onboarding';
-      final isJoinRoute =
-          state.matchedLocation.startsWith('/join') ||
-          state.matchedLocation.startsWith('/invite');
-
-      // Let the splash screen handle its own navigation
-      if (isSplash) return null;
-
-      if (!isLoggedIn && !isAuthRoute && !isOnboarding && !isJoinRoute) {
-        // Save the intended path so we can navigate there after login
-        final intended = state.matchedLocation;
-        if (intended != _routeHome && intended != _routeLogin) {
-          pendingDeepLink = state.uri.toString();
-        }
-        return _routeLogin;
-      }
-      if (isLoggedIn && isAuthRoute) {
-        if (pendingDeepLink != null) {
-          final destination = pendingDeepLink!;
-          pendingDeepLink = null;
-          return destination;
-        }
-        return _routeHome;
-      }
-      return null;
-    },
+    redirect: (context, state) => _authRedirect(ref, state),
     routes: [
       GoRoute(
         path: _routeSplash,
@@ -178,43 +222,7 @@ final routerProvider = Provider<GoRouter>((ref) {
           child: JoinGroupScreen(groupId: state.pathParameters['groupId']!),
         ),
       ),
-      GoRoute(
-        path: '/profile/:userId',
-        pageBuilder: (context, state) => _fadePage(
-          key: state.pageKey,
-          child: buildProfilePage(state.pathParameters['userId']!),
-        ),
-      ),
-      GoRoute(
-        path: '/u/:userId',
-        pageBuilder: (context, state) => _fadePage(
-          key: state.pageKey,
-          child: buildProfilePage(state.pathParameters['userId']!),
-        ),
-      ),
-      GoRoute(
-        path: '/user/:userId',
-        pageBuilder: (context, state) => _fadePage(
-          key: state.pageKey,
-          child: buildProfilePage(state.pathParameters['userId']!),
-        ),
-      ),
-      GoRoute(
-        path: '/profile',
-        redirect: (context, state) {
-          final qp = state.uri.queryParameters;
-          final userId = qp['userId'] ?? qp['uid'] ?? qp['id'] ?? '';
-          if (userId.isEmpty) return _routeHome;
-          return '/profile/$userId';
-        },
-      ),
-      GoRoute(
-        path: '/echo-user/:userId',
-        pageBuilder: (context, state) => _fadePage(
-          key: state.pageKey,
-          child: buildProfilePage(state.pathParameters['userId']!),
-        ),
-      ),
+      ..._profileRoutes(),
     ],
   );
 });

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -937,65 +937,68 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     );
   }
 
+  /// Build the narrow chat panel with voice banner and edge-swipe support.
+  Widget _buildNarrowChatPanel(LiveKitVoiceState voiceRtc, bool voiceActive) {
+    // Show voice lounge when voice is active and user hasn't dismissed it
+    if (voiceActive && _showingLounge) {
+      return Scaffold(
+        body: SafeArea(
+          child: VoiceLoungeScreen(
+            onBackToChat: () => setState(() => _showingLounge = false),
+          ),
+        ),
+      );
+    }
+
+    Widget chatContent = ChatPanel(
+      conversation: _selectedConversation,
+      onGroupInfo: _showGroupInfo,
+      onBack: () => setState(() => _narrowPanelIndex = 0),
+    );
+
+    if (voiceActive && !_showingLounge) {
+      chatContent = Column(
+        children: [
+          _buildVoiceRejoinBanner(voiceRtc),
+          Expanded(child: chatContent),
+        ],
+      );
+    }
+
+    return Scaffold(
+      body: SafeArea(
+        child: PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, _) {
+            if (!didPop) setState(() => _narrowPanelIndex = 0);
+          },
+          child: GestureDetector(
+            onHorizontalDragStart: (startDetails) {
+              _swipeStartX = startDetails.globalPosition.dx;
+            },
+            onHorizontalDragUpdate: (details) {
+              if (_swipeStartX != null &&
+                  _swipeStartX! < _edgeSwipeZone &&
+                  details.globalPosition.dx - _swipeStartX! >
+                      _edgeSwipeThreshold) {
+                _swipeStartX = null;
+                setState(() => _narrowPanelIndex = 0);
+              }
+            },
+            onHorizontalDragEnd: (_) {},
+            child: chatContent,
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildNarrowLayout() {
     final voiceRtc = ref.watch(voiceRtcProvider);
     final voiceActive = voiceRtc.isActive && voiceRtc.channelId != null;
 
     if (_narrowPanelIndex == 1 && _selectedConversation != null) {
-      // Show voice lounge when voice is active and user hasn't dismissed it
-      if (voiceActive && _showingLounge) {
-        return Scaffold(
-          body: SafeArea(
-            child: VoiceLoungeScreen(
-              onBackToChat: () => setState(() => _showingLounge = false),
-            ),
-          ),
-        );
-      }
-
-      Widget chatContent = ChatPanel(
-        conversation: _selectedConversation,
-        onGroupInfo: _showGroupInfo,
-        onBack: () => setState(() => _narrowPanelIndex = 0),
-      );
-
-      // Persistent rejoin banner when voice is active but lounge was dismissed
-      if (voiceActive && !_showingLounge) {
-        chatContent = Column(
-          children: [
-            _buildVoiceRejoinBanner(voiceRtc),
-            Expanded(child: chatContent),
-          ],
-        );
-      }
-
-      return Scaffold(
-        body: SafeArea(
-          child: PopScope(
-            canPop: false,
-            onPopInvokedWithResult: (didPop, _) {
-              if (!didPop) setState(() => _narrowPanelIndex = 0);
-            },
-            child: GestureDetector(
-              onHorizontalDragStart: (startDetails) {
-                _swipeStartX = startDetails.globalPosition.dx;
-              },
-              onHorizontalDragUpdate: (details) {
-                // Edge swipe: zone expanded to 60 px, threshold lowered to 60 px
-                if (_swipeStartX != null &&
-                    _swipeStartX! < _edgeSwipeZone &&
-                    details.globalPosition.dx - _swipeStartX! >
-                        _edgeSwipeThreshold) {
-                  _swipeStartX = null;
-                  setState(() => _narrowPanelIndex = 0);
-                }
-              },
-              onHorizontalDragEnd: (_) {},
-              child: chatContent,
-            ),
-          ),
-        ),
-      );
+      return _buildNarrowChatPanel(voiceRtc, voiceActive);
     }
 
     return Scaffold(
@@ -1057,21 +1060,28 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   double? _swipeStartX;
 
+  /// Whether the update banner should be hidden for the given state.
+  bool _shouldHideUpdateBanner(UpdateState update) {
+    const activeStatuses = {
+      UpdateStatus.downloading,
+      UpdateStatus.readyToInstall,
+      UpdateStatus.installing,
+    };
+    if (!update.updateAvailable &&
+        !activeStatuses.contains(update.status) &&
+        update.status != UpdateStatus.error) {
+      return true;
+    }
+    if (update.dismissed && !activeStatuses.contains(update.status)) {
+      return true;
+    }
+    return false;
+  }
+
   Widget _buildUpdateBanner() {
     final update = ref.watch(updateProvider);
 
-    // Nothing to show
-    if (!update.updateAvailable &&
-        update.status != UpdateStatus.downloading &&
-        update.status != UpdateStatus.readyToInstall &&
-        update.status != UpdateStatus.installing &&
-        update.status != UpdateStatus.error) {
-      return const SizedBox.shrink();
-    }
-    if (update.dismissed &&
-        update.status != UpdateStatus.downloading &&
-        update.status != UpdateStatus.readyToInstall &&
-        update.status != UpdateStatus.installing) {
+    if (_shouldHideUpdateBanner(update)) {
       return const SizedBox.shrink();
     }
 

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -270,6 +270,31 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     return '?';
   }
 
+  /// Send the avatar upload request, retrying once on 401.
+  Future<bool> _sendAvatarWithRetry(String serverUrl, PlatformFile file) async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final token = ref.read(authProvider).token;
+      if (token == null) return false;
+
+      final request = _buildAvatarRequest(serverUrl, token, file);
+      final streamedResponse = await request.send();
+      final body = await streamedResponse.stream.bytesToString();
+      if (!mounted) return false;
+
+      if (streamedResponse.statusCode == 401 && attempt == 0) {
+        final refreshed = await ref
+            .read(authProvider.notifier)
+            .refreshAccessToken();
+        if (!refreshed) return false;
+        continue;
+      }
+
+      _handleAvatarResponse(streamedResponse.statusCode, body);
+      return true;
+    }
+    return false;
+  }
+
   Future<void> _uploadAvatar() async {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.image,
@@ -283,27 +308,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     final serverUrl = ref.read(serverUrlProvider);
 
     try {
-      // Retry once on 401 (token expired during upload).
-      for (var attempt = 0; attempt < 2; attempt++) {
-        final token = ref.read(authProvider).token;
-        if (token == null) return;
-
-        final request = _buildAvatarRequest(serverUrl, token, file);
-        final streamedResponse = await request.send();
-        final body = await streamedResponse.stream.bytesToString();
-        if (!mounted) return;
-
-        if (streamedResponse.statusCode == 401 && attempt == 0) {
-          final refreshed = await ref
-              .read(authProvider.notifier)
-              .refreshAccessToken();
-          if (!refreshed) return;
-          continue;
-        }
-
-        _handleAvatarResponse(streamedResponse.statusCode, body);
-        return;
-      }
+      await _sendAvatarWithRetry(serverUrl, file);
     } catch (e) {
       if (mounted) {
         ToastService.show(context, 'Upload error: $e', type: ToastType.error);
@@ -433,6 +438,156 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     );
   }
 
+  Widget _buildProfileCard(AuthState authState, String username) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: context.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: context.border),
+      ),
+      child: Row(
+        children: [
+          Stack(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(3),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(color: context.accent, width: 2),
+                ),
+                child: CircleAvatar(
+                  radius: 34,
+                  backgroundColor: context.accent,
+                  backgroundImage: authState.avatarUrl != null
+                      ? NetworkImage(
+                          '${ref.read(serverUrlProvider)}${authState.avatarUrl}',
+                          headers: {
+                            'Authorization': 'Bearer ${authState.token}',
+                          },
+                        )
+                      : null,
+                  child: authState.avatarUrl == null
+                      ? Text(
+                          _avatarInitial(username),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 28,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        )
+                      : null,
+                ),
+              ),
+              Positioned(
+                bottom: 0,
+                right: 0,
+                child: GestureDetector(
+                  onTap: _uploadAvatar,
+                  child: Container(
+                    width: 26,
+                    height: 26,
+                    decoration: BoxDecoration(
+                      color: context.surface,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: context.border, width: 2),
+                    ),
+                    child: Icon(
+                      Icons.camera_alt,
+                      size: 13,
+                      color: context.textSecondary,
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 2,
+                right: 2,
+                child: Container(
+                  width: 14,
+                  height: 14,
+                  decoration: BoxDecoration(
+                    color: EchoTheme.online,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: context.surface, width: 2),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (_displayNameController.text.isNotEmpty)
+                  Text(
+                    _displayNameController.text,
+                    style: TextStyle(
+                      color: context.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                Row(
+                  children: [
+                    Text(
+                      '@$username',
+                      style: TextStyle(
+                        color: _displayNameController.text.isNotEmpty
+                            ? context.textMuted
+                            : context.textPrimary,
+                        fontSize: _displayNameController.text.isNotEmpty
+                            ? 13
+                            : 18,
+                        fontWeight: _displayNameController.text.isNotEmpty
+                            ? FontWeight.normal
+                            : FontWeight.w700,
+                      ),
+                    ),
+                    if (_pronounsController.text.isNotEmpty) ...[
+                      const SizedBox(width: 6),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: context.surfaceHover,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Text(
+                          _pronounsController.text,
+                          style: TextStyle(
+                            color: context.textMuted,
+                            fontSize: 11,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                if (_statusController.text.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    _statusController.text,
+                    style: TextStyle(
+                      color: context.textSecondary,
+                      fontSize: 13,
+                      fontStyle: FontStyle.italic,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final authState = ref.watch(authProvider);
@@ -441,157 +596,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     return ListView(
       padding: const EdgeInsets.all(24),
       children: [
-        // Profile card
-        Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: context.surface,
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: context.border),
-          ),
-          child: Row(
-            children: [
-              // Avatar with accent ring + edit overlay
-              Stack(
-                children: [
-                  Container(
-                    padding: const EdgeInsets.all(3),
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border: Border.all(color: context.accent, width: 2),
-                    ),
-                    child: CircleAvatar(
-                      radius: 34,
-                      backgroundColor: context.accent,
-                      backgroundImage: authState.avatarUrl != null
-                          ? NetworkImage(
-                              '${ref.read(serverUrlProvider)}${authState.avatarUrl}',
-                              headers: {
-                                'Authorization': 'Bearer ${authState.token}',
-                              },
-                            )
-                          : null,
-                      child: authState.avatarUrl == null
-                          ? Text(
-                              _avatarInitial(username),
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 28,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            )
-                          : null,
-                    ),
-                  ),
-                  Positioned(
-                    bottom: 0,
-                    right: 0,
-                    child: GestureDetector(
-                      onTap: _uploadAvatar,
-                      child: Container(
-                        width: 26,
-                        height: 26,
-                        decoration: BoxDecoration(
-                          color: context.surface,
-                          shape: BoxShape.circle,
-                          border: Border.all(color: context.border, width: 2),
-                        ),
-                        child: Icon(
-                          Icons.camera_alt,
-                          size: 13,
-                          color: context.textSecondary,
-                        ),
-                      ),
-                    ),
-                  ),
-                  // Online indicator
-                  Positioned(
-                    top: 2,
-                    right: 2,
-                    child: Container(
-                      width: 14,
-                      height: 14,
-                      decoration: BoxDecoration(
-                        color: EchoTheme.online,
-                        shape: BoxShape.circle,
-                        border: Border.all(color: context.surface, width: 2),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(width: 16),
-              // Name + username + status
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (_displayNameController.text.isNotEmpty)
-                      Text(
-                        _displayNameController.text,
-                        style: TextStyle(
-                          color: context.textPrimary,
-                          fontSize: 18,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    Row(
-                      children: [
-                        Text(
-                          '@$username',
-                          style: TextStyle(
-                            color: _displayNameController.text.isNotEmpty
-                                ? context.textMuted
-                                : context.textPrimary,
-                            fontSize: _displayNameController.text.isNotEmpty
-                                ? 13
-                                : 18,
-                            fontWeight: _displayNameController.text.isNotEmpty
-                                ? FontWeight.normal
-                                : FontWeight.w700,
-                          ),
-                        ),
-                        if (_pronounsController.text.isNotEmpty) ...[
-                          const SizedBox(width: 6),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 6,
-                              vertical: 2,
-                            ),
-                            decoration: BoxDecoration(
-                              color: context.surfaceHover,
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            child: Text(
-                              _pronounsController.text,
-                              style: TextStyle(
-                                color: context.textMuted,
-                                fontSize: 11,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                    if (_statusController.text.isNotEmpty) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        _statusController.text,
-                        style: TextStyle(
-                          color: context.textSecondary,
-                          fontSize: 13,
-                          fontStyle: FontStyle.italic,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
+        _buildProfileCard(authState, username),
         const SizedBox(height: 16),
         // Action buttons row
         Row(

--- a/apps/client/lib/src/screens/settings/audio_section.dart
+++ b/apps/client/lib/src/screens/settings/audio_section.dart
@@ -257,6 +257,32 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
     return EchoTheme.online;
   }
 
+  /// Reusable device picker dropdown.
+  Widget _buildDevicePicker({
+    required String label,
+    required List<Map<String, String>> devices,
+    required String currentId,
+    required ValueChanged<String> onChanged,
+  }) {
+    return DropdownButtonFormField<String>(
+      initialValue: devices.any((d) => d['id'] == currentId)
+          ? currentId
+          : 'default',
+      decoration: InputDecoration(labelText: label),
+      items: devices
+          .map(
+            (device) => DropdownMenuItem(
+              value: device['id'],
+              child: Text(device['name']!),
+            ),
+          )
+          .toList(),
+      onChanged: (value) {
+        if (value != null) onChanged(value);
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final voice = ref.watch(voiceSettingsProvider);
@@ -290,60 +316,25 @@ class _AudioSectionState extends ConsumerState<AudioSection> {
           ),
         ),
         const SizedBox(height: 18),
-        DropdownButtonFormField<String>(
-          initialValue: inputDevices.any((d) => d['id'] == voice.inputDeviceId)
-              ? voice.inputDeviceId
-              : 'default',
-          decoration: const InputDecoration(labelText: 'Input Device'),
-          items: inputDevices
-              .map(
-                (device) => DropdownMenuItem(
-                  value: device['id'],
-                  child: Text(device['name']!),
-                ),
-              )
-              .toList(),
-          onChanged: (value) {
-            if (value != null) notifier.setInputDevice(value);
-          },
+        _buildDevicePicker(
+          label: 'Input Device',
+          devices: inputDevices,
+          currentId: voice.inputDeviceId,
+          onChanged: notifier.setInputDevice,
         ),
         const SizedBox(height: 12),
-        DropdownButtonFormField<String>(
-          initialValue:
-              outputDevices.any((d) => d['id'] == voice.outputDeviceId)
-              ? voice.outputDeviceId
-              : 'default',
-          decoration: const InputDecoration(labelText: 'Output Device'),
-          items: outputDevices
-              .map(
-                (device) => DropdownMenuItem(
-                  value: device['id'],
-                  child: Text(device['name']!),
-                ),
-              )
-              .toList(),
-          onChanged: (value) {
-            if (value != null) notifier.setOutputDevice(value);
-          },
+        _buildDevicePicker(
+          label: 'Output Device',
+          devices: outputDevices,
+          currentId: voice.outputDeviceId,
+          onChanged: notifier.setOutputDevice,
         ),
         const SizedBox(height: 12),
-        DropdownButtonFormField<String>(
-          initialValue:
-              cameraDevices.any((d) => d['id'] == voice.cameraDeviceId)
-              ? voice.cameraDeviceId
-              : 'default',
-          decoration: const InputDecoration(labelText: 'Camera'),
-          items: cameraDevices
-              .map(
-                (device) => DropdownMenuItem(
-                  value: device['id'],
-                  child: Text(device['name']!),
-                ),
-              )
-              .toList(),
-          onChanged: (value) {
-            if (value != null) notifier.setCameraDevice(value);
-          },
+        _buildDevicePicker(
+          label: 'Camera',
+          devices: cameraDevices,
+          currentId: voice.cameraDeviceId,
+          onChanged: notifier.setCameraDevice,
         ),
         const SizedBox(height: 16),
         Text(

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -54,50 +54,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
   Future<void> _init() async {
     final stopwatch = Stopwatch()..start();
 
-    // Try auto-login from stored credentials with a timeout so the splash
-    // never hangs on a slow or unreachable network.
-    final auth = ref.read(authProvider.notifier);
-    var loggedIn = false;
-    try {
-      loggedIn = await auth.tryAutoLogin().timeout(
-        const Duration(seconds: 5),
-        onTimeout: () => false,
-      );
-    } catch (_) {
-      // Network error — treat as not logged in, user can retry from login.
-    }
-
-    // If auto-login succeeded, init crypto keys + register push token
-    if (loggedIn) {
-      await ref.read(cryptoProvider.notifier).initAndUploadKeys();
-
-      // Register iOS APNs push token (no-op on other platforms)
-      final authState = ref.read(authProvider);
-      PushTokenService.instance.init(
-        serverUrl: ref.read(serverUrlProvider),
-        authToken: authState.token ?? '',
-        onWake: () => ref.read(websocketProvider.notifier).connect(),
-      );
-    }
-
-    // Support compile-time env vars for CI/testing
-    if (!loggedIn && !kIsWeb) {
-      const envUser = String.fromEnvironment('ECHO_USERNAME');
-      const envPass = String.fromEnvironment('ECHO_PASSWORD');
-      if (envUser.isNotEmpty && envPass.isNotEmpty) {
-        await auth.login(envUser, envPass);
-        if (ref.read(authProvider).isLoggedIn) {
-          await ref.read(cryptoProvider.notifier).initAndUploadKeys();
-          loggedIn = true;
-        }
-      }
-    }
-
-    // Check for updates on non-web platforms
-    if (!kIsWeb) {
-      // Fire-and-forget -- don't block splash on network call
-      ref.read(updateProvider.notifier).check();
-    }
+    final loggedIn = await _attemptAutoLogin();
 
     // Brief splash to let the logo animation complete (reduced from 500ms)
     stopwatch.stop();
@@ -107,43 +64,109 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     }
 
     if (!mounted) return;
+    _navigateAfterInit(loggedIn);
+  }
 
+  /// Try auto-login from stored credentials (with timeout), then attempt
+  /// CI env var login as fallback. Triggers crypto init and push token
+  /// registration on success. Returns whether the user is logged in.
+  Future<bool> _attemptAutoLogin() async {
+    final auth = ref.read(authProvider.notifier);
+    var loggedIn = false;
+    try {
+      loggedIn = await auth.tryAutoLogin().timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => false,
+      );
+    } catch (_) {
+      // Network error -- treat as not logged in.
+    }
+
+    if (loggedIn) {
+      await _initCryptoAndPush();
+    }
+
+    // Support compile-time env vars for CI/testing
+    if (!loggedIn && !kIsWeb) {
+      loggedIn = await _attemptEnvLogin(auth);
+    }
+
+    // Check for updates on non-web platforms
+    if (!kIsWeb) {
+      ref.read(updateProvider.notifier).check();
+    }
+
+    return loggedIn;
+  }
+
+  /// Initialize crypto keys and register push token after login.
+  Future<void> _initCryptoAndPush() async {
+    await ref.read(cryptoProvider.notifier).initAndUploadKeys();
+
+    final authState = ref.read(authProvider);
+    PushTokenService.instance.init(
+      serverUrl: ref.read(serverUrlProvider),
+      authToken: authState.token ?? '',
+      onWake: () => ref.read(websocketProvider.notifier).connect(),
+    );
+  }
+
+  /// Attempt login using compile-time environment variables (CI/testing).
+  Future<bool> _attemptEnvLogin(AuthNotifier auth) async {
+    const envUser = String.fromEnvironment('ECHO_USERNAME');
+    const envPass = String.fromEnvironment('ECHO_PASSWORD');
+    if (envUser.isEmpty || envPass.isEmpty) return false;
+
+    await auth.login(envUser, envPass);
+    if (ref.read(authProvider).isLoggedIn) {
+      await ref.read(cryptoProvider.notifier).initAndUploadKeys();
+      return true;
+    }
+    return false;
+  }
+
+  /// Navigate to the appropriate screen after init completes.
+  void _navigateAfterInit(bool loggedIn) {
     final isLoggedIn = ref.read(authProvider).isLoggedIn;
+
     if (isLoggedIn && pendingDeepLink != null) {
       final destination = pendingDeepLink!;
       pendingDeepLink = null;
       context.go(destination);
-    } else if (isLoggedIn) {
-      // Auto-login from stored token means this is a returning user.
-      // Ensure onboarding flag is set so they always skip the wizard.
-      // New registrations navigate to /onboarding from RegisterScreen.
-      final prefs = await SharedPreferences.getInstance();
-      if (prefs.getBool(kOnboardingCompletedKey) != true) {
-        await prefs.setBool(kOnboardingCompletedKey, true);
-      }
-      if (!mounted) return;
-      context.go('/home');
+      return;
+    }
 
-      // Show one-time notice if encryption keys were regenerated (new device
-      // or secure storage cleared). This means old encrypted messages from
-      // other devices may not be decryptable.
-      final cryptoState = ref.read(cryptoProvider);
-      if (cryptoState.keysWereRegenerated && mounted) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text(
-                'New encryption keys generated. Messages from before '
-                'this login may not be decryptable on this device.',
-              ),
-              duration: Duration(seconds: 6),
+    if (isLoggedIn) {
+      _navigateHome();
+      return;
+    }
+
+    context.go('/login');
+  }
+
+  /// Navigate home, setting onboarding flag and showing crypto notice.
+  Future<void> _navigateHome() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(kOnboardingCompletedKey) != true) {
+      await prefs.setBool(kOnboardingCompletedKey, true);
+    }
+    if (!mounted) return;
+    context.go('/home');
+
+    final cryptoState = ref.read(cryptoProvider);
+    if (cryptoState.keysWereRegenerated && mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'New encryption keys generated. Messages from before '
+              'this login may not be decryptable on this device.',
             ),
-          );
-        });
-      }
-    } else {
-      context.go('/login');
+            duration: Duration(seconds: 6),
+          ),
+        );
+      });
     }
   }
 

--- a/apps/client/lib/src/screens/user_profile_screen.dart
+++ b/apps/client/lib/src/screens/user_profile_screen.dart
@@ -320,195 +320,225 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
       child: Column(
         children: [
-          // Large avatar
           buildAvatar(name: _username, radius: 40, imageUrl: fullAvatarUrl),
           const SizedBox(height: 16),
-          // Display name
-          if (_displayName != null && _displayName!.isNotEmpty)
-            Text(
-              _displayName!,
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 22,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          // Username + pronouns
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                '@$_username',
-                style: TextStyle(
-                  color: _displayName != null
-                      ? context.textMuted
-                      : context.textPrimary,
-                  fontSize: _displayName != null ? 14 : 22,
-                  fontWeight: _displayName != null
-                      ? FontWeight.normal
-                      : FontWeight.bold,
-                ),
-              ),
-              if (_pronouns != null && _pronouns!.isNotEmpty) ...[
-                const SizedBox(width: 8),
-                Text(
-                  _pronouns!,
-                  style: TextStyle(
-                    color: context.textMuted,
-                    fontSize: 13,
-                    fontStyle: FontStyle.italic,
-                  ),
-                ),
-              ],
-            ],
-          ),
-          // Status message
-          if (_statusMessage != null && _statusMessage!.isNotEmpty) ...[
-            const SizedBox(height: 6),
-            Text(
-              _statusMessage!,
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                fontStyle: FontStyle.italic,
-              ),
-            ),
-          ],
+          _buildNameSection(),
+          _buildStatusSection(),
           const SizedBox(height: 12),
-          // Bio
-          if (_bio != null && _bio!.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Text(
-                _bio!,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: context.textSecondary,
-                  fontSize: 14,
-                  height: 1.4,
-                ),
-              ),
-            ),
-          if (_bio != null && _bio!.isNotEmpty) const SizedBox(height: 12),
-          // Website
-          if (_website != null && _website!.isNotEmpty) ...[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.link, size: 14, color: context.accent),
-                const SizedBox(width: 4),
-                Text(
-                  _website!,
-                  style: TextStyle(
-                    color: context.accent,
-                    fontSize: 13,
-                    decoration: TextDecoration.underline,
-                    decorationColor: context.accent,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-          ],
-          // Email
-          if (_email != null && _email!.isNotEmpty) ...[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.email_outlined, size: 14, color: context.textMuted),
-                const SizedBox(width: 4),
-                Text(
-                  _email!,
-                  style: TextStyle(color: context.textMuted, fontSize: 13),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-          ],
-          // Phone
-          if (_phone != null && _phone!.isNotEmpty) ...[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.phone_outlined, size: 14, color: context.textMuted),
-                const SizedBox(width: 4),
-                Text(
-                  _phone!,
-                  style: TextStyle(color: context.textMuted, fontSize: 13),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-          ],
-          // Timezone with local time
-          if (_timezone != null && _timezone!.isNotEmpty) ...[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.schedule, size: 14, color: context.textMuted),
-                const SizedBox(width: 4),
-                Text(
-                  'Local time: ${_formatLocalTime(_timezone!)} ($_timezone)',
-                  style: TextStyle(color: context.textMuted, fontSize: 13),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-          ],
-          // Member since
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                Icons.calendar_today_outlined,
-                size: 14,
-                color: context.textMuted,
-              ),
-              const SizedBox(width: 6),
-              Text(
-                'Member since ${_formatMemberSince(_createdAt)}',
-                style: TextStyle(color: context.textMuted, fontSize: 13),
-              ),
-            ],
-          ),
+          _buildBioSection(),
+          ..._buildContactDetailRows(),
+          _buildMemberSinceRow(),
           const SizedBox(height: 28),
-          // Action buttons
-          if (!_isContact && widget.userId != ref.read(authProvider).userId)
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.icon(
-                onPressed: _addContact,
-                icon: const Icon(Icons.person_add_outlined, size: 18),
-                label: const Text('Add Contact'),
-                style: FilledButton.styleFrom(
-                  backgroundColor: context.accent,
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                ),
-              ),
-            ),
-          if (_isContact)
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.icon(
-                onPressed: null,
-                icon: const Icon(Icons.check, size: 18),
-                label: const Text('Contact'),
-                style: FilledButton.styleFrom(
-                  backgroundColor: EchoTheme.online,
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                ),
-              ),
-            ),
+          _buildActionButton(),
         ],
       ),
     );
+  }
+
+  /// Display name + username + pronouns header section.
+  Widget _buildNameSection() {
+    return Column(
+      children: [
+        if (_displayName != null && _displayName!.isNotEmpty)
+          Text(
+            _displayName!,
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '@$_username',
+              style: TextStyle(
+                color: _displayName != null
+                    ? context.textMuted
+                    : context.textPrimary,
+                fontSize: _displayName != null ? 14 : 22,
+                fontWeight: _displayName != null
+                    ? FontWeight.normal
+                    : FontWeight.bold,
+              ),
+            ),
+            if (_pronouns != null && _pronouns!.isNotEmpty) ...[
+              const SizedBox(width: 8),
+              Text(
+                _pronouns!,
+                style: TextStyle(
+                  color: context.textMuted,
+                  fontSize: 13,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// Status message line (if set).
+  Widget _buildStatusSection() {
+    if (_statusMessage == null || _statusMessage!.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Text(
+        _statusMessage!,
+        style: TextStyle(
+          color: context.textSecondary,
+          fontSize: 13,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+    );
+  }
+
+  /// Bio paragraph (if set).
+  Widget _buildBioSection() {
+    if (_bio == null || _bio!.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Text(
+          _bio!,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 14,
+            height: 1.4,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Build icon+label rows for website, email, phone, and timezone.
+  List<Widget> _buildContactDetailRows() {
+    return [
+      if (_website != null && _website!.isNotEmpty) ...[
+        _iconRow(
+          icon: Icons.link,
+          iconColor: context.accent,
+          text: _website!,
+          textColor: context.accent,
+          underline: true,
+        ),
+        const SizedBox(height: 8),
+      ],
+      if (_email != null && _email!.isNotEmpty) ...[
+        _iconRow(
+          icon: Icons.email_outlined,
+          iconColor: context.textMuted,
+          text: _email!,
+          textColor: context.textMuted,
+        ),
+        const SizedBox(height: 8),
+      ],
+      if (_phone != null && _phone!.isNotEmpty) ...[
+        _iconRow(
+          icon: Icons.phone_outlined,
+          iconColor: context.textMuted,
+          text: _phone!,
+          textColor: context.textMuted,
+        ),
+        const SizedBox(height: 8),
+      ],
+      if (_timezone != null && _timezone!.isNotEmpty) ...[
+        _iconRow(
+          icon: Icons.schedule,
+          iconColor: context.textMuted,
+          text: 'Local time: ${_formatLocalTime(_timezone!)} ($_timezone)',
+          textColor: context.textMuted,
+        ),
+        const SizedBox(height: 8),
+      ],
+    ];
+  }
+
+  Widget _iconRow({
+    required IconData icon,
+    required Color iconColor,
+    required String text,
+    required Color textColor,
+    bool underline = false,
+  }) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14, color: iconColor),
+        const SizedBox(width: 4),
+        Text(
+          text,
+          style: TextStyle(
+            color: textColor,
+            fontSize: 13,
+            decoration: underline ? TextDecoration.underline : null,
+            decorationColor: underline ? textColor : null,
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// "Member since" row.
+  Widget _buildMemberSinceRow() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(Icons.calendar_today_outlined, size: 14, color: context.textMuted),
+        const SizedBox(width: 6),
+        Text(
+          'Member since ${_formatMemberSince(_createdAt)}',
+          style: TextStyle(color: context.textMuted, fontSize: 13),
+        ),
+      ],
+    );
+  }
+
+  /// Add contact / already contact action button.
+  Widget _buildActionButton() {
+    if (!_isContact && widget.userId != ref.read(authProvider).userId) {
+      return SizedBox(
+        width: double.infinity,
+        child: FilledButton.icon(
+          onPressed: _addContact,
+          icon: const Icon(Icons.person_add_outlined, size: 18),
+          label: const Text('Add Contact'),
+          style: FilledButton.styleFrom(
+            backgroundColor: context.accent,
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+            padding: const EdgeInsets.symmetric(vertical: 12),
+          ),
+        ),
+      );
+    }
+    if (_isContact) {
+      return SizedBox(
+        width: double.infinity,
+        child: FilledButton.icon(
+          onPressed: null,
+          icon: const Icon(Icons.check, size: 18),
+          label: const Text('Contact'),
+          style: FilledButton.styleFrom(
+            backgroundColor: EchoTheme.online,
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+            padding: const EdgeInsets.symmetric(vertical: 12),
+          ),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
   }
 }

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -1078,10 +1078,7 @@ class _RemoteScreenShares extends StatelessWidget {
             Positioned(
               top: 8,
               left: 12,
-              child: _buildScreenShareBadge(
-                context,
-                screenShareName,
-              ),
+              child: _buildScreenShareBadge(context, screenShareName),
             ),
           ],
         ),

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -81,6 +81,23 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     return false;
   }
 
+  /// Find a remote participant by SID and return their first track matching
+  /// [source], or null.
+  static lk.VideoTrack? _findRemoteTrack(
+    lk.Room room,
+    String sid,
+    lk.TrackSource source,
+  ) {
+    final participant = room.remoteParticipants.values
+        .where((p) => p.sid.toString() == sid)
+        .firstOrNull;
+    if (participant == null) return null;
+    final pub = participant.videoTrackPublications
+        .where((p) => p.track != null && p.source == source)
+        .firstOrNull;
+    return pub?.track as lk.VideoTrack?;
+  }
+
   /// Resolve a tile key to the matching [VideoTrack] and a mirror flag.
   ///
   /// Keys: 'local', 'remote-{sid}', 'screenshare-local', 'screenshare-{sid}'.
@@ -108,28 +125,14 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     }
     if (tileKey.startsWith('screenshare-')) {
       final sid = tileKey.substring('screenshare-'.length);
-      final participant = room.remoteParticipants.values
-          .where((p) => p.sid.toString() == sid)
-          .firstOrNull;
-      if (participant == null) return (null, false);
-      final pub = participant.videoTrackPublications
-          .where(
-            (p) =>
-                p.track != null && p.source == lk.TrackSource.screenShareVideo,
-          )
-          .firstOrNull;
-      return (pub?.track as lk.VideoTrack?, false);
+      return (
+        _findRemoteTrack(room, sid, lk.TrackSource.screenShareVideo),
+        false,
+      );
     }
     if (tileKey.startsWith('remote-')) {
       final sid = tileKey.substring('remote-'.length);
-      final participant = room.remoteParticipants.values
-          .where((p) => p.sid.toString() == sid)
-          .firstOrNull;
-      if (participant == null) return (null, false);
-      final pub = participant.videoTrackPublications
-          .where((p) => p.track != null && p.source == lk.TrackSource.camera)
-          .firstOrNull;
-      return (pub?.track as lk.VideoTrack?, false);
+      return (_findRemoteTrack(room, sid, lk.TrackSource.camera), false);
     }
     return (null, false);
   }
@@ -752,64 +755,56 @@ class _ParticipantTile extends StatelessWidget {
                 avatarUrl: avatarUrl,
                 isSpeaking: isSpeaking,
               ),
-            // Name label overlay at bottom
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 10,
-                  vertical: 6,
+            _buildNameLabel(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNameLabel(BuildContext context) {
+    return Positioned(
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [Colors.transparent, Colors.black.withValues(alpha: 0.7)],
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                name,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
                 ),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      Colors.transparent,
-                      Colors.black.withValues(alpha: 0.7),
-                    ],
-                  ),
-                ),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        name,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    if (isMuted)
-                      const Padding(
-                        padding: EdgeInsets.only(left: 4),
-                        child: Icon(
-                          Icons.mic_off,
-                          size: 14,
-                          color: EchoTheme.danger,
-                        ),
-                      ),
-                    if (connectionState != null &&
-                        connectionState != 'connected')
-                      Padding(
-                        padding: const EdgeInsets.only(left: 4),
-                        child: Icon(
-                          Icons.signal_cellular_alt,
-                          size: 14,
-                          color: connectionState == 'reconnecting'
-                              ? EchoTheme.warning
-                              : context.textMuted,
-                        ),
-                      ),
-                  ],
-                ),
+                overflow: TextOverflow.ellipsis,
               ),
             ),
+            if (isMuted)
+              const Padding(
+                padding: EdgeInsets.only(left: 4),
+                child: Icon(Icons.mic_off, size: 14, color: EchoTheme.danger),
+              ),
+            if (connectionState != null && connectionState != 'connected')
+              Padding(
+                padding: const EdgeInsets.only(left: 4),
+                child: Icon(
+                  Icons.signal_cellular_alt,
+                  size: 14,
+                  color: connectionState == 'reconnecting'
+                      ? EchoTheme.warning
+                      : context.textMuted,
+                ),
+              ),
           ],
         ),
       ),
@@ -1049,6 +1044,81 @@ class _RemoteScreenShares extends StatelessWidget {
     this.onTileTap,
   });
 
+  /// Build a single screen share tile for a participant.
+  Widget _buildScreenShareTile(
+    BuildContext context,
+    lk.RemoteParticipant participant,
+    lk.VideoTrack track,
+  ) {
+    final screenShareName = _participantDisplayName(participant);
+    final sid = participant.sid.toString();
+    return GestureDetector(
+      onTap: onTileTap != null ? () => onTileTap!(sid) : null,
+      child: Container(
+        width: double.infinity,
+        constraints: spotlight ? null : const BoxConstraints(maxHeight: 400),
+        margin: const EdgeInsets.only(bottom: 16),
+        decoration: BoxDecoration(
+          color: Colors.black,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: context.border),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Stack(
+          children: [
+            Center(
+              child: AspectRatio(
+                aspectRatio: 16 / 9,
+                child: lk.VideoTrackRenderer(
+                  track,
+                  fit: RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
+                ),
+              ),
+            ),
+            Positioned(
+              top: 8,
+              left: 12,
+              child: _buildScreenShareBadge(
+                context,
+                screenShareName,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Badge overlay for screen share tile (name + icon).
+  Widget _buildScreenShareBadge(BuildContext context, String name) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: context.accent.withValues(alpha: 0.85),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.screen_share, size: 14, color: Colors.white),
+          const SizedBox(width: 6),
+          Text(
+            '$name\'s screen',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (onTileTap != null) ...[
+            const SizedBox(width: 6),
+            const Icon(Icons.touch_app, size: 12, color: Colors.white54),
+          ],
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final tiles = <Widget>[];
@@ -1058,79 +1128,11 @@ class _RemoteScreenShares extends StatelessWidget {
         if (pub.track != null &&
             pub.track is lk.VideoTrack &&
             pub.source == lk.TrackSource.screenShareVideo) {
-          final screenShareName = _participantDisplayName(participant);
-          final sid = participant.sid.toString();
           tiles.add(
-            GestureDetector(
-              onTap: onTileTap != null ? () => onTileTap!(sid) : null,
-              child: Container(
-                width: double.infinity,
-                constraints: spotlight
-                    ? null
-                    : const BoxConstraints(maxHeight: 400),
-                margin: const EdgeInsets.only(bottom: 16),
-                decoration: BoxDecoration(
-                  color: Colors.black,
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: context.border),
-                ),
-                clipBehavior: Clip.antiAlias,
-                child: Stack(
-                  children: [
-                    Center(
-                      child: AspectRatio(
-                        aspectRatio: 16 / 9,
-                        child: lk.VideoTrackRenderer(
-                          pub.track! as lk.VideoTrack,
-                          fit: RTCVideoViewObjectFit
-                              .RTCVideoViewObjectFitContain,
-                        ),
-                      ),
-                    ),
-                    Positioned(
-                      top: 8,
-                      left: 12,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 4,
-                        ),
-                        decoration: BoxDecoration(
-                          color: context.accent.withValues(alpha: 0.85),
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(
-                              Icons.screen_share,
-                              size: 14,
-                              color: Colors.white,
-                            ),
-                            const SizedBox(width: 6),
-                            Text(
-                              '$screenShareName\'s screen',
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 11,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            if (onTileTap != null) ...[
-                              const SizedBox(width: 6),
-                              const Icon(
-                                Icons.touch_app,
-                                size: 12,
-                                color: Colors.white54,
-                              ),
-                            ],
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
+            _buildScreenShareTile(
+              context,
+              participant,
+              pub.track! as lk.VideoTrack,
             ),
           );
         }

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -177,6 +177,64 @@ class CryptoService {
     }
   }
 
+  /// Restore identity, signing, and signed prekey from secure storage.
+  Future<void> _restoreKeysFromStorage(
+    SecureKeyStore store,
+    String storedPrivate,
+  ) async {
+    final privateBytes = base64Decode(storedPrivate);
+    final publicBytes = base64Decode((await store.read(_identityPubKeyPref))!);
+    _identityKeyPair = SimpleKeyPairData(
+      privateBytes,
+      publicKey: SimplePublicKey(publicBytes, type: KeyPairType.x25519),
+      type: KeyPairType.x25519,
+    );
+
+    // Restore Ed25519 signing key pair
+    final sigPriv = await store.read(_signingKeyPref);
+    final sigPub = await store.read(_signingPubKeyPref);
+    if (sigPriv != null && sigPub != null) {
+      _signingKeyPair = SimpleKeyPairData(
+        base64Decode(sigPriv),
+        publicKey: SimplePublicKey(
+          base64Decode(sigPub),
+          type: KeyPairType.ed25519,
+        ),
+        type: KeyPairType.ed25519,
+      );
+    } else {
+      _signingKeyPair = await _ed25519.newKeyPair();
+      await _saveSigningKey(store);
+      _keysAreFresh = true;
+    }
+
+    // Restore signed prekey pair
+    final spkPriv = await store.read(_signedPrekeyPref);
+    final spkPub = await store.read(_signedPrekeyPubPref);
+    if (spkPriv != null && spkPub != null) {
+      _signedPrekeyPair = SimpleKeyPairData(
+        base64Decode(spkPriv),
+        publicKey: SimplePublicKey(
+          base64Decode(spkPub),
+          type: KeyPairType.x25519,
+        ),
+        type: KeyPairType.x25519,
+      );
+    } else {
+      _signedPrekeyPair = await _x25519.newKeyPair();
+      await _saveSignedPrekey(store);
+      _keysAreFresh = true;
+    }
+
+    // Always mark identity bundle for upload so the server has the
+    // current bundle.
+    _keysAreFresh = true;
+    _needsOtpReplenishment = false;
+
+    await _loadSessions(store);
+    await _rotateSignedPrekeyIfNeeded(store);
+  }
+
   /// Initialize: load or generate identity key pair, signing key, and signed prekey.
   Future<void> init() async {
     try {
@@ -201,71 +259,7 @@ class CryptoService {
       final storedPrivate = await store.read(_identityKeyPref);
 
       if (storedPrivate != null) {
-        // Restore identity key pair
-        final privateBytes = base64Decode(storedPrivate);
-        final publicBytes = base64Decode(
-          (await store.read(_identityPubKeyPref))!,
-        );
-        _identityKeyPair = SimpleKeyPairData(
-          privateBytes,
-          publicKey: SimplePublicKey(publicBytes, type: KeyPairType.x25519),
-          type: KeyPairType.x25519,
-        );
-
-        // Restore Ed25519 signing key pair
-        final sigPriv = await store.read(_signingKeyPref);
-        final sigPub = await store.read(_signingPubKeyPref);
-        if (sigPriv != null && sigPub != null) {
-          _signingKeyPair = SimpleKeyPairData(
-            base64Decode(sigPriv),
-            publicKey: SimplePublicKey(
-              base64Decode(sigPub),
-              type: KeyPairType.ed25519,
-            ),
-            type: KeyPairType.ed25519,
-          );
-        } else {
-          // Legacy migration: generate signing key if missing
-          _signingKeyPair = await _ed25519.newKeyPair();
-          await _saveSigningKey(store);
-          _keysAreFresh = true;
-        }
-
-        // Restore signed prekey pair
-        final spkPriv = await store.read(_signedPrekeyPref);
-        final spkPub = await store.read(_signedPrekeyPubPref);
-        if (spkPriv != null && spkPub != null) {
-          _signedPrekeyPair = SimpleKeyPairData(
-            base64Decode(spkPriv),
-            publicKey: SimplePublicKey(
-              base64Decode(spkPub),
-              type: KeyPairType.x25519,
-            ),
-            type: KeyPairType.x25519,
-          );
-        } else {
-          // Legacy migration: generate signed prekey if missing
-          _signedPrekeyPair = await _x25519.newKeyPair();
-          await _saveSignedPrekey(store);
-          _keysAreFresh = true;
-        }
-
-        // Always mark identity bundle for upload so the server has the
-        // current bundle.  The upload endpoint is idempotent (UPSERT), so
-        // re-uploading unchanged keys is harmless.  Without this, returning
-        // users who restore keys from secure storage would never upload,
-        // leaving the server without a PreKey bundle (breaking DMs).
-        _keysAreFresh = true;
-        // Do NOT regenerate OTP keys on restore — existing OTP private keys
-        // in SecureKeyStore still match the public keys on the server.
-        // Regenerating would overwrite them and cause key-ID collisions.
-        _needsOtpReplenishment = false;
-
-        // Load persisted sessions
-        await _loadSessions(store);
-
-        // Check if signed prekey needs rotation
-        await _rotateSignedPrekeyIfNeeded(store);
+        await _restoreKeysFromStorage(store, storedPrivate);
       } else {
         // Generate all keys fresh — previous encryption sessions are lost.
         _keysWereRegenerated = true;
@@ -876,121 +870,154 @@ class CryptoService {
         fullWire[0] == _initialMsgMagicV2[0] &&
         fullWire[1] == _initialMsgMagicV2[1];
     if (isV1 || isV2) {
-      // Always accept an initial X3DH message — the peer may have reset their
-      // keys.  Drop any stale session so we establish a fresh one.
-      if (_sessions.containsKey(sessionKey)) {
-        debugPrint(
-          '[Crypto] Replacing stale session for $sessionKey '
-          '(received new X3DH initial message)',
-        );
-        _sessions.remove(sessionKey);
-        final store = SecureKeyStore.instance;
-        await store.delete('$_sessionPrefix$sessionKey');
-      }
-      // Also remove legacy key if we're now using device-specific
-      if (fromDeviceId != null && _sessions.containsKey(peerUserId)) {
-        _sessions.remove(peerUserId);
-        final store = SecureKeyStore.instance;
-        await store.delete('$_sessionPrefix$peerUserId');
-      }
-      // This is an initial message -- establish session as Bob
-      final aliceIdentityBytes = fullWire.sublist(2, 34);
-      final aliceIdentityPub = SimplePublicKey(
-        aliceIdentityBytes,
-        type: KeyPairType.x25519,
+      return _decryptInitialMessage(
+        fullWire: fullWire,
+        isV2: isV2,
+        sessionKey: sessionKey,
+        peerUserId: peerUserId,
+        fromDeviceId: fromDeviceId,
       );
-      final aliceEphemeralPub = SimplePublicKey(
-        fullWire.sublist(34, 66),
-        type: KeyPairType.x25519,
-      );
-
-      // V2 includes a 4-byte OTP key ID after the ephemeral key
-      SimpleKeyPair? bobOtp;
-      final Uint8List sessionWire;
-      if (isV2) {
-        final bd = ByteData.sublistView(fullWire);
-        final otpKeyId = bd.getInt32(66, Endian.little);
-        sessionWire = fullWire.sublist(70);
-        // Look up the OTP key pair by key ID
-        bobOtp = await _loadOtpPrivateKey(otpKeyId);
-        if (bobOtp != null) {
-          debugPrint('[Crypto] Using OTP key_id=$otpKeyId for 4-DH');
-        } else {
-          // V2 means Alice used 4-DH with this OTP. If Bob can't find it,
-          // the shared secrets will NOT match (Alice has DH4 entropy, Bob
-          // doesn't). Fail cleanly rather than creating a broken session.
-          throw Exception(
-            'OTP key_id=$otpKeyId not found. '
-            'Ask the sender to resend the message.',
-          );
-        }
-      } else {
-        sessionWire = fullWire.sublist(66);
-      }
-
-      // Cache peer identity key for safety number generation
-      final peerStore = SecureKeyStore.instance;
-      await peerStore.write(
-        '$_peerIdentityPrefix$peerUserId',
-        base64Encode(aliceIdentityBytes),
-      );
-
-      // Compute X3DH as Bob (responder)
-      if (_signedPrekeyPair == null) await init();
-
-      // Try current signed prekey first, then fall back to previous
-      // in case the peer fetched the old bundle before rotation.
-      Uint8List sharedSecret;
-      SimpleKeyPair prekeyToUse;
-      try {
-        sharedSecret = await X3DH.respond(
-          bobIdentity: _identityKeyPair!,
-          bobSignedPrekey: _signedPrekeyPair!,
-          bobOneTimePrekey: bobOtp,
-          aliceIdentityKey: aliceIdentityPub,
-          aliceEphemeralKey: aliceEphemeralPub,
-        );
-        prekeyToUse = _signedPrekeyPair!;
-      } catch (_) {
-        // Try previous signed prekey
-        final prevPrekey = await _loadPreviousSignedPrekey();
-        if (prevPrekey == null) rethrow;
-        sharedSecret = await X3DH.respond(
-          bobIdentity: _identityKeyPair!,
-          bobSignedPrekey: prevPrekey,
-          bobOneTimePrekey: bobOtp,
-          aliceIdentityKey: aliceIdentityPub,
-          aliceEphemeralKey: aliceEphemeralPub,
-        );
-        prekeyToUse = prevPrekey;
-      }
-
-      // Initialize Double Ratchet as Bob
-      final session = await SignalSession.initBob(sharedSecret, prekeyToUse);
-
-      // Decrypt the actual message
-      final plainBytes = await session.decrypt(sessionWire);
-      _sessions[sessionKey] = session;
-      await _saveSession(sessionKey, session);
-
-      // Consume the OTP -- delete after successful use (one-time)
-      if (bobOtp != null && isV2) {
-        final bd2 = ByteData.sublistView(fullWire);
-        final consumedId = bd2.getInt32(66, Endian.little);
-        await _deleteOtpPrivateKey(consumedId);
-      }
-
-      // An OTP was consumed on the server — check if we need to replenish.
-      // Fire-and-forget so decryption isn't blocked by the network call.
-      unawaited(checkAndReplenishOtpKeys());
-
-      return utf8.decode(plainBytes);
     }
 
-    // Normal message — use existing session only.  Do NOT call
-    // getOrCreateSession() here: creating a brand-new X3DH session for a
-    // non-initial message would produce an incompatible session that can't
-    // decrypt the message and would pollute state.
+    return _decryptNormalMessage(fullWire: fullWire, sessionKey: sessionKey);
+  }
+
+  /// Decrypt an initial X3DH message and establish a new session as Bob.
+  Future<String> _decryptInitialMessage({
+    required Uint8List fullWire,
+    required bool isV2,
+    required String sessionKey,
+    required String peerUserId,
+    required int? fromDeviceId,
+  }) async {
+    await _clearStaleSession(sessionKey, peerUserId, fromDeviceId);
+
+    final aliceIdentityBytes = fullWire.sublist(2, 34);
+    final aliceIdentityPub = SimplePublicKey(
+      aliceIdentityBytes,
+      type: KeyPairType.x25519,
+    );
+    final aliceEphemeralPub = SimplePublicKey(
+      fullWire.sublist(34, 66),
+      type: KeyPairType.x25519,
+    );
+
+    final (:bobOtp, :sessionWire) = await _parseOtpAndSessionWire(
+      fullWire,
+      isV2,
+    );
+
+    // Cache peer identity key for safety number generation
+    final peerStore = SecureKeyStore.instance;
+    await peerStore.write(
+      '$_peerIdentityPrefix$peerUserId',
+      base64Encode(aliceIdentityBytes),
+    );
+
+    if (_signedPrekeyPair == null) await init();
+
+    final (:sharedSecret, :prekeyToUse) = await _computeX3dhResponse(
+      bobOtp: bobOtp,
+      aliceIdentityPub: aliceIdentityPub,
+      aliceEphemeralPub: aliceEphemeralPub,
+    );
+
+    final session = await SignalSession.initBob(sharedSecret, prekeyToUse);
+    final plainBytes = await session.decrypt(sessionWire);
+    _sessions[sessionKey] = session;
+    await _saveSession(sessionKey, session);
+
+    // Consume the OTP -- delete after successful use (one-time)
+    if (bobOtp != null && isV2) {
+      final bd2 = ByteData.sublistView(fullWire);
+      final consumedId = bd2.getInt32(66, Endian.little);
+      await _deleteOtpPrivateKey(consumedId);
+    }
+
+    unawaited(checkAndReplenishOtpKeys());
+    return utf8.decode(plainBytes);
+  }
+
+  /// Drop stale sessions so a fresh X3DH session can be established.
+  Future<void> _clearStaleSession(
+    String sessionKey,
+    String peerUserId,
+    int? fromDeviceId,
+  ) async {
+    if (_sessions.containsKey(sessionKey)) {
+      debugPrint(
+        '[Crypto] Replacing stale session for $sessionKey '
+        '(received new X3DH initial message)',
+      );
+      _sessions.remove(sessionKey);
+      final store = SecureKeyStore.instance;
+      await store.delete('$_sessionPrefix$sessionKey');
+    }
+    if (fromDeviceId != null && _sessions.containsKey(peerUserId)) {
+      _sessions.remove(peerUserId);
+      final store = SecureKeyStore.instance;
+      await store.delete('$_sessionPrefix$peerUserId');
+    }
+  }
+
+  /// Parse the OTP key pair and session wire bytes from the initial message.
+  Future<({SimpleKeyPair? bobOtp, Uint8List sessionWire})>
+  _parseOtpAndSessionWire(Uint8List fullWire, bool isV2) async {
+    if (!isV2) {
+      return (bobOtp: null, sessionWire: fullWire.sublist(66));
+    }
+
+    final bd = ByteData.sublistView(fullWire);
+    final otpKeyId = bd.getInt32(66, Endian.little);
+    final sessionWire = fullWire.sublist(70);
+    final bobOtp = await _loadOtpPrivateKey(otpKeyId);
+    if (bobOtp != null) {
+      debugPrint('[Crypto] Using OTP key_id=$otpKeyId for 4-DH');
+    } else {
+      throw Exception(
+        'OTP key_id=$otpKeyId not found. '
+        'Ask the sender to resend the message.',
+      );
+    }
+    return (bobOtp: bobOtp, sessionWire: sessionWire);
+  }
+
+  /// Compute the X3DH shared secret as Bob, trying current prekey first,
+  /// then falling back to the previous signed prekey.
+  Future<({Uint8List sharedSecret, SimpleKeyPair prekeyToUse})>
+  _computeX3dhResponse({
+    required SimpleKeyPair? bobOtp,
+    required SimplePublicKey aliceIdentityPub,
+    required SimplePublicKey aliceEphemeralPub,
+  }) async {
+    try {
+      final sharedSecret = await X3DH.respond(
+        bobIdentity: _identityKeyPair!,
+        bobSignedPrekey: _signedPrekeyPair!,
+        bobOneTimePrekey: bobOtp,
+        aliceIdentityKey: aliceIdentityPub,
+        aliceEphemeralKey: aliceEphemeralPub,
+      );
+      return (sharedSecret: sharedSecret, prekeyToUse: _signedPrekeyPair!);
+    } catch (_) {
+      final prevPrekey = await _loadPreviousSignedPrekey();
+      if (prevPrekey == null) rethrow;
+      final sharedSecret = await X3DH.respond(
+        bobIdentity: _identityKeyPair!,
+        bobSignedPrekey: prevPrekey,
+        bobOneTimePrekey: bobOtp,
+        aliceIdentityKey: aliceIdentityPub,
+        aliceEphemeralKey: aliceEphemeralPub,
+      );
+      return (sharedSecret: sharedSecret, prekeyToUse: prevPrekey);
+    }
+  }
+
+  /// Decrypt a normal (non-initial) message using an existing session.
+  Future<String> _decryptNormalMessage({
+    required Uint8List fullWire,
+    required String sessionKey,
+  }) async {
     final session = _sessions[sessionKey];
     if (session == null) {
       throw Exception(

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -248,6 +248,40 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     );
   }
 
+  /// Whether a voice channel is currently active (local state or LiveKit).
+  bool _isVoiceChannelActive(String channelId, String? activeVoiceChannelId) {
+    final voiceRtc = ref.read(livekitVoiceProvider);
+    return activeVoiceChannelId == channelId ||
+        (voiceRtc.isActive && voiceRtc.channelId == channelId);
+  }
+
+  /// Handle tap on a voice channel chip: leave or join.
+  Future<void> _handleVoiceChipTap(
+    GroupChannel channel,
+    bool isActive,
+    VoiceSettingsState voiceSettings,
+  ) async {
+    if (isActive) {
+      await _leaveVoiceChannel(channel.id);
+      return;
+    }
+    final shouldJoin = await _confirmVoiceJoin(channel.name);
+    if (!shouldJoin) return;
+    final success = await ref
+        .read(channelsProvider.notifier)
+        .joinVoiceChannel(widget.conversationId, channel.id);
+    if (success && mounted) {
+      await ref
+          .read(livekitVoiceProvider.notifier)
+          .joinChannel(
+            conversationId: widget.conversationId,
+            channelId: channel.id,
+            startMuted: voiceSettings.selfMuted || voiceSettings.selfDeafened,
+          );
+      if (mounted) widget.onVoiceChannelChanged(channel.id);
+    }
+  }
+
   Widget _buildVoiceChannelChip(
     GroupChannel channel,
     List<VoiceSessionMember> participants,
@@ -255,40 +289,12 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     String? activeVoiceChannelId,
   ) {
     final participantCount = participants.length;
-    // Check both the local activeVoiceChannelId AND the LiveKit provider
-    // state — after returning from the voice lounge the local ID may be
-    // cleared while the LiveKit room is still connected.
-    final voiceRtc = ref.read(livekitVoiceProvider);
-    final isActive =
-        activeVoiceChannelId == channel.id ||
-        (voiceRtc.isActive && voiceRtc.channelId == channel.id);
+    final isActive = _isVoiceChannelActive(channel.id, activeVoiceChannelId);
     return Material(
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(20),
-        onTap: () async {
-          final channelsNotifier = ref.read(channelsProvider.notifier);
-          final rtcNotifier = ref.read(livekitVoiceProvider.notifier);
-          if (isActive) {
-            await _leaveVoiceChannel(channel.id);
-          } else {
-            final shouldJoin = await _confirmVoiceJoin(channel.name);
-            if (!shouldJoin) return;
-            final success = await channelsNotifier.joinVoiceChannel(
-              widget.conversationId,
-              channel.id,
-            );
-            if (success && mounted) {
-              await rtcNotifier.joinChannel(
-                conversationId: widget.conversationId,
-                channelId: channel.id,
-                startMuted:
-                    voiceSettings.selfMuted || voiceSettings.selfDeafened,
-              );
-              if (mounted) widget.onVoiceChannelChanged(channel.id);
-            }
-          }
-        },
+        onTap: () => _handleVoiceChipTap(channel, isActive, voiceSettings),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
           decoration: BoxDecoration(
@@ -572,15 +578,10 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     );
   }
 
-  /// Build a grid of video tiles for participants with active video.
-  Widget _buildVideoGrid(LiveKitVoiceState voiceRtc) {
-    final room = ref.read(livekitVoiceProvider.notifier).room;
-    if (room == null) return const SizedBox.shrink();
-
-    // Collect video tracks: local camera + remote video tracks.
+  /// Collect local and remote video tiles from the LiveKit room.
+  List<Widget> _collectVideoTiles(lk.Room room) {
     final tiles = <Widget>[];
 
-    // Local video tile.
     final localVideo = room.localParticipant?.videoTrackPublications
         .where(
           (pub) => pub.track != null && pub.source == lk.TrackSource.camera,
@@ -597,7 +598,6 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
       );
     }
 
-    // Remote video tiles.
     for (final participant in room.remoteParticipants.values) {
       for (final pub in participant.videoTrackPublications) {
         if (pub.track != null && pub.track is lk.VideoTrack) {
@@ -615,7 +615,15 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
         }
       }
     }
+    return tiles;
+  }
 
+  /// Build a grid of video tiles for participants with active video.
+  Widget _buildVideoGrid(LiveKitVoiceState voiceRtc) {
+    final room = ref.read(livekitVoiceProvider.notifier).room;
+    if (room == null) return const SizedBox.shrink();
+
+    final tiles = _collectVideoTiles(room);
     if (tiles.isEmpty) return const SizedBox.shrink();
 
     final int crossAxisCount;

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -503,6 +503,37 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   ///
   /// MultipartRequest streams are consumed on send, so we rebuild the request
   /// on retry rather than replaying the same object.
+  /// Build a multipart upload request for the given file data.
+  http.MultipartRequest _buildUploadRequest({
+    required String serverUrl,
+    required String token,
+    required List<int> bytes,
+    required String fileName,
+    required String mimeType,
+  }) {
+    final request = http.MultipartRequest(
+      'POST',
+      Uri.parse('$serverUrl/api/media/upload'),
+    );
+    request.headers['Authorization'] = 'Bearer $token';
+    request.fields['conversation_id'] = widget.conversation.id;
+
+    final parts = mimeType.split('/');
+    final mediaType = parts.length == 2
+        ? MediaType(parts[0], parts[1])
+        : MediaType('application', _kOctetStream);
+
+    request.files.add(
+      http.MultipartFile.fromBytes(
+        'file',
+        bytes,
+        filename: fileName,
+        contentType: mediaType,
+      ),
+    );
+    return request;
+  }
+
   Future<String?> _uploadWithAuthRetry({
     required String serverUrl,
     required List<int> bytes,
@@ -513,25 +544,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       final token = ref.read(authProvider).token;
       if (token == null) return null;
 
-      final request = http.MultipartRequest(
-        'POST',
-        Uri.parse('$serverUrl/api/media/upload'),
-      );
-      request.headers['Authorization'] = 'Bearer $token';
-      request.fields['conversation_id'] = widget.conversation.id;
-
-      final parts = mimeType.split('/');
-      final mediaType = parts.length == 2
-          ? MediaType(parts[0], parts[1])
-          : MediaType('application', _kOctetStream);
-
-      request.files.add(
-        http.MultipartFile.fromBytes(
-          'file',
-          bytes,
-          filename: fileName,
-          contentType: mediaType,
-        ),
+      final request = _buildUploadRequest(
+        serverUrl: serverUrl,
+        token: token,
+        bytes: bytes,
+        fileName: fileName,
+        mimeType: mimeType,
       );
 
       final response = await request.send();
@@ -542,7 +560,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         return data['url'] as String?;
       }
 
-      // On 401, refresh token and retry once
       if (response.statusCode == 401 && attempt == 0) {
         final refreshed = await ref
             .read(authProvider.notifier)
@@ -551,7 +568,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         continue;
       }
 
-      // Non-retryable failure
       if (mounted) {
         ToastService.show(
           context,
@@ -1011,6 +1027,42 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     return KeyEventResult.ignored;
   }
 
+  /// Handle Ctrl/Cmd key shortcuts (paste, copy, cut).
+  KeyEventResult _handleModifierShortcut(KeyEvent event) {
+    final isCtrlOrMeta =
+        HardwareKeyboard.instance.isControlPressed ||
+        HardwareKeyboard.instance.isMetaPressed;
+    if (!isCtrlOrMeta) return KeyEventResult.ignored;
+
+    if (event.logicalKey == LogicalKeyboardKey.keyV) {
+      return _handlePasteShortcut();
+    }
+    if (event.logicalKey == LogicalKeyboardKey.keyC) {
+      return _handleCopyCutShortcut(false);
+    }
+    if (event.logicalKey == LogicalKeyboardKey.keyX) {
+      return _handleCopyCutShortcut(true);
+    }
+    return KeyEventResult.ignored;
+  }
+
+  /// Up arrow with empty input: edit last own message (Discord behavior).
+  KeyEventResult _handleArrowUpEditLast() {
+    if (!_isTextEmpty || _isEditing) return KeyEventResult.ignored;
+    final messages = ref
+        .read(chatProvider)
+        .messagesForConversation(widget.conversation.id);
+    final myUserId = ref.read(authProvider).userId ?? '';
+    final lastOwn = messages
+        .where((m) => m.isMine && m.fromUserId == myUserId)
+        .lastOrNull;
+    if (lastOwn != null) {
+      enterEditMode(lastOwn);
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
   KeyEventResult _onKeyEvent(
     FocusNode _,
     KeyEvent event,
@@ -1025,52 +1077,17 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       _handleEscapeKey();
     }
 
-    // Enter sends message, Shift+Enter for newline
     if (event.logicalKey == LogicalKeyboardKey.enter &&
         !HardwareKeyboard.instance.isShiftPressed) {
-      if (_isEditing) {
-        _submitEdit();
-      } else {
-        _sendMessage();
-      }
+      _isEditing ? _submitEdit() : _sendMessage();
       return KeyEventResult.handled;
     }
 
-    // Ctrl+V: manually handle paste to bypass browser
-    // context menu on Flutter web (CanvasKit).
-    final isCtrlOrMeta =
-        HardwareKeyboard.instance.isControlPressed ||
-        HardwareKeyboard.instance.isMetaPressed;
+    final modResult = _handleModifierShortcut(event);
+    if (modResult != KeyEventResult.ignored) return modResult;
 
-    if (event.logicalKey == LogicalKeyboardKey.keyV && isCtrlOrMeta) {
-      return _handlePasteShortcut();
-    }
-
-    // Ctrl+C / Ctrl+X: handle copy/cut to prevent
-    // browser context menu on selected text.
-    if (event.logicalKey == LogicalKeyboardKey.keyC && isCtrlOrMeta) {
-      return _handleCopyCutShortcut(false);
-    }
-    if (event.logicalKey == LogicalKeyboardKey.keyX && isCtrlOrMeta) {
-      return _handleCopyCutShortcut(true);
-    }
-
-    // Up arrow with empty input → edit last own message (Discord behavior)
-    if (event.logicalKey == LogicalKeyboardKey.arrowUp &&
-        _isTextEmpty &&
-        !_isEditing) {
-      final messages = ref
-          .read(chatProvider)
-          .messagesForConversation(widget.conversation.id);
-      final myUserId = ref.read(authProvider).userId ?? '';
-      final ownMessages = messages.where(
-        (m) => m.isMine && m.fromUserId == myUserId,
-      );
-      final lastOwn = ownMessages.isNotEmpty ? ownMessages.last : null;
-      if (lastOwn != null) {
-        enterEditMode(lastOwn);
-        return KeyEventResult.handled;
-      }
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      return _handleArrowUpEditLast();
     }
 
     return KeyEventResult.ignored;

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -1074,6 +1074,49 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     );
   }
 
+  Widget _buildMessageListView({
+    required Conversation conv,
+    required List<ChatMessage> messages,
+    required ChatState chatState,
+    required Map<String, String?> memberAvatars,
+    required String myUserId,
+    required String serverUrl,
+    required String authToken,
+  }) {
+    return ListView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.only(bottom: 16),
+      itemCount: messages.length + 1,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          if (chatState.hasMore[conv.id] ?? true) {
+            return SizedBox(
+              height: 48,
+              child: (chatState.loadingHistory[conv.id] ?? false)
+                  ? const Center(
+                      child: SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            );
+          }
+          return const SizedBox(height: 8);
+        }
+        return _buildMessageAtIndex(
+          i: index - 1,
+          messages: messages,
+          memberAvatars: memberAvatars,
+          myUserId: myUserId,
+          serverUrl: serverUrl,
+          authToken: authToken,
+        );
+      },
+    );
+  }
+
   Widget _buildMessageListOrEmpty({
     required Conversation conv,
     required List<ChatMessage> messages,
@@ -1099,37 +1142,14 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     } else {
       child = KeyedSubtree(
         key: const ValueKey('list'),
-        child: ListView.builder(
-          controller: _scrollController,
-          padding: const EdgeInsets.only(bottom: 16),
-          itemCount: messages.length + 1,
-          itemBuilder: (context, index) {
-            if (index == 0) {
-              if (chatState.hasMore[conv.id] ?? true) {
-                return SizedBox(
-                  height: 48,
-                  child: (chatState.loadingHistory[conv.id] ?? false)
-                      ? const Center(
-                          child: SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          ),
-                        )
-                      : const SizedBox.shrink(),
-                );
-              }
-              return const SizedBox(height: 8);
-            }
-            return _buildMessageAtIndex(
-              i: index - 1,
-              messages: messages,
-              memberAvatars: memberAvatars,
-              myUserId: myUserId,
-              serverUrl: serverUrl,
-              authToken: authToken,
-            );
-          },
+        child: _buildMessageListView(
+          conv: conv,
+          messages: messages,
+          chatState: chatState,
+          memberAvatars: memberAvatars,
+          myUserId: myUserId,
+          serverUrl: serverUrl,
+          authToken: authToken,
         ),
       );
     }
@@ -1201,6 +1221,66 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   /// widgets needed (unlike the legacy P2P WebRTC approach).
   List<Widget> _buildVoiceRenderers() => const [];
 
+  /// Floating pill shown when new messages arrive below the scroll viewport.
+  Widget _buildNewMessagesPill() {
+    return Positioned(
+      bottom: 12,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: GestureDetector(
+          onTap: () => _scrollToBottom(settleRetries: 2),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            decoration: BoxDecoration(
+              color: context.accent,
+              borderRadius: BorderRadius.circular(20),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.25),
+                  blurRadius: 8,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  _newMessagesBannerText(),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                const Icon(Icons.arrow_downward, size: 14, color: Colors.white),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Resolve messages for the current conversation and channel.
+  List<ChatMessage> _resolveMessages(
+    Conversation conv,
+    ChatState chatState,
+    String? selectedChannelId,
+    bool includeUnchanneled,
+  ) {
+    if (conv.isGroup) {
+      return chatState.messagesForConversationChannel(
+        conv.id,
+        channelId: selectedChannelId,
+        includeUnchanneled: includeUnchanneled,
+      );
+    }
+    return chatState.messagesForConversation(conv.id);
+  }
+
   // ---------------------------------------------------------------------------
   // Build
   // ---------------------------------------------------------------------------
@@ -1238,13 +1318,12 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     );
 
     final chatState = ref.watch(chatProvider);
-    final messages = conv.isGroup
-        ? chatState.messagesForConversationChannel(
-            conv.id,
-            channelId: selectedChannelId,
-            includeUnchanneled: includeUnchanneled,
-          )
-        : chatState.messagesForConversation(conv.id);
+    final messages = _resolveMessages(
+      conv,
+      chatState,
+      selectedChannelId,
+      includeUnchanneled,
+    );
 
     final isLoadingHistory = chatState.loadingHistory[conv.id] ?? false;
 
@@ -1330,53 +1409,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
                       serverUrl: serverUrl,
                       authToken: authToken,
                     ),
-                    if (_hasNewMessagesBelow)
-                      Positioned(
-                        bottom: 12,
-                        left: 0,
-                        right: 0,
-                        child: Center(
-                          child: GestureDetector(
-                            onTap: () => _scrollToBottom(settleRetries: 2),
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 16,
-                                vertical: 8,
-                              ),
-                              decoration: BoxDecoration(
-                                color: context.accent,
-                                borderRadius: BorderRadius.circular(20),
-                                boxShadow: [
-                                  BoxShadow(
-                                    color: Colors.black.withValues(alpha: 0.25),
-                                    blurRadius: 8,
-                                    offset: const Offset(0, 2),
-                                  ),
-                                ],
-                              ),
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Text(
-                                    _newMessagesBannerText(),
-                                    style: const TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 13,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                  const SizedBox(width: 4),
-                                  const Icon(
-                                    Icons.arrow_downward,
-                                    size: 14,
-                                    color: Colors.white,
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
+                    if (_hasNewMessagesBelow) _buildNewMessagesPill(),
                   ],
                 ),
               ),

--- a/apps/client/lib/src/widgets/connection_status_banner.dart
+++ b/apps/client/lib/src/widgets/connection_status_banner.dart
@@ -30,11 +30,8 @@ class _ConnectionStatusBannerState
     super.dispose();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final wsState = ref.watch(websocketProvider);
-
-    // Detect transition from disconnected -> connected.
+  /// Track connection transition and trigger the green "Connected" flash.
+  void _trackConnectionTransition(WebSocketState wsState) {
     if (!wsState.isConnected) {
       _wasDisconnected = true;
     } else if (_wasDisconnected &&
@@ -50,70 +47,114 @@ class _ConnectionStatusBannerState
         if (mounted) setState(() {});
       });
     }
+  }
+
+  /// Resolve the banner color, label, and spinner visibility from ws state.
+  ({Color color, String label, bool showSpinner}) _resolveBannerStatus(
+    WebSocketState wsState,
+  ) {
+    final maxAttemptsReached =
+        wsState.reconnectAttempts >= 10 && !wsState.isConnected;
+
+    if (wsState.wasReplaced) {
+      return (
+        color: EchoTheme.danger,
+        label: 'Signed in on another device',
+        showSpinner: false,
+      );
+    }
+    if (wsState.isConnected && _showConnectedFlash) {
+      return (color: EchoTheme.online, label: 'Connected', showSpinner: false);
+    }
+    if (maxAttemptsReached) {
+      return (
+        color: EchoTheme.danger,
+        label: 'Connection lost \u2014 messages may be pending',
+        showSpinner: false,
+      );
+    }
+    return (
+      color: const Color(0xFFB45309),
+      label: wsState.reconnectAttempts > 0
+          ? 'Reconnecting... (${wsState.reconnectAttempts})'
+          : 'Reconnecting...',
+      showSpinner: true,
+    );
+  }
+
+  /// Build the leading icon/spinner for the banner.
+  Widget _buildLeadingIcon({
+    required bool showSpinner,
+    required bool isConnected,
+    required Color bannerColor,
+  }) {
+    if (showSpinner) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 10,
+            height: 10,
+            child: CircularProgressIndicator(
+              strokeWidth: 1.5,
+              color: bannerColor,
+            ),
+          ),
+          const SizedBox(width: 6),
+        ],
+      );
+    }
+    final icon = isConnected
+        ? Icons.check_circle_outline
+        : Icons.wifi_off_outlined;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 12, color: bannerColor),
+        const SizedBox(width: 6),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final wsState = ref.watch(websocketProvider);
+    _trackConnectionTransition(wsState);
 
     final bool visible =
         !wsState.isConnected || _showConnectedFlash || wsState.wasReplaced;
     if (!visible) return const SizedBox.shrink();
 
-    final bool maxAttemptsReached =
-        wsState.reconnectAttempts >= 10 && !wsState.isConnected;
-
-    Color bannerColor;
-    String label;
-    bool showSpinner = false;
-
-    if (wsState.wasReplaced) {
-      bannerColor = EchoTheme.danger;
-      label = 'Signed in on another device';
-    } else if (wsState.isConnected && _showConnectedFlash) {
-      bannerColor = EchoTheme.online;
-      label = 'Connected';
-    } else if (maxAttemptsReached) {
-      bannerColor = EchoTheme.danger;
-      label = 'Connection lost \u2014 messages may be pending';
-    } else {
-      bannerColor = const Color(0xFFB45309); // amber-700
-      label = wsState.reconnectAttempts > 0
-          ? 'Reconnecting... (${wsState.reconnectAttempts})'
-          : 'Reconnecting...';
-      showSpinner = true;
-    }
+    final status = _resolveBannerStatus(wsState);
+    final showRetry =
+        (wsState.reconnectAttempts >= 10 && !wsState.isConnected) ||
+        wsState.wasReplaced;
 
     return AnimatedSize(
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeOut,
       child: Container(
         width: double.infinity,
-        color: bannerColor.withValues(alpha: 0.15),
+        color: status.color.withValues(alpha: 0.15),
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 5),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              if (showSpinner)
-                SizedBox(
-                  width: 10,
-                  height: 10,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 1.5,
-                    color: bannerColor,
-                  ),
-                ),
-              if (showSpinner) const SizedBox(width: 6),
-              if (!showSpinner && wsState.isConnected)
-                Icon(Icons.check_circle_outline, size: 12, color: bannerColor),
-              if (!showSpinner && !wsState.isConnected)
-                Icon(Icons.wifi_off_outlined, size: 12, color: bannerColor),
-              if (!showSpinner) const SizedBox(width: 6),
+              _buildLeadingIcon(
+                showSpinner: status.showSpinner,
+                isConnected: wsState.isConnected,
+                bannerColor: status.color,
+              ),
               Text(
-                label,
+                status.label,
                 style: TextStyle(
                   fontSize: 12,
-                  color: bannerColor,
+                  color: status.color,
                   fontWeight: FontWeight.w500,
                 ),
               ),
-              if (maxAttemptsReached || wsState.wasReplaced) ...[
+              if (showRetry) ...[
                 const SizedBox(width: 10),
                 GestureDetector(
                   onTap: () => ref.read(websocketProvider.notifier).connect(),
@@ -123,15 +164,15 @@ class _ConnectionStatusBannerState
                       vertical: 2,
                     ),
                     decoration: BoxDecoration(
-                      color: bannerColor.withValues(alpha: 0.2),
+                      color: status.color.withValues(alpha: 0.2),
                       borderRadius: BorderRadius.circular(10),
-                      border: Border.all(color: bannerColor, width: 1),
+                      border: Border.all(color: status.color, width: 1),
                     ),
                     child: Text(
                       'Retry',
                       style: TextStyle(
                         fontSize: 11,
-                        color: bannerColor,
+                        color: status.color,
                         fontWeight: FontWeight.w600,
                       ),
                     ),

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1093,6 +1093,60 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     );
   }
 
+  Widget _buildListItem({
+    required int index,
+    required List<Conversation> sorted,
+    required int pinnedCount,
+    required String myUserId,
+    required String serverUrl,
+    required Set<String> wsOnlineUsers,
+  }) {
+    if (pinnedCount > 0) {
+      if (index == 0) {
+        return Padding(
+          padding: const EdgeInsets.only(left: 8, top: 4, bottom: 2),
+          child: Text(
+            'PINNED',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: context.textMuted,
+              letterSpacing: 0.5,
+            ),
+          ),
+        );
+      }
+      if (index == pinnedCount + 1) {
+        return Divider(
+          height: 12,
+          thickness: 1,
+          indent: 8,
+          endIndent: 8,
+          color: context.border,
+        );
+      }
+      final convIndex = index <= pinnedCount ? index - 1 : index - 2;
+      if (convIndex >= sorted.length) return const SizedBox.shrink();
+      final conv = sorted[convIndex];
+      return _buildConversationTile(
+        conv,
+        _pinnedIds.contains(conv.id),
+        myUserId,
+        serverUrl,
+        wsOnlineUsers,
+      );
+    }
+
+    final conv = sorted[index];
+    return _buildConversationTile(
+      conv,
+      _pinnedIds.contains(conv.id),
+      myUserId,
+      serverUrl,
+      wsOnlineUsers,
+    );
+  }
+
   Widget _buildConversationList(
     List<Conversation> sorted,
     String myUserId,
@@ -1114,60 +1168,14 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         // Use fixed itemExtent when no section headers/dividers for faster layout.
         itemExtent: extraItems == 0 ? 70 : null,
         itemCount: sorted.length + extraItems,
-        itemBuilder: (context, index) {
-          if (pinnedCount > 0) {
-            // First item: "PINNED" section header
-            if (index == 0) {
-              return Padding(
-                padding: const EdgeInsets.only(left: 8, top: 4, bottom: 2),
-                child: Text(
-                  'PINNED',
-                  style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                    color: context.textMuted,
-                    letterSpacing: 0.5,
-                  ),
-                ),
-              );
-            }
-            // After pinned items: divider
-            if (index == pinnedCount + 1) {
-              return Divider(
-                height: 12,
-                thickness: 1,
-                indent: 8,
-                endIndent: 8,
-                color: context.border,
-              );
-            }
-            // Adjust index for the extra header/divider items
-            final convIndex = index <= pinnedCount ? index - 1 : index - 2;
-            if (convIndex >= sorted.length) {
-              return const SizedBox.shrink();
-            }
-            final conv = sorted[convIndex];
-            final isPinned = _pinnedIds.contains(conv.id);
-            return _buildConversationTile(
-              conv,
-              isPinned,
-              myUserId,
-              serverUrl,
-              wsOnlineUsers,
-            );
-          }
-
-          // No pinned items — render normally
-          final conv = sorted[index];
-          final isPinned = _pinnedIds.contains(conv.id);
-          return _buildConversationTile(
-            conv,
-            isPinned,
-            myUserId,
-            serverUrl,
-            wsOnlineUsers,
-          );
-        },
+        itemBuilder: (context, index) => _buildListItem(
+          index: index,
+          sorted: sorted,
+          pinnedCount: pinnedCount,
+          myUserId: myUserId,
+          serverUrl: serverUrl,
+          wsOnlineUsers: wsOnlineUsers,
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/message/rich_text_content.dart
+++ b/apps/client/lib/src/widgets/message/rich_text_content.dart
@@ -176,90 +176,7 @@ class _RichTextContentState extends State<RichTextContent> {
         spans.addAll(_buildMentionSpans(text.substring(lastEnd, e.start)));
       }
 
-      switch (e.tag) {
-        case 'bold':
-          final inner = e.match.group(1)!;
-          spans.add(
-            TextSpan(
-              text: inner,
-              style: _baseStyle().copyWith(fontWeight: FontWeight.bold),
-            ),
-          );
-        case 'italic':
-          final inner = e.match.group(1)!;
-          spans.add(
-            TextSpan(
-              text: inner,
-              style: _baseStyle().copyWith(fontStyle: FontStyle.italic),
-            ),
-          );
-        case 'underline':
-          final inner = e.match.group(1)!;
-          spans.add(
-            TextSpan(
-              text: inner,
-              style: _baseStyle().copyWith(
-                decoration: TextDecoration.underline,
-                decorationColor: widget.textColor,
-              ),
-            ),
-          );
-        case 'strikethrough':
-          final inner = e.match.group(1)!;
-          spans.add(
-            TextSpan(
-              text: inner,
-              style: _baseStyle().copyWith(
-                decoration: TextDecoration.lineThrough,
-                decorationColor: widget.textColor,
-              ),
-            ),
-          );
-        case 'spoiler':
-          final inner = e.match.group(1)!;
-          spans.add(
-            WidgetSpan(
-              alignment: PlaceholderAlignment.baseline,
-              baseline: TextBaseline.alphabetic,
-              child: _SpoilerText(
-                text: inner,
-                style: _baseStyle(),
-                bgColor: widget.textSecondaryColor,
-              ),
-            ),
-          );
-        case 'masked_link':
-          final linkText = e.match.group(1)!;
-          final url = e.match.group(2)!;
-          spans.add(
-            TextSpan(
-              text: linkText,
-              style: TextStyle(
-                fontSize: 15,
-                color: widget.accentHoverColor,
-                decoration: TextDecoration.underline,
-                decorationColor: widget.accentHoverColor,
-                height: 1.47,
-              ),
-              recognizer: _createLinkRecognizer(url),
-            ),
-          );
-        case 'url':
-          final url = e.match.group(0)!;
-          spans.add(
-            TextSpan(
-              text: url,
-              style: TextStyle(
-                fontSize: 15,
-                color: widget.accentHoverColor,
-                decoration: TextDecoration.underline,
-                decorationColor: widget.accentHoverColor,
-                height: 1.47,
-              ),
-              recognizer: _createLinkRecognizer(url),
-            ),
-          );
-      }
+      spans.add(_buildSpanForTag(e));
 
       lastEnd = e.end;
     }
@@ -269,6 +186,72 @@ class _RichTextContentState extends State<RichTextContent> {
     }
 
     return spans;
+  }
+
+  /// Build a single [InlineSpan] for a matched formatting tag entry.
+  InlineSpan _buildSpanForTag(
+    ({int start, int end, String tag, RegExpMatch match}) e,
+  ) {
+    final linkStyle = TextStyle(
+      fontSize: 15,
+      color: widget.accentHoverColor,
+      decoration: TextDecoration.underline,
+      decorationColor: widget.accentHoverColor,
+      height: 1.47,
+    );
+    switch (e.tag) {
+      case 'bold':
+        return TextSpan(
+          text: e.match.group(1)!,
+          style: _baseStyle().copyWith(fontWeight: FontWeight.bold),
+        );
+      case 'italic':
+        return TextSpan(
+          text: e.match.group(1)!,
+          style: _baseStyle().copyWith(fontStyle: FontStyle.italic),
+        );
+      case 'underline':
+        return TextSpan(
+          text: e.match.group(1)!,
+          style: _baseStyle().copyWith(
+            decoration: TextDecoration.underline,
+            decorationColor: widget.textColor,
+          ),
+        );
+      case 'strikethrough':
+        return TextSpan(
+          text: e.match.group(1)!,
+          style: _baseStyle().copyWith(
+            decoration: TextDecoration.lineThrough,
+            decorationColor: widget.textColor,
+          ),
+        );
+      case 'spoiler':
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: _SpoilerText(
+            text: e.match.group(1)!,
+            style: _baseStyle(),
+            bgColor: widget.textSecondaryColor,
+          ),
+        );
+      case 'masked_link':
+        return TextSpan(
+          text: e.match.group(1)!,
+          style: linkStyle,
+          recognizer: _createLinkRecognizer(e.match.group(2)!),
+        );
+      case 'url':
+        final url = e.match.group(0)!;
+        return TextSpan(
+          text: url,
+          style: linkStyle,
+          recognizer: _createLinkRecognizer(url),
+        );
+      default:
+        return TextSpan(text: e.match.group(0)!, style: _baseStyle());
+    }
   }
 
   /// Build spans for a segment that may contain inline code, bold, italic,

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -186,112 +186,126 @@ class _MessageItemState extends State<MessageItem> {
                     borderRadius: BorderRadius.circular(2),
                   ),
                 ),
-                // Quick reaction row
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: reactionEmojis.map((emoji) {
-                      final alreadyReacted = msg.reactions.any(
-                        (r) => r.emoji == emoji && r.userId == widget.myUserId,
-                      );
-                      return GestureDetector(
-                        onTap: () {
-                          Navigator.pop(sheetContext);
-                          widget.onReactionSelect?.call(msg, emoji);
-                        },
-                        child: Container(
-                          width: 44,
-                          height: 44,
-                          decoration: BoxDecoration(
-                            color: alreadyReacted
-                                ? context.accent.withValues(alpha: 0.2)
-                                : null,
-                            borderRadius: BorderRadius.circular(8),
-                            border: alreadyReacted
-                                ? Border.all(color: context.accent, width: 2)
-                                : null,
-                          ),
-                          alignment: Alignment.center,
-                          child: Text(
-                            emoji,
-                            style: const TextStyle(fontSize: 24),
-                          ),
-                        ),
-                      );
-                    }).toList(),
-                  ),
-                ),
+                _buildQuickReactionRow(sheetContext, msg),
                 Divider(height: 1, color: context.border),
-                // Action list
-                if (widget.onReply != null)
-                  _actionTile(
-                    sheetContext: sheetContext,
-                    icon: Icons.reply_outlined,
-                    label: 'Reply',
-                    onTap: () => widget.onReply?.call(msg),
-                  ),
-                _actionTile(
+                ..._buildActionTiles(
                   sheetContext: sheetContext,
-                  icon: Icons.copy_outlined,
-                  label: mediaUrl != null ? 'Copy link' : 'Copy text',
-                  onTap: () {
-                    final copyText = mediaUrl != null
-                        ? _resolveUrl(mediaUrl)
-                        : msg.content;
-                    Clipboard.setData(ClipboardData(text: copyText));
-                    ToastService.show(
-                      context,
-                      'Copied to clipboard',
-                      type: ToastType.success,
-                    );
-                  },
+                  msg: msg,
+                  isMine: isMine,
+                  mediaUrl: mediaUrl,
                 ),
-                if (mediaUrl != null)
-                  _actionTile(
-                    sheetContext: sheetContext,
-                    icon: Icons.download_outlined,
-                    label: 'Download',
-                    onTap: () => _downloadMedia(mediaUrl),
-                  ),
-                if (isMine && widget.onEdit != null)
-                  _actionTile(
-                    sheetContext: sheetContext,
-                    icon: Icons.edit_outlined,
-                    label: 'Edit',
-                    onTap: () => widget.onEdit?.call(msg),
-                  ),
-                if (msg.pinnedAt == null && widget.onPin != null)
-                  _actionTile(
-                    sheetContext: sheetContext,
-                    icon: Icons.push_pin_outlined,
-                    label: 'Pin',
-                    onTap: () => widget.onPin?.call(msg),
-                  ),
-                if (msg.pinnedAt != null && widget.onUnpin != null)
-                  _actionTile(
-                    sheetContext: sheetContext,
-                    icon: Icons.push_pin,
-                    label: 'Unpin',
-                    onTap: () => widget.onUnpin?.call(msg),
-                  ),
-                if (isMine && widget.onDelete != null)
-                  _actionTile(
-                    sheetContext: sheetContext,
-                    icon: Icons.delete_outlined,
-                    label: 'Delete',
-                    color: EchoTheme.danger,
-                    onTap: () => widget.onDelete?.call(msg),
-                  ),
               ],
             ),
           ),
         );
       },
     );
+  }
+
+  /// Quick reaction emoji row for the mobile action sheet.
+  Widget _buildQuickReactionRow(BuildContext sheetContext, ChatMessage msg) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: reactionEmojis.map((emoji) {
+          final alreadyReacted = msg.reactions.any(
+            (r) => r.emoji == emoji && r.userId == widget.myUserId,
+          );
+          return GestureDetector(
+            onTap: () {
+              Navigator.pop(sheetContext);
+              widget.onReactionSelect?.call(msg, emoji);
+            },
+            child: Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: alreadyReacted
+                    ? context.accent.withValues(alpha: 0.2)
+                    : null,
+                borderRadius: BorderRadius.circular(8),
+                border: alreadyReacted
+                    ? Border.all(color: context.accent, width: 2)
+                    : null,
+              ),
+              alignment: Alignment.center,
+              child: Text(emoji, style: const TextStyle(fontSize: 24)),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  /// Contextual action tiles for the mobile action sheet.
+  List<Widget> _buildActionTiles({
+    required BuildContext sheetContext,
+    required ChatMessage msg,
+    required bool isMine,
+    required String? mediaUrl,
+  }) {
+    return [
+      if (widget.onReply != null)
+        _actionTile(
+          sheetContext: sheetContext,
+          icon: Icons.reply_outlined,
+          label: 'Reply',
+          onTap: () => widget.onReply?.call(msg),
+        ),
+      _actionTile(
+        sheetContext: sheetContext,
+        icon: Icons.copy_outlined,
+        label: mediaUrl != null ? 'Copy link' : 'Copy text',
+        onTap: () {
+          final copyText = mediaUrl != null
+              ? _resolveUrl(mediaUrl)
+              : msg.content;
+          Clipboard.setData(ClipboardData(text: copyText));
+          ToastService.show(
+            context,
+            'Copied to clipboard',
+            type: ToastType.success,
+          );
+        },
+      ),
+      if (mediaUrl != null)
+        _actionTile(
+          sheetContext: sheetContext,
+          icon: Icons.download_outlined,
+          label: 'Download',
+          onTap: () => _downloadMedia(mediaUrl),
+        ),
+      if (isMine && widget.onEdit != null)
+        _actionTile(
+          sheetContext: sheetContext,
+          icon: Icons.edit_outlined,
+          label: 'Edit',
+          onTap: () => widget.onEdit?.call(msg),
+        ),
+      if (msg.pinnedAt == null && widget.onPin != null)
+        _actionTile(
+          sheetContext: sheetContext,
+          icon: Icons.push_pin_outlined,
+          label: 'Pin',
+          onTap: () => widget.onPin?.call(msg),
+        ),
+      if (msg.pinnedAt != null && widget.onUnpin != null)
+        _actionTile(
+          sheetContext: sheetContext,
+          icon: Icons.push_pin,
+          label: 'Unpin',
+          onTap: () => widget.onUnpin?.call(msg),
+        ),
+      if (isMine && widget.onDelete != null)
+        _actionTile(
+          sheetContext: sheetContext,
+          icon: Icons.delete_outlined,
+          label: 'Delete',
+          color: EchoTheme.danger,
+          onTap: () => widget.onDelete?.call(msg),
+        ),
+    ];
   }
 
   Widget _actionTile({
@@ -936,6 +950,104 @@ class _MessageItemState extends State<MessageItem> {
     ];
   }
 
+  /// Build the system event pill (centered, borderless).
+  Widget _buildSystemEventPill(ChatMessage msg) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 24),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: context.surface,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: context.border),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                _systemEventIcon(msg.content),
+                size: 14,
+                color: context.textMuted,
+              ),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  msg.content,
+                  style: TextStyle(
+                    color: context.textMuted,
+                    fontSize: 12,
+                    fontStyle: FontStyle.italic,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Whether the current platform supports touch-based swipe gestures.
+  static bool get _isMobileTouch =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
+  /// Wrap [messageWidget] with swipe-to-reply gesture handlers on mobile.
+  Widget _buildSwipeToReplyWrapper({
+    required bool canSwipe,
+    required ChatMessage msg,
+    required Widget messageWidget,
+  }) {
+    return Stack(
+      children: [
+        if (canSwipe && _swipeDx > 0)
+          Positioned(
+            left: 8,
+            top: 0,
+            bottom: 0,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Opacity(
+                opacity: (_swipeDx / 60).clamp(0.0, 1.0),
+                child: Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: context.accent.withValues(alpha: 0.2),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.reply_rounded,
+                    size: 16,
+                    color: context.accent,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        Transform.translate(offset: Offset(_swipeDx, 0), child: messageWidget),
+      ],
+    );
+  }
+
+  /// Handle long-press: show mobile action sheet or reaction picker.
+  void _handleLongPress(
+    LongPressStartDetails details,
+    ChatMessage msg,
+    bool isMine,
+    String? mediaUrl,
+    bool hasReactions,
+  ) {
+    if (Responsive.isMobile(context)) {
+      _showMobileActionSheet(context, msg, isMine, mediaUrl);
+    } else if (!hasReactions) {
+      widget.onReactionTap?.call(msg, details.globalPosition);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final msg = widget.message;
@@ -943,44 +1055,7 @@ class _MessageItemState extends State<MessageItem> {
     final isFailed = msg.status == MessageStatus.failed;
     final isSending = msg.status == MessageStatus.sending;
 
-    // System events render as centered, borderless pills (like date separators)
-    if (msg.isSystemEvent) {
-      return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 24),
-        child: Center(
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            decoration: BoxDecoration(
-              color: context.surface,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: context.border),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  _systemEventIcon(msg.content),
-                  size: 14,
-                  color: context.textMuted,
-                ),
-                const SizedBox(width: 6),
-                Flexible(
-                  child: Text(
-                    msg.content,
-                    style: TextStyle(
-                      color: context.textMuted,
-                      fontSize: 12,
-                      fontStyle: FontStyle.italic,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
+    if (msg.isSystemEvent) return _buildSystemEventPill(msg);
 
     final mediaUrl = extractMediaUrl(msg.content);
     final hasMedia = mediaUrl != null;
@@ -1006,12 +1081,8 @@ class _MessageItemState extends State<MessageItem> {
     );
 
     final isAlignedEnd = isMine && !widget.compactLayout;
-    final isMobileTouch =
-        !kIsWeb &&
-        (defaultTargetPlatform == TargetPlatform.android ||
-            defaultTargetPlatform == TargetPlatform.iOS);
     final canSwipeToReply =
-        isMobileTouch && widget.onReply != null && !msg.isSystemEvent;
+        _isMobileTouch && widget.onReply != null && !msg.isSystemEvent;
 
     final messageWidget = Container(
       padding: EdgeInsets.only(
@@ -1059,17 +1130,10 @@ class _MessageItemState extends State<MessageItem> {
         child: Semantics(
           label: 'Message from ${msg.fromUsername}. Long press for actions.',
           child: GestureDetector(
-            onLongPressStart: (details) {
-              final isMobile = Responsive.isMobile(context);
-              if (isMobile) {
-                _showMobileActionSheet(context, msg, isMine, mediaUrl);
-              } else if (!hasReactions) {
-                widget.onReactionTap?.call(msg, details.globalPosition);
-              }
-            },
+            onLongPressStart: (details) =>
+                _handleLongPress(details, msg, isMine, mediaUrl, hasReactions),
             onHorizontalDragUpdate: canSwipeToReply
                 ? (details) {
-                    // Only allow rightward swipe (positive dx)
                     final newDx = (_swipeDx + details.delta.dx).clamp(
                       0.0,
                       72.0,
@@ -1083,9 +1147,7 @@ class _MessageItemState extends State<MessageItem> {
                 : null,
             onHorizontalDragEnd: canSwipeToReply
                 ? (_) {
-                    if (_swipeTriggered) {
-                      widget.onReply?.call(msg);
-                    }
+                    if (_swipeTriggered) widget.onReply?.call(msg);
                     setState(() {
                       _swipeDx = 0;
                       _swipeTriggered = false;
@@ -1098,40 +1160,10 @@ class _MessageItemState extends State<MessageItem> {
                     _swipeTriggered = false;
                   })
                 : null,
-            child: Stack(
-              children: [
-                // Reply icon revealed during swipe
-                if (canSwipeToReply && _swipeDx > 0)
-                  Positioned(
-                    left: 8,
-                    top: 0,
-                    bottom: 0,
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: Opacity(
-                        opacity: (_swipeDx / 60).clamp(0.0, 1.0),
-                        child: Container(
-                          width: 32,
-                          height: 32,
-                          decoration: BoxDecoration(
-                            color: context.accent.withValues(alpha: 0.2),
-                            shape: BoxShape.circle,
-                          ),
-                          child: Icon(
-                            Icons.reply_rounded,
-                            size: 16,
-                            color: context.accent,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                // Message content, shifted right during swipe
-                Transform.translate(
-                  offset: Offset(_swipeDx, 0),
-                  child: messageWidget,
-                ),
-              ],
+            child: _buildSwipeToReplyWrapper(
+              canSwipe: canSwipeToReply,
+              msg: msg,
+              messageWidget: messageWidget,
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/quick_switcher_overlay.dart
+++ b/apps/client/lib/src/widgets/quick_switcher_overlay.dart
@@ -65,6 +65,78 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
     );
   }
 
+  /// Handle keyboard navigation (arrows + escape) in the switcher.
+  void _handleKeyNavigation(KeyEvent event) {
+    if (event is! KeyDownEvent) return;
+    final results = _filteredResults();
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      setState(() {
+        _selectedIndex = (_selectedIndex + 1).clamp(0, results.length - 1);
+      });
+      _scrollToSelected();
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      setState(() {
+        _selectedIndex = (_selectedIndex - 1).clamp(0, results.length - 1);
+      });
+      _scrollToSelected();
+    } else if (event.logicalKey == LogicalKeyboardKey.escape) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  /// Build a single result row in the conversation list.
+  Widget _buildResultItem(Conversation conv, bool isSelected) {
+    final title = conv.name ?? conv.id;
+    return Container(
+      height: _itemHeight,
+      decoration: isSelected
+          ? BoxDecoration(
+              border: Border(left: BorderSide(color: context.accent, width: 2)),
+            )
+          : null,
+      child: Material(
+        color: isSelected
+            ? context.accent.withValues(alpha: 0.1)
+            : Colors.transparent,
+        child: InkWell(
+          onTap: () {
+            widget.onSelect(conv);
+            Navigator.of(context).pop();
+          },
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            child: Row(
+              children: [
+                Icon(
+                  conv.isGroup ? Icons.group : Icons.person,
+                  size: 20,
+                  color: context.textSecondary,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: TextStyle(
+                      color: context.textPrimary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (conv.isGroup)
+                  Text(
+                    'Group',
+                    style: TextStyle(color: context.textMuted, fontSize: 11),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final results = _filteredResults();
@@ -72,23 +144,7 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
     return KeyboardListener(
       focusNode: FocusNode(),
       autofocus: true,
-      onKeyEvent: (event) {
-        if (event is! KeyDownEvent) return;
-        final results = _filteredResults();
-        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-          setState(() {
-            _selectedIndex = (_selectedIndex + 1).clamp(0, results.length - 1);
-          });
-          _scrollToSelected();
-        } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          setState(() {
-            _selectedIndex = (_selectedIndex - 1).clamp(0, results.length - 1);
-          });
-          _scrollToSelected();
-        } else if (event.logicalKey == LogicalKeyboardKey.escape) {
-          Navigator.of(context).pop();
-        }
-      },
+      onKeyEvent: _handleKeyNavigation,
       child: GestureDetector(
         onTap: () => Navigator.of(context).pop(),
         child: Material(
@@ -114,7 +170,6 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Search input
                     Padding(
                       padding: const EdgeInsets.all(12),
                       child: TextField(
@@ -153,7 +208,6 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
                         onSubmitted: (_) => _selectCurrent(results),
                       ),
                     ),
-                    // Results list
                     if (results.isEmpty)
                       Padding(
                         padding: const EdgeInsets.all(24),
@@ -170,75 +224,12 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
                         child: ListView.builder(
                           controller: _listScrollController,
                           itemCount: results.length,
-                          itemBuilder: (context, index) {
-                            final conv = results[index];
-                            final isSelected = index == _selectedIndex;
-                            final title = conv.name ?? conv.id;
-                            return Container(
-                              height: _itemHeight,
-                              decoration: isSelected
-                                  ? BoxDecoration(
-                                      border: Border(
-                                        left: BorderSide(
-                                          color: context.accent,
-                                          width: 2,
-                                        ),
-                                      ),
-                                    )
-                                  : null,
-                              child: Material(
-                                color: isSelected
-                                    ? context.accent.withValues(alpha: 0.1)
-                                    : Colors.transparent,
-                                child: InkWell(
-                                  onTap: () {
-                                    widget.onSelect(conv);
-                                    Navigator.of(context).pop();
-                                  },
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 16,
-                                      vertical: 10,
-                                    ),
-                                    child: Row(
-                                      children: [
-                                        Icon(
-                                          conv.isGroup
-                                              ? Icons.group
-                                              : Icons.person,
-                                          size: 20,
-                                          color: context.textSecondary,
-                                        ),
-                                        const SizedBox(width: 12),
-                                        Expanded(
-                                          child: Text(
-                                            title,
-                                            style: TextStyle(
-                                              color: context.textPrimary,
-                                              fontSize: 14,
-                                              fontWeight: FontWeight.w500,
-                                            ),
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        ),
-                                        if (conv.isGroup)
-                                          Text(
-                                            'Group',
-                                            style: TextStyle(
-                                              color: context.textMuted,
-                                              fontSize: 11,
-                                            ),
-                                          ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            );
-                          },
+                          itemBuilder: (context, index) => _buildResultItem(
+                            results[index],
+                            index == _selectedIndex,
+                          ),
                         ),
                       ),
-                    // Hint
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
                       child: Text(

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -29,28 +29,19 @@ pub struct LinkPreviewResponse {
     pub site_name: Option<String>,
 }
 
-/// POST /api/link-preview
-///
-/// Fetches Open Graph metadata from a URL. Requires authentication.
-/// Returns title, description, image, and site name if available.
-pub async fn fetch_preview(
-    _auth: AuthUser,
-    _state: State<Arc<AppState>>,
-    Json(body): Json<LinkPreviewRequest>,
-) -> Result<Json<LinkPreviewResponse>, AppError> {
-    // Basic URL validation
-    if !body.url.starts_with("http://") && !body.url.starts_with("https://") {
+/// Validate URL scheme and reject SSRF-vulnerable addresses.
+fn validate_url(url: &str) -> Result<(), AppError> {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err(AppError::bad_request(
             "URL must start with http:// or https://",
         ));
     }
 
-    // SSRF protection: resolve hostname and reject private/loopback IPs
-    if let Ok(url) = reqwest::Url::parse(&body.url)
-        && let Some(host) = url.host_str()
+    if let Ok(parsed) = reqwest::Url::parse(url)
+        && let Some(host) = parsed.host_str()
     {
         use std::net::ToSocketAddrs;
-        let port = url.port_or_known_default().unwrap_or(80);
+        let port = parsed.port_or_known_default().unwrap_or(80);
         if let Ok(addrs) = format!("{host}:{port}").to_socket_addrs() {
             for addr in addrs {
                 let ip = addr.ip();
@@ -67,6 +58,20 @@ pub async fn fetch_preview(
             }
         }
     }
+
+    Ok(())
+}
+
+/// POST /api/link-preview
+///
+/// Fetches Open Graph metadata from a URL. Requires authentication.
+/// Returns title, description, image, and site name if available.
+pub async fn fetch_preview(
+    _auth: AuthUser,
+    _state: State<Arc<AppState>>,
+    Json(body): Json<LinkPreviewRequest>,
+) -> Result<Json<LinkPreviewResponse>, AppError> {
+    validate_url(&body.url)?;
 
     // Fetch the page with a short timeout
     let client = reqwest::Client::builder()

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -76,6 +76,58 @@ fn extension_for_mime(mime: &str) -> &str {
     }
 }
 
+/// Read the file field, validate MIME type, size, and magic-byte content type.
+async fn validate_and_read_file(
+    field: axum::extract::multipart::Field<'_>,
+) -> Result<(String, String, Vec<u8>), AppError> {
+    let original_filename = field.file_name().unwrap_or("upload").to_string();
+
+    let mut mime_type = field
+        .content_type()
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    if !ALLOWED_MIME_TYPES.contains(&mime_type.as_str()) {
+        return Err(AppError::bad_request(format!(
+            "File type '{mime_type}' is not allowed. Allowed types: {}",
+            ALLOWED_MIME_TYPES.join(", ")
+        )));
+    }
+
+    let data = field
+        .bytes()
+        .await
+        .map_err(|e| AppError::bad_request(format!("Failed to read file data: {e}")))?
+        .to_vec();
+
+    if data.len() > MAX_FILE_SIZE {
+        return Err(AppError::bad_request(format!(
+            "File too large. Maximum size is {} bytes",
+            MAX_FILE_SIZE
+        )));
+    }
+
+    // Validate actual file type via magic bytes -- don't trust client MIME header
+    match infer::get(&data) {
+        Some(inferred) => {
+            let inferred_mime = inferred.mime_type();
+            if !ALLOWED_MIME_TYPES.contains(&inferred_mime) {
+                return Err(AppError::bad_request(format!(
+                    "Detected file type '{inferred_mime}' is not allowed"
+                )));
+            }
+            mime_type = inferred_mime.to_string();
+        }
+        None => {
+            return Err(AppError::bad_request(
+                "Could not detect file type from content. Upload a supported format.",
+            ));
+        }
+    }
+
+    Ok((original_filename, mime_type, data))
+}
+
 /// POST /api/media/upload
 ///
 /// Accepts multipart form data with a `file` field and an optional
@@ -131,53 +183,7 @@ pub async fn upload(
             continue;
         }
 
-        let original_filename = field.file_name().unwrap_or("upload").to_string();
-
-        let mut mime_type = field
-            .content_type()
-            .unwrap_or("application/octet-stream")
-            .to_string();
-
-        if !ALLOWED_MIME_TYPES.contains(&mime_type.as_str()) {
-            return Err(AppError::bad_request(format!(
-                "File type '{mime_type}' is not allowed. Allowed types: {}",
-                ALLOWED_MIME_TYPES.join(", ")
-            )));
-        }
-
-        let data = field
-            .bytes()
-            .await
-            .map_err(|e| AppError::bad_request(format!("Failed to read file data: {e}")))?
-            .to_vec();
-
-        if data.len() > MAX_FILE_SIZE {
-            return Err(AppError::bad_request(format!(
-                "File too large. Maximum size is {} bytes",
-                MAX_FILE_SIZE
-            )));
-        }
-
-        // Validate actual file type via magic bytes — don't trust client MIME header
-        match infer::get(&data) {
-            Some(inferred) => {
-                let inferred_mime = inferred.mime_type();
-                if !ALLOWED_MIME_TYPES.contains(&inferred_mime) {
-                    return Err(AppError::bad_request(format!(
-                        "Detected file type '{inferred_mime}' is not allowed"
-                    )));
-                }
-                mime_type = inferred_mime.to_string();
-            }
-            None => {
-                // Unrecognized file type — reject to prevent bypass
-                return Err(AppError::bad_request(
-                    "Could not detect file type from content. Upload a supported format.",
-                ));
-            }
-        }
-
-        file_data = Some((original_filename, mime_type, data));
+        file_data = Some(validate_and_read_file(field).await?);
     }
 
     let (original_filename, mime_type, data) = file_data

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -497,6 +497,74 @@ async fn handle_broadcast_event<F>(
     }
 }
 
+/// Validate that the message content does not exceed the maximum length.
+fn validate_message_length(state: &AppState, sender_id: Uuid, content: &str) -> bool {
+    const MAX_MESSAGE_LENGTH: usize = 10_000;
+    if content.len() > MAX_MESSAGE_LENGTH {
+        send_error(
+            state,
+            sender_id,
+            &format!(
+                "Message too long: {} characters (max {})",
+                content.len(),
+                MAX_MESSAGE_LENGTH
+            ),
+        );
+        return false;
+    }
+    true
+}
+
+/// Look up conversation security, validate channel usage, and enforce
+/// encryption on direct messages.  Returns the security row, conversation
+/// kind, and resolved channel id on success.
+async fn validate_conversation_security(
+    state: &AppState,
+    sender_id: Uuid,
+    conv_id: Uuid,
+    channel_id: Option<Uuid>,
+) -> Option<(
+    db::messages::ConversationSecurityRow,
+    Option<ConversationKind>,
+    Option<Uuid>,
+)> {
+    let conv_security = match db::messages::get_conversation_security(&state.pool, conv_id).await {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            send_error(state, sender_id, "Conversation not found");
+            return None;
+        }
+        Err(_) => {
+            send_error(state, sender_id, "Database error");
+            return None;
+        }
+    };
+
+    let conv_kind = ConversationKind::from_str_opt(&conv_security.kind);
+    if conv_kind != Some(ConversationKind::Group) && channel_id.is_some() {
+        send_error(
+            state,
+            sender_id,
+            "channel_id is only valid for group conversations",
+        );
+        return None;
+    }
+
+    let resolved_channel_id =
+        resolve_channel(state, sender_id, conv_id, channel_id, conv_kind).await?;
+
+    if conv_kind == Some(ConversationKind::Direct) && !conv_security.is_encrypted {
+        send_error(
+            state,
+            sender_id,
+            "Direct messages must be end-to-end encrypted",
+        );
+        return None;
+    }
+
+    Some((conv_security, conv_kind, resolved_channel_id))
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_send_message(
     state: &AppState,
@@ -510,18 +578,7 @@ async fn handle_send_message(
     reply_to_id: Option<Uuid>,
     device_contents: Option<HashMap<String, String>>,
 ) {
-    // Validate message content length
-    const MAX_MESSAGE_LENGTH: usize = 10_000;
-    if content.len() > MAX_MESSAGE_LENGTH {
-        send_error(
-            state,
-            sender_id,
-            &format!(
-                "Message too long: {} characters (max {})",
-                content.len(),
-                MAX_MESSAGE_LENGTH
-            ),
-        );
+    if !validate_message_length(state, sender_id, &content) {
         return;
     }
 
@@ -530,43 +587,11 @@ async fn handle_send_message(
         return;
     };
 
-    // Enforce encrypted-only direct messages.
-    let conv_security = match db::messages::get_conversation_security(&state.pool, conv_id).await {
-        Ok(Some(row)) => row,
-        Ok(None) => {
-            send_error(state, sender_id, "Conversation not found");
-            return;
-        }
-        Err(_) => {
-            send_error(state, sender_id, "Database error");
-            return;
-        }
-    };
-
-    let conv_kind = ConversationKind::from_str_opt(&conv_security.kind);
-    if conv_kind != Some(ConversationKind::Group) && channel_id.is_some() {
-        send_error(
-            state,
-            sender_id,
-            "channel_id is only valid for group conversations",
-        );
-        return;
-    }
-
-    let Some(resolved_channel_id) =
-        resolve_channel(state, sender_id, conv_id, channel_id, conv_kind).await
+    let Some((conv_security, _conv_kind, resolved_channel_id)) =
+        validate_conversation_security(state, sender_id, conv_id, channel_id).await
     else {
         return;
     };
-
-    if conv_kind == Some(ConversationKind::Direct) && !conv_security.is_encrypted {
-        send_error(
-            state,
-            sender_id,
-            "Direct messages must be end-to-end encrypted",
-        );
-        return;
-    }
 
     let (reply_content, reply_username) = lookup_reply_context(&state.pool, reply_to_id).await;
 


### PR DESCRIPTION
## Summary — Batch 2+3: Complete S3776 sweep

Pure structural refactoring — no behavior changes. Extracted nested conditionals into named private helper methods across 32 methods.

### Batch 2 — Score 20+ (15 methods)
- message_item.dart (29, 28), connection_status_banner.dart (28), splash_screen.dart (28)
- crypto_service.dart (27), user_profile_screen.dart (27), voice_rtc_provider.dart (25)
- channel_bar.dart (24, 23), chat_panel.dart (21), chat_input_bar.dart (21)
- app_router.dart (21), livekit_voice_provider.dart (20), voice_lounge_screen.dart (20)
- quick_switcher_overlay.dart (20)

### Batch 3 — Score 16-19 (17 methods)
- home_screen.dart (19, 17), rich_text_content.dart (19), crypto_provider.dart (18)
- account_section.dart (17, 16), voice_lounge_screen.dart (17, 16)
- audio_section.dart (17), chat_panel.dart (17), conversation_panel.dart (16)
- chat_input_bar.dart (16), crypto_service.dart (16), chat_provider.dart (16)
- handler.rs (19), link_preview.rs (17), media.rs (17)

## Test plan
- [x] `cargo check --workspace` + `cargo test --workspace --lib` — 72 tests pass
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `dart format` — clean