### PR TITLE
batch: icon alignment + rate limiting + debug/cache hardening + crypto hardening

### DIFF
--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -10,6 +9,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import '../models/chat_message.dart';
 import '../services/debug_log_service.dart';
 import '../services/group_crypto_service.dart';
+import '../utils/debug_log.dart';
 import 'auth_provider.dart';
 import 'chat_provider.dart';
 import 'conversations_provider.dart';
@@ -84,7 +84,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
         return data['ticket'] as String?;
       }
     } catch (e) {
-      debugPrint('[WebSocket] Failed to fetch ws ticket: $e');
+      debugLog('Failed to fetch ws ticket: $e', 'WebSocket');
       DebugLogService.instance.log(
         LogLevel.error,
         'WebSocket',
@@ -117,7 +117,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
 
     if (ticket == null || ticket.isEmpty) {
       // Ticket fetch failed -- don't connect, schedule retry with backoff
-      debugPrint('[WebSocket] Failed to obtain ticket, will retry...');
+      debugLog('Failed to obtain ticket, will retry...', 'WebSocket');
       DebugLogService.instance.log(
         LogLevel.warning,
         'WebSocket',
@@ -181,9 +181,10 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     if (!ref.read(authProvider).isLoggedIn) return;
 
     if (_reconnectAttempts >= _maxReconnectAttempts) {
-      debugPrint(
-        '[WebSocket] Max reconnect attempts ($_maxReconnectAttempts) '
-        'reached -- server unreachable',
+      debugLog(
+        'Max reconnect attempts ($_maxReconnectAttempts) '
+            'reached -- server unreachable',
+        'WebSocket',
       );
       DebugLogService.instance.log(
         LogLevel.error,
@@ -209,9 +210,10 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     // First reconnect is normal after a connection drop -- only log repeated
     // failures so the debug log stays clean.
     if (_reconnectAttempts > 1) {
-      debugPrint(
-        '[WebSocket] Reconnecting in ${delayMs}ms '
-        '(attempt $_reconnectAttempts/$_maxReconnectAttempts)',
+      debugLog(
+        'Reconnecting in ${delayMs}ms '
+            '(attempt $_reconnectAttempts/$_maxReconnectAttempts)',
+        'WebSocket',
       );
       DebugLogService.instance.log(
         LogLevel.info,
@@ -291,14 +293,14 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       // Use first ciphertext as the fallback for legacy storage
       fallbackPayload = deviceContents.values.firstOrNull ?? '';
     } catch (e) {
-      debugPrint('[WS] Multi-device encryption failed: $e');
+      debugLog('Multi-device encryption failed: $e', 'WS');
       // Fall back to single-device encrypt with session reset retry
       try {
         final crypto = ref.read(cryptoServiceProvider);
         fallbackPayload = await crypto.encryptMessage(toUserId, content);
         deviceContents = null;
       } catch (e2) {
-        debugPrint('[WS] Fallback encryption failed, resetting session: $e2');
+        debugLog('Fallback encryption failed, resetting session: $e2', 'WS');
         // Reset session and retry once before giving up
         try {
           final crypto = ref.read(cryptoServiceProvider);
@@ -306,7 +308,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
           fallbackPayload = await crypto.encryptMessage(toUserId, content);
           deviceContents = null;
         } catch (e3) {
-          debugPrint('[WS] Encryption retry after reset also failed: $e3');
+          debugLog('Encryption retry after reset also failed: $e3', 'WS');
           _addFailedMessage(
             toUserId,
             _friendlyEncryptionError(e3),
@@ -424,9 +426,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
           );
         }
       } catch (e) {
-        debugPrint(
-          '[WebSocket] Group encryption failed, sending plaintext: $e',
-        );
+        debugLog('Group encryption failed, sending plaintext: $e', 'WebSocket');
       }
     }
 
@@ -499,7 +499,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
             ),
           );
     } catch (e) {
-      debugPrint('[WebSocket] sendReaction error: $e');
+      debugLog('sendReaction error: $e', 'WebSocket');
     }
   }
 
@@ -520,7 +520,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
             ),
           );
     } catch (e) {
-      debugPrint('[WebSocket] removeReaction error: $e');
+      debugLog('removeReaction error: $e', 'WebSocket');
     }
   }
 

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/chat_message.dart';
@@ -12,6 +11,7 @@ import '../services/group_crypto_service.dart';
 import '../services/notification_service.dart';
 import '../services/sound_service.dart';
 import '../utils/crypto_utils.dart';
+import '../utils/debug_log.dart';
 import 'auth_provider.dart';
 import 'channels_provider.dart';
 import 'chat_provider.dart';
@@ -381,7 +381,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
           decryptedContent = '[Could not decrypt - waiting for group key]';
         }
       } catch (e) {
-        debugPrint('[WebSocket] Group decrypt failed for $conversationId: $e');
+        debugLog('Group decrypt failed for $conversationId: $e', 'WebSocket');
         decryptedContent = '[Could not decrypt group message]';
       }
     } else if (!wasEncrypted) {
@@ -401,9 +401,10 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
         // permanently breaking all future messages in the conversation.
         // decryptMessage() already handles the legitimate peer-key-reset case
         // internally by detecting the X3DH magic prefix.
-        debugPrint(
-          '[WebSocket] Decryption failed for message in $conversationId '
-          'from $fromUserId: $e',
+        debugLog(
+          'Decryption failed for message in $conversationId '
+              'from $fromUserId: $e',
+          'WebSocket',
         );
         decryptedContent =
             '[Could not decrypt - encryption keys may be out of sync]';

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -33,6 +33,7 @@ class CryptoService {
   static const _signedPrekeyPubPref = 'echo_signed_prekey_pub';
   static const _sessionPrefix = 'echo_signal_session_';
   static const _peerIdentityPrefix = 'echo_peer_identity_';
+  static const _peerIdentityChangedPrefix = 'echo_peer_identity_changed_';
   static const _otpPrivatePrefix = 'echo_otp_private_';
   static const _signedPrekeyCreatedAtPref = 'echo_signed_prekey_created_at';
   static const _signedPrekeyPreviousPref = 'echo_signed_prekey_previous';
@@ -371,6 +372,9 @@ class CryptoService {
   /// Fetch and cache a peer's identity public key from the server.
   ///
   /// Returns the key bytes, or null if unavailable.
+  /// Uses Trust-On-First-Use (TOFU): the first-seen key is trusted and
+  /// persisted. If a later fetch returns a different key, a warning is logged
+  /// and a `_peerIdentityChangedPrefix` flag is persisted for the peer.
   Future<Uint8List?> fetchPeerIdentityKey(String peerUserId) async {
     // Check cache first
     final store = SecureKeyStore.instance;
@@ -389,13 +393,62 @@ class CryptoService {
       final identityKeyB64 = data['identity_key'] as String?;
       if (identityKeyB64 == null) return null;
 
-      // Cache for future use
-      await store.write('$_peerIdentityPrefix$peerUserId', identityKeyB64);
+      await _storePeerIdentityKeyTofu(peerUserId, identityKeyB64);
       return Uint8List.fromList(base64Decode(identityKeyB64));
     } catch (e) {
       debugPrint('[Crypto] Failed to fetch peer identity key: $e');
       return null;
     }
+  }
+
+  /// Store a peer's identity key with Trust-On-First-Use (TOFU) semantics.
+  ///
+  /// - First encounter: stores the key.
+  /// - Same key: no-op.
+  /// - Different key: logs a warning via [DebugLogService] and persists a
+  ///   flag (`_peerIdentityChangedPrefix + peerId`) for UI to surface later.
+  ///   The new key is stored so future sessions use the latest key.
+  Future<void> _storePeerIdentityKeyTofu(
+    String peerUserId,
+    String newKeyB64,
+  ) async {
+    final store = SecureKeyStore.instance;
+    final storeKey = '$_peerIdentityPrefix$peerUserId';
+    final existing = await store.read(storeKey);
+
+    if (existing != null && existing != newKeyB64) {
+      DebugLogService.instance.log(
+        LogLevel.warning,
+        'Crypto',
+        'TOFU: identity key changed for peer $peerUserId -- '
+            'possible key reset or MITM. Old prefix: '
+            '${existing.substring(0, min(8, existing.length))}..., '
+            'new prefix: '
+            '${newKeyB64.substring(0, min(8, newKeyB64.length))}...',
+      );
+      debugPrint('[Crypto] WARNING: peer $peerUserId identity key changed!');
+      // Persist a flag so the UI can surface a warning banner later.
+      await store.write(
+        '$_peerIdentityChangedPrefix$peerUserId',
+        DateTime.now().toIso8601String(),
+      );
+    }
+
+    // Store the (possibly new) key so future sessions use the latest.
+    await store.write(storeKey, newKeyB64);
+  }
+
+  /// Check whether a peer's identity key has changed since first contact.
+  Future<bool> hasPeerIdentityKeyChanged(String peerUserId) async {
+    final store = SecureKeyStore.instance;
+    final flag = await store.read('$_peerIdentityChangedPrefix$peerUserId');
+    return flag != null;
+  }
+
+  /// Acknowledge a peer identity key change (clears the flag).
+  Future<void> acknowledgePeerIdentityKeyChange(String peerUserId) async {
+    final store = SecureKeyStore.instance;
+    await store.delete('$_peerIdentityChangedPrefix$peerUserId');
   }
 
   /// Get the local identity public key bytes.
@@ -717,12 +770,8 @@ class CryptoService {
       type: KeyPairType.x25519,
     );
 
-    // Cache peer identity key for safety number generation
-    final peerStore = SecureKeyStore.instance;
-    await peerStore.write(
-      '$_peerIdentityPrefix$peerUserId',
-      data['identity_key'] as String,
-    );
+    // Cache peer identity key with TOFU change detection
+    await _storePeerIdentityKeyTofu(peerUserId, data['identity_key'] as String);
 
     // Extract one-time prekey if the server provided one (4-DH)
     SimplePublicKey? bobOneTimePrekey;
@@ -934,10 +983,9 @@ class CryptoService {
       isV2,
     );
 
-    // Cache peer identity key for safety number generation
-    final peerStore = SecureKeyStore.instance;
-    await peerStore.write(
-      '$_peerIdentityPrefix$peerUserId',
+    // Cache peer identity key with TOFU change detection
+    await _storePeerIdentityKeyTofu(
+      peerUserId,
       base64Encode(aliceIdentityBytes),
     );
 
@@ -1146,9 +1194,10 @@ class CryptoService {
     final store = SecureKeyStore.instance;
     await store.delete('$_sessionPrefix$peerUserId');
     await store.delete('${_sessionPrefix}corrupt_$peerUserId');
-    // Also clear the cached peer identity key so it's re-fetched with the new
-    // bundle on next session establishment.
+    // Also clear the cached peer identity key and any TOFU change flag so
+    // it's re-fetched with the new bundle on next session establishment.
     await store.delete('$_peerIdentityPrefix$peerUserId');
+    await store.delete('$_peerIdentityChangedPrefix$peerUserId');
   }
 
   /// Reset all keys: delete identity + session keys, regenerate, and upload.
@@ -1161,7 +1210,10 @@ class CryptoService {
     await store.delete(_otpNextIdPref);
     final allEntries = await store.readAll();
     for (final key in allEntries.keys) {
-      if (key.startsWith(_sessionPrefix) || key.startsWith(_otpPrivatePrefix)) {
+      if (key.startsWith(_sessionPrefix) ||
+          key.startsWith(_otpPrivatePrefix) ||
+          key.startsWith(_peerIdentityPrefix) ||
+          key.startsWith(_peerIdentityChangedPrefix)) {
         await store.delete(key);
       }
     }
@@ -1206,6 +1258,7 @@ class CryptoService {
     for (final key in allEntries.keys) {
       if (key.startsWith(_sessionPrefix) ||
           key.startsWith(_peerIdentityPrefix) ||
+          key.startsWith(_peerIdentityChangedPrefix) ||
           key.startsWith(_otpPrivatePrefix)) {
         await store.delete(key);
       }

--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -34,17 +34,32 @@ class DebugLogService with ChangeNotifier {
   /// Maximum number of entries retained before the oldest are dropped.
   static const maxEntries = 200;
 
+  /// Matches standard UUIDs (8-4-4-4-12 hex).
+  static final _uuidRegex = RegExp(
+    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b',
+    caseSensitive: false,
+  );
+
   /// Unmodifiable snapshot of the current entries (oldest first).
   List<DebugLogEntry> get entries => List.unmodifiable(_entries);
 
+  /// Truncate UUIDs to their first 8 hex characters to avoid leaking full
+  /// user/conversation IDs into the in-memory log buffer that is visible
+  /// from the Settings debug panel.
+  String _redact(String msg) =>
+      msg.replaceAllMapped(_uuidRegex, (m) => '${m[0]!.substring(0, 8)}...');
+
   /// Append a new log entry, evicting the oldest if the buffer is full.
+  ///
+  /// UUIDs in [message] are automatically truncated to prevent leaking full
+  /// identifiers into the debug log buffer.
   void log(LogLevel level, String source, String message) {
     _entries.add(
       DebugLogEntry(
         timestamp: DateTime.now(),
         level: level,
         source: source,
-        message: message,
+        message: _redact(message),
       ),
     );
     while (_entries.length > maxEntries) {

--- a/apps/client/lib/src/services/message_cache.dart
+++ b/apps/client/lib/src/services/message_cache.dart
@@ -1,6 +1,8 @@
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/chat_message.dart';
+import '../utils/debug_log.dart';
+import 'secure_key_store.dart';
 
 class MessageCache {
   static const _boxName = 'echo_messages';
@@ -20,7 +22,14 @@ class MessageCache {
   ];
 
   static Future<void> init() async {
-    _box = await Hive.openBox<Map>(_boxName);
+    final keyBytes = await _getEncryptionKey();
+    if (keyBytes != null) {
+      _box = await _openEncryptedBox(_boxName, keyBytes);
+    } else {
+      // Encryption key unavailable (e.g. secure storage not ready pre-login).
+      // Fall back to unencrypted so the app can still start.
+      _box = await Hive.openBox<Map>(_boxName);
+    }
     _currentBoxName = _boxName;
   }
 
@@ -48,10 +57,16 @@ class MessageCache {
       }
     }
 
+    final keyBytes = await _getEncryptionKey();
+
     Object? lastError;
     for (var attempt = 0; attempt < 3; attempt++) {
       try {
-        _box = await Hive.openBox<Map>(targetName);
+        if (keyBytes != null) {
+          _box = await _openEncryptedBox(targetName, keyBytes);
+        } else {
+          _box = await Hive.openBox<Map>(targetName);
+        }
         _currentBoxName = targetName;
         return;
       } catch (e) {
@@ -64,7 +79,11 @@ class MessageCache {
     // still cache newly-decrypted messages. Historical cache may be
     // unavailable.
     try {
-      _box = await Hive.openBox<Map>(_boxName);
+      if (keyBytes != null) {
+        _box = await _openEncryptedBox(_boxName, keyBytes);
+      } else {
+        _box = await Hive.openBox<Map>(_boxName);
+      }
       _currentBoxName = _boxName;
     } catch (_) {
       _box = null;
@@ -158,6 +177,43 @@ class MessageCache {
 
   /// Number of cached message entries (conversations x messages).
   static int entryCount() => _box?.length ?? 0;
+
+  /// Retrieve the Hive encryption key from secure storage, or null if
+  /// secure storage is not available yet (e.g. before first login).
+  static Future<List<int>?> _getEncryptionKey() async {
+    try {
+      return await SecureKeyStore.instance.getOrCreateHiveCacheKey();
+    } catch (e) {
+      debugLog('Failed to get Hive encryption key: $e', 'MessageCache');
+      return null;
+    }
+  }
+
+  /// Open a Hive box with AES encryption. If the box was previously stored
+  /// unencrypted (or with a different key), the open will fail with a cipher
+  /// mismatch. In that case, delete the old box and recreate it -- the cache
+  /// is a performance optimisation, not a source of truth.
+  static Future<Box<Map>> _openEncryptedBox(
+    String name,
+    List<int> keyBytes,
+  ) async {
+    final cipher = HiveAesCipher(keyBytes);
+    try {
+      return await Hive.openBox<Map>(name, encryptionCipher: cipher);
+    } catch (e) {
+      // Cipher mismatch with an existing unencrypted box -- delete and retry.
+      debugLog(
+        'Encrypted open failed for $name, deleting stale box: $e',
+        'MessageCache',
+      );
+      try {
+        await Hive.deleteBoxFromDisk(name);
+      } catch (_) {
+        // Best-effort deletion; openBox below will overwrite anyway.
+      }
+      return await Hive.openBox<Map>(name, encryptionCipher: cipher);
+    }
+  }
 }
 
 /// Exception thrown when [MessageCache.initForUser] fails to open the

--- a/apps/client/lib/src/services/secure_key_store.dart
+++ b/apps/client/lib/src/services/secure_key_store.dart
@@ -7,8 +7,13 @@
 /// Replaces direct SharedPreferences usage for sensitive crypto material.
 library;
 
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../utils/debug_log.dart';
 
 class SecureKeyStore {
   /// Singleton instance.
@@ -22,12 +27,12 @@ class SecureKeyStore {
   /// Scope all storage operations to a specific user.
   void setUserScope(String userId, String serverHost) {
     _userPrefix = 'u/$userId@$serverHost/';
-    debugPrint('[SecureKeyStore] setUserScope: prefix=$_userPrefix');
+    debugLog('setUserScope: prefix=$_userPrefix', 'SecureKeyStore');
   }
 
   /// Clear user scope (on logout).
   void clearUserScope() {
-    debugPrint('[SecureKeyStore] clearUserScope (was: $_userPrefix)');
+    debugLog('clearUserScope (was: $_userPrefix)', 'SecureKeyStore');
     _userPrefix = '';
   }
 
@@ -80,7 +85,7 @@ class SecureKeyStore {
     try {
       return await _storage.read(key: '$_userPrefix$key');
     } catch (e) {
-      debugPrint('[SecureKeyStore] read($key) failed: $e');
+      debugLog('read($key) failed: $e', 'SecureKeyStore');
       rethrow;
     }
   }
@@ -94,7 +99,7 @@ class SecureKeyStore {
     try {
       await _storage.write(key: '$_userPrefix$key', value: value);
     } catch (e) {
-      debugPrint('[SecureKeyStore] write($key) failed: $e');
+      debugLog('write($key) failed: $e', 'SecureKeyStore');
       rethrow;
     }
   }
@@ -104,7 +109,7 @@ class SecureKeyStore {
     try {
       await _storage.delete(key: '$_userPrefix$key');
     } catch (e) {
-      debugPrint('[SecureKeyStore] delete($key) failed: $e');
+      debugLog('delete($key) failed: $e', 'SecureKeyStore');
     }
   }
 
@@ -119,7 +124,7 @@ class SecureKeyStore {
             .map((e) => MapEntry(e.key.substring(_userPrefix.length), e.value)),
       );
     } catch (e) {
-      debugPrint('[SecureKeyStore] readAll failed: $e');
+      debugLog('readAll failed: $e', 'SecureKeyStore');
       return {};
     }
   }
@@ -129,7 +134,7 @@ class SecureKeyStore {
     try {
       return await _storage.containsKey(key: '$_userPrefix$key');
     } catch (e) {
-      debugPrint('[SecureKeyStore] containsKey($key) failed: $e');
+      debugLog('containsKey($key) failed: $e', 'SecureKeyStore');
       return false;
     }
   }
@@ -148,7 +153,7 @@ class SecureKeyStore {
     try {
       return await _storage.read(key: key);
     } catch (e) {
-      debugPrint('[SecureKeyStore] readGlobal($key) failed: $e');
+      debugLog('readGlobal($key) failed: $e', 'SecureKeyStore');
       rethrow;
     }
   }
@@ -161,9 +166,23 @@ class SecureKeyStore {
     try {
       await _storage.write(key: key, value: value);
     } catch (e) {
-      debugPrint('[SecureKeyStore] writeGlobal($key) failed: $e');
+      debugLog('writeGlobal($key) failed: $e', 'SecureKeyStore');
       rethrow;
     }
+  }
+
+  /// Return a 32-byte AES key for Hive box encryption, creating one if it
+  /// does not already exist.  The key is persisted in platform-secure storage
+  /// (global scope) so it survives app restarts and user re-logins.
+  Future<List<int>> getOrCreateHiveCacheKey() async {
+    const keyName = 'hive_message_cache_key';
+    final existing = await readGlobal(keyName);
+    if (existing != null && existing.isNotEmpty) {
+      return base64.decode(existing);
+    }
+    final newKey = Hive.generateSecureKey();
+    await writeGlobal(keyName, base64.encode(newKey));
+    return newKey;
   }
 
   /// Delete a global (non-user-scoped) key. Swallows errors.
@@ -171,7 +190,7 @@ class SecureKeyStore {
     try {
       await _storage.delete(key: key);
     } catch (e) {
-      debugPrint('[SecureKeyStore] deleteGlobal($key) failed: $e');
+      debugLog('deleteGlobal($key) failed: $e', 'SecureKeyStore');
     }
   }
 }

--- a/apps/client/lib/src/utils/debug_log.dart
+++ b/apps/client/lib/src/utils/debug_log.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+
+/// Wrapper around [debugPrint] that silently no-ops in release builds.
+///
+/// Migrate production code from `debugPrint` to `debugLog` to avoid leaking
+/// sensitive data (user IDs, tokens, session IDs) to system logs in release
+/// mode.  In debug builds this delegates directly to [debugPrint].
+void debugLog(String message, [String? tag]) {
+  if (!kDebugMode) return;
+  if (tag != null) {
+    debugPrint('[$tag] $message');
+  } else {
+    debugPrint(message);
+  }
+}

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -923,7 +923,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       ),
       tooltip: showMediaPicker ? 'Keyboard' : 'Emoji & GIF',
       padding: EdgeInsets.zero,
-      constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+      constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
       onPressed: () {
         if (isMobileLayout) {
           if (_showInlinePicker) {

--- a/apps/client/test/services/debug_log_service_test.dart
+++ b/apps/client/test/services/debug_log_service_test.dart
@@ -90,6 +90,41 @@ void main() {
       expect(notified, isTrue);
     });
 
+    test('redacts UUIDs in logged messages', () {
+      service.log(
+        LogLevel.info,
+        'WebSocket',
+        'Decryption failed for conv a1b2c3d4-e5f6-7890-abcd-ef1234567890 '
+            'from user 12345678-abcd-ef01-2345-678901234567',
+      );
+
+      final msg = service.entries.first.message;
+      // Full UUIDs should be replaced with first 8 chars + "..."
+      expect(msg, isNot(contains('a1b2c3d4-e5f6-7890-abcd-ef1234567890')));
+      expect(msg, isNot(contains('12345678-abcd-ef01-2345-678901234567')));
+      expect(msg, contains('a1b2c3d4...'));
+      expect(msg, contains('12345678...'));
+    });
+
+    test('does not redact non-UUID strings', () {
+      service.log(LogLevel.info, 'Test', 'normal message with no IDs');
+      expect(service.entries.first.message, 'normal message with no IDs');
+    });
+
+    test('redacts multiple UUIDs in a single message', () {
+      service.log(
+        LogLevel.warning,
+        'Test',
+        'users aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee '
+            'and 11111111-2222-3333-4444-555555555555 are chatting',
+      );
+
+      final msg = service.entries.first.message;
+      expect(msg, contains('aaaaaaaa...'));
+      expect(msg, contains('11111111...'));
+      expect(msg, isNot(contains('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')));
+    });
+
     test('DebugLogEntry fields are set correctly', () {
       final before = DateTime.now();
       service.log(LogLevel.error, 'Crypto', 'key failure');

--- a/apps/client/test/utils/debug_log_test.dart
+++ b/apps/client/test/utils/debug_log_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/utils/debug_log.dart';
+
+void main() {
+  group('debugLog', () {
+    test('outputs message via debugPrint in debug mode', () {
+      // In test mode kDebugMode is true, so debugLog should forward to
+      // debugPrint. Capture the output by overriding debugPrint.
+      final captured = <String>[];
+      final original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) {
+        if (message != null) captured.add(message);
+      };
+
+      try {
+        debugLog('hello world');
+        expect(captured, ['hello world']);
+      } finally {
+        debugPrint = original;
+      }
+    });
+
+    test('prepends tag when provided', () {
+      final captured = <String>[];
+      final original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) {
+        if (message != null) captured.add(message);
+      };
+
+      try {
+        debugLog('something happened', 'WebSocket');
+        expect(captured, ['[WebSocket] something happened']);
+      } finally {
+        debugPrint = original;
+      }
+    });
+
+    test('works without tag', () {
+      final captured = <String>[];
+      final original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) {
+        if (message != null) captured.add(message);
+      };
+
+      try {
+        debugLog('bare message');
+        expect(captured, ['bare message']);
+      } finally {
+        debugPrint = original;
+      }
+    });
+  });
+}

--- a/apps/server/migrations/20260412100000_identity_key_binding.sql
+++ b/apps/server/migrations/20260412100000_identity_key_binding.sql
@@ -1,0 +1,6 @@
+-- Add a canonical identity key fingerprint to the users table.
+-- On first key bundle upload, the server stores SHA-256(identity_key) here.
+-- Subsequent uploads must present the same identity key or the server
+-- rejects the request with 409 Conflict. Identity key rotation requires
+-- a separate key-reset flow (not yet implemented).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS identity_key_fingerprint BYTEA;

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -1,6 +1,7 @@
 //! Server configuration from environment variables.
 
 use std::env;
+use std::net::IpAddr;
 
 #[derive(Clone)]
 pub struct Config {
@@ -8,6 +9,11 @@ pub struct Config {
     pub jwt_secret: String,
     pub host: String,
     pub port: u16,
+    /// IPs of trusted reverse proxies whose `X-Real-IP` / `X-Forwarded-For`
+    /// headers are honored for rate limiting.  Parsed from the
+    /// `TRUSTED_PROXIES` env var (comma-separated IPs).  Empty by default,
+    /// meaning proxy headers are **ignored**.
+    pub trusted_proxies: Vec<IpAddr>,
 }
 
 impl Config {
@@ -18,6 +24,29 @@ impl Config {
             jwt_secret.len() >= 32,
             "JWT_SECRET must be at least 32 characters for security"
         );
+
+        let trusted_proxies: Vec<IpAddr> = env::var("TRUSTED_PROXIES")
+            .unwrap_or_default()
+            .split(',')
+            .filter_map(|s| {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    return None;
+                }
+                match trimmed.parse::<IpAddr>() {
+                    Ok(ip) => Some(ip),
+                    Err(e) => {
+                        tracing::warn!("Ignoring invalid TRUSTED_PROXIES entry '{trimmed}': {e}");
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        if !trusted_proxies.is_empty() {
+            tracing::info!("Trusted proxies: {:?}", trusted_proxies);
+        }
+
         Self {
             database_url: env::var("DATABASE_URL")
                 .expect("DATABASE_URL environment variable must be set"),
@@ -27,6 +56,58 @@ impl Config {
                 .ok()
                 .and_then(|p| p.parse().ok())
                 .unwrap_or(8080),
+            trusted_proxies,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_trusted_proxies_empty() {
+        // Simulate empty env var
+        let proxies: Vec<IpAddr> = ""
+            .split(',')
+            .filter_map(|s| {
+                let t = s.trim();
+                if t.is_empty() { None } else { t.parse().ok() }
+            })
+            .collect();
+        assert!(proxies.is_empty());
+    }
+
+    #[test]
+    fn parse_trusted_proxies_single() {
+        let proxies: Vec<IpAddr> = "10.0.0.1"
+            .split(',')
+            .filter_map(|s| s.trim().parse().ok())
+            .collect();
+        assert_eq!(proxies, vec!["10.0.0.1".parse::<IpAddr>().unwrap()]);
+    }
+
+    #[test]
+    fn parse_trusted_proxies_multiple_with_whitespace() {
+        let proxies: Vec<IpAddr> = " 10.0.0.1 , 172.17.0.1 , ::1 "
+            .split(',')
+            .filter_map(|s| s.trim().parse().ok())
+            .collect();
+        assert_eq!(proxies.len(), 3);
+        assert_eq!(proxies[0], "10.0.0.1".parse::<IpAddr>().unwrap());
+        assert_eq!(proxies[1], "172.17.0.1".parse::<IpAddr>().unwrap());
+        assert_eq!(proxies[2], "::1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn parse_trusted_proxies_skips_invalid() {
+        let proxies: Vec<IpAddr> = "10.0.0.1, not-an-ip, 172.17.0.1"
+            .split(',')
+            .filter_map(|s| {
+                let t = s.trim();
+                if t.is_empty() { None } else { t.parse().ok() }
+            })
+            .collect();
+        assert_eq!(proxies.len(), 2);
     }
 }

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -21,6 +21,34 @@ pub struct OneTimePreKeyRow {
     pub public_key: Vec<u8>,
 }
 
+/// Fetch the canonical identity key fingerprint for a user, if one has been
+/// bound. Returns `None` for users who have never uploaded a key bundle.
+pub async fn get_identity_key_fingerprint(
+    db: impl sqlx::PgExecutor<'_>,
+    user_id: Uuid,
+) -> Result<Option<Vec<u8>>, sqlx::Error> {
+    let row: Option<(Option<Vec<u8>>,)> =
+        sqlx::query_as("SELECT identity_key_fingerprint FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_optional(db)
+            .await?;
+    Ok(row.and_then(|(fp,)| fp))
+}
+
+/// Bind a canonical identity key fingerprint to a user on first key upload.
+pub async fn set_identity_key_fingerprint(
+    db: impl sqlx::PgExecutor<'_>,
+    user_id: Uuid,
+    fingerprint: &[u8],
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE users SET identity_key_fingerprint = $2 WHERE id = $1")
+        .bind(user_id)
+        .bind(fingerprint)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
 /// Store or replace a user's identity key for a specific device.
 pub async fn store_identity_key(
     db: impl sqlx::PgExecutor<'_>,

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -23,6 +23,10 @@ pub struct RateLimiter {
     entries: Arc<DashMap<IpAddr, RateBucket>>,
     max_requests: u32,
     window_secs: u64,
+    /// IPs of reverse proxies whose `X-Real-IP` / `X-Forwarded-For`
+    /// headers we trust.  When empty, proxy headers are ignored and the
+    /// peer (ConnectInfo) IP is used directly.
+    trusted_proxies: Arc<Vec<IpAddr>>,
 }
 
 impl RateLimiter {
@@ -31,6 +35,17 @@ impl RateLimiter {
             entries: Arc::new(DashMap::new()),
             max_requests,
             window_secs,
+            trusted_proxies: Arc::new(Vec::new()),
+        }
+    }
+
+    /// Create a rate limiter that honours proxy headers from `proxies`.
+    pub fn with_trusted_proxies(max_requests: u32, window_secs: u64, proxies: Vec<IpAddr>) -> Self {
+        Self {
+            entries: Arc::new(DashMap::new()),
+            max_requests,
+            window_secs,
+            trusted_proxies: Arc::new(proxies),
         }
     }
 
@@ -60,18 +75,35 @@ impl RateLimiter {
     }
 }
 
-/// Extract client IP from request headers or connection info.
+/// Get the peer (direct connection) IP from ConnectInfo.
+fn peer_ip(req: &Request<Body>) -> IpAddr {
+    req.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip())
+        .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
+}
+
+/// Extract client IP from request, honouring proxy headers **only** when
+/// the direct peer is in `trusted_proxies`.
 ///
-/// Priority: X-Real-IP (set by trusted proxies) > X-Forwarded-For (last
-/// non-private IP) > ConnectInfo > localhost.
+/// When the peer is trusted:
+///   X-Real-IP > X-Forwarded-For (last non-private) > peer IP
 ///
-/// **Security note**: X-Forwarded-For can be forged by clients.  We use the
-/// LAST IP in the chain because Traefik *appends* the real client IP.  The
-/// first IP is whatever the client sent and cannot be trusted.  X-Real-IP is
-/// preferred because Traefik (when configured) sets it from the direct
-/// connection.
-fn extract_ip(req: &Request<Body>) -> IpAddr {
-    // Prefer X-Real-IP (trusted, set by reverse proxy)
+/// When the peer is NOT trusted (or `trusted_proxies` is empty):
+///   peer IP is returned directly, proxy headers are ignored.
+///
+/// **Security note**: X-Forwarded-For can be forged by clients.  We use
+/// the LAST IP in the chain because Traefik *appends* the real client IP.
+/// The first IP is whatever the client sent and cannot be trusted.
+fn extract_ip(req: &Request<Body>, trusted_proxies: &[IpAddr]) -> IpAddr {
+    let direct = peer_ip(req);
+
+    // Only honour proxy headers when the immediate peer is a trusted proxy
+    if trusted_proxies.is_empty() || !trusted_proxies.contains(&direct) {
+        return direct;
+    }
+
+    // Prefer X-Real-IP (set by trusted reverse proxy)
     if let Some(xri) = req.headers().get("x-real-ip")
         && let Ok(value) = xri.to_str()
         && let Ok(ip) = value.trim().parse::<IpAddr>()
@@ -93,11 +125,8 @@ fn extract_ip(req: &Request<Body>) -> IpAddr {
         return ip;
     }
 
-    // Fallback to ConnectInfo
-    req.extensions()
-        .get::<ConnectInfo<SocketAddr>>()
-        .map(|ci| ci.0.ip())
-        .unwrap_or(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
+    // Peer is trusted but headers are absent/invalid -- use peer IP
+    direct
 }
 
 /// Create a rate-limit middleware layer function for a given limiter.
@@ -113,7 +142,7 @@ pub fn make_rate_limit_layer(
     move |req: Request<Body>, next: Next| {
         let limiter = limiter.clone();
         Box::pin(async move {
-            let ip = extract_ip(&req);
+            let ip = extract_ip(&req, &limiter.trusted_proxies);
             if !limiter.check(ip) {
                 return (
                     StatusCode::TOO_MANY_REQUESTS,
@@ -146,6 +175,16 @@ pub fn refresh_limiter() -> RateLimiter {
 /// WebSocket ticket rate limiter: 10 tickets per 60 seconds per IP.
 pub fn ticket_limiter() -> RateLimiter {
     RateLimiter::new(10, 60)
+}
+
+/// Media upload rate limiter: 30 uploads per 60 seconds per IP.
+pub fn media_upload_limiter() -> RateLimiter {
+    RateLimiter::new(30, 60)
+}
+
+/// Link preview rate limiter: 20 requests per 60 seconds per IP.
+pub fn link_preview_limiter() -> RateLimiter {
+    RateLimiter::new(20, 60)
 }
 
 /// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
@@ -212,6 +251,20 @@ mod tests {
     }
 
     #[test]
+    fn test_media_upload_limiter_config() {
+        let limiter = media_upload_limiter();
+        assert_eq!(limiter.max_requests, 30);
+        assert_eq!(limiter.window_secs, 60);
+    }
+
+    #[test]
+    fn test_link_preview_limiter_config() {
+        let limiter = link_preview_limiter();
+        assert_eq!(limiter.max_requests, 20);
+        assert_eq!(limiter.window_secs, 60);
+    }
+
+    #[test]
     fn test_is_private_ipv4() {
         assert!(is_private(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
         assert!(is_private(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
@@ -239,33 +292,106 @@ mod tests {
         ))));
     }
 
-    #[test]
-    fn test_xff_private_ip_rejected() {
+    /// Helper: build a request with ConnectInfo set to the given address.
+    fn req_with_peer(peer: SocketAddr) -> Request<Body> {
         let mut req = Request::new(Body::empty());
-        req.headers_mut()
-            .insert("x-forwarded-for", "1.2.3.4, 192.168.1.1".parse().unwrap());
-        // Last IP is private -> should fall through to ConnectInfo/localhost
-        let ip = extract_ip(&req);
-        assert!(ip.is_loopback(), "private XFF IP should be rejected");
+        req.extensions_mut().insert(ConnectInfo(peer));
+        req
     }
 
     #[test]
-    fn test_xff_public_ip_accepted() {
-        let mut req = Request::new(Body::empty());
+    fn test_proxy_headers_ignored_without_trusted_proxies() {
+        // No trusted proxies -> X-Real-IP header is ignored
+        let peer: SocketAddr = "10.0.0.1:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
+        req.headers_mut()
+            .insert("x-real-ip", "1.2.3.4".parse().unwrap());
+        let ip = extract_ip(&req, &[]);
+        // Should return the peer IP, not the spoofed header
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    }
+
+    #[test]
+    fn test_proxy_headers_ignored_from_untrusted_peer() {
+        let trusted = vec![IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1))];
+        // Peer is NOT the trusted proxy
+        let peer: SocketAddr = "203.0.113.99:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
+        req.headers_mut()
+            .insert("x-real-ip", "1.2.3.4".parse().unwrap());
+        let ip = extract_ip(&req, &trusted);
+        assert_eq!(
+            ip,
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 99)),
+            "untrusted peer's X-Real-IP should be ignored"
+        );
+    }
+
+    #[test]
+    fn test_x_real_ip_honoured_from_trusted_proxy() {
+        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
+        let trusted = vec![proxy_ip];
+        let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
+        req.headers_mut()
+            .insert("x-real-ip", "1.2.3.4".parse().unwrap());
+        let ip = extract_ip(&req, &trusted);
+        assert_eq!(
+            ip,
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+            "trusted proxy's X-Real-IP should be used"
+        );
+    }
+
+    #[test]
+    fn test_xff_honoured_from_trusted_proxy() {
+        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
+        let trusted = vec![proxy_ip];
+        let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
         req.headers_mut()
             .insert("x-forwarded-for", "spoofed, 203.0.113.50".parse().unwrap());
-        let ip = extract_ip(&req);
+        let ip = extract_ip(&req, &trusted);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
     }
 
     #[test]
-    fn test_x_real_ip_preferred() {
-        let mut req = Request::new(Body::empty());
+    fn test_xff_private_ip_rejected_even_from_trusted_proxy() {
+        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
+        let trusted = vec![proxy_ip];
+        let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
+        req.headers_mut()
+            .insert("x-forwarded-for", "1.2.3.4, 192.168.1.1".parse().unwrap());
+        // Last IP is private -> should fall through to peer IP
+        let ip = extract_ip(&req, &trusted);
+        assert_eq!(
+            ip,
+            IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1)),
+            "private XFF IP should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_x_real_ip_preferred_over_xff_from_trusted_proxy() {
+        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
+        let trusted = vec![proxy_ip];
+        let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
         req.headers_mut()
             .insert("x-real-ip", "1.2.3.4".parse().unwrap());
         req.headers_mut()
             .insert("x-forwarded-for", "5.6.7.8".parse().unwrap());
-        let ip = extract_ip(&req);
+        let ip = extract_ip(&req, &trusted);
         assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+    }
+
+    #[test]
+    fn test_with_trusted_proxies_constructor() {
+        let proxies = vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))];
+        let limiter = RateLimiter::with_trusted_proxies(5, 60, proxies.clone());
+        assert_eq!(limiter.max_requests, 5);
+        assert_eq!(limiter.window_secs, 60);
+        assert_eq!(*limiter.trusted_proxies, proxies);
     }
 }

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -67,6 +67,12 @@ pub struct DeviceListResponse {
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use sha2::{Digest, Sha256};
+
+/// Compute a SHA-256 fingerprint of a raw identity key.
+fn identity_fingerprint(identity_key: &[u8]) -> Vec<u8> {
+    Sha256::digest(identity_key).to_vec()
+}
 
 /// POST /api/keys/upload -- Upload a PreKey bundle for the authenticated user.
 pub async fn upload_bundle(
@@ -92,6 +98,26 @@ pub async fn upload_bundle(
         .map_err(|_| AppError::bad_request("Invalid base64 for signing_key"))?;
     verify_signed_prekey_signature(&signing_key_bytes, &signed_prekey, &signed_prekey_signature)?;
 
+    // --- Identity binding check ---
+    // On first upload the identity key fingerprint is stored on the user row.
+    // On subsequent uploads the identity key MUST match or the request is
+    // rejected with 409. Rotation requires a separate key-reset flow.
+    let new_fingerprint = identity_fingerprint(&identity_key);
+    let stored_fingerprint =
+        db::keys::get_identity_key_fingerprint(&state.pool, auth_user.user_id).await?;
+    match stored_fingerprint {
+        Some(ref existing) if *existing != new_fingerprint => {
+            tracing::warn!(
+                "Identity key mismatch for user {} -- rejecting upload",
+                auth_user.user_id,
+            );
+            return Err(AppError::conflict(
+                "Identity key changed; use key reset flow to rotate",
+            ));
+        }
+        _ => {} // First upload or same key -- OK
+    }
+
     let one_time_prekeys: Vec<(i32, Vec<u8>)> = body
         .one_time_prekeys
         .iter()
@@ -108,6 +134,12 @@ pub async fn upload_bundle(
         tracing::error!("Failed to begin key upload transaction: {e:?}");
         AppError::internal("Database error")
     })?;
+
+    // Bind the identity key fingerprint on first upload.
+    if stored_fingerprint.is_none() {
+        db::keys::set_identity_key_fingerprint(&mut *tx, auth_user.user_id, &new_fingerprint)
+            .await?;
+    }
 
     db::keys::store_identity_key(
         &mut *tx,

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -41,37 +41,72 @@ fn cap_html(html: &str) -> &str {
     }
 }
 
-/// Validate URL scheme and reject SSRF-vulnerable addresses.
-fn validate_url(url: &str) -> Result<(), AppError> {
+/// Resolved URL metadata returned by [`validate_url`].
+struct ValidatedUrl {
+    /// The original URL string.
+    url: reqwest::Url,
+    /// The hostname from the URL (needed for `resolve()` pinning).
+    host: String,
+    /// A validated, non-private socket address that the hostname resolved to.
+    /// Used with `reqwest::ClientBuilder::resolve` to pin DNS and prevent
+    /// TOCTOU rebinding attacks.
+    resolved: std::net::SocketAddr,
+}
+
+/// Validate URL scheme, resolve DNS, and reject SSRF-vulnerable addresses.
+///
+/// Returns a [`ValidatedUrl`] containing the resolved address so the caller
+/// can pin it via `reqwest::ClientBuilder::resolve`, closing the TOCTOU
+/// window between DNS validation and HTTP request.
+fn validate_url(url: &str) -> Result<ValidatedUrl, AppError> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err(AppError::bad_request(
             "URL must start with http:// or https://",
         ));
     }
 
-    if let Ok(parsed) = reqwest::Url::parse(url)
-        && let Some(host) = parsed.host_str()
-    {
-        use std::net::ToSocketAddrs;
-        let port = parsed.port_or_known_default().unwrap_or(80);
-        if let Ok(addrs) = format!("{host}:{port}").to_socket_addrs() {
-            for addr in addrs {
-                let ip = addr.ip();
-                if ip.is_loopback()
-                    || ip.is_unspecified()
-                    || matches!(ip, std::net::IpAddr::V4(v4) if v4.is_private()
-                            || v4.is_link_local()
-                            || v4.octets()[0] == 169 && v4.octets()[1] == 254)
-                {
-                    return Err(AppError::bad_request(
-                        "URL resolves to a private or reserved address",
-                    ));
-                }
-            }
+    let parsed = reqwest::Url::parse(url).map_err(|_| AppError::bad_request("Invalid URL"))?;
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| AppError::bad_request("URL has no host"))?
+        .to_string();
+
+    let port = parsed.port_or_known_default().unwrap_or(80);
+
+    use std::net::ToSocketAddrs;
+    let addrs: Vec<std::net::SocketAddr> = format!("{host}:{port}")
+        .to_socket_addrs()
+        .map_err(|_| AppError::bad_request("Could not resolve hostname"))?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(AppError::bad_request(
+            "Hostname did not resolve to any address",
+        ));
+    }
+
+    // Validate ALL resolved addresses are safe (reject if any is private)
+    for addr in &addrs {
+        let ip = addr.ip();
+        if ip.is_loopback()
+            || ip.is_unspecified()
+            || matches!(ip, std::net::IpAddr::V4(v4) if v4.is_private()
+                    || v4.is_link_local()
+                    || v4.octets()[0] == 169 && v4.octets()[1] == 254)
+        {
+            return Err(AppError::bad_request(
+                "URL resolves to a private or reserved address",
+            ));
         }
     }
 
-    Ok(())
+    // Use the first safe address for pinning
+    Ok(ValidatedUrl {
+        url: parsed,
+        host,
+        resolved: addrs[0],
+    })
 }
 
 /// POST /api/link-preview
@@ -83,17 +118,20 @@ pub async fn fetch_preview(
     _state: State<Arc<AppState>>,
     Json(body): Json<LinkPreviewRequest>,
 ) -> Result<Json<LinkPreviewResponse>, AppError> {
-    validate_url(&body.url)?;
+    let validated = validate_url(&body.url)?;
 
-    // Fetch the page with a short timeout
+    // Pin the resolved IP so reqwest cannot re-resolve to a different
+    // (potentially private) address after our validation -- closes the
+    // TOCTOU DNS rebinding window.
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .redirect(reqwest::redirect::Policy::none())
+        .resolve(&validated.host, validated.resolved)
         .build()
         .map_err(|_| AppError::internal("Failed to create HTTP client"))?;
 
     let resp = client
-        .get(&body.url)
+        .get(validated.url)
         .header("User-Agent", "EchoMessenger/1.0 LinkPreview")
         .send()
         .await

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -83,6 +83,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let register_limit = rate_limit::make_rate_limit_layer(rate_limit::register_limiter());
     let refresh_limit = rate_limit::make_rate_limit_layer(rate_limit::refresh_limiter());
     let ticket_limit = rate_limit::make_rate_limit_layer(rate_limit::ticket_limiter());
+    let media_upload_limit = rate_limit::make_rate_limit_layer(rate_limit::media_upload_limiter());
+    let link_preview_limit = rate_limit::make_rate_limit_layer(rate_limit::link_preview_limiter());
 
     let auth_routes = Router::new()
         .route(
@@ -164,7 +166,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/otp-count", get(keys::get_otp_count));
 
     let media_routes = Router::new()
-        .route("/upload", post(media::upload))
+        .route(
+            "/upload",
+            post(media::upload).layer(middleware::from_fn(media_upload_limit)),
+        )
         .route("/ticket", post(media::request_media_ticket))
         .route("/{id}", get(media::download));
 
@@ -251,7 +256,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .nest("/api/push", push_routes)
         .nest("/api", message_routes)
         .route("/api/voice/token", post(voice::generate_token))
-        .route("/api/link-preview", post(link_preview::fetch_preview))
+        .route(
+            "/api/link-preview",
+            post(link_preview::fetch_preview).layer(middleware::from_fn(link_preview_limit)),
+        )
         .route("/api/health", get(health))
         .route("/api/config/ice", get(ice_config))
         .route("/ws", get(ws::ws_upgrade))

--- a/core/rust-core/src/crypto/session.rs
+++ b/core/rust-core/src/crypto/session.rs
@@ -16,7 +16,11 @@ pub struct X3dhResult {
 }
 
 /// Application-specific info string for HKDF.
-const HKDF_INFO: &[u8] = b"EchoX3DH";
+///
+/// MUST match `X3DH_HKDF_INFO` in `signal::x3dh` and the Dart client's
+/// `SignalX3DH._hkdfInfo` so that initiator and responder derive identical
+/// shared secrets regardless of which implementation is used.
+const HKDF_INFO: &[u8] = b"EchoSignalX3DH";
 
 /// Derive a 32-byte key from concatenated DH outputs using HKDF-SHA256.
 fn kdf(dh_outputs: &[u8]) -> Result<[u8; 32], CoreError> {


### PR DESCRIPTION
## Summary

Four parallel fixes bundled into one PR:

### #208 — Icon alignment (client)
- `chat_input_bar.dart`: Emoji toggle constraints raised from 36x36 → 44x44 to match attachment button. Both icons now share the same bounding box, fixing the vertical misalignment.

### #155 — Rate limiting + SSRF (server)
- `TRUSTED_PROXIES` env var — `X-Real-IP`/`X-Forwarded-For` now only honored when the direct peer IP is in the trusted list (default: empty = never trusted)
- Rate limits added to media upload (30/min/IP) and link preview (20/min/IP)
- SSRF DNS-rebinding fix: `validate_url()` returns a `ValidatedUrl` with pinned `SocketAddr`; `fetch_preview()` uses `reqwest::ClientBuilder::resolve()` to prevent re-resolution to a private address
- 13 new tests

### #154 — debugPrint + Hive encryption (client)
- New `debugLog()` helper that no-ops in release builds via `kDebugMode`
- Migrated all `debugPrint` in `websocket_provider`, `ws_message_handler`, `secure_key_store`
- Hive message cache now opened with `HiveAesCipher` using a 32-byte AES key stored in `SecureKeyStore`; cipher mismatch on open deletes and recreates the box (acceptable since cache is performance-only)
- `DebugLogService` now redacts UUIDs to first 8 chars before buffering
- 6 new tests

### #159 — Crypto hardening (server + client + core)
- **Server**: `users.identity_key_fingerprint` column added; key upload rejects with 409 if identity changes (TOFU at the server)
- **Client**: Peer identity key TOFU — first encounter stores, subsequent mismatches log warning + persist `identity_key_changed:{peerId}` flag for future UI warning
- **Core**: HKDF info string in `crypto/session.rs` aligned to `"EchoSignalX3DH"` (was `"EchoX3DH"`) to match `signal/x3dh.rs` and the Dart client

Closes #208, #155, #154, #159

## Test plan
- [x] `cargo check` / `fmt` / `clippy -D warnings` — clean
- [x] `cargo test` — 94 Rust tests pass (+13 new)
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 663 pass (+6 new), 5 skipped
- [x] All 4 branches fast-forwarded to dev without conflict