### PR TITLE
fix: batch bugfixes -- dm nav, media auth, web login, ios ui, mobile buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ git push origin dev                 # Triggers lint + dev builds only
 gh pr create --base main            # When ready for release
 ```
 
+## Prerequisites
+
+Rust (edition 2024), Flutter 3.41+ (SDK `^3.11.4`), Docker (for PostgreSQL), Node.js 20+ (for commitlint + Playwright).
+
 ## Build & Run
 
 ```bash
@@ -71,13 +75,13 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - `apps/client/` -- Flutter app, Riverpod state management, GoRouter navigation
 - `core/rust-core/` -- Shared Rust library: Signal Protocol (X3DH + Double Ratchet), crypto primitives, FFI bridge
 
-**Server startup sequence** (main.rs): load .env -> tracing -> create upload dirs (`./uploads/avatars`) -> Config::from_env() -> PG pool + auto-migrate SQL files (`apps/server/migrations/`, 9 migrations) -> spawn WebSocket Hub (DashMap) -> spawn background tasks (stale voice session cleanup every 60s, empty group cleanup) -> build Axum router -> bind with graceful shutdown.
+**Server startup sequence** (main.rs): load .env -> tracing -> create upload dirs (`./uploads/avatars`) -> Config::from_env() -> PG pool + auto-migrate SQL files (`apps/server/migrations/`, 14 migrations) -> spawn WebSocket Hub (DashMap) -> spawn background tasks (stale voice session cleanup every 60s, empty group cleanup) -> build Axum router -> bind with graceful shutdown.
 
 **Key server modules**:
 - `auth/` -- JWT (15-min access + 7-day refresh), Argon2id passwords, AuthUser middleware extractor
 - `ws/hub.rs` -- DashMap<user_id, mpsc::Sender> for lock-free WS routing
 - `ws/handler.rs` -- WS upgrade, message parsing, event dispatch (MessageRelayed, TypingIndicator, Reaction, Online/Offline)
-- `db/` -- 9 query modules (users, messages, contacts, groups, keys, reactions, media, tokens)
+- `db/` -- query modules (users, messages, contacts, groups, keys, reactions, media, tokens, devices, push_tokens)
 - `routes/` -- REST: /api/auth, /api/users, /api/contacts, /api/messages, /api/groups, /api/keys, /api/reactions, /api/media, /api/channels, /api/voice, /api/group_keys, /api/link_preview
 
 **Client init** (main.dart): Hive local DB -> message cache -> load persisted server URL (web: overridable via `?server=` query param) -> load sound prefs -> request notification permission -> SplashScreen handles auto-login + crypto init.
@@ -110,7 +114,7 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - **rustfmt**: max_width=100, Unix newlines, field_init_shorthand + try_shorthand enabled.
 - **Server required env**: `DATABASE_URL` and `JWT_SECRET` (≥32 chars, panics without them). Optional: `HOST` (default `0.0.0.0`), `PORT` (default `8080`), `CORS_ORIGINS` for allowed origins, `RUST_LOG` for log filtering (e.g. `echo_server=debug`).
 - **Traefik routing**: API priority 100, Web priority 1 (API routes must take precedence).
-- **Message wire format**: Initial = `[0xEC, 0x01] + identity_pub(32) + ephemeral_pub(32) + session_wire`; Normal = `header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`. Both base64-wrapped over WebSocket.
+- **Message wire format**: Initial V2 (with OTP) = `[0xEC, 0x02] + identity_pub(32) + ephemeral_pub(32) + otp_id(4 LE) + ratchet_wire`; Initial V1 (no OTP) = `[0xEC, 0x01] + identity_pub(32) + ephemeral_pub(32) + ratchet_wire`; Normal = `header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`. All base64-wrapped over WebSocket.
 - **Soft deletes**: Messages use `is_deleted` flag, not hard deletes.
 
 ## Commit Style

--- a/apps/client/lib/src/providers/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth_provider.dart
@@ -124,6 +124,18 @@ class AuthNotifier extends StateNotifier<AuthState> {
         final userId = data['user_id'] as String? ?? storedUserId ?? '';
         final username = data['username'] as String? ?? storedUsername ?? '';
 
+        // Persist new tokens BEFORE any other async work. The server
+        // already revoked the old refresh token during rotation, so if
+        // _setUserScope throws (e.g. Hive/IndexedDB error on web) or the
+        // page is refreshed before we finish, the new token is safe in
+        // localStorage and the next auto-login attempt will succeed.
+        await _storeTokens(
+          accessToken: newAccessToken,
+          refreshToken: newRefreshToken,
+          userId: userId,
+          username: username,
+        );
+
         await _setUserScope(userId);
         state = AuthState(
           isLoggedIn: true,
@@ -131,13 +143,6 @@ class AuthNotifier extends StateNotifier<AuthState> {
           username: username,
           token: newAccessToken,
           refreshToken: newRefreshToken,
-        );
-
-        await _storeTokens(
-          accessToken: newAccessToken,
-          refreshToken: newRefreshToken,
-          userId: userId,
-          username: username,
         );
         return true;
       } else {
@@ -257,7 +262,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
     final host = Uri.parse(_serverUrl).host;
     SecureKeyStore.instance.setUserScope(userId, host);
     await UserDataDir.instance.setUser(userId, _serverUrl);
-    await MessageCache.initForUser(userId, host);
+    try {
+      await MessageCache.initForUser(userId, host);
+    } catch (e) {
+      // Non-fatal: fall back to the default shared message cache.
+      // On web, Hive/IndexedDB box close/reopen can fail during
+      // page refresh; this must not prevent login.
+      debugPrint('[Auth] MessageCache.initForUser failed (non-fatal): $e');
+    }
   }
 
   /// Clear all stored tokens.
@@ -299,6 +311,13 @@ class AuthNotifier extends StateNotifier<AuthState> {
         final refreshToken = data['refresh_token'] as String?;
         final userId = data['user_id'] as String;
 
+        await _storeTokens(
+          accessToken: accessToken,
+          refreshToken: refreshToken ?? '',
+          userId: userId,
+          username: username,
+        );
+
         await _setUserScope(userId);
         state = AuthState(
           isLoggedIn: true,
@@ -306,13 +325,6 @@ class AuthNotifier extends StateNotifier<AuthState> {
           username: username,
           token: accessToken,
           refreshToken: refreshToken,
-        );
-
-        await _storeTokens(
-          accessToken: accessToken,
-          refreshToken: refreshToken ?? '',
-          userId: userId,
-          username: username,
         );
       } else {
         String errorMsg = 'Registration failed';
@@ -349,6 +361,13 @@ class AuthNotifier extends StateNotifier<AuthState> {
         final userId = data['user_id'] as String;
         final avatarUrl = data['avatar_url'] as String?;
 
+        await _storeTokens(
+          accessToken: accessToken,
+          refreshToken: refreshToken ?? '',
+          userId: userId,
+          username: username,
+        );
+
         await _setUserScope(userId);
         state = AuthState(
           isLoggedIn: true,
@@ -357,13 +376,6 @@ class AuthNotifier extends StateNotifier<AuthState> {
           token: accessToken,
           refreshToken: refreshToken,
           avatarUrl: avatarUrl,
-        );
-
-        await _storeTokens(
-          accessToken: accessToken,
-          refreshToken: refreshToken ?? '',
-          userId: userId,
-          username: username,
         );
 
         // Start background service to keep WebSocket alive on mobile

--- a/apps/client/lib/src/screens/contacts_screen.dart
+++ b/apps/client/lib/src/screens/contacts_screen.dart
@@ -170,7 +170,7 @@ class _ContactsScreenState extends ConsumerState<ContactsScreen> {
         if (widget.onStartConversation != null) {
           widget.onStartConversation!(conv);
         } else {
-          context.go('/home');
+          context.go('/home?conversation=${conv.id}');
         }
       } else {
         ToastService.show(

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -274,8 +274,8 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
                       onPageChanged: (i) => setState(() => _currentPage = i),
                       children: [
                         _buildWelcomePage(context),
-                        _buildAppearancePage(context),
                         _buildAboutYouPage(context),
+                        _buildAppearancePage(context),
                         _buildContactPage(context),
                       ],
                     ),

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -393,6 +393,40 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         if (orientation == Orientation.landscape) {
           return Container(
             color: context.mainBg,
+            child: ClipRect(
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: VertexMeshBackground(
+                      accentColor: context.accent,
+                      backgroundColor: context.mainBg,
+                    ),
+                  ),
+                  Column(
+                    children: [
+                      Expanded(child: contentArea),
+                      controlBar,
+                    ],
+                  ),
+                  Positioned(
+                    top: 12,
+                    left: 12,
+                    child: _buildHeaderBadge(
+                      context,
+                      channelName,
+                      totalParticipants,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        // Portrait: full header bar + content + control bar
+        return Container(
+          color: context.mainBg,
+          child: ClipRect(
             child: Stack(
               children: [
                 Positioned.fill(
@@ -403,47 +437,17 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
                 ),
                 Column(
                   children: [
+                    _LoungeHeader(
+                      channelName: channelName,
+                      participantCount: totalParticipants,
+                      onBackToChat: widget.onBackToChat,
+                    ),
                     Expanded(child: contentArea),
                     controlBar,
                   ],
                 ),
-                Positioned(
-                  top: 12,
-                  left: 12,
-                  child: _buildHeaderBadge(
-                    context,
-                    channelName,
-                    totalParticipants,
-                  ),
-                ),
               ],
             ),
-          );
-        }
-
-        // Portrait: full header bar + content + control bar
-        return Container(
-          color: context.mainBg,
-          child: Stack(
-            children: [
-              Positioned.fill(
-                child: VertexMeshBackground(
-                  accentColor: context.accent,
-                  backgroundColor: context.mainBg,
-                ),
-              ),
-              Column(
-                children: [
-                  _LoungeHeader(
-                    channelName: channelName,
-                    participantCount: totalParticipants,
-                    onBackToChat: widget.onBackToChat,
-                  ),
-                  Expanded(child: contentArea),
-                  controlBar,
-                ],
-              ),
-            ],
           ),
         );
       },

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -1396,21 +1396,24 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
               const ConnectionStatusBanner(),
 
               Expanded(
-                child: Stack(
-                  children: [
-                    _buildMessageListOrEmpty(
-                      conv: conv,
-                      messages: messages,
-                      isLoadingHistory: isLoadingHistory,
-                      displayName: displayName,
-                      chatState: chatState,
-                      memberAvatars: memberAvatars,
-                      myUserId: myUserId,
-                      serverUrl: serverUrl,
-                      authToken: authToken,
-                    ),
-                    if (_hasNewMessagesBelow) _buildNewMessagesPill(),
-                  ],
+                child: GestureDetector(
+                  onTap: () => FocusScope.of(context).unfocus(),
+                  child: Stack(
+                    children: [
+                      _buildMessageListOrEmpty(
+                        conv: conv,
+                        messages: messages,
+                        isLoadingHistory: isLoadingHistory,
+                        displayName: displayName,
+                        chatState: chatState,
+                        memberAvatars: memberAvatars,
+                        myUserId: myUserId,
+                        serverUrl: serverUrl,
+                        authToken: authToken,
+                      ),
+                      if (_hasNewMessagesBelow) _buildNewMessagesPill(),
+                    ],
+                  ),
                 ),
               ),
 

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1079,6 +1079,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
             if (_searchQuery.isEmpty) ...[
               const SizedBox(height: 14),
               SizedBox(
+                width: double.infinity,
                 height: 34,
                 child: FilledButton.icon(
                   onPressed: widget.onNewChat,
@@ -1320,28 +1321,24 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               ),
               if (_searchQuery.isEmpty) ...[
                 const SizedBox(height: 14),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  alignment: WrapAlignment.center,
-                  children: [
-                    SizedBox(
-                      height: 34,
-                      child: FilledButton.icon(
-                        onPressed: widget.onNewGroup,
-                        icon: const Icon(Icons.group_add, size: 16),
-                        label: const Text('Create Group'),
-                      ),
-                    ),
-                    SizedBox(
-                      height: 34,
-                      child: OutlinedButton.icon(
-                        onPressed: widget.onDiscover,
-                        icon: const Icon(Icons.explore_outlined, size: 16),
-                        label: const Text('Discover'),
-                      ),
-                    ),
-                  ],
+                SizedBox(
+                  width: double.infinity,
+                  height: 34,
+                  child: FilledButton.icon(
+                    onPressed: widget.onNewGroup,
+                    icon: const Icon(Icons.group_add, size: 16),
+                    label: const Text('Create Group'),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  height: 34,
+                  child: OutlinedButton.icon(
+                    onPressed: widget.onDiscover,
+                    icon: const Icon(Icons.explore_outlined, size: 16),
+                    label: const Text('Discover'),
+                  ),
                 ),
               ],
             ],

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
@@ -62,12 +63,24 @@ bool isFileUrl(String url) => _fileExtensions.contains(urlExtension(url));
 
 /// Resolves a potentially relative media URL to an absolute URL.
 ///
-/// Does NOT append auth tokens -- callers should use [mediaHeaders] for
-/// authenticated requests, or fetch a media ticket for browser-opened URLs.
+/// On web, appends the auth token as a query parameter because
+/// CachedNetworkImage uses HTML <img> elements which cannot send custom
+/// HTTP headers. On native platforms, callers use [mediaHeaders] instead.
 String resolveMediaUrl(String url, {String? serverUrl, String? authToken}) {
-  if (url.startsWith('http')) return url;
-  final base = serverUrl ?? '';
-  return url.startsWith('/') && base.isNotEmpty ? '$base$url' : url;
+  String resolved = url;
+  if (!url.startsWith('http')) {
+    final base = serverUrl ?? '';
+    if (url.startsWith('/') && base.isNotEmpty) {
+      resolved = '$base$url';
+    }
+  }
+  // On web, <img> tags cannot carry Authorization headers, so pass the
+  // token via query parameter (server accepts ?token= for media downloads).
+  if (kIsWeb && authToken != null && authToken.isNotEmpty) {
+    final separator = resolved.contains('?') ? '&' : '?';
+    resolved = '$resolved${separator}jwt=$authToken';
+  }
+  return resolved;
 }
 
 /// Fetches a single-use media ticket from the server for use in browser URLs.
@@ -127,7 +140,10 @@ List<String> extractEmbeddedImageUrls(String content) {
 }
 
 /// Builds auth headers for media requests.
+///
+/// Returns empty headers on web since auth is passed via URL query parameter.
 Map<String, String> mediaHeaders({String? authToken}) {
+  if (kIsWeb) return const {};
   final headers = <String, String>{};
   if (authToken != null && authToken.isNotEmpty) {
     headers['Authorization'] = 'Bearer $authToken';

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -264,11 +264,13 @@ pub async fn request_media_ticket(
 }
 
 /// Query param for media download -- accepts `?ticket=` (single-use media
-/// ticket) or legacy `?token=` (validated as media ticket, not JWT).
+/// ticket), legacy `?token=` (validated as media ticket, not JWT), or
+/// `?jwt=` (for web clients where <img> tags cannot send auth headers).
 #[derive(Debug, Deserialize)]
 pub struct MediaDownloadQuery {
     pub ticket: Option<String>,
     pub token: Option<String>,
+    pub jwt: Option<String>,
 }
 
 /// GET /api/media/:id
@@ -294,7 +296,13 @@ pub async fn download(
         Uuid::parse_str(&claims.sub)
             .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?
     }
-    // 2. Try ?ticket= or legacy ?token= as media ticket
+    // 2. Try ?jwt= query param (for web clients where <img> tags cannot send headers)
+    else if let Some(jwt_str) = &query.jwt {
+        let claims = jwt::validate_token(jwt_str, &state.jwt_secret)?;
+        Uuid::parse_str(&claims.sub)
+            .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?
+    }
+    // 3. Try ?ticket= or legacy ?token= as media ticket
     else if let Some(ticket_str) = query.ticket.or(query.token) {
         validate_media_ticket(&state, &ticket_str)?
     } else {


### PR DESCRIPTION
## Summary
- **DM navigation**: clicking a contact from contacts screen now correctly opens the 1:1 DM instead of navigating home without a conversation ID
- **Web media loading**: added `?jwt=` query param to server media endpoint; Flutter web CachedNetworkImage can't send auth headers via HTML `<img>` elements, so auth is passed via URL on web
- **Web auth persistence**: persist rotated refresh tokens BEFORE `_setUserScope` to prevent token loss when Hive/IndexedDB errors occur; made `MessageCache.initForUser` non-fatal
- **iOS keyboard**: added tap-to-dismiss gesture on message list area
- **Voice lounge parallax**: wrapped background with ClipRect to prevent overflow above top bar
- **Onboarding flow**: reordered pages — bio after display name, then theme
- **Mobile buttons**: made New Chat / Create Group buttons full-width in empty states

## Test plan
- [ ] Open contacts screen, tap Message on a contact — should open 1:1 DM
- [ ] Load a group chat with images on web — images should load
- [ ] Login on web, refresh page — should stay logged in
- [ ] Open chat on iOS, tap message area to dismiss keyboard
- [ ] Open voice lounge — parallax should not overflow above header
- [ ] Register new account — bio screen should come after display name
- [ ] View empty chats/groups tab on mobile — buttons should be full-width