### PR TITLE
fix(client): unify image cache manager across all media widgets

### DIFF
--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -19,6 +19,12 @@ import 'src/services/user_data_dir.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  // Cap Flutter's in-memory decoded-image cache: 500 images / 100 MB.
+  // The default (1000 images, no byte cap) is too generous for a chat app
+  // that can display hundreds of unique images in one session.
+  PaintingBinding.instance.imageCache.maximumSize = 500;
+  PaintingBinding.instance.imageCache.maximumSizeBytes = 100 * 1024 * 1024;
+
   // Global error boundary: catch unhandled Flutter framework errors so that
   // the red error screen is never shown in production.
   FlutterError.onError = (details) {

--- a/apps/client/lib/src/services/media_cache_service.dart
+++ b/apps/client/lib/src/services/media_cache_service.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+/// Single named disk cache shared by all chat image and avatar widgets.
+///
+/// Using one manager ensures the same image is never re-fetched regardless
+/// of which widget (thumbnail, gallery, avatar) displays it.
+///
+/// Config:
+/// - 500 objects max on disk
+/// - 30-day stale period
+final chatMediaCacheManager = CacheManager(
+  Config(
+    'chatMedia',
+    maxNrOfCacheObjects: 500,
+    stalePeriod: const Duration(days: 30),
+  ),
+);
+
+/// Derives a stable cache key from a URL by stripping query parameters.
+///
+/// Auth tokens, media tickets, and nonces change between requests and would
+/// cause cache misses even when the underlying file hasn't changed. Using
+/// only the URL path as the key guarantees hits on repeated loads.
+String stableMediaCacheKey(String url) {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return url;
+  return uri.replace(queryParameters: {}).toString();
+}

--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -1,6 +1,8 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+import '../services/media_cache_service.dart';
+
 /// Resolves a relative avatar path (e.g. `/api/users/123/avatar`) into a full
 /// URL by prepending the [serverUrl].  Returns `null` when [relativeUrl] is
 /// null or empty so callers can use it directly as the `imageUrl` parameter of
@@ -46,6 +48,8 @@ Widget buildAvatar({
         height: radius * 2,
         child: CachedNetworkImage(
           imageUrl: imageUrl,
+          cacheKey: stableMediaCacheKey(imageUrl),
+          cacheManager: chatMediaCacheManager,
           fit: BoxFit.cover,
           fadeInDuration: Duration.zero,
           fadeOutDuration: Duration.zero,

--- a/apps/client/lib/src/widgets/image_gallery_viewer.dart
+++ b/apps/client/lib/src/widgets/image_gallery_viewer.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
+import '../services/media_cache_service.dart';
 import '../services/toast_service.dart';
 import '../utils/download_helper.dart';
 
@@ -454,6 +455,8 @@ class _GalleryPageState extends State<_GalleryPage> {
 
     return CachedNetworkImage(
       imageUrl: url,
+      cacheKey: stableMediaCacheKey(url),
+      cacheManager: chatMediaCacheManager,
       httpHeaders: widget.headers,
       fit: BoxFit.contain,
       placeholder: (_, _) => const _LoadingSpinner(),

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:url_launcher/url_launcher.dart';
 import 'package:video_player/video_player.dart';
 
+import '../../services/media_cache_service.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../utils/download_helper.dart';
@@ -337,6 +338,8 @@ class MediaContentState extends State<MediaContent> {
                         )
                       : CachedNetworkImage(
                           imageUrl: imageUrl,
+                          cacheKey: stableMediaCacheKey(imageUrl),
+                          cacheManager: chatMediaCacheManager,
                           httpHeaders: headers,
                           fit: BoxFit.contain,
                           placeholder: (_, _) => const SizedBox(
@@ -442,8 +445,8 @@ class MediaContentState extends State<MediaContent> {
                       )
                     : CachedNetworkImage(
                         imageUrl: fullUrl,
-                        cacheKey:
-                            '${fullUrl}_${widget.authToken != null ? 'auth' : 'noauth'}',
+                        cacheKey: stableMediaCacheKey(fullUrl),
+                        cacheManager: chatMediaCacheManager,
                         width: 300,
                         fit: BoxFit.cover,
                         httpHeaders: headers,

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
 import 'package:photo_manager/photo_manager.dart' show PhotoManager;
 
@@ -17,6 +16,7 @@ import '../utils/download_helper.dart';
 import '../utils/clipboard_image_helper.dart' show writeImageToClipboard;
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart' show buildAvatar, avatarColor;
+import '../services/media_cache_service.dart';
 import 'message/media_content.dart';
 import 'message/message_status_icon.dart';
 import 'message/reaction_bar.dart';
@@ -32,15 +32,6 @@ bool get _isMobilePlatform =>
     !kIsWeb &&
     (defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS);
-
-/// Bounded cache manager for chat images to prevent unbounded disk usage.
-final chatImageCacheManager = CacheManager(
-  Config(
-    'chatImages',
-    maxNrOfCacheObjects: 200,
-    stalePeriod: const Duration(days: 30),
-  ),
-);
 
 class MessageItem extends StatefulWidget {
   final ChatMessage message;
@@ -657,8 +648,9 @@ class _MessageItemState extends State<MessageItem>
                   maxScale: 4,
                   child: CachedNetworkImage(
                     imageUrl: imageUrl,
+                    cacheKey: stableMediaCacheKey(imageUrl),
                     httpHeaders: headers,
-                    cacheManager: chatImageCacheManager,
+                    cacheManager: chatMediaCacheManager,
                     fit: BoxFit.contain,
                     placeholder: (_, _) => SizedBox(
                       width: 320,
@@ -1199,9 +1191,10 @@ class _MessageItemState extends State<MessageItem>
                       )
                     : CachedNetworkImage(
                         imageUrl: imgUrl,
+                        cacheKey: stableMediaCacheKey(imgUrl),
                         fit: BoxFit.cover,
                         httpHeaders: headers,
-                        cacheManager: chatImageCacheManager,
+                        cacheManager: chatMediaCacheManager,
                         errorWidget: (_, _, _) => const SizedBox.shrink(),
                         // Reserve the expected image area while loading so
                         // the scroll position does not jump when the image

--- a/apps/client/lib/src/widgets/shared_media_gallery.dart
+++ b/apps/client/lib/src/widgets/shared_media_gallery.dart
@@ -7,6 +7,7 @@ import '../providers/auth_provider.dart';
 import '../providers/chat_provider.dart';
 import '../providers/media_ticket_provider.dart';
 import '../providers/server_url_provider.dart';
+import '../services/media_cache_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/time_utils.dart';
 import 'image_gallery_viewer.dart';
@@ -199,6 +200,8 @@ class _MediaGrid extends StatelessWidget {
                     )
                   : CachedNetworkImage(
                       imageUrl: resolvedUrl,
+                      cacheKey: stableMediaCacheKey(resolvedUrl),
+                      cacheManager: chatMediaCacheManager,
                       httpHeaders: headers,
                       fit: BoxFit.cover,
                       placeholder: (_, _) => _placeholder(context),


### PR DESCRIPTION
## Problem

Images and media feel like they reload on every chat open. Root causes:

1. **Fragmented cache stores** — `chatImageCacheManager` was defined in `message_item.dart` and used at 2 call sites. The 4 other files (`media_content.dart`, `image_gallery_viewer.dart`, `shared_media_gallery.dart`, `avatar_utils.dart`) fell back to `DefaultCacheManager` — a separate disk bucket. Same image, separate downloads.

2. **Unstable cache keys** — `media_content.dart` used `${fullUrl}_auth` as the cache key. On web, URLs include short-lived media tickets as query params, so the key changed every session and always bypassed the cache.

3. **Flutter in-memory image cache unconfigured** — defaulted to 1000 images / no byte cap.

## Fix

- Created `apps/client/lib/src/services/media_cache_service.dart` — a single named `CacheManager` (`chatMedia`, 500 objects, 30 days) and a `stableMediaCacheKey()` helper that strips query params from URLs before they are used as cache keys.
- Wired `chatMediaCacheManager` + `stableMediaCacheKey` into every `CachedNetworkImage` call across all 5 widget files.
- Removed the duplicate local definition from `message_item.dart`.
- Configured `PaintingBinding.imageCache` to 500 images / 100 MB in `main.dart`.