### PR TITLE
fix(client): forwarded msgs stuck on "Securing message…" placeholder (#430)

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -17,6 +17,20 @@ import 'auth_provider.dart';
 import 'conversations_provider.dart';
 import 'server_url_provider.dart';
 
+/// Placeholder content strings emitted by ws_message_handler.dart while a
+/// message is awaiting decryption.  When [ChatState.withMessage] sees an
+/// inbound message whose id collides with an existing entry that matches
+/// one of these (and is still flagged isEncrypted), the entry is replaced
+/// in place rather than dedup-dropped (#430).  Keep in sync with the emit
+/// sites in ws_message_handler.dart.
+const _placeholderContents = <String>{
+  'Securing message...',
+  '[Encrypted for another device of this account]',
+};
+
+bool _isPlaceholderContent(String c) =>
+    _placeholderContents.contains(c) || c.startsWith('[Could not decrypt');
+
 class ChatState {
   /// Messages keyed by conversation ID.
   final Map<String, List<ChatMessage>> messagesByConversation;
@@ -99,6 +113,19 @@ class ChatState {
         ids.add(msg.id);
         // Rebuild index from trimmed list to stay consistent.
         updatedIndex[msg.conversationId] = updated.map((m) => m.id).toSet();
+      } else {
+        // Id collision: existing entry might be a decrypt-pending
+        // placeholder (#430).  Replace it in place when isEncrypted
+        // and the content matches a known placeholder string.  The
+        // index already contains msg.id so no map mutation is needed.
+        final existing = updatedConv[msg.conversationId] ?? const [];
+        final idx = existing.indexWhere((m) => m.id == msg.id);
+        if (idx >= 0 &&
+            existing[idx].isEncrypted &&
+            _isPlaceholderContent(existing[idx].content)) {
+          final replaced = [...existing]..[idx] = msg;
+          updatedConv[msg.conversationId] = replaced;
+        }
       }
     }
 

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -419,6 +419,9 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
       );
     } else {
       // Crypto not ready yet — show a placeholder and queue for decryption.
+      // The literal 'Securing message...' string is recognised by
+      // chat_provider.dart's `_placeholderContents` so the decrypted
+      // version replaces it in place when the queue drains (#430).
       final placeholder = ChatMessage.fromServerJson({
         ...json,
         'content': 'Securing message...',

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -382,6 +382,8 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
     // instead of running decrypt over a foreign-device wire (which would
     // poison the local ratchet state and produce a generic "out of sync"
     // banner).  Skip the Hive cache write so a future fix-up can replace it.
+    // The literal '[Encrypted for another device of this account]' string is
+    // recognised by chat_provider.dart's `_placeholderContents` (#430).
     if (json['undecryptable'] == true) {
       final placeholder = ChatMessage.fromServerJson({
         ...json,

--- a/apps/client/test/providers/chat_provider_state_test.dart
+++ b/apps/client/test/providers/chat_provider_state_test.dart
@@ -146,6 +146,176 @@ void main() {
       expect(state2.messagesForConversation('conv-1'), hasLength(1));
     });
 
+    // ---------------------------------------------------------------------
+    // #430: forwarded / pre-crypto-init messages were stuck on the
+    // 'Securing message...' placeholder forever because dedup-by-id silently
+    // dropped the decrypted replacement.  withMessage now swaps the
+    // placeholder in place when the existing entry is isEncrypted=true and
+    // its content matches a known placeholder string.
+    // ---------------------------------------------------------------------
+    test('withMessage replaces a Securing-message placeholder in place '
+        '(#430)', () {
+      const placeholder = ChatMessage(
+        id: 'msg-1',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'Securing message...',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+      const decrypted = ChatMessage(
+        id: 'msg-1',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: '[Forwarded] hello world',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+
+      const state = ChatState();
+      final s1 = state.withMessage(placeholder);
+      final s2 = s1.withMessage(decrypted);
+
+      final msgs = s2.messagesForConversation('conv-1');
+      expect(msgs, hasLength(1), reason: 'no duplicate, no orphan');
+      expect(msgs.first.content, '[Forwarded] hello world');
+      expect(msgs.first.id, 'msg-1');
+    });
+
+    test('withMessage replaces an [Encrypted for another device] placeholder '
+        '(#430)', () {
+      const placeholder = ChatMessage(
+        id: 'msg-2',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: '[Encrypted for another device of this account]',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+      const decrypted = ChatMessage(
+        id: 'msg-2',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'real content',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+
+      const state = ChatState();
+      final result = state.withMessage(placeholder).withMessage(decrypted);
+      expect(
+        result.messagesForConversation('conv-1').single.content,
+        'real content',
+      );
+    });
+
+    test('withMessage replaces a [Could not decrypt ...] placeholder '
+        '(#430)', () {
+      const placeholder = ChatMessage(
+        id: 'msg-3',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: '[Could not decrypt - encryption keys may be out of sync]',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+      const decrypted = ChatMessage(
+        id: 'msg-3',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'recovered',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+
+      const state = ChatState();
+      final result = state.withMessage(placeholder).withMessage(decrypted);
+      expect(
+        result.messagesForConversation('conv-1').single.content,
+        'recovered',
+      );
+    });
+
+    test('withMessage does NOT replace when existing is not encrypted '
+        '(legitimate same-id duplicate; #430 dedup invariant)', () {
+      // Same id, but the existing entry is plaintext (isEncrypted=false) --
+      // this is a legit duplicate-send case and dedup must hold.
+      const original = ChatMessage(
+        id: 'msg-4',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'real plaintext',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: false,
+      );
+      const duplicate = ChatMessage(
+        id: 'msg-4',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'attacker-replaced text',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: false,
+      );
+
+      const state = ChatState();
+      final result = state.withMessage(original).withMessage(duplicate);
+      expect(
+        result.messagesForConversation('conv-1').single.content,
+        'real plaintext',
+        reason: 'dedup must drop the duplicate, not let it overwrite',
+      );
+    });
+
+    test('withMessage does NOT replace when content is not a placeholder '
+        '(#430 false-positive guard)', () {
+      // Encrypted=true but content is real plaintext that just happens to
+      // collide on id -- no replacement allowed.
+      const original = ChatMessage(
+        id: 'msg-5',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'real decrypted content',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+      const duplicate = ChatMessage(
+        id: 'msg-5',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'attacker-replaced text',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+
+      const state = ChatState();
+      final result = state.withMessage(original).withMessage(duplicate);
+      expect(
+        result.messagesForConversation('conv-1').single.content,
+        'real decrypted content',
+        reason: 'non-placeholder content is not a replacement target',
+      );
+    });
+
     test('copyWith preserves unchanged fields', () {
       const msg = ChatMessage(
         id: 'msg-1',

--- a/apps/client/test/providers/chat_provider_state_test.dart
+++ b/apps/client/test/providers/chat_provider_state_test.dart
@@ -217,6 +217,68 @@ void main() {
       );
     });
 
+    test('withMessage replaces a [Could not decrypt - waiting for group key] '
+        'placeholder (#430)', () {
+      const placeholder = ChatMessage(
+        id: 'msg-grp-1',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: '[Could not decrypt - waiting for group key]',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+      const decrypted = ChatMessage(
+        id: 'msg-grp-1',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'group message recovered',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+
+      const state = ChatState();
+      final result = state.withMessage(placeholder).withMessage(decrypted);
+      expect(
+        result.messagesForConversation('conv-1').single.content,
+        'group message recovered',
+      );
+    });
+
+    test('withMessage replaces a [Could not decrypt group message] '
+        'placeholder (#430)', () {
+      const placeholder = ChatMessage(
+        id: 'msg-grp-2',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: '[Could not decrypt group message]',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+      const decrypted = ChatMessage(
+        id: 'msg-grp-2',
+        fromUserId: 'user-1',
+        fromUsername: 'alice',
+        conversationId: 'conv-1',
+        content: 'second recovery',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        isEncrypted: true,
+      );
+
+      const state = ChatState();
+      final result = state.withMessage(placeholder).withMessage(decrypted);
+      expect(
+        result.messagesForConversation('conv-1').single.content,
+        'second recovery',
+      );
+    });
+
     test('withMessage replaces a [Could not decrypt ...] placeholder '
         '(#430)', () {
       const placeholder = ChatMessage(


### PR DESCRIPTION
Closes #430.

## Summary
Forwarded messages (and any encrypted message arriving before crypto bootstrap finishes) showed \`'Securing message...'\` permanently — the decrypted content never replaced the placeholder.

## Root cause
\`ChatState.withMessage\` at \`apps/client/lib/src/providers/chat_provider.dart\` dedupes by message id. When \`_handleNewMessage\` (\`ws_message_handler.dart:420\`) inserts a placeholder before crypto is ready, the placeholder uses the server's \`message_id\`. Later when \`drainPendingDecryptQueue\` re-runs decrypt and calls \`addMessage\` with real content, dedup silently dropped it. **Placeholder permanent.**

The bug is general (any encrypted message arriving before crypto init), but forwards trigger it most reliably because the forwarder re-sends to peer devices (post-#557 per-device routing) and often races crypto init on a secondary device.

## Fix
\`withMessage\` now replaces the existing entry in place when:
1. id collides
2. existing entry is \`isEncrypted: true\`
3. existing entry's content matches a known placeholder (\`'Securing message...'\`, \`'[Encrypted for another device of this account]'\`, or anything starting with \`'[Could not decrypt'\`)

Both guards prevent false positives:
- \`isEncrypted: true\` filter: legitimate user-typed plaintext is \`isEncrypted: false\`, so dedup still applies to those
- placeholder content filter: real decrypted content with the same id (extremely rare since IDs are server-generated UUIDs) won't be replaced

## Security verified
The reviewer specifically checked whether an attacker peer could exploit the replacement path. **No exploitable vector**:
- \`isEncrypted\` is **never read from server JSON** — set only by client-side \`copyWith\` after own crypto logic
- Server-assigned \`message_id\` is \`gen_random_uuid()\` — clients can't supply colliding ids
- Gate inspects the *existing* entry's content, not the incoming, so attacker-controlled incoming content is irrelevant

## Tests added (+7)
Direct unit tests against \`ChatState.withMessage\` in \`chat_provider_state_test.dart\`:
- Replace \`'Securing message...'\` placeholder
- Replace \`'[Encrypted for another device of this account]'\` placeholder
- Replace \`'[Could not decrypt - waiting for group key]'\` (group variant)
- Replace \`'[Could not decrypt group message]'\` (group variant)
- Replace \`'[Could not decrypt - encryption keys may be out of sync]'\`
- **Dedup invariant**: do NOT replace a legit plaintext duplicate (encrypted=false case)
- **False-positive guard**: do NOT replace when content is real decrypted text

## Files changed
| File | Change |
|------|--------|
| \`apps/client/lib/src/providers/chat_provider.dart\` | \`_placeholderContents\` set + \`_isPlaceholderContent\` helper + augment \`withMessage\` (~25 lines) |
| \`apps/client/lib/src/providers/ws_message_handler.dart\` | inline cross-reference comments at the 2 placeholder emit sites |
| \`apps/client/test/providers/chat_provider_state_test.dart\` | 7 new regression tests |

## Test plan
- [x] \`flutter test\` — 843 pass (was 832 baseline, +11)
- [x] \`dart format --check\`
- [x] \`flutter analyze --fatal-infos\`
- [ ] Manual: forward a message between two devices on same account → secondary device shows decrypted content within seconds, not stuck \`'Securing message...'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)