### PR TITLE
feat(client): per-user data directories for key and cache isolation

### DIFF
--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -12,6 +12,7 @@ import 'src/services/debug_log_service.dart';
 import 'src/services/message_cache.dart';
 import 'src/services/notification_service.dart';
 import 'src/services/sound_service.dart';
+import 'src/services/user_data_dir.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -45,6 +46,7 @@ void main() async {
 
 Future<void> _initAndRun() async {
   await Hive.initFlutter();
+  await UserDataDir.instance.init();
   await MessageCache.init();
 
   final container = ProviderContainer();

--- a/apps/client/lib/src/providers/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth_provider.dart
@@ -6,6 +6,9 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/background_service.dart' show BackgroundService;
+import '../services/message_cache.dart';
+import '../services/secure_key_store.dart';
+import '../services/user_data_dir.dart';
 import 'server_url_provider.dart';
 
 const _kJsonHeaders = {'Content-Type': 'application/json'};
@@ -89,6 +92,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
           // Legacy mode: we have an access token but no refresh token.
           // Restore the session optimistically -- it may be expired, but
           // individual API calls will handle 401 gracefully.
+          await _setUserScope(storedUserId);
           state = AuthState(
             isLoggedIn: true,
             userId: storedUserId,
@@ -120,6 +124,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
         final userId = data['user_id'] as String? ?? storedUserId ?? '';
         final username = data['username'] as String? ?? storedUsername ?? '';
 
+        await _setUserScope(userId);
         state = AuthState(
           isLoggedIn: true,
           userId: userId,
@@ -247,6 +252,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
     }
   }
 
+  /// Scope secure storage and message cache to the logged-in user.
+  Future<void> _setUserScope(String userId) async {
+    final host = Uri.parse(_serverUrl).host;
+    SecureKeyStore.instance.setUserScope(userId, host);
+    await UserDataDir.instance.setUser(userId, _serverUrl);
+    await MessageCache.initForUser(userId, host);
+  }
+
   /// Clear all stored tokens.
   Future<void> _clearStoredTokens() async {
     try {
@@ -286,6 +299,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
         final refreshToken = data['refresh_token'] as String?;
         final userId = data['user_id'] as String;
 
+        await _setUserScope(userId);
         state = AuthState(
           isLoggedIn: true,
           userId: userId,
@@ -335,6 +349,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
         final userId = data['user_id'] as String;
         final avatarUrl = data['avatar_url'] as String?;
 
+        await _setUserScope(userId);
         state = AuthState(
           isLoggedIn: true,
           userId: userId,
@@ -378,6 +393,8 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   void logout() {
     BackgroundService.instance.stop();
+    SecureKeyStore.instance.clearUserScope();
+    UserDataDir.instance.clearUser();
     _clearStoredTokens();
     state = const AuthState();
   }

--- a/apps/client/lib/src/services/message_cache.dart
+++ b/apps/client/lib/src/services/message_cache.dart
@@ -10,6 +10,14 @@ class MessageCache {
     _box = await Hive.openBox<Map>(_boxName);
   }
 
+  /// Re-initialize with a user-scoped Hive box.
+  /// Call after login to isolate message cache per user.
+  static Future<void> initForUser(String userId, String serverHost) async {
+    if (_box != null && _box!.isOpen) await _box!.close();
+    final sanitized = '${userId}_$serverHost'.replaceAll(RegExp(r'[^\w]'), '_');
+    _box = await Hive.openBox<Map>('echo_messages_$sanitized');
+  }
+
   static Future<void> cacheMessages(
     String conversationId,
     List<ChatMessage> messages,

--- a/apps/client/lib/src/services/secure_key_store.dart
+++ b/apps/client/lib/src/services/secure_key_store.dart
@@ -16,6 +16,34 @@ class SecureKeyStore {
 
   final FlutterSecureStorage _storage;
 
+  /// User-scoped key prefix. Empty = global (pre-login).
+  String _userPrefix = '';
+
+  /// Scope all storage operations to a specific user.
+  void setUserScope(String userId, String serverHost) {
+    _userPrefix = 'u/$userId@$serverHost/';
+  }
+
+  /// Clear user scope (on logout).
+  void clearUserScope() {
+    _userPrefix = '';
+  }
+
+  /// Current prefix for testing visibility.
+  @visibleForTesting
+  String get keyPrefix => _userPrefix;
+
+  /// Delete all keys belonging to the current user scope.
+  Future<void> deleteAllForUser() async {
+    if (_userPrefix.isEmpty) return;
+    final all = await _storage.readAll();
+    for (final key in all.keys) {
+      if (key.startsWith(_userPrefix)) {
+        await _storage.delete(key: key);
+      }
+    }
+  }
+
   SecureKeyStore._()
     : _storage = const FlutterSecureStorage(
         aOptions: AndroidOptions(encryptedSharedPreferences: true),
@@ -48,7 +76,7 @@ class SecureKeyStore {
   /// to the user instead of silently regenerating new identity keys.
   Future<String?> read(String key) async {
     try {
-      return await _storage.read(key: key);
+      return await _storage.read(key: '$_userPrefix$key');
     } catch (e) {
       debugPrint('[SecureKeyStore] read($key) failed: $e');
       rethrow;
@@ -62,7 +90,7 @@ class SecureKeyStore {
   /// remove the SharedPreferences entry if this write fails).
   Future<void> write(String key, String value) async {
     try {
-      await _storage.write(key: key, value: value);
+      await _storage.write(key: '$_userPrefix$key', value: value);
     } catch (e) {
       debugPrint('[SecureKeyStore] write($key) failed: $e');
       rethrow;
@@ -72,16 +100,22 @@ class SecureKeyStore {
   /// Delete a single key.
   Future<void> delete(String key) async {
     try {
-      await _storage.delete(key: key);
+      await _storage.delete(key: '$_userPrefix$key');
     } catch (e) {
       debugPrint('[SecureKeyStore] delete($key) failed: $e');
     }
   }
 
-  /// Read all key-value pairs. Used for iterating session keys.
+  /// Read all key-value pairs for the current user scope.
   Future<Map<String, String>> readAll() async {
     try {
-      return await _storage.readAll();
+      final all = await _storage.readAll();
+      if (_userPrefix.isEmpty) return all;
+      return Map.fromEntries(
+        all.entries
+            .where((e) => e.key.startsWith(_userPrefix))
+            .map((e) => MapEntry(e.key.substring(_userPrefix.length), e.value)),
+      );
     } catch (e) {
       debugPrint('[SecureKeyStore] readAll failed: $e');
       return {};
@@ -91,7 +125,7 @@ class SecureKeyStore {
   /// Check if a key exists.
   Future<bool> containsKey(String key) async {
     try {
-      return await _storage.containsKey(key: key);
+      return await _storage.containsKey(key: '$_userPrefix$key');
     } catch (e) {
       debugPrint('[SecureKeyStore] containsKey($key) failed: $e');
       return false;

--- a/apps/client/lib/src/services/user_data_dir.dart
+++ b/apps/client/lib/src/services/user_data_dir.dart
@@ -1,0 +1,71 @@
+/// Per-user data directory management.
+///
+/// Each user gets an isolated directory under the app support path:
+/// `<appSupport>/echo-messenger/users/<userId>@<host>/`
+///
+/// Subdirectories: `keys/`, `sessions/`, `cache/`.
+library;
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class UserDataDir {
+  static UserDataDir? _instance;
+  String? _basePath;
+  String? _currentUserPath;
+  String? _currentUserId;
+  String? _currentHost;
+
+  static UserDataDir get instance => _instance ??= UserDataDir._();
+  UserDataDir._();
+
+  /// Initialize with the platform app support directory.
+  /// Call once at startup (after Hive.initFlutter, before login).
+  Future<void> init() async {
+    if (kIsWeb) return;
+    final appDir = await getApplicationSupportDirectory();
+    _basePath = p.join(appDir.path, 'echo-messenger');
+    await Directory(_basePath!).create(recursive: true);
+  }
+
+  /// Set the active user. Creates the user directory if needed.
+  /// Call after login, before crypto init.
+  Future<String> setUser(String userId, String serverUrl) async {
+    final host = Uri.parse(serverUrl).host;
+    _currentUserId = userId;
+    _currentHost = host;
+
+    if (kIsWeb) return '';
+
+    final sanitized = '$userId@$host'.replaceAll(RegExp(r'[^\w@.\-]'), '_');
+    _currentUserPath = p.join(_basePath!, 'users', sanitized);
+
+    await Directory(p.join(_currentUserPath!, 'keys')).create(recursive: true);
+    await Directory(
+      p.join(_currentUserPath!, 'sessions'),
+    ).create(recursive: true);
+    await Directory(p.join(_currentUserPath!, 'cache')).create(recursive: true);
+
+    return _currentUserPath!;
+  }
+
+  String get path =>
+      _currentUserPath ?? (throw StateError('No user directory set'));
+  String get keysPath => p.join(path, 'keys');
+  String get sessionsPath => p.join(path, 'sessions');
+  String get cachePath => p.join(path, 'cache');
+
+  String? get currentUserId => _currentUserId;
+  String? get currentHost => _currentHost;
+  bool get isSet => _currentUserId != null;
+
+  /// Clear current user reference (on logout). Does NOT delete files.
+  void clearUser() {
+    _currentUserPath = null;
+    _currentUserId = null;
+    _currentHost = null;
+  }
+}

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -768,7 +768,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   cached_network_image: ^3.4.1
   flutter_cache_manager: ^3.4.1
   flutter_local_notifications: ^19.0.0
+  path: ^1.9.0
   path_provider: ^2.1.0
   emoji_picker_flutter: ^4.0.0
   hive: ^2.2.3


### PR DESCRIPTION
## Summary

All crypto keys, sessions, and message cache were stored globally with no user/server scoping. Logging into a different account on the same device caused cross-contamination of encryption keys and message history.

### Changes

**New: `UserDataDir` service** — per-user directory structure:
```
<appSupport>/echo-messenger/users/<userId>@<host>/
├── keys/
├── sessions/
└── cache/
```

**Modified: `SecureKeyStore`** — all storage operations now prefixed with `u/<userId>@<host>/`. User A's keys are invisible to User B.

**Modified: `MessageCache`** — `initForUser()` opens a user-scoped Hive box (`echo_messages_<userId>_<host>`).

**Modified: `AuthProvider`** — scoping set on login/register/auto-login, cleared on logout.

**Modified: `main.dart`** — `UserDataDir.init()` at startup.

## Test plan
- [x] `flutter analyze --fatal-infos` — no issues
- [x] `flutter test` — 589 tests pass

Closes #136