### PR TITLE
refactor(server): split ws handler into message and typing services

### DIFF
--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -16,7 +16,7 @@ use crate::auth::middleware::AuthUser;
 use crate::db;
 use crate::error::AppError;
 use crate::types::{ConversationKind, Role};
-use crate::ws::handler::invalidate_member_cache;
+use crate::ws::typing_service::invalidate_member_cache;
 
 use super::AppState;
 

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -13,7 +13,7 @@ use crate::auth::middleware::AuthUser;
 use crate::db;
 use crate::error::AppError;
 use crate::types::{ConversationKind, Role};
-use crate::ws::handler::invalidate_member_cache;
+use crate::ws::typing_service::invalidate_member_cache;
 
 use super::AppState;
 

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -2,12 +2,10 @@
 
 use axum::extract::ws::{Message as WsMessage, WebSocket};
 use chrono::{DateTime, Utc};
-use dashmap::DashMap;
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::Instant;
@@ -16,23 +14,8 @@ use uuid::Uuid;
 use crate::db;
 use crate::routes::AppState;
 use crate::types::ConversationKind;
-
-/// In-memory cache for conversation membership checks used by the typing
-/// indicator path.  Keyed by (user_id, conversation_id), stores the
-/// tokio::time::Instant when membership was last verified.  Entries older
-/// than `MEMBERSHIP_CACHE_TTL` are treated as expired and re-verified
-/// against the database.
-static MEMBERSHIP_CACHE: LazyLock<DashMap<(Uuid, Uuid), Instant>> = LazyLock::new(DashMap::new);
-const MEMBERSHIP_CACHE_TTL: Duration = Duration::from_secs(60);
-
-/// Cached conversation member IDs.  Keyed by conversation_id, stores the
-/// member list and the instant it was fetched.  Same TTL as membership cache.
-static MEMBER_IDS_CACHE: LazyLock<DashMap<Uuid, (Vec<Uuid>, Instant)>> =
-    LazyLock::new(DashMap::new);
-
-/// Cached conversation kind (e.g. "dm", "group").  Avoids a DB hit on every
-/// typing indicator for the same conversation.
-static CONV_KIND_CACHE: LazyLock<DashMap<Uuid, (String, Instant)>> = LazyLock::new(DashMap::new);
+use crate::ws::message_service;
+use crate::ws::typing_service;
 
 #[derive(Deserialize)]
 #[serde(tag = "type")]
@@ -204,7 +187,7 @@ pub async fn handle_socket(
     state.hub.register(user_id, device_id, tx);
 
     // Broadcast online presence to contacts
-    broadcast_presence(&state, user_id, &username, "online").await;
+    typing_service::broadcast_presence(&state, user_id, &username, "online").await;
 
     // Task: forward hub messages to WebSocket sink
     let send_task = tokio::spawn(async move {
@@ -247,7 +230,7 @@ pub async fn handle_socket(
         }
     });
 
-    deliver_undelivered_messages(&state, user_id, device_id).await;
+    message_service::deliver_undelivered_messages(&state, user_id, device_id).await;
 
     run_receive_loop(&mut receiver, user_id, device_id, &username, &state).await;
 
@@ -259,78 +242,9 @@ pub async fn handle_socket(
     cleanup_user_voice_sessions(&state, user_id).await;
 
     // Broadcast offline presence to contacts
-    broadcast_presence(&state, user_id, &username, "offline").await;
+    typing_service::broadcast_presence(&state, user_id, &username, "offline").await;
 
     tracing::info!("WebSocket disconnected: {} ({})", username, user_id);
-}
-
-/// Deliver any messages that were stored while the user was offline, then mark
-/// them delivered and notify the original senders.
-///
-/// For encrypted DMs, each device has its own ciphertext stored in
-/// `message_device_contents`.  A single batch query fetches all per-device
-/// ciphertexts for the reconnecting device; the canonical `content` column is
-/// used as a fallback when no device-specific row exists (group messages,
-/// unencrypted convs, or messages predating multi-device support).
-async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid, device_id: i32) {
-    let undelivered = match db::messages::get_undelivered(&state.pool, user_id).await {
-        Ok(msgs) => msgs,
-        Err(_) => return,
-    };
-
-    let ids: Vec<Uuid> = undelivered.iter().map(|m| m.id).collect();
-
-    // Batch-fetch all per-device ciphertexts in a single query to avoid N+1.
-    let device_ct_map = db::messages::get_device_contents_batch(&state.pool, &ids, device_id)
-        .await
-        .unwrap_or_default();
-
-    for msg in &undelivered {
-        // Prefer device-specific ciphertext; fall back to canonical content.
-        let content = device_ct_map
-            .get(&msg.id)
-            .cloned()
-            .unwrap_or_else(|| msg.content.clone());
-
-        let server_msg = ServerMessage::NewMessage {
-            message_id: msg.id,
-            from_user_id: msg.sender_id,
-            from_device_id: None, // Offline delivery doesn't track sender device
-            from_username: msg.sender_username.clone(),
-            conversation_id: msg.conversation_id,
-            channel_id: msg.channel_id,
-            content,
-            timestamp: msg.created_at,
-            reply_to_id: msg.reply_to_id,
-            reply_to_content: msg.reply_to_content.clone(),
-            reply_to_username: msg.reply_to_username.clone(),
-            expires_at: None, // Offline delivery: expiry already passed if expired
-        };
-        if let Ok(json) = serde_json::to_string(&server_msg) {
-            state
-                .hub
-                .send_to_device(&user_id, device_id, WsMessage::Text(json.into()));
-        }
-    }
-
-    if ids.is_empty() {
-        return;
-    }
-
-    let _ = db::messages::mark_delivered(&state.pool, &ids).await;
-
-    // Notify original senders that their messages were delivered
-    for msg in &undelivered {
-        let delivered_event = ServerMessage::Delivered {
-            message_id: msg.id,
-            conversation_id: msg.conversation_id,
-        };
-        if let Ok(json) = serde_json::to_string(&delivered_event) {
-            state
-                .hub
-                .send_to(&msg.sender_id, WsMessage::Text(json.into()));
-        }
-    }
 }
 
 /// Rate-limited WebSocket receive loop.
@@ -481,7 +395,7 @@ async fn cleanup_user_voice_sessions(state: &AppState, user_id: Uuid) {
         };
 
     for (channel_id, conversation_id) in removed_sessions {
-        let member_ids = get_member_ids_cached(&state.pool, conversation_id).await;
+        let member_ids = typing_service::get_member_ids_cached(&state.pool, conversation_id).await;
         if let Ok(member_ids) = member_ids {
             let event = serde_json::json!({
                 "type": "voice_session_left",
@@ -540,7 +454,7 @@ async fn handle_text_message(
             device_contents,
             ttl_seconds,
         } => {
-            handle_send_message(
+            message_service::handle_send_message(
                 state,
                 sender_id,
                 sender_device_id,
@@ -559,7 +473,7 @@ async fn handle_text_message(
             conversation_id,
             channel_id,
         } => {
-            handle_typing(
+            typing_service::handle_typing(
                 state,
                 sender_id,
                 sender_username,
@@ -569,7 +483,7 @@ async fn handle_text_message(
             .await;
         }
         ClientMessage::ReadReceipt { conversation_id } => {
-            handle_read_receipt(state, sender_id, conversation_id).await;
+            typing_service::handle_read_receipt(state, sender_id, conversation_id).await;
         }
         ClientMessage::VoiceSignal {
             conversation_id,
@@ -636,791 +550,17 @@ async fn handle_broadcast_event<F>(
 ) where
     F: FnOnce(Uuid, String, Uuid) -> ServerMessage,
 {
-    if !check_membership_cached(&state.pool, conversation_id, sender_id).await {
+    if !typing_service::check_membership_cached(&state.pool, conversation_id, sender_id).await {
         return;
     }
 
-    let member_ids = match get_member_ids_cached(&state.pool, conversation_id).await {
+    let member_ids = match typing_service::get_member_ids_cached(&state.pool, conversation_id).await
+    {
         Ok(ids) => ids,
         Err(_) => return,
     };
 
     let event = build_event(sender_id, sender_username.to_string(), conversation_id);
-    if let Ok(json) = serde_json::to_string(&event) {
-        state
-            .hub
-            .broadcast_json(&member_ids, &json, Some(sender_id));
-    }
-}
-
-/// Validate that the message content does not exceed the maximum length.
-fn validate_message_length(state: &AppState, sender_id: Uuid, content: &str) -> bool {
-    const MAX_MESSAGE_LENGTH: usize = 10_000;
-    if content.len() > MAX_MESSAGE_LENGTH {
-        send_error(
-            state,
-            sender_id,
-            &format!(
-                "Message too long: {} characters (max {})",
-                content.len(),
-                MAX_MESSAGE_LENGTH
-            ),
-        );
-        return false;
-    }
-    true
-}
-
-/// Look up conversation security, validate channel usage, and enforce
-/// encryption on direct messages.  Returns the security row, conversation
-/// kind, and resolved channel id on success.
-async fn validate_conversation_security(
-    state: &AppState,
-    sender_id: Uuid,
-    conv_id: Uuid,
-    channel_id: Option<Uuid>,
-) -> Option<(
-    db::messages::ConversationSecurityRow,
-    Option<ConversationKind>,
-    Option<Uuid>,
-)> {
-    let conv_security = match db::messages::get_conversation_security(&state.pool, conv_id).await {
-        Ok(Some(row)) => row,
-        Ok(None) => {
-            send_error(state, sender_id, "Conversation not found");
-            return None;
-        }
-        Err(_) => {
-            send_error(state, sender_id, "Database error");
-            return None;
-        }
-    };
-
-    let conv_kind = ConversationKind::from_str_opt(&conv_security.kind);
-    if conv_kind != Some(ConversationKind::Group) && channel_id.is_some() {
-        send_error(
-            state,
-            sender_id,
-            "channel_id is only valid for group conversations",
-        );
-        return None;
-    }
-
-    let resolved_channel_id =
-        resolve_channel(state, sender_id, conv_id, channel_id, conv_kind).await?;
-
-    if conv_kind == Some(ConversationKind::Direct) && !conv_security.is_encrypted {
-        send_error(
-            state,
-            sender_id,
-            "Direct messages must be end-to-end encrypted",
-        );
-        return None;
-    }
-
-    Some((conv_security, conv_kind, resolved_channel_id))
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn handle_send_message(
-    state: &AppState,
-    sender_id: Uuid,
-    sender_device_id: i32,
-    sender_username: &str,
-    conversation_id: Option<Uuid>,
-    channel_id: Option<Uuid>,
-    to_user_id: Option<Uuid>,
-    content: String,
-    reply_to_id: Option<Uuid>,
-    device_contents: Option<HashMap<String, String>>,
-    ttl_seconds: Option<i64>,
-) {
-    if !validate_message_length(state, sender_id, &content) {
-        return;
-    }
-
-    let Some(conv_id) = resolve_conversation(state, sender_id, conversation_id, to_user_id).await
-    else {
-        return;
-    };
-
-    let Some((conv_security, _conv_kind, resolved_channel_id)) =
-        validate_conversation_security(state, sender_id, conv_id, channel_id).await
-    else {
-        return;
-    };
-
-    let (reply_content, reply_username) = lookup_reply_context(&state.pool, reply_to_id).await;
-
-    // Store message, send confirmation, and deliver to sender's other devices.
-    let Some(stored) = store_and_confirm(
-        state,
-        sender_id,
-        sender_device_id,
-        conv_id,
-        resolved_channel_id,
-        &content,
-        reply_to_id,
-        &device_contents,
-        ttl_seconds,
-    )
-    .await
-    else {
-        return;
-    };
-
-    let deliver = ServerMessage::NewMessage {
-        message_id: stored.id,
-        from_user_id: sender_id,
-        from_device_id: Some(sender_device_id),
-        from_username: sender_username.to_string(),
-        conversation_id: conv_id,
-        channel_id: stored.channel_id,
-        content,
-        timestamp: stored.created_at,
-        reply_to_id,
-        reply_to_content: reply_content,
-        reply_to_username: reply_username,
-        expires_at: stored.expires_at,
-    };
-
-    fanout_message(
-        state,
-        sender_id,
-        sender_device_id,
-        conv_id,
-        &deliver,
-        stored.id,
-        conv_security.is_encrypted,
-        device_contents,
-    )
-    .await;
-}
-
-/// Persist the message to the database, store per-device ciphertexts, send
-/// a `message_sent` confirmation to the originating device, and relay the
-/// message to the sender's other devices.  Returns the stored message row
-/// on success, or `None` after sending an error to the client.
-#[allow(clippy::too_many_arguments)]
-async fn store_and_confirm(
-    state: &AppState,
-    sender_id: Uuid,
-    sender_device_id: i32,
-    conv_id: Uuid,
-    resolved_channel_id: Option<Uuid>,
-    content: &str,
-    reply_to_id: Option<Uuid>,
-    device_contents: &Option<HashMap<String, String>>,
-    ttl_seconds: Option<i64>,
-) -> Option<db::messages::MessageRow> {
-    // Resolve TTL: use per-message override first, then fall back to conversation setting.
-    // Clamp to valid range: 5 seconds to 1 year. Reject non-positive values.
-    let ttl_seconds = ttl_seconds.filter(|&s| (5..=31_536_000).contains(&s));
-    let effective_ttl = if ttl_seconds.is_some() {
-        ttl_seconds
-    } else {
-        db::messages::get_conversation_ttl(&state.pool, conv_id)
-            .await
-            .unwrap_or(None)
-    };
-
-    // Store message in DB
-    let stored = match db::messages::store_message(
-        &state.pool,
-        conv_id,
-        resolved_channel_id,
-        sender_id,
-        content,
-        reply_to_id,
-        effective_ttl,
-    )
-    .await
-    {
-        Ok(row) => row,
-        Err(_) => {
-            send_error(state, sender_id, "Failed to store message");
-            return None;
-        }
-    };
-
-    // Store per-device ciphertexts if present
-    if let Some(dc) = device_contents {
-        let entries: Vec<(i32, &str)> = dc
-            .iter()
-            .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, v.as_str())))
-            .collect();
-        if !entries.is_empty()
-            && let Err(e) =
-                db::messages::store_device_contents(&state.pool, stored.id, &entries).await
-        {
-            tracing::error!("Failed to store device contents: {e:?}");
-        }
-    }
-
-    // Send confirmation to sender's device
-    let confirm = ServerMessage::MessageSent {
-        message_id: stored.id,
-        conversation_id: conv_id,
-        channel_id: stored.channel_id,
-        timestamp: stored.created_at,
-        expires_at: stored.expires_at,
-    };
-    if let Ok(json) = serde_json::to_string(&confirm) {
-        state
-            .hub
-            .send_to_device(&sender_id, sender_device_id, WsMessage::Text(json.into()));
-    }
-
-    // Self-device delivery: notify sender's OTHER devices about outgoing message
-    if let Some(dc) = device_contents {
-        for (device_id_str, ciphertext) in dc {
-            if let Ok(did) = device_id_str.parse::<i32>() {
-                if did == sender_device_id {
-                    continue; // Don't send to the originating device
-                }
-                let self_msg = ServerMessage::SelfMessage {
-                    message_id: stored.id,
-                    from_device_id: sender_device_id,
-                    conversation_id: conv_id,
-                    channel_id: stored.channel_id,
-                    content: ciphertext.clone(),
-                    timestamp: stored.created_at,
-                    reply_to_id,
-                };
-                if let Ok(json) = serde_json::to_string(&self_msg) {
-                    state
-                        .hub
-                        .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
-                }
-            }
-        }
-    }
-
-    Some(stored)
-}
-
-/// Resolve the target conversation from either an explicit conversation_id or a to_user_id.
-/// Returns None and sends an error to the sender on failure.
-async fn resolve_conversation(
-    state: &AppState,
-    sender_id: Uuid,
-    conversation_id: Option<Uuid>,
-    to_user_id: Option<Uuid>,
-) -> Option<Uuid> {
-    if let Some(cid) = conversation_id {
-        // Verify sender is a member of this conversation
-        match db::groups::is_member(&state.pool, cid, sender_id).await {
-            Ok(true) => Some(cid),
-            Ok(false) => {
-                send_error(state, sender_id, "Not a member of this conversation");
-                None
-            }
-            Err(_) => {
-                send_error(state, sender_id, "Database error");
-                None
-            }
-        }
-    } else if let Some(to_uid) = to_user_id {
-        // Legacy DM path: verify contacts
-        match db::contacts::are_contacts(&state.pool, sender_id, to_uid).await {
-            Ok(true) => {}
-            Ok(false) => {
-                send_error(state, sender_id, "Not a contact");
-                return None;
-            }
-            Err(_) => {
-                send_error(state, sender_id, "Database error");
-                return None;
-            }
-        }
-
-        match db::messages::find_or_create_dm_conversation(&state.pool, sender_id, to_uid).await {
-            Ok(id) => Some(id),
-            Err(_) => {
-                send_error(state, sender_id, "Failed to create conversation");
-                None
-            }
-        }
-    } else {
-        send_error(
-            state,
-            sender_id,
-            "Must provide conversation_id or to_user_id",
-        );
-        None
-    }
-}
-
-/// Resolve the target channel for a message.
-/// Returns `Some(Some(channel_id))` for groups, `Some(None)` for DMs, `None` on error.
-async fn resolve_channel(
-    state: &AppState,
-    sender_id: Uuid,
-    conv_id: Uuid,
-    channel_id: Option<Uuid>,
-    conv_kind: Option<ConversationKind>,
-) -> Option<Option<Uuid>> {
-    if conv_kind != Some(ConversationKind::Group) {
-        return Some(None);
-    }
-
-    if let Some(cid) = channel_id {
-        validate_explicit_channel(state, sender_id, conv_id, cid).await
-    } else {
-        resolve_default_text_channel(state, sender_id, conv_id).await
-    }
-}
-
-/// Validate that an explicit channel_id belongs to the conversation and is a text channel.
-async fn validate_explicit_channel(
-    state: &AppState,
-    sender_id: Uuid,
-    conv_id: Uuid,
-    channel_id: Uuid,
-) -> Option<Option<Uuid>> {
-    let channel = match db::channels::get_channel(&state.pool, channel_id).await {
-        Ok(Some(c)) => c,
-        Ok(None) => {
-            send_error(state, sender_id, "Channel not found");
-            return None;
-        }
-        Err(_) => {
-            send_error(state, sender_id, "Database error");
-            return None;
-        }
-    };
-
-    if channel.conversation_id != conv_id {
-        send_error(state, sender_id, "Channel is not part of this conversation");
-        return None;
-    }
-
-    if channel.kind != "text" {
-        send_error(
-            state,
-            sender_id,
-            "Messages can only be sent to text channels",
-        );
-        return None;
-    }
-
-    Some(Some(channel_id))
-}
-
-/// Look up the default text channel for a group conversation.
-async fn resolve_default_text_channel(
-    state: &AppState,
-    sender_id: Uuid,
-    conv_id: Uuid,
-) -> Option<Option<Uuid>> {
-    match db::channels::get_default_text_channel(&state.pool, conv_id).await {
-        Ok(Some(channel)) => Some(Some(channel.id)),
-        Ok(None) => {
-            send_error(state, sender_id, "No text channel found for this group");
-            None
-        }
-        Err(_) => {
-            send_error(state, sender_id, "Database error");
-            None
-        }
-    }
-}
-
-/// Look up reply context (content and username) for a given reply_to_id.
-async fn lookup_reply_context(
-    pool: &sqlx::PgPool,
-    reply_to_id: Option<Uuid>,
-) -> (Option<String>, Option<String>) {
-    if let Some(rid) = reply_to_id {
-        match db::messages::lookup_reply_context(pool, rid).await {
-            Ok(Some((c, u))) => (Some(c), Some(u)),
-            _ => (None, None),
-        }
-    } else {
-        (None, None)
-    }
-}
-
-/// Common fields extracted from a `ServerMessage::NewMessage` for per-device rewriting
-/// and push notification content.
-struct NewMessageFields {
-    message_id: Uuid,
-    from_user_id: Uuid,
-    from_device_id: Option<i32>,
-    from_username: String,
-    conversation_id: Uuid,
-    channel_id: Option<Uuid>,
-    content: String,
-    timestamp: DateTime<Utc>,
-    reply_to_id: Option<Uuid>,
-    reply_to_content: Option<String>,
-    reply_to_username: Option<String>,
-    expires_at: Option<DateTime<Utc>>,
-}
-
-impl NewMessageFields {
-    /// Extract fields from a `ServerMessage::NewMessage`, returning `None` for other variants.
-    fn extract(message: &ServerMessage) -> Option<Self> {
-        match message {
-            ServerMessage::NewMessage {
-                message_id,
-                from_user_id,
-                from_device_id,
-                from_username,
-                conversation_id,
-                channel_id,
-                content,
-                timestamp,
-                reply_to_id,
-                reply_to_content,
-                reply_to_username,
-                expires_at,
-            } => Some(Self {
-                message_id: *message_id,
-                from_user_id: *from_user_id,
-                from_device_id: *from_device_id,
-                from_username: from_username.clone(),
-                conversation_id: *conversation_id,
-                channel_id: *channel_id,
-                content: content.clone(),
-                timestamp: *timestamp,
-                reply_to_id: *reply_to_id,
-                reply_to_content: reply_to_content.clone(),
-                reply_to_username: reply_to_username.clone(),
-                expires_at: *expires_at,
-            }),
-            _ => None,
-        }
-    }
-}
-
-/// Pre-serialize per-device JSON messages once (keyed by device_id) to avoid
-/// re-serializing the same message for every member in the fanout loop.
-fn build_per_device_json(
-    fields: &NewMessageFields,
-    device_contents: &HashMap<String, String>,
-) -> Vec<(i32, String)> {
-    device_contents
-        .iter()
-        .filter_map(|(device_id_str, ciphertext)| {
-            let did = device_id_str.parse::<i32>().ok()?;
-            let per_device_msg = ServerMessage::NewMessage {
-                message_id: fields.message_id,
-                from_user_id: fields.from_user_id,
-                from_device_id: fields.from_device_id,
-                from_username: fields.from_username.clone(),
-                conversation_id: fields.conversation_id,
-                channel_id: fields.channel_id,
-                content: ciphertext.clone(),
-                timestamp: fields.timestamp,
-                reply_to_id: fields.reply_to_id,
-                reply_to_content: fields.reply_to_content.clone(),
-                reply_to_username: fields.reply_to_username.clone(),
-                expires_at: fields.expires_at,
-            };
-            let json = serde_json::to_string(&per_device_msg).ok()?;
-            Some((did, json))
-        })
-        .collect()
-}
-
-/// Deliver a message to a single member via per-device or legacy delivery.
-/// Returns `true` if the member received the message on at least one device.
-fn deliver_to_member(
-    hub: &crate::ws::hub::Hub,
-    member_id: &Uuid,
-    per_device_json: Option<&[(i32, String)]>,
-    legacy_json: Option<&str>,
-) -> bool {
-    if let Some(device_jsons) = per_device_json {
-        device_jsons.iter().any(|(did, json)| {
-            hub.send_to_device(member_id, *did, WsMessage::Text(json.clone().into()))
-        })
-    } else if let Some(json) = legacy_json {
-        hub.send_to_user(member_id, WsMessage::Text(json.to_owned().into()))
-    } else {
-        false
-    }
-}
-
-/// Mark messages as delivered in the DB and send a delivery confirmation back to the sender.
-async fn send_delivery_confirmation(
-    state: &AppState,
-    sender_id: Uuid,
-    sender_device_id: i32,
-    stored_id: Uuid,
-    conv_id: Uuid,
-) {
-    let _ = db::messages::mark_delivered(&state.pool, &[stored_id]).await;
-
-    let delivered_event = ServerMessage::Delivered {
-        message_id: stored_id,
-        conversation_id: conv_id,
-    };
-    if let Ok(delivered_json) = serde_json::to_string(&delivered_event) {
-        state.hub.send_to_device(
-            &sender_id,
-            sender_device_id,
-            WsMessage::Text(delivered_json.into()),
-        );
-    }
-}
-
-/// Spawn a background task to send push notifications to offline users.
-fn spawn_push_notifications(
-    pool: sqlx::PgPool,
-    offline_user_ids: Vec<Uuid>,
-    sender_name: &str,
-    content: &str,
-    is_encrypted: bool,
-    conv_id: Uuid,
-    stored_id: Uuid,
-) {
-    let sender_name = sender_name.to_string();
-    let content = content.to_string();
-    let handle = tokio::spawn(async move {
-        crate::push::notify_offline_users(
-            &pool,
-            &offline_user_ids,
-            &sender_name,
-            &content,
-            is_encrypted,
-            conv_id,
-            stored_id,
-        )
-        .await;
-    });
-    tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            tracing::error!("Push notification task failed for conv {conv_id}: {e}");
-        }
-    });
-}
-
-/// Fan out a message to all conversation members (except sender), with block filtering
-/// and delivery tracking. Supports per-device ciphertext delivery for multi-device.
-#[allow(clippy::too_many_arguments)]
-async fn fanout_message(
-    state: &AppState,
-    sender_id: Uuid,
-    sender_device_id: i32,
-    conv_id: Uuid,
-    message: &ServerMessage,
-    stored_id: Uuid,
-    is_encrypted: bool,
-    device_contents: Option<HashMap<String, String>>,
-) {
-    let Some(fields) = NewMessageFields::extract(message) else {
-        tracing::error!("fanout_message called with non-NewMessage variant");
-        return;
-    };
-
-    let member_ids = match get_member_ids_cached(&state.pool, conv_id).await {
-        Ok(ids) => ids,
-        Err(_) => {
-            tracing::error!("Failed to get conversation members for fan-out");
-            return;
-        }
-    };
-
-    // Batch check which members have blocked the sender (single query instead of N+1)
-    let blockers: Vec<Uuid> = db::contacts::get_blockers_of(&state.pool, &member_ids, sender_id)
-        .await
-        .unwrap_or_default();
-
-    // Pre-serialize per-device JSON messages and legacy fallback
-    let per_device_json = device_contents
-        .as_ref()
-        .map(|dc| build_per_device_json(&fields, dc));
-    let legacy_json = serde_json::to_string(message).ok();
-
-    let mut any_delivered = false;
-    let mut offline_user_ids = Vec::new();
-
-    let eligible = member_ids
-        .iter()
-        .filter(|id| **id != sender_id && !blockers.contains(id));
-
-    for member_id in eligible {
-        let delivered = deliver_to_member(
-            &state.hub,
-            member_id,
-            per_device_json.as_deref(),
-            legacy_json.as_deref(),
-        );
-        if delivered {
-            any_delivered = true;
-        } else {
-            offline_user_ids.push(*member_id);
-        }
-    }
-
-    if any_delivered {
-        send_delivery_confirmation(state, sender_id, sender_device_id, stored_id, conv_id).await;
-    }
-
-    if !offline_user_ids.is_empty() {
-        spawn_push_notifications(
-            state.pool.clone(),
-            offline_user_ids,
-            &fields.from_username,
-            &fields.content,
-            is_encrypted,
-            conv_id,
-            stored_id,
-        );
-    }
-}
-
-/// Check conversation membership using the in-memory cache.
-/// Returns true if the user is a verified member. Cache entries expire
-/// after `MEMBERSHIP_CACHE_TTL` (60 seconds).
-async fn check_membership_cached(
-    pool: &sqlx::PgPool,
-    conversation_id: Uuid,
-    user_id: Uuid,
-) -> bool {
-    let cache_key = (user_id, conversation_id);
-
-    // Fast path: check cache
-    if let Some(entry) = MEMBERSHIP_CACHE.get(&cache_key)
-        && entry.value().elapsed() < MEMBERSHIP_CACHE_TTL
-    {
-        return true;
-    }
-
-    // Slow path: hit database
-    let is_member = match db::groups::is_member(pool, conversation_id, user_id).await {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-
-    if is_member {
-        MEMBERSHIP_CACHE.insert(cache_key, Instant::now());
-    } else {
-        // Evict stale positive entry if membership was revoked
-        MEMBERSHIP_CACHE.remove(&cache_key);
-    }
-
-    is_member
-}
-
-/// Fetch conversation member IDs with a 60-second in-memory cache.
-async fn get_member_ids_cached(
-    pool: &sqlx::PgPool,
-    conversation_id: Uuid,
-) -> Result<Vec<Uuid>, sqlx::Error> {
-    if let Some(entry) = MEMBER_IDS_CACHE.get(&conversation_id)
-        && entry.value().1.elapsed() < MEMBERSHIP_CACHE_TTL
-    {
-        return Ok(entry.value().0.clone());
-    }
-
-    let members = db::groups::get_conversation_member_ids(pool, conversation_id).await?;
-    MEMBER_IDS_CACHE.insert(conversation_id, (members.clone(), Instant::now()));
-    Ok(members)
-}
-
-/// Fetch conversation kind with a 60-second in-memory cache.
-async fn get_conversation_kind_cached(
-    pool: &sqlx::PgPool,
-    conversation_id: Uuid,
-) -> Option<String> {
-    if let Some(entry) = CONV_KIND_CACHE.get(&conversation_id)
-        && entry.value().1.elapsed() < MEMBERSHIP_CACHE_TTL
-    {
-        return Some(entry.value().0.clone());
-    }
-
-    let kind = db::groups::get_conversation_kind(pool, conversation_id)
-        .await
-        .ok()??;
-    CONV_KIND_CACHE.insert(conversation_id, (kind.clone(), Instant::now()));
-    Some(kind)
-}
-
-/// Invalidate the member-ID cache for a conversation.  Call this when
-/// members are added, removed, or banned.
-pub fn invalidate_member_cache(conversation_id: Uuid) {
-    MEMBER_IDS_CACHE.remove(&conversation_id);
-}
-
-async fn handle_typing(
-    state: &AppState,
-    sender_id: Uuid,
-    sender_username: &str,
-    conversation_id: Uuid,
-    channel_id: Option<Uuid>,
-) {
-    // Verify membership via cache (avoids DB hit on every keystroke)
-    if !check_membership_cached(&state.pool, conversation_id, sender_id).await {
-        return;
-    }
-
-    let kind = match get_conversation_kind_cached(&state.pool, conversation_id).await {
-        Some(k) => k,
-        None => return,
-    };
-
-    let mut resolved_channel_id = None;
-    if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group)
-        && let Some(cid) = channel_id
-    {
-        let channel = match db::channels::get_channel(&state.pool, cid).await {
-            Ok(Some(c)) => c,
-            _ => return,
-        };
-        if channel.conversation_id != conversation_id || channel.kind != "text" {
-            return;
-        }
-        resolved_channel_id = Some(cid);
-    }
-
-    let member_ids = match get_member_ids_cached(&state.pool, conversation_id).await {
-        Ok(ids) => ids,
-        Err(_) => return,
-    };
-
-    let event = ServerMessage::Typing {
-        conversation_id,
-        channel_id: resolved_channel_id,
-        user_id: sender_id,
-        from_username: sender_username.to_string(),
-    };
-    if let Ok(json) = serde_json::to_string(&event) {
-        state
-            .hub
-            .broadcast_json(&member_ids, &json, Some(sender_id));
-    }
-}
-
-async fn handle_read_receipt(state: &AppState, sender_id: Uuid, conversation_id: Uuid) {
-    if !check_membership_cached(&state.pool, conversation_id, sender_id).await {
-        return;
-    }
-
-    // Enforce sender preference: when disabled, do not persist or broadcast.
-    let privacy = match db::users::get_privacy_preferences(&state.pool, sender_id).await {
-        Ok(Some(p)) => p,
-        _ => return,
-    };
-    if !privacy.read_receipts_enabled {
-        return;
-    }
-
-    // Persist the read receipt
-    let _ = db::reactions::mark_read(&state.pool, conversation_id, sender_id).await;
-
-    // Broadcast to other members
-    let member_ids = match get_member_ids_cached(&state.pool, conversation_id).await {
-        Ok(ids) => ids,
-        Err(_) => return,
-    };
-
-    let event = ServerMessage::ReadReceipt {
-        conversation_id,
-        user_id: sender_id,
-    };
     if let Ok(json) = serde_json::to_string(&event) {
         state
             .hub
@@ -1561,52 +701,7 @@ async fn handle_voice_signal(
     }
 }
 
-async fn broadcast_presence(state: &AppState, user_id: Uuid, username: &str, status: &str) {
-    let contact_ids = match db::contacts::list_contact_user_ids(&state.pool, user_id).await {
-        Ok(ids) => ids,
-        Err(e) => {
-            tracing::warn!("Failed to fetch contacts for presence broadcast: {e}");
-            return;
-        }
-    };
-
-    // When coming online, look up stored presence_status so we broadcast
-    // the right status (e.g. "away" or "dnd") rather than always "online".
-    // For "offline" (disconnect), always broadcast "offline" regardless of
-    // stored status. Invisible users also appear offline.
-    let (broadcast_status, presence_status) = if status == "offline" {
-        ("offline".to_string(), "offline".to_string())
-    } else {
-        let stored = db::users::get_presence_status(&state.pool, user_id)
-            .await
-            .unwrap_or(None)
-            .unwrap_or_else(|| "online".to_string());
-        let visible_status = if stored == "invisible" {
-            "offline".to_string()
-        } else {
-            stored.clone()
-        };
-        (visible_status, stored)
-    };
-
-    let presence = serde_json::json!({
-        "type": "presence",
-        "user_id": user_id,
-        "username": username,
-        "status": broadcast_status,
-        "presence_status": presence_status,
-    });
-    let json = match serde_json::to_string(&presence) {
-        Ok(j) => j,
-        Err(_) => return,
-    };
-
-    for cid in &contact_ids {
-        state.hub.send_to(cid, WsMessage::Text(json.clone().into()));
-    }
-}
-
-fn send_error(state: &AppState, user_id: Uuid, message: &str) {
+pub(super) fn send_error(state: &AppState, user_id: Uuid, message: &str) {
     let err = ServerMessage::Error {
         message: message.to_string(),
     };
@@ -1712,7 +807,8 @@ async fn handle_canvas_event(
     }
 
     // Broadcast to all other conversation members.
-    let member_ids = match get_member_ids_cached(&state.pool, conversation_id).await {
+    let member_ids = match typing_service::get_member_ids_cached(&state.pool, conversation_id).await
+    {
         Ok(ids) => ids,
         Err(_) => return,
     };

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -1,7 +1,4 @@
 //! Message send, fanout, and delivery logic.
-//!
-//! Extracted from `ws/handler.rs` as part of a pure refactor; behavior is
-//! unchanged.
 
 use axum::extract::ws::Message as WsMessage;
 use chrono::{DateTime, Utc};

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -1,0 +1,704 @@
+//! Message send, fanout, and delivery logic.
+//!
+//! Extracted from `ws/handler.rs` as part of a pure refactor; behavior is
+//! unchanged.
+
+use axum::extract::ws::Message as WsMessage;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::db;
+use crate::routes::AppState;
+use crate::types::ConversationKind;
+use crate::ws::handler::{ServerMessage, send_error};
+use crate::ws::typing_service::get_member_ids_cached;
+
+pub(super) const MAX_MESSAGE_LENGTH: usize = 10_000;
+
+/// Validate that the message content does not exceed the maximum length.
+pub(super) fn validate_message_length(state: &AppState, sender_id: Uuid, content: &str) -> bool {
+    if content.len() > MAX_MESSAGE_LENGTH {
+        send_error(
+            state,
+            sender_id,
+            &format!(
+                "Message too long: {} characters (max {})",
+                content.len(),
+                MAX_MESSAGE_LENGTH
+            ),
+        );
+        return false;
+    }
+    true
+}
+
+/// Look up conversation security, validate channel usage, and enforce
+/// encryption on direct messages.  Returns the security row, conversation
+/// kind, and resolved channel id on success.
+pub(super) async fn validate_conversation_security(
+    state: &AppState,
+    sender_id: Uuid,
+    conv_id: Uuid,
+    channel_id: Option<Uuid>,
+) -> Option<(
+    db::messages::ConversationSecurityRow,
+    Option<ConversationKind>,
+    Option<Uuid>,
+)> {
+    let conv_security = match db::messages::get_conversation_security(&state.pool, conv_id).await {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            send_error(state, sender_id, "Conversation not found");
+            return None;
+        }
+        Err(_) => {
+            send_error(state, sender_id, "Database error");
+            return None;
+        }
+    };
+
+    let conv_kind = ConversationKind::from_str_opt(&conv_security.kind);
+    if conv_kind != Some(ConversationKind::Group) && channel_id.is_some() {
+        send_error(
+            state,
+            sender_id,
+            "channel_id is only valid for group conversations",
+        );
+        return None;
+    }
+
+    let resolved_channel_id =
+        resolve_channel(state, sender_id, conv_id, channel_id, conv_kind).await?;
+
+    if conv_kind == Some(ConversationKind::Direct) && !conv_security.is_encrypted {
+        send_error(
+            state,
+            sender_id,
+            "Direct messages must be end-to-end encrypted",
+        );
+        return None;
+    }
+
+    Some((conv_security, conv_kind, resolved_channel_id))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn handle_send_message(
+    state: &AppState,
+    sender_id: Uuid,
+    sender_device_id: i32,
+    sender_username: &str,
+    conversation_id: Option<Uuid>,
+    channel_id: Option<Uuid>,
+    to_user_id: Option<Uuid>,
+    content: String,
+    reply_to_id: Option<Uuid>,
+    device_contents: Option<HashMap<String, String>>,
+    ttl_seconds: Option<i64>,
+) {
+    if !validate_message_length(state, sender_id, &content) {
+        return;
+    }
+
+    let Some(conv_id) = resolve_conversation(state, sender_id, conversation_id, to_user_id).await
+    else {
+        return;
+    };
+
+    let Some((conv_security, _conv_kind, resolved_channel_id)) =
+        validate_conversation_security(state, sender_id, conv_id, channel_id).await
+    else {
+        return;
+    };
+
+    let (reply_content, reply_username) = lookup_reply_context(&state.pool, reply_to_id).await;
+
+    // Store message, send confirmation, and deliver to sender's other devices.
+    let Some(stored) = store_and_confirm(
+        state,
+        sender_id,
+        sender_device_id,
+        conv_id,
+        resolved_channel_id,
+        &content,
+        reply_to_id,
+        &device_contents,
+        ttl_seconds,
+    )
+    .await
+    else {
+        return;
+    };
+
+    let deliver = ServerMessage::NewMessage {
+        message_id: stored.id,
+        from_user_id: sender_id,
+        from_device_id: Some(sender_device_id),
+        from_username: sender_username.to_string(),
+        conversation_id: conv_id,
+        channel_id: stored.channel_id,
+        content,
+        timestamp: stored.created_at,
+        reply_to_id,
+        reply_to_content: reply_content,
+        reply_to_username: reply_username,
+        expires_at: stored.expires_at,
+    };
+
+    fanout_message(
+        state,
+        sender_id,
+        sender_device_id,
+        conv_id,
+        &deliver,
+        stored.id,
+        conv_security.is_encrypted,
+        device_contents,
+    )
+    .await;
+}
+
+/// Persist the message to the database, store per-device ciphertexts, send
+/// a `message_sent` confirmation to the originating device, and relay the
+/// message to the sender's other devices.  Returns the stored message row
+/// on success, or `None` after sending an error to the client.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn store_and_confirm(
+    state: &AppState,
+    sender_id: Uuid,
+    sender_device_id: i32,
+    conv_id: Uuid,
+    resolved_channel_id: Option<Uuid>,
+    content: &str,
+    reply_to_id: Option<Uuid>,
+    device_contents: &Option<HashMap<String, String>>,
+    ttl_seconds: Option<i64>,
+) -> Option<db::messages::MessageRow> {
+    // Resolve TTL: use per-message override first, then fall back to conversation setting.
+    // Clamp to valid range: 5 seconds to 1 year. Reject non-positive values.
+    let ttl_seconds = ttl_seconds.filter(|&s| (5..=31_536_000).contains(&s));
+    let effective_ttl = if ttl_seconds.is_some() {
+        ttl_seconds
+    } else {
+        db::messages::get_conversation_ttl(&state.pool, conv_id)
+            .await
+            .unwrap_or(None)
+    };
+
+    // Store message in DB
+    let stored = match db::messages::store_message(
+        &state.pool,
+        conv_id,
+        resolved_channel_id,
+        sender_id,
+        content,
+        reply_to_id,
+        effective_ttl,
+    )
+    .await
+    {
+        Ok(row) => row,
+        Err(_) => {
+            send_error(state, sender_id, "Failed to store message");
+            return None;
+        }
+    };
+
+    // Store per-device ciphertexts if present
+    if let Some(dc) = device_contents {
+        let entries: Vec<(i32, &str)> = dc
+            .iter()
+            .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, v.as_str())))
+            .collect();
+        if !entries.is_empty()
+            && let Err(e) =
+                db::messages::store_device_contents(&state.pool, stored.id, &entries).await
+        {
+            tracing::error!("Failed to store device contents: {e:?}");
+        }
+    }
+
+    // Send confirmation to sender's device
+    let confirm = ServerMessage::MessageSent {
+        message_id: stored.id,
+        conversation_id: conv_id,
+        channel_id: stored.channel_id,
+        timestamp: stored.created_at,
+        expires_at: stored.expires_at,
+    };
+    if let Ok(json) = serde_json::to_string(&confirm) {
+        state
+            .hub
+            .send_to_device(&sender_id, sender_device_id, WsMessage::Text(json.into()));
+    }
+
+    // Self-device delivery: notify sender's OTHER devices about outgoing message
+    if let Some(dc) = device_contents {
+        for (device_id_str, ciphertext) in dc {
+            if let Ok(did) = device_id_str.parse::<i32>() {
+                if did == sender_device_id {
+                    continue; // Don't send to the originating device
+                }
+                let self_msg = ServerMessage::SelfMessage {
+                    message_id: stored.id,
+                    from_device_id: sender_device_id,
+                    conversation_id: conv_id,
+                    channel_id: stored.channel_id,
+                    content: ciphertext.clone(),
+                    timestamp: stored.created_at,
+                    reply_to_id,
+                };
+                if let Ok(json) = serde_json::to_string(&self_msg) {
+                    state
+                        .hub
+                        .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
+                }
+            }
+        }
+    }
+
+    Some(stored)
+}
+
+/// Resolve the target conversation from either an explicit conversation_id or a to_user_id.
+/// Returns None and sends an error to the sender on failure.
+pub(super) async fn resolve_conversation(
+    state: &AppState,
+    sender_id: Uuid,
+    conversation_id: Option<Uuid>,
+    to_user_id: Option<Uuid>,
+) -> Option<Uuid> {
+    if let Some(cid) = conversation_id {
+        // Verify sender is a member of this conversation
+        match db::groups::is_member(&state.pool, cid, sender_id).await {
+            Ok(true) => Some(cid),
+            Ok(false) => {
+                send_error(state, sender_id, "Not a member of this conversation");
+                None
+            }
+            Err(_) => {
+                send_error(state, sender_id, "Database error");
+                None
+            }
+        }
+    } else if let Some(to_uid) = to_user_id {
+        // Legacy DM path: verify contacts
+        match db::contacts::are_contacts(&state.pool, sender_id, to_uid).await {
+            Ok(true) => {}
+            Ok(false) => {
+                send_error(state, sender_id, "Not a contact");
+                return None;
+            }
+            Err(_) => {
+                send_error(state, sender_id, "Database error");
+                return None;
+            }
+        }
+
+        match db::messages::find_or_create_dm_conversation(&state.pool, sender_id, to_uid).await {
+            Ok(id) => Some(id),
+            Err(_) => {
+                send_error(state, sender_id, "Failed to create conversation");
+                None
+            }
+        }
+    } else {
+        send_error(
+            state,
+            sender_id,
+            "Must provide conversation_id or to_user_id",
+        );
+        None
+    }
+}
+
+/// Resolve the target channel for a message.
+/// Returns `Some(Some(channel_id))` for groups, `Some(None)` for DMs, `None` on error.
+pub(super) async fn resolve_channel(
+    state: &AppState,
+    sender_id: Uuid,
+    conv_id: Uuid,
+    channel_id: Option<Uuid>,
+    conv_kind: Option<ConversationKind>,
+) -> Option<Option<Uuid>> {
+    if conv_kind != Some(ConversationKind::Group) {
+        return Some(None);
+    }
+
+    if let Some(cid) = channel_id {
+        validate_explicit_channel(state, sender_id, conv_id, cid).await
+    } else {
+        resolve_default_text_channel(state, sender_id, conv_id).await
+    }
+}
+
+/// Validate that an explicit channel_id belongs to the conversation and is a text channel.
+pub(super) async fn validate_explicit_channel(
+    state: &AppState,
+    sender_id: Uuid,
+    conv_id: Uuid,
+    channel_id: Uuid,
+) -> Option<Option<Uuid>> {
+    let channel = match db::channels::get_channel(&state.pool, channel_id).await {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            send_error(state, sender_id, "Channel not found");
+            return None;
+        }
+        Err(_) => {
+            send_error(state, sender_id, "Database error");
+            return None;
+        }
+    };
+
+    if channel.conversation_id != conv_id {
+        send_error(state, sender_id, "Channel is not part of this conversation");
+        return None;
+    }
+
+    if channel.kind != "text" {
+        send_error(
+            state,
+            sender_id,
+            "Messages can only be sent to text channels",
+        );
+        return None;
+    }
+
+    Some(Some(channel_id))
+}
+
+/// Look up the default text channel for a group conversation.
+pub(super) async fn resolve_default_text_channel(
+    state: &AppState,
+    sender_id: Uuid,
+    conv_id: Uuid,
+) -> Option<Option<Uuid>> {
+    match db::channels::get_default_text_channel(&state.pool, conv_id).await {
+        Ok(Some(channel)) => Some(Some(channel.id)),
+        Ok(None) => {
+            send_error(state, sender_id, "No text channel found for this group");
+            None
+        }
+        Err(_) => {
+            send_error(state, sender_id, "Database error");
+            None
+        }
+    }
+}
+
+/// Look up reply context (content and username) for a given reply_to_id.
+pub(super) async fn lookup_reply_context(
+    pool: &sqlx::PgPool,
+    reply_to_id: Option<Uuid>,
+) -> (Option<String>, Option<String>) {
+    if let Some(rid) = reply_to_id {
+        match db::messages::lookup_reply_context(pool, rid).await {
+            Ok(Some((c, u))) => (Some(c), Some(u)),
+            _ => (None, None),
+        }
+    } else {
+        (None, None)
+    }
+}
+
+/// Common fields extracted from a `ServerMessage::NewMessage` for per-device rewriting
+/// and push notification content.
+pub(super) struct NewMessageFields {
+    pub(super) message_id: Uuid,
+    pub(super) from_user_id: Uuid,
+    pub(super) from_device_id: Option<i32>,
+    pub(super) from_username: String,
+    pub(super) conversation_id: Uuid,
+    pub(super) channel_id: Option<Uuid>,
+    pub(super) content: String,
+    pub(super) timestamp: DateTime<Utc>,
+    pub(super) reply_to_id: Option<Uuid>,
+    pub(super) reply_to_content: Option<String>,
+    pub(super) reply_to_username: Option<String>,
+    pub(super) expires_at: Option<DateTime<Utc>>,
+}
+
+impl NewMessageFields {
+    /// Extract fields from a `ServerMessage::NewMessage`, returning `None` for other variants.
+    fn extract(message: &ServerMessage) -> Option<Self> {
+        match message {
+            ServerMessage::NewMessage {
+                message_id,
+                from_user_id,
+                from_device_id,
+                from_username,
+                conversation_id,
+                channel_id,
+                content,
+                timestamp,
+                reply_to_id,
+                reply_to_content,
+                reply_to_username,
+                expires_at,
+            } => Some(Self {
+                message_id: *message_id,
+                from_user_id: *from_user_id,
+                from_device_id: *from_device_id,
+                from_username: from_username.clone(),
+                conversation_id: *conversation_id,
+                channel_id: *channel_id,
+                content: content.clone(),
+                timestamp: *timestamp,
+                reply_to_id: *reply_to_id,
+                reply_to_content: reply_to_content.clone(),
+                reply_to_username: reply_to_username.clone(),
+                expires_at: *expires_at,
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Pre-serialize per-device JSON messages once (keyed by device_id) to avoid
+/// re-serializing the same message for every member in the fanout loop.
+pub(super) fn build_per_device_json(
+    fields: &NewMessageFields,
+    device_contents: &HashMap<String, String>,
+) -> Vec<(i32, String)> {
+    device_contents
+        .iter()
+        .filter_map(|(device_id_str, ciphertext)| {
+            let did = device_id_str.parse::<i32>().ok()?;
+            let per_device_msg = ServerMessage::NewMessage {
+                message_id: fields.message_id,
+                from_user_id: fields.from_user_id,
+                from_device_id: fields.from_device_id,
+                from_username: fields.from_username.clone(),
+                conversation_id: fields.conversation_id,
+                channel_id: fields.channel_id,
+                content: ciphertext.clone(),
+                timestamp: fields.timestamp,
+                reply_to_id: fields.reply_to_id,
+                reply_to_content: fields.reply_to_content.clone(),
+                reply_to_username: fields.reply_to_username.clone(),
+                expires_at: fields.expires_at,
+            };
+            let json = serde_json::to_string(&per_device_msg).ok()?;
+            Some((did, json))
+        })
+        .collect()
+}
+
+/// Deliver a message to a single member via per-device or legacy delivery.
+/// Returns `true` if the member received the message on at least one device.
+pub(super) fn deliver_to_member(
+    hub: &crate::ws::hub::Hub,
+    member_id: &Uuid,
+    per_device_json: Option<&[(i32, String)]>,
+    legacy_json: Option<&str>,
+) -> bool {
+    if let Some(device_jsons) = per_device_json {
+        device_jsons.iter().any(|(did, json)| {
+            hub.send_to_device(member_id, *did, WsMessage::Text(json.clone().into()))
+        })
+    } else if let Some(json) = legacy_json {
+        hub.send_to_user(member_id, WsMessage::Text(json.to_owned().into()))
+    } else {
+        false
+    }
+}
+
+/// Mark messages as delivered in the DB and send a delivery confirmation back to the sender.
+pub(super) async fn send_delivery_confirmation(
+    state: &AppState,
+    sender_id: Uuid,
+    sender_device_id: i32,
+    stored_id: Uuid,
+    conv_id: Uuid,
+) {
+    let _ = db::messages::mark_delivered(&state.pool, &[stored_id]).await;
+
+    let delivered_event = ServerMessage::Delivered {
+        message_id: stored_id,
+        conversation_id: conv_id,
+    };
+    if let Ok(delivered_json) = serde_json::to_string(&delivered_event) {
+        state.hub.send_to_device(
+            &sender_id,
+            sender_device_id,
+            WsMessage::Text(delivered_json.into()),
+        );
+    }
+}
+
+/// Spawn a background task to send push notifications to offline users.
+pub(super) fn spawn_push_notifications(
+    pool: sqlx::PgPool,
+    offline_user_ids: Vec<Uuid>,
+    sender_name: &str,
+    content: &str,
+    is_encrypted: bool,
+    conv_id: Uuid,
+    stored_id: Uuid,
+) {
+    let sender_name = sender_name.to_string();
+    let content = content.to_string();
+    let handle = tokio::spawn(async move {
+        crate::push::notify_offline_users(
+            &pool,
+            &offline_user_ids,
+            &sender_name,
+            &content,
+            is_encrypted,
+            conv_id,
+            stored_id,
+        )
+        .await;
+    });
+    tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            tracing::error!("Push notification task failed for conv {conv_id}: {e}");
+        }
+    });
+}
+
+/// Fan out a message to all conversation members (except sender), with block filtering
+/// and delivery tracking. Supports per-device ciphertext delivery for multi-device.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn fanout_message(
+    state: &AppState,
+    sender_id: Uuid,
+    sender_device_id: i32,
+    conv_id: Uuid,
+    message: &ServerMessage,
+    stored_id: Uuid,
+    is_encrypted: bool,
+    device_contents: Option<HashMap<String, String>>,
+) {
+    let Some(fields) = NewMessageFields::extract(message) else {
+        tracing::error!("fanout_message called with non-NewMessage variant");
+        return;
+    };
+
+    let member_ids = match get_member_ids_cached(&state.pool, conv_id).await {
+        Ok(ids) => ids,
+        Err(_) => {
+            tracing::error!("Failed to get conversation members for fan-out");
+            return;
+        }
+    };
+
+    // Batch check which members have blocked the sender (single query instead of N+1)
+    let blockers: Vec<Uuid> = db::contacts::get_blockers_of(&state.pool, &member_ids, sender_id)
+        .await
+        .unwrap_or_default();
+
+    // Pre-serialize per-device JSON messages and legacy fallback
+    let per_device_json = device_contents
+        .as_ref()
+        .map(|dc| build_per_device_json(&fields, dc));
+    let legacy_json = serde_json::to_string(message).ok();
+
+    let mut any_delivered = false;
+    let mut offline_user_ids = Vec::new();
+
+    let eligible = member_ids
+        .iter()
+        .filter(|id| **id != sender_id && !blockers.contains(id));
+
+    for member_id in eligible {
+        let delivered = deliver_to_member(
+            &state.hub,
+            member_id,
+            per_device_json.as_deref(),
+            legacy_json.as_deref(),
+        );
+        if delivered {
+            any_delivered = true;
+        } else {
+            offline_user_ids.push(*member_id);
+        }
+    }
+
+    if any_delivered {
+        send_delivery_confirmation(state, sender_id, sender_device_id, stored_id, conv_id).await;
+    }
+
+    if !offline_user_ids.is_empty() {
+        spawn_push_notifications(
+            state.pool.clone(),
+            offline_user_ids,
+            &fields.from_username,
+            &fields.content,
+            is_encrypted,
+            conv_id,
+            stored_id,
+        );
+    }
+}
+
+/// Deliver any messages that were stored while the user was offline, then mark
+/// them delivered and notify the original senders.
+///
+/// For encrypted DMs, each device has its own ciphertext stored in
+/// `message_device_contents`.  A single batch query fetches all per-device
+/// ciphertexts for the reconnecting device; the canonical `content` column is
+/// used as a fallback when no device-specific row exists (group messages,
+/// unencrypted convs, or messages predating multi-device support).
+pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid, device_id: i32) {
+    let undelivered = match db::messages::get_undelivered(&state.pool, user_id).await {
+        Ok(msgs) => msgs,
+        Err(_) => return,
+    };
+
+    let ids: Vec<Uuid> = undelivered.iter().map(|m| m.id).collect();
+
+    // Batch-fetch all per-device ciphertexts in a single query to avoid N+1.
+    let device_ct_map = db::messages::get_device_contents_batch(&state.pool, &ids, device_id)
+        .await
+        .unwrap_or_default();
+
+    for msg in &undelivered {
+        // Prefer device-specific ciphertext; fall back to canonical content.
+        let content = device_ct_map
+            .get(&msg.id)
+            .cloned()
+            .unwrap_or_else(|| msg.content.clone());
+
+        let server_msg = ServerMessage::NewMessage {
+            message_id: msg.id,
+            from_user_id: msg.sender_id,
+            from_device_id: None, // Offline delivery doesn't track sender device
+            from_username: msg.sender_username.clone(),
+            conversation_id: msg.conversation_id,
+            channel_id: msg.channel_id,
+            content,
+            timestamp: msg.created_at,
+            reply_to_id: msg.reply_to_id,
+            reply_to_content: msg.reply_to_content.clone(),
+            reply_to_username: msg.reply_to_username.clone(),
+            expires_at: None, // Offline delivery: expiry already passed if expired
+        };
+        if let Ok(json) = serde_json::to_string(&server_msg) {
+            state
+                .hub
+                .send_to_device(&user_id, device_id, WsMessage::Text(json.into()));
+        }
+    }
+
+    if ids.is_empty() {
+        return;
+    }
+
+    let _ = db::messages::mark_delivered(&state.pool, &ids).await;
+
+    // Notify original senders that their messages were delivered
+    for msg in &undelivered {
+        let delivered_event = ServerMessage::Delivered {
+            message_id: msg.id,
+            conversation_id: msg.conversation_id,
+        };
+        if let Ok(json) = serde_json::to_string(&delivered_event) {
+            state
+                .hub
+                .send_to(&msg.sender_id, WsMessage::Text(json.into()));
+        }
+    }
+}

--- a/apps/server/src/ws/mod.rs
+++ b/apps/server/src/ws/mod.rs
@@ -1,2 +1,4 @@
 pub mod handler;
 pub mod hub;
+pub mod message_service;
+pub mod typing_service;

--- a/apps/server/src/ws/mod.rs
+++ b/apps/server/src/ws/mod.rs
@@ -1,4 +1,4 @@
 pub mod handler;
 pub mod hub;
-pub mod message_service;
-pub mod typing_service;
+pub(crate) mod message_service;
+pub(crate) mod typing_service;

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -1,0 +1,239 @@
+//! Typing indicators, read receipts, presence, and membership caches.
+//!
+//! Extracted from `ws/handler.rs` as part of a pure refactor; behavior is
+//! unchanged.
+
+use axum::extract::ws::Message as WsMessage;
+use dashmap::DashMap;
+use std::sync::LazyLock;
+use std::time::Duration;
+use tokio::time::Instant;
+use uuid::Uuid;
+
+use crate::db;
+use crate::routes::AppState;
+use crate::types::ConversationKind;
+use crate::ws::handler::ServerMessage;
+
+/// In-memory cache for conversation membership checks used by the typing
+/// indicator path.  Keyed by (user_id, conversation_id), stores the
+/// tokio::time::Instant when membership was last verified.  Entries older
+/// than `MEMBERSHIP_CACHE_TTL` are treated as expired and re-verified
+/// against the database.
+static MEMBERSHIP_CACHE: LazyLock<DashMap<(Uuid, Uuid), Instant>> = LazyLock::new(DashMap::new);
+pub(super) const MEMBERSHIP_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Cached conversation member IDs.  Keyed by conversation_id, stores the
+/// member list and the instant it was fetched.  Same TTL as membership cache.
+static MEMBER_IDS_CACHE: LazyLock<DashMap<Uuid, (Vec<Uuid>, Instant)>> =
+    LazyLock::new(DashMap::new);
+
+/// Cached conversation kind (e.g. "dm", "group").  Avoids a DB hit on every
+/// typing indicator for the same conversation.
+static CONV_KIND_CACHE: LazyLock<DashMap<Uuid, (String, Instant)>> = LazyLock::new(DashMap::new);
+
+/// Check conversation membership using the in-memory cache.
+/// Returns true if the user is a verified member. Cache entries expire
+/// after `MEMBERSHIP_CACHE_TTL` (60 seconds).
+pub(super) async fn check_membership_cached(
+    pool: &sqlx::PgPool,
+    conversation_id: Uuid,
+    user_id: Uuid,
+) -> bool {
+    let cache_key = (user_id, conversation_id);
+
+    // Fast path: check cache
+    if let Some(entry) = MEMBERSHIP_CACHE.get(&cache_key)
+        && entry.value().elapsed() < MEMBERSHIP_CACHE_TTL
+    {
+        return true;
+    }
+
+    // Slow path: hit database
+    let is_member = match db::groups::is_member(pool, conversation_id, user_id).await {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+
+    if is_member {
+        MEMBERSHIP_CACHE.insert(cache_key, Instant::now());
+    } else {
+        // Evict stale positive entry if membership was revoked
+        MEMBERSHIP_CACHE.remove(&cache_key);
+    }
+
+    is_member
+}
+
+/// Fetch conversation member IDs with a 60-second in-memory cache.
+pub(super) async fn get_member_ids_cached(
+    pool: &sqlx::PgPool,
+    conversation_id: Uuid,
+) -> Result<Vec<Uuid>, sqlx::Error> {
+    if let Some(entry) = MEMBER_IDS_CACHE.get(&conversation_id)
+        && entry.value().1.elapsed() < MEMBERSHIP_CACHE_TTL
+    {
+        return Ok(entry.value().0.clone());
+    }
+
+    let members = db::groups::get_conversation_member_ids(pool, conversation_id).await?;
+    MEMBER_IDS_CACHE.insert(conversation_id, (members.clone(), Instant::now()));
+    Ok(members)
+}
+
+/// Fetch conversation kind with a 60-second in-memory cache.
+pub(super) async fn get_conversation_kind_cached(
+    pool: &sqlx::PgPool,
+    conversation_id: Uuid,
+) -> Option<String> {
+    if let Some(entry) = CONV_KIND_CACHE.get(&conversation_id)
+        && entry.value().1.elapsed() < MEMBERSHIP_CACHE_TTL
+    {
+        return Some(entry.value().0.clone());
+    }
+
+    let kind = db::groups::get_conversation_kind(pool, conversation_id)
+        .await
+        .ok()??;
+    CONV_KIND_CACHE.insert(conversation_id, (kind.clone(), Instant::now()));
+    Some(kind)
+}
+
+/// Invalidate the member-ID cache for a conversation.  Call this when
+/// members are added, removed, or banned.
+pub fn invalidate_member_cache(conversation_id: Uuid) {
+    MEMBER_IDS_CACHE.remove(&conversation_id);
+}
+
+pub(super) async fn handle_typing(
+    state: &AppState,
+    sender_id: Uuid,
+    sender_username: &str,
+    conversation_id: Uuid,
+    channel_id: Option<Uuid>,
+) {
+    // Verify membership via cache (avoids DB hit on every keystroke)
+    if !check_membership_cached(&state.pool, conversation_id, sender_id).await {
+        return;
+    }
+
+    let kind = match get_conversation_kind_cached(&state.pool, conversation_id).await {
+        Some(k) => k,
+        None => return,
+    };
+
+    let mut resolved_channel_id = None;
+    if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group)
+        && let Some(cid) = channel_id
+    {
+        let channel = match db::channels::get_channel(&state.pool, cid).await {
+            Ok(Some(c)) => c,
+            _ => return,
+        };
+        if channel.conversation_id != conversation_id || channel.kind != "text" {
+            return;
+        }
+        resolved_channel_id = Some(cid);
+    }
+
+    let member_ids = match get_member_ids_cached(&state.pool, conversation_id).await {
+        Ok(ids) => ids,
+        Err(_) => return,
+    };
+
+    let event = ServerMessage::Typing {
+        conversation_id,
+        channel_id: resolved_channel_id,
+        user_id: sender_id,
+        from_username: sender_username.to_string(),
+    };
+    if let Ok(json) = serde_json::to_string(&event) {
+        state
+            .hub
+            .broadcast_json(&member_ids, &json, Some(sender_id));
+    }
+}
+
+pub(super) async fn handle_read_receipt(state: &AppState, sender_id: Uuid, conversation_id: Uuid) {
+    if !check_membership_cached(&state.pool, conversation_id, sender_id).await {
+        return;
+    }
+
+    // Enforce sender preference: when disabled, do not persist or broadcast.
+    let privacy = match db::users::get_privacy_preferences(&state.pool, sender_id).await {
+        Ok(Some(p)) => p,
+        _ => return,
+    };
+    if !privacy.read_receipts_enabled {
+        return;
+    }
+
+    // Persist the read receipt
+    let _ = db::reactions::mark_read(&state.pool, conversation_id, sender_id).await;
+
+    // Broadcast to other members
+    let member_ids = match get_member_ids_cached(&state.pool, conversation_id).await {
+        Ok(ids) => ids,
+        Err(_) => return,
+    };
+
+    let event = ServerMessage::ReadReceipt {
+        conversation_id,
+        user_id: sender_id,
+    };
+    if let Ok(json) = serde_json::to_string(&event) {
+        state
+            .hub
+            .broadcast_json(&member_ids, &json, Some(sender_id));
+    }
+}
+
+pub(super) async fn broadcast_presence(
+    state: &AppState,
+    user_id: Uuid,
+    username: &str,
+    status: &str,
+) {
+    let contact_ids = match db::contacts::list_contact_user_ids(&state.pool, user_id).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!("Failed to fetch contacts for presence broadcast: {e}");
+            return;
+        }
+    };
+
+    // When coming online, look up stored presence_status so we broadcast
+    // the right status (e.g. "away" or "dnd") rather than always "online".
+    // For "offline" (disconnect), always broadcast "offline" regardless of
+    // stored status. Invisible users also appear offline.
+    let (broadcast_status, presence_status) = if status == "offline" {
+        ("offline".to_string(), "offline".to_string())
+    } else {
+        let stored = db::users::get_presence_status(&state.pool, user_id)
+            .await
+            .unwrap_or(None)
+            .unwrap_or_else(|| "online".to_string());
+        let visible_status = if stored == "invisible" {
+            "offline".to_string()
+        } else {
+            stored.clone()
+        };
+        (visible_status, stored)
+    };
+
+    let presence = serde_json::json!({
+        "type": "presence",
+        "user_id": user_id,
+        "username": username,
+        "status": broadcast_status,
+        "presence_status": presence_status,
+    });
+    let json = match serde_json::to_string(&presence) {
+        Ok(j) => j,
+        Err(_) => return,
+    };
+
+    for cid in &contact_ids {
+        state.hub.send_to(cid, WsMessage::Text(json.clone().into()));
+    }
+}

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -1,7 +1,4 @@
 //! Typing indicators, read receipts, presence, and membership caches.
-//!
-//! Extracted from `ws/handler.rs` as part of a pure refactor; behavior is
-//! unchanged.
 
 use axum::extract::ws::Message as WsMessage;
 use dashmap::DashMap;
@@ -99,10 +96,12 @@ pub(super) async fn get_conversation_kind_cached(
     Some(kind)
 }
 
-/// Invalidate the member-ID cache for a conversation.  Call this when
-/// members are added, removed, or banned.
+/// Invalidate the member-ID and membership caches for a conversation.
+/// Call this when members are added, removed, or banned so revoked members
+/// cannot continue to use cached positive membership entries.
 pub fn invalidate_member_cache(conversation_id: Uuid) {
     MEMBER_IDS_CACHE.remove(&conversation_id);
+    MEMBERSHIP_CACHE.retain(|(_, conv_id), _| *conv_id != conversation_id);
 }
 
 pub(super) async fn handle_typing(


### PR DESCRIPTION
## Summary

Pure refactor of `apps/server/src/ws/handler.rs`: 1731 -> 827 lines. Zero behavior change.

### Modules

- **handler.rs** (827 lines): socket lifecycle, receive loop, dispatcher, voice/canvas handlers
- **message_service.rs** (701 lines, NEW): message send, fanout, delivery, conversation resolution
- **typing_service.rs** (238 lines, NEW): typing, read receipts, presence, membership caches

### Additional fixes from review

- `pub mod` -> `pub(crate) mod` for new service modules (tighter visibility)
- `invalidate_member_cache` now also clears `MEMBERSHIP_CACHE` (closes a stale-permission window when members are removed/banned)

## Closes

- #352 (handler.rs god module item; other items in #352 deferred to future PRs)

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets` no warnings  
- [x] `cargo build --workspace` clean
- [x] `cargo test -p echo-server --lib` 72/72 pass
- [x] Integration tests (CI) to validate in the pipeline