### PR TITLE
feat: ux quick-wins from 5-agent review

### DIFF
--- a/apps/client/lib/src/providers/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth_provider.dart
@@ -11,6 +11,7 @@ import '../services/debug_log_service.dart';
 import '../services/message_cache.dart';
 import '../services/secure_key_store.dart';
 import '../services/user_data_dir.dart';
+import '../utils/friendly_error.dart';
 import 'server_url_provider.dart';
 
 const _kJsonHeaders = {'Content-Type': 'application/json'};
@@ -483,17 +484,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
           errorMsg = data['error'] as String? ?? errorMsg;
         } catch (e) {
           debugPrint('[Auth] register response parse failed: $e');
-          errorMsg = 'Server error (${response.statusCode})';
+          errorMsg = friendlyError(
+            Exception('Server error ${response.statusCode}'),
+          );
         }
         state = state.copyWith(isLoading: false, error: errorMsg);
       }
     } catch (e) {
-      final msg = e is TimeoutException
-          ? 'Cannot reach server. Check your connection.'
-          : e.toString().contains('FormatException')
-          ? 'Cannot reach server. Check your connection.'
-          : e.toString();
-      state = state.copyWith(isLoading: false, error: msg);
+      state = state.copyWith(isLoading: false, error: friendlyError(e));
     }
   }
 
@@ -541,17 +539,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
           errorMsg = data['error'] as String? ?? errorMsg;
         } catch (e) {
           debugPrint('[Auth] login response parse failed: $e');
-          errorMsg = 'Server error (${response.statusCode})';
+          errorMsg = friendlyError(
+            Exception('Server error ${response.statusCode}'),
+          );
         }
         state = state.copyWith(isLoading: false, error: errorMsg);
       }
     } catch (e) {
-      final msg = e is TimeoutException
-          ? 'Cannot reach server. Check your connection.'
-          : e.toString().contains('FormatException')
-          ? 'Cannot reach server. Check your connection.'
-          : e.toString();
-      state = state.copyWith(isLoading: false, error: msg);
+      state = state.copyWith(isLoading: false, error: friendlyError(e));
     }
   }
 

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -60,7 +60,7 @@ final themeProvider = StateNotifierProvider<ThemeNotifier, AppThemeSelection>((
 });
 
 // ---------------------------------------------------------------------------
-// Message layout: bubbles (default) or compact (Discord-style)
+// Message layout: compact (Discord-style, default) or bubbles
 // ---------------------------------------------------------------------------
 
 enum MessageLayout { bubbles, compact }
@@ -68,7 +68,7 @@ enum MessageLayout { bubbles, compact }
 class MessageLayoutNotifier extends StateNotifier<MessageLayout> {
   static const _key = 'echo_message_layout';
 
-  MessageLayoutNotifier() : super(MessageLayout.bubbles) {
+  MessageLayoutNotifier() : super(MessageLayout.compact) {
     _load();
   }
 
@@ -76,8 +76,9 @@ class MessageLayoutNotifier extends StateNotifier<MessageLayout> {
     final prefs = await SharedPreferences.getInstance();
     final value = prefs.getString(_key);
     state = switch (value) {
+      'bubbles' => MessageLayout.bubbles,
       'compact' => MessageLayout.compact,
-      _ => MessageLayout.bubbles,
+      _ => MessageLayout.compact,
     };
   }
 

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -206,6 +206,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
         );
       }
     } catch (e) {
+      debugPrint('[Onboarding] avatar upload failed: $e');
       if (mounted) {
         ToastService.show(context, friendlyError(e), type: ToastType.error);
       }

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -15,6 +15,7 @@ import '../providers/server_url_provider.dart';
 import '../providers/theme_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import '../utils/friendly_error.dart';
 import '../widgets/echo_logo_icon.dart';
 
 /// Shared preferences key that gates whether onboarding has been completed.
@@ -206,7 +207,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
       }
     } catch (e) {
       if (mounted) {
-        ToastService.show(context, 'Upload error: $e', type: ToastType.error);
+        ToastService.show(context, friendlyError(e), type: ToastType.error);
       }
     } finally {
       if (mounted) setState(() => _uploadingAvatar = false);

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -12,6 +12,7 @@ import '../../providers/auth_provider.dart';
 import '../../providers/server_url_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
+import '../../utils/friendly_error.dart';
 import '../../widgets/avatar_utils.dart' show resolveAvatarUrl;
 
 class _CountryCode {
@@ -312,7 +313,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
       await _sendAvatarWithRetry(serverUrl, file);
     } catch (e) {
       if (mounted) {
-        ToastService.show(context, 'Upload error: $e', type: ToastType.error);
+        ToastService.show(context, friendlyError(e), type: ToastType.error);
       }
     }
   }
@@ -342,7 +343,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     } else {
       ToastService.show(
         context,
-        'Failed to upload avatar ($statusCode)',
+        friendlyError(Exception('Avatar upload failed $statusCode')),
         type: ToastType.error,
       );
     }

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -312,6 +312,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     try {
       await _sendAvatarWithRetry(serverUrl, file);
     } catch (e) {
+      debugPrint('[Account] avatar upload failed: $e');
       if (mounted) {
         ToastService.show(context, friendlyError(e), type: ToastType.error);
       }

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -11,6 +11,7 @@ import '../providers/crypto_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/websocket_provider.dart';
+import '../services/message_cache.dart';
 import '../services/push_token_service.dart';
 import '../services/update_service.dart' as update_svc;
 import '../router/app_router.dart' show pendingDeepLink;
@@ -32,6 +33,12 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
   late final Animation<double> _fadeAnimation;
   bool _showUpdatePrompt = false;
   bool _loggedIn = false;
+  String _statusText = 'Connecting…';
+
+  void _setStatus(String text) {
+    if (!mounted) return;
+    setState(() => _statusText = text);
+  }
 
   @override
   void initState() {
@@ -59,10 +66,12 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
   Future<void> _init() async {
     final stopwatch = Stopwatch()..start();
 
+    _setStatus('Checking session…');
     final loggedIn = await _attemptAutoLogin();
 
     // Pre-load conversations so home screen doesn't flash empty state
     if (loggedIn) {
+      _setStatus('Loading messages…');
       try {
         await ref
             .read(conversationsProvider.notifier)
@@ -183,7 +192,11 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     context.go('/home');
 
     final cryptoState = ref.read(cryptoProvider);
-    if (cryptoState.keysWereRegenerated && mounted) {
+    // Only warn about regenerated keys when the user had prior messages on
+    // this device. Fresh logins on a new device would otherwise see a
+    // scary "history unavailable" banner that doesn't apply to them.
+    final hadPriorMessages = MessageCache.entryCount() > 0;
+    if (cryptoState.keysWereRegenerated && hadPriorMessages && mounted) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
@@ -355,6 +368,11 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
                   strokeWidth: 2.5,
                   color: context.accent.withValues(alpha: 0.6),
                 ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                _statusText,
+                style: TextStyle(fontSize: 13, color: context.textMuted),
               ),
             ],
           ),

--- a/apps/client/lib/src/utils/friendly_error.dart
+++ b/apps/client/lib/src/utils/friendly_error.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+import 'dart:io';
+
+/// Map technical exceptions to short, user-facing strings.
+///
+/// Prefer this over surfacing raw `e.toString()` in toasts and banners --
+/// users should not see stack-trace fragments, hostnames, or status codes.
+String friendlyError(Object e) {
+  if (e is SocketException) {
+    return "Can't reach Echo. Check your internet connection.";
+  }
+  if (e is TimeoutException) {
+    return 'Echo is taking too long to respond. Try again.';
+  }
+  if (e is FormatException) {
+    return 'The server returned an unexpected response.';
+  }
+  final s = e.toString();
+  if (s.contains('413')) return 'That file is too large.';
+  if (s.contains('429')) return 'Too many requests. Slow down.';
+  if (RegExp(r'\b5\d\d\b').hasMatch(s)) {
+    return 'Echo is temporarily unavailable. Try again in a moment.';
+  }
+  return 'Something went wrong. Try again.';
+}

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/chat_message.dart';
 import '../models/conversation.dart';
@@ -153,19 +154,43 @@ class ChatHeaderBar extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                displayName,
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 15,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
+              _buildNameRow(context, conv, displayName),
               _buildStatusLine(context, ref, conv),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  /// Name row — shows the display name and, for 1:1 conversations, a small
+  /// green "verified" check next to the name when the user has previously
+  /// confirmed the peer's safety number on this device.
+  Widget _buildNameRow(
+    BuildContext context,
+    Conversation conv,
+    String displayName,
+  ) {
+    final nameText = Text(
+      displayName,
+      style: TextStyle(
+        color: context.textPrimary,
+        fontSize: 15,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+
+    if (conv.isGroup) return nameText;
+
+    final peer = conv.members.where((m) => m.userId != myUserId).firstOrNull;
+    if (peer == null) return nameText;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        nameText,
+        _VerifiedBadge(peerUserId: peer.userId),
+      ],
     );
   }
 
@@ -766,6 +791,58 @@ class ChatHeaderBar extends ConsumerWidget {
         );
       }
     }
+  }
+}
+
+/// Tiny green check shown next to a DM peer's name when the user has
+/// previously verified their safety number. Reads `echo_safety_verified_<id>`
+/// from SharedPreferences. Clears itself if the pref changes between rebuilds
+/// (see IdentityKeyChangedBanner which removes the pref on TOFU).
+class _VerifiedBadge extends StatefulWidget {
+  final String peerUserId;
+
+  const _VerifiedBadge({required this.peerUserId});
+
+  @override
+  State<_VerifiedBadge> createState() => _VerifiedBadgeState();
+}
+
+class _VerifiedBadgeState extends State<_VerifiedBadge> {
+  bool _verified = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVerified();
+  }
+
+  @override
+  void didUpdateWidget(covariant _VerifiedBadge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.peerUserId != widget.peerUserId) {
+      setState(() => _verified = false);
+      _loadVerified();
+    }
+  }
+
+  Future<void> _loadVerified() async {
+    final prefs = await SharedPreferences.getInstance();
+    final flag =
+        prefs.getBool('echo_safety_verified_${widget.peerUserId}') ?? false;
+    if (!mounted) return;
+    if (flag != _verified) setState(() => _verified = flag);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_verified) return const SizedBox.shrink();
+    return const Padding(
+      padding: EdgeInsets.only(left: 4),
+      child: Tooltip(
+        message: 'Safety number verified',
+        child: Icon(Icons.verified, size: 14, color: EchoTheme.online),
+      ),
+    );
   }
 }
 

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -1452,9 +1452,58 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       return _handleCopyCutShortcut(false);
     }
     if (event.logicalKey == LogicalKeyboardKey.keyX) {
+      // Ctrl+Shift+X = strikethrough; plain Ctrl+X = cut.
+      if (HardwareKeyboard.instance.isShiftPressed) {
+        return _applyMarkdownWrap(open: '~~', close: '~~');
+      }
       return _handleCopyCutShortcut(true);
     }
+    if (event.logicalKey == LogicalKeyboardKey.keyB &&
+        !HardwareKeyboard.instance.isShiftPressed) {
+      return _applyMarkdownWrap(open: '**', close: '**');
+    }
+    if (event.logicalKey == LogicalKeyboardKey.keyI &&
+        !HardwareKeyboard.instance.isShiftPressed) {
+      return _applyMarkdownWrap(open: '*', close: '*');
+    }
     return KeyEventResult.ignored;
+  }
+
+  /// Wrap the current selection with [open]/[close] markers. When nothing is
+  /// selected, insert both markers at the cursor and leave the caret between
+  /// them so the user can immediately type. Returns [KeyEventResult.handled]
+  /// so the key does not also reach the underlying TextField.
+  KeyEventResult _applyMarkdownWrap({
+    required String open,
+    required String close,
+  }) {
+    final text = _messageController.text;
+    final sel = _messageController.selection;
+    if (!sel.isValid) return KeyEventResult.ignored;
+
+    if (sel.isCollapsed) {
+      final cursor = sel.start;
+      final newText =
+          text.substring(0, cursor) + open + close + text.substring(cursor);
+      _messageController.value = TextEditingValue(
+        text: newText,
+        selection: TextSelection.collapsed(offset: cursor + open.length),
+      );
+      return KeyEventResult.handled;
+    }
+
+    final before = text.substring(0, sel.start);
+    final selected = text.substring(sel.start, sel.end);
+    final after = text.substring(sel.end);
+    final newText = '$before$open$selected$close$after';
+    _messageController.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection(
+        baseOffset: sel.start + open.length,
+        extentOffset: sel.end + open.length,
+      ),
+    );
+    return KeyEventResult.handled;
   }
 
   /// Up arrow with empty input: edit last own message (Discord behavior).

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -22,6 +22,7 @@ import '../providers/privacy_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/theme_provider.dart';
 import '../providers/websocket_provider.dart';
+import '../screens/safety_number_screen.dart';
 import '../screens/user_profile_screen.dart';
 import '../services/message_cache.dart';
 import '../services/saved_messages_service.dart';
@@ -1627,6 +1628,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
 
   Widget _buildMessageAtIndex({
     required int i,
+    required Conversation conv,
     required List<ChatMessage> messages,
     required Map<String, String?> memberAvatars,
     required String myUserId,
@@ -1712,6 +1714,18 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
             onAvatarTap: (userId) {
               UserProfileScreen.show(context, ref, userId);
             },
+            onVerifyIdentity: conv.isGroup
+                ? null
+                : (message) {
+                    final myName = ref.read(authProvider).username ?? 'You';
+                    SafetyNumberScreen.show(
+                      context,
+                      ref,
+                      peerUserId: message.fromUserId,
+                      peerUsername: message.fromUsername,
+                      myUsername: myName,
+                    );
+                  },
             onImageTap: (resolvedUrl) => _openImageGallery(
               tappedUrl: resolvedUrl,
               messages: messages,
@@ -1761,6 +1775,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
           }
           return _buildMessageAtIndex(
             i: index - 1,
+            conv: conv,
             messages: messages,
             memberAvatars: memberAvatars,
             myUserId: myUserId,

--- a/apps/client/lib/src/widgets/identity_key_changed_banner.dart
+++ b/apps/client/lib/src/widgets/identity_key_changed_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/conversation.dart';
 import '../providers/auth_provider.dart';
@@ -62,6 +63,17 @@ class _IdentityKeyChangedBannerState
     final changed = await ref
         .read(cryptoProvider.notifier)
         .hasPeerIdentityKeyChanged(peer.userId);
+
+    if (changed) {
+      // Reset any prior safety-number verification for this peer -- a new
+      // identity key means the old verification no longer applies.
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.remove('echo_safety_verified_${peer.userId}');
+      } catch (_) {
+        // Best-effort; verification state is cosmetic.
+      }
+    }
 
     if (mounted) {
       setState(() {

--- a/apps/client/lib/src/widgets/message/voice_message_widget.dart
+++ b/apps/client/lib/src/widgets/message/voice_message_widget.dart
@@ -58,6 +58,9 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
   Duration _duration = Duration.zero;
   Duration _position = Duration.zero;
 
+  /// Current playback speed. Cycles 1.0 -> 1.5 -> 2.0 -> 1.0 on tap.
+  double _playbackRate = 1.0;
+
   /// Visual-only progress fraction during a drag gesture ([0, 1]).
   /// null means no drag is in progress — use [_progress] instead.
   double? _dragProgress;
@@ -182,6 +185,27 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
   // Helpers
   // ---------------------------------------------------------------------------
 
+  /// Cycle playback rate 1x -> 1.5x -> 2x -> 1x.
+  Future<void> _cyclePlaybackRate() async {
+    final next = switch (_playbackRate) {
+      1.0 => 1.5,
+      1.5 => 2.0,
+      _ => 1.0,
+    };
+    setState(() => _playbackRate = next);
+    try {
+      await _player.setPlaybackRate(next);
+    } catch (e) {
+      debugPrint('[VoiceMsg] setPlaybackRate failed: $e');
+    }
+  }
+
+  String _formatRateLabel(double rate) {
+    // Show "1x" / "2x" without decimal, "1.5x" with one decimal.
+    final isInt = rate == rate.truncateToDouble();
+    return isInt ? '${rate.toInt()}x' : '${rate.toStringAsFixed(1)}x';
+  }
+
   String _formatDuration(Duration d) {
     final m = d.inMinutes.remainder(60);
     final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
@@ -232,7 +256,7 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
         : (showDuration ? _formatDuration(_duration) : '0:00');
 
     return SizedBox(
-      width: 240,
+      width: 272,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -264,6 +288,33 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
                       ),
                     ),
                   ),
+          ),
+          const SizedBox(width: 4),
+          // Playback speed toggle
+          Tooltip(
+            message: 'Playback speed',
+            child: InkWell(
+              onTap: _cyclePlaybackRate,
+              borderRadius: BorderRadius.circular(10),
+              child: Container(
+                width: 32,
+                height: 24,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: accentColor.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  _formatRateLabel(_playbackRate),
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: accentColor,
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ),
+            ),
           ),
           const SizedBox(width: 8),
           // Waveform + duration label

--- a/apps/client/lib/src/widgets/message/voice_message_widget.dart
+++ b/apps/client/lib/src/widgets/message/voice_message_widget.dart
@@ -185,7 +185,6 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
   // Helpers
   // ---------------------------------------------------------------------------
 
-  /// Cycle playback rate 1x -> 1.5x -> 2x -> 1x.
   Future<void> _cyclePlaybackRate() async {
     final next = switch (_playbackRate) {
       1.0 => 1.5,
@@ -195,13 +194,12 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
     setState(() => _playbackRate = next);
     try {
       await _player.setPlaybackRate(next);
-    } catch (e) {
-      debugPrint('[VoiceMsg] setPlaybackRate failed: $e');
+    } catch (_) {
+      // Best-effort; platform may not support playback rate.
     }
   }
 
   String _formatRateLabel(double rate) {
-    // Show "1x" / "2x" without decimal, "1.5x" with one decimal.
     final isInt = rate == rate.truncateToDouble();
     return isInt ? '${rate.toInt()}x' : '${rate.toStringAsFixed(1)}x';
   }
@@ -290,7 +288,6 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
                   ),
           ),
           const SizedBox(width: 4),
-          // Playback speed toggle
           Tooltip(
             message: 'Playback speed',
             child: InkWell(

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -63,6 +63,10 @@ class MessageItem extends StatefulWidget {
   final void Function(ChatMessage message)? onForward;
   final void Function(String replyToId)? onTapReplyQuote;
 
+  /// Called when the tiny lock icon on a received message is tapped.
+  /// When null, the lock icon is non-interactive.
+  final void Function(ChatMessage message)? onVerifyIdentity;
+
   /// Whether this message is currently bookmarked.
   final bool isSaved;
 
@@ -106,6 +110,7 @@ class MessageItem extends StatefulWidget {
     this.onUnsave,
     this.onForward,
     this.onTapReplyQuote,
+    this.onVerifyIdentity,
     this.isSaved = false,
     this.serverUrl,
     this.authToken,
@@ -1347,6 +1352,29 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
+  /// Build the tiny green lock icon shown next to the timestamp on encrypted
+  /// messages. Received-message lock is tappable to open the safety-number
+  /// verification screen; my own lock icon is non-interactive.
+  Widget _buildLockIcon({required ChatMessage msg, required bool isMine}) {
+    const icon = Padding(
+      padding: EdgeInsets.only(left: 3),
+      child: Icon(Icons.lock, size: 10, color: EchoTheme.online),
+    );
+
+    if (isMine || widget.onVerifyIdentity == null) {
+      return icon;
+    }
+
+    return Tooltip(
+      message: 'End-to-end encrypted. Tap to verify.',
+      child: InkWell(
+        onTap: () => widget.onVerifyIdentity!(msg),
+        borderRadius: BorderRadius.circular(6),
+        child: icon,
+      ),
+    );
+  }
+
   /// Build the timestamp row shown below the last message in a group.
   Widget _buildTimestampRow({required ChatMessage msg, required bool isMine}) {
     return Padding(
@@ -1361,11 +1389,7 @@ class _MessageItemState extends State<MessageItem>
             formatMessageTimestamp(msg.timestamp),
             style: TextStyle(fontSize: 11, color: context.textMuted),
           ),
-          if (msg.isEncrypted)
-            const Padding(
-              padding: EdgeInsets.only(left: 3),
-              child: Icon(Icons.lock, size: 10, color: EchoTheme.online),
-            ),
+          if (msg.isEncrypted) _buildLockIcon(msg: msg, isMine: isMine),
           if (msg.pinnedAt != null)
             Padding(
               padding: const EdgeInsets.only(left: 4),

--- a/apps/client/lib/src/widgets/shared_media_gallery.dart
+++ b/apps/client/lib/src/widgets/shared_media_gallery.dart
@@ -9,6 +9,7 @@ import '../providers/media_ticket_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
 import '../utils/time_utils.dart';
+import 'image_gallery_viewer.dart';
 import 'message/media_content.dart';
 
 /// Extracts all shared media (images, videos, files) from a conversation's
@@ -151,6 +152,20 @@ class _MediaGrid extends StatelessWidget {
       );
     }
 
+    // Pre-resolve the full list of image URLs once so every tile knows its
+    // index within the gallery, and can hand the full ordered list to the
+    // multi-image viewer for swipe navigation.
+    final resolvedUrls = [
+      for (final item in items)
+        resolveMediaUrl(
+          item.rawUrl,
+          serverUrl: serverUrl,
+          authToken: authToken,
+          mediaTicket: mediaTicket,
+        ),
+    ];
+    final headers = mediaHeaders(authToken: authToken);
+
     return GridView.builder(
       padding: const EdgeInsets.all(4),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -160,20 +175,18 @@ class _MediaGrid extends StatelessWidget {
       ),
       itemCount: items.length,
       itemBuilder: (context, index) {
-        final item = items[index];
-        final resolvedUrl = resolveMediaUrl(
-          item.rawUrl,
-          serverUrl: serverUrl,
-          authToken: authToken,
-          mediaTicket: mediaTicket,
-        );
-        final headers = mediaHeaders(authToken: authToken);
+        final resolvedUrl = resolvedUrls[index];
 
         return Semantics(
           label: 'view media',
           button: true,
           child: GestureDetector(
-            onTap: () => _showFullImage(context, resolvedUrl, headers),
+            onTap: () => showImageGallery(
+              context: context,
+              imageUrls: resolvedUrls,
+              initialIndex: index,
+              headers: headers,
+            ),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(2),
               child: resolvedUrl.endsWith('.gif')
@@ -202,66 +215,6 @@ class _MediaGrid extends StatelessWidget {
     return Container(
       color: context.surface,
       child: Icon(Icons.image_outlined, color: context.textMuted, size: 24),
-    );
-  }
-
-  void _showFullImage(
-    BuildContext context,
-    String imageUrl,
-    Map<String, String> headers,
-  ) {
-    showDialog<void>(
-      context: context,
-      barrierDismissible: true,
-      barrierColor: Colors.black.withValues(alpha: 0.9),
-      builder: (dialogContext) => Stack(
-        children: [
-          Positioned.fill(
-            child: GestureDetector(
-              onTap: () => Navigator.of(dialogContext).pop(),
-              behavior: HitTestBehavior.opaque,
-              child: const SizedBox.expand(),
-            ),
-          ),
-          Center(
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                maxWidth: MediaQuery.of(dialogContext).size.width * 0.85,
-                maxHeight: MediaQuery.of(dialogContext).size.height * 0.85,
-              ),
-              child: InteractiveViewer(
-                minScale: 0.8,
-                maxScale: 4,
-                child: CachedNetworkImage(
-                  imageUrl: imageUrl,
-                  httpHeaders: headers,
-                  fit: BoxFit.contain,
-                  placeholder: (_, _) => const Center(
-                    child: CircularProgressIndicator(color: Colors.white),
-                  ),
-                  errorWidget: (_, _, _) => const Center(
-                    child: Icon(
-                      Icons.broken_image_outlined,
-                      color: Colors.white54,
-                      size: 48,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            top: 16,
-            right: 16,
-            child: IconButton(
-              icon: const Icon(Icons.close),
-              color: Colors.white,
-              tooltip: 'Close',
-              onPressed: () => Navigator.of(dialogContext).pop(),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/apps/client/test/providers/theme_provider_test.dart
+++ b/apps/client/test/providers/theme_provider_test.dart
@@ -90,30 +90,30 @@ void main() {
       SharedPreferences.setMockInitialValues({});
     });
 
-    test('default layout is bubbles', () async {
-      final notifier = MessageLayoutNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, MessageLayout.bubbles);
-      notifier.dispose();
-    });
-
-    test('loads persisted layout', () async {
-      SharedPreferences.setMockInitialValues({
-        'echo_message_layout': 'compact',
-      });
+    test('default layout is compact (Discord-style)', () async {
       final notifier = MessageLayoutNotifier();
       await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(notifier.state, MessageLayout.compact);
       notifier.dispose();
     });
 
-    test('unknown layout value falls back to bubbles', () async {
+    test('loads persisted bubbles layout', () async {
+      SharedPreferences.setMockInitialValues({
+        'echo_message_layout': 'bubbles',
+      });
+      final notifier = MessageLayoutNotifier();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(notifier.state, MessageLayout.bubbles);
+      notifier.dispose();
+    });
+
+    test('unknown layout value falls back to compact default', () async {
       SharedPreferences.setMockInitialValues({
         'echo_message_layout': 'unknown',
       });
       final notifier = MessageLayoutNotifier();
       await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, MessageLayout.bubbles);
+      expect(notifier.state, MessageLayout.compact);
       notifier.dispose();
     });
 
@@ -121,11 +121,11 @@ void main() {
       final notifier = MessageLayoutNotifier();
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
-      await notifier.setLayout(MessageLayout.compact);
-      expect(notifier.state, MessageLayout.compact);
+      await notifier.setLayout(MessageLayout.bubbles);
+      expect(notifier.state, MessageLayout.bubbles);
 
       final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getString('echo_message_layout'), 'compact');
+      expect(prefs.getString('echo_message_layout'), 'bubbles');
       notifier.dispose();
     });
   });

--- a/apps/client/test/utils/friendly_error_test.dart
+++ b/apps/client/test/utils/friendly_error_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/utils/friendly_error.dart';
+
+void main() {
+  group('friendlyError', () {
+    test('SocketException maps to network-unreachable message', () {
+      final msg = friendlyError(const SocketException('Failed host lookup'));
+      expect(msg, "Can't reach Echo. Check your internet connection.");
+    });
+
+    test('TimeoutException maps to slow-server message', () {
+      final msg = friendlyError(TimeoutException('timed out'));
+      expect(msg, 'Echo is taking too long to respond. Try again.');
+    });
+
+    test('FormatException maps to bad-response message', () {
+      final msg = friendlyError(const FormatException('not json'));
+      expect(msg, 'The server returned an unexpected response.');
+    });
+
+    test('413 in message maps to file-too-large', () {
+      final msg = friendlyError(
+        Exception('Server responded 413 Payload Too Large'),
+      );
+      expect(msg, 'That file is too large.');
+    });
+
+    test('429 in message maps to rate-limit', () {
+      final msg = friendlyError(Exception('got 429 Too Many Requests'));
+      expect(msg, 'Too many requests. Slow down.');
+    });
+
+    test('5xx in message maps to temporarily-unavailable', () {
+      expect(
+        friendlyError(Exception('Server error 503 Service Unavailable')),
+        'Echo is temporarily unavailable. Try again in a moment.',
+      );
+      expect(
+        friendlyError(Exception('500 internal')),
+        'Echo is temporarily unavailable. Try again in a moment.',
+      );
+    });
+
+    test('unknown exception falls through to generic message', () {
+      final msg = friendlyError(Exception('something weird happened'));
+      expect(msg, 'Something went wrong. Try again.');
+    });
+
+    test('does not match 3-digit number that is not a 5xx status', () {
+      // 404 and 200 should not trigger the 5xx branch.
+      expect(
+        friendlyError(Exception('status 404')),
+        'Something went wrong. Try again.',
+      );
+      expect(
+        friendlyError(Exception('status 200')),
+        'Something went wrong. Try again.',
+      );
+    });
+  });
+}

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -4,9 +4,10 @@
 //! WebSocket connection (Android uses a foreground service to stay alive).
 //!
 //! **iOS**: Apple requires APNs to wake suspended apps. This module sends
-//! visible notifications with sender info. For encrypted DMs, only the
-//! sender name is shown ("Alice: Encrypted message"). For plaintext groups,
-//! the actual message preview is included.
+//! visible notifications. For encrypted DMs, both the title and body are
+//! redacted to "New message" so the lock screen leaks neither sender nor
+//! content. For plaintext groups, the sender name and a truncated preview
+//! of the message are included.
 //!
 //! ## Configuration (all optional — push is disabled if not set)
 //!
@@ -193,6 +194,20 @@ struct ApnsPushParams<'a> {
     message_id: Uuid,
 }
 
+/// Build the notification title.
+///
+/// For encrypted messages the sender username is redacted to a neutral
+/// "New message" so a glanced-at lock screen does not leak who is messaging
+/// whom. For plaintext (groups, unencrypted DMs) the sender name is shown
+/// as-is.
+fn format_push_title(sender_username: &str, is_encrypted: bool) -> String {
+    if is_encrypted {
+        "New message".to_string()
+    } else {
+        sender_username.to_string()
+    }
+}
+
 /// Build the notification body text.
 ///
 /// - Encrypted messages get a fixed placeholder (server can't read ciphertext).
@@ -213,9 +228,11 @@ fn format_push_body(content: &str, is_encrypted: bool) -> String {
 
 /// Send an APNs push notification to an iOS device.
 ///
-/// - **Encrypted DMs**: Shows "New message" as the body (server can't
-///   read the ciphertext). The sender name is always visible.
-/// - **Plaintext messages**: Shows a truncated preview of the actual content.
+/// - **Encrypted DMs**: Shows "New message" as both the title and body. The
+///   sender name is redacted so lock-screen glances do not leak who is
+///   messaging whom.
+/// - **Plaintext messages**: Shows the sender name as the title and a
+///   truncated preview of the actual content as the body.
 ///
 /// Uses `mutable-content: 1` so a Notification Service Extension can modify
 /// the payload before display.  Also includes `content-available: 1` to wake
@@ -242,11 +259,12 @@ async fn send_apns_push(p: ApnsPushParams<'_>) {
     let url = format!("https://{host}/3/device/{}", p.device_token);
 
     let body = format_push_body(p.content, p.is_encrypted);
+    let title = format_push_title(p.sender_username, p.is_encrypted);
 
     let payload = serde_json::json!({
         "aps": {
             "alert": {
-                "title": p.sender_username,
+                "title": title,
                 "body": body,
             },
             "sound": "default",
@@ -366,5 +384,21 @@ mod tests {
     #[test]
     fn encrypted_with_long_content_still_returns_placeholder() {
         assert_eq!(format_push_body(&"x".repeat(200), true), "New message");
+    }
+
+    #[test]
+    fn encrypted_title_redacts_sender() {
+        assert_eq!(format_push_title("alice", true), "New message");
+    }
+
+    #[test]
+    fn plaintext_title_shows_sender() {
+        assert_eq!(format_push_title("alice", false), "alice");
+    }
+
+    #[test]
+    fn encrypted_title_redacts_even_long_sender() {
+        let long_name = "a".repeat(200);
+        assert_eq!(format_push_title(&long_name, true), "New message");
     }
 }


### PR DESCRIPTION
## Summary

10 quick-wins consolidated from a cross-perspective UX review (Discord, Slack, Signal, Telegram, and first-time user lenses).

### Chat / UI
- Compact layout is now the default for new users (Discord-style flow)
- Tap-to-verify on per-message lock icon (opens safety number screen)
- Verified badge persists in chat header for 1:1 conversations
- Verification auto-clears when TOFU identity-key change is detected
- Ctrl+B / Ctrl+I / Ctrl+Shift+X formatting shortcuts in composer
- Shared media gallery wired to full swipe/zoom viewer

### Onboarding / Errors
- "Connecting…" / "Checking session…" / "Loading messages…" status below splash spinner
- First-login encryption-keys snackbar is suppressed for users with no prior messages
- Friendly error mapping replaces raw `SocketException`, HTTP codes, and `e.toString()` in:
  - Login flow (auth_provider)
  - Avatar upload in onboarding + account settings
- Raw errors still logged via `debugPrint` for debugging

### Voice + Privacy
- Voice message playback cycles 1x / 1.5x / 2x
- APNs push title is now redacted to "New message" for encrypted DMs (matches body redaction; lock screen no longer leaks sender identity to Apple)

## Review
- 5-agent external UX review (Discord/Slack/Signal/Telegram/first-time) informed the scope
- Internal review: code-quality + security passed; raw errors now preserved in debug logs per reviewer feedback

## Test plan
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets -D warnings` clean
- [x] `cargo test -p echo-server --lib` 75/75 pass (3 new push-title tests)
- [x] `flutter analyze --fatal-infos` no issues
- [x] `flutter test` 792 pass (8 new friendly_error tests)
- [x] Manual: kill network -> friendly "Can't reach Echo"; fresh login -> compact layout; tap lock icon -> safety number screen