### PR TITLE
fix(client): message view polish - edit cache, forwarded badge, avatar, group forward

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -795,6 +795,14 @@ class ChatNotifier extends StateNotifier<ChatState> {
     }).toList();
 
     state = state.copyWith(messagesByConversation: updatedConv);
+
+    // Persist the edit to the local Hive cache so it survives app restart.
+    final edited = updatedConv[conversationId]
+        ?.where((m) => m.id == messageId)
+        .toList();
+    if (edited != null && edited.isNotEmpty) {
+      MessageCache.cacheMessages(conversationId, edited);
+    }
   }
 
   /// Update a message's pin state in local state.

--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -40,12 +40,15 @@ Widget buildAvatar({
 
   if (imageUrl != null && imageUrl.isNotEmpty) {
     return ClipOval(
+      key: ValueKey(imageUrl),
       child: SizedBox(
         width: radius * 2,
         height: radius * 2,
         child: CachedNetworkImage(
           imageUrl: imageUrl,
           fit: BoxFit.cover,
+          fadeInDuration: Duration.zero,
+          fadeOutDuration: Duration.zero,
           placeholder: (_, _) => fallback,
           errorWidget: (_, _, _) => fallback,
         ),

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -1050,11 +1050,19 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       ) async {
         // Add optimistic message so the sender sees it locally immediately.
         String peerUserId = '';
+        String? channelId;
         if (!target.isGroup) {
           final peer = target.members
               .where((m) => m.userId != myUserId)
               .firstOrNull;
           peerUserId = peer?.userId ?? '';
+        } else {
+          // Look up the default text channel so the optimistic message has the
+          // same channelId that the server will return in message_sent.
+          // Without this, _replacePendingMessage's channelId filter never
+          // matches and the pending message times out to failed.
+          final channels = ref.read(channelsProvider).channelsFor(target.id);
+          channelId = channels.where((c) => c.isText).firstOrNull?.id;
         }
         ref
             .read(chatProvider.notifier)
@@ -1063,10 +1071,15 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
               forwardedContent,
               myUserId,
               conversationId: target.id,
+              channelId: channelId,
             );
 
         if (target.isGroup) {
-          await ws.sendGroupMessage(target.id, forwardedContent);
+          await ws.sendGroupMessage(
+            target.id,
+            forwardedContent,
+            channelId: channelId,
+          );
         } else {
           final peer = target.members
               .where((m) => m.userId != myUserId)

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1124,21 +1124,26 @@ class _MessageItemState extends State<MessageItem>
       return _buildDecryptionFailure();
     }
 
+    final displayContent = msg.content.startsWith('[Forwarded] ')
+        ? msg.content.substring('[Forwarded] '.length)
+        : msg.content;
+
     final textColor = _contentTextColor(isMine: isMine, isFailed: isFailed);
     final textWidget = RichTextContent(
-      text: msg.content,
+      text: displayContent,
       textColor: textColor,
       accentHoverColor: context.accentHover,
       textSecondaryColor: context.textSecondary,
     );
 
-    final embeddedImages = extractEmbeddedImageUrls(msg.content);
+    final embeddedImages = extractEmbeddedImageUrls(displayContent);
 
     // Link preview for the first URL (skip attachment-only messages and
     // internal server links).
     Widget? linkPreview;
-    if (!msg.content.startsWith('[img:') && !msg.content.startsWith('[file:')) {
-      final urlMatch = urlRegex.firstMatch(msg.content);
+    if (!displayContent.startsWith('[img:') &&
+        !displayContent.startsWith('[file:')) {
+      final urlMatch = urlRegex.firstMatch(displayContent);
       if (urlMatch != null) {
         final previewUrl = urlMatch.group(0)!;
         final serverHost = Uri.tryParse(widget.serverUrl ?? '')?.host;
@@ -1261,6 +1266,37 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
+  Widget _buildForwardedBadge({required bool isMine}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.forward,
+            size: 12,
+            color: isMine
+                ? Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.7)
+                : context.textMuted,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            'Forwarded',
+            style: TextStyle(
+              fontSize: 11,
+              fontStyle: FontStyle.italic,
+              color: isMine
+                  ? Theme.of(
+                      context,
+                    ).colorScheme.onPrimary.withValues(alpha: 0.7)
+                  : context.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   /// Assemble the children of the bubble Column.
   List<Widget> _bubbleChildren({
     required ChatMessage msg,
@@ -1281,6 +1317,8 @@ class _MessageItemState extends State<MessageItem>
               ? () => widget.onTapReplyQuote!(msg.replyToId!)
               : null,
         ),
+      if (msg.content.startsWith('[Forwarded] '))
+        _buildForwardedBadge(isMine: isMine),
       _buildBubbleContent(
         msg: msg,
         isMine: isMine,


### PR DESCRIPTION
## Summary

Fixes several message view bugs:

### #412 — Edit persistence
`editMessage()` only updated in-memory Riverpod state. After app restart, Hive cache served the old content. Fix: persist the updated message to `MessageCache` after state update.

### #429 — Group forwarded messages disappear
Root cause: `_sendForwardedMessage` called `addOptimistic` and `sendGroupMessage` without a `channelId`. Server's `message_sent` echo included the resolved channel ID. `_replacePendingMessage` FIFO match failed (`null != uuid`), timer expired, message marked failed. Fix: read default text channel from `channelsProvider` before sending, pass `channelId` to both calls.

### Forwarded message UI
`[Forwarded]` prefix was raw text. Now renders a styled badge (forward icon + italic "Forwarded" label, color-matched to bubble side) with the prefix stripped from the message body.

### #435 — Avatar sporadic fallback
`CachedNetworkImage` had no `key` so Flutter reused the old widget when URL changed (null→url race). Fix: `key: ValueKey(imageUrl)` on `ClipOval` forces rebuild on URL change. Added `fadeInDuration/fadeOutDuration: Duration.zero` to prevent flicker.