### PR TITLE
fix(client): skip sender prefix in dm conversation previews

### DIFF
--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -131,6 +131,9 @@ class _ConversationItemState extends State<ConversationItem> {
 
   String? _prependSenderLabel(String? snippet, Conversation conv) {
     if (snippet == null || conv.lastMessageSender == null) return snippet;
+    // DMs: the conversation header already shows the peer's name, so
+    // prefixing the message with the sender is redundant.
+    if (!conv.isGroup) return snippet;
     final myMember = conv.members
         .where((m) => m.userId == widget.myUserId)
         .firstOrNull;


### PR DESCRIPTION
## Summary
- DM previews no longer redundantly show the sender name (e.g., `Alice: hey` → just `hey`)
- Group chat previews still show `Sender: message` since multiple people can send
- One-line change in `conversation_item.dart:_prependSenderLabel()`

Closes #192

## Test plan
- [x] `flutter analyze` — no issues
- [x] Format clean
- [ ] Visual: DM preview shows just the message text
- [ ] Visual: Group preview still shows `Sender: text`