### PR TITLE
fix(ci): add notification extension to ipa export options

### DIFF
--- a/apps/client/ios/ExportOptions.plist
+++ b/apps/client/ios/ExportOptions.plist
@@ -14,6 +14,8 @@
 		<string>Echo App Store Distribution</string>
 		<key>us.echomessenger.app.broadcast</key>
 		<string>Echo Broadcast Distribution</string>
+		<key>us.echomessenger.app.notification-service</key>
+		<string>Echo Notification Service Distribution</string>
 	</dict>
 	<key>signingCertificate</key>
 	<string>Apple Distribution</string>


### PR DESCRIPTION
Add `us.echomessenger.app.notification-service` -> `Echo Notification Service Distribution` mapping to ExportOptions.plist. Without this, the IPA export silently fails and the Rename IPA step can't find the file.