### PR TITLE
chore: relicense AGPL-3.0 → PolyForm Noncommercial 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,133 @@
-GNU AFFERO GENERAL PUBLIC LICENSE
-Version 3, 19 November 2007
+# PolyForm Noncommercial License 1.0.0
 
-Copyright (C) 2026 Echo Contributors
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+Copyright (c) 2026 NC1107
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU Affero General Public License for more details.
+## Acceptance
 
-You should have received a copy of the GNU Affero General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
-The full text of the AGPL-3.0 license is available at:
-https://www.gnu.org/licenses/agpl-3.0.txt
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose. However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software. Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software. For example:
+
+> Required Notice: Copyright NC1107 (https://github.com/NC1107)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -271,4 +271,8 @@ cd apps/client && flutter analyze --fatal-infos
 
 ## License
 
-AGPL-3.0-or-later. See [LICENSE](LICENSE).
+[PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0). See [LICENSE](LICENSE).
+
+This is a **source-available** license — anyone may use, modify, and contribute to Echo for any **non-commercial** purpose (personal, hobby, educational, non-profit, public-research, religious). Selling it, hosting it as a paid service, or using it inside a commercial entity is **not permitted** without a separate commercial license from the copyright holder.
+
+Contributions are welcome via pull request. By submitting a contribution you agree that your changes are released under the same license.

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "echo-server"
 version = "0.1.0"
 edition = "2024"
-license = "AGPL-3.0-or-later"
+license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
 
 [dependencies]
 tokio.workspace = true

--- a/core/rust-core/Cargo.toml
+++ b/core/rust-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "echo-core"
 version = "0.1.0"
 edition = "2024"
-license = "AGPL-3.0-or-later"
+license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
 
 [lib]
 crate-type = ["lib"]

--- a/deny.toml
+++ b/deny.toml
@@ -34,16 +34,17 @@ allow = [
     "CDLA-Permissive-2.0",
 ]
 
-# AGPL-3.0-or-later is the project's own license and must not leak in via
-# transitive deps. Narrow exceptions below cover only first-party workspace
-# crates so a future AGPL dependency won't silently slip through.
+# PolyForm Noncommercial 1.0.0 is the project's own license. SPDX has no
+# canonical identifier for it so cargo-deny treats it as "unknown" — we
+# exception it for first-party crates only, so any future non-commercial
+# dependency won't silently slip through.
 [[licenses.exceptions]]
 name = "echo-core"
-allow = ["AGPL-3.0-or-later"]
+allow = ["LicenseRef-PolyForm-Noncommercial-1.0.0"]
 
 [[licenses.exceptions]]
 name = "echo-server"
-allow = ["AGPL-3.0-or-later"]
+allow = ["LicenseRef-PolyForm-Noncommercial-1.0.0"]
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
Relicenses the project from AGPL-3.0-or-later to PolyForm Noncommercial 1.0.0.

## Why
AGPL prevents closed-source forks but **allows** commercial SaaS hosting (anyone can stand up Echo-as-a-Service, they just have to publish their fork). Project intent is the opposite: anyone can use/modify/contribute for non-commercial purposes, but no commercial entity may build a business on the code.

## What changes
- **LICENSE**: full PolyForm Noncommercial 1.0.0 text (Heather Meeker drafted, Lichess uses it)
- **apps/server + core/rust-core Cargo.toml**: \`license = "LicenseRef-PolyForm-Noncommercial-1.0.0"\` (no canonical SPDX id exists)
- **deny.toml**: first-party crate exceptions updated to the new identifier
- **README**: license section reworked, contribution intent stated

## Permitted use (non-commercial)
- Personal, hobby, educational, religious
- Non-profit, public research, public safety/health, environmental, government
- Charitable organizations
- Contributions back via pull request

## Not permitted (without separate commercial license)
- Selling it
- Hosting it as a paid service
- Using it inside a commercial entity

## Verification
- \`cargo deny check licenses\` → \`licenses ok\` ✅

## Solo-author relicense
No external code contributions have landed; relicense is unilateral. GitHub's licenseInfo will continue to show as "Other" since PolyForm has no SPDX id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)