### PR TITLE
security(ci): add permissions, fix codecov, harden containers

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Conventional Commits

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -9,6 +9,9 @@ on:
       - 'research/**'
       - 'context/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: dev-build-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
@@ -37,6 +40,8 @@ jobs:
       # -- Rust server --
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: e2e
       - name: Build server
         run: cargo build --release --package echo-server
 

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, dev]
     paths: ["apps/client/**"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: flutter-ci-${{ github.ref }}
   cancel-in-progress: true
@@ -43,4 +46,3 @@ jobs:
           files: apps/client/coverage/lcov.info
           flags: flutter
           fail_ci_if_error: false
-        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: release-lint
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Rust tests
@@ -161,6 +163,7 @@ jobs:
           path: |
             echo-linux-x64.tar.gz
             Echo-x86_64.AppImage
+          retention-days: 3
 
   build-windows:
     name: Build Windows Desktop
@@ -221,6 +224,7 @@ jobs:
           path: |
             Echo-Setup-x64.exe
             echo-windows-x64-portable.zip
+          retention-days: 3
 
   build-android:
     name: Build Android APK
@@ -257,6 +261,7 @@ jobs:
         with:
           name: release-android
           path: echo-android-*.apk
+          retention-days: 3
 
   build-ios:
     name: Build iOS IPA
@@ -343,6 +348,7 @@ jobs:
         with:
           name: release-ios
           path: echo-ios-*.ipa
+          retention-days: 3
       - name: Clean up signing
         if: always()
         run: |
@@ -357,6 +363,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: release-build
       - name: Set version in Cargo.toml
         run: |
           sed -i 's/^version = ".*"/version = "${{ needs.version.outputs.version }}"/' apps/server/Cargo.toml
@@ -375,6 +383,7 @@ jobs:
         with:
           name: release-server
           path: echo-server-linux-x64.tar.gz
+          retention-days: 3
 
   docker:
     name: Build Docker Image
@@ -433,6 +442,7 @@ jobs:
         with:
           name: release-web
           path: echo-web.tar.gz
+          retention-days: 3
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,6 +15,9 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
 
+permissions:
+  contents: read
+
 concurrency:
   group: rust-ci-${{ github.ref }}
   cancel-in-progress: true
@@ -47,6 +50,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: rust-ci
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Run tests

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main, dev]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: sonar-${{ github.ref }}
   cancel-in-progress: true
@@ -39,6 +43,8 @@ jobs:
       # -- Rust coverage --
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: sonarcloud
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin --locked
       - name: Generate Rust coverage

--- a/apps/client/Dockerfile.web
+++ b/apps/client/Dockerfile.web
@@ -5,4 +5,5 @@ LABEL build_id=$BUILD_ID
 COPY build/web/ /usr/share/nginx/html/
 RUN echo "$APP_VERSION" > /usr/share/nginx/html/version.txt
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+USER nginx
 EXPOSE 80


### PR DESCRIPTION
## Summary

Fixes #150 -- CI/CD security hardening from audit findings.

### Least-privilege permissions (6 workflows)
Added explicit `permissions: { contents: read }` to `rust-ci`, `flutter-ci`, `e2e`, `commitlint`, `dev-build`. Added `pull-requests: read` for `sonarcloud`. Previously these inherited default `write-all`.

### Web container non-root
Added `USER nginx` to `Dockerfile.web` -- nginx runs as non-root inside the container.

### Codecov fix
Removed `continue-on-error: true` from the Codecov upload step. Coverage failures are now visible (not silently swallowed).

### Rust cache optimization
Added unique `shared-key` to each `Swatinem/rust-cache` usage to prevent cross-workflow cache thrashing.

### Release artifact retention
Added `retention-days: 3` to all 6 `upload-artifact` steps in release workflow. These are intermediate build outputs consumed by the release job -- no need to keep them for 90 days.

## Test plan

- [x] YAML validation passes on all 7 workflow files
- [x] Pre-commit hooks pass
- [ ] CI pipeline runs successfully with new permissions (self-validating)