### PR TITLE
security(client): migrate auth tokens to secure storage

### DIFF
--- a/apps/client/lib/src/providers/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth_provider.dart
@@ -76,22 +76,44 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   String get _serverUrl => ref.read(serverUrlProvider);
 
-  /// Try to auto-login using stored refresh token from SharedPreferences.
+  /// Try to auto-login using stored refresh token.
   ///
-  /// Loads the refresh token, calls the refresh endpoint to get a new access
-  /// token, and restores the session. If the refresh fails (expired, revoked,
-  /// or server unreachable), clears stored tokens and returns false so the
-  /// user must log in manually.
+  /// Reads the refresh token from [SecureKeyStore] (global scope), falling
+  /// back to SharedPreferences for pre-migration installs. Calls the refresh
+  /// endpoint to get a new access token and restores the session. If the
+  /// refresh fails (expired, revoked, or server unreachable), clears stored
+  /// tokens and returns false so the user must log in manually.
   Future<bool> tryAutoLogin() async {
     try {
+      // Migrate tokens from SharedPreferences to secure storage if needed.
+      await migrateTokensFromSharedPreferences();
+
       final prefs = await SharedPreferences.getInstance();
-      final storedRefreshToken = prefs.getString(_keyRefreshToken);
       final storedUserId = prefs.getString(_keyUserId);
       final storedUsername = prefs.getString(_keyUsername);
 
+      // Read refresh token from secure storage first, fall back to prefs
+      // (covers the case where secure storage was unavailable during
+      // migration or during a previous _storeTokens fallback write).
+      String? storedRefreshToken;
+      try {
+        storedRefreshToken = await SecureKeyStore.instance.readGlobal(
+          _keyRefreshToken,
+        );
+      } catch (_) {
+        // Secure storage unavailable -- fall through to prefs.
+      }
+      storedRefreshToken ??= prefs.getString(_keyRefreshToken);
+
       if (storedRefreshToken == null || storedRefreshToken.isEmpty) {
         // No refresh token stored -- check for legacy access token as fallback
-        final legacyToken = prefs.getString(_keyAccessToken);
+        String? legacyToken;
+        try {
+          legacyToken = await SecureKeyStore.instance.readGlobal(
+            _keyAccessToken,
+          );
+        } catch (_) {}
+        legacyToken ??= prefs.getString(_keyAccessToken);
         if (legacyToken != null &&
             legacyToken.isNotEmpty &&
             storedUserId != null &&
@@ -262,24 +284,46 @@ class AuthNotifier extends StateNotifier<AuthState> {
     return response;
   }
 
-  /// Persist tokens to SharedPreferences.
+  /// Persist tokens to secure storage; userId/username to SharedPreferences.
+  ///
+  /// Tokens are written to [SecureKeyStore] using global (non-user-scoped)
+  /// keys because this method is called BEFORE [_setUserScope]. If secure
+  /// storage is unavailable (e.g. locked keyring on Linux), falls back to
+  /// SharedPreferences so the session is not lost.
   Future<void> _storeTokens({
     required String accessToken,
     required String refreshToken,
     required String userId,
     required String username,
   }) async {
+    final store = SecureKeyStore.instance;
+
+    // Write tokens to secure storage (global scope -- no user prefix).
+    try {
+      await store.writeGlobal(_keyAccessToken, accessToken);
+      await store.writeGlobal(_keyRefreshToken, refreshToken);
+    } catch (e) {
+      // Secure storage unavailable -- fall back to SharedPreferences.
+      debugPrint('[Auth] SecureKeyStore unavailable, falling back: $e');
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(_keyAccessToken, accessToken);
+        await prefs.setString(_keyRefreshToken, refreshToken);
+      } catch (e2) {
+        debugPrint('[Auth] _storeTokens fallback also failed: $e2');
+      }
+    }
+
+    // userId and username are not sensitive -- keep in SharedPreferences.
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(_keyAccessToken, accessToken);
-      await prefs.setString(_keyRefreshToken, refreshToken);
       await prefs.setString(_keyUserId, userId);
       await prefs.setString(_keyUsername, username);
 
       // Clean up legacy password key if it exists
       await _clearLegacyCredentials(prefs);
     } catch (e) {
-      debugPrint('[Auth] _storeTokens failed: $e');
+      debugPrint('[Auth] _storeTokens (prefs) failed: $e');
     }
   }
 
@@ -298,8 +342,15 @@ class AuthNotifier extends StateNotifier<AuthState> {
     }
   }
 
-  /// Clear all stored tokens.
+  /// Clear all stored tokens from both secure storage and SharedPreferences.
   Future<void> _clearStoredTokens() async {
+    // Remove tokens from secure storage (global scope).
+    final store = SecureKeyStore.instance;
+    await store.deleteGlobal(_keyAccessToken);
+    await store.deleteGlobal(_keyRefreshToken);
+
+    // Remove everything from SharedPreferences (tokens may exist there
+    // from pre-migration installs or secure-storage fallback writes).
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_keyAccessToken);
@@ -309,6 +360,38 @@ class AuthNotifier extends StateNotifier<AuthState> {
       await _clearLegacyCredentials(prefs);
     } catch (e) {
       debugPrint('[Auth] _clearStoredTokens failed: $e');
+    }
+  }
+
+  /// Migrate auth tokens from SharedPreferences to SecureKeyStore.
+  ///
+  /// Called at the start of [tryAutoLogin] before reading tokens. For each
+  /// token key: if found in SharedPreferences, copies to secure storage via
+  /// [SecureKeyStore.writeGlobal], then removes from SharedPreferences on
+  /// success. If writeGlobal fails (e.g. keyring locked), the key is left in
+  /// SharedPreferences for retry on next launch -- matching the pattern in
+  /// `crypto_service.dart:_migrateFromSharedPreferences`.
+  @visibleForTesting
+  Future<void> migrateTokensFromSharedPreferences() async {
+    final prefs = await SharedPreferences.getInstance();
+    final store = SecureKeyStore.instance;
+
+    for (final key in [_keyAccessToken, _keyRefreshToken]) {
+      final value = prefs.getString(key);
+      if (value != null && value.isNotEmpty) {
+        try {
+          await store.writeGlobal(key, value);
+          await prefs.remove(key);
+          debugPrint(
+            '[Auth] Migrated $key from SharedPreferences to secure storage',
+          );
+        } catch (e) {
+          debugPrint(
+            '[Auth] Migration of $key failed '
+            '(keeping in SharedPreferences for next attempt): $e',
+          );
+        }
+      }
     }
   }
 

--- a/apps/client/lib/src/services/secure_key_store.dart
+++ b/apps/client/lib/src/services/secure_key_store.dart
@@ -133,4 +133,45 @@ class SecureKeyStore {
       return false;
     }
   }
+
+  // -- Global-scope methods (no user prefix) --
+  //
+  // Used for pre-login data such as auth tokens that must be persisted
+  // before user scope is established (e.g. after server-side token
+  // rotation but before _setUserScope completes).
+
+  /// Read a global (non-user-scoped) value by key.
+  ///
+  /// Throws on backend failure so callers can distinguish "not found" (null)
+  /// from "storage unavailable".
+  Future<String?> readGlobal(String key) async {
+    try {
+      return await _storage.read(key: key);
+    } catch (e) {
+      debugPrint('[SecureKeyStore] readGlobal($key) failed: $e');
+      rethrow;
+    }
+  }
+
+  /// Write a global (non-user-scoped) key-value pair.
+  ///
+  /// Throws on backend failure so callers can fall back to less-secure
+  /// storage rather than silently losing the value.
+  Future<void> writeGlobal(String key, String value) async {
+    try {
+      await _storage.write(key: key, value: value);
+    } catch (e) {
+      debugPrint('[SecureKeyStore] writeGlobal($key) failed: $e');
+      rethrow;
+    }
+  }
+
+  /// Delete a global (non-user-scoped) key. Swallows errors.
+  Future<void> deleteGlobal(String key) async {
+    try {
+      await _storage.delete(key: key);
+    } catch (e) {
+      debugPrint('[SecureKeyStore] deleteGlobal($key) failed: $e');
+    }
+  }
 }

--- a/apps/client/test/helpers/fake_secure_key_store.dart
+++ b/apps/client/test/helpers/fake_secure_key_store.dart
@@ -25,6 +25,21 @@ class FakeSecureKeyStore extends SecureKeyStore {
   @override
   Future<bool> containsKey(String key) async => _store.containsKey(key);
 
+  // -- Global-scope overrides (same flat map, no prefix) --
+
+  @override
+  Future<String?> readGlobal(String key) async => _store[key];
+
+  @override
+  Future<void> writeGlobal(String key, String value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> deleteGlobal(String key) async {
+    _store.remove(key);
+  }
+
   /// Dump all keys for debugging.
   Map<String, String> get dump => Map.unmodifiable(_store);
 }

--- a/apps/client/test/providers/auth_provider_test.dart
+++ b/apps/client/test/providers/auth_provider_test.dart
@@ -1,5 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/services/secure_key_store.dart';
+
+import '../helpers/fake_secure_key_store.dart';
 
 void main() {
   group('AuthState', () {
@@ -31,6 +37,103 @@ void main() {
       const state = AuthState();
       expect(state.isLoggedIn, isFalse);
       expect(state.isLoading, isFalse);
+    });
+  });
+
+  group('Token migration from SharedPreferences to SecureKeyStore', () {
+    late FakeSecureKeyStore fakeStore;
+
+    setUp(() {
+      fakeStore = FakeSecureKeyStore();
+      SecureKeyStore.instance = fakeStore;
+    });
+
+    test('migrates tokens from SharedPreferences to SecureKeyStore', () async {
+      SharedPreferences.setMockInitialValues({
+        'echo_auth_access_token': 'old-access-tok',
+        'echo_auth_refresh_token': 'old-refresh-tok',
+        'echo_auth_user_id': 'user-1',
+        'echo_auth_username': 'alice',
+      });
+
+      // Create a minimal AuthNotifier just to call the migration method.
+      // We use a ProviderContainer so Riverpod is happy, but we only need
+      // to exercise migrateTokensFromSharedPreferences which does not
+      // touch the network.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(authProvider.notifier);
+
+      await notifier.migrateTokensFromSharedPreferences();
+
+      // Tokens should now be in secure storage
+      expect(
+        await fakeStore.readGlobal('echo_auth_access_token'),
+        'old-access-tok',
+      );
+      expect(
+        await fakeStore.readGlobal('echo_auth_refresh_token'),
+        'old-refresh-tok',
+      );
+
+      // Tokens should be removed from SharedPreferences
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('echo_auth_access_token'), isNull);
+      expect(prefs.getString('echo_auth_refresh_token'), isNull);
+
+      // Non-sensitive data stays in SharedPreferences
+      expect(prefs.getString('echo_auth_user_id'), 'user-1');
+      expect(prefs.getString('echo_auth_username'), 'alice');
+    });
+
+    test('migration is idempotent', () async {
+      SharedPreferences.setMockInitialValues({
+        'echo_auth_refresh_token': 'refresh-tok',
+      });
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(authProvider.notifier);
+
+      // Run migration twice
+      await notifier.migrateTokensFromSharedPreferences();
+      await notifier.migrateTokensFromSharedPreferences();
+
+      // Token is in secure storage exactly once (value unchanged)
+      expect(
+        await fakeStore.readGlobal('echo_auth_refresh_token'),
+        'refresh-tok',
+      );
+
+      // SharedPreferences is clean
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('echo_auth_refresh_token'), isNull);
+    });
+
+    test('skips empty/null values in SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({'echo_auth_access_token': ''});
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(authProvider.notifier);
+
+      await notifier.migrateTokensFromSharedPreferences();
+
+      // Empty string should NOT be migrated
+      expect(await fakeStore.readGlobal('echo_auth_access_token'), isNull);
+    });
+
+    test('migration with no tokens in SharedPreferences is a no-op', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(authProvider.notifier);
+
+      await notifier.migrateTokensFromSharedPreferences();
+
+      // Secure storage should be empty
+      expect(fakeStore.dump, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #145 -- Moves access and refresh token storage from plaintext SharedPreferences to SecureKeyStore (flutter_secure_storage), which uses platform-backed encrypted storage:
- **Android**: EncryptedSharedPreferences (AES-256)
- **iOS/macOS**: Keychain
- **Linux**: libsecret (GNOME Keyring / KWallet)
- **Windows**: DPAPI

### Changes
- **SecureKeyStore**: Added `readGlobal`/`writeGlobal`/`deleteGlobal` methods that bypass user-scoped prefix (tokens must be stored before user scope is set due to server-side token rotation)
- **AuthProvider**: `_storeTokens` writes to secure storage with SharedPreferences fallback; `tryAutoLogin` reads from secure storage first; `_clearStoredTokens` cleans both stores
- **Migration**: One-time `migrateTokensFromSharedPreferences()` copies tokens from SharedPreferences to secure storage on first launch after upgrade (matches crypto_service.dart pattern)
- **Graceful degradation**: If secure storage is unavailable (e.g., Linux without libsecret), falls back to SharedPreferences

### Non-sensitive data unchanged
`userId` and `username` remain in SharedPreferences (not sensitive, needed for display before crypto init).

## Test plan

- [x] `flutter test` -- 611 tests pass (4 new migration tests)
- [x] `flutter analyze --fatal-infos` -- no issues
- [x] `dart format --set-exit-if-changed .` -- passes
- [x] Pre-commit hooks pass