### PR TITLE
feat: iOS push notifications visible anytime

### DIFF
--- a/apps/client/ios/EchoNotificationService/Info.plist
+++ b/apps/client/ios/EchoNotificationService/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>EchoNotificationService</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/client/ios/EchoNotificationService/NotificationService.swift
+++ b/apps/client/ios/EchoNotificationService/NotificationService.swift
@@ -1,0 +1,36 @@
+import UserNotifications
+
+/// Notification Service Extension that processes push notifications before
+/// display.  Runs in its own process -- works even when the main app is killed.
+///
+/// Currently passes the notification through unchanged.  Future: decrypt
+/// E2E message content via shared Keychain keys.
+class NotificationService: UNNotificationServiceExtension {
+  private var contentHandler: ((UNNotificationContent) -> Void)?
+  private var bestAttemptContent: UNMutableNotificationContent?
+
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+  ) {
+    self.contentHandler = contentHandler
+    bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent
+
+    guard let content = bestAttemptContent else {
+      contentHandler(request.content)
+      return
+    }
+
+    // Future: decrypt content here using shared Keychain group keys.
+    // For now, pass through the server-provided alert as-is.
+
+    contentHandler(content)
+  }
+
+  override func serviceExtensionTimeWillExpire() {
+    // Deliver whatever we have before iOS kills the extension.
+    if let contentHandler, let content = bestAttemptContent {
+      contentHandler(content)
+    }
+  }
+}

--- a/apps/client/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/client/ios/Runner.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		A3FD0A1886AE58FDF2263EA4 /* SampleHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141F900B95493FBC8B63E07A /* SampleHandler.swift */; };
+		4736B3517066C0C6EEAC91DB /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AC57F58986F4AA941050F0 /* NotificationService.swift */; };
+		84D05A6DBECC6C1400B7EA05 /* EchoNotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 23471BB121DC2FFCAEEA6699 /* EchoNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +62,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				8F5C7F9E4CFB17946DE7BA6C /* EchoBroadcast.appex in Embed App Extensions */,
+				84D05A6DBECC6C1400B7EA05 /* EchoNotificationService.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -94,6 +97,9 @@
 		DA3FE96054002B2C7BD612A1 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EBCD54E940CB45F3BB173CE1 /* DarwinNotificationCenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DarwinNotificationCenter.swift; sourceTree = "<group>"; };
 		EEF192E556A681293FF0B911 /* Atomic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
+		C3AC57F58986F4AA941050F0 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		71215A22399C81E41C1FE3C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		23471BB121DC2FFCAEEA6699 /* EchoNotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = EchoNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +113,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D98341ECB8666DFB27486275 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -167,6 +180,7 @@
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				5A31BDF554970E949936D9BC /* Frameworks */,
 				5AC0AEEC9CAAF2FBF4987370 /* EchoBroadcast */,
+				F0119322C17FD5E0D01EEE00 /* EchoNotificationService */,
 			);
 			sourceTree = "<group>";
 		};
@@ -176,6 +190,7 @@
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
 				B717969E2D295AC29E2C65F9 /* EchoBroadcast.appex */,
+				23471BB121DC2FFCAEEA6699 /* EchoNotificationService.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -204,6 +219,15 @@
 				8F9EA70E4D226FAFFEFD48F9 /* ReplayKit.framework */,
 			);
 			name = iOS;
+			sourceTree = "<group>";
+		};
+		F0119322C17FD5E0D01EEE00 /* EchoNotificationService */ = {
+			isa = PBXGroup;
+			children = (
+				C3AC57F58986F4AA941050F0 /* NotificationService.swift */,
+				71215A22399C81E41C1FE3C8 /* Info.plist */,
+			);
+			path = EchoNotificationService;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -265,6 +289,22 @@
 			productReference = B717969E2D295AC29E2C65F9 /* EchoBroadcast.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		37AC53F8EA9FAEC440A2A411 /* EchoNotificationService */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 99A57CDCBF5B4581340E7DDE /* Build configuration list for PBXNativeTarget "EchoNotificationService" */;
+			buildPhases = (
+				DF00175BFFF8D855FE0DD3B7 /* Sources */,
+				D98341ECB8666DFB27486275 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = EchoNotificationService;
+			productName = EchoNotificationService;
+			productReference = 23471BB121DC2FFCAEEA6699 /* EchoNotificationService.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -301,6 +341,7 @@
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
 				A5D403A3DA4906BB298899D1 /* EchoBroadcast */,
+				37AC53F8EA9FAEC440A2A411 /* EchoNotificationService */,
 			);
 		};
 /* End PBXProject section */
@@ -395,6 +436,14 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DF00175BFFF8D855FE0DD3B7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4736B3517066C0C6EEAC91DB /* NotificationService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -785,6 +834,51 @@
 			};
 			name = Release;
 		};
+		1C6A901CAD75CAD9474AE197 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = EchoNotificationService/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				CODE_SIGN_STYLE = Automatic;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8626D0C3212016E97E2F2263 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = EchoNotificationService/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				CODE_SIGN_STYLE = Automatic;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		E9F282614FEC5BC2200A524E /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = EchoNotificationService/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				CODE_SIGN_STYLE = Automatic;
+				SKIP_INSTALL = YES;
+			};
+			name = Profile;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -824,6 +918,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		99A57CDCBF5B4581340E7DDE /* Build configuration list for PBXNativeTarget "EchoNotificationService" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1C6A901CAD75CAD9474AE197 /* Debug */,
+				8626D0C3212016E97E2F2263 /* Release */,
+				E9F282614FEC5BC2200A524E /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/client/ios/Runner/AppDelegate.swift
+++ b/apps/client/ios/Runner/AppDelegate.swift
@@ -59,6 +59,18 @@ import UserNotifications
     NSLog("[Echo] APNs registration failed: \(error.localizedDescription)")
   }
 
+  // MARK: - Foreground Notification Display
+
+  /// Show push notifications even when the app is in the foreground.
+  /// Without this, iOS suppresses the visible banner for foreground apps.
+  override func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.banner, .sound, .badge])
+  }
+
   // MARK: - Silent Push Handling
 
   override func application(

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn encrypted_message_returns_placeholder() {
-        assert_eq!(format_push_body("secret stuff", true), "Encrypted message");
+        assert_eq!(format_push_body("secret stuff", true), "New message");
     }
 
     #[test]
@@ -365,9 +365,6 @@ mod tests {
 
     #[test]
     fn encrypted_with_long_content_still_returns_placeholder() {
-        assert_eq!(
-            format_push_body(&"x".repeat(200), true),
-            "Encrypted message"
-        );
+        assert_eq!(format_push_body(&"x".repeat(200), true), "New message");
     }
 }

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -202,7 +202,7 @@ fn format_push_body(content: &str, is_encrypted: bool) -> String {
     const MAX_PREVIEW_BYTES: usize = 140;
 
     if is_encrypted {
-        "Encrypted message".to_string()
+        "New message".to_string()
     } else if content.len() > MAX_PREVIEW_BYTES {
         let end = content.floor_char_boundary(MAX_PREVIEW_BYTES);
         format!("{}...", &content[..end])
@@ -213,12 +213,13 @@ fn format_push_body(content: &str, is_encrypted: bool) -> String {
 
 /// Send an APNs push notification to an iOS device.
 ///
-/// - **Encrypted DMs**: Shows "Encrypted message" as the body (server can't
+/// - **Encrypted DMs**: Shows "New message" as the body (server can't
 ///   read the ciphertext). The sender name is always visible.
 /// - **Plaintext messages**: Shows a truncated preview of the actual content.
 ///
-/// Also includes `content-available: 1` so the app wakes in the background
-/// and reconnects the WebSocket to fetch the full message.
+/// Uses `mutable-content: 1` so a Notification Service Extension can modify
+/// the payload before display.  Also includes `content-available: 1` to wake
+/// the app for WebSocket reconnect.
 async fn send_apns_push(p: ApnsPushParams<'_>) {
     let config = match get_apns_config() {
         Some(c) => c,
@@ -233,7 +234,12 @@ async fn send_apns_push(p: ApnsPushParams<'_>) {
         }
     };
 
-    let url = format!("https://api.push.apple.com/3/device/{}", p.device_token);
+    let host = if std::env::var("APNS_SANDBOX").is_ok() {
+        "api.sandbox.push.apple.com"
+    } else {
+        "api.push.apple.com"
+    };
+    let url = format!("https://{host}/3/device/{}", p.device_token);
 
     let body = format_push_body(p.content, p.is_encrypted);
 
@@ -246,6 +252,7 @@ async fn send_apns_push(p: ApnsPushParams<'_>) {
             "sound": "default",
             "badge": 1,
             "thread-id": p.conversation_id.to_string(),
+            "mutable-content": 1,
             "content-available": 1,
         },
         "conversation_id": p.conversation_id.to_string(),


### PR DESCRIPTION
## Summary
- Add APNs sandbox/production routing (`APNS_SANDBOX` env var) -- fixes development push delivery
- Add `mutable-content: 1` to APNs payload for Notification Service Extension support
- Add `willPresent` handler in AppDelegate so notifications show in foreground
- Add `EchoNotificationService` extension target for notifications when app is killed
- Change encrypted message body from "Encrypted message" to "New message" (matches Signal/WhatsApp)

## Root cause
iOS notifications only appeared when the app was open because:
1. No `willPresent` handler to show notifications in foreground
2. No Notification Service Extension to process notifications when app is killed
3. Hardcoded production APNs endpoint -- dev builds silently dropped by Apple
4. `content-available: 1` without visible alert infrastructure

## Test plan
- [ ] Set `APNS_SANDBOX=1` on dev server, verify push arrives on dev-signed iOS build
- [ ] Background the app, send message -- notification banner appears
- [ ] Kill the app, send message -- notification banner appears (via extension)
- [ ] Open the app, send message -- notification banner appears (via willPresent)
- [ ] Verify "New message" body text for encrypted DMs