### PR TITLE
fix: multi-device ciphertext recipient-scoping (#522, #500)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -56,6 +56,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -99,7 +108,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -125,10 +134,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "axum"
-version = "0.8.8"
+name = "aws-lc-rs"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "base64",
@@ -154,7 +186,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -182,13 +214,14 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
 dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "futures-core",
  "futures-util",
  "headers",
  "http",
@@ -196,8 +229,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
- "serde_core",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -273,6 +304,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -292,6 +325,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -370,6 +420,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,25 +514,24 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -462,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -537,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -627,6 +704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "echo-core"
 version = "0.1.0"
 dependencies = [
@@ -645,7 +728,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "uuid",
  "x25519-dalek",
@@ -667,7 +750,7 @@ dependencies = [
  "futures-util",
  "infer",
  "jsonwebtoken",
- "rand 0.9.3",
+ "rand 0.10.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -675,7 +758,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-http",
  "tracing",
@@ -842,6 +925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,9 +1043,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -968,6 +1059,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1087,12 +1179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,22 +1292,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1429,21 +1499,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1453,6 +1512,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1468,16 +1586,18 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
@@ -1557,6 +1677,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1784,6 +1910,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,7 +2064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1977,6 +2113,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.3",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2211,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2258,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2125,9 +2334,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2140,22 +2349,22 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2175,7 +2384,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2214,6 +2423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2456,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2249,13 +2465,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2263,9 +2519,10 @@ version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2406,7 +2663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2417,7 +2674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2455,6 +2712,22 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -2952,28 +3225,28 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tungstenite 0.26.2",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -3106,9 +3379,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3124,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3136,7 +3409,6 @@ dependencies = [
  "rand 0.9.3",
  "sha1",
  "thiserror",
- "utf-8",
 ]
 
 [[package]]
@@ -3193,6 +3465,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3403,6 +3681,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,6 +3710,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,6 +3733,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -280,35 +280,46 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       await ref.read(cryptoProvider.notifier).retryKeyUpload();
     }
 
-    Map<String, String>? deviceContents;
+    // Per-user device IDs collide across users (sender device 1 vs recipient
+    // device 1), so per-recipient maps are kept separate end-to-end (#522).
+    Map<String, Map<String, String>>? recipientDeviceContents;
     String fallbackPayload;
     try {
       final crypto = ref.read(cryptoServiceProvider);
       final token = ref.read(authProvider).token ?? '';
       crypto.setToken(token);
 
-      // Multi-device: encrypt per-device for the recipient
-      deviceContents = await crypto.encryptForAllDevices(toUserId, content);
+      final recipientContents = await crypto.encryptForAllDevices(
+        toUserId,
+        content,
+      );
 
-      // Also encrypt for sender's own other devices (self-delivery)
       final myUserId = ref.read(authProvider).userId;
+      Map<String, String> selfContents = const {};
       if (myUserId != null && myUserId.isNotEmpty) {
-        final selfContents = await crypto.encryptForOwnDevices(
-          myUserId,
-          content,
-        );
-        deviceContents.addAll(selfContents);
+        selfContents = await crypto.encryptForOwnDevices(myUserId, content);
       }
 
-      // Use first ciphertext as the fallback for legacy storage
-      fallbackPayload = deviceContents.values.firstOrNull ?? '';
+      recipientDeviceContents = <String, Map<String, String>>{};
+      if (recipientContents.isNotEmpty) {
+        recipientDeviceContents[toUserId] = recipientContents;
+      }
+      if (selfContents.isNotEmpty && myUserId != null && myUserId.isNotEmpty) {
+        recipientDeviceContents[myUserId] = selfContents;
+      }
+
+      // Legacy fallback: prefer the recipient's first ciphertext over self.
+      fallbackPayload =
+          recipientContents.values.firstOrNull ??
+          selfContents.values.firstOrNull ??
+          '';
     } catch (e) {
       debugLog('Multi-device encryption failed: $e', 'WS');
       // Fall back to single-device encrypt with session reset retry
       try {
         final crypto = ref.read(cryptoServiceProvider);
         fallbackPayload = await crypto.encryptMessage(toUserId, content);
-        deviceContents = null;
+        recipientDeviceContents = null;
       } catch (e2) {
         debugLog('Fallback encryption failed, resetting session: $e2', 'WS');
         // Reset session and retry once before giving up
@@ -316,7 +327,7 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
           final crypto = ref.read(cryptoServiceProvider);
           await crypto.invalidateSessionKey(toUserId);
           fallbackPayload = await crypto.encryptMessage(toUserId, content);
-          deviceContents = null;
+          recipientDeviceContents = null;
         } catch (e3) {
           debugLog('Encryption retry after reset also failed: $e3', 'WS');
           _addFailedMessage(
@@ -335,8 +346,8 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       'to_user_id': toUserId,
       'content': fallbackPayload,
     };
-    if (deviceContents != null && deviceContents.isNotEmpty) {
-      msg['device_contents'] = deviceContents;
+    if (recipientDeviceContents != null && recipientDeviceContents.isNotEmpty) {
+      msg['recipient_device_contents'] = recipientDeviceContents;
     }
     if (conversationId != null && conversationId.isNotEmpty) {
       msg['conversation_id'] = conversationId;

--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -76,6 +76,27 @@ Color avatarColor(String name) {
   return colors[index];
 }
 
+/// Palette for sender-name labels above receive bubbles. Tailwind-300 hues,
+/// pre-validated to clear WCAG AA 4.5:1 contrast against the dark recv bubble
+/// surface (~#1F2937). Use this for *text* color; `avatarColor` is for the
+/// avatar's background fill, where contrast against text-on-color matters
+/// instead. Re-validate if the recv bubble color changes (#500).
+const _senderLabelColors = [
+  Color(0xFFFCA5A5), // red-300
+  Color(0xFFFCD34D), // amber-300
+  Color(0xFF6EE7B7), // emerald-300
+  Color(0xFF93C5FD), // blue-300
+  Color(0xFFC4B5FD), // violet-300
+  Color(0xFFFDBA74), // orange-300
+  Color(0xFFF9A8D4), // pink-300
+  Color(0xFF67E8F9), // cyan-300
+];
+
+/// Deterministic, contrast-safe color for a sender-name label.
+Color senderLabelColor(String name) {
+  return _senderLabelColors[name.hashCode.abs() % _senderLabelColors.length];
+}
+
 /// Wider palette for group avatars, derived from group name hash.
 const _groupColors = [
   Color(0xFF22C55E), // green

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -16,7 +16,7 @@ import '../theme/responsive.dart';
 import '../utils/download_helper.dart';
 import '../utils/clipboard_image_helper.dart' show writeImageToClipboard;
 import '../utils/time_utils.dart';
-import 'avatar_utils.dart' show buildAvatar, avatarColor;
+import 'avatar_utils.dart' show buildAvatar, avatarColor, senderLabelColor;
 import '../services/media_cache_service.dart';
 import 'message/media_content.dart';
 import 'message/message_status_icon.dart';
@@ -201,8 +201,16 @@ class _MessageItemState extends State<MessageItem>
     return '${left.inDays}d';
   }
 
-  /// Consistent color for a username -- matches sidebar avatar colors.
-  Color _getUserColor(String userId) {
+  /// Sender-name label color for group messages. Uses a contrast-safe palette
+  /// against the dark recv bubble (#500); the sidebar avatar background still
+  /// uses `avatarColor`, where contrast rules differ.
+  Color _getSenderLabelColor(String userId) {
+    final name = widget.message.fromUsername;
+    return senderLabelColor(name);
+  }
+
+  /// Avatar background color (contrast for the avatar's white initial glyph).
+  Color _getAvatarColor(String userId) {
     final name = widget.message.fromUsername;
     return avatarColor(name);
   }
@@ -975,7 +983,7 @@ class _MessageItemState extends State<MessageItem>
       style: GoogleFonts.inter(
         fontSize: 13,
         fontWeight: FontWeight.w600,
-        color: _getUserColor(msg.fromUserId),
+        color: _getSenderLabelColor(msg.fromUserId),
       ),
     );
 
@@ -1440,7 +1448,7 @@ class _MessageItemState extends State<MessageItem>
               ? buildAvatar(
                   name: msg.fromUsername,
                   radius: 14,
-                  bgColor: _getUserColor(msg.fromUserId),
+                  bgColor: _getAvatarColor(msg.fromUserId),
                   imageUrl: avatarImageUrl,
                 )
               : const SizedBox.shrink(),

--- a/apps/client/test/widgets/avatar_utils_test.dart
+++ b/apps/client/test/widgets/avatar_utils_test.dart
@@ -1,0 +1,37 @@
+import 'package:echo_app/src/widgets/avatar_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+double _contrastRatio(Color a, Color b) {
+  final la = a.computeLuminance();
+  final lb = b.computeLuminance();
+  final lighter = la > lb ? la : lb;
+  final darker = la > lb ? lb : la;
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+void main() {
+  group('senderLabelColor (#500)', () {
+    // The receive bubble surface uses ~#1F2937 in dark mode.
+    const recvSurface = Color(0xFF1F2937);
+
+    test('every palette entry clears WCAG AA 4.5:1 against recv bubble', () {
+      // Sample 64 distinct names to exercise the full palette via mod-N.
+      for (var i = 0; i < 64; i++) {
+        final color = senderLabelColor('user_$i');
+        final ratio = _contrastRatio(color, recvSurface);
+        expect(
+          ratio,
+          greaterThanOrEqualTo(4.5),
+          reason:
+              'senderLabelColor(user_$i) = $color failed contrast on recv bubble',
+        );
+      }
+    });
+
+    test('is deterministic for the same input', () {
+      expect(senderLabelColor('alice'), senderLabelColor('alice'));
+      expect(senderLabelColor('bob'), senderLabelColor('bob'));
+    });
+  });
+}

--- a/apps/server/migrations/20260428100000_recipient_scoped_device_contents.sql
+++ b/apps/server/migrations/20260428100000_recipient_scoped_device_contents.sql
@@ -1,0 +1,21 @@
+-- Recipient-scope per-device ciphertexts (#522).
+--
+-- Per-user device_id values collide across users (every user starts at
+-- device_id=1). The previous PRIMARY KEY (message_id, device_id) silently
+-- dropped one of two ciphertexts whenever the sender's own device and a
+-- recipient's device shared the same id, leading to undecryptable inbox state.
+--
+-- Pre-launch beta: TRUNCATE old rows. The canonical messages.content fallback
+-- in deliver_undelivered_messages keeps replay working; existing offline
+-- ciphertexts would be unrecoverable under the new key shape regardless.
+TRUNCATE TABLE message_device_contents;
+
+ALTER TABLE message_device_contents
+    ADD COLUMN recipient_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE message_device_contents DROP CONSTRAINT message_device_contents_pkey;
+ALTER TABLE message_device_contents
+    ADD PRIMARY KEY (message_id, recipient_user_id, device_id);
+
+DROP INDEX IF EXISTS idx_mdc_device;
+CREATE INDEX idx_mdc_recipient ON message_device_contents(recipient_user_id, device_id);

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -523,61 +523,74 @@ pub async fn get_pinned_messages(
 // ---------------------------------------------------------------------------
 
 /// Store per-device ciphertexts for a message (multi-device encrypted delivery).
+///
+/// Entries are `(recipient_user_id, device_id, ciphertext)`. Per-user device IDs
+/// collide across users (every user starts at device_id=1), so the storage key
+/// is scoped by recipient (#522).
 pub async fn store_device_contents(
     pool: &PgPool,
     message_id: Uuid,
-    entries: &[(i32, &str)],
+    entries: &[(Uuid, i32, &str)],
 ) -> Result<(), sqlx::Error> {
     if entries.is_empty() {
         return Ok(());
     }
-    // Build a batch insert: INSERT INTO ... VALUES ($1,$2,$3), ($1,$4,$5), ...
     let mut query = String::from(
-        "INSERT INTO message_device_contents (message_id, device_id, content) VALUES ",
+        "INSERT INTO message_device_contents \
+         (message_id, recipient_user_id, device_id, content) VALUES ",
     );
     let mut param_idx = 2; // $1 = message_id
     for (i, _) in entries.iter().enumerate() {
         if i > 0 {
             query.push_str(", ");
         }
-        query.push_str(&format!("($1, ${}, ${})", param_idx, param_idx + 1));
-        param_idx += 2;
+        query.push_str(&format!(
+            "($1, ${}, ${}, ${})",
+            param_idx,
+            param_idx + 1,
+            param_idx + 2
+        ));
+        param_idx += 3;
     }
-    query.push_str(" ON CONFLICT (message_id, device_id) DO NOTHING");
+    query.push_str(" ON CONFLICT (message_id, recipient_user_id, device_id) DO NOTHING");
 
     let mut q = sqlx::query(&query).bind(message_id);
-    for (device_id, content) in entries {
-        q = q.bind(device_id).bind(*content);
+    for (recipient_user_id, device_id, content) in entries {
+        q = q.bind(recipient_user_id).bind(device_id).bind(*content);
     }
     q.execute(pool).await?;
     Ok(())
 }
 
-/// Fetch the per-device ciphertext for a specific device.
+/// Fetch the per-device ciphertext for a specific recipient device.
 pub async fn get_device_content(
     pool: &PgPool,
     message_id: Uuid,
+    recipient_user_id: Uuid,
     device_id: i32,
 ) -> Result<Option<String>, sqlx::Error> {
     let row: Option<(String,)> = sqlx::query_as(
         "SELECT content FROM message_device_contents \
-         WHERE message_id = $1 AND device_id = $2",
+         WHERE message_id = $1 AND recipient_user_id = $2 AND device_id = $3",
     )
     .bind(message_id)
+    .bind(recipient_user_id)
     .bind(device_id)
     .fetch_optional(pool)
     .await?;
     Ok(row.map(|(c,)| c))
 }
 
-/// Fetch per-device ciphertexts for a batch of messages for a specific device
-/// in a single query.  Returns a map from message_id to device-specific content.
+/// Fetch per-device ciphertexts for a batch of messages for a specific
+/// recipient device in a single query.  Returns a map from message_id to
+/// device-specific content.
 ///
 /// Used by `deliver_undelivered_messages` to avoid N+1 queries when replaying
 /// the offline queue.
 pub async fn get_device_contents_batch(
     pool: &PgPool,
     message_ids: &[Uuid],
+    recipient_user_id: Uuid,
     device_id: i32,
 ) -> Result<std::collections::HashMap<Uuid, String>, sqlx::Error> {
     if message_ids.is_empty() {
@@ -585,9 +598,10 @@ pub async fn get_device_contents_batch(
     }
     let rows: Vec<(Uuid, String)> = sqlx::query_as(
         "SELECT message_id, content FROM message_device_contents \
-         WHERE message_id = ANY($1) AND device_id = $2",
+         WHERE message_id = ANY($1) AND recipient_user_id = $2 AND device_id = $3",
     )
     .bind(message_ids)
+    .bind(recipient_user_id)
     .bind(device_id)
     .fetch_all(pool)
     .await?;

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -27,10 +27,13 @@ enum ClientMessage {
         to_user_id: Option<Uuid>,
         content: String,
         reply_to_id: Option<Uuid>,
-        /// Per-device ciphertexts: device_id (as string) -> base64 ciphertext.
-        /// When present, enables multi-device delivery.
+        /// Recipient-scoped per-device ciphertexts:
+        /// `recipient_user_id (UUID string) -> { device_id (i32 string) -> base64 ciphertext }`.
+        /// JSON object keys are strings on the wire; conversion to typed
+        /// `(Uuid, i32)` happens at the storage and fanout boundaries. Recipient
+        /// scoping is required because per-user device IDs collide across users (#522).
         #[serde(default)]
-        device_contents: Option<HashMap<String, String>>,
+        recipient_device_contents: Option<HashMap<String, HashMap<String, String>>>,
         /// Optional TTL in seconds. When Some, overrides the conversation-level
         /// disappearing-messages setting for this specific message.
         #[serde(default)]
@@ -464,7 +467,7 @@ async fn handle_text_message(
             to_user_id,
             content,
             reply_to_id,
-            device_contents,
+            recipient_device_contents,
             ttl_seconds,
         } => {
             message_service::handle_send_message(
@@ -477,7 +480,7 @@ async fn handle_text_message(
                 to_user_id,
                 content,
                 reply_to_id,
-                device_contents,
+                recipient_device_contents,
                 ttl_seconds,
             )
             .await;

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -6,6 +6,7 @@
 use axum::extract::ws::Message as WsMessage;
 use dashmap::DashMap;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 use uuid::Uuid;
 
 pub type WsTx = mpsc::Sender<WsMessage>;
@@ -54,11 +55,14 @@ impl Hub {
     }
 
     /// Send a message to ALL connected devices of a user.
+    /// Returns true if at least one device's outbound queue accepted the
+    /// message. Full/closed queues are logged separately so beta-test
+    /// telemetry distinguishes saturation from disconnect cleanup.
     pub fn send_to_user(&self, user_id: &Uuid, msg: WsMessage) -> bool {
         if let Some(devices) = self.connections.get(user_id) {
             let mut any_sent = false;
             for entry in devices.iter() {
-                if entry.value().try_send(msg.clone()).is_ok() {
+                if try_send_logged(entry.value(), msg.clone(), user_id, *entry.key()) {
                     any_sent = true;
                 }
             }
@@ -68,12 +72,14 @@ impl Hub {
         }
     }
 
-    /// Send a message to a specific device of a user.
+    /// Send a message to a specific device of a user. Returns true only when
+    /// the message was actually enqueued — callers in the replay path rely
+    /// on this to avoid prematurely marking messages as delivered (#523).
     pub fn send_to_device(&self, user_id: &Uuid, device_id: i32, msg: WsMessage) -> bool {
         if let Some(devices) = self.connections.get(user_id)
             && let Some(tx) = devices.get(&device_id)
         {
-            return tx.try_send(msg).is_ok();
+            return try_send_logged(tx.value(), msg, user_id, device_id);
         }
         false
     }
@@ -96,6 +102,28 @@ impl Hub {
                 continue;
             }
             self.send_to_user(member_id, msg.clone());
+        }
+    }
+}
+
+fn try_send_logged(tx: &WsTx, msg: WsMessage, user_id: &Uuid, device_id: i32) -> bool {
+    match tx.try_send(msg) {
+        Ok(()) => true,
+        Err(TrySendError::Full(_)) => {
+            tracing::warn!(
+                user_id = %user_id,
+                device_id = device_id,
+                "WS outbound queue full — message not delivered"
+            );
+            false
+        }
+        Err(TrySendError::Closed(_)) => {
+            tracing::debug!(
+                user_id = %user_id,
+                device_id = device_id,
+                "WS outbound queue closed — recipient disconnected"
+            );
+            false
         }
     }
 }
@@ -239,6 +267,62 @@ mod tests {
 
         match rx2.recv().await.unwrap() {
             WsMessage::Text(t) => assert_eq!(t.as_str(), "still here"),
+            _ => panic!("Expected Text"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_returns_false_when_queue_full() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        // Capacity 1, no receiver consumption: second send must fail.
+        let (tx, _rx) = mpsc::channel(1);
+        hub.register(user_id, 1, tx);
+
+        let first = hub.send_to_device(&user_id, 1, WsMessage::Text("first".into()));
+        assert!(first, "first send should fit in capacity-1 queue");
+
+        let second = hub.send_to_device(&user_id, 1, WsMessage::Text("second".into()));
+        assert!(
+            !second,
+            "second send must report failure when queue is full"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_returns_false_when_queue_closed() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx, rx) = mpsc::channel(4);
+        hub.register(user_id, 1, tx);
+        drop(rx);
+
+        let sent = hub.send_to_device(&user_id, 1, WsMessage::Text("dropped".into()));
+        assert!(!sent, "send must report failure once receiver is dropped");
+    }
+
+    #[tokio::test]
+    async fn test_send_to_user_partial_success_with_one_full_queue() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx_full, _rx_full) = mpsc::channel(1);
+        let (tx_ok, mut rx_ok) = mpsc::channel(8);
+
+        hub.register(user_id, 1, tx_full.clone());
+        hub.register(user_id, 2, tx_ok);
+
+        // Pre-fill device 1's queue.
+        tx_full.try_send(WsMessage::Text("filler".into())).unwrap();
+
+        let any_sent = hub.send_to_user(&user_id, WsMessage::Text("payload".into()));
+        assert!(
+            any_sent,
+            "send_to_user should report true when at least one device accepts"
+        );
+
+        // Device 2 should still receive it.
+        match rx_ok.recv().await.unwrap() {
+            WsMessage::Text(t) => assert_eq!(t.as_str(), "payload"),
             _ => panic!("Expected Text"),
         }
     }

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -80,6 +80,14 @@ pub(super) async fn validate_conversation_security(
     Some((conv_security, conv_kind, resolved_channel_id))
 }
 
+/// Recipient-scoped per-device ciphertexts as carried on the wire:
+/// `recipient_user_id (UUID string) -> { device_id (i32 string) -> ciphertext }`.
+/// Per-user device IDs collide across users, so the storage and fanout
+/// addressing must include the recipient (#522). Conversion to typed
+/// `(Uuid, i32)` happens at the storage/fanout boundaries; rows that fail to
+/// parse are logged and skipped.
+pub(super) type RecipientDeviceContents = HashMap<String, HashMap<String, String>>;
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_send_message(
     state: &AppState,
@@ -91,7 +99,7 @@ pub(super) async fn handle_send_message(
     to_user_id: Option<Uuid>,
     content: String,
     reply_to_id: Option<Uuid>,
-    device_contents: Option<HashMap<String, String>>,
+    recipient_device_contents: Option<RecipientDeviceContents>,
     ttl_seconds: Option<i64>,
 ) {
     if !validate_message_length(state, sender_id, &content) {
@@ -121,7 +129,7 @@ pub(super) async fn handle_send_message(
         resolved_channel_id,
         &content,
         reply_to_id,
-        &device_contents,
+        &recipient_device_contents,
         ttl_seconds,
     )
     .await
@@ -152,7 +160,7 @@ pub(super) async fn handle_send_message(
         &deliver,
         stored.id,
         conv_security.is_encrypted,
-        device_contents,
+        recipient_device_contents,
     )
     .await;
 }
@@ -170,7 +178,7 @@ pub(super) async fn store_and_confirm(
     resolved_channel_id: Option<Uuid>,
     content: &str,
     reply_to_id: Option<Uuid>,
-    device_contents: &Option<HashMap<String, String>>,
+    recipient_device_contents: &Option<RecipientDeviceContents>,
     ttl_seconds: Option<i64>,
 ) -> Option<db::messages::MessageRow> {
     // Resolve TTL: use per-message override first, then fall back to conversation setting.
@@ -220,11 +228,20 @@ pub(super) async fn store_and_confirm(
         }
     };
 
-    // Store per-device ciphertexts if present
-    if let Some(dc) = device_contents {
-        let entries: Vec<(i32, &str)> = dc
+    // Store per-device ciphertexts if present, scoped by recipient (#522).
+    if let Some(rdc) = recipient_device_contents {
+        let entries: Vec<(Uuid, i32, &str)> = rdc
             .iter()
-            .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, v.as_str())))
+            .filter_map(|(uid_str, devices)| {
+                let recipient_id = Uuid::parse_str(uid_str).ok()?;
+                Some((recipient_id, devices))
+            })
+            .flat_map(|(recipient_id, devices)| {
+                devices.iter().filter_map(move |(did_str, ct)| {
+                    let did = did_str.parse::<i32>().ok()?;
+                    Some((recipient_id, did, ct.as_str()))
+                })
+            })
             .collect();
         if !entries.is_empty()
             && let Err(e) =
@@ -248,27 +265,31 @@ pub(super) async fn store_and_confirm(
             .send_to_device(&sender_id, sender_device_id, WsMessage::Text(json.into()));
     }
 
-    // Self-device delivery: notify sender's OTHER devices about outgoing message
-    if let Some(dc) = device_contents {
-        for (device_id_str, ciphertext) in dc {
-            if let Ok(did) = device_id_str.parse::<i32>() {
-                if did == sender_device_id {
-                    continue; // Don't send to the originating device
-                }
-                let self_msg = ServerMessage::SelfMessage {
-                    message_id: stored.id,
-                    from_device_id: sender_device_id,
-                    conversation_id: conv_id,
-                    channel_id: stored.channel_id,
-                    content: ciphertext.clone(),
-                    timestamp: stored.created_at,
-                    reply_to_id,
-                };
-                if let Ok(json) = serde_json::to_string(&self_msg) {
-                    state
-                        .hub
-                        .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
-                }
+    // Self-device delivery: notify sender's OTHER devices about outgoing message.
+    // Only the sender's own slice of recipient_device_contents is relevant here.
+    if let Some(rdc) = recipient_device_contents
+        && let Some(self_devices) = rdc.get(&sender_id.to_string())
+    {
+        for (did_str, ciphertext) in self_devices {
+            let Ok(did) = did_str.parse::<i32>() else {
+                continue;
+            };
+            if did == sender_device_id {
+                continue; // Don't send to the originating device
+            }
+            let self_msg = ServerMessage::SelfMessage {
+                message_id: stored.id,
+                from_device_id: sender_device_id,
+                conversation_id: conv_id,
+                channel_id: stored.channel_id,
+                content: ciphertext.clone(),
+                timestamp: stored.created_at,
+                reply_to_id,
+            };
+            if let Ok(json) = serde_json::to_string(&self_msg) {
+                state
+                    .hub
+                    .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
             }
         }
     }
@@ -491,32 +512,40 @@ impl NewMessageFields {
     }
 }
 
-/// Pre-serialize per-device JSON messages once (keyed by device_id) to avoid
+/// Pre-serialize per-device JSON messages once for each recipient to avoid
 /// re-serializing the same message for every member in the fanout loop.
+/// Outer key is `recipient_user_id`, inner is `device_id -> JSON` (#522).
 pub(super) fn build_per_device_json(
     fields: &NewMessageFields,
-    device_contents: &HashMap<String, String>,
-) -> Vec<(i32, String)> {
-    device_contents
+    recipient_device_contents: &RecipientDeviceContents,
+) -> HashMap<Uuid, Vec<(i32, String)>> {
+    recipient_device_contents
         .iter()
-        .filter_map(|(device_id_str, ciphertext)| {
-            let did = device_id_str.parse::<i32>().ok()?;
-            let per_device_msg = ServerMessage::NewMessage {
-                message_id: fields.message_id,
-                from_user_id: fields.from_user_id,
-                from_device_id: fields.from_device_id,
-                from_username: fields.from_username.clone(),
-                conversation_id: fields.conversation_id,
-                channel_id: fields.channel_id,
-                content: ciphertext.clone(),
-                timestamp: fields.timestamp,
-                reply_to_id: fields.reply_to_id,
-                reply_to_content: fields.reply_to_content.clone(),
-                reply_to_username: fields.reply_to_username.clone(),
-                expires_at: fields.expires_at,
-            };
-            let json = serde_json::to_string(&per_device_msg).ok()?;
-            Some((did, json))
+        .filter_map(|(uid_str, devices)| {
+            let recipient_id = Uuid::parse_str(uid_str).ok()?;
+            let entries: Vec<(i32, String)> = devices
+                .iter()
+                .filter_map(|(did_str, ciphertext)| {
+                    let did = did_str.parse::<i32>().ok()?;
+                    let per_device_msg = ServerMessage::NewMessage {
+                        message_id: fields.message_id,
+                        from_user_id: fields.from_user_id,
+                        from_device_id: fields.from_device_id,
+                        from_username: fields.from_username.clone(),
+                        conversation_id: fields.conversation_id,
+                        channel_id: fields.channel_id,
+                        content: ciphertext.clone(),
+                        timestamp: fields.timestamp,
+                        reply_to_id: fields.reply_to_id,
+                        reply_to_content: fields.reply_to_content.clone(),
+                        reply_to_username: fields.reply_to_username.clone(),
+                        expires_at: fields.expires_at,
+                    };
+                    let json = serde_json::to_string(&per_device_msg).ok()?;
+                    Some((did, json))
+                })
+                .collect();
+            Some((recipient_id, entries))
         })
         .collect()
 }
@@ -526,14 +555,17 @@ pub(super) fn build_per_device_json(
 pub(super) fn deliver_to_member(
     hub: &crate::ws::hub::Hub,
     member_id: &Uuid,
-    per_device_json: Option<&[(i32, String)]>,
+    per_recipient_json: Option<&HashMap<Uuid, Vec<(i32, String)>>>,
     legacy_json: Option<&str>,
 ) -> bool {
-    if let Some(device_jsons) = per_device_json {
-        device_jsons.iter().any(|(did, json)| {
+    if let Some(by_recipient) = per_recipient_json
+        && let Some(device_jsons) = by_recipient.get(member_id)
+    {
+        return device_jsons.iter().any(|(did, json)| {
             hub.send_to_device(member_id, *did, WsMessage::Text(json.clone().into()))
-        })
-    } else if let Some(json) = legacy_json {
+        });
+    }
+    if let Some(json) = legacy_json {
         hub.send_to_user(member_id, WsMessage::Text(json.to_owned().into()))
     } else {
         false
@@ -605,7 +637,7 @@ pub(super) async fn fanout_message(
     message: &ServerMessage,
     stored_id: Uuid,
     is_encrypted: bool,
-    device_contents: Option<HashMap<String, String>>,
+    recipient_device_contents: Option<RecipientDeviceContents>,
 ) {
     let Some(fields) = NewMessageFields::extract(message) else {
         tracing::error!("fanout_message called with non-NewMessage variant");
@@ -625,10 +657,10 @@ pub(super) async fn fanout_message(
         .await
         .unwrap_or_default();
 
-    // Pre-serialize per-device JSON messages and legacy fallback
-    let per_device_json = device_contents
+    // Pre-serialize per-recipient device JSON messages and legacy fallback
+    let per_recipient_json = recipient_device_contents
         .as_ref()
-        .map(|dc| build_per_device_json(&fields, dc));
+        .map(|rdc| build_per_device_json(&fields, rdc));
     let legacy_json = serde_json::to_string(message).ok();
 
     let mut any_delivered = false;
@@ -642,7 +674,7 @@ pub(super) async fn fanout_message(
         let delivered = deliver_to_member(
             &state.hub,
             member_id,
-            per_device_json.as_deref(),
+            per_recipient_json.as_ref(),
             legacy_json.as_deref(),
         );
         if delivered {
@@ -690,9 +722,10 @@ pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid
     let all_ids: Vec<Uuid> = undelivered.iter().map(|m| m.id).collect();
 
     // Batch-fetch all per-device ciphertexts in a single query to avoid N+1.
-    let device_ct_map = db::messages::get_device_contents_batch(&state.pool, &all_ids, device_id)
-        .await
-        .unwrap_or_default();
+    let device_ct_map =
+        db::messages::get_device_contents_batch(&state.pool, &all_ids, user_id, device_id)
+            .await
+            .unwrap_or_default();
 
     // Track only IDs that the hub actually accepted into the recipient's
     // outbound queue. Marking a message delivered without confirmed enqueue

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -683,12 +683,23 @@ pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid
         Err(_) => return,
     };
 
-    let ids: Vec<Uuid> = undelivered.iter().map(|m| m.id).collect();
+    if undelivered.is_empty() {
+        return;
+    }
+
+    let all_ids: Vec<Uuid> = undelivered.iter().map(|m| m.id).collect();
 
     // Batch-fetch all per-device ciphertexts in a single query to avoid N+1.
-    let device_ct_map = db::messages::get_device_contents_batch(&state.pool, &ids, device_id)
+    let device_ct_map = db::messages::get_device_contents_batch(&state.pool, &all_ids, device_id)
         .await
         .unwrap_or_default();
+
+    // Track only IDs that the hub actually accepted into the recipient's
+    // outbound queue. Marking a message delivered without confirmed enqueue
+    // loses it forever if the queue was full or the socket had just closed (#523).
+    let mut delivered_ids: Vec<Uuid> = Vec::with_capacity(undelivered.len());
+    let mut delivered_msgs: Vec<&db::messages::MessageWithSender> =
+        Vec::with_capacity(undelivered.len());
 
     for msg in &undelivered {
         // Prefer device-specific ciphertext; fall back to canonical content.
@@ -711,21 +722,33 @@ pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid
             reply_to_username: msg.reply_to_username.clone(),
             expires_at: None, // Offline delivery: expiry already passed if expired
         };
-        if let Ok(json) = serde_json::to_string(&server_msg) {
-            state
-                .hub
-                .send_to_device(&user_id, device_id, WsMessage::Text(json.into()));
+        let Ok(json) = serde_json::to_string(&server_msg) else {
+            continue;
+        };
+        let enqueued = state
+            .hub
+            .send_to_device(&user_id, device_id, WsMessage::Text(json.into()));
+        if enqueued {
+            delivered_ids.push(msg.id);
+            delivered_msgs.push(msg);
+        } else {
+            tracing::warn!(
+                message_id = %msg.id,
+                user_id = %user_id,
+                device_id = device_id,
+                "replay: hub rejected message — leaving as undelivered for next reconnect"
+            );
         }
     }
 
-    if ids.is_empty() {
+    if delivered_ids.is_empty() {
         return;
     }
 
-    let _ = db::messages::mark_delivered(&state.pool, &ids).await;
+    let _ = db::messages::mark_delivered(&state.pool, &delivered_ids).await;
 
     // Notify original senders that their messages were delivered
-    for msg in &undelivered {
+    for msg in delivered_msgs {
         let delivered_event = ServerMessage::Delivered {
             message_id: msg.id,
             conversation_id: msg.conversation_id,

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -371,8 +371,8 @@ async fn message_to_noncontact_returns_error() {
 // Offline delivery with per-device ciphertext
 // ---------------------------------------------------------------------------
 
-/// When a sender includes `device_contents`, offline devices should receive
-/// their own ciphertext on reconnect rather than the canonical fallback.
+/// When a sender includes `recipient_device_contents`, offline devices should
+/// receive their own ciphertext on reconnect rather than the canonical fallback.
 #[tokio::test]
 async fn offline_delivery_uses_per_device_ciphertext() {
     let base = common::spawn_server().await;
@@ -402,8 +402,10 @@ async fn offline_delivery_uses_per_device_ciphertext() {
         "type": "send_message",
         "to_user_id": bob_id,
         "content": canonical_ct,
-        "device_contents": {
-            bob_device_id.to_string(): device_ct,
+        "recipient_device_contents": {
+            bob_id.to_string(): {
+                bob_device_id.to_string(): device_ct,
+            },
         },
     });
     alice_ws
@@ -468,7 +470,7 @@ async fn device_content_db_roundtrip() {
         .expect("TEST_DATABASE_URL or DATABASE_URL must be set");
     let pool = echo_server::db::create_pool(&database_url).await;
 
-    let (alice_token, _alice_id, _alice_name) =
+    let (alice_token, alice_id, _alice_name) =
         common::register_and_login(&client, &base, "dbrtalice").await;
     let (bob_token, bob_id, bob_name) = common::register_and_login(&client, &base, "dbrtbob").await;
     common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
@@ -479,16 +481,20 @@ async fn device_content_db_roundtrip() {
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
-    let device_id: i32 = 99;
-    let device_ct = "DEVICE_99_SPECIFIC_CIPHERTEXT";
+    // Both alice and bob use device_id=1 — this is the exact collision case
+    // that the recipient-scoped storage fix (#522) must resolve.
+    let device_id: i32 = 1;
+    let bob_device_ct = "BOB_DEVICE_1_CIPHERTEXT";
+    let alice_device_ct = "ALICE_DEVICE_1_CIPHERTEXT";
     let canonical = "CANONICAL";
 
     let send_msg = serde_json::json!({
         "type": "send_message",
         "to_user_id": bob_id,
         "content": canonical,
-        "device_contents": {
-            device_id.to_string(): device_ct,
+        "recipient_device_contents": {
+            bob_id.to_string(): { device_id.to_string(): bob_device_ct },
+            alice_id.to_string(): { device_id.to_string(): alice_device_ct },
         },
     });
     alice_ws
@@ -496,28 +502,43 @@ async fn device_content_db_roundtrip() {
         .await
         .unwrap();
 
-    let ack: Value = serde_json::from_str(&read_text_with_timeout(&mut alice_ws).await).unwrap();
-    assert_eq!(ack["type"], "message_sent");
+    let raw = read_text_with_timeout(&mut alice_ws).await;
+    let ack: Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(ack["type"], "message_sent", "send failed: {raw}");
     let message_id = uuid::Uuid::parse_str(ack["message_id"].as_str().unwrap()).unwrap();
 
-    // Verify the device-specific row was persisted.
-    let stored = echo_server::db::messages::get_device_content(&pool, message_id, device_id)
-        .await
-        .expect("db query failed");
+    let bob_uuid = uuid::Uuid::parse_str(&bob_id).unwrap();
+    let alice_uuid = uuid::Uuid::parse_str(&alice_id).unwrap();
+
+    // Both rows must be present — the legacy schema would have dropped one of
+    // them via ON CONFLICT (message_id, device_id) DO NOTHING.
+    let bob_stored =
+        echo_server::db::messages::get_device_content(&pool, message_id, bob_uuid, device_id)
+            .await
+            .expect("db query failed");
     assert_eq!(
-        stored,
-        Some(device_ct.to_string()),
-        "device-specific ciphertext must be stored"
+        bob_stored,
+        Some(bob_device_ct.to_string()),
+        "Bob's device-1 ciphertext must be stored"
     );
 
-    // Unknown device should return None (fall back to canonical at delivery).
-    let missing = echo_server::db::messages::get_device_content(&pool, message_id, 999)
+    let alice_stored =
+        echo_server::db::messages::get_device_content(&pool, message_id, alice_uuid, device_id)
+            .await
+            .expect("db query failed");
+    assert_eq!(
+        alice_stored,
+        Some(alice_device_ct.to_string()),
+        "Alice's device-1 ciphertext must coexist with Bob's despite same device_id"
+    );
+
+    // Unknown user/device should return None.
+    let missing = echo_server::db::messages::get_device_content(&pool, message_id, bob_uuid, 999)
         .await
         .expect("db query failed");
     assert_eq!(missing, None, "unknown device should return None");
 
     let _ = alice_ws.close(None).await;
-    let _ = bob_token; // suppress unused warning
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#522 (severity:high)** — Recipient-scope per-device ciphertext storage. Per-user device IDs collide across users (every user starts at device_id=1); old PK \`(message_id, device_id)\` silently dropped one of two ciphertexts via \`ON CONFLICT DO NOTHING\`, and the client merged self+recipient maps with \`addAll\` before send. New PK \`(message_id, recipient_user_id, device_id)\`; wire field \`device_contents\` → \`recipient_device_contents\` (nested map).
- **#500 (severity:medium, a11y)** — Sender-name labels above recv bubbles now use a contrast-safe palette validated to clear WCAG AA 4.5:1 against the dark recv bubble surface. Avatar background colors unchanged.

## Test plan

- [x] \`cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p echo-server\` — 88 lib + 9 integration tests pass; \`device_content_db_roundtrip\` proves two ciphertexts now coexist under same \`device_id=1\` for different recipients
- [x] \`dart format --set-exit-if-changed .\` — clean
- [x] \`flutter analyze --fatal-infos\` — no issues
- [x] \`flutter test\` — 817/817 pass (incl. new \`avatar_utils_test.dart\` palette contrast checks)
- [ ] Manual smoke: two-device DM where both peers have device_id=1 → both decrypt successfully
- [ ] Manual smoke: group chat sender-name labels readable on dark recv bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)