### PR TITLE
test(client): critical test coverage batch 1 -- auth, conversations, quality fixes

### DIFF
--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -808,7 +808,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
@@ -848,7 +848,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -47,6 +47,8 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   network_image_mock: ^2.1.1
+  path_provider_platform_interface: ^2.1.0
+  plugin_platform_interface: ^2.1.0
 
 flutter:
   uses-material-design: true

--- a/apps/client/test/audit_logic_flaws_test.dart
+++ b/apps/client/test/audit_logic_flaws_test.dart
@@ -187,8 +187,8 @@ void main() {
         // This is a widget-level issue, documented here for tracking.
         //
         // The fix: add `if (_isEditing) return;` before the typing send.
-        expect(true, isTrue, reason: 'Widget-level bug, documented for fix');
       },
+      skip: 'widget-level bug, needs integration test with actual widget',
     );
   });
 
@@ -196,17 +196,20 @@ void main() {
   // H1: Accept contact request doesn't reload conversations
   // =========================================================================
   group('H1: accepting contact request does not create conversation', () {
-    test('conversation list should update after accepting contact', () {
-      // contacts_provider.dart:141-155 — acceptRequest() calls
-      // loadContacts() and loadPending() but NOT
-      // conversationsProvider.loadConversations().
-      //
-      // After accepting, the DM conversation exists on the server but
-      // the local conversation list is stale.
-      //
-      // This is a provider interaction issue — documented for fix.
-      expect(true, isTrue, reason: 'Provider interaction bug, documented');
-    });
+    test(
+      'conversation list should update after accepting contact',
+      () {
+        // contacts_provider.dart:141-155 — acceptRequest() calls
+        // loadContacts() and loadPending() but NOT
+        // conversationsProvider.loadConversations().
+        //
+        // After accepting, the DM conversation exists on the server but
+        // the local conversation list is stale.
+        //
+        // This is a provider interaction issue — documented for fix.
+      },
+      skip: 'provider interaction bug, needs integration test with multiple providers',
+    );
   });
 
   // =========================================================================
@@ -283,16 +286,19 @@ void main() {
   // H5: Search query not cleared on tab switch
   // =========================================================================
   group('H5: search persists across tab switches', () {
-    test('search query from chats tab should not filter contacts tab', () {
-      // conversation_panel.dart:111-119 — _onTabSelected() does NOT
-      // clear _searchQuery. The state variable is widget-local.
-      //
-      // This is a widget-level issue requiring widget test.
-      // Documenting the expected behavior:
-      // When switching tabs, _searchQuery should be cleared or
-      // each tab should have its own independent search.
-      expect(true, isTrue, reason: 'Widget-level bug, documented');
-    });
+    test(
+      'search query from chats tab should not filter contacts tab',
+      () {
+        // conversation_panel.dart:111-119 — _onTabSelected() does NOT
+        // clear _searchQuery. The state variable is widget-local.
+        //
+        // This is a widget-level issue requiring widget test.
+        // Documenting the expected behavior:
+        // When switching tabs, _searchQuery should be cleared or
+        // each tab should have its own independent search.
+      },
+      skip: 'widget-level bug, needs integration test with actual widget',
+    );
   });
 
   // =========================================================================

--- a/apps/client/test/crypto_bugs_test.dart
+++ b/apps/client/test/crypto_bugs_test.dart
@@ -117,27 +117,30 @@ void main() {
       },
     );
 
-    test('PROVES: OTP key_id reuse across uploads - same IDs 0-9 every time', () {
-      // This test documents the code pattern, not a runtime failure.
-      // In crypto_service.dart lines 441-454:
-      //
-      //   for (var i = 0; i < 10; i++) {
-      //     final otpPair = await _x25519.newKeyPair();
-      //     ...
-      //     await store.write('$_otpPrivatePrefix$i', ...);
-      //     otps.add({'key_id': i, 'public_key': pubB64});
-      //   }
-      //
-      // The loop uses hardcoded `i` from 0-9 every time uploadKeys() is called.
-      // This means:
-      //   - Upload 1: keys with IDs [0,1,2,3,4,5,6,7,8,9]
-      //   - Upload 2: keys with IDs [0,1,2,3,4,5,6,7,8,9] (SAME IDs!)
-      //   - Local storage: batch 2 private keys overwrite batch 1
-      //   - Server: ON CONFLICT DO NOTHING -> keeps batch 1 public keys
-      //
-      // This is verified by reading the actual code above.
-      expect(true, isTrue, reason: 'Code pattern documented and verified');
-    });
+    test(
+      'PROVES: OTP key_id reuse across uploads - same IDs 0-9 every time',
+      () {
+        // This test documents the code pattern, not a runtime failure.
+        // In crypto_service.dart lines 441-454:
+        //
+        //   for (var i = 0; i < 10; i++) {
+        //     final otpPair = await _x25519.newKeyPair();
+        //     ...
+        //     await store.write('$_otpPrivatePrefix$i', ...);
+        //     otps.add({'key_id': i, 'public_key': pubB64});
+        //   }
+        //
+        // The loop uses hardcoded `i` from 0-9 every time uploadKeys() is called.
+        // This means:
+        //   - Upload 1: keys with IDs [0,1,2,3,4,5,6,7,8,9]
+        //   - Upload 2: keys with IDs [0,1,2,3,4,5,6,7,8,9] (SAME IDs!)
+        //   - Local storage: batch 2 private keys overwrite batch 1
+        //   - Server: ON CONFLICT DO NOTHING -> keeps batch 1 public keys
+        //
+        // This is verified by reading the actual code above.
+      },
+      skip: 'documents code pattern, needs integration test with actual crypto service',
+    );
   });
 
   group('ROOT CAUSE #3: Historical messages cannot be re-decrypted', () {
@@ -483,8 +486,9 @@ void main() {
       // Note: This test demonstrates the RISK rather than guaranteeing failure.
       // True concurrent failures are timing-dependent. The per-peer lock fix
       // ensures serial execution regardless of timing.
-      expect(true, isTrue, reason: 'Concurrency risk documented');
-    });
+    },
+    skip: 'concurrency risk documented, needs integration test with real async interleaving',
+    );
   });
 
   group('Session persistence verification', () {

--- a/apps/client/test/helpers/fake_path_provider.dart
+++ b/apps/client/test/helpers/fake_path_provider.dart
@@ -1,0 +1,26 @@
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// Fake [PathProviderPlatform] for unit tests.
+///
+/// Returns [basePath] for all directory queries so that code using
+/// `getApplicationSupportDirectory()` (e.g. [UserDataDir]) works without
+/// real platform channels.
+class FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  final String basePath;
+
+  FakePathProvider(this.basePath);
+
+  @override
+  Future<String?> getApplicationSupportPath() async => basePath;
+
+  @override
+  Future<String?> getTemporaryPath() async => basePath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => basePath;
+
+  @override
+  Future<String?> getApplicationCachePath() async => basePath;
+}

--- a/apps/client/test/providers/auth_provider_test.dart
+++ b/apps/client/test/providers/auth_provider_test.dart
@@ -1,11 +1,22 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/server_url_provider.dart';
 import 'package:echo_app/src/services/secure_key_store.dart';
+import 'package:echo_app/src/services/user_data_dir.dart';
 
+import '../helpers/fake_path_provider.dart';
 import '../helpers/fake_secure_key_store.dart';
+import '../helpers/mock_http_client.dart';
 
 void main() {
   group('AuthState', () {
@@ -134,6 +145,479 @@ void main() {
 
       // Secure storage should be empty
       expect(fakeStore.dump, isEmpty);
+    });
+  });
+
+  group('AuthNotifier HTTP', () {
+    late MockHttpClient mockClient;
+    late ProviderContainer container;
+    late FakeSecureKeyStore fakeKeyStore;
+    late Directory tmpDir;
+
+    setUpAll(() {
+      registerHttpFallbackValues();
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      mockClient = MockHttpClient();
+      when(() => mockClient.close()).thenReturn(null);
+      fakeKeyStore = FakeSecureKeyStore();
+      SecureKeyStore.instance = fakeKeyStore;
+
+      // Set up fake path provider so UserDataDir.init() works in tests.
+      tmpDir = Directory.systemTemp.createTempSync('echo_auth_test_');
+      PathProviderPlatform.instance = FakePathProvider(tmpDir.path);
+      Hive.init(tmpDir.path);
+      await UserDataDir.instance.init();
+
+      container = ProviderContainer(
+        overrides: [
+          serverUrlProvider.overrideWith((ref) {
+            final n = ServerUrlNotifier();
+            n.state = 'http://localhost:8080';
+            return n;
+          }),
+        ],
+      );
+    });
+
+    tearDown(() async {
+      container.dispose();
+      await Hive.close();
+      try {
+        tmpDir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+
+    test('login() returns 200 sets logged-in state', () async {
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/login')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            'access_token': 'tok-123',
+            'refresh_token': 'ref-456',
+            'user_id': 'uid-1',
+            'username': 'dev',
+          }),
+          200,
+        ),
+      );
+
+      final notifier = container.read(authProvider.notifier);
+      await http.runWithClient(
+        () => notifier.login('dev', 'pass'),
+        () => mockClient,
+      );
+
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isTrue);
+      expect(st.userId, 'uid-1');
+      expect(st.username, 'dev');
+      expect(st.token, 'tok-123');
+    });
+
+    test('login() returns 401 stays logged out with error', () async {
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/login')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({'error': 'Invalid credentials'}),
+          401,
+        ),
+      );
+
+      final notifier = container.read(authProvider.notifier);
+      await http.runWithClient(
+        () => notifier.login('dev', 'wrong'),
+        () => mockClient,
+      );
+
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isFalse);
+      expect(st.error, isNotNull);
+      expect(st.error, contains('Invalid'));
+    });
+
+    test('login() network error stays logged out with error', () async {
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/login')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenThrow(
+        const SocketException('Connection refused'),
+      );
+
+      final notifier = container.read(authProvider.notifier);
+      await http.runWithClient(
+        () => notifier.login('dev', 'pass'),
+        () => mockClient,
+      );
+
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isFalse);
+      expect(st.error, isNotNull);
+    });
+
+    test('register() returns 201 sets logged-in state', () async {
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/register')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            'access_token': 'reg-tok',
+            'refresh_token': 'reg-ref',
+            'user_id': 'new-uid',
+          }),
+          201,
+        ),
+      );
+
+      final notifier = container.read(authProvider.notifier);
+      await http.runWithClient(
+        () => notifier.register('newuser', 'pass123'),
+        () => mockClient,
+      );
+
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isTrue);
+      expect(st.userId, 'new-uid');
+    });
+
+    test('register() returns 409 stays logged out with error', () async {
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/register')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({'error': 'Username already taken'}),
+          409,
+        ),
+      );
+
+      final notifier = container.read(authProvider.notifier);
+      await http.runWithClient(
+        () => notifier.register('taken', 'pass'),
+        () => mockClient,
+      );
+
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isFalse);
+      expect(st.error, isNotNull);
+      expect(st.error, contains('already taken'));
+    });
+
+    test('register() network error sets error', () async {
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/register')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenThrow(
+        const SocketException('Connection refused'),
+      );
+
+      final notifier = container.read(authProvider.notifier);
+      await http.runWithClient(
+        () => notifier.register('user', 'pass'),
+        () => mockClient,
+      );
+
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isFalse);
+      expect(st.error, isNotNull);
+    });
+
+    test('logout() clears state and tokens', () async {
+      // Pre-set logged-in state with tokens stored.
+      final notifier = container.read(authProvider.notifier);
+      notifier.state = const AuthState(
+        isLoggedIn: true,
+        userId: 'uid-1',
+        username: 'dev',
+        token: 'tok-123',
+        refreshToken: 'ref-456',
+      );
+      await fakeKeyStore.writeGlobal('echo_auth_access_token', 'tok-123');
+      await fakeKeyStore.writeGlobal('echo_auth_refresh_token', 'ref-456');
+
+      notifier.logout();
+
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isFalse);
+      expect(st.token, isNull);
+      expect(st.userId, isNull);
+
+      // Tokens should be cleared from SecureKeyStore (async -- wait a tick).
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        await fakeKeyStore.readGlobal('echo_auth_access_token'),
+        isNull,
+      );
+      expect(
+        await fakeKeyStore.readGlobal('echo_auth_refresh_token'),
+        isNull,
+      );
+    });
+
+    test('tryAutoLogin() with refresh token restores session', () async {
+      // Store a refresh token and user info.
+      await fakeKeyStore.writeGlobal('echo_auth_refresh_token', 'stored-ref');
+      SharedPreferences.setMockInitialValues({
+        'echo_auth_user_id': 'uid-1',
+        'echo_auth_username': 'dev',
+      });
+
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/refresh')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            'access_token': 'new-tok',
+            'refresh_token': 'new-ref',
+            'user_id': 'uid-1',
+            'username': 'dev',
+          }),
+          200,
+        ),
+      );
+
+      final notifier = container.read(authProvider.notifier);
+      final result = await http.runWithClient(
+        () => notifier.tryAutoLogin(),
+        () => mockClient,
+      );
+
+      expect(result, isTrue);
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isTrue);
+      expect(st.token, 'new-tok');
+    });
+
+    test('tryAutoLogin() refresh fails 401 clears tokens', () async {
+      await fakeKeyStore.writeGlobal('echo_auth_refresh_token', 'expired-ref');
+      SharedPreferences.setMockInitialValues({
+        'echo_auth_user_id': 'uid-1',
+        'echo_auth_username': 'dev',
+      });
+
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/refresh')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer((_) async => http.Response('Unauthorized', 401));
+
+      final notifier = container.read(authProvider.notifier);
+      final result = await http.runWithClient(
+        () => notifier.tryAutoLogin(),
+        () => mockClient,
+      );
+
+      expect(result, isFalse);
+      final st = container.read(authProvider);
+      expect(st.isLoggedIn, isFalse);
+
+      // Tokens should be cleared.
+      expect(
+        await fakeKeyStore.readGlobal('echo_auth_refresh_token'),
+        isNull,
+      );
+    });
+
+    test('tryAutoLogin() no stored tokens returns false', () async {
+      // Empty keystore and SharedPreferences.
+      SharedPreferences.setMockInitialValues({});
+
+      final notifier = container.read(authProvider.notifier);
+      final result = await http.runWithClient(
+        () => notifier.tryAutoLogin(),
+        () => mockClient,
+      );
+
+      expect(result, isFalse);
+      expect(container.read(authProvider).isLoggedIn, isFalse);
+    });
+
+    test('refreshAccessToken() success updates token', () async {
+      final notifier = container.read(authProvider.notifier);
+      notifier.state = const AuthState(
+        isLoggedIn: true,
+        userId: 'uid-1',
+        username: 'dev',
+        token: 'old-tok',
+        refreshToken: 'valid-ref',
+      );
+
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/refresh')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            'access_token': 'refreshed-tok',
+            'refresh_token': 'new-ref',
+          }),
+          200,
+        ),
+      );
+
+      final result = await http.runWithClient(
+        () => notifier.refreshAccessToken(),
+        () => mockClient,
+      );
+
+      expect(result, isTrue);
+      expect(container.read(authProvider).token, 'refreshed-tok');
+    });
+
+    test('refreshAccessToken() failure triggers logout', () async {
+      final notifier = container.read(authProvider.notifier);
+      notifier.state = const AuthState(
+        isLoggedIn: true,
+        userId: 'uid-1',
+        username: 'dev',
+        token: 'old-tok',
+        refreshToken: 'expired-ref',
+      );
+
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/refresh')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer((_) async => http.Response('Unauthorized', 401));
+
+      final result = await http.runWithClient(
+        () => notifier.refreshAccessToken(),
+        () => mockClient,
+      );
+
+      expect(result, isFalse);
+      expect(container.read(authProvider).isLoggedIn, isFalse);
+    });
+
+    test('authenticatedRequest() passes through 200', () async {
+      final notifier = container.read(authProvider.notifier);
+      notifier.state = const AuthState(
+        isLoggedIn: true,
+        token: 'valid-tok',
+        refreshToken: 'ref',
+      );
+
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/users/me')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response('{"id":"me"}', 200),
+      );
+
+      final response = await http.runWithClient(
+        () => notifier.authenticatedRequest(
+          (token) => http.get(
+            Uri.parse('http://localhost:8080/api/users/me'),
+            headers: {'Authorization': 'Bearer $token'},
+          ),
+        ),
+        () => mockClient,
+      );
+
+      expect(response.statusCode, 200);
+    });
+
+    test('authenticatedRequest() retries on 401 after refresh', () async {
+      final notifier = container.read(authProvider.notifier);
+      notifier.state = const AuthState(
+        isLoggedIn: true,
+        token: 'expired-tok',
+        refreshToken: 'valid-ref',
+      );
+
+      // First call: 401
+      var callCount = 0;
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/data')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) async {
+        callCount++;
+        if (callCount == 1) {
+          return http.Response('Unauthorized', 401);
+        }
+        return http.Response('{"ok": true}', 200);
+      });
+
+      // Refresh succeeds
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/auth/refresh')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            'access_token': 'new-tok',
+            'refresh_token': 'new-ref',
+          }),
+          200,
+        ),
+      );
+
+      final response = await http.runWithClient(
+        () => notifier.authenticatedRequest(
+          (token) => http.get(
+            Uri.parse('http://localhost:8080/api/data'),
+            headers: {'Authorization': 'Bearer $token'},
+          ),
+        ),
+        () => mockClient,
+      );
+
+      expect(response.statusCode, 200);
+      expect(callCount, 2, reason: 'should have retried after 401');
     });
   });
 }

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -289,6 +290,271 @@ void main() {
 
       expect(notifier.state.error, isNotNull);
       expect(notifier.state.isLoading, isFalse);
+    });
+  });
+
+  group('ConversationsNotifier.getOrCreateDm', () {
+    test('finds existing DM locally without HTTP call', () async {
+      final notifier = container.read(conversationsProvider.notifier);
+      notifier.state = ConversationsState(
+        conversations: [
+          const Conversation(
+            id: 'dm-1',
+            isGroup: false,
+            members: [
+              ConversationMember(userId: 'peer-1', username: 'alice'),
+              ConversationMember(userId: 'me', username: 'testuser'),
+            ],
+          ),
+        ],
+      );
+
+      final result = await http.runWithClient(
+        () => notifier.getOrCreateDm('peer-1', 'alice'),
+        () => mockClient,
+      );
+
+      expect(result.id, 'dm-1');
+      // Verify no HTTP call was made.
+      verifyNever(
+        () => mockClient.post(any(), headers: any(named: 'headers'),
+            body: any(named: 'body'), encoding: any(named: 'encoding')),
+      );
+    });
+
+    test('creates via API when not found locally', () async {
+      when(
+        () => mockClient.post(
+          any(
+            that: predicate<Uri>((u) => u.path == '/api/conversations/dm'),
+          ),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({'conversation_id': 'new-dm-1'}),
+          200,
+        ),
+      );
+
+      // Stub loadConversations to return the newly created DM.
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/conversations')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode([
+            {
+              'conversation_id': 'new-dm-1',
+              'kind': 'direct',
+              'members': [
+                {'user_id': 'peer-1', 'username': 'alice'},
+                {'user_id': 'me', 'username': 'testuser'},
+              ],
+            },
+          ]),
+          200,
+        ),
+      );
+
+      final notifier = container.read(conversationsProvider.notifier);
+      final result = await http.runWithClient(
+        () => notifier.getOrCreateDm('peer-1', 'alice'),
+        () => mockClient,
+      );
+
+      expect(result.id, 'new-dm-1');
+    });
+
+    test('throws DmException when server returns 400', () async {
+      when(
+        () => mockClient.post(
+          any(
+            that: predicate<Uri>((u) => u.path == '/api/conversations/dm'),
+          ),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({'error': 'Not a contact'}),
+          400,
+        ),
+      );
+
+      final notifier = container.read(conversationsProvider.notifier);
+      expect(
+        () => http.runWithClient(
+          () => notifier.getOrCreateDm('stranger-1', 'stranger'),
+          () => mockClient,
+        ),
+        throwsA(isA<DmException>()),
+      );
+    });
+
+    test('throws DmException on network error', () async {
+      when(
+        () => mockClient.post(
+          any(
+            that: predicate<Uri>((u) => u.path == '/api/conversations/dm'),
+          ),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenThrow(const SocketException('Connection refused'));
+
+      final notifier = container.read(conversationsProvider.notifier);
+      expect(
+        () => http.runWithClient(
+          () => notifier.getOrCreateDm('peer-1', 'alice'),
+          () => mockClient,
+        ),
+        throwsA(
+          isA<DmException>().having(
+            (e) => e.message,
+            'message',
+            contains('connect'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('ConversationsNotifier.sendReadReceipt', () {
+    test('success clears unread count', () async {
+      when(
+        () => mockClient.post(
+          any(
+            that: predicate<Uri>(
+              (u) => u.path == '/api/conversations/conv-1/read',
+            ),
+          ),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer((_) async => http.Response('{}', 200));
+
+      final notifier = container.read(conversationsProvider.notifier);
+      notifier.state = ConversationsState(
+        conversations: [
+          const Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
+        ],
+      );
+
+      await http.runWithClient(
+        () => notifier.sendReadReceipt('conv-1'),
+        () => mockClient,
+      );
+
+      expect(notifier.state.conversations.first.unreadCount, 0);
+    });
+
+    test('failure reverts unread count', () async {
+      when(
+        () => mockClient.post(
+          any(
+            that: predicate<Uri>(
+              (u) => u.path == '/api/conversations/conv-1/read',
+            ),
+          ),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenThrow(const SocketException('Connection refused'));
+
+      final notifier = container.read(conversationsProvider.notifier);
+      notifier.state = ConversationsState(
+        conversations: [
+          const Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
+        ],
+      );
+
+      await http.runWithClient(
+        () => notifier.sendReadReceipt('conv-1'),
+        () => mockClient,
+      );
+
+      expect(
+        notifier.state.conversations.first.unreadCount,
+        5,
+        reason: 'unread count should be restored after server failure',
+      );
+    });
+  });
+
+  group('ConversationsNotifier.toggleMute', () {
+    test('success toggles muted state', () async {
+      when(
+        () => mockClient.put(
+          any(
+            that: predicate<Uri>(
+              (u) => u.path == '/api/conversations/conv-1/mute',
+            ),
+          ),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer((_) async => http.Response('{}', 200));
+
+      final notifier = container.read(conversationsProvider.notifier);
+      notifier.state = ConversationsState(
+        conversations: [
+          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+        ],
+      );
+
+      await http.runWithClient(
+        () => notifier.toggleMute('conv-1'),
+        () => mockClient,
+      );
+
+      expect(
+        notifier.state.conversations.first.isMuted,
+        isTrue,
+        reason: 'conversation should be muted after toggle',
+      );
+    });
+
+    test('failure reverts muted state', () async {
+      when(
+        () => mockClient.put(
+          any(
+            that: predicate<Uri>(
+              (u) => u.path == '/api/conversations/conv-1/mute',
+            ),
+          ),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenThrow(const SocketException('Connection refused'));
+
+      final notifier = container.read(conversationsProvider.notifier);
+      notifier.state = ConversationsState(
+        conversations: [
+          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+        ],
+      );
+
+      await http.runWithClient(
+        () => notifier.toggleMute('conv-1'),
+        () => mockClient,
+      );
+
+      expect(
+        notifier.state.conversations.first.isMuted,
+        isFalse,
+        reason: 'muted state should be reverted after server failure',
+      );
     });
   });
 }

--- a/apps/client/test/widget_test.dart
+++ b/apps/client/test/widget_test.dart
@@ -1,8 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  testWidgets('App smoke test', (tester) async {
-    // Placeholder test - will be expanded as screens are built
-    expect(true, isTrue);
-  });
-}


### PR DESCRIPTION
## Summary
- **22 new HTTP-level tests** for AuthNotifier (14) and ConversationsNotifier (8)
- **5 placeholder tests fixed** — `expect(true, isTrue)` replaced with `skip:` parameter
- **1 no-op test deleted** — widget_test.dart was a pure placeholder
- **634 tests pass, 5 intentionally skipped** (up from 618)
- New `FakePathProvider` test helper for unit testing providers that use path_provider

### Auth tests cover
login (200/401/network), register (201/409/network), logout, tryAutoLogin (refresh success/fail/no tokens), refreshAccessToken (success/failure), authenticatedRequest (passthrough/401 retry)

### Conversations tests cover
getOrCreateDm (local find/API create/400 error/network error), sendReadReceipt (success/failure rollback), toggleMute (success/failure revert)

Partial progress on #151

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 634 passed, 5 skipped, 0 failures
- [x] No `expect(true, isTrue)` placeholders remain

Generated with [Claude Code](https://claude.ai/code)