### PR TITLE
feat(server): align HOST/PORT env names with infra (#532)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - **Web renderer**: CanvasKit is the default (and only) renderer in Flutter 3.22+. The `--web-renderer` flag was removed.
 - **Rust edition 2024** used in both Cargo.toml and rustfmt.toml.
 - **rustfmt**: max_width=100, Unix newlines, field_init_shorthand + try_shorthand enabled.
-- **Server required env**: `DATABASE_URL` and `JWT_SECRET` (≥32 chars, panics without them). Optional: `HOST` (default `0.0.0.0`), `PORT` (default `8080`), `CORS_ORIGINS` for allowed origins, `RUST_LOG` for log filtering (e.g. `echo_server=debug`).
+- **Server required env**: `DATABASE_URL` and `JWT_SECRET` (≥32 chars, panics without them). Optional: `SERVER_HOST` (default `0.0.0.0`), `SERVER_PORT` (default `8080`), `CORS_ORIGINS` for allowed origins, `RUST_LOG` for log filtering (e.g. `echo_server=debug`). Legacy `HOST`/`PORT` are still accepted but emit a deprecation warning at startup (#532).
 - **Traefik routing**: API priority 100, Web priority 1 (API routes must take precedence).
 - **Message wire format**: Initial V2 (with OTP) = `[0xEC, 0x02] + identity_pub(32) + ephemeral_pub(32) + otp_id(4 LE) + ratchet_wire`; Initial V1 (no OTP) = `[0xEC, 0x01] + identity_pub(32) + ephemeral_pub(32) + ratchet_wire`; Normal = `header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`. All base64-wrapped over WebSocket.
 - **Soft deletes**: Messages use `is_deleted` flag, not hard deletes.

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -51,14 +51,40 @@ impl Config {
             database_url: env::var("DATABASE_URL")
                 .expect("DATABASE_URL environment variable must be set"),
             jwt_secret,
-            host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".into()),
-            port: env::var("PORT")
-                .ok()
-                .and_then(|p| p.parse().ok())
-                .unwrap_or(8080),
+            host: resolve_host(|k| env::var(k).ok()),
+            port: resolve_port(|k| env::var(k).ok()),
             trusted_proxies,
         }
     }
+}
+
+/// Resolve the bind host, preferring `SERVER_HOST` and falling back to the
+/// legacy `HOST` (with a deprecation warning) so existing self-hosters using
+/// the bare `HOST=` form keep booting cleanly while new deployments adopt
+/// the namespaced env name (#532).
+fn resolve_host<F: Fn(&str) -> Option<String>>(get: F) -> String {
+    if let Some(v) = get("SERVER_HOST") {
+        return v;
+    }
+    if let Some(v) = get("HOST") {
+        tracing::warn!("HOST is deprecated; use SERVER_HOST instead (#532)");
+        return v;
+    }
+    "0.0.0.0".into()
+}
+
+/// Resolve the bind port, preferring `SERVER_PORT` and falling back to the
+/// legacy `PORT` (with a deprecation warning).  Unparseable values silently
+/// fall through to the default 8080, matching the prior behavior (#532).
+fn resolve_port<F: Fn(&str) -> Option<String>>(get: F) -> u16 {
+    if let Some(v) = get("SERVER_PORT") {
+        return v.parse().unwrap_or(8080);
+    }
+    if let Some(v) = get("PORT") {
+        tracing::warn!("PORT is deprecated; use SERVER_PORT instead (#532)");
+        return v.parse().unwrap_or(8080);
+    }
+    8080
 }
 
 #[cfg(test)]
@@ -109,5 +135,62 @@ mod tests {
             })
             .collect();
         assert_eq!(proxies.len(), 2);
+    }
+
+    // -----------------------------------------------------------------
+    // #532: SERVER_HOST/SERVER_PORT precedence + legacy HOST/PORT fallback.
+    // Closure-based fake env keeps these tests parallel-safe -- no
+    // std::env::set_var, which would race against the other test threads.
+    // -----------------------------------------------------------------
+    use std::collections::HashMap;
+
+    fn fake_env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    #[test]
+    fn resolve_host_prefers_server_host_over_legacy() {
+        let host = resolve_host(fake_env(&[("SERVER_HOST", "1.2.3.4"), ("HOST", "5.6.7.8")]));
+        assert_eq!(host, "1.2.3.4");
+    }
+
+    #[test]
+    fn resolve_host_falls_back_to_legacy_host() {
+        let host = resolve_host(fake_env(&[("HOST", "5.6.7.8")]));
+        assert_eq!(host, "5.6.7.8");
+    }
+
+    #[test]
+    fn resolve_host_defaults_when_neither_set() {
+        let host = resolve_host(fake_env(&[]));
+        assert_eq!(host, "0.0.0.0");
+    }
+
+    #[test]
+    fn resolve_port_prefers_server_port_over_legacy() {
+        let port = resolve_port(fake_env(&[("SERVER_PORT", "9090"), ("PORT", "1234")]));
+        assert_eq!(port, 9090);
+    }
+
+    #[test]
+    fn resolve_port_falls_back_to_legacy_port() {
+        let port = resolve_port(fake_env(&[("PORT", "1234")]));
+        assert_eq!(port, 1234);
+    }
+
+    #[test]
+    fn resolve_port_defaults_when_neither_set() {
+        let port = resolve_port(fake_env(&[]));
+        assert_eq!(port, 8080);
+    }
+
+    #[test]
+    fn resolve_port_defaults_on_unparseable_value() {
+        let port = resolve_port(fake_env(&[("SERVER_PORT", "not-a-number")]));
+        assert_eq!(port, 8080);
     }
 }

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -61,7 +61,7 @@ impl Config {
 /// Resolve the bind host, preferring `SERVER_HOST` and falling back to the
 /// legacy `HOST` (with a deprecation warning) so existing self-hosters using
 /// the bare `HOST=` form keep booting cleanly while new deployments adopt
-/// the namespaced env name (#532).
+/// the namespaced env name.  Defaults to `0.0.0.0` if neither is set (#532).
 fn resolve_host<F: Fn(&str) -> Option<String>>(get: F) -> String {
     if let Some(v) = get("SERVER_HOST") {
         return v;
@@ -74,15 +74,25 @@ fn resolve_host<F: Fn(&str) -> Option<String>>(get: F) -> String {
 }
 
 /// Resolve the bind port, preferring `SERVER_PORT` and falling back to the
-/// legacy `PORT` (with a deprecation warning).  Unparseable values silently
-/// fall through to the default 8080, matching the prior behavior (#532).
+/// legacy `PORT` (with a deprecation warning).  Unparseable values fall
+/// through to the default `8080` and emit a warning so a typo'd value is
+/// observable rather than silently ignored (#532).
 fn resolve_port<F: Fn(&str) -> Option<String>>(get: F) -> u16 {
+    fn parse_port_or_warn(name: &str, raw: &str) -> u16 {
+        match raw.parse() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::warn!("{name}='{raw}' is not a valid port; defaulting to 8080");
+                8080
+            }
+        }
+    }
     if let Some(v) = get("SERVER_PORT") {
-        return v.parse().unwrap_or(8080);
+        return parse_port_or_warn("SERVER_PORT", &v);
     }
     if let Some(v) = get("PORT") {
         tracing::warn!("PORT is deprecated; use SERVER_PORT instead (#532)");
-        return v.parse().unwrap_or(8080);
+        return parse_port_or_warn("PORT", &v);
     }
     8080
 }
@@ -191,6 +201,15 @@ mod tests {
     #[test]
     fn resolve_port_defaults_on_unparseable_value() {
         let port = resolve_port(fake_env(&[("SERVER_PORT", "not-a-number")]));
+        assert_eq!(port, 8080);
+    }
+
+    #[test]
+    fn resolve_port_legacy_unparseable_falls_through_to_default() {
+        // Belt-and-suspenders branch coverage: same parse logic on the legacy
+        // arm should also default rather than panic if a future refactor
+        // diverges the two paths.
+        let port = resolve_port(fake_env(&[("PORT", "garbage")]));
         assert_eq!(port, 8080);
     }
 }


### PR DESCRIPTION
Closes #532.

## Summary
The server read `HOST` / `PORT` while every consumer (compose, CI, .env.example) exported `SERVER_HOST` / `SERVER_PORT` — overrides were silently ignored. Server now prefers the namespaced names, falls back to the legacy bare names with a deprecation warning, and emits an explicit warning on unparseable port values instead of silently defaulting.

## Why namespaced names
- 3 of 4 existing call sites (compose, e2e CI, .env.example) already use `SERVER_HOST` / `SERVER_PORT`
- Bare `PORT` collides with Heroku/Render/Fly conventions — a stray `PORT=3000` in someone's environment would silently rebind the server
- Full env audit: `HOST` / `PORT` is the **only** mismatch in the codebase (DATABASE_URL, JWT_SECRET, CORS_ORIGINS, LIVEKIT_*, APNS_*, TURN_* all use unique namespaced names)

## Behavior
| Env vars set | Result | Warning? |
|---|---|---|
| `SERVER_HOST=X SERVER_PORT=N` | binds X:N | none |
| `HOST=X PORT=N` | binds X:N (legacy fallback) | yes — deprecation |
| `SERVER_PORT=garbage` | binds 0.0.0.0:8080 | yes — typo'd value |
| neither set | binds 0.0.0.0:8080 | none |

## Backward compatibility
- Existing self-hosters with `HOST=` / `PORT=` continue to boot identically — only addition is a one-line `tracing::warn` per startup
- Migration path: rename at leisure to silence the warning
- Legacy support removable in a future major version

## Tests added (8 new in `config::tests`)
- `resolve_host_prefers_server_host_over_legacy`
- `resolve_host_falls_back_to_legacy_host`
- `resolve_host_defaults_when_neither_set`
- `resolve_port_prefers_server_port_over_legacy`
- `resolve_port_falls_back_to_legacy_port`
- `resolve_port_defaults_when_neither_set`
- `resolve_port_defaults_on_unparseable_value`
- `resolve_port_legacy_unparseable_falls_through_to_default`

Closure-based fake env keeps tests parallel-safe (no `std::env::set_var` races).

## Files changed
| File | Change |
|------|--------|
| `apps/server/src/config.rs` | new `resolve_host` / `resolve_port` helpers + 8 tests, 24 LOC additions |
| `CLAUDE.md` | doc update + deprecation note |

## Test plan
- [x] `cargo test -p echo-server` — 274 pass (was 266 baseline, +8)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p echo-server -D warnings`
- [ ] Manual: `SERVER_PORT=9090 cargo run -p echo-server` → bind :9090, no warning
- [ ] Manual: `PORT=9090 cargo run -p echo-server` → bind :9090, "PORT is deprecated" warning
- [ ] Manual: `SERVER_PORT=garbage cargo run -p echo-server` → bind :8080, "not a valid port" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)