### PR TITLE
ci(release): concurrency guard + atomic tag reservation (#530)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch --tags --quiet origin
 
+          PUSH_ERR=$(mktemp)
+          trap 'rm -f "$PUSH_ERR"' EXIT
+
           for attempt in 1 2 3 4 5; do
             LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1)
             if [ -z "$LATEST" ]; then
@@ -134,8 +137,25 @@ jobs:
             NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
             NEW_TAG="v${NEW_VERSION}"
 
+            # Idempotency: if a prior attempt of this same step already
+            # pushed the tag (e.g. step retry, runner restart), short-
+            # circuit to success rather than re-tagging and aborting.
+            if git ls-remote --exit-code --tags origin "refs/tags/$NEW_TAG" >/dev/null 2>&1; then
+              REMOTE_SHA=$(git ls-remote --tags origin "refs/tags/$NEW_TAG" | awk '{print $1}')
+              LOCAL_SHA=$(git rev-parse HEAD)
+              if [ "$REMOTE_SHA" = "$LOCAL_SHA" ] || git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+                echo "Tag $NEW_TAG already reserved by this run; skipping push"
+                echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+                echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              # Tag exists but points elsewhere -- bump and retry.
+              git fetch --tags --quiet origin
+              continue
+            fi
+
             git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
-            if git push origin "$NEW_TAG" 2>/tmp/push_err; then
+            if git push origin "$NEW_TAG" 2>"$PUSH_ERR"; then
               echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
               echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
               echo "Reserved $NEW_TAG (previous: $LATEST, attempt $attempt)"
@@ -143,7 +163,7 @@ jobs:
             fi
 
             echo "Push of $NEW_TAG lost a race (attempt $attempt):"
-            cat /tmp/push_err || true
+            cat "$PUSH_ERR" || true
             git tag -d "$NEW_TAG"
             git fetch --tags --quiet origin
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,14 @@ permissions:
   contents: write
   packages: write
 
+# #530: serialize release runs on main so two concurrent pushes don't race
+# on the version tag and ghcr.io image tags.  cancel-in-progress=false is
+# required: cancelling a half-published release leaves orphan tags and
+# partial image pushes -- queueing the next push is safer than racing.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 env:
   FLUTTER_VERSION: '3.41.x'
 
@@ -97,30 +105,53 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: Calculate next version
+      - name: Reserve next version tag (atomic)
         id: version
+        # #530: reserve the tag IMMEDIATELY (before expensive builds) so
+        # downstream jobs reference a real persistent tag instead of one
+        # that gets pushed at the end of the pipeline.  The retry loop is
+        # belt-and-suspenders alongside the workflow-level concurrency
+        # group: protects against manual `git push origin vX.Y.Z` between
+        # CI runs without forcing the operator to abort the release.
+        # If a build later fails, the tag remains as an orphan; the next
+        # release auto-bumps past it.  No double-publish risk.
         run: |
-          # Get the latest version tag, default to v0.0.0
-          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1)
-          if [ -z "$LATEST" ]; then
-            LATEST="v0.0.0"
-          fi
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch --tags --quiet origin
 
-          # Strip the 'v' prefix and split
-          VERSION="${LATEST#v}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          for attempt in 1 2 3 4 5; do
+            LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1)
+            if [ -z "$LATEST" ]; then
+              LATEST="v0.0.0"
+            fi
 
-          # Increment patch
-          PATCH=$((PATCH + 1))
+            VERSION="${LATEST#v}"
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | cut -d. -f3)
+            PATCH=$((PATCH + 1))
 
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          NEW_TAG="v${NEW_VERSION}"
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            NEW_TAG="v${NEW_VERSION}"
 
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
-          echo "New version: $NEW_TAG (previous: $LATEST)"
+            git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+            if git push origin "$NEW_TAG" 2>/tmp/push_err; then
+              echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+              echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+              echo "Reserved $NEW_TAG (previous: $LATEST, attempt $attempt)"
+              exit 0
+            fi
+
+            echo "Push of $NEW_TAG lost a race (attempt $attempt):"
+            cat /tmp/push_err || true
+            git tag -d "$NEW_TAG"
+            git fetch --tags --quiet origin
+          done
+
+          echo "::error::Failed to reserve a release tag after 5 attempts"
+          exit 1
 
   build-linux:
     name: Build Linux Desktop
@@ -577,16 +608,7 @@ jobs:
           pattern: release-*
           path: dist
           merge-multiple: true
-      - name: Create and push annotated tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git rev-parse "${{ needs.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "Tag ${{ needs.version.outputs.tag }} already exists"
-          else
-            git tag -a "${{ needs.version.outputs.tag }}" -m "Release ${{ needs.version.outputs.tag }}"
-            git push origin "${{ needs.version.outputs.tag }}"
-          fi
+      # Tag is already reserved by the `version` job (#530).
       - name: Create GitHub release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,13 +108,11 @@ jobs:
       - name: Reserve next version tag (atomic)
         id: version
         # #530: reserve the tag IMMEDIATELY (before expensive builds) so
-        # downstream jobs reference a real persistent tag instead of one
-        # that gets pushed at the end of the pipeline.  The retry loop is
-        # belt-and-suspenders alongside the workflow-level concurrency
-        # group: protects against manual `git push origin vX.Y.Z` between
-        # CI runs without forcing the operator to abort the release.
-        # If a build later fails, the tag remains as an orphan; the next
-        # release auto-bumps past it.  No double-publish risk.
+        # downstream jobs reference a real persistent tag.  The retry loop
+        # complements the workflow-level concurrency group by handling
+        # manual `git push origin vX.Y.Z` between CI runs without aborting
+        # the release.  If a build later fails the orphan tag is left in
+        # place; the next release auto-bumps past it.
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Closes #530.
Hardening follow-up: #594 (GitHub tag ruleset).

## Summary
Eliminates two race conditions in the release pipeline:

1. **No workflow-level `concurrency:`** — concurrent main pushes spawned duplicate full pipelines (~1-2 hr each)
2. **Tag created at the END of the pipeline** — racy local `git rev-parse` then `git push` could collide; ghcr.io image tags silently overwritten

## Approach: belt-and-suspenders
- **Workflow-level `concurrency: group: release-main, cancel-in-progress: false`** serializes runs (queue, never cancel — a half-published release leaves orphan tags + partial ghcr.io pushes)
- **Atomic tag reservation in the `version` job** (5-attempt retry with auto-bump) — protects against manual `git push origin vX.Y.Z` between CI runs
- **Removed redundant tag-create step** from the `release` job — `softprops/action-gh-release@v2` accepts a pre-existing tag

## Race chain (pre-fix)
Two pushes → both `version` jobs read same `LATEST` → both compute same `NEW_TAG` → both run hours of builds → one wins the tag push, the other either silently no-ops then publishes under wrong tag, or fails entirely. ghcr.io image tags get silently overwritten on the same conflict.

## Idempotency
The reservation step now also checks if `$NEW_TAG` is already on the remote pointing at our HEAD (or an ancestor) — if so, it short-circuits to success. This handles step re-runs / runner restarts after a successful push but before `GITHUB_OUTPUT` was written.

## Orphan tag tradeoff
If a downstream build fails after tag reservation, the tag persists with no GitHub release attached. The next run auto-bumps past it. **No double-publish risk.** Documented inline in the YAML.

## Files changed
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | concurrency block + atomic tag reservation in `version` job + removed tag-create from `release` job |

## Test plan
- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` — YAML valid
- [ ] Manual on next legitimate main merge: confirm `vX.Y.(Z+1)` tag appears immediately after the `version` job (not at end of pipeline)
- [ ] Manual: confirm GitHub release page lists the tag with all expected artifacts
- [ ] Optional: test on a throwaway branch by retargeting `branches: [<test>]` and pushing twice rapidly — verify second run queues, only one tag created

## Out of scope (#594)
- GitHub tag ruleset restricting `v*` to `github-actions[bot]` only — repo settings change
- Job-level `timeout-minutes` to prevent hung release blocking the queue (pre-existing gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)