### PR TITLE
test(client): critical test coverage batch 2 -- chat timers, websocket send failures

### DIFF
--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -322,7 +322,7 @@ packages:
     source: hosted
     version: "4.4.0"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -41,6 +41,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  fake_async: ^1.3.1
   mockito: ^5.4.4
   mocktail: ^1.0.4
   build_runner: ^2.4.8

--- a/apps/client/test/providers/chat_notifier_timer_test.dart
+++ b/apps/client/test/providers/chat_notifier_timer_test.dart
@@ -1,0 +1,204 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/providers/server_url_provider.dart';
+
+/// Create a [ProviderContainer] with overrides for auth + server URL so
+/// [ChatNotifier] can be instantiated without hitting the network.
+ProviderContainer _createContainer() {
+  return ProviderContainer(
+    overrides: [
+      authProvider.overrideWith((ref) {
+        final n = AuthNotifier(ref);
+        n.state = const AuthState(
+          isLoggedIn: true,
+          userId: 'me',
+          username: 'testuser',
+          token: 'fake-token',
+        );
+        return n;
+      }),
+      serverUrlProvider.overrideWith((ref) {
+        final n = ServerUrlNotifier();
+        n.state = 'http://localhost:8080';
+        return n;
+      }),
+    ],
+  );
+}
+
+void main() {
+  group('ChatNotifier send-timeout timer', () {
+    test('pending message transitions to failed after 15s timeout', () {
+      fakeAsync((async) {
+        final container = _createContainer();
+        final notifier = container.read(chatProvider.notifier);
+
+        notifier.addOptimistic(
+          'peer-1',
+          'hello world',
+          'me',
+          conversationId: 'conv-1',
+        );
+
+        // Immediately after adding, should be in sending state.
+        final beforeMsgs = container
+            .read(chatProvider)
+            .messagesForConversation('conv-1');
+        expect(beforeMsgs, hasLength(1));
+        expect(beforeMsgs.first.status, MessageStatus.sending);
+        expect(beforeMsgs.first.id, startsWith('pending_'));
+
+        // Advance just under the 15s threshold — still sending.
+        async.elapse(const Duration(seconds: 14));
+        final midMsgs = container
+            .read(chatProvider)
+            .messagesForConversation('conv-1');
+        expect(midMsgs.first.status, MessageStatus.sending);
+
+        // Advance past 15s — should be failed now.
+        async.elapse(const Duration(seconds: 2));
+        final afterMsgs = container
+            .read(chatProvider)
+            .messagesForConversation('conv-1');
+        expect(afterMsgs, hasLength(1));
+        expect(afterMsgs.first.status, MessageStatus.failed);
+        // Original content preserved in failedContent for retry.
+        expect(afterMsgs.first.failedContent, 'hello world');
+        // User-facing content is the timeout message.
+        expect(
+          afterMsgs.first.content,
+          contains('may not have been delivered'),
+        );
+      });
+    });
+
+    test('confirmSent cancels the 15s timer — message stays sent', () {
+      fakeAsync((async) {
+        final container = _createContainer();
+        addTearDown(container.dispose);
+        final notifier = container.read(chatProvider.notifier);
+
+        notifier.addOptimistic(
+          'peer-1',
+          'confirmed message',
+          'me',
+          conversationId: 'conv-1',
+        );
+
+        // Confirm immediately (server echoed the message back).
+        notifier.confirmSent('server-msg-1', 'conv-1', '2026-01-01T12:00:00Z');
+
+        final confirmedMsgs = container
+            .read(chatProvider)
+            .messagesForConversation('conv-1');
+        expect(confirmedMsgs, hasLength(1));
+        expect(confirmedMsgs.first.id, 'server-msg-1');
+        expect(confirmedMsgs.first.status, MessageStatus.sent);
+
+        // Advance well past 15s — should NOT transition to failed.
+        async.elapse(const Duration(seconds: 20));
+
+        final afterMsgs = container
+            .read(chatProvider)
+            .messagesForConversation('conv-1');
+        expect(afterMsgs, hasLength(1));
+        expect(afterMsgs.first.status, MessageStatus.sent);
+        expect(afterMsgs.first.id, 'server-msg-1');
+      });
+    });
+
+    test('clearConversation cancels pending send timers', () {
+      fakeAsync((async) {
+        final container = _createContainer();
+        final notifier = container.read(chatProvider.notifier);
+
+        notifier.addOptimistic(
+          'peer-1',
+          'message 1',
+          'me',
+          conversationId: 'conv-1',
+        );
+
+        // Clear the conversation before the timer fires.
+        notifier.clearConversation('conv-1');
+
+        // Conversation should be empty.
+        expect(
+          container.read(chatProvider).messagesForConversation('conv-1'),
+          isEmpty,
+        );
+
+        // Advance past 15s — should NOT crash or re-add a failed message.
+        async.elapse(const Duration(seconds: 20));
+
+        // Still empty — the timer was cancelled and didn't fire.
+        expect(
+          container.read(chatProvider).messagesForConversation('conv-1'),
+          isEmpty,
+        );
+
+        container.dispose();
+      });
+    });
+
+    test('confirmSent for one conversation does not affect another', () async {
+      // This test does NOT use fakeAsync because addOptimistic generates
+      // pending IDs from DateTime.now().millisecondsSinceEpoch which is
+      // real wall-clock time (not controlled by fakeAsync). We need distinct
+      // IDs across conversations, so we insert a small real delay.
+      final container = _createContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(chatProvider.notifier);
+
+      notifier.addOptimistic(
+        'peer-1',
+        'conv1 message',
+        'me',
+        conversationId: 'conv-1',
+      );
+      // 2ms real delay ensures a distinct pending ID.
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      notifier.addOptimistic(
+        'peer-2',
+        'conv2 message',
+        'me',
+        conversationId: 'conv-2',
+      );
+
+      // Both conversations should have exactly one pending message.
+      expect(
+        container.read(chatProvider).messagesForConversation('conv-1'),
+        hasLength(1),
+      );
+      expect(
+        container.read(chatProvider).messagesForConversation('conv-2'),
+        hasLength(1),
+      );
+
+      // Confirm conv-2's message.
+      notifier.confirmSent('server-2', 'conv-2', '2026-01-01T12:00:00Z');
+
+      // conv-2 should now be confirmed (sent).
+      final conv2 = container
+          .read(chatProvider)
+          .messagesForConversation('conv-2');
+      expect(conv2, hasLength(1));
+      expect(conv2.first.id, 'server-2');
+      expect(conv2.first.status, MessageStatus.sent);
+
+      // conv-1 should still be pending (sending) — confirming conv-2 did
+      // NOT cancel conv-1's timer or change conv-1's state.
+      final conv1 = container
+          .read(chatProvider)
+          .messagesForConversation('conv-1');
+      expect(conv1, hasLength(1));
+      expect(conv1.first.status, MessageStatus.sending);
+      expect(conv1.first.id, startsWith('pending_'));
+    });
+  });
+}

--- a/apps/client/test/providers/websocket_send_test.dart
+++ b/apps/client/test/providers/websocket_send_test.dart
@@ -1,0 +1,419 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/providers/crypto_provider.dart';
+import 'package:echo_app/src/providers/privacy_provider.dart';
+import 'package:echo_app/src/providers/server_url_provider.dart';
+import 'package:echo_app/src/providers/websocket_provider.dart';
+import 'package:echo_app/src/services/crypto_service.dart';
+
+// ---------------------------------------------------------------------------
+// Test-scoped CryptoService fake
+// ---------------------------------------------------------------------------
+
+/// A CryptoService subclass whose encrypt methods can be configured to throw.
+///
+/// Because CryptoService methods make network calls and interact with secure
+/// storage, we override only the methods exercised by
+/// [WebSocketNotifier.sendMessage].
+class _TestCryptoService extends CryptoService {
+  _TestCryptoService() : super(serverUrl: 'http://localhost:8080');
+
+  bool encryptForAllDevicesThrows = false;
+  bool encryptMessageThrows = false;
+  int invalidateSessionKeyCalls = 0;
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Future<Map<String, String>> encryptForAllDevices(
+    String peerUserId,
+    String plaintext,
+  ) async {
+    if (encryptForAllDevicesThrows) {
+      throw Exception('multi-device encryption failed');
+    }
+    return {'0': 'ciphertext-base64=='};
+  }
+
+  @override
+  Future<Map<String, String>> encryptForOwnDevices(
+    String myUserId,
+    String plaintext,
+  ) async {
+    return {};
+  }
+
+  @override
+  Future<String> encryptMessage(String peerUserId, String plaintext) async {
+    if (encryptMessageThrows) {
+      throw Exception('single-device encryption failed');
+    }
+    return 'ciphertext-base64==';
+  }
+
+  @override
+  Future<void> invalidateSessionKey(String peerUserId) async {
+    invalidateSessionKeyCalls++;
+    // After invalidation, encryptMessage will be called again.
+    // If encryptMessageThrows is still true, the retry also fails.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake CryptoNotifier with spy capability
+// ---------------------------------------------------------------------------
+
+class _SpyCryptoNotifier extends CryptoNotifier {
+  int retryKeyUploadCalls = 0;
+
+  _SpyCryptoNotifier(super.ref, {required CryptoState initial}) {
+    state = initial;
+  }
+
+  @override
+  Future<void> retryKeyUpload() async {
+    retryKeyUploadCalls++;
+  }
+
+  @override
+  Future<void> initAndUploadKeys() async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a [ProviderContainer] wired for WebSocket send tests.
+///
+/// [cryptoState] controls the CryptoNotifier state visible to sendMessage.
+/// [testCrypto] is an optional custom CryptoService fake.
+/// [spyNotifier] if provided, overrides the CryptoNotifier for spy access.
+/// [readReceiptsEnabled] controls the privacy provider state.
+ProviderContainer _createContainer({
+  CryptoState cryptoState = const CryptoState(isInitialized: true),
+  CryptoService? testCrypto,
+  _SpyCryptoNotifier? spyNotifier,
+  bool readReceiptsEnabled = true,
+}) {
+  return ProviderContainer(
+    overrides: [
+      authProvider.overrideWith((ref) {
+        final n = AuthNotifier(ref);
+        n.state = const AuthState(
+          isLoggedIn: true,
+          userId: 'my-user-id',
+          username: 'testuser',
+          token: 'fake-jwt-token',
+        );
+        return n;
+      }),
+      serverUrlProvider.overrideWith((ref) {
+        final n = ServerUrlNotifier();
+        n.state = 'http://localhost:8080';
+        return n;
+      }),
+      if (testCrypto != null)
+        cryptoServiceProvider.overrideWithValue(testCrypto),
+      if (spyNotifier != null)
+        cryptoProvider.overrideWith((ref) => spyNotifier)
+      else
+        cryptoProvider.overrideWith((ref) {
+          final n = _SpyCryptoNotifier(ref, initial: cryptoState);
+          return n;
+        }),
+      privacyProvider.overrideWith((ref) {
+        final n = PrivacyNotifier(ref);
+        n.state = PrivacyState(readReceiptsEnabled: readReceiptsEnabled);
+        return n;
+      }),
+    ],
+  );
+}
+
+void main() {
+  group('WebSocketNotifier.sendMessage failure paths', () {
+    test('crypto not initialized adds failed message with reason', () async {
+      final container = _createContainer(
+        cryptoState: const CryptoState(
+          isInitialized: false,
+          error: 'Secure storage unavailable',
+        ),
+      );
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+      await wsNotifier.sendMessage('peer-1', 'hello', conversationId: 'conv-1');
+
+      // Should have added a failed message to chat state.
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('conv-1');
+      expect(msgs, hasLength(1));
+      expect(msgs.first.status, MessageStatus.failed);
+      expect(msgs.first.isMine, isTrue);
+      // The reason should come from the crypto error.
+      expect(msgs.first.content, 'Secure storage unavailable');
+      // Original content preserved for retry.
+      expect(msgs.first.failedContent, 'hello');
+    });
+
+    test('crypto not initialized with no error uses default message', () async {
+      final container = _createContainer(
+        cryptoState: const CryptoState(isInitialized: false),
+      );
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+      await wsNotifier.sendMessage('peer-1', 'hello', conversationId: 'conv-1');
+
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('conv-1');
+      expect(msgs, hasLength(1));
+      expect(msgs.first.status, MessageStatus.failed);
+      expect(msgs.first.content, 'Encryption not initialized');
+    });
+
+    test(
+      'keysUploadFailed triggers retryKeyUpload before encrypting',
+      () async {
+        final testCrypto = _TestCryptoService();
+        final container = _createContainer(
+          cryptoState: const CryptoState(
+            isInitialized: true,
+            keysUploadFailed: true,
+          ),
+          testCrypto: testCrypto,
+        );
+        addTearDown(container.dispose);
+
+        // Get the spy notifier to check retryKeyUpload was called.
+        final cryptoNotifier =
+            container.read(cryptoProvider.notifier) as _SpyCryptoNotifier;
+
+        final wsNotifier = container.read(websocketProvider.notifier);
+        await wsNotifier.sendMessage(
+          'peer-1',
+          'hello',
+          conversationId: 'conv-1',
+        );
+
+        expect(cryptoNotifier.retryKeyUploadCalls, 1);
+      },
+    );
+
+    test(
+      'all encryption fails produces friendly error, not stack trace',
+      () async {
+        final testCrypto = _TestCryptoService()
+          ..encryptForAllDevicesThrows = true
+          ..encryptMessageThrows = true;
+
+        final container = _createContainer(
+          cryptoState: const CryptoState(isInitialized: true),
+          testCrypto: testCrypto,
+        );
+        addTearDown(container.dispose);
+
+        final wsNotifier = container.read(websocketProvider.notifier);
+        await wsNotifier.sendMessage(
+          'peer-1',
+          'hello',
+          conversationId: 'conv-1',
+        );
+
+        final msgs = container
+            .read(chatProvider)
+            .messagesForConversation('conv-1');
+        expect(msgs, hasLength(1));
+        expect(msgs.first.status, MessageStatus.failed);
+        // Content should be a friendly message, NOT a raw Exception toString.
+        expect(msgs.first.content, isNot(contains('Exception')));
+        expect(msgs.first.content, isNot(contains('stack')));
+        // It should be one of the friendly messages from _friendlyEncryptionError.
+        expect(msgs.first.content, isNotEmpty);
+        // Original text preserved for retry.
+        expect(msgs.first.failedContent, 'hello');
+      },
+    );
+
+    test('multi-device encryption fails but single-device succeeds (no failed '
+        'message)', () async {
+      final testCrypto = _TestCryptoService()
+        ..encryptForAllDevicesThrows = true
+        ..encryptMessageThrows = false;
+
+      final container = _createContainer(
+        cryptoState: const CryptoState(isInitialized: true),
+        testCrypto: testCrypto,
+      );
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+      await wsNotifier.sendMessage('peer-1', 'hello', conversationId: 'conv-1');
+
+      // No failed message should be added -- fallback single-device
+      // encryption succeeded. The message would be sent via _channel?.sink
+      // which is null in tests, so no actual send occurs, but crucially no
+      // failed message is created.
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('conv-1');
+      expect(msgs, isEmpty);
+    });
+
+    test(
+      'all encryption fails calls invalidateSessionKey before final retry',
+      () async {
+        final testCrypto = _TestCryptoService()
+          ..encryptForAllDevicesThrows = true
+          ..encryptMessageThrows = true;
+
+        final container = _createContainer(
+          cryptoState: const CryptoState(isInitialized: true),
+          testCrypto: testCrypto,
+        );
+        addTearDown(container.dispose);
+
+        final wsNotifier = container.read(websocketProvider.notifier);
+        await wsNotifier.sendMessage(
+          'peer-1',
+          'hello',
+          conversationId: 'conv-1',
+        );
+
+        // invalidateSessionKey should have been called once during the
+        // retry-after-reset path.
+        expect(testCrypto.invalidateSessionKeyCalls, 1);
+      },
+    );
+  });
+
+  group('WebSocketNotifier._friendlyEncryptionError', () {
+    // _friendlyEncryptionError is a static method on WebSocketNotifier.
+    // We can't call it directly (it's private), but we CAN verify its
+    // behavior indirectly through sendMessage's failure path.
+
+    test('No PreKey bundle maps to waiting message', () async {
+      final container = _createContainer(
+        cryptoState: const CryptoState(isInitialized: true),
+        testCrypto: _PreKeyErrorCryptoService(),
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(websocketProvider.notifier)
+          .sendMessage('peer-1', 'hi', conversationId: 'conv-1');
+
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('conv-1');
+      expect(msgs, hasLength(1));
+      expect(
+        msgs.first.content,
+        'Waiting for this person to come online to secure the chat.',
+      );
+    });
+  });
+
+  group('WebSocketNotifier.sendReadReceipt', () {
+    test('respects privacy setting when disabled', () {
+      final container = _createContainer(readReceiptsEnabled: false);
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+
+      // sendReadReceipt should exit early when readReceiptsEnabled is false.
+      // Since _channel is null in tests, if it DID try to send it would be
+      // a no-op anyway, but we verify the method doesn't crash and the
+      // privacy check happens by confirming the state is unchanged.
+      wsNotifier.sendReadReceipt('conv-1');
+
+      // No state change -- the WebSocket state should remain as-is.
+      final wsState = container.read(websocketProvider);
+      expect(wsState.isConnected, isFalse);
+    });
+
+    test('attempts to send when privacy allows', () {
+      final container = _createContainer(readReceiptsEnabled: true);
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+
+      // Should not crash -- _channel is null so sink.add is a no-op.
+      wsNotifier.sendReadReceipt('conv-1');
+
+      // No state change expected, method is fire-and-forget.
+      final wsState = container.read(websocketProvider);
+      expect(wsState.isConnected, isFalse);
+    });
+  });
+
+  group('WebSocketNotifier.sendTyping throttle', () {
+    test('does not crash when channel is null', () {
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+
+      // sendTyping should not crash even with null _channel.
+      wsNotifier.sendTyping('conv-1');
+
+      // No state change expected.
+      expect(container.read(websocketProvider).isConnected, isFalse);
+    });
+
+    test('sendTyping with channelId does not crash', () {
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+
+      wsNotifier.sendTyping('conv-1', channelId: 'chan-1');
+
+      expect(container.read(websocketProvider).isConnected, isFalse);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Specialized fakes for specific error scenarios
+// ---------------------------------------------------------------------------
+
+/// CryptoService that always throws "No PreKey bundle found" on all encrypt
+/// paths, triggering the specific friendly error message.
+class _PreKeyErrorCryptoService extends CryptoService {
+  _PreKeyErrorCryptoService() : super(serverUrl: 'http://localhost:8080');
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Future<Map<String, String>> encryptForAllDevices(
+    String peerUserId,
+    String plaintext,
+  ) async {
+    throw Exception('No PreKey bundle found for user');
+  }
+
+  @override
+  Future<Map<String, String>> encryptForOwnDevices(
+    String myUserId,
+    String plaintext,
+  ) async {
+    return {};
+  }
+
+  @override
+  Future<String> encryptMessage(String peerUserId, String plaintext) async {
+    throw Exception('No PreKey bundle found for user');
+  }
+
+  @override
+  Future<void> invalidateSessionKey(String peerUserId) async {}
+}


### PR DESCRIPTION
## Summary
- **15 new tests** covering ChatNotifier timer paths and WebSocketNotifier send failure paths
- `ChatNotifier`: 4 tests for `addOptimistic` 15s timeout, `confirmSent` cancellation, `clearConversation` cleanup, cross-conversation isolation
- `WebSocketNotifier`: 11 tests for `sendMessage` failure paths (crypto not init, keysUploadFailed retry, all-encryption-fails), `_friendlyEncryptionError` mapping, `sendReadReceipt` privacy guard, `sendTyping` safety
- **649 total tests** (up from 634), 5 intentionally skipped, 0 failures

### Test infrastructure added
- `_TestCryptoService` file-scoped fake extending `CryptoService` for crypto-path control
- `_SpyCryptoNotifier` tracking `retryKeyUpload` call counts
- `fake_async` added as explicit dev dependency for timer testing

Partial progress on #151 (batch 2)

## Test plan
- [x] `flutter analyze` — no issues
- [x] `dart format` — no changes needed
- [x] `flutter test` — 649 passed, 5 skipped, 0 failures

Generated with [Claude Code](https://claude.ai/code)