### PR TITLE
fix(client): guard ConversationsNotifier against stale reload races (#515)

### DIFF
--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -122,7 +122,9 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
       );
       // Drop a stale response (a newer call has been issued) before any
       // state mutation so we don't clobber fresh data with an old payload.
-      if (gen != _loadGen) return;
+      // Also bail if the notifier was disposed while we were awaiting --
+      // writing to `state` after dispose throws StateError.
+      if (gen != _loadGen || !mounted) return;
 
       if (response.statusCode == 200) {
         final body = jsonDecode(response.body);
@@ -164,8 +166,9 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
         );
       }
     } catch (e) {
-      // Stale errors must not clobber a fresh success either.
-      if (gen != _loadGen) return;
+      // Stale errors must not clobber a fresh success, and writing to
+      // `state` on a disposed notifier throws.
+      if (gen != _loadGen || !mounted) return;
       state = state.copyWith(isLoading: false, error: _friendlyError(e));
     }
   }

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -44,6 +44,13 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
   /// Cache of decrypted message previews by conversationId.
   final Map<String, String> _decryptedPreviews = {};
 
+  /// Monotonic generation counter for [loadConversations] (#515). Each
+  /// call captures `++_loadGen` and bails before mutating state when
+  /// the captured value no longer matches -- guards against a stale
+  /// in-flight response (e.g. WS reconnect racing pull-to-refresh)
+  /// overwriting fresh state.
+  int _loadGen = 0;
+
   ConversationsNotifier(this.ref) : super(const ConversationsState());
 
   String get _serverUrl => ref.read(serverUrlProvider);
@@ -99,8 +106,13 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
   }
 
   /// Load all conversations from the server.
+  ///
+  /// Uses a monotonic generation counter (#515) so a stale in-flight
+  /// response cannot overwrite fresh state when two reloads overlap
+  /// (e.g. WS reconnect racing pull-to-refresh).  Latest call wins.
   Future<void> loadConversations() async {
     state = state.copyWith(isLoading: true, error: null);
+    final gen = ++_loadGen;
     try {
       final response = await _authenticatedRequest(
         (token) => http.get(
@@ -108,6 +120,9 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
           headers: _headersWithToken(token),
         ),
       );
+      // Drop a stale response (a newer call has been issued) before any
+      // state mutation so we don't clobber fresh data with an old payload.
+      if (gen != _loadGen) return;
 
       if (response.statusCode == 200) {
         final body = jsonDecode(response.body);
@@ -149,6 +164,8 @@ class ConversationsNotifier extends StateNotifier<ConversationsState> {
         );
       }
     } catch (e) {
+      // Stale errors must not clobber a fresh success either.
+      if (gen != _loadGen) return;
       state = state.copyWith(isLoading: false, error: _friendlyError(e));
     }
   }

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -290,6 +291,136 @@ void main() {
 
       expect(notifier.state.error, isNotNull);
       expect(notifier.state.isLoading, isFalse);
+    });
+
+    // -------------------------------------------------------------------
+    // #515: monotonic-generation guard against stale reload responses.
+    // Two concurrent reloads (e.g. WS reconnect racing pull-to-refresh)
+    // must NOT let the older response overwrite the newer one's state.
+    // -------------------------------------------------------------------
+    group('stale-guard (#515)', () {
+      Map<String, dynamic> convFixture(String id, String title) => {
+        'conversation_id': id,
+        'kind': 'group',
+        'title': title,
+        'last_message': 'msg-$id',
+        'last_message_timestamp': '2026-01-15T10:00:00Z',
+        'unread_count': 0,
+        'members': [],
+      };
+
+      test('late stale success does not overwrite fresh success', () async {
+        // Two completers control response ordering on the same URL.
+        final completers = <Completer<http.Response>>[
+          Completer<http.Response>(),
+          Completer<http.Response>(),
+        ];
+        var callIndex = 0;
+        when(
+          () => mockClient.get(
+            any(that: predicate<Uri>((u) => u.path == '/api/conversations')),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer((_) => completers[callIndex++].future);
+
+        final notifier = container.read(conversationsProvider.notifier);
+        await http.runWithClient(() async {
+          // Fire two reloads back-to-back without awaiting.
+          final a = notifier.loadConversations();
+          final b = notifier.loadConversations();
+
+          // Resolve B first with [convB], then A with [convA].
+          completers[1].complete(
+            http.Response(jsonEncode([convFixture('B', 'B')]), 200),
+          );
+          await b;
+          completers[0].complete(
+            http.Response(jsonEncode([convFixture('A', 'A')]), 200),
+          );
+          await a;
+
+          // Latest call (B) must win even though A finished after.
+          expect(notifier.state.conversations, hasLength(1));
+          expect(notifier.state.conversations.first.id, 'B');
+        }, () => mockClient);
+      });
+
+      test('late stale error does not clobber fresh success', () async {
+        final completers = <Completer<http.Response>>[
+          Completer<http.Response>(),
+          Completer<http.Response>(),
+        ];
+        var callIndex = 0;
+        when(
+          () => mockClient.get(
+            any(that: predicate<Uri>((u) => u.path == '/api/conversations')),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer((_) => completers[callIndex++].future);
+
+        final notifier = container.read(conversationsProvider.notifier);
+        await http.runWithClient(() async {
+          final a = notifier.loadConversations(); // will throw
+          final b = notifier.loadConversations(); // succeeds
+
+          completers[1].complete(
+            http.Response(jsonEncode([convFixture('B', 'B')]), 200),
+          );
+          await b;
+          completers[0].completeError(const SocketException('boom'));
+          await a;
+
+          // Stale error must NOT clobber fresh success state.
+          expect(notifier.state.conversations, hasLength(1));
+          expect(notifier.state.conversations.first.id, 'B');
+          expect(notifier.state.error, isNull);
+          expect(notifier.state.isLoading, isFalse);
+        }, () => mockClient);
+      });
+
+      test('isLoading stays true until latest call completes', () async {
+        final completers = <Completer<http.Response>>[
+          Completer<http.Response>(),
+          Completer<http.Response>(),
+        ];
+        var callIndex = 0;
+        when(
+          () => mockClient.get(
+            any(that: predicate<Uri>((u) => u.path == '/api/conversations')),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer((_) => completers[callIndex++].future);
+
+        final notifier = container.read(conversationsProvider.notifier);
+        await http.runWithClient(() async {
+          final a = notifier.loadConversations();
+          final b = notifier.loadConversations();
+
+          // Mid-flight: at least one response still pending.
+          expect(notifier.state.isLoading, isTrue);
+
+          // Resolve the older call first; isLoading must stay true since
+          // the latest is still in flight (and its response will be the
+          // one that flips loading=false).
+          completers[0].complete(
+            http.Response(jsonEncode([convFixture('A', 'A')]), 200),
+          );
+          await a;
+          expect(
+            notifier.state.isLoading,
+            isTrue,
+            reason: 'stale return must not flip loading=false',
+          );
+
+          // Now resolve the latest call -- THIS one is allowed to clear it.
+          completers[1].complete(
+            http.Response(jsonEncode([convFixture('B', 'B')]), 200),
+          );
+          await b;
+          expect(notifier.state.isLoading, isFalse);
+          expect(notifier.state.conversations.first.id, 'B');
+        }, () => mockClient);
+      });
     });
   });
 


### PR DESCRIPTION
Closes #515.
Follow-up filed as #599 (ContactsNotifier has the identical bug).

## Summary
\`ConversationsNotifier.loadConversations()\` had no protection against overlapping calls. Realistic race: WS reconnect (\`websocket_provider.dart:153\`) firing concurrently with manual pull-to-refresh (\`home_screen.dart:163\`), or one of 8 group-info admin actions firing while a WS-driven reload is still in flight. An older in-flight HTTP response could arrive AFTER a newer one and overwrite fresh state.

## Fix
Standard Riverpod monotonic-generation pattern. Each call captures \`final gen = ++_loadGen;\` after setting \`isLoading: true\`. Both the success/non-200 and catch branches bail with \`if (gen != _loadGen || !mounted) return\` before mutating state.

\`\`\`dart
int _loadGen = 0;

Future<void> loadConversations() async {
  state = state.copyWith(isLoading: true, error: null);
  final gen = ++_loadGen;
  try {
    final response = await _authenticatedRequest(...);
    if (gen != _loadGen || !mounted) return;
    if (response.statusCode == 200) { ... } else { ... }
  } catch (e) {
    if (gen != _loadGen || !mounted) return;
    state = state.copyWith(error: ...);
  }
}
\`\`\`

**Properties:**
- Latest call wins regardless of arrival order
- \`isLoading\` only flips false when the LATEST finishes
- Stale errors don't clobber fresh successes
- \`getOrCreateDm\` and \`createGroup\` benefit transitively (delegate to \`loadConversations\`)
- \`!mounted\` guard prevents StateError when the notifier is disposed mid-flight (e.g. user logs out during a slow request)
- 12 call sites across 9 files need **no changes** — guard is internal

## Test plan
- [x] 3 new race tests using sequential \`Completer<http.Response>\` stubs:
  - late stale success does not overwrite fresh success
  - late stale error does not clobber fresh state
  - isLoading stays true until latest call completes
- [x] All 19 \`conversations_http_test.dart\` tests pass
- [x] Full suite: 839 Flutter tests pass
- [x] \`dart format --check\` + \`flutter analyze --fatal-infos\` clean

## Files changed
| File | Change |
|------|--------|
| \`apps/client/lib/src/providers/conversations_provider.dart\` | \`_loadGen\` field + 2 guards (~10 lines incl. mounted check) |
| \`apps/client/test/providers/conversations_http_test.dart\` | \`dart:async\` import + 3 race tests (~130 lines) |

## Out of scope
- Mutex/queue serialization (we want latest-wins, not FIFO)
- ContactsNotifier identical bug → tracked as #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)