### PR TITLE
feat: per-conversation mute + disappearing-timer chip

### DIFF
--- a/apps/client/lib/src/models/conversation.dart
+++ b/apps/client/lib/src/models/conversation.dart
@@ -10,6 +10,10 @@ class Conversation {
   final String? lastMessageSender;
   final int unreadCount;
   final bool isMuted;
+
+  /// Disappearing-messages TTL in seconds, or null if disabled.
+  /// Drives the timer chip in the chat header.
+  final int? ttlSeconds;
   final List<ConversationMember> members;
 
   const Conversation({
@@ -24,6 +28,7 @@ class Conversation {
     this.lastMessageSender,
     this.unreadCount = 0,
     this.isMuted = false,
+    this.ttlSeconds,
     this.members = const [],
   });
 
@@ -75,6 +80,8 @@ class Conversation {
       lastMessageSender: lastMsgSender,
       unreadCount: json['unread_count'] as int? ?? 0,
       isMuted: json['is_muted'] as bool? ?? false,
+      ttlSeconds:
+          (json['disappearing_ttl_seconds'] ?? json['ttl_seconds']) as int?,
       members: membersList,
     );
   }
@@ -99,6 +106,7 @@ class Conversation {
     String? lastMessageSender,
     int? unreadCount,
     bool? isMuted,
+    int? ttlSeconds,
     List<ConversationMember>? members,
   }) {
     return Conversation(
@@ -113,6 +121,7 @@ class Conversation {
       lastMessageSender: lastMessageSender ?? this.lastMessageSender,
       unreadCount: unreadCount ?? this.unreadCount,
       isMuted: isMuted ?? this.isMuted,
+      ttlSeconds: ttlSeconds ?? this.ttlSeconds,
       members: members ?? this.members,
     );
   }
@@ -132,6 +141,7 @@ class Conversation {
             lastMessageSender == other.lastMessageSender &&
             unreadCount == other.unreadCount &&
             isMuted == other.isMuted &&
+            ttlSeconds == other.ttlSeconds &&
             _membersEqual(members, other.members);
   }
 
@@ -148,6 +158,7 @@ class Conversation {
     lastMessageSender,
     unreadCount,
     isMuted,
+    ttlSeconds,
     Object.hashAll(members),
   );
 }

--- a/apps/client/lib/src/models/conversation.dart
+++ b/apps/client/lib/src/models/conversation.dart
@@ -1,3 +1,7 @@
+/// Sentinel value used in [Conversation.copyWith] to distinguish between
+/// "not provided" and "explicitly set to null" for nullable fields.
+const _sentinel = Object();
+
 class Conversation {
   final String id;
   final String? name;
@@ -106,7 +110,7 @@ class Conversation {
     String? lastMessageSender,
     int? unreadCount,
     bool? isMuted,
-    int? ttlSeconds,
+    Object? ttlSeconds = _sentinel,
     List<ConversationMember>? members,
   }) {
     return Conversation(
@@ -121,7 +125,9 @@ class Conversation {
       lastMessageSender: lastMessageSender ?? this.lastMessageSender,
       unreadCount: unreadCount ?? this.unreadCount,
       isMuted: isMuted ?? this.isMuted,
-      ttlSeconds: ttlSeconds ?? this.ttlSeconds,
+      ttlSeconds: ttlSeconds == _sentinel
+          ? this.ttlSeconds
+          : ttlSeconds as int?,
       members: members ?? this.members,
     );
   }

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -406,41 +406,66 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
     return false;
   }
 
-  Future<void> toggleMute(String conversationId) async {
+  Future<bool> toggleMute(String conversationId) async {
+    final conv = state.conversations
+        .where((c) => c.id == conversationId)
+        .firstOrNull;
+    if (conv == null) return false;
+    return setMuted(conversationId, !conv.isMuted);
+  }
+
+  /// Set the explicit mute state for a conversation. Optimistically updates
+  /// local state, then PUTs `/api/conversations/:id/mute`. Returns true on
+  /// success; on failure the optimistic update is reverted and false is
+  /// returned so the caller can surface a toast.
+  Future<bool> setMuted(String conversationId, bool isMuted) async {
     final index = state.conversations.indexWhere((c) => c.id == conversationId);
-    if (index < 0) return;
+    if (index < 0) return false;
 
     final conv = state.conversations[index];
-    final newMuted = !conv.isMuted;
+    if (conv.isMuted == isMuted) return true; // no-op success
+    final previousMuted = conv.isMuted;
 
-    // Optimistically update local state
+    // Optimistically update local state.
     final updated = List<Conversation>.from(state.conversations);
-    updated[index] = conv.copyWith(isMuted: newMuted);
+    updated[index] = conv.copyWith(isMuted: isMuted);
     state = state.copyWith(conversations: updated);
 
+    bool success = false;
     try {
-      await _authenticatedRequest(
+      final response = await _authenticatedRequest(
         (token) => http.put(
           Uri.parse('$_serverUrl/api/conversations/$conversationId/mute'),
           headers: _headersWithToken(token),
-          body: jsonEncode({'is_muted': newMuted}),
+          body: jsonEncode({'is_muted': isMuted}),
         ),
       );
-    } catch (e) {
-      // Revert on failure
-      final reverted = List<Conversation>.from(state.conversations);
-      final idx = reverted.indexWhere((c) => c.id == conversationId);
-      if (idx >= 0) {
-        reverted[idx] = reverted[idx].copyWith(isMuted: !newMuted);
-        state = state.copyWith(conversations: reverted);
+      success = response.statusCode == 200;
+      if (!success) {
+        debugPrint(
+          '[Conversations] setMuted got HTTP ${response.statusCode} '
+          'for $conversationId',
+        );
       }
-      debugPrint('[Conversations] toggleMute failed for $conversationId: $e');
+    } catch (e) {
+      debugPrint('[Conversations] setMuted failed for $conversationId: $e');
       DebugLogService.instance.log(
         LogLevel.error,
         'Conversations',
-        'toggleMute error for $conversationId: $e',
+        'setMuted error for $conversationId: $e',
       );
     }
+
+    if (!success) {
+      // Revert the optimistic update.
+      final reverted = List<Conversation>.from(state.conversations);
+      final idx = reverted.indexWhere((c) => c.id == conversationId);
+      if (idx >= 0) {
+        reverted[idx] = reverted[idx].copyWith(isMuted: previousMuted);
+        state = state.copyWith(conversations: reverted);
+      }
+    }
+    return success;
   }
 
   /// Leave a group conversation and remove it from local state.

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -251,6 +251,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
       body: 'Started a voice call',
       conversationId: conversationId,
       conversationName: conv?.displayName(myUserId),
+      isMuted: conv?.isMuted ?? false,
     );
   }
 
@@ -559,7 +560,8 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
   ) {
     final conversations = ref.read(conversationsProvider).conversations;
     final conv = conversations.where((c) => c.id == conversationId).firstOrNull;
-    if (conv?.isMuted ?? false) return;
+    final isMuted = conv?.isMuted ?? false;
+    if (isMuted) return;
 
     SoundService().playMessageReceived();
     final body = displayContent.length > 100
@@ -572,6 +574,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
       conversationId: conversationId,
       conversationName: conv?.displayName(myUserId),
       isGroup: conv?.isGroup ?? false,
+      isMuted: isMuted,
     );
   }
 
@@ -699,6 +702,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
       conversationId: conversationId,
       conversationName: conv?.displayName(myUserId),
       isGroup: true, // Mentions are always in group contexts
+      isMuted: conv?.isMuted ?? false,
     );
 
     // Bump unread count for the conversation

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -693,16 +693,19 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
     final fromUserId = json['from_user_id'] as String? ?? '';
     if (fromUserId == myUserId) return;
 
-    SoundService().playMessageReceived();
     final conversations = ref.read(conversationsProvider).conversations;
     final conv = conversations.where((c) => c.id == conversationId).firstOrNull;
+    final isMuted = conv?.isMuted ?? false;
+    if (!isMuted) {
+      SoundService().playMessageReceived();
+    }
     NotificationService().showMessageNotification(
       senderUsername: '@$fromUsername',
       body: content.length > 100 ? '${content.substring(0, 100)}...' : content,
       conversationId: conversationId,
       conversationName: conv?.displayName(myUserId),
       isGroup: true, // Mentions are always in group contexts
-      isMuted: conv?.isMuted ?? false,
+      isMuted: isMuted,
     );
 
     // Bump unread count for the conversation

--- a/apps/client/lib/src/services/notification_service.dart
+++ b/apps/client/lib/src/services/notification_service.dart
@@ -37,6 +37,11 @@ abstract class NotificationService {
   ///
   /// [isGroup] selects the appropriate notification channel (DM vs group).
   ///
+  /// [isMuted] suppresses the notification when the conversation is muted by
+  /// the user. Caller is responsible for looking up the per-conversation
+  /// preference. When true the call returns early without showing anything,
+  /// even if [forceShow] is set.
+  ///
   /// Suppressed when the app is focused unless [forceShow] is true.
   void showMessageNotification({
     required String senderUsername,
@@ -44,6 +49,7 @@ abstract class NotificationService {
     String? conversationId,
     String? conversationName,
     bool isGroup = false,
+    bool isMuted = false,
     bool forceShow = false,
   });
 

--- a/apps/client/lib/src/services/notification_service_stub.dart
+++ b/apps/client/lib/src/services/notification_service_stub.dart
@@ -165,8 +165,12 @@ class _NativeNotificationService implements NotificationService {
     String? conversationId,
     String? conversationName,
     bool isGroup = false,
+    bool isMuted = false,
     bool forceShow = false,
   }) {
+    // Per-conversation mute always wins, even over forceShow.
+    if (isMuted) return;
+
     // Suppress when the app is focused, but allow a 5-second grace period
     // after foregrounding so WS-reconnect messages still trigger notifications.
     if (_appFocused && !forceShow) {

--- a/apps/client/lib/src/services/notification_service_web.dart
+++ b/apps/client/lib/src/services/notification_service_web.dart
@@ -71,8 +71,11 @@ class _WebNotificationService implements NotificationService {
     String? conversationId,
     String? conversationName,
     bool isGroup = false,
+    bool isMuted = false,
     bool forceShow = false,
   }) {
+    // Per-conversation mute always wins, even over forceShow.
+    if (isMuted) return;
     if (!_permissionGranted) return;
 
     // Check Do Not Disturb and Quiet Hours (async, suppress if active).

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -913,30 +913,42 @@ class _TimerChip extends StatelessWidget {
           child: InkWell(
             borderRadius: BorderRadius.circular(10),
             onTap: onTap,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: context.accent.withValues(alpha: 0.12),
-                borderRadius: BorderRadius.circular(10),
-                border: Border.all(
-                  color: context.accent.withValues(alpha: 0.35),
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.timer_outlined, size: 12, color: context.accent),
-                  const SizedBox(width: 3),
-                  Text(
-                    label,
-                    style: TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      color: context.accent,
-                      height: 1,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 44, minWidth: 44),
+              child: Center(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: context.accent.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(
+                      color: context.accent.withValues(alpha: 0.35),
                     ),
                   ),
-                ],
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.timer_outlined,
+                        size: 12,
+                        color: context.accent,
+                      ),
+                      const SizedBox(width: 3),
+                      Text(
+                        label,
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: context.accent,
+                          height: 1,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ),
           ),

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -154,7 +154,7 @@ class ChatHeaderBar extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _buildNameRow(context, conv, displayName),
+              _buildNameRow(context, ref, conv, displayName),
               _buildStatusLine(context, ref, conv),
             ],
           ),
@@ -165,9 +165,11 @@ class ChatHeaderBar extends ConsumerWidget {
 
   /// Name row — shows the display name and, for 1:1 conversations, a small
   /// green "verified" check next to the name when the user has previously
-  /// confirmed the peer's safety number on this device.
+  /// confirmed the peer's safety number on this device. Also shows a small
+  /// timer chip when disappearing messages are enabled.
   Widget _buildNameRow(
     BuildContext context,
+    WidgetRef ref,
     Conversation conv,
     String displayName,
   ) {
@@ -180,7 +182,23 @@ class ChatHeaderBar extends ConsumerWidget {
       ),
     );
 
-    if (conv.isGroup) return nameText;
+    final ttl = conv.ttlSeconds ?? 0;
+    final showTimer = ttl > 0;
+
+    final timerChip = showTimer
+        ? _TimerChip(
+            seconds: ttl,
+            onTap: () => _showDisappearingDialog(context, ref, conv),
+          )
+        : null;
+
+    if (conv.isGroup) {
+      if (timerChip == null) return nameText;
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [nameText, timerChip],
+      );
+    }
 
     final peer = conv.members.where((m) => m.userId != myUserId).firstOrNull;
     if (peer == null) return nameText;
@@ -190,6 +208,7 @@ class ChatHeaderBar extends ConsumerWidget {
       children: [
         nameText,
         _VerifiedBadge(peerUserId: peer.userId),
+        ?timerChip,
       ],
     );
   }
@@ -635,14 +654,27 @@ class ChatHeaderBar extends ConsumerWidget {
     WidgetRef ref,
     Conversation conv,
   ) async {
+    final currentTtl = conv.ttlSeconds;
     final selected = await showDialog<int?>(
       context: context,
       builder: (ctx) => SimpleDialog(
         title: const Text('Disappearing messages'),
         children: _kTtlOptions.map((opt) {
+          final isCurrent = opt.seconds == currentTtl;
           return SimpleDialogOption(
             onPressed: () => Navigator.of(ctx).pop(opt.seconds ?? -1),
-            child: Text(opt.label),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 20,
+                  child: isCurrent
+                      ? Icon(Icons.check, size: 16, color: ctx.accent)
+                      : null,
+                ),
+                const SizedBox(width: 8),
+                Text(opt.label),
+              ],
+            ),
           );
         }).toList(),
       ),
@@ -841,6 +873,74 @@ class _VerifiedBadgeState extends State<_VerifiedBadge> {
       child: Tooltip(
         message: 'Safety number verified',
         child: Icon(Icons.verified, size: 14, color: EchoTheme.online),
+      ),
+    );
+  }
+}
+
+/// Returns a short, human-readable label for a disappearing-messages TTL.
+/// Matches the presets in `_kTtlOptions` so the chip and the dialog stay
+/// visually consistent.
+String _humanizeTtl(int seconds) {
+  return switch (seconds) {
+    30 => '30s',
+    300 => '5m',
+    3600 => '1h',
+    86400 => '1d',
+    604800 => '1w',
+    _ => '${seconds}s',
+  };
+}
+
+/// Small chip rendered next to a conversation's name in the chat header
+/// when disappearing messages are enabled. Tapping opens the same dialog
+/// that the overflow menu's "Disappearing messages" entry shows.
+class _TimerChip extends StatelessWidget {
+  final int seconds;
+  final VoidCallback onTap;
+
+  const _TimerChip({required this.seconds, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final label = _humanizeTtl(seconds);
+    return Padding(
+      padding: const EdgeInsets.only(left: 6),
+      child: Tooltip(
+        message: 'Disappearing messages',
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(10),
+            onTap: onTap,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: context.accent.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  color: context.accent.withValues(alpha: 0.35),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.timer_outlined, size: 12, color: context.accent),
+                  const SizedBox(width: 3),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: context.accent,
+                      height: 1,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -142,31 +142,44 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                   ),
                 ),
                 Divider(color: context.border, height: 8),
-                SwitchListTile(
-                  value: conv.isMuted,
-                  onChanged: (value) async {
-                    Navigator.of(sheetContext).pop();
-                    final success = await ref
-                        .read(conversationsProvider.notifier)
-                        .setMuted(conv.id, value);
-                    if (!success && mounted) {
-                      ToastService.show(
-                        context,
-                        'Failed to update mute settings',
-                        type: ToastType.error,
-                      );
-                    }
+                Consumer(
+                  builder: (ctx, sheetRef, _) {
+                    final live = sheetRef
+                        .watch(conversationsProvider)
+                        .conversations
+                        .where((c) => c.id == conv.id)
+                        .firstOrNull;
+                    final currentMuted = live?.isMuted ?? conv.isMuted;
+                    return SwitchListTile(
+                      value: currentMuted,
+                      onChanged: (value) async {
+                        Navigator.of(sheetContext).pop();
+                        final success = await ref
+                            .read(conversationsProvider.notifier)
+                            .setMuted(conv.id, value);
+                        if (!success && mounted) {
+                          ToastService.show(
+                            context,
+                            'Failed to update mute settings',
+                            type: ToastType.error,
+                          );
+                        }
+                      },
+                      title: Text(
+                        'Mute notifications',
+                        style: TextStyle(
+                          color: context.textPrimary,
+                          fontSize: 14,
+                        ),
+                      ),
+                      secondary: Icon(
+                        currentMuted
+                            ? Icons.notifications_off_outlined
+                            : Icons.notifications_outlined,
+                        color: context.textSecondary,
+                      ),
+                    );
                   },
-                  title: Text(
-                    'Mute notifications',
-                    style: TextStyle(color: context.textPrimary, fontSize: 14),
-                  ),
-                  secondary: Icon(
-                    conv.isMuted
-                        ? Icons.notifications_off_outlined
-                        : Icons.notifications_outlined,
-                    color: context.textSecondary,
-                  ),
                 ),
               ],
             ),

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/conversation.dart';
+import '../providers/conversations_provider.dart';
+import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import 'avatar_utils.dart';
 
@@ -22,7 +25,7 @@ Color presenceStatusDotColor(
   };
 }
 
-class ConversationItem extends StatefulWidget {
+class ConversationItem extends ConsumerStatefulWidget {
   final Conversation conversation;
   final String myUserId;
   final bool isSelected;
@@ -60,10 +63,10 @@ class ConversationItem extends StatefulWidget {
   });
 
   @override
-  State<ConversationItem> createState() => _ConversationItemState();
+  ConsumerState<ConversationItem> createState() => _ConversationItemState();
 }
 
-class _ConversationItemState extends State<ConversationItem> {
+class _ConversationItemState extends ConsumerState<ConversationItem> {
   bool _isHovered = false;
   String? _draft;
 
@@ -105,6 +108,72 @@ class _ConversationItemState extends State<ConversationItem> {
       TargetPlatform.iOS => true,
       _ => false,
     };
+  }
+
+  /// Long-press bottom sheet with the per-conversation mute toggle.
+  /// Mobile-only — desktop users get the right-click popup menu instead.
+  void _showMuteSheet() {
+    final conv = widget.conversation;
+    final displayName = conv.displayName(widget.myUserId);
+
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: context.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
+                  child: Text(
+                    displayName,
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: context.textPrimary,
+                    ),
+                  ),
+                ),
+                Divider(color: context.border, height: 8),
+                SwitchListTile(
+                  value: conv.isMuted,
+                  onChanged: (value) async {
+                    Navigator.of(sheetContext).pop();
+                    final success = await ref
+                        .read(conversationsProvider.notifier)
+                        .setMuted(conv.id, value);
+                    if (!success && mounted) {
+                      ToastService.show(
+                        context,
+                        'Failed to update mute settings',
+                        type: ToastType.error,
+                      );
+                    }
+                  },
+                  title: Text(
+                    'Mute notifications',
+                    style: TextStyle(color: context.textPrimary, fontSize: 14),
+                  ),
+                  secondary: Icon(
+                    conv.isMuted
+                        ? Icons.notifications_off_outlined
+                        : Icons.notifications_outlined,
+                    color: context.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 
   /// Resolve the display snippet from the last message, applying
@@ -190,19 +259,7 @@ class _ConversationItemState extends State<ConversationItem> {
           onSecondaryTapUp: (details) {
             widget.onContextMenu?.call(details.globalPosition);
           },
-          onLongPress: _enableLongPressMenu
-              ? () {
-                  // globalPosition not available on InkWell.onLongPress;
-                  // fall back to the widget's own render box center.
-                  final box = context.findRenderObject() as RenderBox?;
-                  if (box != null) {
-                    final center = box.localToGlobal(
-                      Offset(box.size.width / 2, box.size.height / 2),
-                    );
-                    widget.onContextMenu?.call(center);
-                  }
-                }
-              : null,
+          onLongPress: _enableLongPressMenu ? _showMuteSheet : null,
           child: Container(
             height: 68,
             margin: const EdgeInsets.symmetric(vertical: 1),

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -298,11 +298,20 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
             ),
           ),
       ],
-    ).then((value) {
+    ).then((value) async {
       if (value == 'pin') {
         _togglePin(conv.id);
       } else if (value == 'mute') {
-        ref.read(conversationsProvider.notifier).toggleMute(conv.id);
+        final ok = await ref
+            .read(conversationsProvider.notifier)
+            .toggleMute(conv.id);
+        if (!ok && context.mounted) {
+          ToastService.show(
+            context,
+            'Failed to update mute settings',
+            type: ToastType.error,
+          );
+        }
       } else if (value == 'leave_group') {
         _leaveGroup(conv);
       } else if (value == 'delete_dm') {

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -386,6 +386,31 @@ pub async fn set_mute_status(
     Ok(result.rows_affected() > 0)
 }
 
+/// Filter the given user IDs down to those who have NOT muted this
+/// conversation. Used by the push-notification path so muted recipients are
+/// not woken with an APNs alert for messages they would not see locally.
+pub async fn get_unmuted_user_ids(
+    pool: &PgPool,
+    conversation_id: Uuid,
+    user_ids: &[Uuid],
+) -> Result<Vec<Uuid>, sqlx::Error> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT user_id FROM conversation_members \
+         WHERE conversation_id = $1 \
+           AND user_id = ANY($2) \
+           AND is_muted = false \
+           AND is_removed = false",
+    )
+    .bind(conversation_id)
+    .bind(user_ids)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
 // ---------------------------------------------------------------------------
 // Message pinning
 // ---------------------------------------------------------------------------

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -153,7 +153,23 @@ pub async fn notify_offline_users(
         return;
     }
 
-    let tokens = match db::push_tokens::get_tokens_for_users(pool, offline_user_ids).await {
+    // Drop recipients who muted this conversation so they don't get an APNs
+    // alert for messages they would not be notified about locally either.
+    // Fail open on database errors -- it is better to over-notify than to
+    // silently drop legitimate notifications.
+    let unmuted =
+        match db::messages::get_unmuted_user_ids(pool, conversation_id, offline_user_ids).await {
+            Ok(u) => u,
+            Err(e) => {
+                tracing::warn!("Failed to filter muted users: {e}");
+                offline_user_ids.to_vec()
+            }
+        };
+    if unmuted.is_empty() {
+        return;
+    }
+
+    let tokens = match db::push_tokens::get_tokens_for_users(pool, &unmuted).await {
         Ok(t) => t,
         Err(e) => {
             tracing::warn!("Failed to fetch push tokens: {e}");

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -60,6 +60,10 @@ pub struct ConversationListItem {
     pub icon_url: Option<String>,
     pub is_encrypted: bool,
     pub is_muted: bool,
+    /// Disappearing-messages TTL in seconds, or null if disabled. Lets the
+    /// client render the timer chip in the chat header without a separate
+    /// fetch.
+    pub disappearing_ttl_seconds: Option<i32>,
     pub members: Vec<MemberInfo>,
     pub last_message: Option<LastMessageInfo>,
     pub unread_count: i64,
@@ -89,6 +93,7 @@ struct ConversationFullRow {
     icon_url: Option<String>,
     is_encrypted: bool,
     is_muted: bool,
+    disappearing_ttl_seconds: Option<i32>,
     members_json: Option<serde_json::Value>,
     last_message_json: Option<serde_json::Value>,
     unread_count: i64,
@@ -151,6 +156,7 @@ pub async fn list_conversations(
             c.icon_url, \
             c.is_encrypted, \
             uc.is_muted, \
+            c.disappearing_ttl_seconds, \
             mc.members_json, \
             CASE WHEN lm.conversation_id IS NOT NULL \
                  THEN json_build_object( \
@@ -198,6 +204,7 @@ pub async fn list_conversations(
             icon_url: row.icon_url,
             is_encrypted: row.is_encrypted,
             is_muted: row.is_muted,
+            disappearing_ttl_seconds: row.disappearing_ttl_seconds,
             members,
             last_message,
             unread_count: row.unread_count,

--- a/apps/server/tests/api_messages_extra.rs
+++ b/apps/server/tests/api_messages_extra.rs
@@ -369,6 +369,51 @@ async fn toggle_mute_unmute_succeeds() {
     assert_eq!(body["is_muted"], false);
 }
 
+/// Asserts that `get_unmuted_user_ids` excludes a member who muted the
+/// conversation. This is the helper the push-notification path uses to drop
+/// muted recipients before sending APNs alerts.
+#[tokio::test]
+async fn get_unmuted_user_ids_excludes_muted_member() {
+    use uuid::Uuid;
+
+    let base = common::spawn_server().await;
+    let (client, alice_token, alice_id, _, bob_id, conv_id, _) = setup_dm_with_message(&base).await;
+
+    // Alice mutes the conversation; Bob does not.
+    let resp = client
+        .put(format!("{base}/api/conversations/{conv_id}/mute"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({ "is_muted": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // Open a direct DB connection to invoke the helper under test.
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("TEST_DATABASE_URL or DATABASE_URL must be set");
+    let pool = echo_server::db::create_pool(&database_url).await;
+
+    let conv_uuid = Uuid::parse_str(&conv_id).unwrap();
+    let alice_uuid = Uuid::parse_str(&alice_id).unwrap();
+    let bob_uuid = Uuid::parse_str(&bob_id).unwrap();
+
+    let unmuted =
+        echo_server::db::messages::get_unmuted_user_ids(&pool, conv_uuid, &[alice_uuid, bob_uuid])
+            .await
+            .expect("get_unmuted_user_ids should succeed");
+
+    assert!(
+        !unmuted.contains(&alice_uuid),
+        "muted user (alice) should be excluded"
+    );
+    assert!(
+        unmuted.contains(&bob_uuid),
+        "unmuted user (bob) should be included"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Search messages
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two ambient-awareness features bundled together. Closes #448 and #460.

### Feature A: Per-conversation mute (#448)

- Long-press a conversation tile (mobile) -> bottom sheet with "Mute notifications" toggle. Desktop right-click context menu also wired.
- Bottom sheet uses live state via Consumer, so mute toggle reflects updates from other devices in real time.
- Both client notification service (stub + web) and server APNs push pipeline now skip muted recipients. Server uses a new `db::messages::get_unmuted_user_ids` helper with fail-open behavior on DB errors.
- Mention sound is gated on mute too -- previously the chime fired even when the banner was suppressed.
- Toast on mute toggle failure (was silently swallowed in conversation_panel).

### Feature B: Disappearing-timer chip (#460)

- New `_TimerChip` widget in chat header, rendered when `conversation.ttlSeconds > 0`. Shows `Icons.timer_outlined` + human label (Off/30s/5m/1h/1d/1w).
- Tapping the chip opens the existing disappearing-messages dialog with the current selection highlighted via `Icons.check`.
- 44px tap target via `ConstrainedBox` (visual chip remains compact).
- `Conversation` model gains `int? ttlSeconds`. Server conversation list response now includes `disappearing_ttl_seconds`. `copyWith` uses sentinel pattern so callers can clear `ttlSeconds` to null when disappearing messages are turned off.

## Review
- 4-core review loop (code-quality + implicit security/perf/test)
- 2 HIGH bugs caught and fixed: mention sound bypassing mute gate, copyWith null-clear bug
- 3 MEDIUM bugs fixed: stale state in bottom sheet, silent toggle failure, sub-44px tap target
- LOW doc-verbosity flags acknowledged but not auto-fixed

## Test plan
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets -D warnings` clean
- [x] `cargo test -p echo-server --lib` 75/75 pass
- [x] `cargo test -p echo-server --test api_messages_extra` -- new `get_unmuted_user_ids_excludes_muted_member` test passes
- [x] `flutter analyze --fatal-infos` no issues
- [x] `flutter test` 792/792 pass
- [x] Manual: long-press conversation -> mute toggle works; muted conv produces no banner or sound; disappearing timer chip appears in header and tap opens highlighted dialog