### PR TITLE
test(client): add semantic labels across all screens for playwright e2e

### DIFF
--- a/apps/client/lib/src/screens/contacts_screen.dart
+++ b/apps/client/lib/src/screens/contacts_screen.dart
@@ -487,24 +487,30 @@ class _ContactsScreenState extends ConsumerState<ContactsScreen> {
   }
 
   Widget _buildMessageButton(String userId, String username) {
-    return SizedBox(
-      height: 32,
-      width: 90,
-      child: Material(
-        color: context.accentLight,
-        borderRadius: BorderRadius.circular(6),
-        child: InkWell(
+    return Semantics(
+      label: 'message $username',
+      button: true,
+      child: SizedBox(
+        height: 32,
+        width: 90,
+        child: Material(
+          color: context.accentLight,
           borderRadius: BorderRadius.circular(6),
-          onTap: _isStartingDm ? null : () => _messageContact(userId, username),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Center(
-              child: Text(
-                'Message',
-                style: TextStyle(
-                  color: context.accent,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w500,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(6),
+            onTap: _isStartingDm
+                ? null
+                : () => _messageContact(userId, username),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: Center(
+                child: Text(
+                  'Message',
+                  style: TextStyle(
+                    color: context.accent,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ),
             ),
@@ -571,43 +577,47 @@ class _SearchResultCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Row(
-          children: [
-            buildAvatar(
-              name: user.username,
-              radius: 20,
-              imageUrl: avatarImageUrl,
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    user.displayName ?? user.username,
-                    style: TextStyle(
-                      color: context.textPrimary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const SizedBox(height: 1),
-                  Text(
-                    '@${user.username}',
-                    style: TextStyle(
-                      color: context.textSecondary,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
+    return Semantics(
+      label: 'search result: ${user.username}',
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              buildAvatar(
+                name: user.username,
+                radius: 20,
+                imageUrl: avatarImageUrl,
               ),
-            ),
-            _buildTrailing(context),
-          ],
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      user.displayName ?? user.username,
+                      style: TextStyle(
+                        color: context.textPrimary,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 1),
+                    Text(
+                      '@${user.username}',
+                      style: TextStyle(
+                        color: context.textSecondary,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              _buildTrailing(context),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -497,41 +497,45 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                   child: Tooltip(
                     message: displayName,
                     preferBelow: false,
-                    child: GestureDetector(
-                      onTap: () => _selectConversation(conv),
-                      child: Center(
-                        child: Container(
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            border: isSelected
-                                ? Border.all(color: context.accent, width: 2)
-                                : null,
-                          ),
-                          child: Builder(
-                            builder: (_) {
-                              final peer = conv.members
-                                  .where((m) => m.userId != myUserId)
-                                  .firstOrNull;
-                              final peerAvatarUrl =
-                                  (!conv.isGroup && peer?.avatarUrl != null)
-                                  ? '$serverUrl${peer!.avatarUrl}'
-                                  : null;
-                              return buildAvatar(
-                                name: displayName,
-                                radius: 18,
-                                imageUrl: peerAvatarUrl,
-                                bgColor: conv.isGroup
-                                    ? groupAvatarColor(displayName)
-                                    : null,
-                                fallbackIcon: conv.isGroup
-                                    ? const Icon(
-                                        Icons.group,
-                                        size: 16,
-                                        color: Colors.white,
-                                      )
-                                    : null,
-                              );
-                            },
+                    child: Semantics(
+                      label: 'conversation: $displayName',
+                      button: true,
+                      child: GestureDetector(
+                        onTap: () => _selectConversation(conv),
+                        child: Center(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              border: isSelected
+                                  ? Border.all(color: context.accent, width: 2)
+                                  : null,
+                            ),
+                            child: Builder(
+                              builder: (_) {
+                                final peer = conv.members
+                                    .where((m) => m.userId != myUserId)
+                                    .firstOrNull;
+                                final peerAvatarUrl =
+                                    (!conv.isGroup && peer?.avatarUrl != null)
+                                    ? '$serverUrl${peer!.avatarUrl}'
+                                    : null;
+                                return buildAvatar(
+                                  name: displayName,
+                                  radius: 18,
+                                  imageUrl: peerAvatarUrl,
+                                  bgColor: conv.isGroup
+                                      ? groupAvatarColor(displayName)
+                                      : null,
+                                  fallbackIcon: conv.isGroup
+                                      ? const Icon(
+                                          Icons.group,
+                                          size: 16,
+                                          color: Colors.white,
+                                        )
+                                      : null,
+                                );
+                              },
+                            ),
                           ),
                         ),
                       ),
@@ -1034,36 +1038,42 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     final channelName =
         channels.where((c) => c.id == channelId).firstOrNull?.name ?? 'Voice';
 
-    return Material(
-      color: EchoTheme.online.withValues(alpha: 0.12),
-      child: InkWell(
-        onTap: () => setState(() {
-          _showingLounge = true;
-          _userDismissedLounge = false;
-        }),
-        child: Container(
-          height: 40,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          decoration: BoxDecoration(
-            border: Border(bottom: BorderSide(color: context.border, width: 1)),
-          ),
-          child: Row(
-            children: [
-              const Icon(Icons.graphic_eq, size: 16, color: EchoTheme.online),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  '● $channelName — Tap to view voice',
-                  style: const TextStyle(
-                    color: EchoTheme.online,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
+    return Semantics(
+      label: 'rejoin voice channel',
+      button: true,
+      child: Material(
+        color: EchoTheme.online.withValues(alpha: 0.12),
+        child: InkWell(
+          onTap: () => setState(() {
+            _showingLounge = true;
+            _userDismissedLounge = false;
+          }),
+          child: Container(
+            height: 40,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: context.border, width: 1),
               ),
-              Icon(Icons.chevron_right, size: 16, color: context.textMuted),
-            ],
+            ),
+            child: Row(
+              children: [
+                const Icon(Icons.graphic_eq, size: 16, color: EchoTheme.online),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '● $channelName — Tap to view voice',
+                    style: const TextStyle(
+                      color: EchoTheme.online,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                Icon(Icons.chevron_right, size: 16, color: context.textMuted),
+              ],
+            ),
           ),
         ),
       ),

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -338,50 +338,54 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
           const SizedBox(height: 32),
 
           // Avatar circle
-          GestureDetector(
-            onTap: _uploadingAvatar ? null : _pickAvatar,
-            child: Stack(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(3),
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    border: Border.all(color: context.accent, width: 2),
-                  ),
-                  child: CircleAvatar(
-                    radius: 48,
-                    backgroundColor: context.surface,
-                    backgroundImage: _avatarImage(auth, serverUrl),
-                    child: _avatarChild(auth, username),
-                  ),
-                ),
-                Positioned(
-                  bottom: 0,
-                  right: 0,
-                  child: Container(
-                    width: 30,
-                    height: 30,
+          Semantics(
+            label: 'pick avatar',
+            button: true,
+            child: GestureDetector(
+              onTap: _uploadingAvatar ? null : _pickAvatar,
+              child: Stack(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(3),
                     decoration: BoxDecoration(
-                      color: context.accent,
                       shape: BoxShape.circle,
-                      border: Border.all(color: context.mainBg, width: 2),
+                      border: Border.all(color: context.accent, width: 2),
                     ),
-                    child: _uploadingAvatar
-                        ? const Padding(
-                            padding: EdgeInsets.all(6),
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
+                    child: CircleAvatar(
+                      radius: 48,
+                      backgroundColor: context.surface,
+                      backgroundImage: _avatarImage(auth, serverUrl),
+                      child: _avatarChild(auth, username),
+                    ),
+                  ),
+                  Positioned(
+                    bottom: 0,
+                    right: 0,
+                    child: Container(
+                      width: 30,
+                      height: 30,
+                      decoration: BoxDecoration(
+                        color: context.accent,
+                        shape: BoxShape.circle,
+                        border: Border.all(color: context.mainBg, width: 2),
+                      ),
+                      child: _uploadingAvatar
+                          ? const Padding(
+                              padding: EdgeInsets.all(6),
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Colors.white,
+                              ),
+                            )
+                          : const Icon(
+                              Icons.camera_alt,
+                              size: 14,
                               color: Colors.white,
                             ),
-                          )
-                        : const Icon(
-                            Icons.camera_alt,
-                            size: 14,
-                            color: Colors.white,
-                          ),
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           const SizedBox(height: 8),
@@ -657,49 +661,54 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
               itemBuilder: (context, index) {
                 final t = _onboardingThemes[index];
                 final isSelected = currentTheme == t.selection;
-                return GestureDetector(
-                  onTap: () =>
-                      ref.read(themeProvider.notifier).setTheme(t.selection),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      AnimatedContainer(
-                        duration: const Duration(milliseconds: 200),
-                        width: 44,
-                        height: 44,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: t.bg,
-                          border: Border.all(
-                            color: isSelected ? t.accent : context.border,
-                            width: isSelected ? 2.5 : 1.5,
+                return Semantics(
+                  label: '${t.label} theme',
+                  button: true,
+                  selected: isSelected,
+                  child: GestureDetector(
+                    onTap: () =>
+                        ref.read(themeProvider.notifier).setTheme(t.selection),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        AnimatedContainer(
+                          duration: const Duration(milliseconds: 200),
+                          width: 44,
+                          height: 44,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: t.bg,
+                            border: Border.all(
+                              color: isSelected ? t.accent : context.border,
+                              width: isSelected ? 2.5 : 1.5,
+                            ),
                           ),
-                        ),
-                        child: Center(
-                          child: Container(
-                            width: 18,
-                            height: 18,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: t.accent,
+                          child: Center(
+                            child: Container(
+                              width: 18,
+                              height: 18,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: t.accent,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 6),
-                      Text(
-                        t.label,
-                        style: TextStyle(
-                          color: isSelected
-                              ? context.accent
-                              : context.textSecondary,
-                          fontSize: 11,
-                          fontWeight: isSelected
-                              ? FontWeight.w600
-                              : FontWeight.w400,
+                        const SizedBox(height: 6),
+                        Text(
+                          t.label,
+                          style: TextStyle(
+                            color: isSelected
+                                ? context.accent
+                                : context.textSecondary,
+                            fontSize: 11,
+                            fontWeight: isSelected
+                                ? FontWeight.w600
+                                : FontWeight.w400,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 );
               },

--- a/apps/client/lib/src/screens/safety_number_screen.dart
+++ b/apps/client/lib/src/screens/safety_number_screen.dart
@@ -296,53 +296,57 @@ class _SafetyNumberScreenState extends ConsumerState<SafetyNumberScreen> {
           const SizedBox(height: 24),
 
           // Safety number digits
-          GestureDetector(
-            onTap: () {
-              Clipboard.setData(ClipboardData(text: _safetyNumber!));
-              ToastService.show(
-                context,
-                'Safety number copied',
-                type: ToastType.success,
-              );
-            },
-            child: Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: context.surface,
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: context.border),
-              ),
-              child: Column(
-                children: [
-                  Text(
-                    formatted,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: context.textPrimary,
-                      fontSize: 18,
-                      fontWeight: FontWeight.w500,
-                      fontFamily: 'monospace',
-                      letterSpacing: 2,
-                      height: 1.6,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(Icons.copy, size: 12, color: context.textMuted),
-                      const SizedBox(width: 4),
-                      Text(
-                        'Tap to copy',
-                        style: TextStyle(
-                          color: context.textMuted,
-                          fontSize: 11,
-                        ),
+          Semantics(
+            label: 'copy safety number',
+            button: true,
+            child: GestureDetector(
+              onTap: () {
+                Clipboard.setData(ClipboardData(text: _safetyNumber!));
+                ToastService.show(
+                  context,
+                  'Safety number copied',
+                  type: ToastType.success,
+                );
+              },
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: context.surface,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: context.border),
+                ),
+                child: Column(
+                  children: [
+                    Text(
+                      formatted,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: context.textPrimary,
+                        fontSize: 18,
+                        fontWeight: FontWeight.w500,
+                        fontFamily: 'monospace',
+                        letterSpacing: 2,
+                        height: 1.6,
                       ),
-                    ],
-                  ),
-                ],
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.copy, size: 12, color: context.textMuted),
+                        const SizedBox(width: 4),
+                        Text(
+                          'Tap to copy',
+                          style: TextStyle(
+                            color: context.textMuted,
+                            fontSize: 11,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -482,20 +482,24 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
               Positioned(
                 bottom: 0,
                 right: 0,
-                child: GestureDetector(
-                  onTap: _uploadAvatar,
-                  child: Container(
-                    width: 26,
-                    height: 26,
-                    decoration: BoxDecoration(
-                      color: context.surface,
-                      shape: BoxShape.circle,
-                      border: Border.all(color: context.border, width: 2),
-                    ),
-                    child: Icon(
-                      Icons.camera_alt,
-                      size: 13,
-                      color: context.textSecondary,
+                child: Semantics(
+                  label: 'pick avatar',
+                  button: true,
+                  child: GestureDetector(
+                    onTap: _uploadAvatar,
+                    child: Container(
+                      width: 26,
+                      height: 26,
+                      decoration: BoxDecoration(
+                        color: context.surface,
+                        shape: BoxShape.circle,
+                        border: Border.all(color: context.border, width: 2),
+                      ),
+                      child: Icon(
+                        Icons.camera_alt,
+                        size: 13,
+                        color: context.textSecondary,
+                      ),
                     ),
                   ),
                 ),

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -304,81 +304,86 @@ class _ThemeCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 160,
-      child: Material(
-        color: isSelected ? context.accentLight : Colors.transparent,
-        borderRadius: BorderRadius.circular(10),
-        child: InkWell(
-          onTap: onTap,
+    return Semantics(
+      label: '${data.label} theme',
+      button: true,
+      selected: isSelected,
+      child: SizedBox(
+        width: 160,
+        child: Material(
+          color: isSelected ? context.accentLight : Colors.transparent,
           borderRadius: BorderRadius.circular(10),
-          hoverColor: context.surfaceHover,
-          child: Container(
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(10),
-              border: Border.all(
-                color: isSelected ? context.accent : context.border,
-                width: isSelected ? 2 : 1,
-              ),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Thumbnail
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(6),
-                  child: SizedBox(
-                    height: 90,
-                    width: double.infinity,
-                    child: data.preview != null
-                        ? _ThemeThumbnail(colors: data.preview!)
-                        : _SystemThemeThumbnail(),
-                  ),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(10),
+            hoverColor: context.surfaceHover,
+            child: Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  color: isSelected ? context.accent : context.border,
+                  width: isSelected ? 2 : 1,
                 ),
-                const SizedBox(height: 8),
-                // Label row
-                Row(
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            data.label,
-                            style: TextStyle(
-                              color: isSelected
-                                  ? context.accent
-                                  : context.textPrimary,
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          const SizedBox(height: 1),
-                          Text(
-                            data.subtitle,
-                            style: TextStyle(
-                              color: context.textMuted,
-                              fontSize: 11,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ],
-                      ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Thumbnail
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(6),
+                    child: SizedBox(
+                      height: 90,
+                      width: double.infinity,
+                      child: data.preview != null
+                          ? _ThemeThumbnail(colors: data.preview!)
+                          : _SystemThemeThumbnail(),
                     ),
-                    if (isSelected)
-                      Padding(
-                        padding: const EdgeInsets.only(left: 4),
-                        child: Icon(
-                          Icons.check_circle,
-                          size: 18,
-                          color: context.accent,
+                  ),
+                  const SizedBox(height: 8),
+                  // Label row
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              data.label,
+                              style: TextStyle(
+                                color: isSelected
+                                    ? context.accent
+                                    : context.textPrimary,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(height: 1),
+                            Text(
+                              data.subtitle,
+                              style: TextStyle(
+                                color: context.textMuted,
+                                fontSize: 11,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ],
                         ),
                       ),
-                  ],
-                ),
-              ],
+                      if (isSelected)
+                        Padding(
+                          padding: const EdgeInsets.only(left: 4),
+                          child: Icon(
+                            Icons.check_circle,
+                            size: 18,
+                            color: context.accent,
+                          ),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -683,55 +688,63 @@ class _LayoutOption extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: isSelected ? context.accentLight : Colors.transparent,
-      borderRadius: BorderRadius.circular(10),
-      child: InkWell(
-        onTap: onTap,
+    return Semantics(
+      label: '$label layout',
+      button: true,
+      selected: isSelected,
+      child: Material(
+        color: isSelected ? context.accentLight : Colors.transparent,
         borderRadius: BorderRadius.circular(10),
-        hoverColor: context.surfaceHover,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(10),
-            border: Border.all(
-              color: isSelected ? context.accent : context.border,
-              width: 1,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(10),
+          hoverColor: context.surfaceHover,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: isSelected ? context.accent : context.border,
+                width: 1,
+              ),
             ),
-          ),
-          child: Row(
-            children: [
-              Icon(
-                icon,
-                size: 22,
-                color: isSelected ? context.accent : context.textSecondary,
-              ),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      label,
-                      style: TextStyle(
-                        color: isSelected
-                            ? context.accent
-                            : context.textPrimary,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      subtitle,
-                      style: TextStyle(color: context.textMuted, fontSize: 12),
-                    ),
-                  ],
+            child: Row(
+              children: [
+                Icon(
+                  icon,
+                  size: 22,
+                  color: isSelected ? context.accent : context.textSecondary,
                 ),
-              ),
-              if (isSelected)
-                Icon(Icons.check_circle, size: 20, color: context.accent),
-            ],
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        style: TextStyle(
+                          color: isSelected
+                              ? context.accent
+                              : context.textPrimary,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        style: TextStyle(
+                          color: context.textMuted,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (isSelected)
+                  Icon(Icons.check_circle, size: 20, color: context.accent),
+              ],
+            ),
           ),
         ),
       ),

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -191,26 +191,31 @@ class SettingsNavList extends StatelessWidget {
       labelColor = context.textPrimary;
     }
 
-    return Material(
-      color: isSelected ? context.accentLight : Colors.transparent,
-      child: InkWell(
-        onTap: isLogout ? onLogout : () => onTap(section!),
-        hoverColor: context.surfaceHover,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              Icon(icon, size: 20, color: iconColor),
-              const SizedBox(width: 12),
-              Text(
-                label,
-                style: TextStyle(
-                  color: labelColor,
-                  fontSize: 14,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+    return Semantics(
+      label: isLogout ? 'log out' : '$label settings',
+      button: true,
+      selected: isSelected,
+      child: Material(
+        color: isSelected ? context.accentLight : Colors.transparent,
+        child: InkWell(
+          onTap: isLogout ? onLogout : () => onTap(section!),
+          hoverColor: context.surfaceHover,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(icon, size: 20, color: iconColor),
+                const SizedBox(width: 12),
+                Text(
+                  label,
+                  style: TextStyle(
+                    color: labelColor,
+                    fontSize: 14,
+                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -206,42 +206,47 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
 
   Widget _buildTextChannelChip(GroupChannel channel) {
     final isSelected = widget.selectedTextChannelId == channel.id;
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(20),
-        onTap: () => widget.onTextChannelChanged(channel.id),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-          decoration: BoxDecoration(
-            color: isSelected
-                ? context.accent.withValues(alpha: 0.15)
-                : context.surface.withValues(alpha: 0.6),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
+    return Semantics(
+      label: 'text channel: ${channel.name}',
+      button: true,
+      selected: isSelected,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20),
+          onTap: () => widget.onTextChannelChanged(channel.id),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
               color: isSelected
-                  ? context.accent.withValues(alpha: 0.4)
-                  : context.border,
+                  ? context.accent.withValues(alpha: 0.15)
+                  : context.surface.withValues(alpha: 0.6),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(
+                color: isSelected
+                    ? context.accent.withValues(alpha: 0.4)
+                    : context.border,
+              ),
             ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.tag,
-                size: 14,
-                color: isSelected ? context.accent : context.textSecondary,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                channel.name,
-                style: TextStyle(
-                  color: isSelected ? context.accent : context.textPrimary,
-                  fontSize: 12,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.tag,
+                  size: 14,
+                  color: isSelected ? context.accent : context.textSecondary,
                 ),
-              ),
-            ],
+                const SizedBox(width: 4),
+                Text(
+                  channel.name,
+                  style: TextStyle(
+                    color: isSelected ? context.accent : context.textPrimary,
+                    fontSize: 12,
+                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -290,53 +295,57 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
   ) {
     final participantCount = participants.length;
     final isActive = _isVoiceChannelActive(channel.id, activeVoiceChannelId);
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(20),
-        onTap: () => _handleVoiceChipTap(channel, isActive, voiceSettings),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-          decoration: BoxDecoration(
-            color: isActive
-                ? context.accent.withValues(alpha: 0.15)
-                : context.surface.withValues(alpha: 0.6),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
+    return Semantics(
+      label: 'voice channel: ${channel.name}',
+      button: true,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20),
+          onTap: () => _handleVoiceChipTap(channel, isActive, voiceSettings),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
               color: isActive
-                  ? context.accent.withValues(alpha: 0.4)
-                  : context.border,
+                  ? context.accent.withValues(alpha: 0.15)
+                  : context.surface.withValues(alpha: 0.6),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(
+                color: isActive
+                    ? context.accent.withValues(alpha: 0.4)
+                    : context.border,
+              ),
             ),
-          ),
-          child: Tooltip(
-            message: participants.isEmpty
-                ? 'No one in voice'
-                : participants.map((p) => p.username).join('\n'),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.volume_up_outlined,
-                  size: 14,
-                  color: isActive ? context.accent : context.textSecondary,
-                ),
-                const SizedBox(width: 4),
-                Text(
-                  channel.name,
-                  style: TextStyle(
-                    color: isActive ? context.accent : context.textPrimary,
-                    fontSize: 12,
-                    fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+            child: Tooltip(
+              message: participants.isEmpty
+                  ? 'No one in voice'
+                  : participants.map((p) => p.username).join('\n'),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.volume_up_outlined,
+                    size: 14,
+                    color: isActive ? context.accent : context.textSecondary,
                   ),
-                ),
-                if (participantCount > 0) ...[
                   const SizedBox(width: 4),
                   Text(
-                    '($participantCount)',
-                    style: TextStyle(color: context.textMuted, fontSize: 11),
+                    channel.name,
+                    style: TextStyle(
+                      color: isActive ? context.accent : context.textPrimary,
+                      fontSize: 12,
+                      fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+                    ),
                   ),
+                  if (participantCount > 0) ...[
+                    const SizedBox(width: 4),
+                    Text(
+                      '($participantCount)',
+                      style: TextStyle(color: context.textMuted, fontSize: 11),
+                    ),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -117,7 +117,11 @@ class ChatHeaderBar extends ConsumerWidget {
               : null,
         );
         if (conv.isGroup && onGroupInfo != null) {
-          return GestureDetector(onTap: onGroupInfo, child: avatar);
+          return Semantics(
+            label: 'group info',
+            button: true,
+            child: GestureDetector(onTap: onGroupInfo, child: avatar),
+          );
         }
         return avatar;
       },
@@ -131,31 +135,35 @@ class ChatHeaderBar extends ConsumerWidget {
     String displayName,
   ) {
     return Expanded(
-      child: GestureDetector(
-        onTap: conv.isGroup
-            ? onGroupInfo
-            : () {
-                final peer = conv.members
-                    .where((m) => m.userId != myUserId)
-                    .firstOrNull;
-                if (peer != null) {
-                  UserProfileScreen.show(context, ref, peer.userId);
-                }
-              },
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              displayName,
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
+      child: Semantics(
+        label: 'view $displayName details',
+        button: true,
+        child: GestureDetector(
+          onTap: conv.isGroup
+              ? onGroupInfo
+              : () {
+                  final peer = conv.members
+                      .where((m) => m.userId != myUserId)
+                      .firstOrNull;
+                  if (peer != null) {
+                    UserProfileScreen.show(context, ref, peer.userId);
+                  }
+                },
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                displayName,
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
-            ),
-            _buildStatusLine(context, ref, conv),
-          ],
+              _buildStatusLine(context, ref, conv),
+            ],
+          ),
         ),
       ),
     );
@@ -444,9 +452,13 @@ class ChatHeaderBar extends ConsumerWidget {
               style: TextStyle(fontSize: 11, color: EchoTheme.warning),
             ),
           ),
-          GestureDetector(
-            onTap: onDismissEncryptionBanner,
-            child: Icon(Icons.close, size: 14, color: context.textMuted),
+          Semantics(
+            label: 'dismiss encryption banner',
+            button: true,
+            child: GestureDetector(
+              onTap: onDismissEncryptionBanner,
+              child: Icon(Icons.close, size: 14, color: context.textMuted),
+            ),
           ),
         ],
       ),
@@ -491,23 +503,27 @@ class ChatHeaderBar extends ConsumerWidget {
               style: TextStyle(fontSize: 11, color: EchoTheme.warning),
             ),
           ),
-          GestureDetector(
-            onTap: () => _resetPeerKeys(context, ref, conv, myUserId),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-              decoration: BoxDecoration(
-                color: EchoTheme.warning.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(10),
-                border: Border.all(
-                  color: EchoTheme.warning.withValues(alpha: 0.4),
+          Semantics(
+            label: 'reset encryption keys',
+            button: true,
+            child: GestureDetector(
+              onTap: () => _resetPeerKeys(context, ref, conv, myUserId),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: EchoTheme.warning.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color: EchoTheme.warning.withValues(alpha: 0.4),
+                  ),
                 ),
-              ),
-              child: const Text(
-                'Repair',
-                style: TextStyle(
-                  fontSize: 11,
-                  color: EchoTheme.warning,
-                  fontWeight: FontWeight.w600,
+                child: const Text(
+                  'Repair',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: EchoTheme.warning,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -1242,35 +1242,43 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       left: 0,
       right: 0,
       child: Center(
-        child: GestureDetector(
-          onTap: () => _scrollToBottom(settleRetries: 2),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            decoration: BoxDecoration(
-              color: context.accent,
-              borderRadius: BorderRadius.circular(20),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.25),
-                  blurRadius: 8,
-                  offset: const Offset(0, 2),
-                ),
-              ],
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  _newMessagesBannerText(),
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
+        child: Semantics(
+          label: 'scroll to new messages',
+          button: true,
+          child: GestureDetector(
+            onTap: () => _scrollToBottom(settleRetries: 2),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(
+                color: context.accent,
+                borderRadius: BorderRadius.circular(20),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.25),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
                   ),
-                ),
-                const SizedBox(width: 4),
-                const Icon(Icons.arrow_downward, size: 14, color: Colors.white),
-              ],
+                ],
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _newMessagesBannerText(),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  const Icon(
+                    Icons.arrow_downward,
+                    size: 14,
+                    color: Colors.white,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/connection_status_banner.dart
+++ b/apps/client/lib/src/widgets/connection_status_banner.dart
@@ -156,24 +156,28 @@ class _ConnectionStatusBannerState
               ),
               if (showRetry) ...[
                 const SizedBox(width: 10),
-                GestureDetector(
-                  onTap: () => ref.read(websocketProvider.notifier).connect(),
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 8,
-                      vertical: 2,
-                    ),
-                    decoration: BoxDecoration(
-                      color: status.color.withValues(alpha: 0.2),
-                      borderRadius: BorderRadius.circular(10),
-                      border: Border.all(color: status.color, width: 1),
-                    ),
-                    child: Text(
-                      'Retry',
-                      style: TextStyle(
-                        fontSize: 11,
-                        color: status.color,
-                        fontWeight: FontWeight.w600,
+                Semantics(
+                  label: 'retry connection',
+                  button: true,
+                  child: GestureDetector(
+                    onTap: () => ref.read(websocketProvider.notifier).connect(),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: status.color.withValues(alpha: 0.2),
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(color: status.color, width: 1),
+                      ),
+                      child: Text(
+                        'Retry',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: status.color,
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
                     ),
                   ),

--- a/apps/client/lib/src/widgets/contact_item.dart
+++ b/apps/client/lib/src/widgets/contact_item.dart
@@ -49,85 +49,93 @@ class _ContactItemState extends State<ContactItem> {
         child: Row(
           children: [
             Expanded(
-              child: InkWell(
-                borderRadius: BorderRadius.circular(8),
-                onTap: widget.onProfile,
-                child: Row(
-                  children: [
-                    // Avatar with online dot
-                    Stack(
-                      children: [
-                        buildAvatar(
-                          name: username,
-                          radius: 18,
-                          imageUrl: fullAvatarUrl,
-                        ),
-                        Positioned(
-                          bottom: 0,
-                          right: 0,
-                          child: Container(
-                            width: 10,
-                            height: 10,
-                            decoration: BoxDecoration(
-                              color: EchoTheme.online,
-                              shape: BoxShape.circle,
-                              border: Border.all(
-                                color: context.sidebarBg,
-                                width: 2,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(width: 12),
-                    // Name
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.start,
+              child: Semantics(
+                label: 'contact: $username',
+                button: true,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(8),
+                  onTap: widget.onProfile,
+                  child: Row(
+                    children: [
+                      // Avatar with online dot
+                      Stack(
                         children: [
-                          Text(
-                            displayName ?? username,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w500,
-                              color: context.textPrimary,
-                            ),
+                          buildAvatar(
+                            name: username,
+                            radius: 18,
+                            imageUrl: fullAvatarUrl,
                           ),
-                          if (displayName != null)
-                            Text(
-                              '@$username',
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: context.textMuted,
+                          Positioned(
+                            bottom: 0,
+                            right: 0,
+                            child: Container(
+                              width: 10,
+                              height: 10,
+                              decoration: BoxDecoration(
+                                color: EchoTheme.online,
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  color: context.sidebarBg,
+                                  width: 2,
+                                ),
                               ),
                             ),
+                          ),
                         ],
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: 12),
+                      // Name
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              displayName ?? username,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                                color: context.textPrimary,
+                              ),
+                            ),
+                            if (displayName != null)
+                              Text(
+                                '@$username',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: context.textMuted,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
-            SizedBox(
-              height: 28,
-              child: Material(
-                color: context.accentLight,
-                borderRadius: BorderRadius.circular(6),
-                child: InkWell(
+            Semantics(
+              label: 'message $username',
+              button: true,
+              child: SizedBox(
+                height: 28,
+                child: Material(
+                  color: context.accentLight,
                   borderRadius: BorderRadius.circular(6),
-                  onTap: widget.onMessage,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    child: Center(
-                      child: Text(
-                        'Message',
-                        style: TextStyle(
-                          color: context.accent,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w500,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(6),
+                    onTap: widget.onMessage,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      child: Center(
+                        child: Text(
+                          'Message',
+                          style: TextStyle(
+                            color: context.accent,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w500,
+                          ),
                         ),
                       ),
                     ),

--- a/apps/client/lib/src/widgets/gif_picker_widget.dart
+++ b/apps/client/lib/src/widgets/gif_picker_widget.dart
@@ -230,21 +230,26 @@ class _GifPickerWidgetState extends State<GifPickerWidget> {
       itemCount: _results.length,
       itemBuilder: (ctx, i) {
         final gif = _results[i];
-        return GestureDetector(
-          onTap: () {
-            widget.onGifSelected(gif.sendUrl, gif.slug);
-            _trackShare(gif.slug);
-          },
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(6),
-            child: Image.network(
-              gif.previewUrl,
-              fit: BoxFit.cover,
-              errorBuilder: (_, e, st) => Container(
-                color: context.mainBg,
-                child: Icon(
-                  Icons.broken_image_outlined,
-                  color: context.textMuted,
+        return Semantics(
+          label: 'send gif',
+          image: true,
+          button: true,
+          child: GestureDetector(
+            onTap: () {
+              widget.onGifSelected(gif.sendUrl, gif.slug);
+              _trackShare(gif.slug);
+            },
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: Image.network(
+                gif.previewUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (_, e, st) => Container(
+                  color: context.mainBg,
+                  child: Icon(
+                    Icons.broken_image_outlined,
+                    color: context.textMuted,
+                  ),
                 ),
               ),
             ),

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -256,46 +256,50 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
       }
     }
 
-    return InkWell(
-      onTap: () {
-        Navigator.of(context).pop();
-        widget.onResultTap(r.conversationId, r.messageId);
-      },
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Text(
-                  r.senderUsername,
-                  style: TextStyle(
-                    color: context.textPrimary,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
+    return Semantics(
+      label: 'search result by ${r.senderUsername}',
+      button: true,
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).pop();
+          widget.onResultTap(r.conversationId, r.messageId);
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    r.senderUsername,
+                    style: TextStyle(
+                      color: context.textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
-                ),
-                const SizedBox(width: 6),
-                Text(
-                  'in ${r.conversationName}',
-                  style: TextStyle(color: context.textMuted, fontSize: 12),
-                ),
-                const Spacer(),
-                Text(
-                  timeLabel,
-                  style: TextStyle(color: context.textMuted, fontSize: 11),
-                ),
-              ],
-            ),
-            const SizedBox(height: 2),
-            Text(
-              preview,
-              style: TextStyle(color: context.textSecondary, fontSize: 13),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
+                  const SizedBox(width: 6),
+                  Text(
+                    'in ${r.conversationName}',
+                    style: TextStyle(color: context.textMuted, fontSize: 12),
+                  ),
+                  const Spacer(),
+                  Text(
+                    timeLabel,
+                    style: TextStyle(color: context.textMuted, fontSize: 11),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 2),
+              Text(
+                preview,
+                style: TextStyle(color: context.textSecondary, fontSize: 13),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/input/attachment_preview.dart
+++ b/apps/client/lib/src/widgets/input/attachment_preview.dart
@@ -138,9 +138,13 @@ class AttachmentPreview extends StatelessWidget {
           ),
         const SizedBox(width: 6),
         // Remove button
-        GestureDetector(
-          onTap: onClear,
-          child: Icon(Icons.close, size: 16, color: context.textMuted),
+        Semantics(
+          label: 'remove attachment',
+          button: true,
+          child: GestureDetector(
+            onTap: onClear,
+            child: Icon(Icons.close, size: 16, color: context.textMuted),
+          ),
         ),
       ],
     );

--- a/apps/client/lib/src/widgets/input/input_status_bar.dart
+++ b/apps/client/lib/src/widgets/input/input_status_bar.dart
@@ -53,9 +53,13 @@ class InputStatusBar extends StatelessWidget {
             ),
           ),
           if (isEditing && onCancelEdit != null)
-            GestureDetector(
-              onTap: onCancelEdit,
-              child: Icon(Icons.close, size: 14, color: context.textMuted),
+            Semantics(
+              label: 'cancel edit',
+              button: true,
+              child: GestureDetector(
+                onTap: onCancelEdit,
+                child: Icon(Icons.close, size: 14, color: context.textMuted),
+              ),
             ),
         ],
       ),

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -63,30 +63,34 @@ class _MentionItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Row(
-          children: [
-            Icon(Icons.alternate_email, size: 14, color: context.accent),
-            const SizedBox(width: 8),
-            Text(
-              member.username,
-              style: TextStyle(
-                fontSize: 13,
-                color: context.textPrimary,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            if (member.role != null) ...[
-              const SizedBox(width: 6),
+    return Semantics(
+      label: 'mention ${member.username}',
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              Icon(Icons.alternate_email, size: 14, color: context.accent),
+              const SizedBox(width: 8),
               Text(
-                member.role!,
-                style: TextStyle(fontSize: 11, color: context.textMuted),
+                member.username,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: context.textPrimary,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
+              if (member.role != null) ...[
+                const SizedBox(width: 6),
+                Text(
+                  member.role!,
+                  style: TextStyle(fontSize: 11, color: context.textMuted),
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/input/reply_preview_bar.dart
+++ b/apps/client/lib/src/widgets/input/reply_preview_bar.dart
@@ -60,9 +60,13 @@ class ReplyPreviewBar extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 8),
-          GestureDetector(
-            onTap: onDismiss,
-            child: Icon(Icons.close, size: 14, color: context.textMuted),
+          Semantics(
+            label: 'dismiss reply preview',
+            button: true,
+            child: GestureDetector(
+              onTap: onDismiss,
+              child: Icon(Icons.close, size: 14, color: context.textMuted),
+            ),
           ),
         ],
       ),

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -252,85 +252,89 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
     final showRemove =
         widget.canRemove && !widget.isMe && _isHovered && !_isRemoving;
 
-    return GestureDetector(
-      onTap: () {
-        UserProfileScreen.show(context, ref, member.userId);
-      },
-      child: MouseRegion(
-        onEnter: (_) => setState(() => _isHovered = true),
-        onExit: (_) => setState(() => _isHovered = false),
-        child: Container(
-          height: 40,
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Row(
-            children: [
-              // Avatar
-              buildAvatar(
-                name: member.username,
-                radius: 10,
-                imageUrl: member.avatarUrl != null
-                    ? '${ref.watch(serverUrlProvider)}${member.avatarUrl}'
-                    : null,
-              ),
-              const SizedBox(width: 8),
-              // Online dot
-              Container(
-                width: 8,
-                height: 8,
-                decoration: BoxDecoration(
-                  color: EchoTheme.online,
-                  shape: BoxShape.circle,
-                  border: Border.all(color: context.sidebarBg, width: 1.5),
+    return Semantics(
+      label: 'member: ${member.username}',
+      button: true,
+      child: GestureDetector(
+        onTap: () {
+          UserProfileScreen.show(context, ref, member.userId);
+        },
+        child: MouseRegion(
+          onEnter: (_) => setState(() => _isHovered = true),
+          onExit: (_) => setState(() => _isHovered = false),
+          child: Container(
+            height: 40,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Row(
+              children: [
+                // Avatar
+                buildAvatar(
+                  name: member.username,
+                  radius: 10,
+                  imageUrl: member.avatarUrl != null
+                      ? '${ref.watch(serverUrlProvider)}${member.avatarUrl}'
+                      : null,
                 ),
-              ),
-              const SizedBox(width: 8),
-              // Username
-              Expanded(
-                child: Row(
-                  children: [
-                    Flexible(
-                      child: Text(
-                        member.username,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: context.textSecondary,
-                          fontSize: 13,
+                const SizedBox(width: 8),
+                // Online dot
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: EchoTheme.online,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: context.sidebarBg, width: 1.5),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // Username
+                Expanded(
+                  child: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          member.username,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: context.textSecondary,
+                            fontSize: 13,
+                          ),
                         ),
                       ),
-                    ),
-                    if (member.role != null &&
-                        (member.role == 'owner' || member.role == 'admin'))
-                      _buildRoleBadge(member.role!),
-                  ],
-                ),
-              ),
-              // Remove button
-              if (showRemove)
-                SizedBox(
-                  width: 44,
-                  height: 44,
-                  child: IconButton(
-                    icon: const Icon(Icons.close, size: 14),
-                    color: context.textMuted,
-                    tooltip: 'Remove member',
-                    onPressed: _removeMember,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(
-                      minWidth: 44,
-                      minHeight: 44,
-                    ),
+                      if (member.role != null &&
+                          (member.role == 'owner' || member.role == 'admin'))
+                        _buildRoleBadge(member.role!),
+                    ],
                   ),
                 ),
-              if (_isRemoving)
-                SizedBox(
-                  width: 14,
-                  height: 14,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: context.textMuted,
+                // Remove button
+                if (showRemove)
+                  SizedBox(
+                    width: 44,
+                    height: 44,
+                    child: IconButton(
+                      icon: const Icon(Icons.close, size: 14),
+                      color: context.textMuted,
+                      tooltip: 'Remove member',
+                      onPressed: _removeMember,
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(
+                        minWidth: 44,
+                        minHeight: 44,
+                      ),
+                    ),
                   ),
-                ),
-            ],
+                if (_isRemoving)
+                  SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: context.textMuted,
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
       ),

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -670,16 +670,20 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
 
     // Not yet tapped — show play button thumbnail (no controller allocated).
     if (!_userTappedPlay && c == null) {
-      return GestureDetector(
-        onTap: _initAndPlay,
-        child: Container(
-          height: 170,
-          color: widget.mainBg,
-          child: Center(
-            child: Icon(
-              Icons.play_circle_outline,
-              size: 44,
-              color: widget.textMuted,
+      return Semantics(
+        label: 'play video',
+        button: true,
+        child: GestureDetector(
+          onTap: _initAndPlay,
+          child: Container(
+            height: 170,
+            color: widget.mainBg,
+            child: Center(
+              child: Icon(
+                Icons.play_circle_outline,
+                size: 44,
+                color: widget.textMuted,
+              ),
             ),
           ),
         ),
@@ -706,16 +710,20 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
 
     // Init failed -- show static placeholder
     if (_initFailed || c == null) {
-      return GestureDetector(
-        onTap: widget.onOpen,
-        child: Container(
-          height: 170,
-          color: widget.mainBg,
-          child: Center(
-            child: Icon(
-              Icons.play_circle_outline,
-              size: 44,
-              color: widget.textMuted,
+      return Semantics(
+        label: 'open video externally',
+        button: true,
+        child: GestureDetector(
+          onTap: widget.onOpen,
+          child: Container(
+            height: 170,
+            color: widget.mainBg,
+            child: Center(
+              child: Icon(
+                Icons.play_circle_outline,
+                size: 44,
+                color: widget.textMuted,
+              ),
             ),
           ),
         ),
@@ -723,29 +731,33 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
     }
 
     // Initialised -- show player with controls
-    return GestureDetector(
-      onTap: _togglePlayPause,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          AspectRatio(
-            aspectRatio: c.value.aspectRatio.clamp(0.5, 3.0),
-            child: VideoPlayer(c),
-          ),
-          if (!c.value.isPlaying)
-            Container(
-              padding: const EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.5),
-                shape: BoxShape.circle,
-              ),
-              child: const Icon(
-                Icons.play_arrow,
-                size: 32,
-                color: Colors.white,
-              ),
+    return Semantics(
+      label: 'toggle video playback',
+      button: true,
+      child: GestureDetector(
+        onTap: _togglePlayPause,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            AspectRatio(
+              aspectRatio: c.value.aspectRatio.clamp(0.5, 3.0),
+              child: VideoPlayer(c),
             ),
-        ],
+            if (!c.value.isPlaying)
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: Colors.black.withValues(alpha: 0.5),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.play_arrow,
+                  size: 32,
+                  color: Colors.white,
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -28,38 +28,42 @@ class ReactionBar extends StatelessWidget {
         decoration: TextDecoration.none,
         color: context.textPrimary,
       ),
-      child: GestureDetector(
-        onTapUp: (details) => onTap?.call(details.globalPosition),
-        child: Container(
-          height: 24,
-          padding: const EdgeInsets.symmetric(horizontal: 6),
-          decoration: BoxDecoration(
-            color: context.surface,
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: context.border, width: 1),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              for (final emoji in uniqueEmojis)
-                Padding(
-                  padding: const EdgeInsets.only(right: 2),
-                  child: Text(
-                    emoji,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      decoration: TextDecoration.none,
+      child: Semantics(
+        label: 'reaction: ${uniqueEmojis.join(" ")} ($totalCount)',
+        button: true,
+        child: GestureDetector(
+          onTapUp: (details) => onTap?.call(details.globalPosition),
+          child: Container(
+            height: 24,
+            padding: const EdgeInsets.symmetric(horizontal: 6),
+            decoration: BoxDecoration(
+              color: context.surface,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: context.border, width: 1),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final emoji in uniqueEmojis)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 2),
+                    child: Text(
+                      emoji,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        decoration: TextDecoration.none,
+                      ),
                     ),
                   ),
-                ),
-              if (totalCount > 1) ...[
-                const SizedBox(width: 2),
-                Text(
-                  '$totalCount',
-                  style: TextStyle(fontSize: 12, color: context.textMuted),
-                ),
+                if (totalCount > 1) ...[
+                  const SizedBox(width: 2),
+                  Text(
+                    '$totalCount',
+                    style: TextStyle(fontSize: 12, color: context.textMuted),
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
         ),
       ),

--- a/apps/client/lib/src/widgets/message/rich_text_content.dart
+++ b/apps/client/lib/src/widgets/message/rich_text_content.dart
@@ -690,21 +690,25 @@ class _SpoilerTextState extends State<_SpoilerText> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => setState(() => _revealed = !_revealed),
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(horizontal: 2),
-        decoration: BoxDecoration(
-          color: _revealed
-              ? widget.bgColor.withValues(alpha: 0.15)
-              : widget.bgColor.withValues(alpha: 0.8),
-          borderRadius: BorderRadius.circular(3),
-        ),
-        child: Text(
-          widget.text,
-          style: widget.style.copyWith(
-            color: _revealed ? widget.style.color : Colors.transparent,
+    return Semantics(
+      label: 'reveal spoiler',
+      button: true,
+      child: GestureDetector(
+        onTap: () => setState(() => _revealed = !_revealed),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.symmetric(horizontal: 2),
+          decoration: BoxDecoration(
+            color: _revealed
+                ? widget.bgColor.withValues(alpha: 0.15)
+                : widget.bgColor.withValues(alpha: 0.8),
+            borderRadius: BorderRadius.circular(3),
+          ),
+          child: Text(
+            widget.text,
+            style: widget.style.copyWith(
+              color: _revealed ? widget.style.color : Colors.transparent,
+            ),
           ),
         ),
       ),
@@ -769,26 +773,30 @@ class _CodeBlockWidgetState extends State<_CodeBlockWidget> {
             Positioned(
               top: 8,
               right: 8,
-              child: GestureDetector(
-                onTap: _copy,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    color: widget.bgColor,
-                    borderRadius: BorderRadius.circular(4),
-                    border: Border.all(
-                      color: widget.textColor.withValues(alpha: 0.2),
+              child: Semantics(
+                label: 'copy code block',
+                button: true,
+                child: GestureDetector(
+                  onTap: _copy,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
                     ),
-                  ),
-                  child: Text(
-                    _copied ? 'Copied!' : 'Copy',
-                    style: TextStyle(
-                      fontSize: 11,
-                      color: widget.textColor.withValues(alpha: 0.7),
-                      fontWeight: FontWeight.w600,
+                    decoration: BoxDecoration(
+                      color: widget.bgColor,
+                      borderRadius: BorderRadius.circular(4),
+                      border: Border.all(
+                        color: widget.textColor.withValues(alpha: 0.2),
+                      ),
+                    ),
+                    child: Text(
+                      _copied ? 'Copied!' : 'Copy',
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: widget.textColor.withValues(alpha: 0.7),
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
                 ),

--- a/apps/client/lib/src/widgets/quick_switcher_overlay.dart
+++ b/apps/client/lib/src/widgets/quick_switcher_overlay.dart
@@ -94,42 +94,46 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
               border: Border(left: BorderSide(color: context.accent, width: 2)),
             )
           : null,
-      child: Material(
-        color: isSelected
-            ? context.accent.withValues(alpha: 0.1)
-            : Colors.transparent,
-        child: InkWell(
-          onTap: () {
-            widget.onSelect(conv);
-            Navigator.of(context).pop();
-          },
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-            child: Row(
-              children: [
-                Icon(
-                  conv.isGroup ? Icons.group : Icons.person,
-                  size: 20,
-                  color: context.textSecondary,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    title,
-                    style: TextStyle(
-                      color: context.textPrimary,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
+      child: Semantics(
+        label: 'switch to: $title',
+        button: true,
+        child: Material(
+          color: isSelected
+              ? context.accent.withValues(alpha: 0.1)
+              : Colors.transparent,
+          child: InkWell(
+            onTap: () {
+              widget.onSelect(conv);
+              Navigator.of(context).pop();
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: Row(
+                children: [
+                  Icon(
+                    conv.isGroup ? Icons.group : Icons.person,
+                    size: 20,
+                    color: context.textSecondary,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: context.textPrimary,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    overflow: TextOverflow.ellipsis,
                   ),
-                ),
-                if (conv.isGroup)
-                  Text(
-                    'Group',
-                    style: TextStyle(color: context.textMuted, fontSize: 11),
-                  ),
-              ],
+                  if (conv.isGroup)
+                    Text(
+                      'Group',
+                      style: TextStyle(color: context.textMuted, fontSize: 11),
+                    ),
+                ],
+              ),
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/shared_media_gallery.dart
+++ b/apps/client/lib/src/widgets/shared_media_gallery.dart
@@ -161,24 +161,29 @@ class _MediaGrid extends StatelessWidget {
         );
         final headers = mediaHeaders(authToken: authToken);
 
-        return GestureDetector(
-          onTap: () => _showFullImage(context, resolvedUrl, headers),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(2),
-            child: resolvedUrl.endsWith('.gif')
-                ? Image.network(
-                    resolvedUrl,
-                    fit: BoxFit.cover,
-                    gaplessPlayback: true,
-                    errorBuilder: (_, _, _) => _placeholder(context),
-                  )
-                : CachedNetworkImage(
-                    imageUrl: resolvedUrl,
-                    httpHeaders: headers,
-                    fit: BoxFit.cover,
-                    placeholder: (_, _) => _placeholder(context),
-                    errorWidget: (_, _, _) => _placeholder(context),
-                  ),
+        return Semantics(
+          label: 'view media',
+          image: true,
+          button: true,
+          child: GestureDetector(
+            onTap: () => _showFullImage(context, resolvedUrl, headers),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(2),
+              child: resolvedUrl.endsWith('.gif')
+                  ? Image.network(
+                      resolvedUrl,
+                      fit: BoxFit.cover,
+                      gaplessPlayback: true,
+                      errorBuilder: (_, _, _) => _placeholder(context),
+                    )
+                  : CachedNetworkImage(
+                      imageUrl: resolvedUrl,
+                      httpHeaders: headers,
+                      fit: BoxFit.cover,
+                      placeholder: (_, _) => _placeholder(context),
+                      errorWidget: (_, _, _) => _placeholder(context),
+                    ),
+            ),
           ),
         );
       },

--- a/apps/client/lib/src/widgets/shared_media_gallery.dart
+++ b/apps/client/lib/src/widgets/shared_media_gallery.dart
@@ -163,7 +163,6 @@ class _MediaGrid extends StatelessWidget {
 
         return Semantics(
           label: 'view media',
-          image: true,
           button: true,
           child: GestureDetector(
             onTap: () => _showFullImage(context, resolvedUrl, headers),


### PR DESCRIPTION
## Summary
- Add ~40 `Semantics` wrappers to `GestureDetector`/`InkWell` widgets across 24 files
- Enables Playwright E2E tests to use `getByRole('button', { name: ... })` instead of fragile pixel coordinates
- Follows existing pattern from `conversation_panel.dart` tab chips
- Skips widgets already accessible via `tooltip:`, `labelText:`, or built-in Material semantics

Closes #187

## Test plan
- [x] `flutter analyze` -- no issues
- [x] `flutter test` -- 611/611 pass
- [x] No logic changes -- only Semantics wrappers added
- [ ] Spot-check: `page.getByRole('button', { name: /message alice/i })` finds contact item
- [ ] Spot-check: `page.getByRole('button', { name: /account settings/i })` finds settings nav

Generated with [Claude Code](https://claude.ai/code)