### PR TITLE
fix(ci): ios notification extension signing and apns config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,16 +289,19 @@ jobs:
           IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
           IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
           IOS_BROADCAST_PROFILE_BASE64: ${{ secrets.IOS_BROADCAST_PROFILE_BASE64 }}
+          IOS_NOTIFICATION_SERVICE_PROFILE_BASE64: ${{ secrets.IOS_NOTIFICATION_SERVICE_PROFILE_BASE64 }}
         run: |
           CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
           PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
           BROADCAST_PP_PATH=$RUNNER_TEMP/build_broadcast_pp.mobileprovision
+          NOTIF_PP_PATH=$RUNNER_TEMP/build_notif_pp.mobileprovision
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
 
           echo "$IOS_CERTIFICATE_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
           echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PP_PATH"
           echo "$IOS_BROADCAST_PROFILE_BASE64" | base64 --decode > "$BROADCAST_PP_PATH"
+          echo "$IOS_NOTIFICATION_SERVICE_PROFILE_BASE64" | base64 --decode > "$NOTIF_PP_PATH"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
@@ -321,6 +324,11 @@ jobs:
           BROADCAST_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< \
             $(security cms -D -i "$BROADCAST_PP_PATH"))
           cp "$BROADCAST_PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${BROADCAST_UUID}.mobileprovision
+
+          # Install notification service extension provisioning profile
+          NOTIF_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< \
+            $(security cms -D -i "$NOTIF_PP_PATH"))
+          cp "$NOTIF_PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${NOTIF_UUID}.mobileprovision
       - name: Set up App Store Connect API key
         env:
           ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}

--- a/apps/client/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/client/ios/Runner.xcodeproj/project.pbxproj
@@ -840,7 +840,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = TEAM_ID_PLACEHOLDER;
 				INFOPLIST_FILE = EchoNotificationService/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -853,32 +853,42 @@
 		8626D0C3212016E97E2F2263 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = TEAM_ID_PLACEHOLDER;
 				INFOPLIST_FILE = EchoNotificationService/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Echo Notification Service Distribution";
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
 		E9F282614FEC5BC2200A524E /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = TEAM_ID_PLACEHOLDER;
 				INFOPLIST_FILE = EchoNotificationService/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Echo Notification Service Distribution";
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
 		};


### PR DESCRIPTION
## Summary
- Switch EchoNotificationService Release/Profile to manual signing (matches EchoBroadcast pattern)
- Add `PROVISIONING_PROFILE_SPECIFIER = "Echo Notification Service Distribution"` 
- Install `IOS_NOTIFICATION_SERVICE_PROFILE_BASE64` provisioning profile in CI
- Pass APNs env vars through docker-compose.prod.yml to server container

Fixes the iOS CI build failure from #438/#439.