### PR TITLE
fix(client): linux tray menu UX + offline banner test coverage (#558 #499)

### DIFF
--- a/apps/client/lib/src/services/tray_service_io.dart
+++ b/apps/client/lib/src/services/tray_service_io.dart
@@ -8,9 +8,19 @@ import 'package:window_manager/window_manager.dart';
 ///
 /// Initialise once after login with [TrayService.init]. Updates the tray
 /// tooltip to reflect the current unread message count via [updateBadge].
-/// The context menu provides "Show Echo" and "Quit" actions. Clicking the
-/// tray icon toggles the main window visibility. The close button minimises
-/// the app to the tray instead of quitting.
+/// The context menu provides Show / Hide / Quit actions; the close button
+/// minimises the app to the tray instead of quitting.
+///
+/// **Platform behavior**:
+/// - **Windows / macOS**: left-click toggles the window directly via
+///   [onTrayIconMouseDown]; right-click opens the context menu.
+/// - **Linux** (libappindicator / StatusNotifierItem): the D-Bus protocol
+///   that GNOME/KDE shells implement does NOT deliver MouseDown events
+///   when a context menu is attached — any click opens the menu. The menu
+///   items therefore ARE the interaction surface on Linux. Show / Hide /
+///   Quit are first-class entries so users can toggle visibility in two
+///   clicks. Switching tray packages does not help: `system_tray` has the
+///   same SNI limitation; `tray_icon` uses deprecated GtkStatusIcon (#558).
 ///
 /// Safe to call on all platforms — all methods are no-ops on web and mobile.
 class TrayService with TrayListener, WindowListener {
@@ -36,9 +46,11 @@ class TrayService with TrayListener, WindowListener {
 
     // Each step is guarded so a failure later in the sequence (notably
     // setContextMenu, which is flaky on some Linux compositors) doesn't
-    // leave the icon unresponsive: the click listener still attaches even
-    // if the menu can't be installed, so right-click might be inert but
-    // left-click toggles the window.
+    // leave the icon unresponsive: the click listener still attaches
+    // even if the menu can't be installed, which keeps Windows/macOS
+    // left-click usable.  On Linux the menu IS the interaction surface
+    // (see class docstring), so install failure here means tray is
+    // effectively dead until next login.
     var iconShown = false;
     try {
       await trayManager.setIcon(_iconPath());
@@ -99,6 +111,10 @@ class TrayService with TrayListener, WindowListener {
 
   @override
   void onTrayIconMouseDown() {
+    // Windows + macOS path: the OS delivers a real MouseDown, so we toggle
+    // the window directly.  Linux/libappindicator never fires this when a
+    // context menu is attached -- any click opens the menu instead, and
+    // the user toggles via the Show/Hide menu entries (#558).
     _toggleWindow();
   }
 
@@ -113,6 +129,8 @@ class TrayService with TrayListener, WindowListener {
       case 'show':
         windowManager.show();
         windowManager.focus();
+      case 'hide':
+        windowManager.hide();
       case 'quit':
         windowManager.setPreventClose(false);
         windowManager.close();
@@ -126,10 +144,15 @@ class TrayService with TrayListener, WindowListener {
   }
 
   Future<void> _setContextMenu() async {
+    // Show / Hide are first-class menu items because on Linux any click on
+    // the icon opens this menu (libappindicator/SNI does not deliver
+    // MouseDown when a menu is attached) -- they are the only path to
+    // toggle window visibility on that platform (#558).
     await trayManager.setContextMenu(
       Menu(
         items: [
           MenuItem(key: 'show', label: 'Show Echo'),
+          MenuItem(key: 'hide', label: 'Hide Echo'),
           MenuItem.separator(),
           MenuItem(key: 'quit', label: 'Quit'),
         ],

--- a/apps/client/test/widgets/connection_status_banner_test.dart
+++ b/apps/client/test/widgets/connection_status_banner_test.dart
@@ -46,6 +46,26 @@ void main() {
       expect(find.textContaining('Connected'), findsNothing);
     });
 
+    testWidgets('shows reconnecting label without counter on first attempt', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap((ref) {
+          final n = _TestWsNotifier(ref);
+          n.setStateForTest(
+            const WebSocketState(isConnected: false, reconnectAttempts: 0),
+          );
+          return n;
+        }),
+      );
+
+      // The most common transient state: just disconnected, attempt count
+      // still zero -- banner shows the bare "Reconnecting..." label without
+      // the (N) suffix.
+      expect(find.text('Reconnecting...'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
     testWidgets('shows reconnecting state with attempt counter', (
       tester,
     ) async {
@@ -121,6 +141,10 @@ void main() {
       notifier.setStateForTest(
         const WebSocketState(isConnected: true, reconnectAttempts: 0),
       );
+      // Two pumps are required: the first runs the Riverpod rebuild which
+      // schedules a postFrameCallback inside _trackConnectionTransition;
+      // the second drains that callback so _showConnectedFlash is true
+      // before the next assertion.
       await tester.pump();
       await tester.pump();
       expect(find.text('Connected'), findsOneWidget);

--- a/apps/client/test/widgets/connection_status_banner_test.dart
+++ b/apps/client/test/widgets/connection_status_banner_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/providers/websocket_provider.dart';
+import 'package:echo_app/src/widgets/connection_status_banner.dart';
+
+/// Test subclass of [WebSocketNotifier] that exposes a public state setter
+/// and replaces [connect] with a no-op so the Retry button doesn't fire
+/// real network traffic.  We pass a real [Ref] from the ProviderScope so
+/// the inherited init (typing-cleanup Timer) is harmless under the
+/// fake_async pump cadence the widget tests use.
+class _TestWsNotifier extends WebSocketNotifier {
+  _TestWsNotifier(super.ref);
+
+  void setStateForTest(WebSocketState next) => state = next;
+
+  @override
+  Future<void> connect() async {
+    // Swallow the Retry-button call -- the test does not need a real WS.
+  }
+}
+
+ProviderScope _wrap(_TestWsNotifier Function(Ref) build) {
+  return ProviderScope(
+    overrides: [websocketProvider.overrideWith((ref) => build(ref))],
+    child: const MaterialApp(home: Scaffold(body: ConnectionStatusBanner())),
+  );
+}
+
+void main() {
+  group('ConnectionStatusBanner (#499)', () {
+    testWidgets('hidden when connected', (tester) async {
+      await tester.pumpWidget(
+        _wrap((ref) {
+          final n = _TestWsNotifier(ref);
+          n.setStateForTest(const WebSocketState(isConnected: true));
+          return n;
+        }),
+      );
+
+      // Banner collapses to SizedBox.shrink when connected.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.textContaining('Reconnecting'), findsNothing);
+      expect(find.textContaining('Connection lost'), findsNothing);
+      expect(find.textContaining('Connected'), findsNothing);
+    });
+
+    testWidgets('shows reconnecting state with attempt counter', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap((ref) {
+          final n = _TestWsNotifier(ref);
+          n.setStateForTest(
+            const WebSocketState(isConnected: false, reconnectAttempts: 2),
+          );
+          return n;
+        }),
+      );
+
+      expect(find.text('Reconnecting... (2)'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Retry'), findsNothing);
+    });
+
+    testWidgets('shows connection-lost + retry after 10 attempts', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap((ref) {
+          final n = _TestWsNotifier(ref);
+          n.setStateForTest(
+            const WebSocketState(isConnected: false, reconnectAttempts: 10),
+          );
+          return n;
+        }),
+      );
+
+      expect(
+        find.textContaining('Connection lost'),
+        findsOneWidget,
+        reason: 'red banner replaces the spinner once max attempts hit',
+      );
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('shows session-replaced label + retry', (tester) async {
+      await tester.pumpWidget(
+        _wrap((ref) {
+          final n = _TestWsNotifier(ref);
+          n.setStateForTest(
+            const WebSocketState(isConnected: false, wasReplaced: true),
+          );
+          return n;
+        }),
+      );
+
+      expect(find.text('Signed in on another device'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('flashes Connected after reconnect, then auto-hides', (
+      tester,
+    ) async {
+      late _TestWsNotifier notifier;
+      await tester.pumpWidget(
+        _wrap((ref) {
+          notifier = _TestWsNotifier(ref);
+          notifier.setStateForTest(
+            const WebSocketState(isConnected: false, reconnectAttempts: 1),
+          );
+          return notifier;
+        }),
+      );
+      // Initial reconnecting state visible.
+      expect(find.text('Reconnecting... (1)'), findsOneWidget);
+
+      // Simulate reconnect.
+      notifier.setStateForTest(
+        const WebSocketState(isConnected: true, reconnectAttempts: 0),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Connected'), findsOneWidget);
+
+      // After the 1.5s timer + AnimatedSize close, the banner is gone.
+      await tester.pump(const Duration(milliseconds: 1600));
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(find.text('Connected'), findsNothing);
+    });
+  });
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,12 +12,22 @@ pre-commit:
       run: |
         FLUTTER_BIN=$(dirname "$(which flutter 2>/dev/null || echo "$HOME/.flutter/bin/flutter")")
         export PATH="$FLUTTER_BIN:$PATH"
+        # Hook env from `git commit` includes GIT_DIR pointing at the consumer
+        # worktree; flutter then resolves its own version against that and
+        # caches "0.0.0-unknown", which breaks pub solving.  Drop the git env
+        # so flutter runs `git rev-parse` inside its own SDK repo.
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
         cd apps/client && dart format --set-exit-if-changed .
     flutter-analyze:
       glob: "*.dart"
       run: |
         FLUTTER_BIN=$(dirname "$(which flutter 2>/dev/null || echo "$HOME/.flutter/bin/flutter")")
         export PATH="$FLUTTER_BIN:$PATH"
+        # Hook env from `git commit` includes GIT_DIR pointing at the consumer
+        # worktree; flutter then resolves its own version against that and
+        # caches "0.0.0-unknown", which breaks pub solving.  Drop the git env
+        # so flutter runs `git rev-parse` inside its own SDK repo.
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
         cd apps/client && flutter analyze --fatal-infos
 
 commit-msg:


### PR DESCRIPTION
Closes #558.
Closes #499.

## Summary
Two-issue batch PR — quick wins for beta readiness.

## #558 — Linux tray icon non-interactive (real root cause)
The user-reported "clicks do nothing" is an unsolvable libappindicator/StatusNotifierItem (D-Bus) limitation, not a bug in our code. The protocol does **not** deliver `MouseDown` events when a context menu is attached — any click opens the menu instead. Switching tray packages doesn't help: \`system_tray\` has the same SNI limitation, \`tray_icon\` uses deprecated GtkStatusIcon.

**Fix:** accept platform reality. Promote **Show / Hide** to first-class menu items so users have a one-click path to toggle visibility on Linux. Windows/macOS backends still deliver MouseDown so direct left-click toggle keeps working there. Class docstring rewritten to document the limitation so future maintainers don't re-litigate it.

\`\`\`
[ Show Echo  ]
[ Hide Echo  ]
[ ────────── ]
[ Quit       ]
\`\`\`

## #499 — Offline banner already implemented; just needed tests
Surprise finding: \`connection_status_banner.dart\` (197 LOC) is fully built and **already mounted** in \`chat_panel.dart:2309\` with full state coverage (reconnecting + spinner, connection-lost + retry after 10 attempts, green "Connected" flash on recovery, "Signed in on another device" variant). Zero tests for it though, which is why the issue stayed open.

**Fix:** 6 widget tests covering the visibility matrix:
- hidden when connected
- bare "Reconnecting..." (attempts=0)
- "Reconnecting... (N)" with spinner
- "Connection lost" + Retry after 10 attempts
- "Signed in on another device" + Retry (wasReplaced)
- Connected flash → auto-hides after 1.5s + 200ms animation

Uses a \`_TestWsNotifier\` subclass of \`WebSocketNotifier\` with no-op \`connect()\` so the Retry button doesn't fire real network traffic.

## Files changed
| File | Change |
|------|--------|
| \`apps/client/lib/src/services/tray_service_io.dart\` | Show/Hide menu items, libappindicator docstring |
| \`apps/client/test/widgets/connection_status_banner_test.dart\` | NEW — 6 widget tests |
| \`lefthook.yml\` | hook env fix (mirrors PR #587 commit \`d097497\`) |

## Test plan
- [x] \`flutter test\` — 832 pass (was 826 baseline, +6)
- [x] \`dart format --check\`
- [x] \`flutter analyze --fatal-infos\`
- [ ] Manual on Linux: \`flutter run -d linux\` → click tray icon → menu opens with Show/Hide/Quit; each performs the expected action
- [ ] Manual: kill server while app open → "Reconnecting…" banner appears; restart server → "Connected" flash → auto-hides

## Known environment dependency
Linux tray requires the AppIndicator GNOME extension on stock GNOME (Fedora 43 etc). Without it the tray icon won't appear at all — not a code bug. Worth documenting in the README as a Linux desktop install note (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)