### PR TITLE
fix(client): crypto_provider silent plaintext degradation

### DIFF
--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -93,8 +93,8 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
   /// Initialize crypto and upload keys to the server.
   ///
   /// On Linux, libsecret may fail to unlock the keyring (PlatformException).
-  /// In that case crypto degrades gracefully -- the user can still chat
-  /// without encryption rather than seeing a red error toast.
+  /// When this happens DM sending is blocked (the send button is disabled)
+  /// and a degradation banner is shown so the user can retry.
   Future<void> initAndUploadKeys() async {
     if (state.isInitialized) return;
 
@@ -172,6 +172,7 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
     } catch (e) {
       DebugLogService.instance.log(LogLevel.error, 'Crypto', 'Init failed: $e');
       state = state.copyWith(
+        isInitialized: false,
         isUploading: false,
         error: 'Crypto init failed: $e',
       );

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -1186,7 +1186,9 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       buttonColor = context.accent;
     }
 
-    return Padding(
+    final cryptoBlocked = isDm && !cryptoReady;
+
+    Widget button = Padding(
       padding: const EdgeInsets.only(right: 4),
       child: Semantics(
         label: _isEditing ? 'Confirm edit' : 'Send message',
@@ -1221,6 +1223,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         ),
       ),
     );
+
+    if (cryptoBlocked) {
+      button = Tooltip(message: 'Encryption unavailable', child: button);
+    }
+
+    return button;
   }
 
   Widget _buildInputRow({

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -25,6 +25,7 @@ import 'channel_bar.dart';
 import 'chat_header_bar.dart';
 import 'chat_input_bar.dart';
 import 'connection_status_banner.dart';
+import 'crypto_degraded_banner.dart';
 import 'message_item.dart';
 import 'message_search_overlay.dart';
 
@@ -1416,6 +1417,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
                 ),
 
               const ConnectionStatusBanner(),
+              const CryptoDegradedBanner(),
 
               Expanded(
                 child: GestureDetector(

--- a/apps/client/lib/src/widgets/crypto_degraded_banner.dart
+++ b/apps/client/lib/src/widgets/crypto_degraded_banner.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/crypto_provider.dart';
+import '../theme/echo_theme.dart';
+
+/// Displays a persistent amber banner when the Signal Protocol crypto layer
+/// failed to initialize (e.g. keyring unavailable on Linux). Offers a Retry
+/// button so the user can re-attempt initialization without restarting.
+class CryptoDegradedBanner extends ConsumerWidget {
+  const CryptoDegradedBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cryptoState = ref.watch(cryptoProvider);
+    final visible = !cryptoState.isInitialized && cryptoState.error != null;
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+      child: visible
+          ? Semantics(
+              label: 'encryption unavailable warning',
+              child: Container(
+                width: double.infinity,
+                color: EchoTheme.warning.withValues(alpha: 0.15),
+                padding: const EdgeInsets.symmetric(vertical: 5),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.lock_open_outlined,
+                      size: 12,
+                      color: EchoTheme.warning,
+                    ),
+                    const SizedBox(width: 6),
+                    Flexible(
+                      child: Text(
+                        cryptoState.error!,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: EchoTheme.warning,
+                          fontWeight: FontWeight.w500,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Semantics(
+                      label: 'retry encryption',
+                      button: true,
+                      child: GestureDetector(
+                        onTap: () => ref
+                            .read(cryptoProvider.notifier)
+                            .initAndUploadKeys(),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: EchoTheme.warning.withValues(alpha: 0.2),
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(
+                              color: EchoTheme.warning,
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            'Retry',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: EchoTheme.warning,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : const SizedBox.shrink(),
+    );
+  }
+}

--- a/apps/client/test/helpers/mock_providers.dart
+++ b/apps/client/test/helpers/mock_providers.dart
@@ -192,19 +192,29 @@ class _FakeWebSocketNotifier extends WebSocketNotifier {
 // ---------------------------------------------------------------------------
 
 /// Override [cryptoProvider] with an initialized state (crypto ready).
-Override cryptoOverride({bool isInitialized = true}) {
+///
+/// Pass a full [CryptoState] via [cryptoState] for fine-grained control, or
+/// use the simpler [isInitialized] flag for the common case.
+Override cryptoOverride({bool isInitialized = true, CryptoState? cryptoState}) {
   return cryptoProvider.overrideWith(
-    (ref) => _FakeCryptoNotifier(ref, isInitialized: isInitialized),
+    (ref) => FakeCryptoNotifier(
+      ref,
+      initial: cryptoState ?? CryptoState(isInitialized: isInitialized),
+    ),
   );
 }
 
-class _FakeCryptoNotifier extends CryptoNotifier {
-  _FakeCryptoNotifier(super.ref, {bool isInitialized = true}) {
-    state = CryptoState(isInitialized: isInitialized);
+class FakeCryptoNotifier extends CryptoNotifier {
+  FakeCryptoNotifier(super.ref, {CryptoState initial = const CryptoState()}) {
+    state = initial;
   }
 
+  int initCallCount = 0;
+
   @override
-  Future<void> initAndUploadKeys() async {}
+  Future<void> initAndUploadKeys() async {
+    initCallCount++;
+  }
 
   @override
   Future<void> retryKeyUpload() async {}

--- a/apps/client/test/providers/crypto_provider_test.dart
+++ b/apps/client/test/providers/crypto_provider_test.dart
@@ -1,6 +1,11 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:echo_app/src/providers/crypto_provider.dart';
+import 'package:echo_app/src/widgets/crypto_degraded_banner.dart';
+
+import '../helpers/mock_providers.dart';
+import '../helpers/pump_app.dart';
 
 void main() {
   group('CryptoState', () {
@@ -57,6 +62,104 @@ void main() {
 
       final withError = state.copyWith(error: 'test error');
       expect(withError.error, 'test error');
+    });
+  });
+
+  group('CryptoState error transitions', () {
+    test('isInitialized is false after general catch', () {
+      const base = CryptoState();
+      final errored = base.copyWith(
+        isInitialized: false,
+        isUploading: false,
+        error: 'Crypto init failed: some error',
+      );
+      expect(errored.isInitialized, isFalse);
+      expect(errored.error, contains('Crypto init failed'));
+    });
+
+    test('isInitialized is false after PlatformException', () {
+      final errored = const CryptoState().copyWith(
+        isInitialized: false,
+        isUploading: false,
+        error: 'Keyring unavailable',
+      );
+      expect(errored.isInitialized, isFalse);
+      expect(errored.error, isNotNull);
+    });
+
+    test('isInitialized is false after key upload failure', () {
+      final errored = const CryptoState().copyWith(
+        isInitialized: false,
+        keysUploadFailed: true,
+        isUploading: false,
+      );
+      expect(errored.isInitialized, isFalse);
+      expect(errored.keysUploadFailed, isTrue);
+    });
+
+    test('error is cleared on successful init', () {
+      final errored = const CryptoState().copyWith(error: 'old error');
+      final success = errored.copyWith(isInitialized: true, error: null);
+      expect(success.isInitialized, isTrue);
+      expect(success.error, isNull);
+    });
+  });
+
+  group('CryptoDegradedBanner', () {
+    testWidgets('shows when crypto has error and is not initialized', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const CryptoDegradedBanner(),
+        overrides: [
+          cryptoOverride(
+            cryptoState: const CryptoState(
+              isInitialized: false,
+              error: 'Keyring unavailable',
+            ),
+          ),
+        ],
+      );
+
+      expect(find.text('Keyring unavailable'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.byIcon(Icons.lock_open_outlined), findsOneWidget);
+    });
+
+    testWidgets('hides when crypto is initialized', (tester) async {
+      await tester.pumpApp(
+        const CryptoDegradedBanner(),
+        overrides: [
+          cryptoOverride(cryptoState: const CryptoState(isInitialized: true)),
+        ],
+      );
+
+      expect(find.text('Keyring unavailable'), findsNothing);
+      expect(find.text('Retry'), findsNothing);
+    });
+
+    testWidgets('retry button triggers initAndUploadKeys', (tester) async {
+      late FakeCryptoNotifier capturedNotifier;
+      await tester.pumpApp(
+        const CryptoDegradedBanner(),
+        overrides: [
+          cryptoProvider.overrideWith((ref) {
+            capturedNotifier = FakeCryptoNotifier(
+              ref,
+              initial: const CryptoState(
+                isInitialized: false,
+                error: 'Keyring unavailable',
+              ),
+            );
+            return capturedNotifier;
+          }),
+        ],
+      );
+
+      expect(capturedNotifier.initCallCount, 0);
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+      expect(capturedNotifier.initCallCount, 1);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Hardened `initAndUploadKeys()` general catch block to explicitly set `isInitialized: false`
- New persistent `CryptoDegradedBanner` warns users when encryption is unavailable (modeled on `ConnectionStatusBanner`)
- Tooltip on disabled send button explains why DMs can't be sent
- Updated stale comment that incorrectly described "graceful degradation"
- 7 new tests for crypto error state transitions and banner behavior (618 total)

Closes #171

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 618/618 pass (7 new)
- [ ] Manual: simulate keyring failure → banner shows → retry works → send blocked with tooltip

Generated with [Claude Code](https://claude.ai/code)