### PR TITLE
fix(client): harden hive message cache for browser restart (#198)

### DIFF
--- a/apps/client/lib/src/providers/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth_provider.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/background_service.dart' show BackgroundService;
+import '../services/debug_log_service.dart';
 import '../services/message_cache.dart';
 import '../services/secure_key_store.dart';
 import '../services/user_data_dir.dart';
@@ -339,6 +340,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
       // On web, Hive/IndexedDB box close/reopen can fail during
       // page refresh; this must not prevent login.
       debugPrint('[Auth] MessageCache.initForUser failed (non-fatal): $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'Auth',
+        'MessageCache.initForUser failed: $e. '
+            'History may be unavailable this session.',
+      );
     }
   }
 

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -18,6 +18,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'debug_log_service.dart';
 import 'secure_key_store.dart';
 import 'signal_session.dart';
 import 'signal_x3dh.dart';
@@ -455,6 +456,11 @@ class CryptoService {
         }
       }
     }
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'Crypto',
+      'Loaded ${_sessions.length} session(s) from storage on init',
+    );
   }
 
   /// Force-reset a corrupted or broken session with a peer.

--- a/apps/client/lib/src/services/message_cache.dart
+++ b/apps/client/lib/src/services/message_cache.dart
@@ -6,16 +6,73 @@ class MessageCache {
   static const _boxName = 'echo_messages';
   static Box<Map>? _box;
 
+  /// Name of the currently-open Hive box, used to make [initForUser]
+  /// idempotent (skip close/reopen when the target box is already active).
+  static String? _currentBoxName;
+
+  /// Strings that represent decryption failures. These must never be cached
+  /// because doing so permanently replaces the real ciphertext and blocks
+  /// future decrypt retries.
+  static const List<String> _failureSentinels = [
+    '[Message encrypted - history unavailable]',
+    '[Encrypted history]',
+    '[Could not decrypt - encryption keys may be out of sync]',
+  ];
+
   static Future<void> init() async {
     _box = await Hive.openBox<Map>(_boxName);
+    _currentBoxName = _boxName;
   }
 
   /// Re-initialize with a user-scoped Hive box.
   /// Call after login to isolate message cache per user.
+  ///
+  /// Idempotent: returns immediately if the target box is already open.
+  /// Retries up to 3 times on failure (web IndexedDB can be flaky during
+  /// page refresh). Falls back to the generic shared box on total failure
+  /// so the session can still cache newly-decrypted messages, then throws
+  /// [MessageCacheException] to let the caller log the issue.
   static Future<void> initForUser(String userId, String serverHost) async {
-    if (_box != null && _box!.isOpen) await _box!.close();
     final sanitized = '${userId}_$serverHost'.replaceAll(RegExp(r'[^\w]'), '_');
-    _box = await Hive.openBox<Map>('echo_messages_$sanitized');
+    final targetName = 'echo_messages_$sanitized';
+
+    // Already open on the correct box -- nothing to do.
+    if (_currentBoxName == targetName && _box?.isOpen == true) return;
+
+    // Close the previous box if it is open and belongs to a different user.
+    if (_box != null && _box!.isOpen && _currentBoxName != targetName) {
+      try {
+        await _box!.close();
+      } catch (_) {
+        // Close failures on web are non-fatal; the new open will handle it.
+      }
+    }
+
+    Object? lastError;
+    for (var attempt = 0; attempt < 3; attempt++) {
+      try {
+        _box = await Hive.openBox<Map>(targetName);
+        _currentBoxName = targetName;
+        return;
+      } catch (e) {
+        lastError = e;
+        await Future<void>.delayed(Duration(milliseconds: 100 * (attempt + 1)));
+      }
+    }
+
+    // All attempts failed -- fall back to generic box so this session can
+    // still cache newly-decrypted messages. Historical cache may be
+    // unavailable.
+    try {
+      _box = await Hive.openBox<Map>(_boxName);
+      _currentBoxName = _boxName;
+    } catch (_) {
+      _box = null;
+      _currentBoxName = null;
+    }
+    throw MessageCacheException(
+      'Failed to open user-scoped Hive box after 3 attempts: $lastError',
+    );
   }
 
   static Future<void> cacheMessages(
@@ -26,6 +83,9 @@ class MessageCache {
     if (box == null) return;
     for (final msg in messages) {
       if (msg.id.startsWith('pending_')) continue;
+      // Skip failure sentinels -- caching these would permanently replace the
+      // real ciphertext and block future retries.
+      if (_failureSentinels.contains(msg.content)) continue;
       await box.put('$conversationId:${msg.id}', msg.toJson());
     }
   }
@@ -96,6 +156,17 @@ class MessageCache {
     await _box?.clear();
   }
 
-  /// Number of cached message entries (conversations × messages).
+  /// Number of cached message entries (conversations x messages).
   static int entryCount() => _box?.length ?? 0;
+}
+
+/// Exception thrown when [MessageCache.initForUser] fails to open the
+/// user-scoped Hive box after all retry attempts.
+class MessageCacheException implements Exception {
+  final String message;
+
+  MessageCacheException(this.message);
+
+  @override
+  String toString() => 'MessageCacheException: $message';
 }

--- a/apps/client/test/services/message_cache_test.dart
+++ b/apps/client/test/services/message_cache_test.dart
@@ -1,0 +1,168 @@
+import 'dart:io';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/services/message_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// Helper to build a minimal [ChatMessage] for cache tests.
+ChatMessage _msg({
+  required String id,
+  String conversationId = 'conv-1',
+  String content = 'hello',
+  String fromUserId = 'sender-1',
+  String timestamp = '2025-01-01T00:00:00Z',
+}) {
+  return ChatMessage(
+    id: id,
+    fromUserId: fromUserId,
+    fromUsername: 'test-user',
+    conversationId: conversationId,
+    content: content,
+    timestamp: timestamp,
+    isMine: false,
+  );
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    tempDir = await Directory.systemTemp.createTemp('hive_cache_test_');
+    Hive.init(tempDir.path);
+    await MessageCache.init();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    try {
+      await tempDir.delete(recursive: true);
+    } catch (_) {}
+  });
+
+  group('MessageCache.initForUser', () {
+    test('is idempotent -- second call with same user is a no-op', () async {
+      await MessageCache.initForUser('user-1', 'example.com');
+      // Second call should return immediately without error.
+      await MessageCache.initForUser('user-1', 'example.com');
+    });
+
+    test('switches between users and isolates cached data', () async {
+      await MessageCache.initForUser('user-a', 'example.com');
+      final msg = _msg(id: 'msg-switch-1');
+      await MessageCache.cacheMessages('conv-1', [msg]);
+
+      // Verify cached for user-a.
+      expect(
+        MessageCache.getCachedMessage('conv-1', 'msg-switch-1', 'user-a'),
+        isNotNull,
+      );
+
+      // Switch to user-b -- cache should be empty.
+      await MessageCache.initForUser('user-b', 'example.com');
+      expect(
+        MessageCache.getCachedMessage('conv-1', 'msg-switch-1', 'user-b'),
+        isNull,
+      );
+
+      // Switch back to user-a -- data should still be there.
+      await MessageCache.initForUser('user-a', 'example.com');
+      expect(
+        MessageCache.getCachedMessage('conv-1', 'msg-switch-1', 'user-a'),
+        isNotNull,
+      );
+    });
+  });
+
+  group('MessageCache.cacheMessages', () {
+    test('skips failure sentinels', () async {
+      await MessageCache.initForUser('user-sentinels', 'example.com');
+
+      final sentinels = [
+        '[Message encrypted - history unavailable]',
+        '[Encrypted history]',
+        '[Could not decrypt - encryption keys may be out of sync]',
+      ];
+
+      for (var i = 0; i < sentinels.length; i++) {
+        final msg = _msg(id: 'sentinel-$i', content: sentinels[i]);
+        await MessageCache.cacheMessages('conv-1', [msg]);
+        expect(
+          MessageCache.getCachedMessage(
+            'conv-1',
+            'sentinel-$i',
+            'user-sentinels',
+          ),
+          isNull,
+          reason: 'sentinel "${sentinels[i]}" should not be cached',
+        );
+      }
+    });
+
+    test('skips pending_ messages', () async {
+      await MessageCache.initForUser('user-pending', 'example.com');
+      final msg = _msg(id: 'pending_xyz', content: 'real content');
+      await MessageCache.cacheMessages('conv-1', [msg]);
+      expect(
+        MessageCache.getCachedMessage('conv-1', 'pending_xyz', 'user-pending'),
+        isNull,
+      );
+    });
+
+    test('caches normal messages', () async {
+      await MessageCache.initForUser('user-normal', 'example.com');
+      final msg = _msg(id: 'msg-normal-1', content: 'hi there');
+      await MessageCache.cacheMessages('conv-1', [msg]);
+      final cached = MessageCache.getCachedMessage(
+        'conv-1',
+        'msg-normal-1',
+        'user-normal',
+      );
+      expect(cached, isNotNull);
+      expect(cached!.content, 'hi there');
+    });
+  });
+
+  group('MessageCache.getLatestCachedPreview', () {
+    test('returns the most recent message content', () async {
+      await MessageCache.initForUser('user-preview', 'example.com');
+      await MessageCache.cacheMessages('conv-preview', [
+        _msg(
+          id: 'old',
+          conversationId: 'conv-preview',
+          content: 'old message',
+          timestamp: '2025-01-01T00:00:00Z',
+        ),
+        _msg(
+          id: 'mid',
+          conversationId: 'conv-preview',
+          content: 'mid message',
+          timestamp: '2025-06-01T00:00:00Z',
+        ),
+        _msg(
+          id: 'new',
+          conversationId: 'conv-preview',
+          content: 'new message',
+          timestamp: '2025-12-01T00:00:00Z',
+        ),
+      ]);
+
+      final preview = MessageCache.getLatestCachedPreview('conv-preview');
+      expect(preview, 'new message');
+    });
+
+    test('returns null for unknown conversation', () async {
+      await MessageCache.initForUser('user-preview2', 'example.com');
+      expect(MessageCache.getLatestCachedPreview('conv-unknown'), isNull);
+    });
+  });
+
+  group('MessageCacheException', () {
+    test('toString includes message', () {
+      final ex = MessageCacheException('test error');
+      expect(ex.toString(), 'MessageCacheException: test error');
+      expect(ex.message, 'test error');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Harden `MessageCache.initForUser`** — idempotent, retries 3x on web IndexedDB races, falls back to generic box on total failure
- **Skip failure sentinels** — `cacheMessages` no longer writes `[Message encrypted - history unavailable]` etc. which would permanently overwrite real ciphertext
- **Track current box name** so repeat calls with same user are no-ops
- **Surface cache init failures** to `DebugLogService` (not just `debugPrint`)
- **Log session load count** in `CryptoService._loadSessions` for diagnostic visibility
- **8 new tests** covering idempotency, user switching, failure sentinel filtering, pending message skip

Closes #198

## Root cause
On web page refresh, `initForUser` close-then-reopen of the Hive box can fail silently (IndexedDB lock/timing issue), leaving the cache pointing at a closed handle. All subsequent `cacheMessages`/`getCachedMessage` calls silently no-op. History decrypt can't find cached plaintext → "Message encrypted - history unavailable" for all previous messages.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `dart format` — clean
- [x] `flutter test` — 657 passed, 5 skipped, 0 failures (+8 new)
- [ ] Manual: web browser restart → previously decrypted messages visible

Generated with [Claude Code](https://claude.ai/code)