### PR TITLE
test(server): add critical integration tests for keys, group keys, and websocket handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ flutter build web --release --pwa-strategy=none --dart-define=APP_VERSION=X.Y.Z
 ## Tests
 
 ```bash
-cargo test --workspace                            # Rust: 53 tests (Signal Protocol + server)
+cargo test --workspace                            # Rust: 241 tests (Signal Protocol + server integration)
 cargo test -p echo-server -- test_name            # Run a single Rust test
 cd apps/client && flutter test                    # Flutter: 55 tests (crypto, models, state)
 cd apps/client && flutter test test/path_test.dart # Run a single Flutter test file

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ See [docs/setup.md](docs/setup.md) for full setup instructions.
 
 ### Running Tests
 ```bash
-cargo test --workspace                        # 53 Rust tests
+cargo test --workspace                        # 241 Rust tests
 cd apps/client && flutter test                # 55 Flutter tests
 ./scripts/test_e2e.sh                         # E2E integration tests
 npx playwright test                           # Visual tests

--- a/apps/server/tests/api_group_keys.rs
+++ b/apps/server/tests/api_group_keys.rs
@@ -253,13 +253,14 @@ async fn get_version_returns_correct_envelope() {
             { "user_id": owner_id, "encrypted_key": "v1-key" }
         ]
     });
-    client
+    let resp = client
         .post(format!("{base}/api/groups/{group_id}/keys"))
         .header("Authorization", format!("Bearer {owner_token}"))
         .json(&body)
         .send()
         .await
         .unwrap();
+    assert_eq!(resp.status().as_u16(), 201, "upload v1 failed");
 
     // Upload v2
     let body = serde_json::json!({
@@ -268,13 +269,14 @@ async fn get_version_returns_correct_envelope() {
             { "user_id": owner_id, "encrypted_key": "v2-key" }
         ]
     });
-    client
+    let resp = client
         .post(format!("{base}/api/groups/{group_id}/keys"))
         .header("Authorization", format!("Bearer {owner_token}"))
         .json(&body)
         .send()
         .await
         .unwrap();
+    assert_eq!(resp.status().as_u16(), 201, "upload v2 failed");
 
     // Fetch v1 specifically
     let resp = client

--- a/apps/server/tests/api_group_keys.rs
+++ b/apps/server/tests/api_group_keys.rs
@@ -5,24 +5,6 @@ mod common;
 use reqwest::Client;
 use serde_json::Value;
 
-/// Helper: create a group and return its id.
-async fn create_group(client: &Client, base: &str, token: &str, name: &str) -> String {
-    let resp = client
-        .post(format!("{base}/api/groups"))
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&serde_json::json!({ "name": name }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(
-        resp.status().as_u16(),
-        201,
-        "create_group should return 201"
-    );
-    let body: Value = resp.json().await.unwrap();
-    body["id"].as_str().unwrap().to_string()
-}
-
 // ---------------------------------------------------------------------------
 // Upload
 // ---------------------------------------------------------------------------
@@ -33,7 +15,7 @@ async fn upload_group_key_as_owner_returns_201() {
     let client = Client::new();
     let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkown").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKGroup").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKGroup").await;
 
     let body = serde_json::json!({
         "key_version": 1,
@@ -61,7 +43,7 @@ async fn upload_group_key_as_member_rejected() {
     let (owner_token, _owner_id, _) = common::register_and_login(&client, &base, "gkmemown").await;
     let (member_token, member_id, _) = common::register_and_login(&client, &base, "gkmem").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKMemGroup").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKMemGroup").await;
     common::add_member_to_group(&client, &base, &owner_token, &group_id, &member_id).await;
 
     let body = serde_json::json!({
@@ -88,7 +70,7 @@ async fn upload_group_key_as_nonmember_rejected() {
     let (owner_token, _owner_id, _) = common::register_and_login(&client, &base, "gknmown").await;
     let (stranger_token, stranger_id, _) = common::register_and_login(&client, &base, "gknm").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKNonMemGroup").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKNonMemGroup").await;
 
     let body = serde_json::json!({
         "key_version": 1,
@@ -117,7 +99,7 @@ async fn upload_group_key_empty_envelopes_returns_400() {
     let client = Client::new();
     let (owner_token, _owner_id, _) = common::register_and_login(&client, &base, "gkempty").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKEmptyEnv").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKEmptyEnv").await;
 
     let body = serde_json::json!({
         "key_version": 1,
@@ -140,7 +122,7 @@ async fn upload_group_key_zero_version_returns_400() {
     let client = Client::new();
     let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkv0").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKZeroVer").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKZeroVer").await;
 
     let body = serde_json::json!({
         "key_version": 0,
@@ -165,7 +147,7 @@ async fn upload_group_key_duplicate_version_returns_409() {
     let client = Client::new();
     let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkdup").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKDupVer").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKDupVer").await;
 
     let body = serde_json::json!({
         "key_version": 1,
@@ -212,7 +194,7 @@ async fn get_latest_returns_my_envelope() {
     let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gklown").await;
     let (member_token, member_id, _) = common::register_and_login(&client, &base, "gklmem").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKLatest").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKLatest").await;
     common::add_member_to_group(&client, &base, &owner_token, &group_id, &member_id).await;
 
     // Upload envelopes for both users
@@ -262,7 +244,7 @@ async fn get_version_returns_correct_envelope() {
     let client = Client::new();
     let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkvown").await;
 
-    let group_id = create_group(&client, &base, &owner_token, "GKVersion").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKVersion").await;
 
     // Upload v1
     let body = serde_json::json!({

--- a/apps/server/tests/api_group_keys.rs
+++ b/apps/server/tests/api_group_keys.rs
@@ -1,0 +1,320 @@
+//! Integration tests for group encryption key upload and retrieval.
+
+mod common;
+
+use reqwest::Client;
+use serde_json::Value;
+
+/// Helper: create a group and return its id.
+async fn create_group(client: &Client, base: &str, token: &str, name: &str) -> String {
+    let resp = client
+        .post(format!("{base}/api/groups"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "create_group should return 201"
+    );
+    let body: Value = resp.json().await.unwrap();
+    body["id"].as_str().unwrap().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Upload
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn upload_group_key_as_owner_returns_201() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkown").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKGroup").await;
+
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "owner-envelope-aes-key" }
+        ]
+    });
+
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["key_version"], 1);
+}
+
+#[tokio::test]
+async fn upload_group_key_as_member_rejected() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _owner_id, _) = common::register_and_login(&client, &base, "gkmemown").await;
+    let (member_token, member_id, _) = common::register_and_login(&client, &base, "gkmem").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKMemGroup").await;
+    common::add_member_to_group(&client, &base, &owner_token, &group_id, &member_id).await;
+
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": member_id, "encrypted_key": "attempt" }
+        ]
+    });
+
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {member_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[tokio::test]
+async fn upload_group_key_as_nonmember_rejected() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _owner_id, _) = common::register_and_login(&client, &base, "gknmown").await;
+    let (stranger_token, stranger_id, _) = common::register_and_login(&client, &base, "gknm").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKNonMemGroup").await;
+
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": stranger_id, "encrypted_key": "attempt" }
+        ]
+    });
+
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {stranger_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn upload_group_key_empty_envelopes_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _owner_id, _) = common::register_and_login(&client, &base, "gkempty").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKEmptyEnv").await;
+
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": []
+    });
+
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn upload_group_key_zero_version_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkv0").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKZeroVer").await;
+
+    let body = serde_json::json!({
+        "key_version": 0,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "attempt" }
+        ]
+    });
+
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn upload_group_key_duplicate_version_returns_409() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkdup").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKDupVer").await;
+
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "first" }
+        ]
+    });
+
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+
+    // Same version again
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "second" }
+        ]
+    });
+
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 409);
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_latest_returns_my_envelope() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gklown").await;
+    let (member_token, member_id, _) = common::register_and_login(&client, &base, "gklmem").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKLatest").await;
+    common::add_member_to_group(&client, &base, &owner_token, &group_id, &member_id).await;
+
+    // Upload envelopes for both users
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "owner-secret" },
+            { "user_id": member_id, "encrypted_key": "member-secret" }
+        ]
+    });
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+
+    // Owner fetches latest -- should see their own envelope
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/latest"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["encrypted_key"], "owner-secret");
+    assert_eq!(body["key_version"], 1);
+
+    // Member fetches latest -- should see their own envelope
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/latest"))
+        .header("Authorization", format!("Bearer {member_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["encrypted_key"], "member-secret");
+}
+
+#[tokio::test]
+async fn get_version_returns_correct_envelope() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkvown").await;
+
+    let group_id = create_group(&client, &base, &owner_token, "GKVersion").await;
+
+    // Upload v1
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "v1-key" }
+        ]
+    });
+    client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    // Upload v2
+    let body = serde_json::json!({
+        "key_version": 2,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "v2-key" }
+        ]
+    });
+    client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    // Fetch v1 specifically
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/1"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["encrypted_key"], "v1-key");
+    assert_eq!(body["key_version"], 1);
+
+    // Fetch v2 specifically
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/2"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["encrypted_key"], "v2-key");
+    assert_eq!(body["key_version"], 2);
+}

--- a/apps/server/tests/api_keys.rs
+++ b/apps/server/tests/api_keys.rs
@@ -1,0 +1,506 @@
+//! Integration tests for PreKey bundle upload, fetch, and device management.
+
+mod common;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use ed25519_dalek::{Signer, SigningKey};
+use rand::RngCore as _;
+use reqwest::Client;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Upload
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn upload_bundle_returns_201() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _uid, _) = common::register_and_login(&client, &base, "keyup").await;
+
+    common::upload_prekey_bundle(&client, &base, &token, 0, 3).await;
+    // upload_prekey_bundle already asserts 201
+}
+
+#[tokio::test]
+async fn upload_bundle_without_auth_returns_401() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        "signed_prekey": BASE64.encode(b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        "signed_prekey_signature": BASE64.encode([0u8; 64]),
+        "signed_prekey_id": 1,
+        "one_time_prekeys": [],
+        "device_id": 0,
+        "signing_key": BASE64.encode([0u8; 32]),
+    });
+
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[tokio::test]
+async fn upload_bundle_bad_signature_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _uid, _) = common::register_and_login(&client, &base, "keybadsig").await;
+
+    // Generate two different signing keys: one to produce the signature,
+    // another for the `signing_key` field. The server should reject the
+    // mismatch.
+    let mut secret_a = [0u8; 32];
+    rand::rng().fill_bytes(&mut secret_a);
+    let signing_key_a = SigningKey::from_bytes(&secret_a);
+
+    let mut secret_b = [0u8; 32];
+    rand::rng().fill_bytes(&mut secret_b);
+    let signing_key_b = SigningKey::from_bytes(&secret_b);
+
+    let mut signed_prekey = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut signed_prekey);
+
+    // Sign with key A but upload key B's public key
+    let signature = signing_key_a.sign(&signed_prekey);
+
+    let mut identity_key = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut identity_key);
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": 1,
+        "one_time_prekeys": [],
+        "device_id": 0,
+        "signing_key": BASE64.encode(signing_key_b.verifying_key().to_bytes()),
+    });
+
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn upload_bundle_invalid_base64_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _uid, _) = common::register_and_login(&client, &base, "keyb64").await;
+
+    let body = serde_json::json!({
+        "identity_key": "not!valid!base64!!!",
+        "signed_prekey": BASE64.encode([0u8; 32]),
+        "signed_prekey_signature": BASE64.encode([0u8; 64]),
+        "signed_prekey_id": 1,
+        "one_time_prekeys": [],
+        "device_id": 0,
+        "signing_key": BASE64.encode([0u8; 32]),
+    });
+
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_bundle_returns_uploaded_data() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (token_a, uid_a, _) = common::register_and_login(&client, &base, "keyfetcha").await;
+    let (token_b, _uid_b, _) = common::register_and_login(&client, &base, "keyfetchb").await;
+
+    let bundle = common::upload_prekey_bundle(&client, &base, &token_a, 0, 1).await;
+
+    let resp = client
+        .get(format!("{base}/api/keys/bundle/{uid_a}"))
+        .header("Authorization", format!("Bearer {token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+
+    assert_eq!(body["identity_key"], BASE64.encode(&bundle.identity_key));
+    assert_eq!(body["signed_prekey"], BASE64.encode(&bundle.signed_prekey));
+    assert_eq!(body["signed_prekey_id"], bundle.signed_prekey_id);
+
+    // Verify signing_key is present
+    assert_eq!(
+        body["signing_key"].as_str().unwrap(),
+        BASE64.encode(&bundle.signing_key_bytes)
+    );
+}
+
+#[tokio::test]
+async fn get_bundle_no_keys_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (token_a, uid_a, _) = common::register_and_login(&client, &base, "keynobnd").await;
+    let (token_b, _uid_b, _) = common::register_and_login(&client, &base, "keynobnd2").await;
+
+    // Don't upload any keys for user A
+    let _ = token_a; // silence unused warning
+
+    let resp = client
+        .get(format!("{base}/api/keys/bundle/{uid_a}"))
+        .header("Authorization", format!("Bearer {token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn get_bundle_consumes_one_time_prekey() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (token_a, uid_a, _) = common::register_and_login(&client, &base, "keyotpa").await;
+    let (token_b, _uid_b, _) = common::register_and_login(&client, &base, "keyotpb").await;
+
+    common::upload_prekey_bundle(&client, &base, &token_a, 0, 3).await;
+
+    // Fetch 3 times -- each should return a unique OTP
+    let mut seen_key_ids = Vec::new();
+    for _ in 0..3 {
+        let resp = client
+            .get(format!("{base}/api/keys/bundle/{uid_a}"))
+            .header("Authorization", format!("Bearer {token_b}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let body: Value = resp.json().await.unwrap();
+
+        let otp = &body["one_time_prekey"];
+        assert!(
+            otp.is_object(),
+            "fetch {}: should return an OTP",
+            seen_key_ids.len() + 1
+        );
+        let kid = otp["key_id"].as_i64().unwrap();
+        assert!(
+            !seen_key_ids.contains(&kid),
+            "OTP key_id {kid} already consumed"
+        );
+        seen_key_ids.push(kid);
+    }
+
+    // 4th fetch: OTPs exhausted
+    let resp = client
+        .get(format!("{base}/api/keys/bundle/{uid_a}"))
+        .header("Authorization", format!("Bearer {token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["one_time_prekey"].is_null(),
+        "4th fetch should have no OTP left"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// OTP count
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn otp_count_reflects_remaining() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (token_a, uid_a, _) = common::register_and_login(&client, &base, "keyotp5a").await;
+    let (token_b, _uid_b, _) = common::register_and_login(&client, &base, "keyotp5b").await;
+
+    common::upload_prekey_bundle(&client, &base, &token_a, 0, 5).await;
+
+    // Should be 5 initially
+    let resp = client
+        .get(format!("{base}/api/keys/otp-count?device_id=0"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["count"], 5);
+
+    // Consume 1 by fetching
+    client
+        .get(format!("{base}/api/keys/bundle/{uid_a}"))
+        .header("Authorization", format!("Bearer {token_b}"))
+        .send()
+        .await
+        .unwrap();
+
+    // Should be 4
+    let resp = client
+        .get(format!("{base}/api/keys/otp-count?device_id=0"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["count"], 4);
+}
+
+// ---------------------------------------------------------------------------
+// Identity key binding
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn identity_key_mismatch_returns_409() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _uid, _) = common::register_and_login(&client, &base, "keyid409").await;
+
+    // First upload -- binds identity key
+    common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
+
+    // Second upload with DIFFERENT identity key
+    let mut secret = [0u8; 32];
+    rand::rng().fill_bytes(&mut secret);
+    let signing_key = SigningKey::from_bytes(&secret);
+    let signing_key_pub = signing_key.verifying_key().to_bytes();
+
+    let mut new_identity_key = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut new_identity_key);
+
+    let mut signed_prekey = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut signed_prekey);
+    let signature = signing_key.sign(&signed_prekey);
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&new_identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": 1,
+        "one_time_prekeys": [],
+        "device_id": 0,
+        "signing_key": BASE64.encode(signing_key_pub),
+    });
+
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 409);
+}
+
+#[tokio::test]
+async fn identity_key_same_allows_reupload() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _uid, _) = common::register_and_login(&client, &base, "keyreup").await;
+
+    let bundle = common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
+
+    // Re-upload with SAME identity key but fresh signed prekey
+    let mut signed_prekey = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut signed_prekey);
+    let signature = bundle.signing_key.sign(&signed_prekey);
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&bundle.identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": 2,
+        "one_time_prekeys": [],
+        "device_id": 0,
+        "signing_key": BASE64.encode(&bundle.signing_key_bytes),
+    });
+
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-device
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_devices_returns_device_ids() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, uid, _) = common::register_and_login(&client, &base, "keydev").await;
+
+    // Upload for device 0 and device 1 (need same identity key)
+    let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
+
+    // Device 1: re-use the same identity_key bytes to pass the binding check
+    let mut signed_prekey = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut signed_prekey);
+    let signature = bundle0.signing_key.sign(&signed_prekey);
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&bundle0.identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": 2,
+        "one_time_prekeys": [],
+        "device_id": 1,
+        "signing_key": BASE64.encode(&bundle0.signing_key_bytes),
+    });
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+
+    // Fetch device list
+    let (token_other, _, _) = common::register_and_login(&client, &base, "keydevother").await;
+    let resp = client
+        .get(format!("{base}/api/keys/devices/{uid}"))
+        .header("Authorization", format!("Bearer {token_other}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    let device_ids: Vec<i64> = body["device_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_i64().unwrap())
+        .collect();
+    assert!(device_ids.contains(&0), "should list device 0");
+    assert!(device_ids.contains(&1), "should list device 1");
+}
+
+#[tokio::test]
+async fn get_all_bundles_returns_all_devices() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, uid, _) = common::register_and_login(&client, &base, "keyallbnd").await;
+
+    let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 1).await;
+
+    // Device 1 with same identity
+    let mut signed_prekey = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut signed_prekey);
+    let signature = bundle0.signing_key.sign(&signed_prekey);
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&bundle0.identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": 2,
+        "one_time_prekeys": [],
+        "device_id": 1,
+        "signing_key": BASE64.encode(&bundle0.signing_key_bytes),
+    });
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+
+    let (token_other, _, _) = common::register_and_login(&client, &base, "keyallbndoth").await;
+    let resp = client
+        .get(format!("{base}/api/keys/bundles/{uid}"))
+        .header("Authorization", format!("Bearer {token_other}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    let bundles = body["bundles"].as_array().unwrap();
+    assert_eq!(bundles.len(), 2, "should have bundles for 2 devices");
+
+    let dev_ids: Vec<i64> = bundles
+        .iter()
+        .map(|b| b["device_id"].as_i64().unwrap())
+        .collect();
+    assert!(dev_ids.contains(&0));
+    assert!(dev_ids.contains(&1));
+}
+
+#[tokio::test]
+async fn revoke_device_removes_keys() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, uid, _) = common::register_and_login(&client, &base, "keyrevoke").await;
+
+    let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
+
+    // Upload device 1
+    let mut signed_prekey = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut signed_prekey);
+    let signature = bundle0.signing_key.sign(&signed_prekey);
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&bundle0.identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": 2,
+        "one_time_prekeys": [],
+        "device_id": 1,
+        "signing_key": BASE64.encode(&bundle0.signing_key_bytes),
+    });
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+
+    // Revoke device 1
+    let resp = client
+        .delete(format!("{base}/api/keys/device/1"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 204);
+
+    // Fetch device 1 bundle should fail
+    let (token_other, _, _) = common::register_and_login(&client, &base, "keyrevoth").await;
+    let resp = client
+        .get(format!("{base}/api/keys/bundle/{uid}/1"))
+        .header("Authorization", format!("Bearer {token_other}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}

--- a/apps/server/tests/api_keys.rs
+++ b/apps/server/tests/api_keys.rs
@@ -5,7 +5,7 @@ mod common;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use ed25519_dalek::{Signer, SigningKey};
-use rand::RngCore as _;
+use rand::RngCore;
 use reqwest::Client;
 use serde_json::Value;
 
@@ -28,8 +28,8 @@ async fn upload_bundle_without_auth_returns_401() {
     let client = Client::new();
 
     let body = serde_json::json!({
-        "identity_key": BASE64.encode(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-        "signed_prekey": BASE64.encode(b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        "identity_key": BASE64.encode([0u8; 32]),
+        "signed_prekey": BASE64.encode([0u8; 32]),
         "signed_prekey_signature": BASE64.encode([0u8; 64]),
         "signed_prekey_id": 1,
         "one_time_prekeys": [],
@@ -55,22 +55,24 @@ async fn upload_bundle_bad_signature_returns_400() {
     // Generate two different signing keys: one to produce the signature,
     // another for the `signing_key` field. The server should reject the
     // mismatch.
+    let mut rng = rand::rng();
+
     let mut secret_a = [0u8; 32];
-    rand::rng().fill_bytes(&mut secret_a);
+    rng.fill_bytes(&mut secret_a);
     let signing_key_a = SigningKey::from_bytes(&secret_a);
 
     let mut secret_b = [0u8; 32];
-    rand::rng().fill_bytes(&mut secret_b);
+    rng.fill_bytes(&mut secret_b);
     let signing_key_b = SigningKey::from_bytes(&secret_b);
 
     let mut signed_prekey = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut signed_prekey);
+    rng.fill_bytes(&mut signed_prekey);
 
     // Sign with key A but upload key B's public key
     let signature = signing_key_a.sign(&signed_prekey);
 
     let mut identity_key = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut identity_key);
+    rng.fill_bytes(&mut identity_key);
 
     let body = serde_json::json!({
         "identity_key": BASE64.encode(&identity_key),
@@ -278,16 +280,18 @@ async fn identity_key_mismatch_returns_409() {
     common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
 
     // Second upload with DIFFERENT identity key
+    let mut rng = rand::rng();
+
     let mut secret = [0u8; 32];
-    rand::rng().fill_bytes(&mut secret);
+    rng.fill_bytes(&mut secret);
     let signing_key = SigningKey::from_bytes(&secret);
     let signing_key_pub = signing_key.verifying_key().to_bytes();
 
     let mut new_identity_key = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut new_identity_key);
+    rng.fill_bytes(&mut new_identity_key);
 
     let mut signed_prekey = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut signed_prekey);
+    rng.fill_bytes(&mut signed_prekey);
     let signature = signing_key.sign(&signed_prekey);
 
     let body = serde_json::json!({

--- a/apps/server/tests/api_keys.rs
+++ b/apps/server/tests/api_keys.rs
@@ -20,7 +20,6 @@ async fn upload_bundle_returns_201() {
     let (token, _uid, _) = common::register_and_login(&client, &base, "keyup").await;
 
     common::upload_prekey_bundle(&client, &base, &token, 0, 3).await;
-    // upload_prekey_bundle already asserts 201
 }
 
 #[tokio::test]
@@ -158,11 +157,8 @@ async fn get_bundle_no_keys_returns_400() {
     let base = common::spawn_server().await;
     let client = Client::new();
 
-    let (token_a, uid_a, _) = common::register_and_login(&client, &base, "keynobnd").await;
+    let (_token_a, uid_a, _) = common::register_and_login(&client, &base, "keynobnd").await;
     let (token_b, _uid_b, _) = common::register_and_login(&client, &base, "keynobnd2").await;
-
-    // Don't upload any keys for user A
-    let _ = token_a; // silence unused warning
 
     let resp = client
         .get(format!("{base}/api/keys/bundle/{uid_a}"))
@@ -357,31 +353,8 @@ async fn get_devices_returns_device_ids() {
     let client = Client::new();
     let (token, uid, _) = common::register_and_login(&client, &base, "keydev").await;
 
-    // Upload for device 0 and device 1 (need same identity key)
     let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
-
-    // Device 1: re-use the same identity_key bytes to pass the binding check
-    let mut signed_prekey = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut signed_prekey);
-    let signature = bundle0.signing_key.sign(&signed_prekey);
-
-    let body = serde_json::json!({
-        "identity_key": BASE64.encode(&bundle0.identity_key),
-        "signed_prekey": BASE64.encode(&signed_prekey),
-        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
-        "signed_prekey_id": 2,
-        "one_time_prekeys": [],
-        "device_id": 1,
-        "signing_key": BASE64.encode(&bundle0.signing_key_bytes),
-    });
-    let resp = client
-        .post(format!("{base}/api/keys/upload"))
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&body)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status().as_u16(), 201);
+    common::upload_additional_device(&client, &base, &token, &bundle0, 1).await;
 
     // Fetch device list
     let (token_other, _, _) = common::register_and_login(&client, &base, "keydevother").await;
@@ -410,29 +383,7 @@ async fn get_all_bundles_returns_all_devices() {
     let (token, uid, _) = common::register_and_login(&client, &base, "keyallbnd").await;
 
     let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 1).await;
-
-    // Device 1 with same identity
-    let mut signed_prekey = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut signed_prekey);
-    let signature = bundle0.signing_key.sign(&signed_prekey);
-
-    let body = serde_json::json!({
-        "identity_key": BASE64.encode(&bundle0.identity_key),
-        "signed_prekey": BASE64.encode(&signed_prekey),
-        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
-        "signed_prekey_id": 2,
-        "one_time_prekeys": [],
-        "device_id": 1,
-        "signing_key": BASE64.encode(&bundle0.signing_key_bytes),
-    });
-    let resp = client
-        .post(format!("{base}/api/keys/upload"))
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&body)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status().as_u16(), 201);
+    common::upload_additional_device(&client, &base, &token, &bundle0, 1).await;
 
     let (token_other, _, _) = common::register_and_login(&client, &base, "keyallbndoth").await;
     let resp = client
@@ -461,29 +412,7 @@ async fn revoke_device_removes_keys() {
     let (token, uid, _) = common::register_and_login(&client, &base, "keyrevoke").await;
 
     let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
-
-    // Upload device 1
-    let mut signed_prekey = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut signed_prekey);
-    let signature = bundle0.signing_key.sign(&signed_prekey);
-
-    let body = serde_json::json!({
-        "identity_key": BASE64.encode(&bundle0.identity_key),
-        "signed_prekey": BASE64.encode(&signed_prekey),
-        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
-        "signed_prekey_id": 2,
-        "one_time_prekeys": [],
-        "device_id": 1,
-        "signing_key": BASE64.encode(&bundle0.signing_key_bytes),
-    });
-    let resp = client
-        .post(format!("{base}/api/keys/upload"))
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&body)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status().as_u16(), 201);
+    common::upload_additional_device(&client, &base, &token, &bundle0, 1).await;
 
     // Revoke device 1
     let resp = client

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -8,7 +8,11 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use echo_server::{db, routes, ws};
+use ed25519_dalek::{Signer, SigningKey};
+use rand::RngCore as _;
 use reqwest::Client;
 use serde_json::Value;
 use tokio::sync::OnceCell;
@@ -162,4 +166,171 @@ pub async fn get_ws_ticket(client: &Client, base: &str, token: &str) -> String {
 pub fn unique_username(prefix: &str) -> String {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     format!("{prefix}_{}", &suffix[..8])
+}
+
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+
+/// Register a new user, log in, and return `(token, user_id, username)`.
+pub async fn register_and_login(
+    client: &Client,
+    base: &str,
+    prefix: &str,
+) -> (String, String, String) {
+    let username = unique_username(prefix);
+    register(client, base, &username, "password123").await;
+    let (token, user_id) = login(client, base, &username, "password123").await;
+    (token, user_id, username)
+}
+
+/// Send a contact request from A to B, accept it, then create the DM
+/// conversation so callers get back a `conversation_id`.
+pub async fn make_contacts(
+    client: &Client,
+    base: &str,
+    token_a: &str,
+    token_b: &str,
+    user_b_id: &str,
+    username_b: &str,
+) -> String {
+    // A requests B
+    let resp = client
+        .post(format!("{base}/api/contacts/request"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({ "username": username_b }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201, "contact request should 201");
+    let body: Value = resp.json().await.unwrap();
+    let contact_id = body["contact_id"].as_str().unwrap().to_string();
+
+    // B accepts
+    let resp = client
+        .post(format!("{base}/api/contacts/accept"))
+        .header("Authorization", format!("Bearer {token_b}"))
+        .json(&serde_json::json!({ "contact_id": contact_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200, "accept contact should 200");
+
+    // Create the DM conversation explicitly so we have a conversation_id
+    let resp = client
+        .post(format!("{base}/api/messages/conversations/dm"))
+        .header("Authorization", format!("Bearer {token_a}"))
+        .json(&serde_json::json!({ "peer_user_id": user_b_id }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    body["conversation_id"]
+        .as_str()
+        .expect("make_contacts: missing conversation_id")
+        .to_string()
+}
+
+/// Add a user to a group (caller must be owner/admin).
+pub async fn add_member_to_group(
+    client: &Client,
+    base: &str,
+    owner_token: &str,
+    group_id: &str,
+    member_user_id: &str,
+) {
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/members"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&serde_json::json!({ "user_id": member_user_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "add_member_to_group should return 200"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PreKey bundle helpers
+// ---------------------------------------------------------------------------
+
+/// Data returned from `upload_prekey_bundle` for later assertions.
+pub struct PreKeyBundleData {
+    pub identity_key: Vec<u8>,
+    pub signed_prekey: Vec<u8>,
+    pub signing_key_bytes: Vec<u8>,
+    pub signing_key: SigningKey,
+    pub signed_prekey_id: i32,
+    pub otp_key_ids: Vec<i32>,
+}
+
+/// Upload a valid PreKey bundle and return the raw key material for assertions.
+pub async fn upload_prekey_bundle(
+    client: &Client,
+    base: &str,
+    token: &str,
+    device_id: i32,
+    num_otps: usize,
+) -> PreKeyBundleData {
+    let mut secret = [0u8; 32];
+    rand::rng().fill_bytes(&mut secret);
+    let signing_key = SigningKey::from_bytes(&secret);
+    let signing_key_pub = signing_key.verifying_key().to_bytes();
+
+    let mut identity_key = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut identity_key);
+
+    let mut signed_prekey = vec![0u8; 32];
+    rand::rng().fill_bytes(&mut signed_prekey);
+
+    let signature = signing_key.sign(&signed_prekey);
+
+    let signed_prekey_id = 1;
+    let mut otps = Vec::new();
+    let mut otp_key_ids = Vec::new();
+    for i in 0..num_otps {
+        let mut otp_key = vec![0u8; 32];
+        rand::rng().fill_bytes(&mut otp_key);
+        let key_id = (i + 1) as i32;
+        otp_key_ids.push(key_id);
+        otps.push(serde_json::json!({
+            "key_id": key_id,
+            "public_key": BASE64.encode(&otp_key),
+        }));
+    }
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": signed_prekey_id,
+        "one_time_prekeys": otps,
+        "device_id": device_id,
+        "signing_key": BASE64.encode(signing_key_pub),
+    });
+
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "upload_prekey_bundle should return 201"
+    );
+
+    PreKeyBundleData {
+        identity_key,
+        signed_prekey,
+        signing_key_bytes: signing_key_pub.to_vec(),
+        signing_key,
+        signed_prekey_id,
+        otp_key_ids,
+    }
 }

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -12,7 +12,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use echo_server::{db, routes, ws};
 use ed25519_dalek::{Signer, SigningKey};
-use rand::RngCore as _;
+use rand::RngCore;
 use reqwest::Client;
 use serde_json::Value;
 use tokio::sync::OnceCell;
@@ -258,6 +258,24 @@ pub async fn add_member_to_group(
     );
 }
 
+/// Create a group and return its id.
+pub async fn create_group(client: &Client, base: &str, token: &str, name: &str) -> String {
+    let resp = client
+        .post(format!("{base}/api/groups"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "create_group should return 201"
+    );
+    let body: Value = resp.json().await.unwrap();
+    body["id"].as_str().unwrap().to_string()
+}
+
 // ---------------------------------------------------------------------------
 // PreKey bundle helpers
 // ---------------------------------------------------------------------------
@@ -280,16 +298,18 @@ pub async fn upload_prekey_bundle(
     device_id: i32,
     num_otps: usize,
 ) -> PreKeyBundleData {
+    let mut rng = rand::rng();
+
     let mut secret = [0u8; 32];
-    rand::rng().fill_bytes(&mut secret);
+    rng.fill_bytes(&mut secret);
     let signing_key = SigningKey::from_bytes(&secret);
     let signing_key_pub = signing_key.verifying_key().to_bytes();
 
     let mut identity_key = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut identity_key);
+    rng.fill_bytes(&mut identity_key);
 
     let mut signed_prekey = vec![0u8; 32];
-    rand::rng().fill_bytes(&mut signed_prekey);
+    rng.fill_bytes(&mut signed_prekey);
 
     let signature = signing_key.sign(&signed_prekey);
 
@@ -298,7 +318,7 @@ pub async fn upload_prekey_bundle(
     let mut otp_key_ids = Vec::new();
     for i in 0..num_otps {
         let mut otp_key = vec![0u8; 32];
-        rand::rng().fill_bytes(&mut otp_key);
+        rng.fill_bytes(&mut otp_key);
         let key_id = (i + 1) as i32;
         otp_key_ids.push(key_id);
         otps.push(serde_json::json!({
@@ -338,4 +358,36 @@ pub async fn upload_prekey_bundle(
         signed_prekey_id,
         otp_key_ids,
     }
+}
+
+/// Upload an additional device bundle reusing the identity key from a previous upload.
+pub async fn upload_additional_device(
+    client: &Client,
+    base: &str,
+    token: &str,
+    bundle0: &PreKeyBundleData,
+    device_id: i32,
+) {
+    let mut rng = rand::rng();
+    let mut signed_prekey = vec![0u8; 32];
+    rng.fill_bytes(&mut signed_prekey);
+    let signature = bundle0.signing_key.sign(&signed_prekey);
+
+    let body = serde_json::json!({
+        "identity_key": BASE64.encode(&bundle0.identity_key),
+        "signed_prekey": BASE64.encode(&signed_prekey),
+        "signed_prekey_signature": BASE64.encode(signature.to_bytes()),
+        "signed_prekey_id": 2,
+        "one_time_prekeys": [],
+        "device_id": device_id,
+        "signing_key": BASE64.encode(&bundle0.signing_key_bytes),
+    });
+    let resp = client
+        .post(format!("{base}/api/keys/upload"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
 }

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -218,16 +218,21 @@ pub async fn make_contacts(
 
     // Create the DM conversation explicitly so we have a conversation_id
     let resp = client
-        .post(format!("{base}/api/messages/conversations/dm"))
+        .post(format!("{base}/api/conversations/dm"))
         .header("Authorization", format!("Bearer {token_a}"))
         .json(&serde_json::json!({ "peer_user_id": user_b_id }))
         .send()
         .await
         .unwrap();
-    let body: Value = resp.json().await.unwrap();
+    let status = resp.status().as_u16();
+    let body: Value = resp.json().await.unwrap_or_else(|e| {
+        panic!("make_contacts: create_dm returned status {status}, JSON parse error: {e}");
+    });
     body["conversation_id"]
         .as_str()
-        .expect("make_contacts: missing conversation_id")
+        .unwrap_or_else(|| {
+            panic!("make_contacts: missing conversation_id in response: {body}");
+        })
         .to_string()
 }
 

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -15,64 +15,22 @@ async fn alice_sends_bob_receives() {
     let base = common::spawn_server().await;
     let client = Client::new();
 
-    // -- Register Alice and Bob -----------------------------------------------
-    let alice_name = common::unique_username("alice");
-    let bob_name = common::unique_username("bob");
+    let (alice_token, _alice_id, alice_name) =
+        common::register_and_login(&client, &base, "alice").await;
+    let (bob_token, bob_id, bob_name) = common::register_and_login(&client, &base, "bob").await;
 
-    common::register(&client, &base, &alice_name, "password123").await;
-    common::register(&client, &base, &bob_name, "password123").await;
+    common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
 
-    let (alice_token, _alice_id) = common::login(&client, &base, &alice_name, "password123").await;
-    let (bob_token, bob_id) = common::login(&client, &base, &bob_name, "password123").await;
-
-    // -- Make them contacts ---------------------------------------------------
-    let resp = client
-        .post(format!("{base}/api/contacts/request"))
-        .header("Authorization", format!("Bearer {alice_token}"))
-        .json(&serde_json::json!({ "username": bob_name }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status().as_u16(), 201);
-    let body: Value = resp.json().await.unwrap();
-    let contact_id = body["contact_id"].as_str().unwrap();
-
-    let resp = client
-        .post(format!("{base}/api/contacts/accept"))
-        .header("Authorization", format!("Bearer {bob_token}"))
-        .json(&serde_json::json!({ "contact_id": contact_id }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status().as_u16(), 200);
-
-    // -- Get WS tickets -------------------------------------------------------
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
 
-    // -- Connect WebSockets ---------------------------------------------------
-    let ws_base = base.replace("http://", "ws://");
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
 
-    let (mut alice_ws, _) =
-        tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={alice_ticket}"))
-            .await
-            .expect("Alice WS connect failed");
-
-    let (mut bob_ws, _) =
-        tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={bob_ticket}"))
-            .await
-            .expect("Bob WS connect failed");
-
-    // Give the server a moment to register both connections and deliver any
-    // presence events before we send a message.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    // Drain any presence/backlog messages from both sockets before the test
-    // message so they don't interfere with assertions.
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
 
-    // -- Alice sends a message to Bob -----------------------------------------
     let send_msg = serde_json::json!({
         "type": "send_message",
         "to_user_id": bob_id,
@@ -105,7 +63,6 @@ async fn alice_sends_bob_receives() {
         "from_username should be Alice"
     );
 
-    // Clean up
     let _ = alice_ws.close(None).await;
     let _ = bob_ws.close(None).await;
 }
@@ -326,12 +283,14 @@ async fn group_message_fanout() {
     assert_eq!(bob_msg["type"], "new_message");
     assert_eq!(bob_msg["content"], "hello group");
     assert_eq!(bob_msg["from_username"], alice_name.as_str());
+    assert_eq!(bob_msg["conversation_id"], group_id.as_str());
 
     // Charlie should get new_message
     let charlie_event = read_text_with_timeout(&mut charlie_ws).await;
     let charlie_msg: Value = serde_json::from_str(&charlie_event).unwrap();
     assert_eq!(charlie_msg["type"], "new_message");
     assert_eq!(charlie_msg["content"], "hello group");
+    assert_eq!(charlie_msg["conversation_id"], group_id.as_str());
 
     let _ = alice_ws.close(None).await;
     let _ = bob_ws.close(None).await;
@@ -432,6 +391,9 @@ async fn read_text_with_timeout(ws: &mut WsStream) -> String {
             Ok(Some(Ok(Message::Text(text)))) => return text.to_string(),
             Ok(Some(Ok(Message::Ping(_)))) => continue,
             Ok(Some(Ok(Message::Pong(_)))) => continue,
+            Ok(Some(Ok(Message::Close(_)))) => {
+                panic!("WS connection closed before expected message")
+            }
             Ok(Some(Ok(other))) => panic!("Unexpected WS message: {other:?}"),
             Ok(Some(Err(e))) => panic!("WS error: {e}"),
             Ok(None) => panic!("WS stream ended unexpectedly"),

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -110,6 +110,337 @@ async fn alice_sends_bob_receives() {
     let _ = bob_ws.close(None).await;
 }
 
+// ---------------------------------------------------------------------------
+// Typing indicator
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn typing_indicator_broadcast() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, alice_name) =
+        common::register_and_login(&client, &base, "typalice").await;
+    let (bob_token, bob_id, bob_name) = common::register_and_login(&client, &base, "typbob").await;
+
+    let conv_id =
+        common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_ws).await;
+
+    // Alice sends typing indicator
+    let typing_msg = serde_json::json!({
+        "type": "typing",
+        "conversation_id": conv_id,
+    });
+    alice_ws
+        .send(Message::Text(typing_msg.to_string().into()))
+        .await
+        .expect("Alice typing send failed");
+
+    // Bob should receive typing event
+    let bob_event = read_text_with_timeout(&mut bob_ws).await;
+    let event: Value = serde_json::from_str(&bob_event).expect("Bob typing JSON parse failed");
+    assert_eq!(event["type"], "typing", "Bob should get typing event");
+    assert_eq!(event["conversation_id"], conv_id);
+    assert_eq!(event["from_username"], alice_name.as_str());
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+}
+
+// ---------------------------------------------------------------------------
+// Read receipt
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn read_receipt_broadcast() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "rralice").await;
+    let (bob_token, bob_id, bob_name) = common::register_and_login(&client, &base, "rrbob").await;
+
+    let conv_id =
+        common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_ws).await;
+
+    // Alice sends a message to create some content to read
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": conv_id,
+        "content": "hello for read receipt test",
+    });
+    alice_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("Alice send failed");
+
+    // Drain the message_sent and new_message events
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_ws).await;
+
+    // Bob sends read receipt
+    let rr_msg = serde_json::json!({
+        "type": "read_receipt",
+        "conversation_id": conv_id,
+    });
+    bob_ws
+        .send(Message::Text(rr_msg.to_string().into()))
+        .await
+        .expect("Bob read_receipt send failed");
+
+    // Alice should receive read_receipt
+    let alice_event = read_text_with_timeout(&mut alice_ws).await;
+    let event: Value =
+        serde_json::from_str(&alice_event).expect("Alice read_receipt JSON parse failed");
+    assert_eq!(
+        event["type"], "read_receipt",
+        "Alice should get read_receipt"
+    );
+    assert_eq!(event["conversation_id"], conv_id);
+    assert_eq!(event["user_id"], bob_id.as_str());
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+}
+
+// ---------------------------------------------------------------------------
+// Key reset
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn key_reset_broadcast() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, alice_id, alice_name) =
+        common::register_and_login(&client, &base, "kralice").await;
+    let (bob_token, bob_id, bob_name) = common::register_and_login(&client, &base, "krbob").await;
+
+    let conv_id =
+        common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_ws).await;
+
+    // Alice sends key_reset
+    let kr_msg = serde_json::json!({
+        "type": "key_reset",
+        "conversation_id": conv_id,
+    });
+    alice_ws
+        .send(Message::Text(kr_msg.to_string().into()))
+        .await
+        .expect("Alice key_reset send failed");
+
+    // Bob should receive key_reset
+    let bob_event = read_text_with_timeout(&mut bob_ws).await;
+    let event: Value = serde_json::from_str(&bob_event).expect("Bob key_reset JSON parse failed");
+    assert_eq!(event["type"], "key_reset", "Bob should get key_reset");
+    assert_eq!(event["conversation_id"], conv_id);
+    assert_eq!(event["from_user_id"], alice_id.as_str());
+    assert_eq!(event["from_username"], alice_name.as_str());
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+}
+
+// ---------------------------------------------------------------------------
+// Group message fan-out
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn group_message_fanout() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, alice_name) =
+        common::register_and_login(&client, &base, "gfalice").await;
+    let (bob_token, bob_id, _bob_name) = common::register_and_login(&client, &base, "gfbob").await;
+    let (charlie_token, charlie_id, _charlie_name) =
+        common::register_and_login(&client, &base, "gfcharlie").await;
+
+    let group_id = create_group(&client, &base, &alice_token, "FanoutGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &bob_id).await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &charlie_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+    let charlie_ticket = common::get_ws_ticket(&client, &base, &charlie_token).await;
+
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+    let mut charlie_ws = connect_ws(&base, &charlie_ticket).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_ws).await;
+    drain_pending(&mut charlie_ws).await;
+
+    // Alice sends a message to the group
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group_id,
+        "content": "hello group",
+    });
+    alice_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("Alice group send failed");
+
+    // Alice should get message_sent
+    let alice_event = read_text_with_timeout(&mut alice_ws).await;
+    let alice_msg: Value = serde_json::from_str(&alice_event).unwrap();
+    assert_eq!(alice_msg["type"], "message_sent");
+
+    // Bob should get new_message
+    let bob_event = read_text_with_timeout(&mut bob_ws).await;
+    let bob_msg: Value = serde_json::from_str(&bob_event).unwrap();
+    assert_eq!(bob_msg["type"], "new_message");
+    assert_eq!(bob_msg["content"], "hello group");
+    assert_eq!(bob_msg["from_username"], alice_name.as_str());
+
+    // Charlie should get new_message
+    let charlie_event = read_text_with_timeout(&mut charlie_ws).await;
+    let charlie_msg: Value = serde_json::from_str(&charlie_event).unwrap();
+    assert_eq!(charlie_msg["type"], "new_message");
+    assert_eq!(charlie_msg["content"], "hello group");
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+    let _ = charlie_ws.close(None).await;
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn invalid_json_returns_error() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (token, _uid, _) = common::register_and_login(&client, &base, "wsinvalid").await;
+    let ticket = common::get_ws_ticket(&client, &base, &token).await;
+
+    let mut ws = connect_ws(&base, &ticket).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drain_pending(&mut ws).await;
+
+    // Send invalid JSON
+    ws.send(Message::Text("not valid json {{{".into()))
+        .await
+        .expect("send failed");
+
+    let event = read_text_with_timeout(&mut ws).await;
+    let msg: Value = serde_json::from_str(&event).expect("error JSON parse failed");
+    assert_eq!(msg["type"], "error", "should get error event");
+
+    let _ = ws.close(None).await;
+}
+
+#[tokio::test]
+async fn message_to_noncontact_returns_error() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "ncalice").await;
+    let (_eve_token, eve_id, _) = common::register_and_login(&client, &base, "nceve").await;
+
+    // Alice and Eve are NOT contacts
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drain_pending(&mut alice_ws).await;
+
+    // Alice tries to message Eve (not a contact)
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "to_user_id": eve_id,
+        "content": "hey stranger",
+    });
+    alice_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("Alice send failed");
+
+    let event = read_text_with_timeout(&mut alice_ws).await;
+    let msg: Value = serde_json::from_str(&event).expect("error JSON parse failed");
+    assert_eq!(msg["type"], "error", "should get error for non-contact");
+    assert!(
+        msg["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Not a contact"),
+        "error message should mention 'Not a contact'"
+    );
+
+    let _ = alice_ws.close(None).await;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn connect_ws(base: &str, ticket: &str) -> WsStream {
+    let ws_base = base.replace("http://", "ws://");
+    let (ws, _) = tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={ticket}"))
+        .await
+        .expect("WS connect failed");
+    ws
+}
+
+/// Helper: create a group and return its id.
+async fn create_group(client: &Client, base: &str, token: &str, name: &str) -> String {
+    let resp = client
+        .post(format!("{base}/api/groups"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "create_group should return 201"
+    );
+    let body: Value = resp.json().await.unwrap();
+    body["id"].as_str().unwrap().to_string()
+}
+
 /// Read a text message from the WebSocket with a 5-second timeout.
 /// Panics if no text message arrives in time.
 async fn read_text_with_timeout(

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -287,7 +287,7 @@ async fn group_message_fanout() {
     let (charlie_token, charlie_id, _charlie_name) =
         common::register_and_login(&client, &base, "gfcharlie").await;
 
-    let group_id = create_group(&client, &base, &alice_token, "FanoutGroup").await;
+    let group_id = common::create_group(&client, &base, &alice_token, "FanoutGroup").await;
     common::add_member_to_group(&client, &base, &alice_token, &group_id, &bob_id).await;
     common::add_member_to_group(&client, &base, &alice_token, &group_id, &charlie_id).await;
 
@@ -423,31 +423,9 @@ async fn connect_ws(base: &str, ticket: &str) -> WsStream {
     ws
 }
 
-/// Helper: create a group and return its id.
-async fn create_group(client: &Client, base: &str, token: &str, name: &str) -> String {
-    let resp = client
-        .post(format!("{base}/api/groups"))
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&serde_json::json!({ "name": name }))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(
-        resp.status().as_u16(),
-        201,
-        "create_group should return 201"
-    );
-    let body: Value = resp.json().await.unwrap();
-    body["id"].as_str().unwrap().to_string()
-}
-
 /// Read a text message from the WebSocket with a 5-second timeout.
 /// Panics if no text message arrives in time.
-async fn read_text_with_timeout(
-    ws: &mut tokio_tungstenite::WebSocketStream<
-        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-    >,
-) -> String {
+async fn read_text_with_timeout(ws: &mut WsStream) -> String {
     let timeout = std::time::Duration::from_secs(5);
     loop {
         match tokio::time::timeout(timeout, ws.next()).await {
@@ -463,11 +441,7 @@ async fn read_text_with_timeout(
 }
 
 /// Drain any pending messages from the socket (non-blocking).
-async fn drain_pending(
-    ws: &mut tokio_tungstenite::WebSocketStream<
-        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-    >,
-) {
+async fn drain_pending(ws: &mut WsStream) {
     while let Ok(Some(Ok(_))) =
         tokio::time::timeout(std::time::Duration::from_millis(100), ws.next()).await
     {}


### PR DESCRIPTION
## Summary
- Add 27 Rust integration tests covering three previously untested server modules
- **PreKey bundle pipeline** (`routes/keys.rs`): 13 tests covering upload, auth, signature verification, OTP consumption, identity key binding, multi-device, and device revocation
- **Group key management** (`routes/group_keys.rs`): 8 tests covering RBAC, validation, version conflict detection, and per-member envelope isolation
- **WebSocket handler** (`ws/handler.rs`): 6 new tests for typing indicators, read receipts, key reset broadcast, group message fanout, and error handling
- Add shared test helpers to `common/mod.rs`: `create_group`, `register_and_login`, `make_contacts`, `upload_prekey_bundle`, `upload_additional_device`
- Update Rust test count in docs from 53 to 241

## Test Plan
- [ ] `cargo test --workspace` passes (241 tests, 0 failures)
- [ ] `cargo clippy --workspace --all-targets` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] All pre-commit hooks pass

Closes #151