### PR TITLE
feat(client): image clipboard copy and desktop update check

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -763,7 +763,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               ..._buildMembersPanel(),
             ],
           ),
-          if (voiceActive) _buildDesktopVoiceDock(animatedSidebarWidth),
+          if (voiceActive && !_showSettings)
+            _buildDesktopVoiceDock(animatedSidebarWidth),
         ],
       ),
     );
@@ -808,6 +809,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             ? _toggleMembers
             : null,
         hideVoiceDock: true,
+        onShowLounge: () => setState(() {
+          _showingLounge = true;
+          _userDismissedLounge = false;
+        }),
       );
     }
     return _buildEmptyState();
@@ -932,6 +937,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       rightPanel = ChatPanel(
         conversation: _selectedConversation,
         onGroupInfo: _showGroupInfo,
+        onShowLounge: () => setState(() {
+          _showingLounge = true;
+          _userDismissedLounge = false;
+        }),
       );
     } else {
       rightPanel = _buildEmptyState();
@@ -981,6 +990,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       conversation: _selectedConversation,
       onGroupInfo: _showGroupInfo,
       onBack: () => setState(() => _narrowPanelIndex = 0),
+      onShowLounge: () => setState(() {
+        _showingLounge = true;
+        _userDismissedLounge = false;
+      }),
     );
 
     if (voiceActive && !_showingLounge) {

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -175,93 +175,91 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
       ),
     ];
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 640),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
-          children: [
-            Text(
-              'Theme',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 900),
+      child: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          Text(
+            'Theme',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
             ),
-            const SizedBox(height: 4),
-            Text(
-              'Choose a theme and message layout.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Choose a theme and message layout.',
+            style: TextStyle(
+              color: context.textSecondary,
+              fontSize: 13,
+              height: 1.5,
             ),
-            const Divider(height: 24),
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: themeOptions
-                  .map(
-                    (data) => _ThemeCard(
-                      data: data,
-                      isSelected: currentTheme == data.selection,
-                      onTap: () => ref
-                          .read(themeProvider.notifier)
-                          .setTheme(data.selection),
-                    ),
-                  )
-                  .toList(),
+          ),
+          const Divider(height: 24),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: themeOptions
+                .map(
+                  (data) => _ThemeCard(
+                    data: data,
+                    isSelected: currentTheme == data.selection,
+                    onTap: () => ref
+                        .read(themeProvider.notifier)
+                        .setTheme(data.selection),
+                  ),
+                )
+                .toList(),
+          ),
+          const SizedBox(height: 32),
+          Text(
+            'Message Layout',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
             ),
-            const SizedBox(height: 32),
-            Text(
-              'Message Layout',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
+          ),
+          const SizedBox(height: 16),
+          _LayoutOption(
+            label: 'Bubbles',
+            subtitle: 'Chat bubbles aligned left and right',
+            icon: Icons.chat_bubble_outline,
+            isSelected:
+                ref.watch(messageLayoutProvider) == MessageLayout.bubbles,
+            onTap: () => ref
+                .read(messageLayoutProvider.notifier)
+                .setLayout(MessageLayout.bubbles),
+          ),
+          const SizedBox(height: 8),
+          _LayoutOption(
+            label: 'Compact',
+            subtitle: 'Discord-style, all messages left-aligned',
+            icon: Icons.format_align_left_outlined,
+            isSelected:
+                ref.watch(messageLayoutProvider) == MessageLayout.compact,
+            onTap: () => ref
+                .read(messageLayoutProvider.notifier)
+                .setLayout(MessageLayout.compact),
+          ),
+          const SizedBox(height: 24),
+          // GIF autoplay
+          SwitchListTile.adaptive(
+            contentPadding: EdgeInsets.zero,
+            title: Text(
+              'Auto-play GIFs',
+              style: TextStyle(color: context.textPrimary, fontSize: 14),
             ),
-            const SizedBox(height: 16),
-            _LayoutOption(
-              label: 'Bubbles',
-              subtitle: 'Chat bubbles aligned left and right',
-              icon: Icons.chat_bubble_outline,
-              isSelected:
-                  ref.watch(messageLayoutProvider) == MessageLayout.bubbles,
-              onTap: () => ref
-                  .read(messageLayoutProvider.notifier)
-                  .setLayout(MessageLayout.bubbles),
+            subtitle: Text(
+              'When off, GIFs show as static thumbnails with a play button.',
+              style: TextStyle(color: context.textMuted, fontSize: 12),
             ),
-            const SizedBox(height: 8),
-            _LayoutOption(
-              label: 'Compact',
-              subtitle: 'Discord-style, all messages left-aligned',
-              icon: Icons.format_align_left_outlined,
-              isSelected:
-                  ref.watch(messageLayoutProvider) == MessageLayout.compact,
-              onTap: () => ref
-                  .read(messageLayoutProvider.notifier)
-                  .setLayout(MessageLayout.compact),
-            ),
-            const SizedBox(height: 24),
-            // GIF autoplay
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Auto-play GIFs',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'When off, GIFs show as static thumbnails with a play button.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: _gifAutoplay,
-              onChanged: _setGifAutoplay,
-            ),
-          ],
-        ),
+            value: _gifAutoplay,
+            onChanged: _setGifAutoplay,
+          ),
+        ],
       ),
     );
   }

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -12,10 +12,12 @@ import '../providers/server_url_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../services/push_token_service.dart';
+import '../services/update_service.dart' as update_svc;
 import '../router/app_router.dart' show pendingDeepLink;
 import '../screens/onboarding_wizard.dart' show kOnboardingCompletedKey;
 import '../theme/echo_theme.dart';
 import '../widgets/echo_logo_icon.dart';
+import '../version.dart';
 
 class SplashScreen extends ConsumerStatefulWidget {
   const SplashScreen({super.key});
@@ -28,6 +30,8 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     with SingleTickerProviderStateMixin {
   late final AnimationController _fadeController;
   late final Animation<double> _fadeAnimation;
+  bool _showUpdatePrompt = false;
+  bool _loggedIn = false;
 
   @override
   void initState() {
@@ -77,6 +81,18 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     }
 
     if (!mounted) return;
+
+    // On desktop, if an update is available, show the update prompt
+    // instead of navigating immediately.
+    final updateState = ref.read(updateProvider);
+    if (!kIsWeb && update_svc.canAutoUpdate && updateState.updateAvailable) {
+      setState(() {
+        _showUpdatePrompt = true;
+        _loggedIn = loggedIn;
+      });
+      return;
+    }
+
     _navigateAfterInit(loggedIn);
   }
 
@@ -106,7 +122,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
 
     // Check for updates on non-web platforms
     if (!kIsWeb) {
-      ref.read(updateProvider.notifier).check();
+      await ref.read(updateProvider.notifier).check();
     }
 
     return loggedIn;
@@ -183,8 +199,135 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     }
   }
 
+  Widget _buildUpdatePrompt(BuildContext context) {
+    final update = ref.watch(updateProvider);
+    final isDownloading = update.status == UpdateStatus.downloading;
+    final isInstalling = update.status == UpdateStatus.installing;
+    final isReady = update.status == UpdateStatus.readyToInstall;
+    final isError = update.status == UpdateStatus.error;
+    final isBusy = isDownloading || isInstalling;
+
+    return Scaffold(
+      backgroundColor: context.mainBg,
+      body: Center(
+        child: FadeTransition(
+          opacity: _fadeAnimation,
+          child: Container(
+            width: 360,
+            padding: const EdgeInsets.all(32),
+            decoration: BoxDecoration(
+              color: context.surface,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: context.border),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const EchoLogoIcon(size: 48),
+                const SizedBox(height: 16),
+                Text(
+                  'Update Available',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                    color: context.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'v$appVersion  ->  v${update.latestVersion}',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: context.textMuted,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+                const SizedBox(height: 24),
+                if (isDownloading) ...[
+                  LinearProgressIndicator(
+                    value: update.downloadProgress,
+                    color: context.accent,
+                    backgroundColor: context.border,
+                    minHeight: 4,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Downloading... ${(update.downloadProgress * 100).toInt()}%',
+                    style: TextStyle(fontSize: 12, color: context.textMuted),
+                  ),
+                ],
+                if (isInstalling)
+                  Text(
+                    'Installing...',
+                    style: TextStyle(fontSize: 12, color: context.textMuted),
+                  ),
+                if (isError) ...[
+                  Text(
+                    update.errorMessage ?? 'Download failed',
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: Colors.redAccent,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                ],
+                if (isReady) ...[
+                  FilledButton.icon(
+                    onPressed: () =>
+                        ref.read(updateProvider.notifier).applyUpdate(),
+                    icon: const Icon(Icons.restart_alt, size: 16),
+                    label: const Text('Restart to Update'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: context.accent,
+                      minimumSize: const Size(double.infinity, 40),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                ],
+                if (!isReady && !isInstalling) ...[
+                  if (!isDownloading)
+                    FilledButton(
+                      onPressed: () =>
+                          ref.read(updateProvider.notifier).downloadUpdate(),
+                      style: FilledButton.styleFrom(
+                        backgroundColor: context.accent,
+                        minimumSize: const Size(double.infinity, 40),
+                      ),
+                      child: const Text('Download Update'),
+                    ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: isBusy
+                        ? null
+                        : () => _navigateAfterInit(_loggedIn),
+                    style: TextButton.styleFrom(
+                      minimumSize: const Size(double.infinity, 40),
+                    ),
+                    child: Text(
+                      'Skip',
+                      style: TextStyle(
+                        color: isBusy
+                            ? context.textMuted.withValues(alpha: 0.4)
+                            : context.textMuted,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    if (_showUpdatePrompt) {
+      return _buildUpdatePrompt(context);
+    }
+
     return Scaffold(
       backgroundColor: context.mainBg,
       body: Center(

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -476,7 +476,16 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
           setState(() => _showDrawingTools = !_showDrawingTools),
       drawingToolsLayerLink: _drawingToolsLayerLink,
       spotlightMode: _spotlightMode,
-      onToggleSpotlight: () => setState(() => _spotlightMode = !_spotlightMode),
+      onToggleSpotlight: () {
+        setState(() {
+          _spotlightMode = !_spotlightMode;
+          // Disable drawing when entering spotlight mode
+          if (_spotlightMode) {
+            _isDrawing = false;
+            _showDrawingTools = false;
+          }
+        });
+      },
     );
 
     final drawingOverlay = LoungeDrawingCanvas(
@@ -501,35 +510,33 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
                     ),
                   ),
                   Column(children: [Expanded(child: contentArea)]),
-                  Positioned.fill(child: drawingOverlay),
+                  if (!_spotlightMode) Positioned.fill(child: drawingOverlay),
                   if (_showDrawingTools)
-                    Positioned.fill(
-                      child: CompositedTransformFollower(
-                        link: _drawingToolsLayerLink,
-                        showWhenUnlinked: false,
-                        targetAnchor: Alignment.topCenter,
-                        followerAnchor: Alignment.bottomCenter,
-                        offset: const Offset(0, -10),
-                        child: Material(
-                          color: Colors.transparent,
-                          child: _DrawingToolsPanel(
-                            child: _DrawingToolsMenu(
-                              drawingCanvasKey: _drawingCanvasKey,
-                              onToggleDrawing: () {
-                                setState(() => _isDrawing = !_isDrawing);
-                              },
-                              isDrawing: _isDrawing,
-                              conversationId: conversationId,
-                              onRequestClose: () =>
-                                  setState(() => _showDrawingTools = false),
-                            ),
+                    CompositedTransformFollower(
+                      link: _drawingToolsLayerLink,
+                      showWhenUnlinked: false,
+                      targetAnchor: Alignment.topCenter,
+                      followerAnchor: Alignment.bottomCenter,
+                      offset: const Offset(0, -10),
+                      child: Material(
+                        color: Colors.transparent,
+                        child: _DrawingToolsPanel(
+                          child: _DrawingToolsMenu(
+                            drawingCanvasKey: _drawingCanvasKey,
+                            onToggleDrawing: () {
+                              setState(() => _isDrawing = !_isDrawing);
+                            },
+                            isDrawing: _isDrawing,
+                            conversationId: conversationId,
+                            onRequestClose: () =>
+                                setState(() => _showDrawingTools = false),
                           ),
                         ),
                       ),
                     ),
                   Positioned(bottom: 16, left: 0, right: 0, child: dock),
                   Positioned(
-                    top: 12,
+                    top: 16,
                     left: 60,
                     child: _buildHeaderBadge(
                       context,
@@ -567,28 +574,26 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
                     const SizedBox(height: 80),
                   ],
                 ),
-                Positioned.fill(child: drawingOverlay),
+                if (!_spotlightMode) Positioned.fill(child: drawingOverlay),
                 if (_showDrawingTools)
-                  Positioned.fill(
-                    child: CompositedTransformFollower(
-                      link: _drawingToolsLayerLink,
-                      showWhenUnlinked: false,
-                      targetAnchor: Alignment.topCenter,
-                      followerAnchor: Alignment.bottomCenter,
-                      offset: const Offset(0, -10),
-                      child: Material(
-                        color: Colors.transparent,
-                        child: _DrawingToolsPanel(
-                          child: _DrawingToolsMenu(
-                            drawingCanvasKey: _drawingCanvasKey,
-                            onToggleDrawing: () {
-                              setState(() => _isDrawing = !_isDrawing);
-                            },
-                            isDrawing: _isDrawing,
-                            conversationId: conversationId,
-                            onRequestClose: () =>
-                                setState(() => _showDrawingTools = false),
-                          ),
+                  CompositedTransformFollower(
+                    link: _drawingToolsLayerLink,
+                    showWhenUnlinked: false,
+                    targetAnchor: Alignment.topCenter,
+                    followerAnchor: Alignment.bottomCenter,
+                    offset: const Offset(0, -10),
+                    child: Material(
+                      color: Colors.transparent,
+                      child: _DrawingToolsPanel(
+                        child: _DrawingToolsMenu(
+                          drawingCanvasKey: _drawingCanvasKey,
+                          onToggleDrawing: () {
+                            setState(() => _isDrawing = !_isDrawing);
+                          },
+                          isDrawing: _isDrawing,
+                          conversationId: conversationId,
+                          onRequestClose: () =>
+                              setState(() => _showDrawingTools = false),
                         ),
                       ),
                     ),
@@ -1322,17 +1327,18 @@ class _FloatingDock extends ConsumerWidget {
                   ),
                 ],
               ),
-            // ── Draw toggle + 3-dot (tools) ──
-            _DockButtonWithSubmenu(
-              icon: Icons.edit,
-              tooltip: isDrawing ? 'Stop drawing' : 'Draw',
-              isActive: isDrawing,
-              activeColor: context.accent,
-              onPressed: onToggleDrawing,
-              onSubmenuTap: onToggleDrawingTools,
-              submenuActive: showDrawingTools,
-              submenuLayerLink: drawingToolsLayerLink,
-            ),
+            // ── Draw toggle + 3-dot (tools) ── (hidden in spotlight mode)
+            if (!spotlightMode)
+              _DockButtonWithSubmenu(
+                icon: Icons.edit,
+                tooltip: isDrawing ? 'Stop drawing' : 'Draw',
+                isActive: isDrawing,
+                activeColor: context.accent,
+                onPressed: onToggleDrawing,
+                onSubmenuTap: onToggleDrawingTools,
+                submenuActive: showDrawingTools,
+                submenuLayerLink: drawingToolsLayerLink,
+              ),
             _dockDivider(context),
             // ── Deafen (tap only) ──
             _buildDockItem(
@@ -2488,7 +2494,7 @@ class _DraggableScreenShareWindowState
               width: _width,
               height: _height,
               decoration: BoxDecoration(
-                color: Colors.black,
+                color: Colors.black.withValues(alpha: 0.85),
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(
                   color: (widget.isLocal ? EchoTheme.danger : EchoTheme.accent)

--- a/apps/client/lib/src/utils/clipboard_image_helper_io.dart
+++ b/apps/client/lib/src/utils/clipboard_image_helper_io.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
 const _mimeImagePng = 'image/png';
@@ -154,4 +154,74 @@ Future<ClipboardImageData?> _readMacOSClipboard() async {
     mimeType: _mimeImagePng,
     fileName: 'clipboard_image.png',
   );
+}
+
+/// Write image bytes to the system clipboard.
+Future<bool> writeImageToClipboard(Uint8List bytes, String mimeType) async {
+  try {
+    if (Platform.isLinux) {
+      return _writeLinuxClipboard(bytes, mimeType);
+    } else if (Platform.isWindows) {
+      return _writeWindowsClipboard(bytes);
+    } else if (Platform.isMacOS) {
+      return _writeMacOSClipboard(bytes);
+    }
+  } catch (e) {
+    debugPrint('[Clipboard] writeImageToClipboard failed: $e');
+  }
+  return false;
+}
+
+Future<bool> _writeLinuxClipboard(Uint8List bytes, String mimeType) async {
+  final process = await Process.start('xclip', [
+    '-selection',
+    'clipboard',
+    '-t',
+    mimeType,
+  ]);
+  process.stdin.add(bytes);
+  await process.stdin.close();
+  final exitCode = await process.exitCode;
+  return exitCode == 0;
+}
+
+Future<bool> _writeWindowsClipboard(Uint8List bytes) async {
+  final tempDir = await getTemporaryDirectory();
+  final tempPath = '${tempDir.path}\\clipboard_write.png';
+  await File(tempPath).writeAsBytes(bytes);
+
+  final result = await Process.run('powershell', [
+    '-NoProfile',
+    '-Command',
+    '''
+    Add-Type -AssemblyName System.Windows.Forms
+    \$img = [System.Drawing.Image]::FromFile("$tempPath")
+    [System.Windows.Forms.Clipboard]::SetImage(\$img)
+    \$img.Dispose()
+    Write-Output "ok"
+    ''',
+  ]);
+
+  try {
+    await File(tempPath).delete();
+  } catch (_) {}
+
+  return result.exitCode == 0 && (result.stdout as String).contains('ok');
+}
+
+Future<bool> _writeMacOSClipboard(Uint8List bytes) async {
+  final tempDir = await getTemporaryDirectory();
+  final tempPath = '${tempDir.path}/clipboard_write.png';
+  await File(tempPath).writeAsBytes(bytes);
+
+  final result = await Process.run('osascript', [
+    '-e',
+    'set the clipboard to (read (POSIX file "$tempPath") as «class PNGf»)',
+  ]);
+
+  try {
+    await File(tempPath).delete();
+  } catch (_) {}
+
+  return result.exitCode == 0;
 }

--- a/apps/client/lib/src/utils/clipboard_image_helper_stub.dart
+++ b/apps/client/lib/src/utils/clipboard_image_helper_stub.dart
@@ -15,3 +15,7 @@ class ClipboardImageData {
 Future<ClipboardImageData?> readImageFromClipboard() async {
   return null;
 }
+
+Future<bool> writeImageToClipboard(Uint8List bytes, String mimeType) async {
+  return false;
+}

--- a/apps/client/lib/src/utils/clipboard_image_helper_web.dart
+++ b/apps/client/lib/src/utils/clipboard_image_helper_web.dart
@@ -52,3 +52,19 @@ Future<ClipboardImageData?> readImageFromClipboard() async {
   }
   return null;
 }
+
+Future<bool> writeImageToClipboard(Uint8List bytes, String mimeType) async {
+  try {
+    final clipboard = web.window.navigator.clipboard;
+    final blob = web.Blob(
+      [bytes.toJS].toJS,
+      web.BlobPropertyBag(type: mimeType),
+    );
+    final item = web.ClipboardItem({mimeType: blob}.jsify() as JSObject);
+    await clipboard.write([item].toJS).toDart;
+    return true;
+  } catch (_) {
+    // Clipboard API not available or permission denied
+  }
+  return false;
+}

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -18,6 +18,7 @@ class ChannelBar extends ConsumerStatefulWidget {
   final bool hideVoiceDock;
   final ValueChanged<String?> onTextChannelChanged;
   final ValueChanged<String?> onVoiceChannelChanged;
+  final VoidCallback? onShowLounge;
 
   const ChannelBar({
     super.key,
@@ -27,6 +28,7 @@ class ChannelBar extends ConsumerStatefulWidget {
     this.hideVoiceDock = false,
     required this.onTextChannelChanged,
     required this.onVoiceChannelChanged,
+    this.onShowLounge,
   });
 
   @override
@@ -264,7 +266,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     VoiceSettingsState voiceSettings,
   ) async {
     if (isActive) {
-      await _leaveVoiceChannel(channel.id);
+      widget.onShowLounge?.call();
       return;
     }
     final shouldJoin = await _confirmVoiceJoin(channel.name);

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -37,6 +37,7 @@ class ChatPanel extends ConsumerStatefulWidget {
   final VoidCallback? onMembersToggle;
   final VoidCallback? onGroupInfo;
   final VoidCallback? onBack;
+  final VoidCallback? onShowLounge;
   final bool hideVoiceDock;
 
   const ChatPanel({
@@ -45,6 +46,7 @@ class ChatPanel extends ConsumerStatefulWidget {
     this.onMembersToggle,
     this.onGroupInfo,
     this.onBack,
+    this.onShowLounge,
     this.hideVoiceDock = false,
   });
 
@@ -1437,6 +1439,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
                       setState(() => _activeVoiceChannelId = channelId);
                     }
                   },
+                  onShowLounge: widget.onShowLounge,
                 ),
 
               if (_showSearch)

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -13,6 +13,7 @@ import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
 import '../utils/download_helper.dart';
+import '../utils/clipboard_image_helper.dart' show writeImageToClipboard;
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart' show buildAvatar, avatarColor;
 import 'message/media_content.dart';
@@ -208,6 +209,59 @@ class _MessageItemState extends State<MessageItem> {
     }
   }
 
+  /// Fetch image bytes from the server and copy them to the system clipboard.
+  Future<void> _copyImageToClipboard(String rawUrl) async {
+    final url = _resolveUrl(rawUrl);
+    try {
+      final response = await http.get(Uri.parse(url), headers: _mediaHeaders());
+      if (!mounted) return;
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        ToastService.show(
+          context,
+          'Failed to copy image',
+          type: ToastType.error,
+        );
+        return;
+      }
+
+      final contentType = response.headers['content-type'] ?? 'image/png';
+      final success = await writeImageToClipboard(
+        response.bodyBytes,
+        contentType,
+      );
+      if (!mounted) return;
+
+      if (success) {
+        ToastService.show(context, 'Image copied', type: ToastType.success);
+      } else {
+        // Fallback: copy the URL if image clipboard write not supported
+        Clipboard.setData(ClipboardData(text: url));
+        ToastService.show(
+          context,
+          'Image copy not supported, link copied',
+          type: ToastType.info,
+        );
+      }
+    } catch (_) {
+      if (!mounted) return;
+      ToastService.show(context, 'Failed to copy image', type: ToastType.error);
+    }
+  }
+
+  /// Returns true if the media message contains an image (not video/file).
+  bool _isImageMedia(String content, String mediaUrl) {
+    if (content.trimLeft().startsWith('[img:')) return true;
+    if (isImageUrl(mediaUrl)) return true;
+    // API media URLs without extension -- check content-type prefix
+    final lower = mediaUrl.toLowerCase();
+    if (lower.contains('/api/media/') &&
+        !content.startsWith('[video:') &&
+        !content.startsWith('[file:')) {
+      return true;
+    }
+    return false;
+  }
+
   /// Shows a bottom action sheet for mobile users (replaces hover actions).
   void _showMobileActionSheet(
     BuildContext context,
@@ -307,6 +361,7 @@ class _MessageItemState extends State<MessageItem> {
     required bool isMine,
     required String? mediaUrl,
   }) {
+    final isImage = mediaUrl != null && _isImageMedia(msg.content, mediaUrl);
     return [
       if (widget.onReply != null)
         _actionTile(
@@ -314,6 +369,13 @@ class _MessageItemState extends State<MessageItem> {
           icon: Icons.reply_outlined,
           label: 'Reply',
           onTap: () => widget.onReply?.call(msg),
+        ),
+      if (isImage)
+        _actionTile(
+          sheetContext: sheetContext,
+          icon: Icons.image_outlined,
+          label: 'Copy image',
+          onTap: () => _copyImageToClipboard(mediaUrl),
         ),
       _actionTile(
         sheetContext: sheetContext,
@@ -481,6 +543,7 @@ class _MessageItemState extends State<MessageItem> {
   }
 
   Widget _buildHoverActions(ChatMessage msg, bool isMine, {String? mediaUrl}) {
+    final isImage = mediaUrl != null && _isImageMedia(msg.content, mediaUrl);
     return Container(
       decoration: BoxDecoration(
         color: context.surface.withValues(alpha: 0.95),
@@ -490,9 +553,15 @@ class _MessageItemState extends State<MessageItem> {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (isImage)
+            _HoverActionButton(
+              icon: Icons.image_outlined,
+              tooltip: 'Copy image',
+              onPressed: () => _copyImageToClipboard(mediaUrl),
+            ),
           _HoverActionButton(
             icon: Icons.copy_outlined,
-            tooltip: 'Copy',
+            tooltip: mediaUrl != null ? 'Copy link' : 'Copy',
             onPressed: () {
               final copyText = mediaUrl != null
                   ? _resolveUrl(mediaUrl)
@@ -500,7 +569,7 @@ class _MessageItemState extends State<MessageItem> {
               Clipboard.setData(ClipboardData(text: copyText));
               ToastService.show(
                 context,
-                mediaUrl != null ? 'Media URL copied' : 'Copied to clipboard',
+                mediaUrl != null ? 'Link copied' : 'Copied to clipboard',
                 type: ToastType.success,
               );
             },


### PR DESCRIPTION
- Copy image bytes to system clipboard instead of media URL
- Add platform-specific writeImageToClipboard (Linux/Windows/macOS/Web)
- Show 'Copy image' action for image messages in hover and mobile menus
- Add desktop update notification on splash screen
- Fix voice lounge button returning to call instead of hanging up