### PR TITLE
fix(client): conv timestamp align, sender ttl, hover overlap

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -296,6 +296,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
     String conversationId,
     String timestamp, {
     String? channelId,
+    DateTime? expiresAt,
   }) {
     // Replace the most recent pending/sending message in this conversation
     // with the server-assigned ID so that delivery receipts can match it.
@@ -311,6 +312,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
         messageId,
         timestamp,
         channelId,
+        expiresAt,
       );
       // Cancel only the timer for the specific pending message that was
       // confirmed — not all pending timers in the conversation.
@@ -352,6 +354,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
     String messageId,
     String timestamp,
     String? channelId,
+    DateTime? expiresAt,
   ) {
     for (var i = 0; i < messages.length; i++) {
       final msg = messages[i];
@@ -366,6 +369,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
           timestamp: timestamp,
           status: MessageStatus.sent,
           channelId: channelId ?? msg.channelId,
+          expiresAt: expiresAt ?? msg.expiresAt,
         );
         updatedConv[conversationId] = updatedMessages;
         return pendingId;

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -310,6 +310,10 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
     final conversationId = json['conversation_id'] as String;
     final channelId = json['channel_id'] as String?;
     final timestamp = json['timestamp'] as String;
+    final expiresAtRaw = json['expires_at'];
+    final expiresAt = expiresAtRaw is String
+        ? DateTime.tryParse(expiresAtRaw)
+        : null;
     ref
         .read(chatProvider.notifier)
         .confirmSent(
@@ -317,6 +321,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
           conversationId,
           timestamp,
           channelId: channelId,
+          expiresAt: expiresAt,
         );
     // Update status to sent
     ref

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -439,33 +439,45 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
             ),
           ),
         const Spacer(),
-        if (showMoreButton)
-          Semantics(
-            label: 'More options for $displayName',
-            button: true,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(4),
-              onTapDown: (details) {
-                widget.onContextMenu?.call(details.globalPosition);
-              },
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: Icon(
-                  Icons.more_horiz,
-                  size: 16,
-                  color: context.textMuted,
-                ),
-              ),
-            ),
-          )
-        else if (widget.timestamp.isNotEmpty)
-          Text(
-            widget.timestamp,
-            style: TextStyle(
-              fontSize: 11,
-              color: hasUnread ? context.accent : context.textMuted,
-            ),
+        SizedBox(
+          width: 56,
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: showMoreButton
+                ? Semantics(
+                    label: 'More options for $displayName',
+                    button: true,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(4),
+                      onTapDown: (details) {
+                        widget.onContextMenu?.call(details.globalPosition);
+                      },
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 4),
+                        child: Icon(
+                          Icons.more_horiz,
+                          size: 16,
+                          color: context.textMuted,
+                        ),
+                      ),
+                    ),
+                  )
+                : (widget.timestamp.isNotEmpty
+                      ? Text(
+                          widget.timestamp,
+                          maxLines: 1,
+                          overflow: TextOverflow.clip,
+                          textAlign: TextAlign.end,
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: hasUnread
+                                ? context.accent
+                                : context.textMuted,
+                          ),
+                        )
+                      : const SizedBox.shrink()),
           ),
+        ),
       ],
     );
   }

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1547,7 +1547,7 @@ class _MessageItemState extends State<MessageItem>
     required String? mediaUrl,
   }) {
     return Positioned(
-      top: widget.compactLayout ? -28 : (widget.showHeader ? 0 : -12),
+      top: -28,
       left: isMine ? null : 36,
       right: isMine ? 0 : 8,
       child: ExcludeSemantics(


### PR DESCRIPTION
## Summary
Three small UI/UX bug fixes from production screenshots:

- **Conversation list timestamps** now pin to a fixed-width right-aligned column. Previously "Yesterday"/"Mon"/"Apr 17" sat at varying horizontal positions because the trailing \`Text\` was unbounded.
- **Sender's disappearing-timer messages** now expire correctly. Server already broadcasts \`expires_at\` in the \`MessageSent\` confirmation; the client was dropping it. Now parsed in \`_handleMessageSent\` and threaded through \`confirmSent\` -> \`_replacePendingMessage\` -> \`copyWith\`. Receiver path was already correct.
- **Hover overlay** no longer covers the message body. Anchored at constant \`top: -28\` instead of \`0\` when \`showHeader\` is true. Parent Stack uses \`Clip.none\` so the negative offset renders cleanly above the bubble.

## Test plan
- [x] \`flutter analyze --fatal-infos\` clean
- [x] \`flutter test\` -- all 812 tests pass
- [ ] Manual: timestamp column alignment in conversation list
- [ ] Manual: sender's TTL message disappears at 0s on sender's screen
- [ ] Manual: hover overlay floats above bubble, never overlaps message text