### PR TITLE
feat: multi-device management UI with last_seen + logout-others

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,6 @@ Three compose files in `infra/docker/`:
 ## Known Limitations
 
 1. Session keys cached forever in memory (no TTL)
-2. Multi-device: schema exists but single-device in practice
+2. Multi-device: key-level revoke + last_seen + platform metadata work end-to-end; refresh tokens are not yet bound per device, so "logout all others" only kicks connected sessions via WS and truly offline sessions get blocked at next key operation.
 3. `core/rust-core/src/api.rs` has `todo!()` stubs (FFI bridge not integrated)
 4. Rate limiting is in-memory only (resets on server restart)

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -35,10 +35,20 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
   final _random = math.Random();
   final _voiceSignalController =
       StreamController<Map<String, dynamic>>.broadcast();
+  final _deviceRevokedController =
+      StreamController<Map<String, dynamic>>.broadcast();
 
   @override
   StreamController<Map<String, dynamic>> get voiceSignalController =>
       _voiceSignalController;
+
+  @override
+  StreamController<Map<String, dynamic>> get deviceRevokedController =>
+      _deviceRevokedController;
+
+  /// Stream of `device_revoked` events for the authenticated user.
+  Stream<Map<String, dynamic>> get deviceRevokedEvents =>
+      _deviceRevokedController.stream;
 
   /// Throttle: track last typing event sent per conversation.
   final Map<String, DateTime> _lastTypingSent = {};
@@ -648,6 +658,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     _reconnectTimer = null;
     _typingCleanupTimer?.cancel();
     _voiceSignalController.close();
+    _deviceRevokedController.close();
     disconnect();
     super.dispose();
   }

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -101,6 +101,11 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
   Ref get ref;
   StreamController<Map<String, dynamic>> get voiceSignalController;
 
+  /// Broadcast of `device_revoked` events for the current user. UI surfaces
+  /// (e.g. the Devices settings screen) listen here so they can refresh their
+  /// lists when another device is revoked.
+  StreamController<Map<String, dynamic>> get deviceRevokedController;
+
   /// Messages received before crypto was initialized.
   /// Drained by [drainPendingDecryptQueue] once crypto is ready.
   final List<Map<String, dynamic>> _pendingDecryptQueue = [];
@@ -264,6 +269,9 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
     final myDeviceId = ref.read(cryptoServiceProvider).isInitialized
         ? ref.read(cryptoServiceProvider).deviceId
         : null;
+
+    // Always broadcast so interested UIs (Devices settings) can refresh.
+    deviceRevokedController.add(json);
 
     if (revokedDeviceId != null &&
         myDeviceId != null &&

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -265,7 +265,9 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
   }
 
   void _handleDeviceRevoked(Map<String, dynamic> json) {
-    final revokedDeviceId = json['device_id'] as int?;
+    // Use `num?` + toInt() so dart2js (web) doesn't blow up when the JSON
+    // number is decoded as a double rather than an int.
+    final revokedDeviceId = (json['device_id'] as num?)?.toInt();
     final myDeviceId = ref.read(cryptoServiceProvider).isInitialized
         ? ref.read(cryptoServiceProvider).deviceId
         : null;

--- a/apps/client/lib/src/screens/settings/devices_section.dart
+++ b/apps/client/lib/src/screens/settings/devices_section.dart
@@ -39,7 +39,12 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
         final myDeviceId = ref.read(cryptoServiceProvider).isInitialized
             ? ref.read(cryptoServiceProvider).deviceId
             : null;
-        if (revokedId is int && revokedId != myDeviceId && mounted) {
+        // Coalesce rapid bursts (e.g. revoke-others emits N events) into a
+        // single refresh -- skip if we're already reloading.
+        if (revokedId is int &&
+            revokedId != myDeviceId &&
+            mounted &&
+            !_loading) {
           _loadDevices();
         }
       });
@@ -484,9 +489,10 @@ class _Device {
 
   const _Device({required this.deviceId, this.platform, this.lastSeen});
 
-  /// Best-effort display label. Falls back to a generic "Device" when the
-  /// server has no platform string stored (e.g. older clients).
-  String get displayLabel => platform ?? 'Device';
+  /// Best-effort display label. Falls back to a device-id-specific label when
+  /// the server has no platform string stored (e.g. older clients) so that
+  /// multiple unknown devices remain distinguishable in the list.
+  String get displayLabel => platform ?? 'Device $deviceId';
 }
 
 String _formatLastSeen(String? isoString) {
@@ -494,7 +500,11 @@ String _formatLastSeen(String? isoString) {
   try {
     final dt = DateTime.parse(isoString).toLocal();
     final diff = DateTime.now().difference(dt);
-    if (diff.inMinutes < 60) return 'just now';
+    if (diff.inMinutes < 2) return 'just now';
+    if (diff.inMinutes < 60) {
+      final m = diff.inMinutes;
+      return '$m ${m == 1 ? 'minute' : 'minutes'} ago';
+    }
     if (diff.inHours < 24) {
       final h = diff.inHours;
       return '$h ${h == 1 ? 'hour' : 'hours'} ago';

--- a/apps/client/lib/src/screens/settings/devices_section.dart
+++ b/apps/client/lib/src/screens/settings/devices_section.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
 
@@ -9,6 +10,7 @@ import 'package:http/http.dart' as http;
 import '../../providers/auth_provider.dart';
 import '../../providers/crypto_provider.dart';
 import '../../providers/server_url_provider.dart';
+import '../../providers/websocket_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 
@@ -23,11 +25,31 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
   List<_Device> _devices = [];
   bool _loading = true;
   String? _error;
+  StreamSubscription<Map<String, dynamic>>? _deviceRevokedSub;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _loadDevices());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadDevices();
+      // Refresh when any device_revoked event arrives for another device.
+      final ws = ref.read(websocketProvider.notifier);
+      _deviceRevokedSub = ws.deviceRevokedEvents.listen((event) {
+        final revokedId = event['device_id'];
+        final myDeviceId = ref.read(cryptoServiceProvider).isInitialized
+            ? ref.read(cryptoServiceProvider).deviceId
+            : null;
+        if (revokedId is int && revokedId != myDeviceId && mounted) {
+          _loadDevices();
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _deviceRevokedSub?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadDevices() async {
@@ -55,24 +77,30 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
 
       if (response.statusCode == 200) {
         final body = jsonDecode(response.body);
-        final List<dynamic> deviceIds;
+        // New shape: { user_id, devices: [{device_id, platform, last_seen}] }
+        // Old shape (backward compat): { user_id, device_ids: [<int>] } or a
+        // bare list of device_id integers.
+        final List<dynamic> rawDevices;
         if (body is List) {
-          deviceIds = body;
+          rawDevices = body;
         } else if (body is Map<String, dynamic>) {
-          deviceIds = body['device_ids'] as List<dynamic>? ?? [];
+          rawDevices =
+              (body['devices'] as List<dynamic>?) ??
+              (body['device_ids'] as List<dynamic>?) ??
+              [];
         } else {
-          deviceIds = [];
+          rawDevices = [];
         }
         setState(() {
-          _devices = deviceIds.map((d) {
+          _devices = rawDevices.map((d) {
             if (d is Map<String, dynamic>) {
               return _Device(
                 deviceId: (d['device_id'] as num).toInt(),
-                label: d['label'] as String? ?? 'Device',
+                platform: d['platform'] as String?,
                 lastSeen: d['last_seen'] as String?,
               );
             }
-            // Server returns plain device_id integers
+            // Legacy: bare device_id integer
             return _Device(deviceId: (d as num).toInt());
           }).toList();
           _loading = false;
@@ -101,7 +129,7 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
           side: BorderSide(color: context.border),
         ),
         title: Text(
-          'Revoke ${device.label}',
+          'Revoke ${device.displayLabel}',
           style: const TextStyle(
             color: EchoTheme.danger,
             fontSize: 18,
@@ -109,7 +137,7 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
           ),
         ),
         content: Text(
-          'This will remove ${device.label} from your account. '
+          'This will remove ${device.displayLabel} from your account. '
           'Any active session on that device will be signed out immediately.',
           style: TextStyle(
             color: context.textSecondary,
@@ -154,6 +182,91 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
           ToastService.show(
             context,
             'Failed to revoke device (${response.statusCode})',
+            type: ToastType.error,
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ToastService.show(context, 'Network error', type: ToastType.error);
+      }
+    }
+  }
+
+  /// Revoke every device except the current one after confirming with the user.
+  Future<void> _revokeOtherDevices(int currentDeviceId) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: context.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: context.border),
+        ),
+        title: Text(
+          'Log out all other devices',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        content: Text(
+          'This will log out every device except this one. Continue?',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 14,
+            height: 1.5,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
+            child: const Text('Log out others'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    final serverUrl = ref.read(serverUrlProvider);
+    try {
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.post(
+              Uri.parse('$serverUrl/api/keys/devices/revoke-others'),
+              headers: {
+                'Authorization': 'Bearer $token',
+                'Content-Type': 'application/json',
+              },
+              body: jsonEncode({'current_device_id': currentDeviceId}),
+            ),
+          );
+
+      if (response.statusCode == 200) {
+        final body = jsonDecode(response.body) as Map<String, dynamic>;
+        final count = (body['revoked'] as num?)?.toInt() ?? 0;
+        if (mounted) {
+          ToastService.show(
+            context,
+            count == 1
+                ? 'Logged out 1 other device'
+                : 'Logged out $count other devices',
+          );
+        }
+        await _loadDevices();
+      } else {
+        if (mounted) {
+          ToastService.show(
+            context,
+            'Failed to log out other devices (${response.statusCode})',
             type: ToastType.error,
           );
         }
@@ -295,7 +408,7 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
                     Text(
                       isThisDevice
                           ? _currentPlatformName()
-                          : device.label ?? 'Device ${device.deviceId}',
+                          : device.displayLabel,
                       style: TextStyle(
                         color: context.textPrimary,
                         fontWeight: FontWeight.w500,
@@ -343,6 +456,22 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
               );
             },
           ),
+        if (!_loading &&
+            _error == null &&
+            myDeviceId != null &&
+            _devices.any((d) => d.deviceId != myDeviceId))
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: () => _revokeOtherDevices(myDeviceId),
+                icon: const Icon(Icons.devices_other, size: 18),
+                label: const Text('Log out all other devices'),
+                style: TextButton.styleFrom(foregroundColor: EchoTheme.danger),
+              ),
+            ),
+          ),
       ],
     );
   }
@@ -350,10 +479,14 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
 
 class _Device {
   final int deviceId;
-  final String? label;
+  final String? platform;
   final String? lastSeen;
 
-  const _Device({required this.deviceId, this.label, this.lastSeen});
+  const _Device({required this.deviceId, this.platform, this.lastSeen});
+
+  /// Best-effort display label. Falls back to a generic "Device" when the
+  /// server has no platform string stored (e.g. older clients).
+  String get displayLabel => platform ?? 'Device';
 }
 
 String _formatLastSeen(String? isoString) {

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -11,6 +11,7 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show Platform;
 import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
@@ -607,6 +608,20 @@ class CryptoService {
     await store.write('$_sessionPrefix$peerId', jsonEncode(json));
   }
 
+  /// Human-readable label for the current platform, sent to the server as part
+  /// of the prekey bundle so the device-management UI can display "iOS",
+  /// "Linux", etc. Returns `null` on unrecognised platforms so the server
+  /// falls back to its stored value.
+  String? _platformString() {
+    if (kIsWeb) return 'Web';
+    if (Platform.isIOS) return 'iOS';
+    if (Platform.isAndroid) return 'Android';
+    if (Platform.isMacOS) return 'macOS';
+    if (Platform.isWindows) return 'Windows';
+    if (Platform.isLinux) return 'Linux';
+    return null;
+  }
+
   /// Upload our public keys to the server as a PreKey bundle.
   ///
   /// Includes:
@@ -646,7 +661,7 @@ class CryptoService {
       _needsOtpReplenishment = false;
     }
 
-    final body = jsonEncode({
+    final payload = <String, dynamic>{
       'identity_key': pubKeyB64,
       'signing_key': signingPubB64,
       'signed_prekey': spkPubB64,
@@ -654,7 +669,12 @@ class CryptoService {
       'signed_prekey_id': 1,
       'one_time_prekeys': otps,
       'device_id': _deviceId,
-    });
+    };
+    final platform = _platformString();
+    if (platform != null) {
+      payload['platform'] = platform;
+    }
+    final body = jsonEncode(payload);
 
     final response = await http.post(
       Uri.parse('$serverUrl/api/keys/upload'),

--- a/apps/client/test/providers/ws_message_handler_test.dart
+++ b/apps/client/test/providers/ws_message_handler_test.dart
@@ -101,6 +101,10 @@ class _TestWsHandler extends StateNotifier<WebSocketState>
   final StreamController<Map<String, dynamic>> voiceSignalController =
       StreamController<Map<String, dynamic>>.broadcast();
 
+  @override
+  final StreamController<Map<String, dynamic>> deviceRevokedController =
+      StreamController<Map<String, dynamic>>.broadcast();
+
   _TestWsHandler(this.ref) : super(const WebSocketState());
 }
 

--- a/apps/server/migrations/20260424000000_identity_keys_device_metadata.sql
+++ b/apps/server/migrations/20260424000000_identity_keys_device_metadata.sql
@@ -1,0 +1,6 @@
+ALTER TABLE identity_keys
+    ADD COLUMN IF NOT EXISTS platform TEXT,
+    ADD COLUMN IF NOT EXISTS last_seen TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_identity_keys_last_seen
+    ON identity_keys (user_id, last_seen DESC);

--- a/apps/server/migrations/20260424000000_identity_keys_device_metadata.sql
+++ b/apps/server/migrations/20260424000000_identity_keys_device_metadata.sql
@@ -1,6 +1,3 @@
 ALTER TABLE identity_keys
     ADD COLUMN IF NOT EXISTS platform TEXT,
     ADD COLUMN IF NOT EXISTS last_seen TIMESTAMPTZ;
-
-CREATE INDEX IF NOT EXISTS idx_identity_keys_last_seen
-    ON identity_keys (user_id, last_seen DESC);

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -332,6 +332,48 @@ pub async fn revoke_device(
     Ok(r1.rows_affected() > 0)
 }
 
+/// Revoke every device belonging to `user_id` except `keep_device_id` in a
+/// single transaction. Returns the list of device IDs that were revoked so the
+/// caller can fan out WS notifications without another DB round-trip.
+pub async fn revoke_devices_except(
+    pool: &PgPool,
+    user_id: Uuid,
+    keep_device_id: i32,
+) -> Result<Vec<i32>, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    let revoked: Vec<(i32,)> = sqlx::query_as(
+        "SELECT device_id FROM identity_keys \
+         WHERE user_id = $1 AND device_id != $2",
+    )
+    .bind(user_id)
+    .bind(keep_device_id)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    sqlx::query("DELETE FROM identity_keys WHERE user_id = $1 AND device_id != $2")
+        .bind(user_id)
+        .bind(keep_device_id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("DELETE FROM signed_prekeys WHERE user_id = $1 AND device_id != $2")
+        .bind(user_id)
+        .bind(keep_device_id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("DELETE FROM one_time_prekeys WHERE user_id = $1 AND device_id != $2")
+        .bind(user_id)
+        .bind(keep_device_id)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok(revoked.into_iter().map(|(id,)| id).collect())
+}
+
 /// Count available (unused) one-time prekeys for a user's device.
 pub async fn count_one_time_prekeys(
     pool: &PgPool,

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -62,23 +62,32 @@ pub async fn clear_identity_key_fingerprint(
 }
 
 /// Store or replace a user's identity key for a specific device.
+///
+/// If `platform` is provided, it is written alongside the identity keys so the
+/// UI can show "iOS", "Linux", etc. Omitted platforms leave the existing value
+/// intact (useful for OTP replenishment that re-uploads the identity without
+/// new metadata).
 pub async fn store_identity_key(
     db: impl sqlx::PgExecutor<'_>,
     user_id: Uuid,
     device_id: i32,
     identity_key: &[u8],
     signing_key: Option<&[u8]>,
+    platform: Option<&str>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "INSERT INTO identity_keys (user_id, device_id, identity_key, signing_key) \
-         VALUES ($1, $2, $3, $4) \
+        "INSERT INTO identity_keys (user_id, device_id, identity_key, signing_key, platform) \
+         VALUES ($1, $2, $3, $4, $5) \
          ON CONFLICT (user_id, device_id) DO UPDATE \
-         SET identity_key = $3, signing_key = $4",
+         SET identity_key = $3, \
+             signing_key = $4, \
+             platform = COALESCE($5, identity_keys.platform)",
     )
     .bind(user_id)
     .bind(device_id)
     .bind(identity_key)
     .bind(signing_key)
+    .bind(platform)
     .execute(db)
     .await?;
     Ok(())
@@ -250,15 +259,45 @@ pub async fn get_prekey_bundle(
     }))
 }
 
-/// Return device_ids registered for a given user (capped at 10).
-pub async fn get_user_devices(pool: &PgPool, user_id: Uuid) -> Result<Vec<i32>, sqlx::Error> {
-    let rows: Vec<(i32,)> = sqlx::query_as(
-        "SELECT device_id FROM identity_keys WHERE user_id = $1 ORDER BY device_id DESC LIMIT 10",
+/// Device metadata returned by [`get_user_devices`].
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct DeviceRow {
+    pub device_id: i32,
+    pub platform: Option<String>,
+    pub last_seen: Option<DateTime<Utc>>,
+}
+
+/// Return devices registered for a given user (capped at 10), including
+/// their platform and last-seen timestamp.
+pub async fn get_user_devices(pool: &PgPool, user_id: Uuid) -> Result<Vec<DeviceRow>, sqlx::Error> {
+    sqlx::query_as::<_, DeviceRow>(
+        "SELECT device_id, platform, last_seen \
+         FROM identity_keys \
+         WHERE user_id = $1 \
+         ORDER BY device_id DESC \
+         LIMIT 10",
     )
     .bind(user_id)
     .fetch_all(pool)
+    .await
+}
+
+/// Update the `last_seen` timestamp for a user's device to NOW(). Called on
+/// WebSocket connect so the device list reflects recent activity.
+pub async fn update_last_seen(
+    pool: &PgPool,
+    user_id: Uuid,
+    device_id: i32,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE identity_keys SET last_seen = NOW() \
+         WHERE user_id = $1 AND device_id = $2",
+    )
+    .bind(user_id)
+    .bind(device_id)
+    .execute(pool)
     .await?;
-    Ok(rows.into_iter().map(|(d,)| d).collect())
+    Ok(())
 }
 
 /// Revoke all keys for a specific (user_id, device_id) pair.

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -193,6 +193,13 @@ pub fn key_reset_limiter() -> RateLimiter {
     RateLimiter::new(3, 300)
 }
 
+/// Revoke-others rate limiter: 3 requests per 60 seconds per IP.
+/// Revoking every other device is a disruptive op -- cap it tightly so
+/// stolen tokens can't wipe a user's whole device list in a loop.
+pub fn revoke_others_limiter() -> RateLimiter {
+    RateLimiter::new(3, 60)
+}
+
 /// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
 fn is_private(ip: IpAddr) -> bool {
     match ip {

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -32,6 +32,10 @@ pub struct UploadBundleRequest {
     pub device_id: i32,
     /// Ed25519 signing public key, base64-encoded. Required to prevent MITM attacks.
     pub signing_key: String,
+    /// Optional human-readable platform label (e.g. "iOS", "Linux") written
+    /// alongside the identity key so the device-management UI can display it.
+    #[serde(default)]
+    pub platform: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,11 +61,31 @@ pub struct OneTimePreKeyResponse {
     pub public_key: String,
 }
 
+/// Device info returned in the device list response.
+#[derive(Debug, Serialize)]
+pub struct DeviceInfo {
+    pub device_id: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_seen: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl From<db::keys::DeviceRow> for DeviceInfo {
+    fn from(row: db::keys::DeviceRow) -> Self {
+        DeviceInfo {
+            device_id: row.device_id,
+            platform: row.platform,
+            last_seen: row.last_seen,
+        }
+    }
+}
+
 /// Response body for device list query.
 #[derive(Debug, Serialize)]
 pub struct DeviceListResponse {
     pub user_id: Uuid,
-    pub device_ids: Vec<i32>,
+    pub devices: Vec<DeviceInfo>,
 }
 
 use base64::Engine;
@@ -183,6 +207,7 @@ pub async fn upload_bundle(
         device_id,
         &identity_key,
         Some(&signing_key_bytes),
+        body.platform.as_deref(),
     )
     .await?;
     db::keys::store_signed_prekey(
@@ -259,9 +284,9 @@ pub async fn get_bundle(
             // No device 0 — find the most recently registered device and use that
             let devices = db::keys::get_user_devices(&state.pool, user_id).await?;
             let mut found = None;
-            for device_id in devices {
+            for device in devices {
                 if let Some(b) =
-                    db::keys::get_prekey_bundle(&state.pool, user_id, device_id).await?
+                    db::keys::get_prekey_bundle(&state.pool, user_id, device.device_id).await?
                 {
                     found = Some(b);
                     break;
@@ -317,17 +342,16 @@ pub async fn get_device_bundle(
     Ok(Json(response))
 }
 
-/// GET /api/keys/devices/:user_id -- List all device_ids for a user.
+/// GET /api/keys/devices/:user_id -- List all devices for a user, including
+/// their platform and last_seen timestamp.
 pub async fn get_devices(
     State(state): State<Arc<AppState>>,
     _auth_user: AuthUser,
     Path(user_id): Path<Uuid>,
 ) -> Result<impl IntoResponse, AppError> {
-    let device_ids = db::keys::get_user_devices(&state.pool, user_id).await?;
-    Ok(Json(DeviceListResponse {
-        user_id,
-        device_ids,
-    }))
+    let rows = db::keys::get_user_devices(&state.pool, user_id).await?;
+    let devices: Vec<DeviceInfo> = rows.into_iter().map(DeviceInfo::from).collect();
+    Ok(Json(DeviceListResponse { user_id, devices }))
 }
 
 /// Response for a single device bundle within the all-bundles response.
@@ -351,10 +375,11 @@ pub async fn get_all_bundles(
     _auth_user: AuthUser,
     Path(user_id): Path<Uuid>,
 ) -> Result<impl IntoResponse, AppError> {
-    let device_ids = db::keys::get_user_devices(&state.pool, user_id).await?;
+    let devices = db::keys::get_user_devices(&state.pool, user_id).await?;
     let mut bundles = Vec::new();
 
-    for device_id in device_ids {
+    for device in devices {
+        let device_id = device.device_id;
         if let Some(bundle) = db::keys::get_prekey_bundle(&state.pool, user_id, device_id).await? {
             let signing_key = match require_signing_key(&bundle, user_id) {
                 Ok(sk) => sk,
@@ -409,6 +434,62 @@ pub async fn revoke_device(
     }
 
     Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+/// Request body for `POST /api/keys/devices/revoke-others`.
+#[derive(Debug, Deserialize)]
+pub struct RevokeOthersRequest {
+    pub current_device_id: i32,
+}
+
+/// POST /api/keys/devices/revoke-others -- Revoke every device belonging to
+/// the authenticated user except `current_device_id`. Broadcasts a
+/// `device_revoked` event for each revoked device so live sessions log out
+/// immediately. Returns `{ "revoked": <count> }`.
+pub async fn revoke_other_devices(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Json(body): Json<RevokeOthersRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    use crate::ws::handler::ServerMessage;
+    use axum::extract::ws::Message as WsMessage;
+
+    let devices = db::keys::get_user_devices(&state.pool, auth_user.user_id).await?;
+
+    let mut revoked = 0usize;
+    for device in devices {
+        if device.device_id == body.current_device_id {
+            continue;
+        }
+
+        let found = db::keys::revoke_device(&state.pool, auth_user.user_id, device.device_id)
+            .await
+            .map_err(|_| AppError::internal("Database error"))?;
+
+        if !found {
+            continue;
+        }
+
+        revoked += 1;
+
+        let event = ServerMessage::DeviceRevoked {
+            device_id: device.device_id,
+        };
+        if let Ok(json) = serde_json::to_string(&event) {
+            state
+                .hub
+                .send_to_user(&auth_user.user_id, WsMessage::Text(json.into()));
+        }
+    }
+
+    tracing::info!(
+        "User {} revoked {} other devices (kept device {})",
+        auth_user.user_id,
+        revoked,
+        body.current_device_id,
+    );
+
+    Ok(Json(serde_json::json!({ "revoked": revoked })))
 }
 
 /// Request body for key reset -- requires current password for re-authentication.

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -137,6 +137,14 @@ pub async fn upload_bundle(
         .decode(&body.signed_prekey_signature)
         .map_err(|_| AppError::bad_request("Invalid base64 for signed_prekey_signature"))?;
 
+    // Platform label is surfaced in the device management UI; cap its length
+    // so a malicious client can't bloat the row with unbounded text.
+    if let Some(platform) = body.platform.as_deref()
+        && platform.len() > 32
+    {
+        return Err(AppError::bad_request("platform too long (max 32 chars)"));
+    }
+
     let device_id = body.device_id;
 
     // Decode and verify signing_key + signature (required for MITM prevention).
@@ -454,26 +462,33 @@ pub async fn revoke_other_devices(
     use crate::ws::handler::ServerMessage;
     use axum::extract::ws::Message as WsMessage;
 
+    // Self-lockout guard: refuse the request if the caller's current_device_id
+    // is not actually registered for this user. Without this check a client
+    // that passed a bogus ID (e.g. after a botched re-install) would silently
+    // wipe every one of its own devices.
     let devices = db::keys::get_user_devices(&state.pool, auth_user.user_id).await?;
+    if !devices
+        .iter()
+        .any(|d| d.device_id == body.current_device_id)
+    {
+        return Err(AppError::bad_request(
+            "current_device_id not found among your registered devices",
+        ));
+    }
 
-    let mut revoked = 0usize;
-    for device in devices {
-        if device.device_id == body.current_device_id {
-            continue;
-        }
-
-        let found = db::keys::revoke_device(&state.pool, auth_user.user_id, device.device_id)
+    // Perform the bulk delete in a single transaction and get back the list
+    // of revoked device IDs for WS fan-out.
+    let revoked_ids =
+        db::keys::revoke_devices_except(&state.pool, auth_user.user_id, body.current_device_id)
             .await
-            .map_err(|_| AppError::internal("Database error"))?;
+            .map_err(|e| {
+                tracing::error!("revoke_devices_except failed: {e:?}");
+                AppError::internal("Database error")
+            })?;
 
-        if !found {
-            continue;
-        }
-
-        revoked += 1;
-
+    for device_id in &revoked_ids {
         let event = ServerMessage::DeviceRevoked {
-            device_id: device.device_id,
+            device_id: *device_id,
         };
         if let Ok(json) = serde_json::to_string(&event) {
             state
@@ -485,11 +500,11 @@ pub async fn revoke_other_devices(
     tracing::info!(
         "User {} revoked {} other devices (kept device {})",
         auth_user.user_id,
-        revoked,
+        revoked_ids.len(),
         body.current_device_id,
     );
 
-    Ok(Json(serde_json::json!({ "revoked": revoked })))
+    Ok(Json(serde_json::json!({ "revoked": revoked_ids.len() })))
 }
 
 /// Request body for key reset -- requires current password for re-authentication.

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -175,6 +175,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .route("/bundles/{user_id}", get(keys::get_all_bundles))
         .route("/devices/{user_id}", get(keys::get_devices))
+        .route("/devices/revoke-others", post(keys::revoke_other_devices))
         .route("/device/{device_id}", delete(keys::revoke_device))
         .route("/otp-count", get(keys::get_otp_count));
 

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -87,6 +87,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let media_upload_limit = rate_limit::make_rate_limit_layer(rate_limit::media_upload_limiter());
     let link_preview_limit = rate_limit::make_rate_limit_layer(rate_limit::link_preview_limiter());
     let key_reset_limit = rate_limit::make_rate_limit_layer(rate_limit::key_reset_limiter());
+    let revoke_others_limit =
+        rate_limit::make_rate_limit_layer(rate_limit::revoke_others_limiter());
 
     let auth_routes = Router::new()
         .route(
@@ -174,8 +176,13 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             get(keys::get_device_bundle),
         )
         .route("/bundles/{user_id}", get(keys::get_all_bundles))
+        // NOTE: register `/devices/revoke-others` BEFORE `/devices/{user_id}`
+        // so the static path always wins the route match.
+        .route(
+            "/devices/revoke-others",
+            post(keys::revoke_other_devices).layer(middleware::from_fn(revoke_others_limit)),
+        )
         .route("/devices/{user_id}", get(keys::get_devices))
-        .route("/devices/revoke-others", post(keys::revoke_other_devices))
         .route("/device/{device_id}", delete(keys::revoke_device))
         .route("/otp-count", get(keys::get_otp_count));
 

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -230,6 +230,17 @@ pub async fn handle_socket(
         }
     });
 
+    // Update device last_seen so the management UI reflects recent activity.
+    // Fire-and-forget: a failure here must not affect the connection.
+    if let Err(e) = db::keys::update_last_seen(&state.pool, user_id, device_id).await {
+        tracing::warn!(
+            "Failed to update last_seen for user {} device {}: {:?}",
+            user_id,
+            device_id,
+            e,
+        );
+    }
+
     message_service::deliver_undelivered_messages(&state, user_id, device_id).await;
 
     run_receive_loop(&mut receiver, user_id, device_id, &username, &state).await;

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -231,14 +231,16 @@ pub async fn handle_socket(
     });
 
     // Update device last_seen so the management UI reflects recent activity.
-    // Fire-and-forget: a failure here must not affect the connection.
-    if let Err(e) = db::keys::update_last_seen(&state.pool, user_id, device_id).await {
-        tracing::warn!(
-            "Failed to update last_seen for user {} device {}: {:?}",
-            user_id,
-            device_id,
-            e,
-        );
+    // Fire-and-forget: the connection must not block on a DB write here.
+    {
+        let pool = state.pool.clone();
+        tokio::spawn(async move {
+            if let Err(e) = db::keys::update_last_seen(&pool, user_id, device_id).await {
+                tracing::warn!(
+                    "update_last_seen failed for user {user_id} device {device_id}: {e}"
+                );
+            }
+        });
     }
 
     message_service::deliver_undelivered_messages(&state, user_id, device_id).await;

--- a/apps/server/tests/api_keys.rs
+++ b/apps/server/tests/api_keys.rs
@@ -370,14 +370,19 @@ async fn get_devices_returns_device_ids() {
         .unwrap();
     assert_eq!(resp.status().as_u16(), 200);
     let body: Value = resp.json().await.unwrap();
-    let device_ids: Vec<i64> = body["device_ids"]
-        .as_array()
-        .unwrap()
+    let devices = body["devices"].as_array().expect("devices array present");
+    let device_ids: Vec<i64> = devices
         .iter()
-        .map(|v| v.as_i64().unwrap())
+        .map(|d| d["device_id"].as_i64().unwrap())
         .collect();
     assert!(device_ids.contains(&0), "should list device 0");
     assert!(device_ids.contains(&1), "should list device 1");
+    // Each entry must at minimum expose a device_id; platform and last_seen
+    // are optional and only populated once the client uploads metadata or the
+    // device connects over WebSocket.
+    for d in devices {
+        assert!(d.get("device_id").is_some(), "missing device_id field");
+    }
 }
 
 #[tokio::test]
@@ -436,4 +441,46 @@ async fn revoke_device_removes_keys() {
         .await
         .unwrap();
     assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn revoke_other_devices_keeps_current_drops_rest() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, uid, _) = common::register_and_login(&client, &base, "keyrevothers").await;
+
+    // Upload three devices (0, 1, 2)
+    let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
+    common::upload_additional_device(&client, &base, &token, &bundle0, 1).await;
+    common::upload_additional_device(&client, &base, &token, &bundle0, 2).await;
+
+    // Keep device 0, revoke the rest.
+    let resp = client
+        .post(format!("{base}/api/keys/devices/revoke-others"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "current_device_id": 0 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["revoked"].as_i64().unwrap(), 2, "should revoke 2");
+
+    // Only device 0 should remain in the device list.
+    let (token_other, _, _) = common::register_and_login(&client, &base, "keyrevothersobs").await;
+    let resp = client
+        .get(format!("{base}/api/keys/devices/{uid}"))
+        .header("Authorization", format!("Bearer {token_other}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    let device_ids: Vec<i64> = body["devices"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["device_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(device_ids, vec![0], "only device 0 should remain");
 }

--- a/apps/server/tests/api_keys.rs
+++ b/apps/server/tests/api_keys.rs
@@ -444,6 +444,79 @@ async fn revoke_device_removes_keys() {
 }
 
 #[tokio::test]
+async fn revoke_other_devices_without_auth_returns_401() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/keys/devices/revoke-others"))
+        .json(&serde_json::json!({ "current_device_id": 0 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[tokio::test]
+async fn revoke_other_devices_with_unknown_current_id_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _uid, _) = common::register_and_login(&client, &base, "keyrevunknown").await;
+
+    // Upload exactly one device (device 0).
+    common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
+
+    // Pass a current_device_id that isn't registered.
+    let resp = client
+        .post(format!("{base}/api/keys/devices/revoke-others"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "current_device_id": -1 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn revoke_other_devices_with_single_device_returns_zero() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, uid, _) = common::register_and_login(&client, &base, "keyrevsingle").await;
+
+    // Upload exactly one device (device 0).
+    common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
+
+    let resp = client
+        .post(format!("{base}/api/keys/devices/revoke-others"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "current_device_id": 0 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["revoked"].as_i64().unwrap(), 0, "nothing to revoke");
+
+    // Device 0 must still be in the device list.
+    let (token_other, _, _) = common::register_and_login(&client, &base, "keyrevsingleob").await;
+    let resp = client
+        .get(format!("{base}/api/keys/devices/{uid}"))
+        .header("Authorization", format!("Bearer {token_other}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    let device_ids: Vec<i64> = body["devices"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["device_id"].as_i64().unwrap())
+        .collect();
+    assert_eq!(device_ids, vec![0], "device 0 must still exist");
+}
+
+#[tokio::test]
 async fn revoke_other_devices_keeps_current_drops_rest() {
     let base = common::spawn_server().await;
     let client = Client::new();


### PR DESCRIPTION
## Summary

Closes #237 (MVP scope) and fixes #431.

### User-facing
- Settings > Devices shows **platform name** (iOS / Linux / Web / etc) for every device instead of generic "Device {id}"
- Shows real **last_seen** timestamps (closes #431 -- "Last seen: Never" bug)
- New **"Log out all other devices"** button with confirmation dialog
- Device list auto-refreshes when a peer device is revoked

### Server
- Migration: `platform TEXT` and `last_seen TIMESTAMPTZ` on `identity_keys`
- New endpoint: `POST /api/keys/devices/revoke-others { current_device_id }` -- atomic bulk revoke, rate-limited 3/60s
- `GET /api/keys/devices/:user_id` now returns `{ devices: [{device_id, platform, last_seen}] }` (client has backward-compat parser)
- `last_seen` updated (fire-and-forget) on every WS connect
- `platform` captured on key upload (max 32 chars), stored with `COALESCE` so OTP replenishment doesn't wipe it

### Out of scope (future PRs)
- Per-device refresh-token binding (requires auth rework)
- Device name editing
- IP/geolocation tracking

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -D warnings` clean
- [x] `cargo test -p echo-server --lib` 72/72 pass
- [x] `cargo test -p echo-server --test api_keys` 17/17 pass (3 new tests for revoke-others)
- [x] `flutter analyze --fatal-infos` no issues
- [x] `flutter test` 773 pass
- [x] Manual: open Settings > Devices, verify platform + last_seen display, test "Log out all other devices"

## Review
Internal review loop: 4 core + 3 specialists (database, API, backend architect). All HIGH and MEDIUM severity findings addressed:
- Self-lockout guard when current_device_id isn't in the list
- Atomic bulk revoke (single transaction instead of N)
- `update_last_seen` off hot path (tokio::spawn)
- Dropped unused index
- Route ordering (literal before dynamic)
- Rate limit on revoke-others (3/60s)
- Platform length cap (32 chars)
- Client: safer num cast, last_seen bucket fix, debounced reload, unique device labels