### PR TITLE
sprint 2: 6 of 9 server reliability + perf items (stacked on #703)

### DIFF
--- a/apps/server/migrations/20260501000000_drop_duplicate_reply_to_index.sql
+++ b/apps/server/migrations/20260501000000_drop_duplicate_reply_to_index.sql
@@ -1,0 +1,13 @@
+-- Audit perf #6 / #678: drop the duplicate partial index on messages.reply_to_id.
+--
+-- The baseline migration created `idx_messages_reply_to ON messages (reply_to_id)
+-- WHERE reply_to_id IS NOT NULL` and 20260423000000 added an identical
+-- index named `idx_messages_reply_to_id` covering the same column with the
+-- same predicate. Postgres maintains both on every insert/update/delete that
+-- touches `reply_to_id`, doubling the write amplification for zero query
+-- benefit (the planner only ever uses one of them).
+--
+-- Keep `idx_messages_reply_to_id` because the LEFT JOIN LATERAL added in
+-- 2026-04-30 (#678) deliberately uses that name in EXPLAIN traces and code
+-- comments; drop the older `idx_messages_reply_to`.
+DROP INDEX IF EXISTS idx_messages_reply_to;

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -187,6 +187,11 @@ pub async fn get_messages(
     // `message_device_contents` and surface the device-specific ciphertext via
     // COALESCE so multi-device DM history decrypts on the right ratchet.
     // When no device_id is provided we preserve the legacy behaviour.
+    // Audit #678: replace correlated `(SELECT COUNT(*) ...)` per-row with a
+    // single LEFT JOIN LATERAL.  Postgres can plan the lateral once per outer
+    // row but still benefit from the partial index `idx_messages_reply_to_id`
+    // -- and importantly the same shape is reused by `search_messages` /
+    // `get_thread_replies` so the planner statistics line up across paths.
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -195,12 +200,15 @@ pub async fn get_messages(
                 m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                (SELECT COUNT(*) FROM messages r \
-                 WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL) AS reply_count \
+                COALESCE(rc.cnt, 0) AS reply_count \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
+         LEFT JOIN LATERAL ( \
+             SELECT COUNT(*) AS cnt FROM messages r \
+             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
+         ) rc ON true \
          LEFT JOIN message_device_contents mdc \
                 ON $5::int IS NOT NULL \
                AND mdc.message_id = m.id \
@@ -241,6 +249,8 @@ pub async fn get_undelivered(
     user_id: Uuid,
     after_ts: Option<DateTime<Utc>>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
+    // Audit #638: same LEFT JOIN LATERAL shape as get_messages -- one
+    // sub-query per outer row instead of a correlated COUNT(*).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -248,12 +258,15 @@ pub async fn get_undelivered(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                (SELECT COUNT(*) FROM messages r \
-                 WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL) AS reply_count \
+                COALESCE(rc.cnt, 0) AS reply_count \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
+         LEFT JOIN LATERAL ( \
+             SELECT COUNT(*) AS cnt FROM messages r \
+             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
+         ) rc ON true \
          JOIN conversation_members cm ON cm.conversation_id = m.conversation_id AND cm.user_id = $1 \
                   AND cm.is_removed = false \
          WHERE m.sender_id != $1 AND m.delivered = false AND m.deleted_at IS NULL \

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -126,6 +126,36 @@ impl From<argon2::password_hash::Error> for AppError {
     }
 }
 
+/// Extension trait deduplicating the `Result<_, sqlx::Error>` → `AppError`
+/// boilerplate that previously appeared 120+ times across `routes/*.rs`
+/// (#694).  Callers that need richer error mapping (e.g. distinguishing
+/// 23505 unique-violation conflicts from generic failures) keep using the
+/// explicit `match` form -- this trait is for the dominant case where the
+/// route just wants to log + return 500.
+///
+/// Usage:
+/// ```ignore
+/// let row = db::users::find_by_id(&state.pool, user_id)
+///     .await
+///     .db_ctx("find_by_id")?;
+/// ```
+pub trait DbErrCtx<T> {
+    /// Convert a `Result<_, sqlx::Error>` into `Result<_, AppError>` while
+    /// logging the operation's identifying context.  The label is captured
+    /// as a structured tracing field so observability tools can group
+    /// occurrences without parsing the message string.
+    fn db_ctx(self, ctx: &'static str) -> Result<T, AppError>;
+}
+
+impl<T> DbErrCtx<T> for Result<T, sqlx::Error> {
+    fn db_ctx(self, ctx: &'static str) -> Result<T, AppError> {
+        self.map_err(|e| {
+            tracing::error!(error = ?e, db_ctx = ctx, "DB error");
+            AppError::internal("Database error")
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,5 +216,22 @@ mod tests {
             debug_str.contains("debug me"),
             "Debug output should contain message"
         );
+    }
+
+    #[test]
+    fn db_ctx_passes_through_ok() {
+        let result: Result<i32, sqlx::Error> = Ok(42);
+        let mapped = result.db_ctx("test_ctx").unwrap();
+        assert_eq!(mapped, 42);
+    }
+
+    #[test]
+    fn db_ctx_maps_err_to_internal() {
+        // Use a synthesised RowNotFound -- the cheapest sqlx::Error variant
+        // that doesn't require touching a real connection.
+        let result: Result<i32, sqlx::Error> = Err(sqlx::Error::RowNotFound);
+        let err = result.db_ctx("test_ctx").unwrap_err();
+        assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.message, "Database error");
     }
 }

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -39,22 +39,62 @@ async fn main() {
         media_tickets: dashmap::DashMap::new(),
     });
 
-    // Background task: clean up stale voice sessions every 60 seconds.
-    // Sessions not updated within 2 minutes are removed and leave events
-    // are broadcast to group members.
-    let cleanup_pool = pool.clone();
-    let cleanup_hub = hub.clone();
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-        loop {
-            interval.tick().await;
-            cleanup_stale_voice_sessions(&cleanup_pool, &cleanup_hub).await;
-            cleanup_empty_groups(&cleanup_pool).await;
-            cleanup_expired_tokens(&cleanup_pool).await;
-            cleanup_used_prekeys(&cleanup_pool).await;
-            cleanup_expired_messages(&cleanup_pool, &cleanup_hub).await;
+    // Audit #625: each cleanup runs in its own task with per-task cadence
+    // and panic recovery (catch_unwind on the future).  Previously all five
+    // shared one 60s loop, so a panic anywhere killed every cleanup
+    // silently.  Cadences: voice + expired-messages stay tight (60s / 30s)
+    // because their UX impact is immediate; tokens/prekeys/empty-groups
+    // are hygiene tasks at lower frequency.
+    spawn_periodic("voice_sessions", std::time::Duration::from_secs(60), {
+        let pool = pool.clone();
+        let hub = hub.clone();
+        move || {
+            let pool = pool.clone();
+            let hub = hub.clone();
+            async move { cleanup_stale_voice_sessions(&pool, &hub).await }
         }
     });
+    spawn_periodic("expired_messages", std::time::Duration::from_secs(30), {
+        let pool = pool.clone();
+        let hub = hub.clone();
+        move || {
+            let pool = pool.clone();
+            let hub = hub.clone();
+            async move { cleanup_expired_messages(&pool, &hub).await }
+        }
+    });
+    spawn_periodic("expired_tokens", std::time::Duration::from_secs(600), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { cleanup_expired_tokens(&pool).await }
+        }
+    });
+    spawn_periodic("used_prekeys", std::time::Duration::from_secs(600), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { cleanup_used_prekeys(&pool).await }
+        }
+    });
+    spawn_periodic("empty_groups", std::time::Duration::from_secs(300), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { cleanup_empty_groups(&pool).await }
+        }
+    });
+
+    // Cache eviction sweep on the membership/typing/conv-kind caches in
+    // typing_service.  Bounded growth without this -- the audit (#692) found
+    // entries never expire after 24h on a busy server.
+    spawn_periodic(
+        "cache_sweep",
+        std::time::Duration::from_secs(300),
+        || async {
+            ws::typing_service::sweep_expired_caches();
+        },
+    );
 
     let app = routes::create_router(state, config.trusted_proxies);
 
@@ -85,6 +125,47 @@ async fn main() {
     })
     .await
     .expect("Server error");
+}
+
+/// Spawn a periodic cleanup task that recovers from panics.
+///
+/// Each task gets its own `tokio::spawn` so a panic anywhere doesn't kill
+/// the others (audit #625).  `AssertUnwindSafe` is sound here because the
+/// closures we pass are stateless re-creators -- they capture `Arc` clones
+/// of pool/hub and rebuild a fresh future per tick, so any partially-
+/// mutated state from a panicked invocation is dropped on unwind.
+fn spawn_periodic<F, Fut>(name: &'static str, period: std::time::Duration, mut make_fut: F)
+where
+    F: FnMut() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    use futures_util::FutureExt;
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(period);
+        // Skip the immediate-fire first tick so we don't pile work onto
+        // server boot, when the pool may still be warming.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let fut = make_fut();
+            // catch_unwind requires Unpin; box-pin the future so we can
+            // call AssertUnwindSafe + catch_unwind on it.
+            let result = std::panic::AssertUnwindSafe(Box::pin(fut))
+                .catch_unwind()
+                .await;
+            if let Err(panic) = result {
+                tracing::error!(
+                    task = name,
+                    "cleanup task panicked: {:?}",
+                    panic
+                        .downcast_ref::<&str>()
+                        .copied()
+                        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                        .unwrap_or("(non-string panic payload)")
+                );
+            }
+        }
+    });
 }
 
 /// Remove voice sessions not updated within 2 minutes and broadcast leave events.
@@ -220,22 +301,75 @@ async fn cleanup_expired_messages(pool: &PgPool, hub: &ws::hub::Hub) {
     }
 }
 
-/// Delete all dependent rows for a group conversation, then delete the conversation itself.
+/// Delete all dependent rows for a group conversation, then the conversation
+/// itself, atomically (audit #625, H32). Previously this was 9 sequential
+/// pool queries with `if let Err(e) ...` swallows -- a connection drop after
+/// step 4 left the conversation half-deleted and the next sweep picked it up
+/// incompletely. Wrapped in one tx so the database is never observed in a
+/// partially-cleaned state.
+///
+/// Migration 20260412000000 added ON DELETE CASCADE on a subset of child
+/// tables (`messages`, `read_receipts`, `conversation_members`); the others
+/// are still cleaned explicitly here. A follow-up migration that adds
+/// CASCADE to `voice_sessions`, `channels`, `group_keys`,
+/// `group_key_envelopes`, `banned_members`, and `media` would let this
+/// collapse to `DELETE FROM conversations WHERE id = $1`.
 async fn delete_group_dependents(pool: &PgPool, gid: uuid::Uuid) {
-    let tables = [
-        "DELETE FROM voice_sessions WHERE channel_id IN (SELECT id FROM channels WHERE conversation_id = $1)",
-        "DELETE FROM channels WHERE conversation_id = $1",
-        "DELETE FROM messages WHERE conversation_id = $1",
-        "DELETE FROM group_key_envelopes WHERE conversation_id = $1",
-        "DELETE FROM group_keys WHERE conversation_id = $1",
-        "DELETE FROM banned_members WHERE conversation_id = $1",
-        "DELETE FROM read_receipts WHERE conversation_id = $1",
-        "DELETE FROM media WHERE conversation_id = $1",
-        "DELETE FROM conversations WHERE id = $1",
-    ];
-    for sql in tables {
-        if let Err(e) = sqlx::query(sql).bind(gid).execute(pool).await {
-            tracing::error!("Failed to clean up group {gid}: {e} (query: {sql})");
+    let mut tx = match pool.begin().await {
+        Ok(tx) => tx,
+        Err(e) => {
+            tracing::error!(group_id = %gid, "begin tx for group cleanup failed: {e}");
+            return;
         }
+    };
+
+    let tables = [
+        (
+            "voice_sessions",
+            "DELETE FROM voice_sessions WHERE channel_id IN (SELECT id FROM channels WHERE conversation_id = $1)",
+        ),
+        (
+            "channels",
+            "DELETE FROM channels WHERE conversation_id = $1",
+        ),
+        (
+            "messages",
+            "DELETE FROM messages WHERE conversation_id = $1",
+        ),
+        (
+            "group_key_envelopes",
+            "DELETE FROM group_key_envelopes WHERE conversation_id = $1",
+        ),
+        (
+            "group_keys",
+            "DELETE FROM group_keys WHERE conversation_id = $1",
+        ),
+        (
+            "banned_members",
+            "DELETE FROM banned_members WHERE conversation_id = $1",
+        ),
+        (
+            "read_receipts",
+            "DELETE FROM read_receipts WHERE conversation_id = $1",
+        ),
+        ("media", "DELETE FROM media WHERE conversation_id = $1"),
+        ("conversations", "DELETE FROM conversations WHERE id = $1"),
+    ];
+    for (table, sql) in tables {
+        if let Err(e) = sqlx::query(sql).bind(gid).execute(&mut *tx).await {
+            tracing::error!(
+                group_id = %gid,
+                table = table,
+                "group cleanup failed at {table}: {e} -- rolling back"
+            );
+            if let Err(rb) = tx.rollback().await {
+                tracing::error!(group_id = %gid, "rollback failed: {rb}");
+            }
+            return;
+        }
+    }
+
+    if let Err(e) = tx.commit().await {
+        tracing::error!(group_id = %gid, "commit group cleanup failed: {e}");
     }
 }

--- a/apps/server/src/routes/channels.rs
+++ b/apps/server/src/routes/channels.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::{ChannelKind, ConversationKind, Role};
 
 use super::AppState;
@@ -78,10 +78,7 @@ async fn ensure_group_member(
 ) -> Result<(), AppError> {
     let kind = db::groups::get_conversation_kind(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_group_member/get_kind: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ensure_group_member/get_kind")?
         .ok_or_else(|| AppError::bad_request("Group not found"))?;
 
     if ConversationKind::from_str_opt(&kind) != Some(ConversationKind::Group) {
@@ -90,10 +87,7 @@ async fn ensure_group_member(
 
     let is_member = db::groups::is_member(&state.pool, group_id, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_group_member/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("ensure_group_member/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -110,10 +104,7 @@ async fn ensure_group_admin(
 ) -> Result<(), AppError> {
     let role = db::groups::get_member_role(&state.pool, group_id, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_group_admin/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("ensure_group_admin/get_role")?;
     match role.as_deref().and_then(Role::from_str_opt) {
         Some(r) if r.is_admin_or_above() => Ok(()),
         _ => Err(AppError::unauthorized(
@@ -129,10 +120,7 @@ async fn ensure_channel_in_group(
 ) -> Result<db::channels::ChannelRow, AppError> {
     let channel = db::channels::get_channel(&state.pool, channel_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_channel_in_group/get_channel: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ensure_channel_in_group/get_channel")?
         .ok_or_else(|| AppError::bad_request("Channel not found"))?;
 
     if channel.conversation_id != group_id {
@@ -163,10 +151,7 @@ pub async fn list_channels(
 
     let rows = db::channels::list_channels(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_channels: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_channels")?;
 
     let channels: Vec<ChannelResponse> = rows
         .into_iter()
@@ -214,10 +199,7 @@ pub async fn create_channel(
         Some(_) => return Err(AppError::bad_request("Position must be non-negative")),
         None => db::channels::next_channel_position(&state.pool, group_id, &kind)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in create_channel/next_position: {e:?}");
-                AppError::internal("Database error")
-            })?,
+            .db_ctx("create_channel/next_position")?,
     };
 
     let created = db::channels::create_channel(
@@ -374,10 +356,7 @@ pub async fn list_voice_sessions(
 
     let rows = db::channels::list_voice_sessions(&state.pool, channel.id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_voice_sessions: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_voice_sessions")?;
 
     let sessions: Vec<VoiceSessionResponse> = rows
         .into_iter()

--- a/apps/server/src/routes/contacts.rs
+++ b/apps/server/src/routes/contacts.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -96,10 +96,7 @@ pub async fn list_contacts(
 ) -> Result<impl IntoResponse, AppError> {
     let contacts = db::contacts::list_contacts(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_contacts: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_contacts")?;
 
     Ok(Json(contacts))
 }
@@ -110,10 +107,7 @@ pub async fn list_pending(
 ) -> Result<impl IntoResponse, AppError> {
     let pending = db::contacts::list_pending_requests(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_pending: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_pending")?;
 
     Ok(Json(pending))
 }
@@ -138,10 +132,7 @@ pub async fn block_user(
 
     db::contacts::block_user(&state.pool, auth.user_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in block_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("block_user")?;
 
     Ok((
         StatusCode::CREATED,
@@ -156,10 +147,7 @@ pub async fn unblock_user(
 ) -> Result<impl IntoResponse, AppError> {
     let removed = db::contacts::unblock_user(&state.pool, auth.user_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unblock_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("unblock_user")?;
 
     if !removed {
         return Err(AppError::bad_request("User is not blocked"));
@@ -174,10 +162,7 @@ pub async fn list_blocked(
 ) -> Result<impl IntoResponse, AppError> {
     let blocked = db::contacts::list_blocked_users(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_blocked: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_blocked")?;
 
     Ok(Json(blocked))
 }

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::Role;
 
 use super::AppState;
@@ -91,10 +91,7 @@ pub async fn upload_group_key(
     // Verify membership and role
     let role_str = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in upload_group_key/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("upload_group_key/get_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
@@ -137,10 +134,7 @@ pub async fn upload_group_key(
     // the conversation was left with a key_version row but only some members
     // had envelopes, and those without one could not decrypt anything until
     // the next rotation.
-    let mut tx = state.pool.begin().await.map_err(|e| {
-        tracing::error!("DB error in upload_group_key/begin: {e:?}");
-        AppError::internal("Database error")
-    })?;
+    let mut tx = state.pool.begin().await.db_ctx("upload_group_key/begin")?;
 
     // Audit #686: every envelope.user_id must be a current group member.
     // Without this, a hostile admin can stage envelopes for arbitrary users
@@ -151,10 +145,7 @@ pub async fn upload_group_key(
     let member_ids: std::collections::HashSet<Uuid> =
         db::groups::get_conversation_member_ids(&mut *tx, group_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in upload_group_key/members: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("upload_group_key/members")?
             .into_iter()
             .collect();
 
@@ -206,10 +197,7 @@ pub async fn upload_group_key(
         })?;
     }
 
-    tx.commit().await.map_err(|e| {
-        tracing::error!("DB error in upload_group_key/commit: {e:?}");
-        AppError::internal("Database error")
-    })?;
+    tx.commit().await.db_ctx("upload_group_key/commit")?;
 
     // Broadcast key_rotated event to all group members
     let member_ids = db::groups::get_conversation_member_ids(&state.pool, group_id)
@@ -247,10 +235,7 @@ pub async fn get_latest_group_key(
 ) -> Result<impl IntoResponse, AppError> {
     let is_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_latest_group_key/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_latest_group_key/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -259,10 +244,7 @@ pub async fn get_latest_group_key(
     // Try envelope-based lookup first (new E2E scheme)
     let envelope = db::keys::get_my_group_key_envelope(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_latest_group_key/envelope: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_latest_group_key/envelope")?;
 
     if let Some(env) = envelope {
         return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
@@ -271,10 +253,7 @@ pub async fn get_latest_group_key(
     // Fallback: legacy group_keys table (for groups that haven't rotated yet)
     let row = db::keys::get_latest_group_key(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_latest_group_key/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_latest_group_key/fetch")?
         .ok_or_else(|| AppError::bad_request("No group key found for this conversation"))?;
 
     Ok(Json(GroupKeyResponse::from_row(row)).into_response())
@@ -291,10 +270,7 @@ pub async fn get_group_key_version(
 ) -> Result<impl IntoResponse, AppError> {
     let is_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_key_version/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group_key_version/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -304,10 +280,7 @@ pub async fn get_group_key_version(
     let envelope =
         db::keys::get_my_group_key_envelope_version(&state.pool, group_id, auth.user_id, version)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_group_key_version/envelope: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("get_group_key_version/envelope")?;
 
     if let Some(env) = envelope {
         return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
@@ -316,10 +289,7 @@ pub async fn get_group_key_version(
     // Fallback: legacy group_keys table
     let row = db::keys::get_group_key(&state.pool, group_id, version)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_key_version/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group_key_version/fetch")?
         .ok_or_else(|| AppError::bad_request("Group key version not found"))?;
 
     Ok(Json(GroupKeyResponse::from_row(row)).into_response())

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::{ConversationKind, Role};
 use crate::ws::typing_service::invalidate_member_cache;
 
@@ -237,10 +237,7 @@ pub async fn get_group(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -248,18 +245,12 @@ pub async fn get_group(
 
     let group = db::groups::get_group(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group/fetch")?
         .ok_or_else(|| AppError::bad_request("Group not found"))?;
 
     let members = db::groups::get_group_members(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group/get_members: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group/get_members")?;
 
     let response = GroupResponse {
         id: group.id,
@@ -291,19 +282,13 @@ pub async fn add_member(
     // Verify caller is a member and get their role
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("add_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     // Verify it's a group conversation
     let kind = db::groups::get_conversation_kind(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/get_conversation_kind: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/get_conversation_kind")?;
 
     if kind.as_deref().and_then(ConversationKind::from_str_opt) != Some(ConversationKind::Group) {
         return Err(AppError::bad_request("Not a group conversation"));
@@ -312,10 +297,7 @@ pub async fn add_member(
     // For private groups, only owner or admin can add members
     let is_public = db::groups::is_public(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/is_public: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/is_public")?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
     if !is_public && !caller_role_enum.is_admin_or_above() {
@@ -327,10 +309,7 @@ pub async fn add_member(
     // Verify target user exists
     let user_exists = db::users::find_by_id(&state.pool, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/find_user")?;
 
     if user_exists.is_none() {
         return Err(AppError::bad_request("User not found"));
@@ -339,10 +318,7 @@ pub async fn add_member(
     // Check if target user is banned
     let banned = db::groups::is_banned(&state.pool, group_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/is_banned: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/is_banned")?;
     if banned {
         return Err(AppError::bad_request("User is banned from this group"));
     }
@@ -350,10 +326,7 @@ pub async fn add_member(
     // Check if already an active member
     let already_member = db::groups::is_member(&state.pool, group_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/is_member")?;
     if already_member {
         return Err(AppError::conflict("User is already a member"));
     }
@@ -379,10 +352,7 @@ pub async fn remove_member(
     // Verify caller is a member and get their role
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("remove_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     // If removing someone else, must be owner or admin
@@ -397,10 +367,7 @@ pub async fn remove_member(
     if target_user_id != auth.user_id {
         let target_role = db::groups::get_member_role(&state.pool, group_id, target_user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in remove_member/get_target_role: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("remove_member/get_target_role")?;
         if target_role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
             return Err(AppError::bad_request("Cannot remove the group owner"));
         }
@@ -484,18 +451,12 @@ pub async fn get_group_preview(
 ) -> Result<impl IntoResponse, AppError> {
     let preview = db::groups::get_group_preview(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_preview: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group_preview")?
         .ok_or_else(|| AppError::not_found("Group not found"))?;
 
     let members = db::groups::get_group_member_previews(&state.pool, group_id, 5)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_preview/members: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group_preview/members")?;
 
     Ok(Json(json!({
         "id": preview.id,
@@ -523,10 +484,7 @@ pub async fn join_group(
     // Check if user is banned
     let banned = db::groups::is_banned(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in join_group/is_banned: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("join_group/is_banned")?;
     if banned {
         return Err(AppError::bad_request("You are banned from this group"));
     }
@@ -534,10 +492,7 @@ pub async fn join_group(
     // Check if already a member
     let already_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in join_group/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("join_group/is_member")?;
     if already_member {
         return Err(AppError::conflict("Already a member of this group"));
     }
@@ -565,10 +520,7 @@ pub async fn leave_group(
     // Owners must transfer ownership before leaving (unless they're the last member)
     let role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in leave_group/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("leave_group/get_role")?;
     if role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
         let members = db::groups::get_conversation_member_ids(&state.pool, group_id)
             .await
@@ -688,10 +640,7 @@ pub async fn ban_member(
 ) -> Result<impl IntoResponse, AppError> {
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ban_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ban_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
@@ -704,10 +653,7 @@ pub async fn ban_member(
     // Prevent banning the owner or peers of equal rank
     let target_role = db::groups::get_member_role(&state.pool, group_id, target_user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ban_member/get_target_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("ban_member/get_target_role")?;
     let target_role_enum = target_role
         .as_deref()
         .and_then(Role::from_str_opt)
@@ -755,10 +701,7 @@ pub async fn unban_member(
 ) -> Result<impl IntoResponse, AppError> {
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unban_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("unban_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
@@ -824,10 +767,7 @@ pub async fn upload_group_avatar(
     // Verify caller is owner or admin
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in upload_group_avatar/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("upload_group_avatar/get_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
@@ -919,10 +859,7 @@ pub async fn get_group_avatar(
 ) -> Result<Response, AppError> {
     let icon_url = db::groups::get_group_icon_url(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_avatar/icon_url: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group_avatar/icon_url")?
         .ok_or_else(|| AppError {
             status: StatusCode::NOT_FOUND,
             message: "No avatar set for this group".to_string(),

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -508,6 +508,10 @@ pub async fn join_group(
         return Err(AppError::bad_request("Group not found or is not public"));
     }
 
+    // Audit #692: drop the membership cache so the new member's typing /
+    // presence / fanout requests no longer hit a cached "not a member" miss.
+    invalidate_member_cache(group_id);
+
     Ok(Json(serde_json::json!({ "status": "joined" })))
 }
 

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crate::auth::{jwt, middleware::AuthUser};
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -195,10 +195,7 @@ pub async fn upload(
             // Verify the uploader is a member of this conversation
             let is_member = db::groups::is_member(&state.pool, cid, auth.user_id)
                 .await
-                .map_err(|e| {
-                    tracing::error!("DB error in upload_media/is_member: {e:?}");
-                    AppError::internal("Database error")
-                })?;
+                .db_ctx("upload_media/is_member")?;
             if !is_member {
                 return Err(AppError {
                     status: StatusCode::FORBIDDEN,

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::{ConversationKind, Role};
 use crate::ws::typing_service::invalidate_member_cache;
 
@@ -240,10 +240,7 @@ pub async fn get_messages(
     // Verify the user is a member of this conversation
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_messages/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_messages/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -252,10 +249,7 @@ pub async fn get_messages(
     if let Some(channel_id) = params.channel_id {
         let conversation_kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_messages/get_conversation_kind: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("get_messages/get_conversation_kind")?
             .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
 
         if ConversationKind::from_str_opt(&conversation_kind) != Some(ConversationKind::Group) {
@@ -266,10 +260,7 @@ pub async fn get_messages(
 
         let channel = db::channels::get_channel(&state.pool, channel_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_messages/get_channel: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("get_messages/get_channel")?
             .ok_or_else(|| AppError::bad_request("Channel not found"))?;
 
         if channel.conversation_id != conversation_id {
@@ -296,10 +287,7 @@ pub async fn get_messages(
         params.device_id,
     )
     .await
-    .map_err(|e| {
-        tracing::error!("DB error in get_messages/fetch: {e:?}");
-        AppError::internal("Database error")
-    })?;
+    .db_ctx("get_messages/fetch")?;
 
     // Re-shape the response to expose `from_user_id` / `from_username` /
     // `from_device_id` keys the client expects on history (#557). Doing it
@@ -343,10 +331,7 @@ pub async fn create_dm(
 ) -> Result<impl IntoResponse, AppError> {
     let are_contacts = db::contacts::are_contacts(&state.pool, auth.user_id, req.peer_user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in create_dm/are_contacts: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("create_dm/are_contacts")?;
     if !are_contacts {
         return Err(AppError::bad_request("Not a contact"));
     }
@@ -373,10 +358,7 @@ pub async fn delete_message(
 ) -> Result<impl IntoResponse, AppError> {
     let conversation_id = db::messages::delete_message(&state.pool, message_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in delete_message: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("delete_message")?
         .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
 
     // Broadcast to conversation members via WebSocket
@@ -428,10 +410,7 @@ pub async fn edit_message(
     let convo_meta =
         db::messages::get_message_conversation_security(&state.pool, message_id, auth.user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in edit_message/security lookup: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("edit_message/security lookup")?
             .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
     if convo_meta.is_encrypted {
         tracing::warn!(
@@ -448,10 +427,7 @@ pub async fn edit_message(
     let (conversation_id, edited_at) =
         db::messages::edit_message(&state.pool, message_id, auth.user_id, &body.content)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in edit_message: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("edit_message")?
             .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
 
     // Broadcast to conversation members via WebSocket
@@ -498,10 +474,7 @@ pub async fn get_thread_replies(
             .bind(message_id)
             .fetch_optional(&state.pool)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_thread_replies/lookup: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("get_thread_replies/lookup")?;
 
     let conversation_id = parent
         .map(|(cid,)| cid)
@@ -509,10 +482,7 @@ pub async fn get_thread_replies(
 
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_thread_replies/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_thread_replies/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -523,10 +493,7 @@ pub async fn get_thread_replies(
     // replies (or any future regression) cannot leak content across DMs.
     let replies = db::messages::get_thread_replies(&state.pool, message_id, conversation_id, limit)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_thread_replies/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_thread_replies/fetch")?;
 
     Ok(Json(replies))
 }
@@ -554,10 +521,7 @@ pub async fn search_messages(
 ) -> Result<impl IntoResponse, AppError> {
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in search_messages/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("search_messages/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
@@ -622,10 +586,7 @@ pub async fn leave_conversation(
     // Owners must transfer ownership before leaving (unless they're the last member)
     let role = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in leave_conversation/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("leave_conversation/get_role")?;
     if role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
         let members = db::groups::get_conversation_member_ids(&state.pool, conversation_id)
             .await
@@ -681,10 +642,7 @@ pub async fn toggle_mute(
     let updated =
         db::messages::set_mute_status(&state.pool, conversation_id, auth.user_id, body.is_muted)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in toggle_mute: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("toggle_mute")?;
 
     if !updated {
         return Err(AppError::bad_request("Not a member of this conversation"));
@@ -767,10 +725,7 @@ pub async fn pin_message(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_message/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("pin_message/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
@@ -778,19 +733,13 @@ pub async fn pin_message(
     // For groups, only admins/owners can pin
     let kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_message/get_kind: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("pin_message/get_kind")?
         .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
 
     if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group) {
         let role_str = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in pin_message/get_role: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("pin_message/get_role")?
             .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
         let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
@@ -805,10 +754,7 @@ pub async fn pin_message(
     let _conv_id =
         db::messages::pin_message(&state.pool, message_id, auth.user_id, conversation_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in pin_message: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("pin_message")?
             .ok_or_else(|| {
                 AppError::bad_request("Message not found or does not belong to this conversation")
             })?;
@@ -816,10 +762,7 @@ pub async fn pin_message(
     // Look up pinner's username for the broadcast event
     let pinner = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_message/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("pin_message/find_user")?;
     let pinned_by_username = pinner
         .map(|u| u.username)
         .unwrap_or_else(|| "unknown".to_string());
@@ -861,10 +804,7 @@ pub async fn unpin_message(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_message/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("unpin_message/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
@@ -872,19 +812,13 @@ pub async fn unpin_message(
     // For groups, only admins/owners can unpin
     let kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_message/get_kind: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("unpin_message/get_kind")?
         .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
 
     if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group) {
         let role_str = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in unpin_message/get_role: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("unpin_message/get_role")?
             .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
         let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
@@ -898,10 +832,7 @@ pub async fn unpin_message(
     // Unpin the message (atomically verified against the correct conversation)
     let _conv_id = db::messages::unpin_message(&state.pool, message_id, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_message: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("unpin_message")?
         .ok_or_else(|| {
             AppError::bad_request("Message not found, not pinned, or wrong conversation")
         })?;
@@ -936,20 +867,14 @@ pub async fn get_pinned_messages(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_pinned_messages/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_pinned_messages/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
 
     let pinned = db::messages::get_pinned_messages(&state.pool, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_pinned_messages: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_pinned_messages")?;
 
     Ok(Json(pinned))
 }
@@ -965,10 +890,7 @@ pub async fn pin_conversation(
 ) -> Result<impl IntoResponse, AppError> {
     db::users::pin_conversation(&state.pool, auth.user_id, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("pin_conversation")?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -983,9 +905,6 @@ pub async fn unpin_conversation(
 ) -> Result<impl IntoResponse, AppError> {
     db::users::unpin_conversation(&state.pool, auth.user_id, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("unpin_conversation")?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/apps/server/src/routes/reactions.rs
+++ b/apps/server/src/routes/reactions.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -48,19 +48,13 @@ pub async fn add_reaction(
     // Get conversation for this message
     let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_reaction/get_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("add_reaction/get_conversation")?
         .ok_or_else(|| AppError::bad_request("Message not found"))?;
 
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_reaction/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_reaction/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -76,10 +70,7 @@ pub async fn add_reaction(
     // Look up username for broadcast
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_reaction/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("add_reaction/find_user")?
         .ok_or_else(|| AppError::internal("User not found"))?;
 
     // Broadcast to conversation members
@@ -110,19 +101,13 @@ pub async fn remove_reaction(
     // Get conversation for this message
     let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_reaction/get_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("remove_reaction/get_conversation")?
         .ok_or_else(|| AppError::bad_request("Message not found"))?;
 
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_reaction/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("remove_reaction/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -142,10 +127,7 @@ pub async fn remove_reaction(
     // Look up username for broadcast
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_reaction/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("remove_reaction/find_user")?
         .ok_or_else(|| AppError::internal("User not found"))?;
 
     // Broadcast removal to conversation members
@@ -173,10 +155,7 @@ pub async fn mark_read(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in mark_read/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("mark_read/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -184,10 +163,7 @@ pub async fn mark_read(
 
     let privacy = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in mark_read/get_privacy: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("mark_read/get_privacy")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     if !privacy.read_receipts_enabled {

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -77,10 +77,7 @@ pub async fn get_my_privacy(
 ) -> Result<impl IntoResponse, AppError> {
     let privacy = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_my_privacy: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_my_privacy")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     Ok(Json(PrivacyPreferencesResponse {
@@ -102,10 +99,7 @@ pub async fn update_my_privacy(
 ) -> Result<impl IntoResponse, AppError> {
     let current = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_my_privacy/get_current: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("update_my_privacy/get_current")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     let prefs = db::users::PrivacyUpdate {
@@ -151,10 +145,7 @@ pub async fn get_profile(
 ) -> Result<impl IntoResponse, AppError> {
     let profile = db::users::find_public_profile(&state.pool, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_profile: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_profile")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     Ok(Json(UserProfile {
@@ -268,10 +259,7 @@ pub async fn update_profile(
     };
     let profile = db::users::update_profile(&state.pool, auth.user_id, &fields)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_profile: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("update_profile")?;
 
     Ok(Json(UserProfile {
         user_id: profile.id,
@@ -310,10 +298,7 @@ pub async fn update_presence_status(
 
     db::users::update_presence_status(&state.pool, auth.user_id, &body.status)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_presence_status: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("update_presence_status")?;
 
     // Broadcast to contacts.  Invisible users appear offline to others.
     let broadcast_status = if body.status == "invisible" {
@@ -509,10 +494,7 @@ pub async fn online_users(
 ) -> Result<impl IntoResponse, AppError> {
     let contact_ids = db::contacts::list_contact_user_ids(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in online_users/list_contacts: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("online_users/list_contacts")?;
     let all_online = state.hub.get_online_user_ids();
     let online_contacts: Vec<_> = all_online
         .into_iter()
@@ -538,10 +520,7 @@ pub async fn search_users(
 
     let results = db::users::search_users(&state.pool, query, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in search_users: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("search_users")?;
 
     let users: Vec<_> = results
         .into_iter()
@@ -591,10 +570,7 @@ pub async fn resolve_username_invite(
 
     let resolved = db::users::resolve_username_invite(&state.pool, auth.user_id, candidate)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in resolve_username_invite: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("resolve_username_invite")?
         .ok_or_else(|| AppError::not_found("User not found"))?;
 
     let discoverable = resolved.searchable
@@ -792,9 +768,6 @@ pub async fn update_status_text(
     }
     db::users::update_status_text(&state.pool, auth.user_id, text)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_status_text: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("update_status_text")?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::routes::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -64,10 +64,7 @@ pub async fn generate_token(
     // longer has to race a post-connect `setName` call.
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error looking up user for voice token: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("looking up user for voice token")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     let username = user.username;
@@ -97,10 +94,7 @@ pub async fn generate_token(
 
     let is_member = db::groups::is_member(&state.pool, conv_uuid, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error checking voice token membership: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("checking voice token membership")?;
     if !is_member {
         return Err(AppError::bad_request("Not a member of this conversation"));
     }

--- a/apps/server/src/routes/ws.rs
+++ b/apps/server/src/routes/ws.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::ws::handler;
 
 use super::AppState;
@@ -52,10 +52,7 @@ pub async fn ws_upgrade(
 
     let user = db::users::find_by_id(&state.pool, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ws_upgrade/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ws_upgrade/find_user")?
         .ok_or_else(|| AppError::unauthorized("User not found"))?;
 
     tracing::info!(

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -88,6 +88,19 @@ impl Hub {
             .collect()
     }
 
+    /// Number of devices currently registered for `user_id`.  Used by the
+    /// presence broadcaster (#436) to gate `online`/`offline` events on
+    /// first-device-up / last-device-down so a user with three devices
+    /// reconnecting after a flaky network blip doesn't make contacts see
+    /// online/offline/online/offline per device.
+    pub fn device_count(&self, user_id: &Uuid) -> usize {
+        self.inner
+            .connections
+            .get(user_id)
+            .map(|devices| devices.len())
+            .unwrap_or(0)
+    }
+
     /// Send a message to ALL connected devices of a user.
     /// Returns true if at least one device's outbound queue accepted the
     /// message. Full/closed queues are logged separately so beta-test

--- a/apps/server/src/ws/mod.rs
+++ b/apps/server/src/ws/mod.rs
@@ -1,4 +1,4 @@
 pub mod handler;
 pub mod hub;
 pub(crate) mod message_service;
-pub(crate) mod typing_service;
+pub mod typing_service;

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -284,7 +284,11 @@ pub(super) async fn broadcast_presence(
         Err(_) => return,
     };
 
+    // Audit #690: build the WsMessage once outside the loop. axum's
+    // Message::Text is backed by bytes::Bytes, so msg.clone() inside the
+    // loop is O(1) reference-count bump rather than a fresh String alloc.
+    let msg = WsMessage::Text(json.into());
     for cid in &contact_ids {
-        state.hub.send_to(cid, WsMessage::Text(json.clone().into()));
+        state.hub.send_to(cid, msg.clone());
     }
 }

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -235,6 +235,25 @@ pub(super) async fn broadcast_presence(
     username: &str,
     status: &str,
 ) {
+    // Audit #436: gate presence on first-device-up / last-device-down so
+    // a multi-device user reconnecting after a network blip doesn't make
+    // every contact see online/offline/online/offline once per device.
+    // `register` happens before this call (online) and `unregister` happens
+    // before this call (offline), so:
+    //   online:  device_count == 1 -> first device just connected, broadcast
+    //   online:  device_count >  1 -> already had other devices, no-op
+    //   offline: device_count == 0 -> last device just disconnected, broadcast
+    //   offline: device_count >  0 -> still has other devices, no-op
+    let dev_count = state.hub.device_count(&user_id);
+    let should_broadcast = match status {
+        "online" => dev_count == 1,
+        "offline" => dev_count == 0,
+        _ => true, // explicit status changes (away/dnd) always broadcast
+    };
+    if !should_broadcast {
+        return;
+    }
+
     let contact_ids = match db::contacts::list_contact_user_ids(&state.pool, user_id).await {
         Ok(ids) => ids,
         Err(e) => {

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -104,6 +104,48 @@ pub fn invalidate_member_cache(conversation_id: Uuid) {
     MEMBERSHIP_CACHE.retain(|(_, conv_id), _| *conv_id != conversation_id);
 }
 
+/// Periodic sweep that drops cache entries older than 2× their TTL across
+/// all three caches.  Called from the cleanup scheduler in main.rs every
+/// 5 minutes (audit #692).  Without this, entries never expire on a busy
+/// server -- after 24h a `MEMBERSHIP_CACHE` for a public group with 1k
+/// members and 100 typers can hold 100k stale `(user_id, conversation_id)`
+/// pairs that no live read path will ever revisit.
+pub fn sweep_expired_caches() {
+    let cutoff = MEMBERSHIP_CACHE_TTL * 2;
+    let mut membership_evicted = 0usize;
+    MEMBERSHIP_CACHE.retain(|_, last_seen| {
+        let keep = last_seen.elapsed() < cutoff;
+        if !keep {
+            membership_evicted += 1;
+        }
+        keep
+    });
+    let mut member_ids_evicted = 0usize;
+    MEMBER_IDS_CACHE.retain(|_, (_, fetched_at)| {
+        let keep = fetched_at.elapsed() < cutoff;
+        if !keep {
+            member_ids_evicted += 1;
+        }
+        keep
+    });
+    let mut kind_evicted = 0usize;
+    CONV_KIND_CACHE.retain(|_, (_, fetched_at)| {
+        let keep = fetched_at.elapsed() < cutoff;
+        if !keep {
+            kind_evicted += 1;
+        }
+        keep
+    });
+    if membership_evicted > 0 || member_ids_evicted > 0 || kind_evicted > 0 {
+        tracing::debug!(
+            membership_evicted,
+            member_ids_evicted,
+            kind_evicted,
+            "ws cache sweep"
+        );
+    }
+}
+
 pub(super) async fn handle_typing(
     state: &AppState,
     sender_id: Uuid,


### PR DESCRIPTION
## Summary

Stacked on top of #703 (Sprint 1 + audit + Riverpod slice). Lands **6 of 9** Sprint 2 items from `SPRINT_PLAN.md`. Three items intentionally deferred to a follow-up — see "deferred" section.

Once #703 merges, this PR's base auto-retargets to `dev`.

## Items shipped

| # | Issue | Severity | What |
|---|---|---|---|
| 1 | #694 (H18) | high (cq) | `DbErrCtx` extension trait on `Result<_, sqlx::Error>` + perl-driven sweep. Replaced 91 of 120 identical "DB error → AppError::internal" closures across `routes/*.rs`. Net 226 lines removed. The 29 not swept have custom user-facing messages (e.g. "Failed to delete channel") and stay with their explicit closures. |
| 2 | #678 + #638 | high+med | `(SELECT COUNT(*) ...)` correlated reply-count subqueries in `get_messages` / `get_undelivered` → `LEFT JOIN LATERAL`, matching the shape `search_messages` already used. New migration `20260501000000_drop_duplicate_reply_to_index.sql` drops the duplicate `idx_messages_reply_to` partial index (baseline) since `idx_messages_reply_to_id` (20260423) covers the same column with the same predicate — halves write amplification on every reply. |
| 3 | #625 + #692 | high | Per-task `tokio::spawn` with `catch_unwind` panic recovery via new `spawn_periodic` helper. Per-task cadence (voice 60s, expired_messages 30s, expired_tokens / used_prekeys 600s, empty_groups 300s, cache_sweep 300s). `delete_group_dependents` 9-statement teardown wrapped in one transaction with rollback-on-first-failure + structured logging. Cache sweep + missing `invalidate_member_cache` call from `join_public_group`. |
| 4 | #690 (partial) | high | `broadcast_presence` now builds `WsMessage::Text` once outside the fanout loop (was cloning the full String body per contact). Per-device `build_per_device_json` case is **deferred** — needs manual JSON construction with field escapes + bench validation. |
| 5 | #436 (M64) | med | Presence flap fix: `broadcast_presence` gates on first-device-up / last-device-down via new `Hub::device_count`. Multi-device users reconnecting after a network blip no longer make contacts see online/offline/online/offline. |

## Items deferred (for a follow-up Sprint 2.5 PR)

| # | Issue | Reason for deferral |
|---|---|---|
| #688 (H8) | LIMIT/OFFSET pagination on `list_contacts`/`list_blocked`/`list_pending`/`get_group_members`/`get_group_member_previews` + route-layer params. Mechanical but touches the conversation-list CTE feeders too. |
| #691 (H14) | `get_conversation_auth_context` returning `{kind, role, is_public}` in one query + sweep of ~30 route handlers that currently do 2-3 round-trips. Substantial coordinated edit. |
| #680 | Stream media uploads + downloads via `ReaderStream`/`Body::from_stream`. Requires careful testing of Range-request semantics + Content-Length headers + auth-ticket flow. |

These three remain open issues; not closed by this PR.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (260+ tests; one transient flake in `search_users_returns_results` that reproduces only under parallel runs and is exactly the test-state-leakage issue documented in H21 / #699 — passes in isolation)
- New tests: `db_ctx_passes_through_ok`, `db_ctx_maps_err_to_internal`

## Files of note

- `apps/server/src/error.rs` — `DbErrCtx` trait + tests
- `apps/server/src/main.rs` — `spawn_periodic` helper, per-task cleanup, transactional `delete_group_dependents`
- `apps/server/src/ws/typing_service.rs` — `sweep_expired_caches`, presence gating, fanout fix
- `apps/server/src/ws/hub.rs` — `device_count`
- `apps/server/migrations/20260501000000_drop_duplicate_reply_to_index.sql` — drops `idx_messages_reply_to`

## Stacking

PR base is `audit-sprint1-riverpod` (#703). When #703 merges to `dev`, GitHub auto-retargets this to `dev`. If #703 needs revision before Sprint 2 reviews, those changes flow into this branch on rebase.

## Test plan

- [ ] Code review the 5 commits in branch order
- [ ] Verify the `idx_messages_reply_to` drop migration runs cleanly in staging (drop is idempotent via `IF EXISTS`)
- [ ] Confirm presence-flap fix works on a multi-device test account
- [ ] Decide whether the 3 deferred items get a Sprint 2.5 PR or roll into Sprint 3