### PR TITLE
fix(client): notification extension signing for ios ci

### DIFF
--- a/apps/client/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/client/ios/Runner.xcodeproj/project.pbxproj
@@ -837,45 +837,48 @@
 		1C6A901CAD75CAD9474AE197 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = TEAM_ID_PLACEHOLDER;
 				INFOPLIST_FILE = EchoNotificationService/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				CODE_SIGN_STYLE = Automatic;
-				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		8626D0C3212016E97E2F2263 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = TEAM_ID_PLACEHOLDER;
 				INFOPLIST_FILE = EchoNotificationService/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				CODE_SIGN_STYLE = Automatic;
-				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
 		E9F282614FEC5BC2200A524E /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = TEAM_ID_PLACEHOLDER;
 				INFOPLIST_FILE = EchoNotificationService/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				CODE_SIGN_STYLE = Automatic;
-				SKIP_INSTALL = YES;
 			};
 			name = Profile;
 		};

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -10,6 +10,10 @@ services:
       SERVER_PORT: 8080
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY}
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET}
+      APNS_KEY_ID: ${APNS_KEY_ID}
+      APNS_TEAM_ID: ${APNS_TEAM_ID}
+      APNS_AUTH_KEY_BASE64: ${APNS_AUTH_KEY_BASE64}
+      APNS_TOPIC: ${APNS_TOPIC:-us.echomessenger.app}
     volumes:
       - uploads:/app/uploads
     depends_on:


### PR DESCRIPTION
## Summary
- Add `DEVELOPMENT_TEAM = TEAM_ID_PLACEHOLDER` to EchoNotificationService build configs (Debug/Release/Profile)
- Fixes iOS CI build failure: "Signing for EchoNotificationService requires a development team"

One-line fix for the CI failure from PR #438.