### PR TITLE
fix(client): show decrypted previews from hive cache on app startup

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -14,6 +14,7 @@ import '../services/group_crypto_service.dart';
 import '../services/message_cache.dart';
 import '../utils/crypto_utils.dart';
 import 'auth_provider.dart';
+import 'conversations_provider.dart';
 import 'server_url_provider.dart';
 
 class ChatState {
@@ -440,6 +441,18 @@ class ChatNotifier extends StateNotifier<ChatState> {
       );
       newMessages.add(msg);
     }
+
+    // Update conversation preview with the latest decrypted message so the
+    // conversation list shows plaintext instead of "Encrypted message".
+    if (newMessages.isNotEmpty && conversationId != null) {
+      final latest = newMessages.last;
+      if (!looksEncrypted(latest.content)) {
+        ref
+            .read(conversationsProvider.notifier)
+            .updateDecryptedPreview(conversationId, latest.content);
+      }
+    }
+
     return newMessages;
   }
 

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 
 import '../models/conversation.dart';
 import '../services/debug_log_service.dart';
+import '../services/message_cache.dart';
 import '../services/notification_service.dart';
 import '../utils/crypto_utils.dart';
 import 'auth_provider.dart';
@@ -121,7 +122,11 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
         for (var i = 0; i < conversations.length; i++) {
           final conv = conversations[i];
           if (conv.lastMessage != null && looksEncrypted(conv.lastMessage!)) {
-            final cached = _decryptedPreviews[conv.id];
+            var cached = _decryptedPreviews[conv.id];
+            if (cached == null) {
+              cached = MessageCache.getLatestCachedPreview(conv.id);
+              if (cached != null) _decryptedPreviews[conv.id] = cached;
+            }
             conversations[i] = conv.copyWith(
               lastMessage: cached ?? 'Encrypted message',
             );
@@ -203,6 +208,12 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
       _decryptedPreviews[conversationId] = newContent;
       state = state.copyWith(conversations: updated);
     }
+  }
+
+  /// Store a decrypted preview for a conversation so the conversation list
+  /// shows the decrypted text instead of "Encrypted message".
+  void updateDecryptedPreview(String conversationId, String content) {
+    _decryptedPreviews[conversationId] = content;
   }
 
   /// Update the encryption flag for a conversation locally.

--- a/apps/client/lib/src/services/message_cache.dart
+++ b/apps/client/lib/src/services/message_cache.dart
@@ -69,6 +69,29 @@ class MessageCache {
     return ChatMessage.fromServerJson(json, myUserId);
   }
 
+  /// Return the content of the most recent cached message for a conversation.
+  /// Used by loadConversations() to show decrypted previews for messages that
+  /// were decrypted in a previous session and stored in the Hive cache.
+  static String? getLatestCachedPreview(String conversationId) {
+    final box = _box;
+    if (box == null) return null;
+    String? latest;
+    String? latestTimestamp;
+    for (final key in box.keys) {
+      if (!(key as String).startsWith('$conversationId:')) continue;
+      final raw = box.get(key);
+      if (raw == null) continue;
+      final json = Map<String, dynamic>.from(raw);
+      final ts =
+          json['created_at'] as String? ?? json['timestamp'] as String? ?? '';
+      if (latestTimestamp == null || ts.compareTo(latestTimestamp) > 0) {
+        latestTimestamp = ts;
+        latest = json['content'] as String?;
+      }
+    }
+    return latest;
+  }
+
   static Future<void> clearAll() async {
     await _box?.clear();
   }

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -398,8 +398,9 @@ void main() {
       expect(find.textContaining('[img:'), findsNothing);
     });
 
-    testWidgets('sender label prepends "You" for own messages in groups',
-        (tester) async {
+    testWidgets('sender label prepends "You" for own messages in groups', (
+      tester,
+    ) async {
       final conv = _makeConversation(
         isGroup: true,
         lastMessage: 'my message',

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -398,8 +398,10 @@ void main() {
       expect(find.textContaining('[img:'), findsNothing);
     });
 
-    testWidgets('sender label prepends "You" for own messages', (tester) async {
+    testWidgets('sender label prepends "You" for own messages in groups',
+        (tester) async {
       final conv = _makeConversation(
+        isGroup: true,
         lastMessage: 'my message',
         lastMessageSender: 'me',
         members: const [

--- a/apps/client/test/widgets/conversation_panel_test.dart
+++ b/apps/client/test/widgets/conversation_panel_test.dart
@@ -66,10 +66,10 @@ void main() {
       );
       await tester.pump();
 
-      // DM conversation shows sender prefix
-      expect(find.text('alice: Hey there!'), findsOneWidget);
+      // DM conversation shows message without sender prefix
+      expect(find.textContaining('Hey there!'), findsOneWidget);
       // Group conversation prefixes sender: "bob: Meeting at 3pm"
-      expect(find.text('bob: Meeting at 3pm'), findsOneWidget);
+      expect(find.textContaining('bob: Meeting at 3pm'), findsOneWidget);
     });
 
     testWidgets('shows unread indicator dot for conversations with unreads', (


### PR DESCRIPTION
## Summary
- Conversation previews now consult the Hive message cache when the in-memory decrypted-preview map misses
- Chat history decryption now populates the preview cache so re-opening the app shows decrypted previews
- Added `MessageCache.getLatestCachedPreview()` + `ConversationsNotifier.updateDecryptedPreview()`
- Updated 2 tests to reflect DM sender-prefix skip from #192

Closes #193

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 634 pass, 5 skipped
- [ ] Manual: restart app → previously decrypted conversations show real text instead of "Encrypted message"

Generated with [Claude Code](https://claude.ai/code)