### PR TITLE
security(server): refresh token in HttpOnly cookie (#342)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - **Traefik routing**: API priority 100, Web priority 1 (API routes must take precedence).
 - **Message wire format**: Initial V2 (with OTP) = `[0xEC, 0x02] + identity_pub(32) + ephemeral_pub(32) + otp_id(4 LE) + ratchet_wire`; Initial V1 (no OTP) = `[0xEC, 0x01] + identity_pub(32) + ephemeral_pub(32) + ratchet_wire`; Normal = `header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`. All base64-wrapped over WebSocket.
 - **Soft deletes**: Messages use `is_deleted` flag, not hard deletes.
+- **Refresh tokens (web)**: HttpOnly + Secure + SameSite=Strict cookie scoped to `/api/auth`; mobile/desktop continue to use the JSON body. `/refresh` accepts either; cookie wins. CORS requires explicit origins (not `*`) when cookie auth is enabled.
 
 ## Commit Style
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "thiserror",
+ "time",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "cookie",
  "futures-core",
  "futures-util",
  "headers",
@@ -452,6 +453,17 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -15,7 +15,7 @@ chrono.workspace = true
 
 # Web framework
 axum = { version = "0.8", features = ["ws", "multipart"] }
-axum-extra = { version = "0.12", features = ["typed-header"] }
+axum-extra = { version = "0.12", features = ["typed-header", "cookie"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "set-header"] }
 

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -16,6 +16,8 @@ chrono.workspace = true
 # Web framework
 axum = { version = "0.8", features = ["ws", "multipart"] }
 axum-extra = { version = "0.12", features = ["typed-header", "cookie"] }
+# Used by cookie max_age (#342). Matches the version pulled in by `cookie`.
+time = "0.3"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "set-header"] }
 

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -382,7 +382,8 @@ pub async fn logout(
 ) -> Result<impl IntoResponse, AppError> {
     db::tokens::revoke_all_user_tokens(&state.pool, auth_user.user_id).await?;
     let jar = jar.add(clear_refresh_cookie());
-    Ok((jar, StatusCode::NO_CONTENT))
+    // Convention: StatusCode first, then CookieJar, matching register/login.
+    Ok((StatusCode::NO_CONTENT, jar))
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -65,9 +65,10 @@ pub struct AuthResponse {
     pub avatar_url: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub struct RefreshRequest {
-    pub refresh_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -228,9 +229,24 @@ pub async fn login(
 /// code path.
 pub async fn refresh(
     State(state): State<Arc<AppState>>,
-    Json(body): Json<RefreshRequest>,
+    jar: CookieJar,
+    body: Option<Json<RefreshRequest>>,
 ) -> Result<impl IntoResponse, AppError> {
-    let token_hash = jwt::hash_refresh_token(&body.refresh_token);
+    // Cookie wins when both are present so the web client's HttpOnly cookie
+    // can never be silently overridden by a malicious JSON body. Mobile/desktop
+    // clients keep sending the token in the body and that path still works.
+    let cookie_token = jar
+        .get(REFRESH_COOKIE_NAME)
+        .map(|c| c.value().to_string())
+        .filter(|s| !s.is_empty());
+    let body_token = body
+        .and_then(|Json(b)| b.refresh_token)
+        .filter(|s| !s.is_empty());
+    let raw_token = cookie_token
+        .or(body_token)
+        .ok_or_else(|| AppError::unauthorized("Missing refresh token"))?;
+
+    let token_hash = jwt::hash_refresh_token(&raw_token);
 
     let mut tx = state
         .pool
@@ -344,10 +360,15 @@ pub async fn refresh(
 
     let access_token = jwt::create_token(row.user_id, &state.jwt_secret)?;
 
-    Ok(Json(RefreshResponse {
-        access_token,
-        refresh_token: new_raw_token,
-    }))
+    let jar = jar.add(build_refresh_cookie(new_raw_token.clone()));
+
+    Ok((
+        jar,
+        Json(RefreshResponse {
+            access_token,
+            refresh_token: new_raw_token,
+        }),
+    ))
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -4,6 +4,7 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -13,6 +14,38 @@ use crate::db;
 use crate::error::AppError;
 
 use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Refresh token cookie helpers (#342)
+//
+// The web client stores the refresh token in an HttpOnly + Secure +
+// SameSite=Strict cookie scoped to `/api/auth`. Mobile/desktop continue to
+// receive the token in the JSON body for backward compatibility. `/refresh`
+// accepts either; cookie wins when both are present.
+// ---------------------------------------------------------------------------
+
+const REFRESH_COOKIE_NAME: &str = "echo_refresh";
+const REFRESH_COOKIE_MAX_AGE_SECS: i64 = 7 * 24 * 60 * 60;
+
+fn build_refresh_cookie(value: String) -> Cookie<'static> {
+    Cookie::build((REFRESH_COOKIE_NAME, value))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .path("/api/auth")
+        .max_age(time::Duration::seconds(REFRESH_COOKIE_MAX_AGE_SECS))
+        .build()
+}
+
+fn clear_refresh_cookie() -> Cookie<'static> {
+    Cookie::build((REFRESH_COOKIE_NAME, ""))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .path("/api/auth")
+        .max_age(time::Duration::ZERO)
+        .build()
+}
 
 // ---------------------------------------------------------------------------
 // Request / response types
@@ -105,6 +138,7 @@ async fn issue_refresh_token(
 
 pub async fn register(
     State(state): State<Arc<AppState>>,
+    jar: CookieJar,
     Json(body): Json<AuthRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     validate_username(&body.username)?;
@@ -118,6 +152,9 @@ pub async fn register(
     let access_token = jwt::create_token(user_id, &state.jwt_secret)?;
     let (refresh_token, _family_id) = issue_refresh_token(&state.pool, user_id).await?;
 
+    // Web clients consume the cookie; mobile/desktop still read the JSON body.
+    let jar = jar.add(build_refresh_cookie(refresh_token.clone()));
+
     let response = AuthResponse {
         user_id: user_id.to_string(),
         access_token,
@@ -125,7 +162,7 @@ pub async fn register(
         avatar_url: None,
     };
 
-    Ok((StatusCode::CREATED, Json(response)))
+    Ok((StatusCode::CREATED, jar, Json(response)))
 }
 
 // ---------------------------------------------------------------------------
@@ -134,6 +171,7 @@ pub async fn register(
 
 pub async fn login(
     State(state): State<Arc<AppState>>,
+    jar: CookieJar,
     Json(body): Json<AuthRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     // Pre-computed Argon2id hash of a random string. Used when the requested
@@ -163,6 +201,8 @@ pub async fn login(
     let access_token = jwt::create_token(user.id, &state.jwt_secret)?;
     let (refresh_token, _family_id) = issue_refresh_token(&state.pool, user.id).await?;
 
+    let jar = jar.add(build_refresh_cookie(refresh_token.clone()));
+
     let response = AuthResponse {
         user_id: user.id.to_string(),
         access_token,
@@ -170,7 +210,7 @@ pub async fn login(
         avatar_url: user.avatar_url,
     };
 
-    Ok(Json(response))
+    Ok((jar, Json(response)))
 }
 
 // ---------------------------------------------------------------------------
@@ -316,10 +356,12 @@ pub async fn refresh(
 
 pub async fn logout(
     State(state): State<Arc<AppState>>,
+    jar: CookieJar,
     auth_user: AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     db::tokens::revoke_all_user_tokens(&state.pool, auth_user.user_id).await?;
-    Ok(StatusCode::NO_CONTENT)
+    let jar = jar.add(clear_refresh_cookie());
+    Ok((jar, StatusCode::NO_CONTENT))
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -62,9 +62,14 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let allowed_headers = [header::CONTENT_TYPE, header::AUTHORIZATION];
 
     let cors = if cors_origins == "*" {
+        // Browsers reject `Access-Control-Allow-Credentials: true` paired with
+        // `Access-Control-Allow-Origin: *`, so the wildcard branch CANNOT enable
+        // credentials. The web client's HttpOnly refresh cookie (#342) requires
+        // explicit origins -- set `CORS_ORIGINS` to a comma-separated list.
         tracing::warn!(
-            "CORS_ORIGINS is set to '*' — allowing all origins. \
-             This is insecure for production. Set explicit origins."
+            "CORS_ORIGINS is set to '*' — allowing all origins WITHOUT credentials. \
+             This is insecure for production and disables cookie-based refresh. \
+             Set explicit origins to enable credentialed requests."
         );
         CorsLayer::new()
             .allow_origin(AllowOrigin::any())
@@ -79,6 +84,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             .allow_origin(AllowOrigin::list(origins))
             .allow_methods(allowed_methods)
             .allow_headers(allowed_headers)
+            // Required for the web client to send the HttpOnly refresh cookie
+            // back to /api/auth/refresh and /api/auth/logout (#342).
+            .allow_credentials(true)
     };
 
     let login_limit = rate_limit::make_rate_limit_layer(rate_limit::login_limiter());

--- a/apps/server/tests/api_auth.rs
+++ b/apps/server/tests/api_auth.rs
@@ -342,3 +342,114 @@ async fn refresh_cookie_takes_precedence() {
     assert!(body["access_token"].as_str().is_some());
     assert!(body["refresh_token"].as_str().is_some());
 }
+
+/// /refresh with NEITHER a cookie NOR a body token must 401 -- the only
+/// new error branch introduced by the cookie path (#342).
+#[tokio::test]
+async fn refresh_with_no_token_anywhere_returns_401() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("refresh request failed");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "no cookie + no body must be unauthorized"
+    );
+}
+
+/// After /logout the server-side refresh token is revoked.  Replaying the
+/// previously-set cookie value against /refresh must therefore 401 even
+/// though the cookie attributes themselves still parse cleanly (#342).
+#[tokio::test]
+async fn refresh_with_logged_out_cookie_returns_401() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("logoutreplay");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_resp = common::login_raw(&client, &base, &username, "password123").await;
+    assert_eq!(login_resp.status().as_u16(), 200);
+
+    let raw_cookie = find_set_cookie(&login_resp, "echo_refresh")
+        .expect("login Set-Cookie")
+        .to_string();
+    let cookie_header = raw_cookie
+        .split(';')
+        .next()
+        .expect("cookie name=value")
+        .trim()
+        .to_string();
+
+    let body: serde_json::Value = login_resp.json().await.unwrap();
+    let access_token = body["access_token"].as_str().unwrap().to_string();
+
+    // Log out -- revokes the refresh family server-side and clears the cookie.
+    let resp = client
+        .post(format!("{base}/api/auth/logout"))
+        .header("Authorization", format!("Bearer {access_token}"))
+        .send()
+        .await
+        .expect("logout request failed");
+    assert_eq!(resp.status().as_u16(), 204);
+
+    // Replay the captured cookie -- server must reject because the underlying
+    // refresh family was revoked.
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .header(reqwest::header::COOKIE, &cookie_header)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("refresh request failed");
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "revoked cookie must not refresh"
+    );
+}
+
+/// A cleared cookie (`echo_refresh=`) must NOT short-circuit the body token
+/// lookup -- the empty-string filter in the cookie/body resolution chain
+/// is what makes mobile/desktop fallback robust when a stale cleared cookie
+/// is still attached by the browser (#342).
+#[tokio::test]
+async fn refresh_empty_cookie_falls_through_to_body() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("emptycookie");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_body: serde_json::Value = client
+        .post(format!("{base}/api/auth/login"))
+        .json(&serde_json::json!({ "username": username, "password": "password123" }))
+        .send()
+        .await
+        .expect("login failed")
+        .json()
+        .await
+        .unwrap();
+    let body_token = login_body["refresh_token"].as_str().unwrap().to_string();
+
+    // Send an empty echo_refresh cookie alongside a valid body token.  The
+    // server's `.filter(|s| !s.is_empty())` guard must let the body token win.
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .header(reqwest::header::COOKIE, "echo_refresh=")
+        .json(&serde_json::json!({ "refresh_token": body_token }))
+        .send()
+        .await
+        .expect("refresh request failed");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "empty cookie must fall through to body token, not 401"
+    );
+}

--- a/apps/server/tests/api_auth.rs
+++ b/apps/server/tests/api_auth.rs
@@ -143,3 +143,202 @@ async fn refresh_token_revoked_returns_401() {
         "replaying a revoked refresh token should return 401"
     );
 }
+
+// ---------------------------------------------------------------------------
+// HttpOnly refresh-token cookie (#342)
+// ---------------------------------------------------------------------------
+
+/// Find the first `Set-Cookie` header whose value starts with `name=`.
+fn find_set_cookie<'a>(resp: &'a reqwest::Response, name: &str) -> Option<&'a str> {
+    let prefix = format!("{name}=");
+    resp.headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .find(|s| s.starts_with(&prefix))
+}
+
+/// Assert a Set-Cookie header has the expected security attributes.
+fn assert_refresh_cookie_attrs(set_cookie: &str, expect_max_age: &str) {
+    let lower = set_cookie.to_ascii_lowercase();
+    assert!(lower.contains("httponly"), "missing HttpOnly: {set_cookie}");
+    assert!(lower.contains("secure"), "missing Secure: {set_cookie}");
+    assert!(
+        lower.contains("samesite=strict"),
+        "missing SameSite=Strict: {set_cookie}"
+    );
+    assert!(
+        lower.contains("path=/api/auth"),
+        "missing Path=/api/auth: {set_cookie}"
+    );
+    assert!(
+        lower.contains(&format!("max-age={expect_max_age}")),
+        "expected Max-Age={expect_max_age}: {set_cookie}"
+    );
+}
+
+#[tokio::test]
+async fn login_sets_refresh_cookie() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("cookielogin");
+
+    common::register(&client, &base, &username, "password123").await;
+    let resp = common::login_raw(&client, &base, &username, "password123").await;
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let set_cookie =
+        find_set_cookie(&resp, "echo_refresh").expect("login should set echo_refresh cookie");
+    assert_refresh_cookie_attrs(set_cookie, "604800");
+}
+
+#[tokio::test]
+async fn register_sets_refresh_cookie() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("cookiereg");
+
+    let resp = common::register_raw(&client, &base, &username, "password123").await;
+    assert_eq!(resp.status().as_u16(), 201);
+
+    let set_cookie =
+        find_set_cookie(&resp, "echo_refresh").expect("register should set echo_refresh cookie");
+    assert_refresh_cookie_attrs(set_cookie, "604800");
+}
+
+#[tokio::test]
+async fn logout_clears_refresh_cookie() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("cookielogout");
+
+    common::register(&client, &base, &username, "password123").await;
+    let (token, _user_id) = common::login(&client, &base, &username, "password123").await;
+
+    let resp = client
+        .post(format!("{base}/api/auth/logout"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .expect("logout request failed");
+    assert_eq!(resp.status().as_u16(), 204);
+
+    let set_cookie =
+        find_set_cookie(&resp, "echo_refresh").expect("logout should clear echo_refresh cookie");
+    assert_refresh_cookie_attrs(set_cookie, "0");
+}
+
+#[tokio::test]
+async fn refresh_via_cookie_only() {
+    let base = common::spawn_server().await;
+    // Echo's refresh cookie sets `Secure`, which reqwest's cookie_store would
+    // drop over plaintext HTTP. The test server is plain HTTP, so we attach
+    // the cookie header manually below instead of relying on the jar.
+    let client = Client::new();
+
+    let username = common::unique_username("refcookie");
+    common::register(&client, &base, &username, "password123").await;
+    let login_resp = common::login_raw(&client, &base, &username, "password123").await;
+    assert_eq!(login_resp.status().as_u16(), 200);
+
+    let raw_cookie = find_set_cookie(&login_resp, "echo_refresh")
+        .expect("login Set-Cookie")
+        .to_string();
+    let cookie_value = raw_cookie
+        .split(';')
+        .next()
+        .expect("cookie name=value")
+        .trim()
+        .to_string();
+
+    // Send /refresh with empty body and the cookie attached manually.
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .header(reqwest::header::COOKIE, &cookie_value)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("refresh request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let new_set_cookie =
+        find_set_cookie(&resp, "echo_refresh").expect("refresh should rotate cookie");
+    assert_refresh_cookie_attrs(new_set_cookie, "604800");
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["access_token"].as_str().is_some());
+    assert!(body["refresh_token"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn refresh_via_body_still_works() {
+    // Backward-compatibility check: mobile/desktop clients have no cookie jar.
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("refbody");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_body: serde_json::Value = client
+        .post(format!("{base}/api/auth/login"))
+        .json(&serde_json::json!({ "username": username, "password": "password123" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let refresh_token = login_body["refresh_token"].as_str().unwrap();
+
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": refresh_token }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["access_token"].as_str().is_some());
+    assert!(body["refresh_token"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn refresh_cookie_takes_precedence() {
+    // When both a valid cookie and a stale/invalid body token are present,
+    // the cookie wins -- the body cannot override the HttpOnly cookie.
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("refprec");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_resp = common::login_raw(&client, &base, &username, "password123").await;
+    assert_eq!(login_resp.status().as_u16(), 200);
+
+    let raw_cookie = find_set_cookie(&login_resp, "echo_refresh")
+        .expect("login Set-Cookie")
+        .to_string();
+    let cookie_value = raw_cookie
+        .split(';')
+        .next()
+        .expect("cookie name=value")
+        .trim()
+        .to_string();
+
+    // Body carries a junk token. Cookie carries the real one. Cookie wins.
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .header(reqwest::header::COOKIE, &cookie_value)
+        .json(&serde_json::json!({ "refresh_token": "deadbeef-not-a-real-token" }))
+        .send()
+        .await
+        .expect("refresh request failed");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "cookie should take precedence over body"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["access_token"].as_str().is_some());
+    assert!(body["refresh_token"].as_str().is_some());
+}

--- a/apps/server/tests/api_auth.rs
+++ b/apps/server/tests/api_auth.rs
@@ -453,3 +453,59 @@ async fn refresh_empty_cookie_falls_through_to_body() {
         "empty cookie must fall through to body token, not 401"
     );
 }
+
+/// A web client that refreshes via the cookie path must invalidate the body
+/// token issued at login as part of the same family rotation.  Without this
+/// guarantee, an XSS that captured the body token at login could keep using
+/// it after the cookie was rotated -- defeating the point of the cookie
+/// (#342).
+#[tokio::test]
+async fn refresh_cookie_rotation_invalidates_prior_body_token() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("mixedmode");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_resp = common::login_raw(&client, &base, &username, "password123").await;
+    assert_eq!(login_resp.status().as_u16(), 200);
+
+    let raw_cookie = find_set_cookie(&login_resp, "echo_refresh")
+        .expect("login Set-Cookie")
+        .to_string();
+    let cookie_header = raw_cookie
+        .split(';')
+        .next()
+        .expect("cookie name=value")
+        .trim()
+        .to_string();
+
+    let body: serde_json::Value = login_resp.json().await.unwrap();
+    let original_body_token = body["refresh_token"].as_str().unwrap().to_string();
+
+    // Rotate via the cookie path.
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .header(reqwest::header::COOKIE, &cookie_header)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("cookie refresh failed");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "cookie rotation should succeed"
+    );
+
+    // The body token from login is now superseded -- replaying it must 401.
+    let resp = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": original_body_token }))
+        .send()
+        .await
+        .expect("body refresh request failed");
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "body token must be invalidated by cookie-path rotation"
+    );
+}


### PR DESCRIPTION
Closes #342.
Follow-up tracked in #589 (web client work).

## Summary
Server-side hardening that issues the refresh token as an HttpOnly + Secure + SameSite=Strict cookie scoped to `/api/auth`, while keeping the JSON body field unchanged for mobile/desktop backward compat. This is the **server half** of the fix; the web client switch to `BrowserClient(withCredentials: true)` is tracked separately as #589 so this PR can ship and bake without coupling client + server release cycles.

## Why
Refresh token in plaintext localStorage on web means any XSS can exfiltrate persistent account credentials. HttpOnly cookies are immune to JS-based exfiltration. The web deployment is single-host (echo-messenger.us serves both web and `/api`), so `SameSite=Strict` is sufficient with no cross-origin complications.

## Changes
| Layer | What |
|---|---|
| `Cargo.toml` | Enable `axum-extra` `cookie` feature; add `time = "0.3"` direct dep for `time::Duration` (matches version pinned by `cookie` crate) |
| `routes/auth.rs` | New `build_refresh_cookie` / `clear_refresh_cookie` helpers. `register`/`login`/`refresh` set cookie via `CookieJar`. `/refresh` resolves token = cookie OR body (cookie wins). `/logout` clears cookie. |
| `routes/mod.rs` | `allow_credentials(true)` only on the explicit-origin CORS branch. Wildcard branch keeps credentials off (browsers reject the combination). |
| `tests/api_auth.rs` | 10 new integration tests |
| `CLAUDE.md` | Note the convention under Critical Conventions |

## Cookie attributes
```
Set-Cookie: echo_refresh=<token>; HttpOnly; Secure; SameSite=Strict; Path=/api/auth; Max-Age=604800
```
- `Path=/api/auth` — cookie is **never** sent to message, media, group, or any other route.
- `Domain` deliberately not set — single-host, no subdomain leak.
- `Max-Age=604800` (7d) matches the existing DB-side refresh expiry.

## Backward compatibility
- `AuthResponse` / `RefreshResponse` JSON shapes are **unchanged** — mobile/desktop unaffected.
- `/refresh` still accepts the JSON body identically; cookie is additive and only takes precedence when both are present.
- `api_auth_refresh_race.rs` passes **unmodified** (regression smoke test for the JSON body contract).
- `CORS_ORIGINS=*` keeps working with a warning; credentialed requests are disabled in that mode (production uses explicit origins anyway).

## Tests added (10 new, all green)
| Test | Asserts |
|---|---|
| `login_sets_refresh_cookie` | Set-Cookie attributes (HttpOnly, Secure, SameSite=Strict, Path, Max-Age=604800) |
| `register_sets_refresh_cookie` | Same on /register 201 |
| `logout_clears_refresh_cookie` | Set-Cookie has Max-Age=0 |
| `refresh_via_cookie_only` | Cookie path → 200 + new Set-Cookie |
| `refresh_via_body_still_works` | Body path → 200 (mobile/desktop backward compat) |
| `refresh_cookie_takes_precedence` | Both → cookie wins |
| `refresh_with_no_token_anywhere_returns_401` | New error branch coverage |
| `refresh_with_logged_out_cookie_returns_401` | Cookie replay after logout is rejected (server-side revocation works) |
| `refresh_empty_cookie_falls_through_to_body` | Empty cookie doesn't suppress body fallback |
| `refresh_cookie_rotation_invalidates_prior_body_token` | Cookie-path rotation invalidates the body token issued at login (XSS protection) |

## Test plan
- [x] `cargo test -p echo-server --test api_auth` — 17/17 pass
- [x] `cargo test -p echo-server --test api_auth_refresh_race` — 1/1 pass (unmodified)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p echo-server --all-targets -- -D warnings`
- [ ] Manual: `curl -i -X POST http://localhost:8080/api/auth/login -d ...` — verify Set-Cookie attributes
- [ ] Production: deploy server, observe new cookie on /login responses (web client #589 will start consuming it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)