### PR TITLE
security(client): hard-fail group encryption instead of plaintext downgrade (#344)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - Rust reference: `core/rust-core/src/signal/`
 - Dart production: `apps/client/lib/src/services/signal_protocol.dart`, `signal_x3dh.dart`, `signal_session.dart`
 - 1:1 messages: X3DH key exchange + Double Ratchet (end-to-end encrypted)
-- Group messages: group key envelopes infrastructure exists (`group_crypto_service.dart`, `routes/group_keys.rs`) but not fully wired
+- Group messages: group key envelopes infrastructure exists (`group_crypto_service.dart`, `routes/group_keys.rs`) but not fully wired. When `is_encrypted=true` is enabled on a group, `sendGroupMessage` hard-fails on encryption errors instead of falling back to plaintext (#344) — server-side ciphertext-only enforcement is tracked separately (#591)
 
 **Voice & Video** (LiveKit integration):
 - Server: `routes/voice.rs` handles call signaling and LiveKit token generation

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -414,11 +414,6 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
 
   /// Send a message to a group conversation.
   ///
-  /// If the conversation has encryption enabled and a group encryption key is
-  /// available, the message content is AES-256-GCM encrypted before being
-  /// sent. Otherwise the message is sent as plaintext (backward compatible).
-  /// Send a message to a group conversation.
-  ///
   /// When the conversation is marked `isEncrypted=true`, encryption MUST
   /// succeed before the message goes on the wire.  If the group key is
   /// unavailable or encryption raises, the message surfaces as a failed

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -375,6 +375,10 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
     if (msg.contains('No session for')) {
       return 'Encryption session expired. Tap to retry.';
     }
+    // #344: surfaced when sendGroupMessage cannot fetch the group key.
+    if (msg.contains('No group session') || msg.contains('group key')) {
+      return 'Group encryption key not available yet. Tap to retry.';
+    }
     if (msg.contains('cannot decrypt') || msg.contains('Could not decrypt')) {
       return 'Message could not be decrypted.';
     }

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -417,15 +417,21 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
   /// If the conversation has encryption enabled and a group encryption key is
   /// available, the message content is AES-256-GCM encrypted before being
   /// sent. Otherwise the message is sent as plaintext (backward compatible).
+  /// Send a message to a group conversation.
+  ///
+  /// When the conversation is marked `isEncrypted=true`, encryption MUST
+  /// succeed before the message goes on the wire.  If the group key is
+  /// unavailable or encryption raises, the message surfaces as a failed
+  /// `ChatMessage` (tap-to-retry via `_retryMessage`) and the WS frame is
+  /// NOT sent.  This closes the silent plaintext downgrade vector (#344).
+  /// Unencrypted groups (`isEncrypted=false`, the default) keep sending
+  /// plaintext as before -- that path is intentional, not a downgrade.
   Future<void> sendGroupMessage(
     String conversationId,
     String content, {
     String? channelId,
     String? replyToId,
   }) async {
-    String payload = content;
-
-    // Only attempt group encryption if the conversation is marked encrypted
     final conversation = ref
         .read(conversationsProvider)
         .conversations
@@ -433,22 +439,40 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
         .firstOrNull;
     final isEncrypted = conversation?.isEncrypted ?? false;
 
+    final String payload;
     if (isEncrypted) {
       try {
         final groupCrypto = ref.read(groupCryptoServiceProvider);
         final token = ref.read(authProvider).token ?? '';
         groupCrypto.setToken(token);
         final keyResult = await groupCrypto.getGroupKey(conversationId);
-        if (keyResult != null) {
-          final (_, keyBase64) = keyResult;
-          payload = await GroupCryptoService.encryptGroupMessage(
-            content,
-            keyBase64,
+        if (keyResult == null) {
+          // No group session yet -- hard fail rather than leak plaintext.
+          _addFailedMessage(
+            '',
+            _friendlyEncryptionError('No group session'),
+            conversationId: conversationId,
+            originalContent: content,
           );
+          return;
         }
+        final (_, keyBase64) = keyResult;
+        payload = await GroupCryptoService.encryptGroupMessage(
+          content,
+          keyBase64,
+        );
       } catch (e) {
-        debugLog('Group encryption failed, sending plaintext: $e', 'WebSocket');
+        debugLog('Group encryption failed: $e', 'WebSocket');
+        _addFailedMessage(
+          '',
+          _friendlyEncryptionError(e),
+          conversationId: conversationId,
+          originalContent: content,
+        );
+        return;
       }
+    } else {
+      payload = content;
     }
 
     final msg = <String, dynamic>{

--- a/apps/client/test/providers/websocket_send_test.dart
+++ b/apps/client/test/providers/websocket_send_test.dart
@@ -2,13 +2,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/models/conversation.dart';
 import 'package:echo_app/src/providers/auth_provider.dart';
 import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/providers/conversations_provider.dart';
 import 'package:echo_app/src/providers/crypto_provider.dart';
 import 'package:echo_app/src/providers/privacy_provider.dart';
 import 'package:echo_app/src/providers/server_url_provider.dart';
 import 'package:echo_app/src/providers/websocket_provider.dart';
 import 'package:echo_app/src/services/crypto_service.dart';
+import 'package:echo_app/src/services/group_crypto_service.dart';
 
 // ---------------------------------------------------------------------------
 // Test-scoped CryptoService fake
@@ -85,6 +88,37 @@ class _SpyCryptoNotifier extends CryptoNotifier {
 }
 
 // ---------------------------------------------------------------------------
+// Test-scoped GroupCryptoService fake (#344)
+// ---------------------------------------------------------------------------
+
+/// GroupCryptoService double whose `getGroupKey` is configurable per test.
+class _TestGroupCryptoService extends GroupCryptoService {
+  _TestGroupCryptoService() : super(serverUrl: 'http://localhost:8080');
+
+  /// When true, `getGroupKey` throws to exercise the catch arm.
+  bool getGroupKeyThrows = false;
+
+  /// When non-null, `getGroupKey` returns this. Default null = no key, which
+  /// is the silent-downgrade trigger pre-#344.
+  (int, String)? getGroupKeyResult;
+
+  @override
+  Future<(int, String)?> getGroupKey(String conversationId) async {
+    if (getGroupKeyThrows) {
+      throw Exception('group key fetch blew up');
+    }
+    return getGroupKeyResult;
+  }
+}
+
+/// Build a Conversation marked as an encrypted group for the tests below.
+Conversation _encryptedGroup(String id) =>
+    Conversation(id: id, isGroup: true, isEncrypted: true);
+
+Conversation _unencryptedGroup(String id) =>
+    Conversation(id: id, isGroup: true, isEncrypted: false);
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -97,10 +131,12 @@ class _SpyCryptoNotifier extends CryptoNotifier {
 ProviderContainer _createContainer({
   CryptoState cryptoState = const CryptoState(isInitialized: true),
   CryptoService? testCrypto,
+  GroupCryptoService? testGroupCrypto,
   _SpyCryptoNotifier? spyNotifier,
   bool readReceiptsEnabled = true,
+  List<Conversation> seedConversations = const [],
 }) {
-  return ProviderContainer(
+  final container = ProviderContainer(
     overrides: [
       authProvider.overrideWith((ref) {
         final n = AuthNotifier(ref);
@@ -119,6 +155,8 @@ ProviderContainer _createContainer({
       }),
       if (testCrypto != null)
         cryptoServiceProvider.overrideWithValue(testCrypto),
+      if (testGroupCrypto != null)
+        groupCryptoServiceProvider.overrideWithValue(testGroupCrypto),
       if (spyNotifier != null)
         cryptoProvider.overrideWith((ref) => spyNotifier)
       else
@@ -133,6 +171,13 @@ ProviderContainer _createContainer({
       }),
     ],
   );
+  // Seed conversations directly into the StateNotifier's state -- the public
+  // API (loadConversations) makes a network call we'd rather not stub.
+  if (seedConversations.isNotEmpty) {
+    final notifier = container.read(conversationsProvider.notifier);
+    notifier.state = ConversationsState(conversations: seedConversations);
+  }
+  return container;
 }
 
 void main() {
@@ -377,6 +422,78 @@ void main() {
       wsNotifier.sendTyping('conv-1', channelId: 'chan-1');
 
       expect(container.read(websocketProvider).isConnected, isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #344: sendGroupMessage must hard-fail on encryption failure -- the
+  // pre-fix code silently fell through to plaintext when the group key was
+  // unavailable or encryption raised, allowing a downgrade attack.
+  // -------------------------------------------------------------------------
+  group('WebSocketNotifier.sendGroupMessage downgrade protection (#344)', () {
+    test('encrypted group + null group key adds failed message', () async {
+      final groupCrypto = _TestGroupCryptoService(); // getGroupKeyResult = null
+      final container = _createContainer(
+        testGroupCrypto: groupCrypto,
+        seedConversations: [_encryptedGroup('grp-1')],
+      );
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+      await wsNotifier.sendGroupMessage('grp-1', 'leak this');
+
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('grp-1');
+      expect(msgs, hasLength(1));
+      expect(msgs.first.status, MessageStatus.failed);
+      expect(msgs.first.isMine, isTrue);
+      // Plaintext must be retained for retry, not sent over the wire.
+      expect(msgs.first.failedContent, 'leak this');
+      expect(msgs.first.content, isNot(equals('leak this')));
+    });
+
+    test('encrypted group + getGroupKey throws adds failed message', () async {
+      final groupCrypto = _TestGroupCryptoService()..getGroupKeyThrows = true;
+      final container = _createContainer(
+        testGroupCrypto: groupCrypto,
+        seedConversations: [_encryptedGroup('grp-2')],
+      );
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+      await wsNotifier.sendGroupMessage('grp-2', 'also leak this');
+
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('grp-2');
+      expect(msgs, hasLength(1));
+      expect(msgs.first.status, MessageStatus.failed);
+      expect(msgs.first.failedContent, 'also leak this');
+    });
+
+    test('unencrypted group does NOT add a failed message (plaintext path '
+        'preserved)', () async {
+      // No group crypto override needed -- the !isEncrypted branch never
+      // invokes it.  Default getGroupKeyResult=null would NOT trigger the
+      // failure path because isEncrypted=false short-circuits the check.
+      final container = _createContainer(
+        seedConversations: [_unencryptedGroup('grp-3')],
+      );
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+      await wsNotifier.sendGroupMessage('grp-3', 'public message');
+
+      // No failed message: the plaintext path completed silently
+      // (the WS sink is null in the test harness, so the actual frame
+      // is a no-op -- we are guarding the behavioral invariant that
+      // unencrypted groups don't accidentally route through the failure
+      // surface).
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('grp-3');
+      expect(msgs, isEmpty);
     });
   });
 }

--- a/apps/client/test/providers/websocket_send_test.dart
+++ b/apps/client/test/providers/websocket_send_test.dart
@@ -472,6 +472,27 @@ void main() {
       expect(msgs.first.failedContent, 'also leak this');
     });
 
+    test('conversation not in cache defaults to plaintext (documents '
+        'current boundary behavior)', () async {
+      // No seedConversations -- the conversationsProvider has no row for
+      // grp-unknown.  The current code defaults isEncrypted=false in that
+      // case and falls through to plaintext (no failed message).  This
+      // test pins the boundary so a future regression that changes the
+      // `?? false` default is visible.  If the security model later
+      // requires hard-failing on unknown conversations, update here AND
+      // sendGroupMessage in lockstep.
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final wsNotifier = container.read(websocketProvider.notifier);
+      await wsNotifier.sendGroupMessage('grp-unknown', 'silent plaintext?');
+
+      final msgs = container
+          .read(chatProvider)
+          .messagesForConversation('grp-unknown');
+      expect(msgs, isEmpty);
+    });
+
     test('unencrypted group does NOT add a failed message (plaintext path '
         'preserved)', () async {
       // No group crypto override needed -- the !isEncrypted branch never

--- a/apps/client/test/providers/websocket_send_test.dart
+++ b/apps/client/test/providers/websocket_send_test.dart
@@ -450,7 +450,11 @@ void main() {
       expect(msgs.first.isMine, isTrue);
       // Plaintext must be retained for retry, not sent over the wire.
       expect(msgs.first.failedContent, 'leak this');
-      expect(msgs.first.content, isNot(equals('leak this')));
+      // #344-specific friendly error -- locks the new branch in
+      // _friendlyEncryptionError so a future generic-fallback regression
+      // (or removal of the dedicated message) is visible.
+      expect(msgs.first.content, contains('Group encryption key'));
+      expect(msgs.first.content, contains('Tap to retry'));
     });
 
     test('encrypted group + getGroupKey throws adds failed message', () async {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,12 +12,22 @@ pre-commit:
       run: |
         FLUTTER_BIN=$(dirname "$(which flutter 2>/dev/null || echo "$HOME/.flutter/bin/flutter")")
         export PATH="$FLUTTER_BIN:$PATH"
+        # Hook env from `git commit` includes GIT_DIR pointing at the consumer
+        # worktree; flutter then resolves its own version against that and
+        # caches "0.0.0-unknown", which breaks pub solving.  Drop the git env
+        # so flutter runs `git rev-parse` inside its own SDK repo.
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
         cd apps/client && dart format --set-exit-if-changed .
     flutter-analyze:
       glob: "*.dart"
       run: |
         FLUTTER_BIN=$(dirname "$(which flutter 2>/dev/null || echo "$HOME/.flutter/bin/flutter")")
         export PATH="$FLUTTER_BIN:$PATH"
+        # Hook env from `git commit` includes GIT_DIR pointing at the consumer
+        # worktree; flutter then resolves its own version against that and
+        # caches "0.0.0-unknown", which breaks pub solving.  Drop the git env
+        # so flutter runs `git rev-parse` inside its own SDK repo.
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
         cd apps/client && flutter analyze --fatal-infos
 
 commit-msg:


### PR DESCRIPTION
Closes #344.
Server-side enforcement follow-up: #591.

## Summary
Closes the silent plaintext downgrade vector in `sendGroupMessage`. When a group is marked `isEncrypted=true` and encryption fails (null group key OR exception), the message now surfaces as a tap-to-retry failed message instead of silently going on the wire as plaintext.

## Root cause
```dart
// pre-fix: silent fallback
String payload = content;  // plaintext default
if (isEncrypted) {
  try {
    final keyResult = await groupCrypto.getGroupKey(conversationId);
    if (keyResult != null) {                              // silent skip
      payload = await GroupCryptoService.encryptGroupMessage(...);
    }
  } catch (e) {
    debugLog('Group encryption failed, sending plaintext: $e');  // swallowed
  }
}
_channel?.sink.add(jsonEncode({'content': payload, ...}));  // plaintext leaked
```
An attacker who could disrupt key distribution forced unencrypted broadcasts with no user-visible signal.

## Fix
```dart
final String payload;
if (isEncrypted) {
  try {
    final keyResult = await groupCrypto.getGroupKey(conversationId);
    if (keyResult == null) {
      _addFailedMessage('', _friendlyEncryptionError('No group session'),
        conversationId: conversationId, originalContent: content);
      return;  // hard fail
    }
    payload = await GroupCryptoService.encryptGroupMessage(...);
  } catch (e) {
    _addFailedMessage('', _friendlyEncryptionError(e),
      conversationId: conversationId, originalContent: content);
    return;  // hard fail
  }
} else {
  payload = content;  // unencrypted groups unchanged
}
```
Mirrors the existing DM `sendMessage` hard-fail pattern. Uses Dart's `final String payload` definite-assignment so any future code path that drops a `return` fails to compile.

## Why safe to hard-fail
- Default `isEncrypted=false` for new groups — most groups unaffected
- No UI today flips groups to `isEncrypted=true` — affected population is small
- Existing `_addFailedMessage` + `chat_panel::_retryMessage` retry UX already exists for groups

## Tests added (4)
1. `encrypted group + null group key` → asserts failed message with friendly content `'Group encryption key... Tap to retry'`
2. `encrypted group + getGroupKey throws` → asserts failed message
3. `unknown conversation in cache` → documents the `?? false` boundary (regression guard if someone changes the default)
4. `unencrypted group` → asserts no failed message (preserves intentional plaintext branch)

All 830 Flutter tests pass (was 829).

## Files changed
| File | Change |
|------|--------|
| `apps/client/lib/src/providers/websocket_provider.dart` | hard-fail in `sendGroupMessage`, dedicated `_friendlyEncryptionError` branch for group-key-missing |
| `apps/client/test/providers/websocket_send_test.dart` | 4 regression tests + `_TestGroupCryptoService` test double |
| `lefthook.yml` | unset GIT_DIR vars in flutter hooks (mirrors PR #587) |
| `CLAUDE.md` | note hard-fail behavior under crypto section |

## Out of scope (#591 follow-up)
A compromised client device can still send a plaintext WS frame to an encrypted group conversation; the server doesn't enforce ciphertext-only on `is_encrypted=true && kind='group'`. Filed as #591 — server-side fix in `validate_conversation_security`.

## Test plan
- [x] `flutter test test/providers/websocket_send_test.dart` — 15/15 pass
- [x] `flutter test` — 830 pass
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [ ] Manual: enable `isEncrypted=true` on a test group, force `getGroupKey` failure, attempt send → expect failed-bubble with retry, NO plaintext frame on the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)