### PR TITLE
fix(server): add cascade fks, fix toctou races, add data cleanup

### DIFF
--- a/apps/server/migrations/20260412000000_cascade_conversation_fks.sql
+++ b/apps/server/migrations/20260412000000_cascade_conversation_fks.sql
@@ -1,0 +1,18 @@
+-- Add ON DELETE CASCADE to conversation FKs that were missing it.
+-- This lets DELETE FROM conversations properly cascade to child rows
+-- instead of failing with FK violations or requiring manual cleanup.
+
+-- conversation_members
+ALTER TABLE conversation_members DROP CONSTRAINT IF EXISTS conversation_members_conversation_id_fkey;
+ALTER TABLE conversation_members ADD CONSTRAINT conversation_members_conversation_id_fkey
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE;
+
+-- messages
+ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_conversation_id_fkey;
+ALTER TABLE messages ADD CONSTRAINT messages_conversation_id_fkey
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE;
+
+-- read_receipts
+ALTER TABLE read_receipts DROP CONSTRAINT IF EXISTS read_receipts_conversation_id_fkey;
+ALTER TABLE read_receipts ADD CONSTRAINT read_receipts_conversation_id_fkey
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE;

--- a/apps/server/src/db/contacts.rs
+++ b/apps/server/src/db/contacts.rs
@@ -15,14 +15,18 @@ pub struct ContactRow {
     pub created_at: DateTime<Utc>,
 }
 
+/// Create a contact request. Uses a transaction to prevent a TOCTOU race
+/// between the user lookup, block check, and insert.
 pub async fn create_contact_request(
     pool: &PgPool,
     requester_id: Uuid,
     target_username: &str,
 ) -> Result<Uuid, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
     let target = sqlx::query_as::<_, (Uuid,)>("SELECT id FROM users WHERE username = $1")
         .bind(target_username)
-        .fetch_optional(pool)
+        .fetch_optional(&mut *tx)
         .await?
         .ok_or(sqlx::Error::RowNotFound)?;
 
@@ -30,8 +34,19 @@ pub async fn create_contact_request(
 
     // Check if either party has blocked the other -- return a generic error
     // (same as "user not found") to avoid leaking block status.
-    let blocked = is_either_blocked(pool, requester_id, target_id).await?;
-    if blocked {
+    let blocked: (bool,) = sqlx::query_as(
+        "SELECT EXISTS(\
+            SELECT 1 FROM blocked_users \
+            WHERE (blocker_id = $1 AND blocked_id = $2) \
+               OR (blocker_id = $2 AND blocked_id = $1)\
+        )",
+    )
+    .bind(requester_id)
+    .bind(target_id)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if blocked.0 {
         return Err(sqlx::Error::RowNotFound);
     }
 
@@ -40,9 +55,10 @@ pub async fn create_contact_request(
     )
     .bind(requester_id)
     .bind(target_id)
-    .fetch_one(pool)
+    .fetch_one(&mut *tx)
     .await?;
 
+    tx.commit().await?;
     Ok(row.0)
 }
 

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -141,33 +141,27 @@ pub async fn list_public_groups(
 }
 
 /// Join a public group. Returns an error if the group is not public.
+///
+/// Uses a single atomic INSERT ... SELECT to avoid a TOCTOU race between
+/// checking `is_public` and inserting the membership row.
 pub async fn join_public_group(
     pool: &PgPool,
     group_id: Uuid,
     user_id: Uuid,
 ) -> Result<bool, sqlx::Error> {
-    // Check that the conversation exists and is public
-    let row: Option<(bool,)> =
-        sqlx::query_as("SELECT is_public FROM conversations WHERE id = $1 AND kind = 'group'")
-            .bind(group_id)
-            .fetch_optional(pool)
-            .await?;
+    let result = sqlx::query(
+        "INSERT INTO conversation_members (conversation_id, user_id, role) \
+         SELECT $1, $2, 'member' \
+         FROM conversations \
+         WHERE id = $1 AND kind = 'group' AND is_public = true \
+         ON CONFLICT (conversation_id, user_id) DO NOTHING",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .execute(pool)
+    .await?;
 
-    match row {
-        Some((true,)) => {
-            sqlx::query(
-                "INSERT INTO conversation_members (conversation_id, user_id, role) VALUES ($1, $2, 'member') \
-                 ON CONFLICT DO NOTHING",
-            )
-            .bind(group_id)
-            .bind(user_id)
-            .execute(pool)
-            .await?;
-            Ok(true)
-        }
-        Some((false,)) => Ok(false),
-        None => Ok(false),
-    }
+    Ok(result.rows_affected() > 0)
 }
 
 /// Get group info by conversation ID.
@@ -306,23 +300,26 @@ pub async fn user_has_public_group_named(
 
 /// Delete a group conversation. Only the owner can delete it.
 /// Deleting the conversation cascades to members and messages via FK constraints.
+///
+/// Uses a single atomic DELETE with an EXISTS subquery to avoid a TOCTOU race
+/// between the ownership check and the delete.
 pub async fn delete_group(
     pool: &PgPool,
     group_id: Uuid,
     owner_id: Uuid,
 ) -> Result<bool, sqlx::Error> {
-    // Verify the caller is the owner
-    let role = get_member_role(pool, group_id, owner_id).await?;
-    use crate::types::Role;
-    if role.as_deref().and_then(Role::from_str_opt) != Some(Role::Owner) {
-        return Ok(false);
-    }
-    // Delete conversation (cascades to members, messages via FK)
-    sqlx::query("DELETE FROM conversations WHERE id = $1")
-        .bind(group_id)
-        .execute(pool)
-        .await?;
-    Ok(true)
+    let result = sqlx::query(
+        "DELETE FROM conversations WHERE id = $1 AND EXISTS(\
+             SELECT 1 FROM conversation_members \
+             WHERE conversation_id = $1 AND user_id = $2 AND role = 'owner'\
+         )",
+    )
+    .bind(group_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
 }
 
 /// Check if a group is public.

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -49,6 +49,8 @@ async fn main() {
             interval.tick().await;
             cleanup_stale_voice_sessions(&cleanup_pool, &cleanup_hub).await;
             cleanup_empty_groups(&cleanup_pool).await;
+            cleanup_expired_tokens(&cleanup_pool).await;
+            cleanup_used_prekeys(&cleanup_pool).await;
         }
     });
 
@@ -137,6 +139,43 @@ async fn cleanup_empty_groups(pool: &PgPool) {
 
     for (gid,) in &empty_group_ids {
         delete_group_dependents(pool, *gid).await;
+    }
+}
+
+/// Remove expired or revoked refresh tokens to prevent unbounded table growth.
+async fn cleanup_expired_tokens(pool: &PgPool) {
+    let result = sqlx::query(
+        "DELETE FROM refresh_tokens \
+         WHERE expires_at < now() - interval '7 days' \
+            OR (revoked = true AND created_at < now() - interval '1 day')",
+    )
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(r) if r.rows_affected() > 0 => {
+            tracing::info!(
+                "Cleaned {} expired/revoked refresh tokens",
+                r.rows_affected()
+            );
+        }
+        Err(e) => tracing::warn!("Refresh token cleanup error: {e}"),
+        _ => {}
+    }
+}
+
+/// Remove consumed one-time prekeys that are no longer needed.
+async fn cleanup_used_prekeys(pool: &PgPool) {
+    let result = sqlx::query("DELETE FROM one_time_prekeys WHERE used = true")
+        .execute(pool)
+        .await;
+
+    match result {
+        Ok(r) if r.rows_affected() > 0 => {
+            tracing::info!("Cleaned {} used one-time prekeys", r.rows_affected());
+        }
+        Err(e) => tracing::warn!("One-time prekey cleanup error: {e}"),
+        _ => {}
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #149 -- Addresses database integrity issues found during the code audit.

### ON DELETE CASCADE (new migration)
- Added CASCADE to `conversation_members`, `messages`, `read_receipts` FK references to `conversations(id)`
- Fixes: group deletion no longer fails with FK violations

### TOCTOU Race Conditions
- **join_public_group**: Replaced check-then-insert with atomic `INSERT INTO ... SELECT ... WHERE is_public = true ON CONFLICT DO NOTHING`
- **delete_group**: Replaced role-check-then-delete with atomic `DELETE ... WHERE EXISTS(owner check)`
- **create_contact_request**: Wrapped user lookup + block check + insert in a transaction

### Periodic Data Cleanup
- Added `cleanup_expired_tokens`: purges refresh tokens expired >7 days or revoked >1 day
- Added `cleanup_used_prekeys`: purges consumed one-time prekeys

## Test plan

- [x] `cargo test -p echo-server --lib` -- 45 tests pass
- [x] `cargo clippy --workspace --all-targets` -- zero warnings
- [x] `cargo fmt --all -- --check` -- passes
- [x] Pre-commit hooks pass