### PR TITLE
fix(client): notification extension bundle id mismatch

### DIFF
--- a/apps/client/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/client/ios/Runner.xcodeproj/project.pbxproj
@@ -842,7 +842,7 @@
 				INFOPLIST_FILE = EchoNotificationService/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
+				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.notification-service;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
@@ -860,7 +860,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
+				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.notification-service;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Echo Notification Service Distribution";
 				SDKROOT = iphoneos;
@@ -881,7 +881,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.EchoNotificationService;
+				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app.notification-service;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Echo Notification Service Distribution";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary
Fix iOS build failure: bundle ID `us.echomessenger.app.EchoNotificationService` didn't match provisioning profile's `us.echomessenger.app.notification-service`.

One-line fix across 3 occurrences in project.pbxproj.