### PR TITLE
security(client): session key TTL + LRU + zeroing for forward secrecy (#343)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Three compose files in `infra/docker/`:
 
 ## Known Limitations
 
-1. Session keys cached forever in memory (no TTL)
+1. Session keys cached in memory with 24h idle TTL + 200-entry LRU cap; evicted entries have key material zeroed and reload from secure storage on demand.
 2. Multi-device: key-level revoke + last_seen + platform metadata work end-to-end; refresh tokens are not yet bound per device, so "logout all others" only kicks connected sessions via WS and truly offline sessions get blocked at next key operation.
 3. `core/rust-core/src/api.rs` has `todo!()` stubs (FFI bridge not integrated)
 4. Rate limiting is in-memory only (resets on server restart)

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -21,6 +21,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'debug_log_service.dart';
 import 'secure_key_store.dart';
+import 'session_cache.dart';
 import 'signal_session.dart';
 import 'signal_x3dh.dart';
 
@@ -76,7 +77,11 @@ class CryptoService {
   SimpleKeyPair? _identityKeyPair;
   SimpleKeyPair? _signedPrekeyPair;
   SimpleKeyPair? _signingKeyPair;
-  final Map<String, SignalSession> _sessions = {};
+
+  /// In-memory Signal session cache with TTL + LRU + zeroing (#343).
+  /// Sessions persist on disk via [_saveSession]; eviction is non-destructive
+  /// and the cache reloads from secure storage on miss.
+  final SessionCache _sessions = SessionCache();
   X3dhInitResult? _lastX3dhResult;
   int? _lastOtpKeyId;
   bool _keysAreFresh = false;
@@ -569,7 +574,7 @@ class CryptoService {
         final peerId = entry.key.substring(_sessionPrefix.length);
         try {
           final json = jsonDecode(entry.value) as Map<String, dynamic>;
-          _sessions[peerId] = SignalSession.fromJson(json);
+          _sessions.put(peerId, SignalSession.fromJson(json));
         } catch (e) {
           debugPrint('[Crypto] Quarantining corrupted session for $peerId: $e');
           // Quarantine instead of deleting — preserve data for potential
@@ -606,6 +611,24 @@ class CryptoService {
     final store = SecureKeyStore.instance;
     final json = await session.toJson();
     await store.write('$_sessionPrefix$peerId', jsonEncode(json));
+  }
+
+  /// On cache miss, attempt to reload a single session from secure storage
+  /// before falling back to X3DH (#343 -- non-destructive eviction).
+  /// Returns null if no persisted session exists or it cannot be parsed.
+  Future<SignalSession?> _reloadSession(String key) async {
+    try {
+      final store = SecureKeyStore.instance;
+      final raw = await store.read('$_sessionPrefix$key');
+      if (raw == null || raw.isEmpty) return null;
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      final session = SignalSession.fromJson(json);
+      _sessions.put(key, session);
+      return session;
+    } catch (e) {
+      debugPrint('[Crypto] Failed to reload session for $key: $e');
+      return null;
+    }
   }
 
   /// Human-readable label for the current platform, sent to the server as part
@@ -805,9 +828,13 @@ class CryptoService {
   /// Otherwise, fetches the peer's prekey bundle from the server, performs X3DH
   /// to establish a shared secret, and initializes a new Double Ratchet session.
   Future<SignalSession> getOrCreateSession(String peerUserId) async {
-    if (_sessions.containsKey(peerUserId)) {
-      return _sessions[peerUserId]!;
-    }
+    final cached = _sessions.get(peerUserId);
+    if (cached != null) return cached;
+
+    // Cache miss may be due to TTL/LRU eviction -- attempt non-destructive
+    // reload from secure storage before falling back to a fresh X3DH.
+    final reloaded = await _reloadSession(peerUserId);
+    if (reloaded != null) return reloaded;
 
     if (_identityKeyPair == null) await init();
 
@@ -904,7 +931,7 @@ class CryptoService {
       bobSignedPrekey,
     );
 
-    _sessions[peerUserId] = session;
+    _sessions.put(peerUserId, session);
     _lastX3dhResult = x3dhResult; // Save for initial message prefix
     await _saveSession(peerUserId, session);
 
@@ -963,8 +990,10 @@ class CryptoService {
     String peerUserId,
     String plaintext,
   ) async {
-    var isNewSession = !_sessions.containsKey(peerUserId);
     var session = await getOrCreateSession(peerUserId);
+    // "New" means X3DH just ran (initial message will need the X3DH prefix).
+    // A session reloaded from secure storage after cache eviction is NOT new.
+    var isNewSession = _lastX3dhResult != null;
     final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
 
     Uint8List wire;
@@ -991,6 +1020,8 @@ class CryptoService {
     final finalWire = await _buildInitialWire(wire);
 
     await _saveSession(peerUserId, session);
+    // Refresh LRU ordering after in-place mutation.
+    _sessions.put(peerUserId, session);
     return base64Encode(finalWire);
   }
 
@@ -1097,7 +1128,7 @@ class CryptoService {
 
     final session = await SignalSession.initBob(sharedSecret, prekeyToUse);
     final plainBytes = await session.decrypt(sessionWire);
-    _sessions[sessionKey] = session;
+    _sessions.put(sessionKey, session);
     await _saveSession(sessionKey, session);
 
     // Consume the OTP -- delete after successful use (one-time)
@@ -1191,7 +1222,9 @@ class CryptoService {
     required Uint8List fullWire,
     required String sessionKey,
   }) async {
-    final session = _sessions[sessionKey];
+    // Cache miss may be a TTL/LRU eviction -- try to reload from disk first.
+    var session = _sessions.get(sessionKey);
+    session ??= await _reloadSession(sessionKey);
     if (session == null) {
       throw Exception(
         'No session for $sessionKey — cannot decrypt normal message. '
@@ -1203,6 +1236,8 @@ class CryptoService {
     try {
       final plainBytes = await session.decrypt(fullWire);
       await _saveSession(sessionKey, session);
+      // Refresh LRU ordering after in-place mutation.
+      _sessions.put(sessionKey, session);
       return utf8.decode(plainBytes);
     } catch (e) {
       // Session is stale/corrupted — clear it. The next incoming initial
@@ -1250,11 +1285,14 @@ class CryptoService {
         return null;
       }
 
-      final session = _sessions[peerUserId];
+      var session = _sessions.get(peerUserId);
+      session ??= await _reloadSession(peerUserId);
       if (session == null) return null;
 
       final plainBytes = await session.decrypt(fullWire);
       await _saveSession(peerUserId, session);
+      // Refresh LRU ordering after in-place mutation.
+      _sessions.put(peerUserId, session);
       return utf8.decode(plainBytes);
     } catch (_) {
       return null;
@@ -1475,13 +1513,18 @@ class CryptoService {
     Map<String, dynamic> bundleData,
   ) async {
     final sessionKey = '$peerUserId:$deviceId';
-    if (_sessions.containsKey(sessionKey)) {
-      return _sessions[sessionKey]!;
-    }
+    final cached = _sessions.get(sessionKey);
+    if (cached != null) return cached;
+
+    // Cache miss may be due to TTL/LRU eviction -- try non-destructive reload.
+    final reloaded = await _reloadSession(sessionKey);
+    if (reloaded != null) return reloaded;
+
     // Fall back to legacy session if it exists (pre-multi-device)
-    if (_sessions.containsKey(peerUserId)) {
-      return _sessions[peerUserId]!;
-    }
+    final legacy = _sessions.get(peerUserId);
+    if (legacy != null) return legacy;
+    final legacyReloaded = await _reloadSession(peerUserId);
+    if (legacyReloaded != null) return legacyReloaded;
 
     if (_identityKeyPair == null) await init();
 
@@ -1555,7 +1598,7 @@ class CryptoService {
       bobSignedPrekey,
     );
 
-    _sessions[sessionKey] = session;
+    _sessions.put(sessionKey, session);
     await _saveSession(sessionKey, session);
     return session;
   }
@@ -1597,6 +1640,8 @@ class CryptoService {
           final finalWire = await _buildInitialWire(wire);
 
           await _saveSession(sessionKey, session);
+          // Refresh LRU ordering after in-place mutation.
+          _sessions.put(sessionKey, session);
           return base64Encode(finalWire);
         });
         results[deviceId.toString()] = ct;
@@ -1636,6 +1681,8 @@ class CryptoService {
             final finalWire = await _buildInitialWire(wire);
 
             await _saveSession(sessionKey, session);
+            // Refresh LRU ordering after in-place mutation.
+            _sessions.put(sessionKey, session);
             return base64Encode(finalWire);
           });
           results[deviceId.toString()] = ct;

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -78,9 +78,8 @@ class CryptoService {
   SimpleKeyPair? _signedPrekeyPair;
   SimpleKeyPair? _signingKeyPair;
 
-  /// In-memory Signal session cache with TTL + LRU + zeroing (#343).
   /// Sessions persist on disk via [_saveSession]; eviction is non-destructive
-  /// and the cache reloads from secure storage on miss.
+  /// and the cache reloads from secure storage on miss (#343).
   final SessionCache _sessions = SessionCache();
   X3dhInitResult? _lastX3dhResult;
   int? _lastOtpKeyId;
@@ -990,6 +989,9 @@ class CryptoService {
     String peerUserId,
     String plaintext,
   ) async {
+    // Defensive: clear any stale result from a prior aborted call so the
+    // isNewSession derivation below reflects only this call's X3DH outcome.
+    _lastX3dhResult = null;
     var session = await getOrCreateSession(peerUserId);
     // "New" means X3DH just ran (initial message will need the X3DH prefix).
     // A session reloaded from secure storage after cache eviction is NOT new.
@@ -1049,9 +1051,9 @@ class CryptoService {
   String _sessionKeyFor(String peerUserId, int? deviceId) {
     if (deviceId != null) {
       final key = '$peerUserId:$deviceId';
-      if (_sessions.containsKey(key)) return key;
+      if (_sessions.isFresh(key)) return key;
       // Fall back to legacy key if device-specific doesn't exist yet
-      if (_sessions.containsKey(peerUserId)) return peerUserId;
+      if (_sessions.isFresh(peerUserId)) return peerUserId;
       return key; // Will create with device-specific key
     }
     return peerUserId;
@@ -1148,6 +1150,7 @@ class CryptoService {
     String peerUserId,
     int? fromDeviceId,
   ) async {
+    // containsKey (not isFresh) intentional: drop any in-map entry, expired or not.
     if (_sessions.containsKey(sessionKey)) {
       debugPrint(
         '[Crypto] Replacing stale session for $sessionKey '
@@ -1157,6 +1160,7 @@ class CryptoService {
       final store = SecureKeyStore.instance;
       await store.delete('$_sessionPrefix$sessionKey');
     }
+    // containsKey (not isFresh) intentional: drop any in-map entry, expired or not.
     if (fromDeviceId != null && _sessions.containsKey(peerUserId)) {
       _sessions.remove(peerUserId);
       final store = SecureKeyStore.instance;
@@ -1305,7 +1309,7 @@ class CryptoService {
   /// the server for the peer's key bundle and returns true when one is
   /// available.
   Future<bool> canEstablishSession(String peerUserId) async {
-    if (_sessions.containsKey(peerUserId)) return true;
+    if (_sessions.isFresh(peerUserId)) return true;
     try {
       final response = await http.get(
         Uri.parse('$serverUrl/api/keys/bundle/$peerUserId'),
@@ -1319,7 +1323,7 @@ class CryptoService {
 
   /// Check if we have a session for a peer (no network call needed).
   bool hasSessionKey(String peerUserId) {
-    return _sessions.containsKey(peerUserId);
+    return _sessions.isFresh(peerUserId);
   }
 
   /// Invalidate the cached session for a peer so the next call to

--- a/apps/client/lib/src/services/session_cache.dart
+++ b/apps/client/lib/src/services/session_cache.dart
@@ -15,7 +15,6 @@ import 'dart:collection';
 
 import 'signal_session.dart';
 
-/// LRU + TTL cache for [SignalSession] instances.
 class SessionCache {
   /// Default idle TTL: 24 hours.
   static const Duration defaultTtl = Duration(hours: 24);
@@ -42,7 +41,9 @@ class SessionCache {
     Duration sweepInterval = defaultSweepInterval,
   }) : _now = clock ?? DateTime.now,
        _sweepInterval = sweepInterval,
-       _enablePeriodicEviction = enablePeriodicEviction;
+       _enablePeriodicEviction = enablePeriodicEviction {
+    assert(maxEntries > 0, 'SessionCache.maxEntries must be positive');
+  }
 
   /// Lazily start the periodic sweep on first insertion. Avoids leaking
   /// timers in widget tests that construct a [CryptoService] but never
@@ -73,11 +74,12 @@ class SessionCache {
   SignalSession? get(String key) {
     final entry = _entries.remove(key);
     if (entry == null) return null;
-    if (_now().difference(entry.lastAccessed) >= ttl) {
+    final now = _now();
+    if (now.difference(entry.lastAccessed) >= ttl) {
       _zeroAndDrop(entry);
       return null;
     }
-    entry.lastAccessed = _now();
+    entry.lastAccessed = now;
     _entries[key] = entry; // re-insert at end -> most recent
     return entry.session;
   }
@@ -115,6 +117,15 @@ class SessionCache {
   /// True when [key] is present (does not refresh LRU order).
   bool containsKey(String key) => _entries.containsKey(key);
 
+  /// Returns whether [key] has a non-expired entry without refreshing LRU
+  /// ordering or evicting on miss.  Use for "is the session usable?" checks
+  /// where mutating state is undesired.
+  bool isFresh(String key) {
+    final entry = _entries[key];
+    if (entry == null) return false;
+    return _now().difference(entry.lastAccessed) < ttl;
+  }
+
   /// Drop all expired entries. Called periodically by the sweep timer and
   /// exposed for tests.
   void evictExpired() {
@@ -136,6 +147,10 @@ class SessionCache {
       _zeroAndDrop(entry);
     }
     _entries.clear();
+    // Cancel the sweep timer; the next put() re-arms it via
+    // _ensureSweepTimer.
+    _sweepTimer?.cancel();
+    _sweepTimer = null;
   }
 
   /// Cancel the periodic sweep and clear all entries. Safe to call multiple

--- a/apps/client/lib/src/services/session_cache.dart
+++ b/apps/client/lib/src/services/session_cache.dart
@@ -1,0 +1,168 @@
+/// LRU + TTL cache for Signal Protocol session state with secure zeroing.
+///
+/// Forward-secrecy hardening (#343): sessions are evicted from RAM after a
+/// configurable idle TTL or when the cache exceeds [SessionCache.maxEntries].
+/// Evicted session key material (root key, chain keys, skipped message keys)
+/// is explicitly zeroed before the entry is dropped.
+///
+/// On cache miss the caller is expected to reload the session from persistent
+/// storage (`SecureKeyStore`) -- eviction is non-destructive to the on-disk
+/// state.
+library;
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'signal_session.dart';
+
+/// LRU + TTL cache for [SignalSession] instances.
+class SessionCache {
+  /// Default idle TTL: 24 hours.
+  static const Duration defaultTtl = Duration(hours: 24);
+
+  /// Default LRU cap: 200 sessions.
+  static const int defaultMaxEntries = 200;
+
+  /// Default sweep interval: 15 minutes.
+  static const Duration defaultSweepInterval = Duration(minutes: 15);
+
+  final Duration ttl;
+  final int maxEntries;
+  final DateTime Function() _now;
+  final Duration _sweepInterval;
+  final bool _enablePeriodicEviction;
+  final LinkedHashMap<String, _Entry> _entries = LinkedHashMap();
+  Timer? _sweepTimer;
+
+  SessionCache({
+    this.ttl = defaultTtl,
+    this.maxEntries = defaultMaxEntries,
+    DateTime Function()? clock,
+    bool enablePeriodicEviction = true,
+    Duration sweepInterval = defaultSweepInterval,
+  }) : _now = clock ?? DateTime.now,
+       _sweepInterval = sweepInterval,
+       _enablePeriodicEviction = enablePeriodicEviction;
+
+  /// Lazily start the periodic sweep on first insertion. Avoids leaking
+  /// timers in widget tests that construct a [CryptoService] but never
+  /// populate the cache.
+  void _ensureSweepTimer() {
+    if (!_enablePeriodicEviction || _sweepTimer != null) return;
+    _sweepTimer = Timer.periodic(_sweepInterval, (_) {
+      evictExpired();
+      // Stop the timer when the cache empties so we don't leak in tests.
+      if (_entries.isEmpty) {
+        _sweepTimer?.cancel();
+        _sweepTimer = null;
+      }
+    });
+  }
+
+  /// Number of cached entries.
+  int get length => _entries.length;
+
+  /// True when no entries are cached.
+  bool get isEmpty => _entries.isEmpty;
+
+  /// Returns the cached session if present and not expired; refreshes the
+  /// LRU ordering for the entry.
+  ///
+  /// Returns null on miss or expiry. An expired entry is evicted as a side
+  /// effect (and its key material zeroed).
+  SignalSession? get(String key) {
+    final entry = _entries.remove(key);
+    if (entry == null) return null;
+    if (_now().difference(entry.lastAccessed) >= ttl) {
+      _zeroAndDrop(entry);
+      return null;
+    }
+    entry.lastAccessed = _now();
+    _entries[key] = entry; // re-insert at end -> most recent
+    return entry.session;
+  }
+
+  /// Insert or replace a session. Evicts the LRU entry when the cache exceeds
+  /// [maxEntries]. If [key] already exists, the previous session's key
+  /// material is zeroed before being replaced.
+  void put(String key, SignalSession session) {
+    final existing = _entries.remove(key);
+    if (existing != null && !identical(existing.session, session)) {
+      _zeroAndDrop(existing);
+    }
+    _entries[key] = _Entry(session, _now());
+    while (_entries.length > maxEntries) {
+      final firstKey = _entries.keys.first;
+      final dropped = _entries.remove(firstKey)!;
+      _zeroAndDrop(dropped);
+    }
+    _ensureSweepTimer();
+  }
+
+  /// Remove and zero a single entry. Returns whether anything was removed.
+  bool remove(String key) {
+    final entry = _entries.remove(key);
+    if (entry == null) return false;
+    _zeroAndDrop(entry);
+    return true;
+  }
+
+  /// Apply [fn] to every cached session. Read-only iteration.
+  void forEach(void Function(String key, SignalSession session) fn) {
+    _entries.forEach((k, e) => fn(k, e.session));
+  }
+
+  /// True when [key] is present (does not refresh LRU order).
+  bool containsKey(String key) => _entries.containsKey(key);
+
+  /// Drop all expired entries. Called periodically by the sweep timer and
+  /// exposed for tests.
+  void evictExpired() {
+    final now = _now();
+    final expired = <String>[];
+    for (final e in _entries.entries) {
+      if (now.difference(e.value.lastAccessed) >= ttl) {
+        expired.add(e.key);
+      }
+    }
+    for (final k in expired) {
+      _zeroAndDrop(_entries.remove(k)!);
+    }
+  }
+
+  /// Zero and remove every entry. Used on logout or full reset.
+  void clear() {
+    for (final entry in _entries.values) {
+      _zeroAndDrop(entry);
+    }
+    _entries.clear();
+  }
+
+  /// Cancel the periodic sweep and clear all entries. Safe to call multiple
+  /// times.
+  void dispose() {
+    _sweepTimer?.cancel();
+    _sweepTimer = null;
+    clear();
+  }
+
+  void _zeroAndDrop(_Entry entry) {
+    final s = entry.session;
+    s.rootKey.fillRange(0, s.rootKey.length, 0);
+    s.sendChainKey.fillRange(0, s.sendChainKey.length, 0);
+    final recv = s.recvChainKey;
+    if (recv != null) {
+      recv.fillRange(0, recv.length, 0);
+    }
+    for (final mk in s.skippedKeys.values) {
+      mk.fillRange(0, mk.length, 0);
+    }
+    s.skippedKeys.clear();
+  }
+}
+
+class _Entry {
+  final SignalSession session;
+  DateTime lastAccessed;
+  _Entry(this.session, this.lastAccessed);
+}

--- a/apps/client/test/services/session_cache_test.dart
+++ b/apps/client/test/services/session_cache_test.dart
@@ -1,0 +1,224 @@
+import 'package:cryptography/cryptography.dart';
+import 'package:echo_app/src/services/session_cache.dart';
+import 'package:echo_app/src/services/signal_session.dart';
+import 'package:echo_app/src/services/signal_x3dh.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Build a real, encrypt-capable Alice [SignalSession] via X3DH so we have
+/// a session whose internal key material is non-zero (initBob leaves
+/// sendChainKey as zeros, which would defeat the zeroing assertions).
+Future<SignalSession> makeSession() async {
+  final x25519 = X25519();
+  final aliceIdentity = await x25519.newKeyPair();
+  final bobIdentity = await x25519.newKeyPair();
+  final bobSignedPrekey = await x25519.newKeyPair();
+
+  final bobIdentityPub = await bobIdentity.extractPublicKey();
+  final bobSignedPrekeyPub = await bobSignedPrekey.extractPublicKey();
+
+  final initResult = await X3DH.initiate(
+    aliceIdentity: aliceIdentity,
+    bobIdentityKey: bobIdentityPub,
+    bobSignedPrekey: bobSignedPrekeyPub,
+  );
+
+  return SignalSession.initAlice(initResult.sharedSecret, bobSignedPrekeyPub);
+}
+
+void main() {
+  late DateTime now;
+  DateTime nowFn() => now;
+
+  group('SessionCache', () {
+    setUp(() {
+      now = DateTime(2026, 1, 1, 12, 0);
+    });
+
+    test('put then get returns the same session', () async {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      final s = await makeSession();
+      cache.put('peer-1', s);
+      expect(identical(cache.get('peer-1'), s), isTrue);
+      expect(cache.length, 1);
+      cache.dispose();
+    });
+
+    test('get returns null on miss', () {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      expect(cache.get('nobody'), isNull);
+      cache.dispose();
+    });
+
+    test('expired entries are evicted on get', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        ttl: const Duration(hours: 1),
+        enablePeriodicEviction: false,
+      );
+      cache.put('peer-1', await makeSession());
+      now = now.add(const Duration(hours: 2));
+      expect(cache.get('peer-1'), isNull);
+      expect(cache.length, 0);
+      cache.dispose();
+    });
+
+    test('LRU eviction at maxEntries', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        maxEntries: 3,
+        enablePeriodicEviction: false,
+      );
+      cache.put('a', await makeSession());
+      cache.put('b', await makeSession());
+      cache.put('c', await makeSession());
+      cache.put('d', await makeSession()); // evicts 'a'
+      expect(cache.containsKey('a'), isFalse);
+      expect(cache.containsKey('b'), isTrue);
+      expect(cache.containsKey('c'), isTrue);
+      expect(cache.containsKey('d'), isTrue);
+      expect(cache.length, 3);
+      cache.dispose();
+    });
+
+    test('LRU promotion: get refreshes ordering', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        maxEntries: 3,
+        enablePeriodicEviction: false,
+      );
+      cache.put('a', await makeSession());
+      cache.put('b', await makeSession());
+      cache.put('c', await makeSession());
+      cache.get('a'); // 'a' is most recent now
+      cache.put('d', await makeSession()); // should evict 'b'
+      expect(cache.containsKey('a'), isTrue);
+      expect(cache.containsKey('b'), isFalse);
+      expect(cache.containsKey('c'), isTrue);
+      expect(cache.containsKey('d'), isTrue);
+      cache.dispose();
+    });
+
+    test('eviction zeroes key material', () async {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      final s = await makeSession();
+      final rootKeyRef = s.rootKey;
+      final sendChainRef = s.sendChainKey;
+      expect(
+        rootKeyRef.any((b) => b != 0),
+        isTrue,
+        reason: 'pre: rootKey should be non-zero',
+      );
+      expect(
+        sendChainRef.any((b) => b != 0),
+        isTrue,
+        reason: 'pre: sendChainKey should be non-zero',
+      );
+
+      cache.put('peer-1', s);
+      cache.remove('peer-1');
+
+      expect(
+        rootKeyRef.every((b) => b == 0),
+        isTrue,
+        reason: 'post: rootKey should be zeroed',
+      );
+      expect(
+        sendChainRef.every((b) => b == 0),
+        isTrue,
+        reason: 'post: sendChainKey should be zeroed',
+      );
+      cache.dispose();
+    });
+
+    test('replace via put zeroes the previous session', () async {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      final s1 = await makeSession();
+      final s2 = await makeSession();
+      final ref = s1.rootKey;
+      cache.put('peer-1', s1);
+      cache.put('peer-1', s2);
+      expect(
+        ref.every((b) => b == 0),
+        isTrue,
+        reason: 'replaced session must be zeroed',
+      );
+      expect(identical(cache.get('peer-1'), s2), isTrue);
+      cache.dispose();
+    });
+
+    test('evictExpired drops only expired', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        ttl: const Duration(hours: 1),
+        enablePeriodicEviction: false,
+      );
+      cache.put('a', await makeSession());
+      now = now.add(const Duration(minutes: 30));
+      cache.put('b', await makeSession());
+      // Advance so 'a' is 1.5h old (expired) and 'b' is 1h old (boundary,
+      // also expired given >= ttl semantics).
+      now = now.add(const Duration(hours: 1));
+      cache.evictExpired();
+      expect(cache.containsKey('a'), isFalse);
+      // 'b' is exactly at the TTL boundary; with >= ttl semantics it is
+      // also evicted.  This is the intended conservative behaviour.
+      expect(cache.containsKey('b'), isFalse);
+      cache.dispose();
+    });
+
+    test('evictExpired keeps fresh entries', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        ttl: const Duration(hours: 1),
+        enablePeriodicEviction: false,
+      );
+      cache.put('a', await makeSession());
+      now = now.add(const Duration(minutes: 30));
+      cache.evictExpired();
+      expect(cache.containsKey('a'), isTrue);
+      cache.dispose();
+    });
+
+    test('clear zeroes and removes all', () async {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      final s = await makeSession();
+      final ref = s.rootKey;
+      cache.put('peer-1', s);
+      cache.clear();
+      expect(cache.length, 0);
+      expect(ref.every((b) => b == 0), isTrue);
+      cache.dispose();
+    });
+
+    test('forEach visits every entry', () async {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      cache.put('a', await makeSession());
+      cache.put('b', await makeSession());
+      final keys = <String>[];
+      cache.forEach((k, _) => keys.add(k));
+      expect(keys, containsAll(<String>['a', 'b']));
+      cache.dispose();
+    });
+
+    test('remove returns false on missing key', () {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      expect(cache.remove('nobody'), isFalse);
+      cache.dispose();
+    });
+
+    test('dispose cancels timer and clears entries', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        sweepInterval: const Duration(milliseconds: 50),
+      );
+      final s = await makeSession();
+      final ref = s.rootKey;
+      cache.put('peer-1', s);
+      cache.dispose();
+      expect(cache.length, 0);
+      expect(ref.every((b) => b == 0), isTrue);
+      // Calling dispose again is safe.
+      cache.dispose();
+    });
+  });
+}

--- a/apps/client/test/services/session_cache_test.dart
+++ b/apps/client/test/services/session_cache_test.dart
@@ -206,6 +206,63 @@ void main() {
       cache.dispose();
     });
 
+    test('evictExpired keeps entries just below TTL', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        ttl: const Duration(hours: 1),
+        enablePeriodicEviction: false,
+      );
+      cache.put('a', await makeSession());
+      // Advance to TTL minus 1 second -- should still be fresh.
+      now = now.add(const Duration(hours: 1) - const Duration(seconds: 1));
+      cache.evictExpired();
+      expect(cache.containsKey('a'), isTrue);
+      cache.dispose();
+    });
+
+    test('isFresh returns true for non-expired entry', () async {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      cache.put('a', await makeSession());
+      expect(cache.isFresh('a'), isTrue);
+      cache.dispose();
+    });
+
+    test('isFresh returns false for expired entry without evicting', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        ttl: const Duration(hours: 1),
+        enablePeriodicEviction: false,
+      );
+      cache.put('a', await makeSession());
+      now = now.add(const Duration(hours: 2));
+      expect(cache.isFresh('a'), isFalse);
+      // Entry is still in the underlying map (containsKey true) until evicted.
+      expect(cache.containsKey('a'), isTrue);
+      cache.dispose();
+    });
+
+    test('isFresh returns false for missing entry', () {
+      final cache = SessionCache(clock: nowFn, enablePeriodicEviction: false);
+      expect(cache.isFresh('nope'), isFalse);
+      cache.dispose();
+    });
+
+    test('isFresh does not refresh LRU ordering', () async {
+      final cache = SessionCache(
+        clock: nowFn,
+        maxEntries: 3,
+        enablePeriodicEviction: false,
+      );
+      cache.put('a', await makeSession());
+      cache.put('b', await makeSession());
+      cache.put('c', await makeSession());
+      cache.isFresh('a'); // should not refresh
+      cache.put('d', await makeSession()); // should still evict 'a'
+      expect(cache.containsKey('a'), isFalse);
+      expect(cache.containsKey('d'), isTrue);
+      cache.dispose();
+    });
+
     test('dispose cancels timer and clears entries', () async {
       final cache = SessionCache(
         clock: nowFn,


### PR DESCRIPTION
## Summary

Closes #343. Hardens forward secrecy on the Dart Signal Protocol session cache.

### What changed
- **24h idle TTL** on cached sessions — entries not used for 24 hours are evicted from RAM
- **200-entry LRU cap** — bounds in-memory growth on long-running clients
- **Explicit zeroing** of `Uint8List` key material (`rootKey`, `sendChainKey`, `recvChainKey`, all `skippedKeys` entries) before drop. Dart GC alone doesn't guarantee timely zeroing.
- **15-min periodic sweep** for proactive eviction. Lazy-started on first put; auto-cancels when cache empties to avoid leaking timers in widget tests.
- **Reload-on-miss** from `SecureKeyStore` — eviction is non-destructive. On the next encrypt/decrypt with an evicted peer, the session is silently reloaded from secure storage. No X3DH re-handshake unless disk has nothing.
- **`SessionCache.isFresh(key)`** — TTL-aware presence check that doesn't mutate LRU order, used by UI-facing checks (`canEstablishSession`, `hasSessionKey`) and the routing path in `_sessionKeyFor`.

### Why
Per CLAUDE.md known-limitation #1: "Session keys cached forever in memory (no TTL)". A memory dump of the running client at any point exposed all decrypted root keys, chain keys, ratchet private keys, and up to 1000 skipped message keys per session. This undermined the forward-secrecy guarantee that Double Ratchet provides.

### Files changed
- `apps/client/lib/src/services/session_cache.dart` (NEW, 183 lines) — encapsulated TTL+LRU+zero behavior
- `apps/client/lib/src/services/crypto_service.dart` (modified, +93/-22) — replaced raw `Map<String, SignalSession>` with `SessionCache`; added reload-on-miss; defensive `_lastX3dhResult` clear
- `apps/client/test/services/session_cache_test.dart` (NEW, 281 lines) — 18 tests covering TTL boundaries, LRU eviction/promotion, zeroing, isFresh semantics, periodic sweep
- `CLAUDE.md` — updated known-limitations item #1

### Review feedback fixes (in commit #2)
- `_sessionKeyFor` was using TTL-unaware `containsKey` — would route to expired sessions causing false decrypt failures. Replaced with `isFresh`. (HIGH)
- Stale `_lastX3dhResult` race could persist across aborted encrypt calls. Defensive clear at top of `_encryptMessageImpl`. (HIGH)
- `SessionCache.get` now captures `now` once for boundary consistency. (MEDIUM)
- `assert(maxEntries > 0)` in constructor. (MEDIUM)
- `clear()` cancels timer for clean teardown. (LOW)
- 5 new tests covering `isFresh` and TTL near-boundary regression. (test gap)

## Test plan
- [x] `dart format --set-exit-if-changed` clean
- [x] `flutter analyze --fatal-infos` no issues
- [x] `flutter test test/services/session_cache_test.dart` 18/18 pass
- [x] `flutter test` 811 pass (was 793; +18 new tests)
- [x] Existing crypto roundtrip tests still pass (reload-on-miss is transparent)