### PR TITLE
fix(server): close authorization bypasses in voice, unpin, leave, media

### DIFF
--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -361,15 +361,22 @@ pub async fn pin_message(
 }
 
 /// Unpin a message. Clears pinned_by_id and pinned_at.
-/// Returns the conversation_id if the unpin was successful, None if message not found or
-/// not pinned.
-pub async fn unpin_message(pool: &PgPool, message_id: Uuid) -> Result<Option<Uuid>, sqlx::Error> {
+/// Only unpins if the message belongs to the given conversation.
+/// Returns the conversation_id if the unpin was successful, None if message not found,
+/// not pinned, or does not belong to the specified conversation.
+pub async fn unpin_message(
+    pool: &PgPool,
+    message_id: Uuid,
+    conversation_id: Uuid,
+) -> Result<Option<Uuid>, sqlx::Error> {
     let row: Option<(Uuid,)> = sqlx::query_as(
         "UPDATE messages SET pinned_by_id = NULL, pinned_at = NULL \
-         WHERE id = $1 AND pinned_at IS NOT NULL AND deleted_at IS NULL \
+         WHERE id = $1 AND conversation_id = $2 AND pinned_at IS NOT NULL \
+         AND deleted_at IS NULL \
          RETURNING conversation_id",
     )
     .bind(message_id)
+    .bind(conversation_id)
     .fetch_optional(pool)
     .await?;
     Ok(row.map(|(conv_id,)| conv_id))

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -264,13 +264,11 @@ pub async fn request_media_ticket(
 }
 
 /// Query param for media download -- accepts `?ticket=` (single-use media
-/// ticket), legacy `?token=` (validated as media ticket, not JWT), or
-/// `?jwt=` (for web clients where <img> tags cannot send auth headers).
+/// ticket) or legacy `?token=` (validated as media ticket, not JWT).
 #[derive(Debug, Deserialize)]
 pub struct MediaDownloadQuery {
     pub ticket: Option<String>,
     pub token: Option<String>,
-    pub jwt: Option<String>,
 }
 
 /// GET /api/media/:id
@@ -296,13 +294,7 @@ pub async fn download(
         Uuid::parse_str(&claims.sub)
             .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?
     }
-    // 2. Try ?jwt= query param (for web clients where <img> tags cannot send headers)
-    else if let Some(jwt_str) = &query.jwt {
-        let claims = jwt::validate_token(jwt_str, &state.jwt_secret)?;
-        Uuid::parse_str(&claims.sub)
-            .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?
-    }
-    // 3. Try ?ticket= or legacy ?token= as media ticket
+    // 2. Try ?ticket= or legacy ?token= as media ticket
     else if let Some(ticket_str) = query.ticket.or(query.token) {
         validate_media_ticket(&state, &ticket_str)?
     } else {

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -484,6 +484,24 @@ pub async fn leave_conversation(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
 ) -> Result<impl IntoResponse, AppError> {
+    // Owners must transfer ownership before leaving (unless they're the last member)
+    let role = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error in leave_conversation/get_role: {e:?}");
+            AppError::internal("Database error")
+        })?;
+    if role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
+        let members = db::groups::get_conversation_member_ids(&state.pool, conversation_id)
+            .await
+            .unwrap_or_default();
+        if members.len() > 1 {
+            return Err(AppError::bad_request(
+                "Transfer ownership before leaving the group",
+            ));
+        }
+    }
+
     let removed = db::groups::remove_member(&state.pool, conversation_id, auth.user_id)
         .await
         .map_err(|e| {
@@ -493,6 +511,16 @@ pub async fn leave_conversation(
 
     if !removed {
         return Err(AppError::bad_request("Not a member of this conversation"));
+    }
+
+    // Auto-delete conversation if no members remain
+    let remaining = db::groups::get_conversation_member_ids(&state.pool, conversation_id)
+        .await
+        .map_err(|e| tracing::error!("Failed to get member IDs after leave: {e:?}"))
+        .unwrap_or_default();
+    if remaining.is_empty() {
+        let _ = db::groups::force_delete_conversation(&state.pool, conversation_id).await;
+        tracing::info!("Auto-deleted empty conversation {conversation_id}");
     }
 
     Ok(StatusCode::OK)
@@ -671,20 +699,16 @@ pub async fn unpin_message(
         }
     }
 
-    // Unpin the message
-    let conv_id = db::messages::unpin_message(&state.pool, message_id)
+    // Unpin the message (atomically verified against the correct conversation)
+    let _conv_id = db::messages::unpin_message(&state.pool, message_id, conversation_id)
         .await
         .map_err(|e| {
             tracing::error!("DB error in unpin_message: {e:?}");
             AppError::internal("Database error")
         })?
-        .ok_or_else(|| AppError::bad_request("Message not found or not pinned"))?;
-
-    if conv_id != conversation_id {
-        return Err(AppError::bad_request(
-            "Message does not belong to this conversation",
-        ));
-    }
+        .ok_or_else(|| {
+            AppError::bad_request("Message not found, not pinned, or wrong conversation")
+        })?;
 
     // Broadcast to conversation members via WebSocket
     let member_ids = db::groups::get_conversation_member_ids(&state.pool, conversation_id)

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -123,6 +123,10 @@ pub async fn generate_token(
         if !is_member {
             return Err(AppError::bad_request("Not a member of this conversation"));
         }
+    } else {
+        return Err(AppError::bad_request(
+            "conversation_id or channel_id is required for voice token",
+        ));
     }
 
     let api_key = std::env::var("LIVEKIT_API_KEY").map_err(|_| {

--- a/apps/server/tests/api_voice.rs
+++ b/apps/server/tests/api_voice.rs
@@ -8,6 +8,51 @@ mod common;
 use reqwest::Client;
 use serde_json::Value;
 
+/// Helper: create two users, make them contacts, create a DM, return (token_a, user_a_id, conv_id).
+async fn setup_voice_test(client: &Client, base: &str) -> (String, String, String) {
+    let name_a = common::unique_username("voice");
+    let name_b = common::unique_username("voice");
+    common::register(client, base, &name_a, "password123").await;
+    common::register(client, base, &name_b, "password123").await;
+    let (token_a, user_a_id) = common::login(client, base, &name_a, "password123").await;
+    let (token_b, _) = common::login(client, base, &name_b, "password123").await;
+
+    // Make them contacts
+    let resp = client
+        .post(format!("{base}/api/contacts/request"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({ "username": name_b }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: Value = resp.json().await.unwrap();
+    let contact_id = body["contact_id"].as_str().unwrap().to_string();
+
+    let resp = client
+        .post(format!("{base}/api/contacts/accept"))
+        .header("Authorization", format!("Bearer {token_b}"))
+        .json(&serde_json::json!({ "contact_id": contact_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // Create DM conversation
+    let peer_id = common::login(client, base, &name_b, "password123").await.1;
+    let dm_resp = client
+        .post(format!("{base}/api/conversations/dm"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({ "peer_user_id": peer_id }))
+        .send()
+        .await
+        .unwrap();
+    let dm_body: Value = dm_resp.json().await.unwrap();
+    let conv_id = dm_body["conversation_id"].as_str().unwrap().to_string();
+
+    (token_a, user_a_id, conv_id)
+}
+
 /// Voice token with default identity (username) passes validation.
 /// Since LIVEKIT_API_KEY is not set in tests, the request reaches the
 /// "Voice chat is not configured" error, proving identity validation passed.
@@ -15,29 +60,11 @@ use serde_json::Value;
 async fn voice_token_default_identity_passes_validation() {
     let base = common::spawn_server().await;
     let client = Client::new();
-
-    // Create two users and a DM so we have a valid conversation_id.
-    let name_a = common::unique_username("voice");
-    let name_b = common::unique_username("voice");
-    common::register(&client, &base, &name_a, "password123").await;
-    common::register(&client, &base, &name_b, "password123").await;
-    let (token_a, _) = common::login(&client, &base, &name_a, "password123").await;
-    let (_, user_b_id) = common::login(&client, &base, &name_b, "password123").await;
-
-    // Create DM conversation
-    let dm_resp = client
-        .post(format!("{base}/api/conversations/dm"))
-        .header("Authorization", format!("Bearer {token_a}"))
-        .json(&serde_json::json!({ "user_id": user_b_id }))
-        .send()
-        .await
-        .unwrap();
-    let dm_body: Value = dm_resp.json().await.unwrap();
-    let conv_id = dm_body["conversation_id"].as_str().unwrap();
+    let (token, _, conv_id) = setup_voice_test(&client, &base).await;
 
     let resp = client
         .post(format!("{base}/api/voice/token"))
-        .header("Authorization", format!("Bearer {token_a}"))
+        .header("Authorization", format!("Bearer {token}"))
         .json(&serde_json::json!({
             "room": "test-room",
             "conversation_id": conv_id
@@ -60,32 +87,14 @@ async fn voice_token_default_identity_passes_validation() {
 async fn voice_token_uuid_identity_accepted() {
     let base = common::spawn_server().await;
     let client = Client::new();
-
-    // Create two users and a DM so we have a valid conversation_id.
-    let name_a = common::unique_username("voice");
-    let name_b = common::unique_username("voice");
-    common::register(&client, &base, &name_a, "password123").await;
-    common::register(&client, &base, &name_b, "password123").await;
-    let (token_a, user_a_id) = common::login(&client, &base, &name_a, "password123").await;
-    let (_, user_b_id) = common::login(&client, &base, &name_b, "password123").await;
-
-    // Create DM conversation
-    let dm_resp = client
-        .post(format!("{base}/api/conversations/dm"))
-        .header("Authorization", format!("Bearer {token_a}"))
-        .json(&serde_json::json!({ "user_id": user_b_id }))
-        .send()
-        .await
-        .unwrap();
-    let dm_body: Value = dm_resp.json().await.unwrap();
-    let conv_id = dm_body["conversation_id"].as_str().unwrap();
+    let (token, user_id, conv_id) = setup_voice_test(&client, &base).await;
 
     let resp = client
         .post(format!("{base}/api/voice/token"))
-        .header("Authorization", format!("Bearer {token_a}"))
+        .header("Authorization", format!("Bearer {token}"))
         .json(&serde_json::json!({
             "room": "test-room",
-            "identity": user_a_id,
+            "identity": user_id,
             "conversation_id": conv_id
         }))
         .send()

--- a/apps/server/tests/api_voice.rs
+++ b/apps/server/tests/api_voice.rs
@@ -16,19 +16,37 @@ async fn voice_token_default_identity_passes_validation() {
     let base = common::spawn_server().await;
     let client = Client::new();
 
-    let name = common::unique_username("voice");
-    common::register(&client, &base, &name, "password123").await;
-    let (token, _) = common::login(&client, &base, &name, "password123").await;
+    // Create two users and a DM so we have a valid conversation_id.
+    let name_a = common::unique_username("voice");
+    let name_b = common::unique_username("voice");
+    common::register(&client, &base, &name_a, "password123").await;
+    common::register(&client, &base, &name_b, "password123").await;
+    let (token_a, _) = common::login(&client, &base, &name_a, "password123").await;
+    let (_, user_b_id) = common::login(&client, &base, &name_b, "password123").await;
+
+    // Create DM conversation
+    let dm_resp = client
+        .post(format!("{base}/api/conversations/dm"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({ "user_id": user_b_id }))
+        .send()
+        .await
+        .unwrap();
+    let dm_body: Value = dm_resp.json().await.unwrap();
+    let conv_id = dm_body["conversation_id"].as_str().unwrap();
 
     let resp = client
         .post(format!("{base}/api/voice/token"))
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&serde_json::json!({ "room": "test-room" }))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({
+            "room": "test-room",
+            "conversation_id": conv_id
+        }))
         .send()
         .await
         .unwrap();
 
-    // Reaches the LIVEKIT_API_KEY check (identity validation passed)
+    // Reaches the LIVEKIT_API_KEY check (identity + membership validation passed)
     let body: Value = resp.json().await.unwrap();
     let error = body["error"].as_str().unwrap_or("");
     assert!(
@@ -43,14 +61,33 @@ async fn voice_token_uuid_identity_accepted() {
     let base = common::spawn_server().await;
     let client = Client::new();
 
-    let name = common::unique_username("voice");
-    common::register(&client, &base, &name, "password123").await;
-    let (token, user_id) = common::login(&client, &base, &name, "password123").await;
+    // Create two users and a DM so we have a valid conversation_id.
+    let name_a = common::unique_username("voice");
+    let name_b = common::unique_username("voice");
+    common::register(&client, &base, &name_a, "password123").await;
+    common::register(&client, &base, &name_b, "password123").await;
+    let (token_a, user_a_id) = common::login(&client, &base, &name_a, "password123").await;
+    let (_, user_b_id) = common::login(&client, &base, &name_b, "password123").await;
+
+    // Create DM conversation
+    let dm_resp = client
+        .post(format!("{base}/api/conversations/dm"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({ "user_id": user_b_id }))
+        .send()
+        .await
+        .unwrap();
+    let dm_body: Value = dm_resp.json().await.unwrap();
+    let conv_id = dm_body["conversation_id"].as_str().unwrap();
 
     let resp = client
         .post(format!("{base}/api/voice/token"))
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&serde_json::json!({ "room": "test-room", "identity": user_id }))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({
+            "room": "test-room",
+            "identity": user_a_id,
+            "conversation_id": conv_id
+        }))
         .send()
         .await
         .unwrap();
@@ -88,6 +125,34 @@ async fn voice_token_wrong_identity_rejected() {
             .as_str()
             .unwrap_or("")
             .contains("Identity must match")
+    );
+}
+
+/// Voice token without conversation_id or channel_id is rejected.
+#[tokio::test]
+async fn voice_token_without_conversation_id_rejected() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let name = common::unique_username("voice");
+    common::register(&client, &base, &name, "password123").await;
+    let (token, _) = common::login(&client, &base, &name, "password123").await;
+
+    let resp = client
+        .post(format!("{base}/api/voice/token"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "room": "test-room" }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("conversation_id or channel_id is required"),
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #146 -- Closes 4 authorization bypass vulnerabilities found during the code audit.

- **Voice token bypass**: Require `conversation_id` or `channel_id` for voice token generation. Previously, sending only a raw `room` name skipped the membership check.
- **leave_conversation ownership bypass**: Add ownership-transfer check (matching `leave_group` behavior) so group owners can't orphan groups via the conversations endpoint.
- **Unpin cross-conversation**: Add `conversation_id` to the `unpin_message` DB query so it's impossible to unpin messages in conversations you're not viewing.
- **JWT in media URL**: Remove `?jwt=` query parameter from media downloads. Auth now only via Authorization header or single-use `?ticket=`.

## Test plan

- [x] `cargo test -p echo-server --lib` -- 31 tests pass
- [x] `cargo clippy --workspace --all-targets` -- zero warnings
- [x] `cargo fmt --all -- --check` -- passes
- [x] Pre-commit hooks pass