### PR TITLE
fix(deps): pin connectivity_plus to 6.x (7.x needs macos 26 sdk)

### DIFF
--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: "direct overridden"
     description:
       name: connectivity_plus
-      sha256: b8fe52979ff12432ecf8f0abf6ff70410b1bb734be1c9e4f2f86807ad7166c79
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "6.1.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -67,7 +67,7 @@ dependency_overrides:
   # Stub out broken record_linux — voice recording is mobile/web only.
   record_linux:
     path: record_linux_stub
-  # connectivity_plus 7.1.1 uses NWPath.isUltraConstrained which requires
+  # connectivity_plus 7.x uses NWPath.isUltraConstrained which requires
   # the macOS 26 SDK (Xcode 26). GitHub macOS-15 runners ship Xcode 16.4
-  # with macOS 15.5 SDK, so cap below 7.1.1 until runners upgrade.
-  connectivity_plus: '>=6.0.0 <7.1.1'
+  # with macOS 15.5 SDK, so pin to 6.x until runners upgrade.
+  connectivity_plus: ^6.1.5


### PR DESCRIPTION
## Summary
Followup hotfix to #546. The cap to <7.1.1 picked 7.1.0 — but 7.1.0 *also* uses \`NWPath.isUltraConstrained\` (macOS 26 SDK). The breaking call was introduced earlier in the 7.x line than I assumed.

Pinning to \`^6.1.5\` (the version on the previous green release) via \`dependency_overrides\`. \`livekit_client\` accepts whatever connectivity_plus version, so the override is safe.

## Test plan
- [x] \`flutter analyze --fatal-infos\` clean
- [x] \`livekit_voice_provider_test.dart\` passes
- [ ] CI: macOS Desktop build succeeds after merge