### PR TITLE
fix(server): prevent UTF-8 slice panic in push notification truncation

### DIFF
--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -199,12 +199,12 @@ struct ApnsPushParams<'a> {
 /// - Plaintext longer than 140 bytes is truncated at a character boundary
 ///   to avoid slicing through a multi-byte UTF-8 sequence.
 fn format_push_body(content: &str, is_encrypted: bool) -> String {
-    const MAX_PREVIEW: usize = 140;
+    const MAX_PREVIEW_BYTES: usize = 140;
 
     if is_encrypted {
         "Encrypted message".to_string()
-    } else if content.len() > MAX_PREVIEW {
-        let end = content.floor_char_boundary(MAX_PREVIEW);
+    } else if content.len() > MAX_PREVIEW_BYTES {
+        let end = content.floor_char_boundary(MAX_PREVIEW_BYTES);
         format!("{}...", &content[..end])
     } else {
         content.to_string()
@@ -326,17 +326,15 @@ mod tests {
 
     #[test]
     fn multibyte_boundary_mid_char_no_panic() {
-        // 'e\u{0301}' ("e" + combining accent) is 3 bytes. 46 * 3 = 138, 47 * 3 = 141.
-        // At 47 chars, byte 140 is mid-character (second byte of the 47th 'e\u{0301}').
+        // "e\u{0301}" = 'e' (1 byte) + combining acute U+0301 (2 bytes) = 3 bytes per unit.
+        // 47 units = 141 bytes (> 140). Byte 140 is 0x81, the continuation byte of the
+        // 47th combining accent. floor_char_boundary(140) = 139, the start of that accent.
         let accent = "e\u{0301}".repeat(47); // 141 bytes
         assert_eq!(accent.len(), 141);
         let body = format_push_body(&accent, false);
         assert!(body.ends_with("..."));
-        // Should truncate to 46 full characters (138 bytes) + "..."
-        // because byte 139 is 'e' but byte 140 is the combining accent's
-        // first byte, and floor_char_boundary(140) = 139 (the 'e').
-        // Actually let's just verify it doesn't panic and is valid UTF-8.
-        assert!(body.len() <= 143);
+        // 139 content bytes + 3 "..." = 142 bytes total.
+        assert_eq!(body.len(), 142);
     }
 
     #[test]
@@ -351,5 +349,18 @@ mod tests {
         let body = format_push_body(&over, false);
         assert!(body.ends_with("..."));
         assert_eq!(body, format!("{}...", "a".repeat(140)));
+    }
+
+    #[test]
+    fn empty_string_returned_as_is() {
+        assert_eq!(format_push_body("", false), "");
+    }
+
+    #[test]
+    fn encrypted_with_long_content_still_returns_placeholder() {
+        assert_eq!(
+            format_push_body(&"x".repeat(200), true),
+            "Encrypted message"
+        );
     }
 }

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -193,6 +193,24 @@ struct ApnsPushParams<'a> {
     message_id: Uuid,
 }
 
+/// Build the notification body text.
+///
+/// - Encrypted messages get a fixed placeholder (server can't read ciphertext).
+/// - Plaintext longer than 140 bytes is truncated at a character boundary
+///   to avoid slicing through a multi-byte UTF-8 sequence.
+fn format_push_body(content: &str, is_encrypted: bool) -> String {
+    const MAX_PREVIEW: usize = 140;
+
+    if is_encrypted {
+        "Encrypted message".to_string()
+    } else if content.len() > MAX_PREVIEW {
+        let end = content.floor_char_boundary(MAX_PREVIEW);
+        format!("{}...", &content[..end])
+    } else {
+        content.to_string()
+    }
+}
+
 /// Send an APNs push notification to an iOS device.
 ///
 /// - **Encrypted DMs**: Shows "Encrypted message" as the body (server can't
@@ -217,15 +235,7 @@ async fn send_apns_push(p: ApnsPushParams<'_>) {
 
     let url = format!("https://api.push.apple.com/3/device/{}", p.device_token);
 
-    // Encrypted DMs: server can't read content, show generic body.
-    // Plaintext: show a truncated preview.
-    let body = if p.is_encrypted {
-        "Encrypted message".to_string()
-    } else if p.content.len() > 140 {
-        format!("{}...", &p.content[..140])
-    } else {
-        p.content.to_string()
-    };
+    let body = format_push_body(p.content, p.is_encrypted);
 
     let payload = serde_json::json!({
         "aps": {
@@ -276,5 +286,70 @@ async fn send_apns_push(p: ApnsPushParams<'_>) {
         Err(e) => {
             tracing::warn!("APNs HTTP request failed for user {}: {e}", p.user_id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypted_message_returns_placeholder() {
+        assert_eq!(format_push_body("secret stuff", true), "Encrypted message");
+    }
+
+    #[test]
+    fn short_plaintext_returned_as_is() {
+        assert_eq!(format_push_body("hello", false), "hello");
+    }
+
+    #[test]
+    fn ascii_over_140_truncated_with_ellipsis() {
+        let long = "a".repeat(200);
+        let body = format_push_body(&long, false);
+        assert!(body.ends_with("..."));
+        // 140 chars of 'a' + "..."
+        assert_eq!(body.len(), 143);
+    }
+
+    #[test]
+    fn emoji_over_140_truncated_without_panic() {
+        // Each emoji is 4 bytes; 36 emojis = 144 bytes (> 140).
+        let emojis = "\u{1F600}".repeat(36);
+        assert_eq!(emojis.len(), 144);
+        let body = format_push_body(&emojis, false);
+        assert!(body.ends_with("..."));
+        // floor_char_boundary(140) for 4-byte chars = 140 -> lands at byte 140
+        // which is the start of the 36th emoji, so we keep 35 emojis (140 bytes).
+        assert_eq!(body, format!("{}...", "\u{1F600}".repeat(35)));
+    }
+
+    #[test]
+    fn multibyte_boundary_mid_char_no_panic() {
+        // 'e\u{0301}' ("e" + combining accent) is 3 bytes. 46 * 3 = 138, 47 * 3 = 141.
+        // At 47 chars, byte 140 is mid-character (second byte of the 47th 'e\u{0301}').
+        let accent = "e\u{0301}".repeat(47); // 141 bytes
+        assert_eq!(accent.len(), 141);
+        let body = format_push_body(&accent, false);
+        assert!(body.ends_with("..."));
+        // Should truncate to 46 full characters (138 bytes) + "..."
+        // because byte 139 is 'e' but byte 140 is the combining accent's
+        // first byte, and floor_char_boundary(140) = 139 (the 'e').
+        // Actually let's just verify it doesn't panic and is valid UTF-8.
+        assert!(body.len() <= 143);
+    }
+
+    #[test]
+    fn exactly_140_bytes_no_truncation() {
+        let exact = "a".repeat(140);
+        assert_eq!(format_push_body(&exact, false), exact);
+    }
+
+    #[test]
+    fn exactly_141_bytes_truncated() {
+        let over = "a".repeat(141);
+        let body = format_push_body(&over, false);
+        assert!(body.ends_with("..."));
+        assert_eq!(body, format!("{}...", "a".repeat(140)));
     }
 }

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -183,3 +183,36 @@ fn html_decode(s: &str) -> String {
         .replace("&#39;", "'")
         .replace("&#x27;", "'")
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn html_truncation_at_multibyte_boundary_no_panic() {
+        // Build a string just over 256 KB using 3-byte UTF-8 chars (e.g., "あ" = 3 bytes).
+        let ch = "あ"; // 3 bytes
+        let count = 262_144 / 3 + 10; // exceeds 262_144 bytes
+        let html: String = ch.repeat(count);
+        assert!(html.len() > 262_144);
+
+        let truncated = if html.len() > 262_144 {
+            &html[..html.floor_char_boundary(262_144)]
+        } else {
+            &html
+        };
+
+        // Must not panic, must be valid UTF-8, must be <= 262_144 bytes.
+        assert!(truncated.len() <= 262_144);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn html_under_limit_not_truncated() {
+        let html = "Hello, world!";
+        let result = if html.len() > 262_144 {
+            &html[..html.floor_char_boundary(262_144)]
+        } else {
+            html
+        };
+        assert_eq!(result, "Hello, world!");
+    }
+}

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -110,7 +110,7 @@ pub async fn fetch_preview(
         .await
         .map_err(|_| AppError::bad_request("Failed to read response"))?;
     let html = if html.len() > 262_144 {
-        &html[..262_144]
+        &html[..html.floor_char_boundary(262_144)]
     } else {
         &html
     };

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -29,6 +29,18 @@ pub struct LinkPreviewResponse {
     pub site_name: Option<String>,
 }
 
+/// Maximum HTML response bytes to process (256 KB).
+const MAX_HTML_BYTES: usize = 262_144;
+
+/// Cap HTML to [`MAX_HTML_BYTES`] at a valid UTF-8 boundary.
+fn cap_html(html: &str) -> &str {
+    if html.len() > MAX_HTML_BYTES {
+        &html[..html.floor_char_boundary(MAX_HTML_BYTES)]
+    } else {
+        html
+    }
+}
+
 /// Validate URL scheme and reject SSRF-vulnerable addresses.
 fn validate_url(url: &str) -> Result<(), AppError> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
@@ -109,11 +121,7 @@ pub async fn fetch_preview(
         .text()
         .await
         .map_err(|_| AppError::bad_request("Failed to read response"))?;
-    let html = if html.len() > 262_144 {
-        &html[..html.floor_char_boundary(262_144)]
-    } else {
-        &html
-    };
+    let html = cap_html(&html);
 
     // Extract Open Graph tags with simple regex (no HTML parser dependency)
     let title = extract_og_content(html, "og:title").or_else(|| extract_tag_content(html, "title"));
@@ -186,33 +194,42 @@ fn html_decode(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn html_truncation_at_multibyte_boundary_no_panic() {
-        // Build a string just over 256 KB using 3-byte UTF-8 chars (e.g., "あ" = 3 bytes).
-        let ch = "あ"; // 3 bytes
-        let count = 262_144 / 3 + 10; // exceeds 262_144 bytes
-        let html: String = ch.repeat(count);
-        assert!(html.len() > 262_144);
-
-        let truncated = if html.len() > 262_144 {
-            &html[..html.floor_char_boundary(262_144)]
-        } else {
-            &html
-        };
-
-        // Must not panic, must be valid UTF-8, must be <= 262_144 bytes.
-        assert!(truncated.len() <= 262_144);
-        assert!(truncated.is_char_boundary(truncated.len()));
-    }
+    use super::*;
 
     #[test]
     fn html_under_limit_not_truncated() {
         let html = "Hello, world!";
-        let result = if html.len() > 262_144 {
-            &html[..html.floor_char_boundary(262_144)]
-        } else {
-            html
-        };
-        assert_eq!(result, "Hello, world!");
+        assert_eq!(cap_html(html), "Hello, world!");
+    }
+
+    #[test]
+    fn html_exactly_at_limit_not_truncated() {
+        let html = "a".repeat(MAX_HTML_BYTES);
+        assert_eq!(cap_html(&html).len(), MAX_HTML_BYTES);
+    }
+
+    #[test]
+    fn html_one_over_limit_truncated() {
+        let html = "a".repeat(MAX_HTML_BYTES + 1);
+        assert_eq!(cap_html(&html).len(), MAX_HTML_BYTES);
+    }
+
+    #[test]
+    fn html_3byte_chars_at_boundary_no_panic() {
+        // "あ" = 3 bytes. Build a string exceeding the limit.
+        let html: String = "あ".repeat(MAX_HTML_BYTES / 3 + 10);
+        assert!(html.len() > MAX_HTML_BYTES);
+        let truncated = cap_html(&html);
+        assert!(truncated.len() <= MAX_HTML_BYTES);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn html_4byte_emoji_at_boundary_no_panic() {
+        let html: String = "\u{1F600}".repeat(MAX_HTML_BYTES / 4 + 10);
+        assert!(html.len() > MAX_HTML_BYTES);
+        let truncated = cap_html(&html);
+        assert!(truncated.len() <= MAX_HTML_BYTES);
+        assert!(truncated.is_char_boundary(truncated.len()));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #147 -- Server panics when truncating push notification body containing multi-byte UTF-8 characters (emoji, CJK, accented letters).

- **push.rs**: Replace `&content[..140]` with `str::floor_char_boundary(140)` to prevent panic on multi-byte chars at the truncation boundary. Extract `format_push_body()` helper for testability.
- **link_preview.rs**: Same fix for `&html[..262_144]` (256KB HTML cap). Extract `cap_html()` helper with named `MAX_HTML_BYTES` constant.
- **Tests**: 14 new unit tests covering encrypted/plaintext/emoji/CJK/boundary/edge cases for both modules.

## Test plan

- [x] `cargo test -p echo-server --lib` -- 45 tests pass (14 new)
- [x] `cargo clippy --workspace --all-targets` -- zero warnings
- [x] `cargo fmt --all -- --check` -- passes
- [x] Pre-commit hooks (lefthook) -- pass on all commits