### PR TITLE
style(client): dart format test files that failed ci

### DIFF
--- a/apps/client/test/audit_logic_flaws_test.dart
+++ b/apps/client/test/audit_logic_flaws_test.dart
@@ -208,7 +208,8 @@ void main() {
         //
         // This is a provider interaction issue — documented for fix.
       },
-      skip: 'provider interaction bug, needs integration test with multiple providers',
+      skip:
+          'provider interaction bug, needs integration test with multiple providers',
     );
   });
 

--- a/apps/client/test/crypto_bugs_test.dart
+++ b/apps/client/test/crypto_bugs_test.dart
@@ -139,7 +139,8 @@ void main() {
         //
         // This is verified by reading the actual code above.
       },
-      skip: 'documents code pattern, needs integration test with actual crypto service',
+      skip:
+          'documents code pattern, needs integration test with actual crypto service',
     );
   });
 
@@ -427,67 +428,70 @@ void main() {
   });
 
   group('ROOT CAUSE #7: Concurrent session access', () {
-    test('PROVES: Interleaved async decrypt corrupts state', () async {
-      final aliceIdentity = await x25519.newKeyPair();
-      final bobIdentity = await x25519.newKeyPair();
-      final bobSignedPrekey = await x25519.newKeyPair();
+    test(
+      'PROVES: Interleaved async decrypt corrupts state',
+      () async {
+        final aliceIdentity = await x25519.newKeyPair();
+        final bobIdentity = await x25519.newKeyPair();
+        final bobSignedPrekey = await x25519.newKeyPair();
 
-      final bobIdentityPub = await bobIdentity.extractPublicKey();
-      final bobSignedPrekeyPub = await bobSignedPrekey.extractPublicKey();
-      final aliceIdentityPub = await aliceIdentity.extractPublicKey();
+        final bobIdentityPub = await bobIdentity.extractPublicKey();
+        final bobSignedPrekeyPub = await bobSignedPrekey.extractPublicKey();
+        final aliceIdentityPub = await aliceIdentity.extractPublicKey();
 
-      final initResult = await X3DH.initiate(
-        aliceIdentity: aliceIdentity,
-        bobIdentityKey: bobIdentityPub,
-        bobSignedPrekey: bobSignedPrekeyPub,
-      );
-      final bobSecret = await X3DH.respond(
-        bobIdentity: bobIdentity,
-        bobSignedPrekey: bobSignedPrekey,
-        aliceIdentityKey: aliceIdentityPub,
-        aliceEphemeralKey: initResult.ephemeralPublic,
-      );
-
-      final alice = await SignalSession.initAlice(
-        initResult.sharedSecret,
-        bobSignedPrekeyPub,
-      );
-      final bob = await SignalSession.initBob(bobSecret, bobSignedPrekey);
-
-      // Alice sends 5 messages
-      final wires = <Uint8List>[];
-      for (var i = 0; i < 5; i++) {
-        wires.add(
-          await alice.encrypt(
-            Uint8List.fromList(utf8.encode('concurrent msg $i')),
-          ),
+        final initResult = await X3DH.initiate(
+          aliceIdentity: aliceIdentity,
+          bobIdentityKey: bobIdentityPub,
+          bobSignedPrekey: bobSignedPrekeyPub,
         );
-      }
+        final bobSecret = await X3DH.respond(
+          bobIdentity: bobIdentity,
+          bobSignedPrekey: bobSignedPrekey,
+          aliceIdentityKey: aliceIdentityPub,
+          aliceEphemeralKey: initResult.ephemeralPublic,
+        );
 
-      // Simulate concurrent decryption: launch all decrypts at once
-      // In a single-threaded Dart event loop, these will interleave at await points
-      final futures = wires.map((w) => bob.decrypt(w)).toList();
+        final alice = await SignalSession.initAlice(
+          initResult.sharedSecret,
+          bobSignedPrekeyPub,
+        );
+        final bob = await SignalSession.initBob(bobSecret, bobSignedPrekey);
 
-      // This may or may not fail depending on timing, but documents the risk.
-      // In practice, the encrypt/decrypt methods contain multiple awaits where
-      // interleaving can occur. With in-order messages this usually works,
-      // but with out-of-order messages + DH ratchet steps, corruption is possible.
-      try {
-        final results = await Future.wait(futures);
-        // If all succeed, they should contain the correct messages
+        // Alice sends 5 messages
+        final wires = <Uint8List>[];
         for (var i = 0; i < 5; i++) {
-          expect(utf8.decode(results[i]), contains('concurrent msg'));
+          wires.add(
+            await alice.encrypt(
+              Uint8List.fromList(utf8.encode('concurrent msg $i')),
+            ),
+          );
         }
-      } catch (e) {
-        // If any fail, the concurrency issue is demonstrated
-        // ignore: avoid_print
-        print('Concurrent decrypt failure (expected): $e');
-      }
-      // Note: This test demonstrates the RISK rather than guaranteeing failure.
-      // True concurrent failures are timing-dependent. The per-peer lock fix
-      // ensures serial execution regardless of timing.
-    },
-    skip: 'concurrency risk documented, needs integration test with real async interleaving',
+
+        // Simulate concurrent decryption: launch all decrypts at once
+        // In a single-threaded Dart event loop, these will interleave at await points
+        final futures = wires.map((w) => bob.decrypt(w)).toList();
+
+        // This may or may not fail depending on timing, but documents the risk.
+        // In practice, the encrypt/decrypt methods contain multiple awaits where
+        // interleaving can occur. With in-order messages this usually works,
+        // but with out-of-order messages + DH ratchet steps, corruption is possible.
+        try {
+          final results = await Future.wait(futures);
+          // If all succeed, they should contain the correct messages
+          for (var i = 0; i < 5; i++) {
+            expect(utf8.decode(results[i]), contains('concurrent msg'));
+          }
+        } catch (e) {
+          // If any fail, the concurrency issue is demonstrated
+          // ignore: avoid_print
+          print('Concurrent decrypt failure (expected): $e');
+        }
+        // Note: This test demonstrates the RISK rather than guaranteeing failure.
+        // True concurrent failures are timing-dependent. The per-peer lock fix
+        // ensures serial execution regardless of timing.
+      },
+      skip:
+          'concurrency risk documented, needs integration test with real async interleaving',
     );
   });
 

--- a/apps/client/test/providers/auth_provider_test.dart
+++ b/apps/client/test/providers/auth_provider_test.dart
@@ -232,10 +232,8 @@ void main() {
           encoding: any(named: 'encoding'),
         ),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({'error': 'Invalid credentials'}),
-          401,
-        ),
+        (_) async =>
+            http.Response(jsonEncode({'error': 'Invalid credentials'}), 401),
       );
 
       final notifier = container.read(authProvider.notifier);
@@ -258,9 +256,7 @@ void main() {
           body: any(named: 'body'),
           encoding: any(named: 'encoding'),
         ),
-      ).thenThrow(
-        const SocketException('Connection refused'),
-      );
+      ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(authProvider.notifier);
       await http.runWithClient(
@@ -312,10 +308,8 @@ void main() {
           encoding: any(named: 'encoding'),
         ),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({'error': 'Username already taken'}),
-          409,
-        ),
+        (_) async =>
+            http.Response(jsonEncode({'error': 'Username already taken'}), 409),
       );
 
       final notifier = container.read(authProvider.notifier);
@@ -338,9 +332,7 @@ void main() {
           body: any(named: 'body'),
           encoding: any(named: 'encoding'),
         ),
-      ).thenThrow(
-        const SocketException('Connection refused'),
-      );
+      ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(authProvider.notifier);
       await http.runWithClient(
@@ -375,14 +367,8 @@ void main() {
 
       // Tokens should be cleared from SecureKeyStore (async -- wait a tick).
       await Future<void>.delayed(Duration.zero);
-      expect(
-        await fakeKeyStore.readGlobal('echo_auth_access_token'),
-        isNull,
-      );
-      expect(
-        await fakeKeyStore.readGlobal('echo_auth_refresh_token'),
-        isNull,
-      );
+      expect(await fakeKeyStore.readGlobal('echo_auth_access_token'), isNull);
+      expect(await fakeKeyStore.readGlobal('echo_auth_refresh_token'), isNull);
     });
 
     test('tryAutoLogin() with refresh token restores session', () async {
@@ -451,10 +437,7 @@ void main() {
       expect(st.isLoggedIn, isFalse);
 
       // Tokens should be cleared.
-      expect(
-        await fakeKeyStore.readGlobal('echo_auth_refresh_token'),
-        isNull,
-      );
+      expect(await fakeKeyStore.readGlobal('echo_auth_refresh_token'), isNull);
     });
 
     test('tryAutoLogin() no stored tokens returns false', () async {
@@ -548,9 +531,7 @@ void main() {
           any(that: predicate<Uri>((u) => u.path == '/api/users/me')),
           headers: any(named: 'headers'),
         ),
-      ).thenAnswer(
-        (_) async => http.Response('{"id":"me"}', 200),
-      );
+      ).thenAnswer((_) async => http.Response('{"id":"me"}', 200));
 
       final response = await http.runWithClient(
         () => notifier.authenticatedRequest(
@@ -598,10 +579,7 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => http.Response(
-          jsonEncode({
-            'access_token': 'new-tok',
-            'refresh_token': 'new-ref',
-          }),
+          jsonEncode({'access_token': 'new-tok', 'refresh_token': 'new-ref'}),
           200,
         ),
       );

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -317,26 +317,26 @@ void main() {
       expect(result.id, 'dm-1');
       // Verify no HTTP call was made.
       verifyNever(
-        () => mockClient.post(any(), headers: any(named: 'headers'),
-            body: any(named: 'body'), encoding: any(named: 'encoding')),
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
       );
     });
 
     test('creates via API when not found locally', () async {
       when(
         () => mockClient.post(
-          any(
-            that: predicate<Uri>((u) => u.path == '/api/conversations/dm'),
-          ),
+          any(that: predicate<Uri>((u) => u.path == '/api/conversations/dm')),
           headers: any(named: 'headers'),
           body: any(named: 'body'),
           encoding: any(named: 'encoding'),
         ),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({'conversation_id': 'new-dm-1'}),
-          200,
-        ),
+        (_) async =>
+            http.Response(jsonEncode({'conversation_id': 'new-dm-1'}), 200),
       );
 
       // Stub loadConversations to return the newly created DM.
@@ -373,18 +373,13 @@ void main() {
     test('throws DmException when server returns 400', () async {
       when(
         () => mockClient.post(
-          any(
-            that: predicate<Uri>((u) => u.path == '/api/conversations/dm'),
-          ),
+          any(that: predicate<Uri>((u) => u.path == '/api/conversations/dm')),
           headers: any(named: 'headers'),
           body: any(named: 'body'),
           encoding: any(named: 'encoding'),
         ),
       ).thenAnswer(
-        (_) async => http.Response(
-          jsonEncode({'error': 'Not a contact'}),
-          400,
-        ),
+        (_) async => http.Response(jsonEncode({'error': 'Not a contact'}), 400),
       );
 
       final notifier = container.read(conversationsProvider.notifier);
@@ -400,9 +395,7 @@ void main() {
     test('throws DmException on network error', () async {
       when(
         () => mockClient.post(
-          any(
-            that: predicate<Uri>((u) => u.path == '/api/conversations/dm'),
-          ),
+          any(that: predicate<Uri>((u) => u.path == '/api/conversations/dm')),
           headers: any(named: 'headers'),
           body: any(named: 'body'),
           encoding: any(named: 'encoding'),


### PR DESCRIPTION
## Summary
- Dart format 4 test files that were committed with `LEFTHOOK=0` in a worktree (worktree hook env issue)
- Files: audit_logic_flaws_test.dart, crypto_bugs_test.dart, auth_provider_test.dart, conversations_http_test.dart

## Test plan
- [x] `dart format --set-exit-if-changed .` — 0 changed
- [x] `flutter test` — 634 pass, 5 skipped