### PR TITLE
feat: ui overhaul -- fix 8 user-reported ux pain points

### DIFF
--- a/apps/client/lib/src/providers/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth_provider.dart
@@ -559,8 +559,20 @@ class AuthNotifier extends StateNotifier<AuthState> {
     state = state.copyWith(avatarUrl: url);
   }
 
+  /// Set of presence status values accepted by the server. Keeping the
+  /// client honest here avoids sending garbage that the server would just
+  /// reject with a 400 -- and protects callers that build the string from
+  /// user input or enum conversions.
+  static const _validPresenceStatuses = <String>{
+    'online',
+    'away',
+    'dnd',
+    'invisible',
+  };
+
   /// Update the user's presence status locally and on the server.
   Future<void> setPresenceStatus(String status) async {
+    if (!_validPresenceStatuses.contains(status)) return;
     if (!state.isLoggedIn) return;
     // Optimistically update local state immediately.
     state = state.copyWith(presenceStatus: status);

--- a/apps/client/lib/src/utils/fuzzy_score.dart
+++ b/apps/client/lib/src/utils/fuzzy_score.dart
@@ -1,0 +1,40 @@
+/// Fuzzy matching helper for search & filter UIs.
+///
+/// Returns a score in `[0, 1]` for how well [query] matches [candidate]:
+///   * 0 = no match (not all query characters found in order)
+///   * 1 = all query characters appear consecutively at the start
+///
+/// Matching is case-insensitive. Consecutive matches ("runs") receive a small
+/// bonus so prefix/contiguous matches score higher than scattered ones.
+///
+/// Use together with a threshold (e.g. `> 0.3`) to filter and sort results.
+double fuzzyScore(String query, String candidate) {
+  if (query.isEmpty) return 0;
+  final q = query.toLowerCase();
+  final c = candidate.toLowerCase();
+
+  int qi = 0;
+  int consecutive = 0;
+  double score = 0;
+
+  for (int ci = 0; ci < c.length && qi < q.length; ci++) {
+    if (c[ci] == q[qi]) {
+      score += 1 + consecutive * 0.5; // bonus for runs
+      consecutive++;
+      qi++;
+    } else {
+      consecutive = 0;
+    }
+  }
+
+  // Not all query characters were matched in order -> no match.
+  if (qi < q.length) return 0;
+
+  // Normalize by the maximum achievable score (all characters consecutive).
+  // Sum of 1 + 0.5 * i for i in [0, n-1] = n + 0.5 * n * (n - 1) / 2.
+  final n = q.length;
+  final maxScore = n + 0.5 * n * (n - 1) / 2;
+  if (maxScore <= 0) return 0;
+
+  return (score / maxScore).clamp(0.0, 1.0);
+}

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -79,6 +79,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   bool _isTextEmpty = true;
   bool _showMediaPicker = false;
 
+  /// True when the composer has wrapped to 2+ visible lines (either by
+  /// explicit newlines or by soft-wrapping long text). When true, the
+  /// attach "+" and emoji toggle are stacked vertically to reclaim
+  /// horizontal space for the text field.
+  bool _isMultiline = false;
+
   /// Inline picker visible on mobile (replaces keyboard).
   bool _showInlinePicker = false;
 
@@ -293,8 +299,14 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   void _onTextChanged() {
     final text = _messageController.text;
     final empty = text.trim().isEmpty;
-    if (empty != _isTextEmpty) {
-      setState(() => _isTextEmpty = empty);
+    // Detect multiline either via explicit newlines or long content that
+    // is likely to soft-wrap at typical widths (~40 chars at fontSize 14).
+    final multiline = text.contains('\n') || text.length > 40;
+    if (empty != _isTextEmpty || multiline != _isMultiline) {
+      setState(() {
+        _isTextEmpty = empty;
+        _isMultiline = multiline;
+      });
     }
     // Schedule draft save when not in edit mode and not suppressed
     if (!_isEditing && !_suppressDraftSave) {
@@ -1664,6 +1676,40 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       return _buildRecordingRow();
     }
 
+    // When composing multi-line content, stack the attach "+" and the
+    // emoji / GIF toggle vertically on the left so the text field can
+    // use the full remaining horizontal space.
+    final Widget leading;
+    if (_isEditing) {
+      leading = const SizedBox(width: 12);
+    } else if (_isMultiline) {
+      leading = Padding(
+        padding: const EdgeInsets.only(bottom: 4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildAttachFileButton(),
+            const SizedBox(height: 2),
+            _buildMediaPickerToggle(
+              showMediaPicker: showMediaPicker,
+              isMobileLayout: isMobileLayout,
+            ),
+          ],
+        ),
+      );
+    } else {
+      leading = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildAttachFileButton(),
+          _buildMediaPickerToggle(
+            showMediaPicker: showMediaPicker,
+            isMobileLayout: isMobileLayout,
+          ),
+        ],
+      );
+    }
+
     return Container(
       constraints: const BoxConstraints(minHeight: 44),
       decoration: BoxDecoration(
@@ -1677,14 +1723,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          // Attach file + media picker toggle (hidden in edit mode)
-          if (!_isEditing) _buildAttachFileButton(),
-          if (!_isEditing)
-            _buildMediaPickerToggle(
-              showMediaPicker: showMediaPicker,
-              isMobileLayout: isMobileLayout,
-            ),
-          if (_isEditing) const SizedBox(width: 12),
+          leading,
           // Text field
           _buildTextField(
             showMediaPicker: showMediaPicker,

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -17,6 +17,7 @@ Color presenceStatusDotColor(
     'online' => EchoTheme.online,
     'away' => EchoTheme.warning,
     'dnd' => EchoTheme.danger,
+    'invisible' => const Color(0xFF6B6B6F),
     _ => const Color(0xFF6B6B6F),
   };
 }
@@ -38,6 +39,10 @@ class ConversationItem extends StatefulWidget {
   final VoidCallback onTap;
   final void Function(Offset position)? onContextMenu;
 
+  /// Number of group members (other than the current user) currently online.
+  /// Only consulted when [Conversation.isGroup] is true.
+  final int onlineMemberCount;
+
   const ConversationItem({
     super.key,
     required this.conversation,
@@ -51,6 +56,7 @@ class ConversationItem extends StatefulWidget {
     required this.timestamp,
     required this.onTap,
     this.onContextMenu,
+    this.onlineMemberCount = 0,
   });
 
   @override
@@ -305,6 +311,9 @@ class _ConversationItemState extends State<ConversationItem> {
         defaultTargetPlatform != TargetPlatform.android &&
         defaultTargetPlatform != TargetPlatform.iOS;
 
+    final conv = widget.conversation;
+    final showGroupOnline = conv.isGroup && widget.onlineMemberCount > 0;
+
     return Row(
       children: [
         if (widget.isPinned)
@@ -312,7 +321,7 @@ class _ConversationItemState extends State<ConversationItem> {
             padding: const EdgeInsets.only(right: 4),
             child: Icon(Icons.push_pin, size: 12, color: context.textMuted),
           ),
-        Expanded(
+        Flexible(
           child: Text(
             displayName,
             overflow: TextOverflow.ellipsis,
@@ -323,6 +332,41 @@ class _ConversationItemState extends State<ConversationItem> {
             ),
           ),
         ),
+        if (showGroupOnline)
+          Padding(
+            padding: const EdgeInsets.only(left: 6),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: EchoTheme.online.withValues(alpha: 0.18),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 6,
+                    height: 6,
+                    decoration: const BoxDecoration(
+                      color: EchoTheme.online,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 3),
+                  Text(
+                    '${widget.onlineMemberCount}',
+                    style: const TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w700,
+                      color: EchoTheme.online,
+                      height: 1,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        const Spacer(),
         if (showMoreButton)
           Semantics(
             label: 'More options for $displayName',

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1334,8 +1334,6 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         : conv.members.where((m) => m.userId != myUserId).firstOrNull;
     final isPeerOnline = peer != null && wsOnlineUsers.contains(peer.userId);
 
-    // For groups, count how many members (excluding me) are currently online.
-    // The count is shown as a small pill next to the group name.
     final onlineMemberCount = conv.isGroup
         ? conv.members
               .where(

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
@@ -79,6 +81,10 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   /// Pinned conversation IDs
   Set<String> _pinnedIds = {};
 
+  /// Debounce timer for the search field. Delays the fuzzy-score recompute
+  /// so we don't run it on every keystroke.
+  Timer? _searchDebounce;
+
   @override
   void initState() {
     super.initState();
@@ -109,7 +115,19 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     _searchController.dispose();
     _searchFocusNode.dispose();
     _keyboardListenerFocusNode.dispose();
+    _searchDebounce?.cancel();
     super.dispose();
+  }
+
+  /// Debounced search handler (150ms). Avoids running fuzzyScore over every
+  /// conversation on every keystroke.
+  void _onSearchChanged(String value) {
+    final trimmed = value.trim();
+    _searchDebounce?.cancel();
+    _searchDebounce = Timer(const Duration(milliseconds: 150), () {
+      if (!mounted) return;
+      setState(() => _searchQuery = trimmed);
+    });
   }
 
   // Pending contacts refresh is handled by HomeScreen's timer -- no duplicate here.
@@ -187,6 +205,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   }
 
   void _clearSearch() {
+    _searchDebounce?.cancel();
     setState(() {
       _searchQuery = '';
       _isSearching = false;
@@ -515,8 +534,10 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         final lastMsg = conv.lastMessage ?? '';
         final nameScore = fuzzyScore(query, name);
         final msgScore = fuzzyScore(query, lastMsg);
-        final score = nameScore * 2 + msgScore; // name matches weigh more
-        if (score > 0.3) {
+        // Weighted sum normalised back into [0, 1] so the threshold is
+        // meaningful. Raw weights were nameScore*2 + msgScore (max 3).
+        final score = (nameScore * 2 + msgScore) / 3;
+        if (score > 0.2) {
           scored.add((conv: conv, score: score));
         }
       }
@@ -772,11 +793,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
                 contentPadding: const EdgeInsets.symmetric(vertical: 10),
                 isDense: true,
               ),
-              onChanged: (value) {
-                setState(() {
-                  _searchQuery = value.trim();
-                });
-              },
+              onChanged: _onSearchChanged,
             ),
           ),
           if (_searchQuery.isNotEmpty)

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -13,6 +13,7 @@ import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import '../utils/fuzzy_score.dart';
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart';
 import 'conversation_item.dart';
@@ -504,14 +505,23 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         break;
     }
 
-    // Apply search filter.
+    // Apply search filter using fuzzy scoring so typos/abbreviations still
+    // match and the best match appears first.
     if (_searchQuery.isNotEmpty) {
-      final query = _searchQuery.toLowerCase();
-      result = result.where((conv) {
-        final name = conv.displayName(myUserId).toLowerCase();
-        final lastMsg = (conv.lastMessage ?? '').toLowerCase();
-        return name.contains(query) || lastMsg.contains(query);
-      }).toList();
+      final query = _searchQuery;
+      final scored = <({Conversation conv, double score})>[];
+      for (final conv in result) {
+        final name = conv.displayName(myUserId);
+        final lastMsg = conv.lastMessage ?? '';
+        final nameScore = fuzzyScore(query, name);
+        final msgScore = fuzzyScore(query, lastMsg);
+        final score = nameScore * 2 + msgScore; // name matches weigh more
+        if (score > 0.3) {
+          scored.add((conv: conv, score: score));
+        }
+      }
+      scored.sort((a, b) => b.score.compareTo(a.score));
+      result = scored.map((e) => e.conv).toList();
     }
 
     return result;
@@ -1323,6 +1333,17 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         ? null
         : conv.members.where((m) => m.userId != myUserId).firstOrNull;
     final isPeerOnline = peer != null && wsOnlineUsers.contains(peer.userId);
+
+    // For groups, count how many members (excluding me) are currently online.
+    // The count is shown as a small pill next to the group name.
+    final onlineMemberCount = conv.isGroup
+        ? conv.members
+              .where(
+                (m) => m.userId != myUserId && wsOnlineUsers.contains(m.userId),
+              )
+              .length
+        : 0;
+
     return ConversationItem(
       conversation: conv,
       myUserId: myUserId,
@@ -1335,6 +1356,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       onTap: () => widget.onConversationTap(conv),
       onContextMenu: (position) =>
           _showConversationContextMenu(context, conv, position),
+      onlineMemberCount: onlineMemberCount,
     );
   }
 }

--- a/apps/client/lib/src/widgets/forward_message_dialog.dart
+++ b/apps/client/lib/src/widgets/forward_message_dialog.dart
@@ -5,6 +5,7 @@ import '../models/conversation.dart';
 import '../providers/auth_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../theme/echo_theme.dart';
+import '../utils/fuzzy_score.dart';
 import 'avatar_utils.dart' show buildAvatar, avatarColor;
 
 /// Shows a modal dialog that lets the user pick a conversation to forward a
@@ -40,13 +41,20 @@ class _ForwardMessageDialogState extends ConsumerState<_ForwardMessageDialog> {
   }
 
   List<Conversation> _filtered(List<Conversation> all, String myUserId) {
-    final q = _query.trim().toLowerCase();
+    final q = _query.trim();
     if (q.isEmpty) return all;
-    return all.where((conv) {
-      final name = conv.displayName(myUserId).toLowerCase();
-      if (name.contains(q)) return true;
-      return conv.members.any((m) => m.username.toLowerCase().contains(q));
-    }).toList();
+    final scored = <({Conversation conv, double score})>[];
+    for (final conv in all) {
+      final name = conv.displayName(myUserId);
+      double best = fuzzyScore(q, name);
+      for (final m in conv.members) {
+        final s = fuzzyScore(q, m.username);
+        if (s > best) best = s;
+      }
+      if (best > 0.3) scored.add((conv: conv, score: best));
+    }
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    return scored.map((e) => e.conv).toList();
   }
 
   @override

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -11,6 +11,7 @@ import '../providers/conversations_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
+import '../utils/fuzzy_score.dart';
 
 /// Global message search overlay (Ctrl+Shift+F or search icon).
 ///
@@ -83,20 +84,34 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
         final list = jsonDecode(response.body) as List;
         final conversations = ref.read(conversationsProvider).conversations;
         final myUserId = ref.read(authProvider).userId ?? '';
+        final parsed = list.map((item) {
+          final e = item as Map<String, dynamic>;
+          final convId = (e['conversation_id'] ?? '').toString();
+          final conv = conversations.where((c) => c.id == convId).firstOrNull;
+          return _SearchResult(
+            messageId: (e['message_id'] ?? '').toString(),
+            conversationId: convId,
+            conversationName: conv?.displayName(myUserId) ?? 'Unknown',
+            senderUsername: (e['sender_username'] ?? '').toString(),
+            content: (e['content'] ?? '').toString(),
+            timestamp: (e['created_at'] ?? '').toString(),
+          );
+        }).toList();
+        // Re-rank server results by fuzzy score so the best match bubbles
+        // to the top. Score against content + conversation + sender.
+        parsed.sort((a, b) {
+          final sa =
+              fuzzyScore(query, a.content) +
+              0.5 * fuzzyScore(query, a.conversationName) +
+              0.25 * fuzzyScore(query, a.senderUsername);
+          final sb =
+              fuzzyScore(query, b.content) +
+              0.5 * fuzzyScore(query, b.conversationName) +
+              0.25 * fuzzyScore(query, b.senderUsername);
+          return sb.compareTo(sa);
+        });
         setState(() {
-          _results = list.map((item) {
-            final e = item as Map<String, dynamic>;
-            final convId = (e['conversation_id'] ?? '').toString();
-            final conv = conversations.where((c) => c.id == convId).firstOrNull;
-            return _SearchResult(
-              messageId: (e['message_id'] ?? '').toString(),
-              conversationId: convId,
-              conversationName: conv?.displayName(myUserId) ?? 'Unknown',
-              senderUsername: (e['sender_username'] ?? '').toString(),
-              content: (e['content'] ?? '').toString(),
-              timestamp: (e['created_at'] ?? '').toString(),
-            );
-          }).toList();
+          _results = parsed;
           _loading = false;
         });
       } else {

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -30,6 +30,7 @@ class GlobalSearchOverlay extends ConsumerStatefulWidget {
 class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
   final _controller = TextEditingController();
   final _focusNode = FocusNode();
+  final _keyboardFocusNode = FocusNode();
   Timer? _debounce;
   List<_SearchResult> _results = [];
   bool _loading = false;
@@ -45,6 +46,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
   void dispose() {
     _controller.dispose();
     _focusNode.dispose();
+    _keyboardFocusNode.dispose();
     _debounce?.cancel();
     super.dispose();
   }
@@ -133,7 +135,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     final width = isMobile ? MediaQuery.of(context).size.width - 32 : 560.0;
 
     return KeyboardListener(
-      focusNode: FocusNode(),
+      focusNode: _keyboardFocusNode,
       onKeyEvent: (event) {
         if (event is KeyDownEvent &&
             event.logicalKey == LogicalKeyboardKey.escape) {

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -97,8 +97,6 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
             timestamp: (e['created_at'] ?? '').toString(),
           );
         }).toList();
-        // Re-rank server results by fuzzy score so the best match bubbles
-        // to the top. Score against content + conversation + sender.
         parsed.sort((a, b) {
           final sa =
               fuzzyScore(query, a.content) +

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -339,9 +339,13 @@ class MediaContentState extends State<MediaContent> {
                           imageUrl: imageUrl,
                           httpHeaders: headers,
                           fit: BoxFit.contain,
-                          placeholder: (_, _) => const Center(
-                            child: CircularProgressIndicator(
-                              color: Colors.white,
+                          placeholder: (_, _) => const SizedBox(
+                            width: 320,
+                            height: 240,
+                            child: Center(
+                              child: CircularProgressIndicator(
+                                color: Colors.white,
+                              ),
                             ),
                           ),
                           errorWidget: (_, _, _) => const Center(
@@ -460,9 +464,12 @@ class MediaContentState extends State<MediaContent> {
                             ),
                           ),
                         ),
+                        // Reserve the typical image area while loading so
+                        // the bubble height is stable and scroll position
+                        // does not jump once the bytes arrive.
                         placeholder: (_, _) => Container(
                           width: 300,
-                          height: 80,
+                          height: 200,
                           decoration: BoxDecoration(
                             color: context.surface,
                             borderRadius: BorderRadius.circular(12),

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1140,9 +1140,6 @@ class _MessageItemState extends State<MessageItem>
                   ? widget.onImageTap!(imgUrl)
                   : _showImageViewer(imageUrl: imgUrl),
               child: ConstrainedBox(
-                // Constrain both dimensions so a tall image doesn't
-                // swallow the scroll viewport. Width bound keeps
-                // portrait crops from stretching wider than the bubble.
                 constraints: const BoxConstraints(
                   maxWidth: 400,
                   maxHeight: 320,
@@ -1272,8 +1269,6 @@ class _MessageItemState extends State<MessageItem>
     required bool isFailed,
     required bool hasMedia,
   }) {
-    // Tighter padding in compact mode so consecutive rows read more like
-    // a single continuous stream and less like separate messages.
     final EdgeInsets padding;
     if (hasMedia) {
       padding = const EdgeInsets.all(4);
@@ -1413,11 +1408,6 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  /// Build the "N replies" link shown below messages that have thread replies.
-  ///
-  /// Rendered as a rounded accent pill with an `InkWell` tap target so the
-  /// affordance is visually distinct from regular timestamps and has a
-  /// proper touch/hover highlight.
   Widget _buildReplyCountBadge({
     required ChatMessage msg,
     required bool isMine,
@@ -1522,10 +1512,6 @@ class _MessageItemState extends State<MessageItem>
   }
 
   /// Build the main message row containing the avatar and bubble.
-  ///
-  /// In compact mode follow-up messages (showHeader=false) drop the avatar
-  /// and instead indent by the avatar column width so the bubble stacks
-  /// directly under the previous bubble -- no repeated avatar, no jog.
   List<Widget> _buildMessageRowChildren({
     required ChatMessage msg,
     required bool isMine,

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -620,9 +620,13 @@ class _MessageItemState extends State<MessageItem>
                     httpHeaders: headers,
                     cacheManager: chatImageCacheManager,
                     fit: BoxFit.contain,
-                    placeholder: (_, _) => Center(
-                      child: CircularProgressIndicator(
-                        color: Theme.of(context).colorScheme.onPrimary,
+                    placeholder: (_, _) => SizedBox(
+                      width: 320,
+                      height: 240,
+                      child: Center(
+                        child: CircularProgressIndicator(
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
                       ),
                     ),
                     errorWidget: (_, _, _) => Center(
@@ -907,19 +911,43 @@ class _MessageItemState extends State<MessageItem>
   }
 
   /// Build the sender name label shown above the message bubble.
+  ///
+  /// In compact layout the sender name and timestamp share a single inline
+  /// row ("Username 12:34 PM") to save vertical space. Everywhere else the
+  /// name stands alone on its own line above the bubble.
   Widget _buildSenderNameLabel({
     required ChatMessage msg,
     required bool hasMedia,
   }) {
+    final nameText = Text(
+      msg.fromUsername,
+      style: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        color: _getUserColor(msg.fromUserId),
+      ),
+    );
+
+    final padding = EdgeInsets.only(bottom: 4, left: hasMedia ? 8 : 0);
+
+    if (!widget.compactLayout) {
+      return Padding(padding: padding, child: nameText);
+    }
+
     return Padding(
-      padding: EdgeInsets.only(bottom: 4, left: hasMedia ? 8 : 0),
-      child: Text(
-        msg.fromUsername,
-        style: TextStyle(
-          fontSize: 12,
-          fontWeight: FontWeight.w600,
-          color: _getUserColor(msg.fromUserId),
-        ),
+      padding: padding,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          nameText,
+          const SizedBox(width: 6),
+          Text(
+            formatMessageTimestamp(msg.timestamp),
+            style: TextStyle(fontSize: 10, color: context.textMuted),
+          ),
+        ],
       ),
     );
   }
@@ -1112,7 +1140,13 @@ class _MessageItemState extends State<MessageItem>
                   ? widget.onImageTap!(imgUrl)
                   : _showImageViewer(imageUrl: imgUrl),
               child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 400),
+                // Constrain both dimensions so a tall image doesn't
+                // swallow the scroll viewport. Width bound keeps
+                // portrait crops from stretching wider than the bubble.
+                constraints: const BoxConstraints(
+                  maxWidth: 400,
+                  maxHeight: 320,
+                ),
                 child: imgUrl.endsWith('.gif')
                     ? Image.network(
                         imgUrl,
@@ -1127,16 +1161,20 @@ class _MessageItemState extends State<MessageItem>
                         httpHeaders: headers,
                         cacheManager: chatImageCacheManager,
                         errorWidget: (_, _, _) => const SizedBox.shrink(),
-                        placeholder: (_, _) => SizedBox(
-                          height: 60,
-                          child: Center(
-                            child: SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: context.textMuted,
-                              ),
+                        // Reserve the expected image area while loading so
+                        // the scroll position does not jump when the image
+                        // finally decodes.
+                        placeholder: (_, _) => Container(
+                          height: 200,
+                          width: 300,
+                          color: context.surface,
+                          alignment: Alignment.center,
+                          child: SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: context.textMuted,
                             ),
                           ),
                         ),
@@ -1234,11 +1272,20 @@ class _MessageItemState extends State<MessageItem>
     required bool isFailed,
     required bool hasMedia,
   }) {
+    // Tighter padding in compact mode so consecutive rows read more like
+    // a single continuous stream and less like separate messages.
+    final EdgeInsets padding;
+    if (hasMedia) {
+      padding = const EdgeInsets.all(4);
+    } else if (widget.compactLayout) {
+      padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 4);
+    } else {
+      padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
+    }
+
     return Container(
       constraints: const BoxConstraints(maxWidth: 520),
-      padding: hasMedia
-          ? const EdgeInsets.all(4)
-          : const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: padding,
       decoration: BoxDecoration(
         color: _bubbleColor(isMine: isMine, isFailed: isFailed),
         borderRadius: _bubbleBorderRadius(isMine: isMine),
@@ -1367,6 +1414,10 @@ class _MessageItemState extends State<MessageItem>
   }
 
   /// Build the "N replies" link shown below messages that have thread replies.
+  ///
+  /// Rendered as a rounded accent pill with an `InkWell` tap target so the
+  /// affordance is visually distinct from regular timestamps and has a
+  /// proper touch/hover highlight.
   Widget _buildReplyCountBadge({
     required ChatMessage msg,
     required bool isMine,
@@ -1375,28 +1426,39 @@ class _MessageItemState extends State<MessageItem>
     final label = count == 1 ? '1 reply' : '$count replies';
     return Padding(
       padding: EdgeInsets.only(top: 4, left: isMine ? 0 : 36),
-      child: Semantics(
-        label: 'View $label',
-        button: true,
-        child: GestureDetector(
-          onTap: () => widget.onViewThread?.call(msg),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: isMine
-                ? MainAxisAlignment.end
-                : MainAxisAlignment.start,
-            children: [
-              Icon(Icons.forum_outlined, size: 12, color: context.accent),
-              const SizedBox(width: 4),
-              Text(
-                label,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: context.accent,
-                  fontWeight: FontWeight.w500,
+      child: Align(
+        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+        child: Semantics(
+          label: 'View $label',
+          button: true,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: () => widget.onViewThread?.call(msg),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: context.accent.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.forum_outlined, size: 12, color: context.accent),
+                    const SizedBox(width: 4),
+                    Text(
+                      label,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: context.accent,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
                 ),
               ),
-            ],
+            ),
           ),
         ),
       ),
@@ -1460,16 +1522,29 @@ class _MessageItemState extends State<MessageItem>
   }
 
   /// Build the main message row containing the avatar and bubble.
+  ///
+  /// In compact mode follow-up messages (showHeader=false) drop the avatar
+  /// and instead indent by the avatar column width so the bubble stacks
+  /// directly under the previous bubble -- no repeated avatar, no jog.
   List<Widget> _buildMessageRowChildren({
     required ChatMessage msg,
     required bool isMine,
     required Widget bubbleWithReactions,
   }) {
+    final needsAvatarColumn = !isMine || widget.compactLayout;
+    if (!needsAvatarColumn) {
+      return [Flexible(child: bubbleWithReactions)];
+    }
+
+    // Compact follow-up: reserve the avatar column with whitespace instead
+    // of re-drawing the avatar.  28 (avatar) + 8 (gap) = 36.
+    if (widget.compactLayout && !widget.showHeader) {
+      return [const SizedBox(width: 36), Flexible(child: bubbleWithReactions)];
+    }
+
     return [
-      if (!isMine || widget.compactLayout) ...[
-        _buildAvatarSection(msg: msg),
-        const SizedBox(width: 8),
-      ],
+      _buildAvatarSection(msg: msg),
+      const SizedBox(width: 8),
       Flexible(child: bubbleWithReactions),
     ];
   }
@@ -1609,11 +1684,20 @@ class _MessageItemState extends State<MessageItem>
     final canSwipeToReply =
         _isMobileTouch && widget.onReply != null && !msg.isSystemEvent;
 
+    // In compact mode, the gap between bubbles from the same sender is
+    // reduced so the conversation reads as a single stream.
+    final double topPad;
+    if (widget.showHeader) {
+      topPad = widget.compactLayout ? 4 : 8;
+    } else {
+      topPad = widget.compactLayout ? 1 : 2;
+    }
+
     final messageWidget = Container(
       padding: EdgeInsets.only(
         left: 24,
         right: 24,
-        top: widget.showHeader ? 8 : 2,
+        top: topPad,
         bottom: hasReactions ? 4 : 2,
       ),
       child: Stack(

--- a/apps/client/lib/src/widgets/message_search_overlay.dart
+++ b/apps/client/lib/src/widgets/message_search_overlay.dart
@@ -89,9 +89,6 @@ class _MessageSearchOverlayState extends ConsumerState<MessageSearchOverlay> {
               ),
             )
             .toList();
-        // Re-rank by fuzzy-score of the message content so the most
-        // likely match appears first, not just whatever order the
-        // server returned them in.
         parsed.sort((a, b) {
           final sa = fuzzyScore(query, a.content);
           final sb = fuzzyScore(query, b.content);

--- a/apps/client/lib/src/widgets/message_search_overlay.dart
+++ b/apps/client/lib/src/widgets/message_search_overlay.dart
@@ -10,6 +10,7 @@ import '../models/chat_message.dart';
 import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
+import '../utils/fuzzy_score.dart';
 
 /// Overlay widget for searching messages within a conversation.
 ///
@@ -80,16 +81,25 @@ class _MessageSearchOverlayState extends ConsumerState<MessageSearchOverlay> {
 
       if (response.statusCode == 200) {
         final list = jsonDecode(response.body) as List;
+        final parsed = list
+            .map(
+              (e) => ChatMessage.fromServerJson(
+                e as Map<String, dynamic>,
+                myUserId,
+              ),
+            )
+            .toList();
+        // Re-rank by fuzzy-score of the message content so the most
+        // likely match appears first, not just whatever order the
+        // server returned them in.
+        parsed.sort((a, b) {
+          final sa = fuzzyScore(query, a.content);
+          final sb = fuzzyScore(query, b.content);
+          return sb.compareTo(sa);
+        });
         setState(() {
           _searchQuery = query;
-          _searchResults = list
-              .map(
-                (e) => ChatMessage.fromServerJson(
-                  e as Map<String, dynamic>,
-                  myUserId,
-                ),
-              )
-              .toList();
+          _searchResults = parsed;
         });
       } else {
         setState(() {

--- a/apps/client/lib/src/widgets/user_status_bar.dart
+++ b/apps/client/lib/src/widgets/user_status_bar.dart
@@ -84,7 +84,6 @@ class UserStatusBar extends ConsumerWidget {
                   .toList(),
               child: Row(
                 children: [
-                  // Avatar with status indicator dot
                   Stack(
                     children: [
                       CircleAvatar(
@@ -115,7 +114,6 @@ class UserStatusBar extends ConsumerWidget {
                     ],
                   ),
                   const SizedBox(width: 10),
-                  // Username and status
                   Expanded(
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,

--- a/apps/client/lib/src/widgets/user_status_bar.dart
+++ b/apps/client/lib/src/widgets/user_status_bar.dart
@@ -2,7 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/auth_provider.dart';
+import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import 'conversation_item.dart' show presenceStatusDotColor;
+
+/// Human-readable label for a presence status identifier.
+String presenceStatusLabel(String status) {
+  return switch (status) {
+    'online' => 'Online',
+    'away' => 'Away',
+    'dnd' => 'Do Not Disturb',
+    'invisible' => 'Invisible',
+    _ => 'Online',
+  };
+}
+
+/// Ordered list of selectable statuses for the quick picker.
+const List<String> _kStatusOptions = ['online', 'away', 'dnd', 'invisible'];
 
 class UserStatusBar extends ConsumerWidget {
   const UserStatusBar({super.key});
@@ -12,6 +28,8 @@ class UserStatusBar extends ConsumerWidget {
     final authState = ref.watch(authProvider);
     final username = authState.username ?? 'User';
     final initial = username.isNotEmpty ? username[0].toUpperCase() : '?';
+    final status = authState.presenceStatus;
+    final dotColor = presenceStatusDotColor(context, status, true);
 
     return Container(
       height: 60,
@@ -22,57 +40,108 @@ class UserStatusBar extends ConsumerWidget {
       ),
       child: Row(
         children: [
-          // Avatar with online indicator
-          Stack(
-            children: [
-              CircleAvatar(
-                radius: 16,
-                backgroundColor: context.accent,
-                child: Text(
-                  initial,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-              Positioned(
-                bottom: 0,
-                right: 0,
-                child: Container(
-                  width: 10,
-                  height: 10,
-                  decoration: BoxDecoration(
-                    color: EchoTheme.online,
-                    shape: BoxShape.circle,
-                    border: Border.all(color: context.mainBg, width: 2),
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(width: 10),
-          // Username and status
           Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  username,
-                  style: TextStyle(
-                    color: context.textPrimary,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
+            child: PopupMenuButton<String>(
+              tooltip: 'Change status',
+              position: PopupMenuPosition.over,
+              color: context.surface,
+              onSelected: (selected) async {
+                await ref
+                    .read(authProvider.notifier)
+                    .setPresenceStatus(selected);
+                if (context.mounted) {
+                  ToastService.show(
+                    context,
+                    'Status set to ${presenceStatusLabel(selected)}',
+                    type: ToastType.success,
+                  );
+                }
+              },
+              itemBuilder: (ctx) => _kStatusOptions
+                  .map(
+                    (s) => PopupMenuItem<String>(
+                      value: s,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: 10,
+                            height: 10,
+                            decoration: BoxDecoration(
+                              color: presenceStatusDotColor(ctx, s, true),
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            presenceStatusLabel(s),
+                            style: TextStyle(color: ctx.textPrimary),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                  .toList(),
+              child: Row(
+                children: [
+                  // Avatar with status indicator dot
+                  Stack(
+                    children: [
+                      CircleAvatar(
+                        radius: 16,
+                        backgroundColor: context.accent,
+                        child: Text(
+                          initial,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      Positioned(
+                        bottom: 0,
+                        right: 0,
+                        child: Container(
+                          width: 10,
+                          height: 10,
+                          decoration: BoxDecoration(
+                            color: dotColor,
+                            shape: BoxShape.circle,
+                            border: Border.all(color: context.mainBg, width: 2),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-                Text(
-                  'Online',
-                  style: TextStyle(color: context.textMuted, fontSize: 11),
-                ),
-              ],
+                  const SizedBox(width: 10),
+                  // Username and status
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          username,
+                          style: TextStyle(
+                            color: context.textPrimary,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        Text(
+                          presenceStatusLabel(status),
+                          style: TextStyle(
+                            color: context.textMuted,
+                            fontSize: 11,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
           // Settings gear

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'dart:ui' show ImageFilter;
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/gestures.dart';
@@ -19,7 +20,7 @@ import '../utils/canvas_utils.dart';
 // Constants
 // ---------------------------------------------------------------------------
 
-const double _kAvatarSize = 72.0;
+const double _kAvatarSize = 48.0;
 const double _kAvatarHalfSize = _kAvatarSize / 2;
 
 // ---------------------------------------------------------------------------
@@ -631,6 +632,54 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
 
     final hasVideo = info.videoTrack != null;
 
+    // Frosted-glass tile that lets the vertex-mesh background show through.
+    // For video tiles skip the blur so the video feed stays crisp.  The
+    // speaking ring is drawn on the outer container so it sits OVER the
+    // blur and remains visible at all times.
+    final innerContent = hasVideo
+        ? lk.VideoTrackRenderer(
+            info.videoTrack!,
+            fit: RTCVideoViewObjectFit.RTCVideoViewObjectFitCover,
+            mirrorMode: info.mirror
+                ? lk.VideoViewMirrorMode.mirror
+                : lk.VideoViewMirrorMode.off,
+          )
+        : info.avatarUrl != null
+        ? CachedNetworkImage(
+            imageUrl: info.avatarUrl!,
+            httpHeaders: widget.httpHeaders,
+            fit: BoxFit.cover,
+            placeholder: (_, _) => _initialsWidget(initial),
+            errorWidget: (_, _, _) => _initialsWidget(initial),
+          )
+        : _initialsWidget(initial);
+
+    Widget tile = Container(
+      width: _kAvatarSize,
+      height: _kAvatarSize,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: hasVideo ? Colors.black : Colors.black.withValues(alpha: 0.35),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: hasVideo
+          ? innerContent
+          : Stack(
+              fit: StackFit.expand,
+              children: [
+                // Frosted-glass blur layer lets the canvas background
+                // bleed through as a soft wash.
+                BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+                  child: Container(color: avatarColor.withValues(alpha: 0.55)),
+                ),
+                innerContent,
+              ],
+            ),
+    );
+
+    // Outer container draws the speaking ring outside the blur so it
+    // stays crisp and never gets washed out by the BackdropFilter.
     Widget avatar = AnimatedScale(
       scale: scale,
       duration: const Duration(milliseconds: 150),
@@ -639,7 +688,6 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
         height: _kAvatarSize,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: hasVideo ? Colors.black : avatarColor,
           border: Border.all(color: speakRingColor, width: ringWidth),
           boxShadow: [
             BoxShadow(
@@ -649,24 +697,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
             ),
           ],
         ),
-        clipBehavior: Clip.antiAlias,
-        child: hasVideo
-            ? lk.VideoTrackRenderer(
-                info.videoTrack!,
-                fit: RTCVideoViewObjectFit.RTCVideoViewObjectFitCover,
-                mirrorMode: info.mirror
-                    ? lk.VideoViewMirrorMode.mirror
-                    : lk.VideoViewMirrorMode.off,
-              )
-            : info.avatarUrl != null
-            ? CachedNetworkImage(
-                imageUrl: info.avatarUrl!,
-                httpHeaders: widget.httpHeaders,
-                fit: BoxFit.cover,
-                placeholder: (_, _) => _initialsWidget(initial),
-                errorWidget: (_, _, _) => _initialsWidget(initial),
-              )
-            : _initialsWidget(initial),
+        child: ClipOval(child: tile),
       ),
     );
 
@@ -725,7 +756,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
       initial,
       style: const TextStyle(
         color: Colors.white,
-        fontSize: 26,
+        fontSize: 18,
         fontWeight: FontWeight.bold,
       ),
     ),

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -1,5 +1,4 @@
 import 'dart:math' as math;
-import 'dart:ui' show ImageFilter;
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/gestures.dart';
@@ -617,6 +616,10 @@ class _DraggableAvatar extends StatefulWidget {
 }
 
 class _DraggableAvatarState extends State<_DraggableAvatar> {
+  /// Tracks the live drag position so `onPanEnd` commits the latest value
+  /// instead of the stale `widget.currentPos` prop from before the drag.
+  CanvasPoint? _localPos;
+
   @override
   Widget build(BuildContext context) {
     final info = widget.participant;
@@ -655,7 +658,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
       height: _kAvatarSize,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: hasVideo ? Colors.black : Colors.black.withValues(alpha: 0.35),
+        color: hasVideo ? Colors.black : Colors.black.withValues(alpha: 0.45),
       ),
       clipBehavior: Clip.antiAlias,
       child: hasVideo
@@ -663,10 +666,9 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
           : Stack(
               fit: StackFit.expand,
               children: [
-                BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-                  child: Container(color: avatarColor.withValues(alpha: 0.55)),
-                ),
+                // Solid semi-transparent fill instead of a per-tile
+                // BackdropFilter -- avoids N GPU blur passes per frame.
+                Container(color: avatarColor.withValues(alpha: 0.55)),
                 innerContent,
               ],
             ),
@@ -689,7 +691,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
             ),
           ],
         ),
-        child: ClipOval(child: tile),
+        child: tile,
       ),
     );
 
@@ -729,14 +731,17 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
           if (s.width <= 0 || s.height <= 0) return;
           final dx = details.delta.dx / s.width;
           final dy = details.delta.dy / s.height;
+          final base = _localPos ?? widget.currentPos;
           final newPos = CanvasPoint(
-            x: (widget.currentPos.x + dx).clamp(0.0, 1.0),
-            y: (widget.currentPos.y + dy).clamp(0.0, 1.0),
+            x: (base.x + dx).clamp(0.0, 1.0),
+            y: (base.y + dy).clamp(0.0, 1.0),
           );
+          _localPos = newPos;
           widget.onDrag(newPos);
         },
         onPanEnd: (_) {
-          widget.onDragEnd(widget.currentPos);
+          widget.onDragEnd(_localPos ?? widget.currentPos);
+          _localPos = null;
         },
         child: content,
       ),

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -632,10 +632,6 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
 
     final hasVideo = info.videoTrack != null;
 
-    // Frosted-glass tile that lets the vertex-mesh background show through.
-    // For video tiles skip the blur so the video feed stays crisp.  The
-    // speaking ring is drawn on the outer container so it sits OVER the
-    // blur and remains visible at all times.
     final innerContent = hasVideo
         ? lk.VideoTrackRenderer(
             info.videoTrack!,
@@ -667,8 +663,6 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
           : Stack(
               fit: StackFit.expand,
               children: [
-                // Frosted-glass blur layer lets the canvas background
-                // bleed through as a soft wash.
                 BackdropFilter(
                   filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
                   child: Container(color: avatarColor.withValues(alpha: 0.55)),
@@ -678,8 +672,6 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
             ),
     );
 
-    // Outer container draws the speaking ring outside the blur so it
-    // stays crisp and never gets washed out by the BackdropFilter.
     Widget avatar = AnimatedScale(
       scale: scale,
       duration: const Duration(milliseconds: 150),

--- a/apps/client/test/utils/fuzzy_score_test.dart
+++ b/apps/client/test/utils/fuzzy_score_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/utils/fuzzy_score.dart';
+
+void main() {
+  group('fuzzyScore', () {
+    test('returns 0 for empty query', () {
+      expect(fuzzyScore('', 'anything'), 0);
+    });
+
+    test('returns 0 when query has characters not present in order', () {
+      expect(fuzzyScore('xyz', 'abc'), 0);
+      // 'ba' not found in 'abc' (would need 'b' before 'a')
+      expect(fuzzyScore('ba', 'abc'), 0);
+    });
+
+    test('perfect prefix match scores 1.0', () {
+      expect(fuzzyScore('abc', 'abc'), closeTo(1.0, 0.001));
+      expect(fuzzyScore('ali', 'alice'), closeTo(1.0, 0.001));
+    });
+
+    test('is case-insensitive', () {
+      expect(fuzzyScore('ALICE', 'alice'), closeTo(1.0, 0.001));
+      expect(fuzzyScore('Alice', 'ALICE'), closeTo(1.0, 0.001));
+    });
+
+    test('consecutive matches score higher than scattered', () {
+      final consecutive = fuzzyScore('ace', 'aceAAA');
+      final scattered = fuzzyScore('ace', 'a_c_e');
+      expect(consecutive, greaterThan(scattered));
+    });
+
+    test('substring match in middle still returns positive score', () {
+      final s = fuzzyScore('bob', 'alice-bob-charlie');
+      expect(s, greaterThan(0));
+      expect(s, lessThanOrEqualTo(1.0));
+    });
+
+    test('single-character query always returns a valid score', () {
+      expect(fuzzyScore('a', 'a'), closeTo(1.0, 0.001));
+      expect(fuzzyScore('a', 'abc'), closeTo(1.0, 0.001));
+      expect(fuzzyScore('a', 'b'), 0);
+    });
+
+    test('score is clamped to [0, 1]', () {
+      for (final pair in [
+        ['a', 'a'],
+        ['abc', 'abc'],
+        ['ab', 'abababab'],
+        ['', 'anything'],
+        ['xyz', 'abc'],
+      ]) {
+        final s = fuzzyScore(pair[0], pair[1]);
+        expect(s, greaterThanOrEqualTo(0));
+        expect(s, lessThanOrEqualTo(1.0));
+      }
+    });
+
+    test('sorts candidates so best match is first', () {
+      const query = 'ali';
+      final candidates = ['bob', 'charlie', 'alice', 'alinka'];
+      final scored =
+          candidates.map((c) => (name: c, score: fuzzyScore(query, c))).toList()
+            ..sort((a, b) => b.score.compareTo(a.score));
+
+      // alice / alinka both have 'ali' as prefix; bob has no match.
+      expect(scored.first.name, anyOf('alice', 'alinka'));
+      expect(scored.last.name, 'bob');
+      expect(scored.last.score, 0);
+    });
+  });
+}

--- a/apps/client/test/widgets/user_status_bar_test.dart
+++ b/apps/client/test/widgets/user_status_bar_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/user_status_bar.dart';
+
+void main() {
+  group('presenceStatusLabel', () {
+    test('maps known statuses to human-readable labels', () {
+      expect(presenceStatusLabel('online'), 'Online');
+      expect(presenceStatusLabel('away'), 'Away');
+      expect(presenceStatusLabel('dnd'), 'Do Not Disturb');
+      expect(presenceStatusLabel('invisible'), 'Invisible');
+    });
+
+    test('falls back to Online for unknown values', () {
+      expect(presenceStatusLabel(''), 'Online');
+      expect(presenceStatusLabel('bogus'), 'Online');
+    });
+  });
+}

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -366,13 +366,29 @@ async fn broadcast_presence_with_status(
         }
     };
 
-    let presence = serde_json::json!({
-        "type": "presence",
-        "user_id": user_id,
-        "username": username,
-        "status": broadcast_status,
-        "presence_status": presence_status,
-    });
+    // Privacy: when the user's stored status is "invisible", the contact-
+    // visible payload is "offline". Do NOT leak the raw "invisible" value in
+    // the `presence_status` field -- a patched client could otherwise observe
+    // it and defeat the invisibility. The user's own session keeps the raw
+    // value via the PATCH response, which is separate from this broadcast.
+    let hide_presence_status = presence_status == "invisible" && broadcast_status == "offline";
+
+    let presence = if hide_presence_status {
+        serde_json::json!({
+            "type": "presence",
+            "user_id": user_id,
+            "username": username,
+            "status": broadcast_status,
+        })
+    } else {
+        serde_json::json!({
+            "type": "presence",
+            "user_id": user_id,
+            "username": username,
+            "status": broadcast_status,
+            "presence_status": presence_status,
+        })
+    };
     if let Ok(json) = serde_json::to_string(&presence) {
         for cid in &contact_ids {
             state.hub.send_to(cid, WsMessage::Text(json.clone().into()));

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -204,29 +204,32 @@ pub(super) async fn broadcast_presence(
     // When coming online, look up stored presence_status so we broadcast
     // the right status (e.g. "away" or "dnd") rather than always "online".
     // For "offline" (disconnect), always broadcast "offline" regardless of
-    // stored status. Invisible users also appear offline.
+    // stored status. Invisible users also appear offline -- and we omit
+    // the presence_status field entirely so observers cannot distinguish
+    // invisible from truly offline.
     let (broadcast_status, presence_status) = if status == "offline" {
-        ("offline".to_string(), "offline".to_string())
+        ("offline".to_string(), None)
     } else {
         let stored = db::users::get_presence_status(&state.pool, user_id)
             .await
             .unwrap_or(None)
             .unwrap_or_else(|| "online".to_string());
-        let visible_status = if stored == "invisible" {
-            "offline".to_string()
+        if stored == "invisible" {
+            ("offline".to_string(), None)
         } else {
-            stored.clone()
-        };
-        (visible_status, stored)
+            (stored.clone(), Some(stored))
+        }
     };
 
-    let presence = serde_json::json!({
+    let mut presence = serde_json::json!({
         "type": "presence",
         "user_id": user_id,
         "username": username,
         "status": broadcast_status,
-        "presence_status": presence_status,
     });
+    if let Some(ps) = presence_status {
+        presence["presence_status"] = serde_json::Value::String(ps);
+    }
     let json = match serde_json::to_string(&presence) {
         Ok(j) => j,
         Err(_) => return,


### PR DESCRIPTION
## Summary

One big PR addressing user-reported UX issues from production testing on 2026-04-23. Closes #419, #420, #421, #423, #424, #426, #427, #210. Defers #425 (rich text toolbar) as separate PR.

### What changed

| Issue | Change |
|-------|--------|
| #419 | Composer: + and emoji buttons stack vertically when text is multiline |
| #420 | Quick status picker: click user bar to switch Online/Away/DND/Invisible |
| #421 | Fuzzy search: reranks results with partial + typo-tolerant matching |
| #423 | Thread indicator: colored pill with reply count + forum icon |
| #424 | Online dots + "online N" badge on group conversations |
| #426 | Image placeholders reserve 200px height to stop scroll jumps |
| #427 | Compact mode: Discord-style density (inline name + timestamp, reduced padding) |
| #210 | Voice lounge: smaller 48px avatars + semi-transparent tiles |

### Bonus fixes from review

- Drag-end position staleness in voice canvas
- FocusNode leak in global search overlay
- Search debounce (150ms) on conversation filter
- Fuzzy score threshold normalized to [0,1]
- **Privacy**: `presence_status: invisible` no longer broadcast on presence events (both server paths). Invisible users now indistinguishable from truly offline.
- Status input validation in auth provider

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` 784/784 pass (11 new tests)
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean
- [x] `cargo test -p echo-server --lib` 72/72 pass
- [x] Manual: compose multiline message -> buttons stack
- [x] Manual: click user status -> picker opens
- [x] Manual: type "alce" in contact search -> "alice" ranks high
- [x] Manual: group with online members shows "• N" pill
- [x] Manual: image load doesn't jump scroll position
- [x] Manual: compact mode density matches Discord

## Review
Internal review loop: 4 core reviewers. All HIGH (3) and MEDIUM (5) findings addressed plus 1 mirrored privacy leak found during review fixes.