### PR TITLE
fix(client): DM encryption resilience — auto-reset stale sessions

### DIFF
--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -292,20 +292,29 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       fallbackPayload = deviceContents.values.firstOrNull ?? '';
     } catch (e) {
       debugPrint('[WS] Multi-device encryption failed: $e');
-      // Fall back to single-device encrypt
+      // Fall back to single-device encrypt with session reset retry
       try {
         final crypto = ref.read(cryptoServiceProvider);
         fallbackPayload = await crypto.encryptMessage(toUserId, content);
         deviceContents = null;
       } catch (e2) {
-        debugPrint('[WS] Fallback encryption also failed: $e2');
-        _addFailedMessage(
-          toUserId,
-          _friendlyEncryptionError(e2),
-          conversationId: conversationId,
-          originalContent: content,
-        );
-        return;
+        debugPrint('[WS] Fallback encryption failed, resetting session: $e2');
+        // Reset session and retry once before giving up
+        try {
+          final crypto = ref.read(cryptoServiceProvider);
+          await crypto.invalidateSessionKey(toUserId);
+          fallbackPayload = await crypto.encryptMessage(toUserId, content);
+          deviceContents = null;
+        } catch (e3) {
+          debugPrint('[WS] Encryption retry after reset also failed: $e3');
+          _addFailedMessage(
+            toUserId,
+            _friendlyEncryptionError(e3),
+            conversationId: conversationId,
+            originalContent: content,
+          );
+          return;
+        }
       }
     }
 

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -282,6 +282,14 @@ class CryptoService {
 
         _keysAreFresh = true;
         _needsOtpReplenishment = true; // Fresh install needs OTP keys
+
+        // Purge any stale sessions from storage — they reference the old keys.
+        final allEntries = await store.readAll();
+        for (final key in allEntries.keys) {
+          if (key.startsWith(_sessionPrefix)) {
+            await store.delete(key);
+          }
+        }
       }
     } catch (e) {
       rethrow;
@@ -802,18 +810,29 @@ class CryptoService {
     String peerUserId,
     String plaintext,
   ) async {
-    final isNewSession = !_sessions.containsKey(peerUserId);
-    final session = await getOrCreateSession(peerUserId);
+    var isNewSession = !_sessions.containsKey(peerUserId);
+    var session = await getOrCreateSession(peerUserId);
     final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
 
-    // Write-ahead: save session state BEFORE mutation so that if the app
-    // crashes between encrypt and the post-save, the session reloads to the
-    // pre-mutation state.  The unsent message can safely be re-encrypted.
-    if (!isNewSession) {
-      await _saveSession(peerUserId, session);
+    Uint8List wire;
+    try {
+      // Write-ahead: save session state BEFORE mutation so that if the app
+      // crashes between encrypt and the post-save, the session reloads to the
+      // pre-mutation state.  The unsent message can safely be re-encrypted.
+      if (!isNewSession) {
+        await _saveSession(peerUserId, session);
+      }
+      wire = await session.encrypt(plaintextBytes);
+    } catch (e) {
+      // Session corrupted/stale — clear and retry once with fresh X3DH
+      debugPrint('[Crypto] Encrypt failed for $peerUserId, resetting session: $e');
+      _sessions.remove(peerUserId);
+      await SecureKeyStore.instance.delete('$_sessionPrefix$peerUserId');
+      isNewSession = true;
+      session = await getOrCreateSession(peerUserId);
+      wire = await session.encrypt(plaintextBytes);
     }
 
-    final wire = await session.encrypt(plaintextBytes);
     final finalWire = await _buildInitialWire(wire);
 
     await _saveSession(peerUserId, session);
@@ -1027,9 +1046,22 @@ class CryptoService {
     }
     // Write-ahead: save before mutation so crash recovery replays correctly
     await _saveSession(sessionKey, session);
-    final plainBytes = await session.decrypt(fullWire);
-    await _saveSession(sessionKey, session);
-    return utf8.decode(plainBytes);
+    try {
+      final plainBytes = await session.decrypt(fullWire);
+      await _saveSession(sessionKey, session);
+      return utf8.decode(plainBytes);
+    } catch (e) {
+      // Session is stale/corrupted — clear it. The next incoming initial
+      // message from this peer will establish a fresh session via X3DH.
+      // We do NOT create a new outgoing session here (that would break sync).
+      debugPrint(
+        '[Crypto] Normal decrypt failed for $sessionKey, '
+        'clearing stale session: $e',
+      );
+      _sessions.remove(sessionKey);
+      await SecureKeyStore.instance.delete('$_sessionPrefix$sessionKey');
+      rethrow;
+    }
   }
 
   /// Attempt to decrypt a historical message using the existing session.

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -626,7 +626,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       if (conv.isGroup) {
         await ws.sendGroupMessage(
           conv.id,
-          message.content,
+          message.failedContent ?? message.content,
           channelId: message.channelId,
           replyToId: message.replyToId,
         );
@@ -638,7 +638,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         if (peer == null) return;
         await ws.sendMessage(
           peer.userId,
-          message.content,
+          message.failedContent ?? message.content,
           conversationId: conv.id,
           replyToId: message.replyToId,
         );


### PR DESCRIPTION
## Summary

DM encryption was brittle — stale sessions from key regeneration or keyring failures caused permanent "encryption failed" / "[Encrypted message]" with no recovery path. This PR makes encryption self-healing.

### Changes

**A. Purge sessions on key regeneration** (`crypto_service.dart init()`)
When identity keys are regenerated, all stored sessions are now deleted. They referenced the old keys and would fail on every attempt.

**B. Auto-retry encrypt with session reset** (`crypto_service.dart _encryptMessageImpl()`)
If `session.encrypt()` fails, clears the stale session and retries once with a fresh X3DH key exchange.

**C. Clear stale session on decrypt failure** (`crypto_service.dart _decryptNormalMessage()`)
When normal-message decryption fails (bad MAC, wrong key), the stale session is cleared so the peer's next initial X3DH message will be accepted cleanly. Does NOT create a new outgoing session.

**D. Fix retry to use original content** (`chat_panel.dart _retryMessage()`)
Was sending the error message text instead of the user's original message. Now uses `failedContent ?? content`.

**E. Auto-retry send with session reset** (`websocket_provider.dart sendMessage()`)
On encryption failure, resets the session via `invalidateSessionKey()` and retries once before showing error to user.

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 589 tests pass
- [ ] Manual: two clients, fresh accounts, send DM → encrypts and decrypts
- [ ] Manual: regenerate keys on one client, send DM → auto-recovers

Closes #127