### PR TITLE
sprint 4: triaged quick-wins + comment-bloat sweep + god-module triage (stacked on #710)

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -75,13 +75,11 @@ jobs:
           print(f"Coverage {pct:.1f}% meets the required {threshold:.0f}% threshold.")
           EOF
       - name: Upload Flutter coverage
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: apps/client/coverage/lcov.info
           flags: flutter
-          # Codecov rejects tokenless uploads on protected branches; the
-          # coverage threshold check above is already enforced separately,
-          # so let the upload fail soft until CODECOV_TOKEN is wired up.
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - **Server required env**: `DATABASE_URL` and `JWT_SECRET` (≥32 chars, panics without them). Optional: `SERVER_HOST` (default `0.0.0.0`), `SERVER_PORT` (default `8080`), `CORS_ORIGINS` for allowed origins, `RUST_LOG` for log filtering (e.g. `echo_server=debug`). Legacy `HOST`/`PORT` are still accepted but emit a deprecation warning at startup (#532).
 - **Traefik routing**: API priority 100, Web priority 1 (API routes must take precedence).
 - **Message wire format**: Initial V2 (with OTP) = `[0xEC, 0x02] + identity_pub(32) + ephemeral_pub(32) + otp_id(4 LE) + ratchet_wire`; Initial V1 (no OTP) = `[0xEC, 0x01] + identity_pub(32) + ephemeral_pub(32) + ratchet_wire`; Normal = `header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`. All base64-wrapped over WebSocket.
-- **Soft deletes**: Messages use `is_deleted` flag, not hard deletes.
+- **Soft deletes**: Messages use a `deleted_at TIMESTAMPTZ NULL` column; queries filter with `deleted_at IS NULL`. Hard deletes only happen during `cleanup_expired_messages` (disappearing TTL) and `delete_group_dependents`.
 - **Refresh tokens (web)**: HttpOnly + Secure + SameSite=Strict cookie scoped to `/api/auth`; mobile/desktop continue to use the JSON body. `/refresh` accepts either; cookie wins. CORS requires explicit origins (not `*`) when cookie auth is enabled.
 
 ## Commit Style
@@ -155,5 +155,5 @@ Three compose files in `infra/docker/`:
 
 1. Session keys cached in memory with 24h idle TTL + 200-entry LRU cap; evicted entries have key material zeroed and reload from secure storage on demand.
 2. Multi-device: key-level revoke + last_seen + platform metadata work end-to-end; refresh tokens are not yet bound per device, so "logout all others" only kicks connected sessions via WS and truly offline sessions get blocked at next key operation.
-3. `core/rust-core/src/api.rs` has `todo!()` stubs (FFI bridge not integrated)
+3. `core/rust-core` ships Signal Protocol primitives only (X3DH, Double Ratchet, key types). The originally-planned FFI bridge to a Dart-side runtime never landed; the Dart client re-implements the protocol in pure Dart and the rust-core code path is exercised only by Rust integration tests. A few transitive deps (`rusqlite`, `tokio-tungstenite`, `reqwest`) sit in `Cargo.toml` from that abandoned design and could be pruned.
 4. Rate limiting is in-memory only (resets on server restart)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "dotenvy",
+ "echo-core",
  "ed25519-dalek",
  "futures-util",
  "infer",

--- a/apps/client/analysis_options.yaml
+++ b/apps/client/analysis_options.yaml
@@ -23,6 +23,8 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    prefer_const_constructors: true
+    prefer_const_literals_to_create_immutables: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/apps/client/lib/src/providers/contacts_provider.dart
+++ b/apps/client/lib/src/providers/contacts_provider.dart
@@ -56,6 +56,12 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
   bool _isPendingLoadInFlight = false;
   DateTime? _lastPendingLoadedAt;
 
+  /// Monotonic generation counter for [loadContacts] (#599). Each call
+  /// captures `++_loadGen` and bails before mutating state when the captured
+  /// value no longer matches -- guards against a stale in-flight response
+  /// overwriting fresh state when two reloads overlap.
+  int _loadGen = 0;
+
   ContactsNotifier(this.ref) : super(const ContactsState());
 
   String get _serverUrl => ref.read(serverUrlProvider);
@@ -74,6 +80,7 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
 
   Future<void> loadContacts() async {
     state = state.copyWith(isLoading: true, error: null);
+    final gen = ++_loadGen;
     try {
       final response = await _authenticatedRequest(
         (token) => http.get(
@@ -81,6 +88,10 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
           headers: _headersWithToken(token),
         ),
       );
+      // Drop a stale response -- a newer call has been issued or the notifier
+      // was disposed while awaiting.
+      if (gen != _loadGen || !mounted) return;
+
       if (response.statusCode == 200) {
         final list = (jsonDecode(response.body) as List)
             .map((e) => Contact.fromJson(e as Map<String, dynamic>))
@@ -93,6 +104,7 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
         );
       }
     } catch (e) {
+      if (gen != _loadGen || !mounted) return;
       state = state.copyWith(isLoading: false, error: e.toString());
     }
   }

--- a/apps/client/lib/src/screens/settings/privacy_section.dart
+++ b/apps/client/lib/src/screens/settings/privacy_section.dart
@@ -586,11 +586,11 @@ class _PrivacySectionState extends ConsumerState<PrivacySection> {
         ),
         if (crypto.isInitialized && !crypto.keysUploadFailed) ...[
           const SizedBox(height: 12),
-          Row(
+          const Row(
             children: [
-              const Icon(Icons.verified_user, color: Colors.green, size: 18),
-              const SizedBox(width: 8),
-              const Text(
+              Icon(Icons.verified_user, color: Colors.green, size: 18),
+              SizedBox(width: 8),
+              Text(
                 'Encryption keys active',
                 style: TextStyle(
                   color: Colors.green,

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -24,6 +24,7 @@ import 'avatar_utils.dart' show buildAvatar, groupAvatarColor, resolveAvatarUrl;
 import 'shared_media_gallery.dart';
 
 const _disappearingMessagesLabel = 'Disappearing messages';
+const _kAuthorizationHeader = 'Authorization';
 
 class ChatHeaderBar extends ConsumerWidget {
   final Conversation conversation;
@@ -721,7 +722,7 @@ class ChatHeaderBar extends ConsumerWidget {
             (token) => http.put(
               Uri.parse('$serverUrl/api/conversations/${conv.id}/disappearing'),
               headers: {
-                'Authorization': 'Bearer $token',
+                _kAuthorizationHeader: 'Bearer $token',
                 'Content-Type': 'application/json',
               },
               body: jsonEncode({'ttl_seconds': ttl}),
@@ -905,7 +906,7 @@ class _IdentityChangedBadgeState extends ConsumerState<_IdentityChangedBadge> {
       padding: const EdgeInsets.only(left: 4),
       child: Semantics(
         label: 'identity changed warning',
-        child: Tooltip(
+        child: const Tooltip(
           message: "Identity changed -- verify safety number",
           child: Icon(
             Icons.warning_amber_rounded,
@@ -1089,7 +1090,7 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                 '/${widget.conversationId}/pinned',
               ),
               headers: {
-                'Authorization': 'Bearer $token',
+                _kAuthorizationHeader: 'Bearer $token',
                 'Content-Type': 'application/json',
               },
             ),
@@ -1140,7 +1141,7 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                 '/${widget.conversationId}'
                 '/messages/${message.id}/pin',
               ),
-              headers: {'Authorization': 'Bearer $token'},
+              headers: {_kAuthorizationHeader: 'Bearer $token'},
             ),
           );
 

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -724,12 +724,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'chat',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.person_add_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.person_add_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text('New Chat', overflow: TextOverflow.ellipsis),
                     ),
                   ],
@@ -742,12 +742,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'group',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.group_add_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.group_add_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text('New Group', overflow: TextOverflow.ellipsis),
                     ),
                   ],
@@ -760,12 +760,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'discover',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.explore_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.explore_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text(
                         'Discover Groups',
                         overflow: TextOverflow.ellipsis,
@@ -781,12 +781,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'saved',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.bookmark_border_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.bookmark_border_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text(
                         'Saved Messages',
                         overflow: TextOverflow.ellipsis,

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -798,7 +798,10 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
             ),
           ],
         ),
-        if (pendingCount > 0)
+        if (pendingCount > 0 &&
+            (kIsWeb ||
+                defaultTargetPlatform == TargetPlatform.android ||
+                defaultTargetPlatform == TargetPlatform.iOS))
           Positioned(
             // Re-center the badge on the larger 44×44 button.
             top: 6,

--- a/apps/client/lib/src/widgets/crypto_degraded_banner.dart
+++ b/apps/client/lib/src/widgets/crypto_degraded_banner.dart
@@ -37,7 +37,7 @@ class CryptoDegradedBanner extends ConsumerWidget {
                     Flexible(
                       child: Text(
                         cryptoState.error!,
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 12,
                           color: EchoTheme.warning,
                           fontWeight: FontWeight.w500,

--- a/apps/client/lib/src/widgets/identity_key_changed_banner.dart
+++ b/apps/client/lib/src/widgets/identity_key_changed_banner.dart
@@ -147,7 +147,7 @@ class _IdentityKeyChangedBannerState
                       child: Text(
                         "Security alert: $_peerUsername's identity key "
                         'has changed. Verify their safety number.',
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 12,
                           color: EchoTheme.warning,
                           fontWeight: FontWeight.w500,
@@ -203,7 +203,7 @@ class _IdentityKeyChangedBannerState
                               width: 1,
                             ),
                           ),
-                          child: Text(
+                          child: const Text(
                             'Trust new key',
                             style: TextStyle(
                               fontSize: 11,

--- a/apps/client/lib/src/widgets/quick_switcher_overlay.dart
+++ b/apps/client/lib/src/widgets/quick_switcher_overlay.dart
@@ -152,7 +152,7 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
       child: GestureDetector(
         onTap: () => Navigator.of(context).pop(),
         child: Material(
-          color: Colors.black54,
+          color: context.mainBg.withValues(alpha: 0.54),
           child: Center(
             child: GestureDetector(
               onTap: () {}, // prevent backdrop tap
@@ -165,7 +165,7 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
                   border: Border.all(color: context.border),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.4),
+                      color: context.mainBg.withValues(alpha: 0.4),
                       blurRadius: 24,
                       offset: const Offset(0, 8),
                     ),

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -657,7 +657,9 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
       height: _kAvatarSize,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: hasVideo ? Colors.black : Colors.black.withValues(alpha: 0.45),
+        color: hasVideo
+            ? context.chatBg
+            : context.chatBg.withValues(alpha: 0.45),
       ),
       clipBehavior: Clip.antiAlias,
       child: hasVideo
@@ -684,7 +686,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
           border: Border.all(color: speakRingColor, width: ringWidth),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.35),
+              color: context.mainBg.withValues(alpha: 0.35),
               blurRadius: 8,
               offset: const Offset(0, 3),
             ),
@@ -703,13 +705,13 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
           decoration: BoxDecoration(
-            color: Colors.black54,
+            color: context.surface.withValues(alpha: 0.54),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Text(
             info.name,
-            style: const TextStyle(
-              color: Colors.white,
+            style: TextStyle(
+              color: context.textPrimary,
               fontSize: 11,
               fontWeight: FontWeight.w500,
             ),
@@ -750,8 +752,8 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
   Widget _initialsWidget(String initial) => Center(
     child: Text(
       initial,
-      style: const TextStyle(
-        color: Colors.white,
+      style: TextStyle(
+        color: context.textPrimary,
         fontSize: 18,
         fontWeight: FontWeight.bold,
       ),
@@ -802,7 +804,7 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                 borderRadius: BorderRadius.circular(4),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.4),
+                    color: context.mainBg.withValues(alpha: 0.4),
                     blurRadius: 8,
                     offset: const Offset(0, 2),
                   ),
@@ -815,11 +817,8 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                   httpHeaders: widget.httpHeaders ?? const {},
                   fit: BoxFit.cover,
                   errorWidget: (_, _, _) => Container(
-                    color: Colors.grey[800],
-                    child: const Icon(
-                      Icons.broken_image,
-                      color: Colors.white54,
-                    ),
+                    color: context.surfaceHover,
+                    child: Icon(Icons.broken_image, color: context.textMuted),
                   ),
                 ),
               ),
@@ -833,15 +832,15 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                   child: Container(
                     width: 32,
                     height: 32,
-                    decoration: const BoxDecoration(
-                      color: Colors.black54,
+                    decoration: BoxDecoration(
+                      color: context.surface.withValues(alpha: 0.54),
                       shape: BoxShape.circle,
                     ),
                     alignment: Alignment.center,
-                    child: const Icon(
+                    child: Icon(
                       Icons.close,
                       size: 16,
-                      color: Colors.white,
+                      color: context.textPrimary,
                     ),
                   ),
                 ),

--- a/apps/client/test/audit_logic_flaws_test.dart
+++ b/apps/client/test/audit_logic_flaws_test.dart
@@ -30,7 +30,7 @@ void main() {
       const state = ChatState();
 
       // Add 3 pending messages
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'pending_1000',
         fromUserId: 'me',
         fromUsername: 'Me',
@@ -40,7 +40,7 @@ void main() {
         isMine: true,
         status: MessageStatus.sending,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'pending_2000',
         fromUserId: 'me',
         fromUsername: 'Me',
@@ -50,7 +50,7 @@ void main() {
         isMine: true,
         status: MessageStatus.sending,
       );
-      final msg3 = ChatMessage(
+      final msg3 = const ChatMessage(
         id: 'pending_3000',
         fromUserId: 'me',
         fromUsername: 'Me',
@@ -234,7 +234,7 @@ void main() {
       // BEFORE the server call. No rollback on failure.
 
       const conv = Conversation(id: 'conv1', isGroup: false, unreadCount: 5);
-      final state = ConversationsState(conversations: [conv]);
+      final state = const ConversationsState(conversations: [conv]);
       expect(state.conversations.first.unreadCount, 5);
 
       // After markAsRead, count is 0 regardless of server response
@@ -263,7 +263,7 @@ void main() {
       // Stale messages remain in memory.
 
       const chatState = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -334,7 +334,7 @@ void main() {
       // chat_provider.dart:79 — replyToMessage is a global field in ChatState,
       // not scoped to a conversation. Switching conversations doesn't clear it.
 
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg_in_conv1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -365,7 +365,7 @@ void main() {
       'ConversationsState supports restoring unread count after failure',
       () {
         const conv = Conversation(id: 'conv1', isGroup: false, unreadCount: 5);
-        final state = ConversationsState(conversations: [conv]);
+        final state = const ConversationsState(conversations: [conv]);
 
         // Optimistically clear
         final updated = List<Conversation>.from(state.conversations);
@@ -392,7 +392,7 @@ void main() {
   group('H3 fix: clearConversation removes cached messages', () {
     test('ChatState can remove all messages for a conversation', () {
       const state = ChatState();
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -401,7 +401,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'bob',
         fromUsername: 'bob',
@@ -462,7 +462,7 @@ void main() {
   group('H6 fix: reaction guard on deleted messages', () {
     test('message existence check prevents reaction on deleted message', () {
       const state = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -537,7 +537,7 @@ void main() {
   // =========================================================================
   group('M2 fix: edit mode clears reply state', () {
     test('entering edit should clear replyToMessage', () {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',

--- a/apps/client/test/models/canvas_models_test.dart
+++ b/apps/client/test/models/canvas_models_test.dart
@@ -21,14 +21,11 @@ void main() {
 
   group('CanvasStroke', () {
     test('pen stroke round-trips through JSON', () {
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 'stroke-1',
         color: '#FF0000',
         width: 4.0,
-        points: const [
-          CanvasPoint(x: 0.1, y: 0.2),
-          CanvasPoint(x: 0.3, y: 0.4),
-        ],
+        points: [CanvasPoint(x: 0.1, y: 0.2), CanvasPoint(x: 0.3, y: 0.4)],
         kind: StrokeKind.pen,
       );
 
@@ -43,11 +40,11 @@ void main() {
     });
 
     test('eraser stroke preserves kind', () {
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 'e-1',
         color: '#00000000',
         width: 10.0,
-        points: const [CanvasPoint(x: 0.5, y: 0.5)],
+        points: [CanvasPoint(x: 0.5, y: 0.5)],
         kind: StrokeKind.eraser,
       );
       final json = stroke.toJson();
@@ -135,7 +132,7 @@ void main() {
       final updated = state.copyWith(
         isLoaded: true,
         selectedTool: CanvasTool.eraser,
-        currentColor: Color(0xFFFF0000),
+        currentColor: const Color(0xFFFF0000),
         strokeWidth: 8.0,
       );
       expect(updated.isLoaded, isTrue);
@@ -152,11 +149,11 @@ void main() {
 
     test('copyWith strokes appends correctly', () {
       const state = CanvasState();
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 's1',
         color: '#00FF00',
         width: 3.0,
-        points: const [CanvasPoint(x: 0.0, y: 0.0)],
+        points: [CanvasPoint(x: 0.0, y: 0.0)],
       );
       final updated = state.copyWith(strokes: [stroke]);
       expect(updated.strokes.length, 1);

--- a/apps/client/test/models/conversation_test.dart
+++ b/apps/client/test/models/conversation_test.dart
@@ -52,11 +52,11 @@ void main() {
     });
 
     test('displayName shows group name for groups', () {
-      final conv = Conversation(
+      final conv = const Conversation(
         id: 'conv-1',
         name: 'Team Chat',
         isGroup: true,
-        members: const [
+        members: [
           ConversationMember(userId: 'user-1', username: 'alice'),
           ConversationMember(userId: 'user-2', username: 'bob'),
         ],
@@ -66,10 +66,10 @@ void main() {
     });
 
     test('displayName shows peer name for 1:1', () {
-      final conv = Conversation(
+      final conv = const Conversation(
         id: 'conv-1',
         isGroup: false,
-        members: const [
+        members: [
           ConversationMember(userId: 'user-1', username: 'alice'),
           ConversationMember(userId: 'user-2', username: 'bob'),
         ],
@@ -80,7 +80,7 @@ void main() {
     });
 
     test('copyWith updates specified fields', () {
-      final conv = Conversation(
+      final conv = const Conversation(
         id: 'conv-1',
         name: 'Old Name',
         isGroup: true,

--- a/apps/client/test/providers/canvas_provider_test.dart
+++ b/apps/client/test/providers/canvas_provider_test.dart
@@ -15,14 +15,11 @@ void main() {
   group('handleCanvasEvent – stroke', () {
     test('appends stroke to state', () {
       var state = const CanvasState(isLoaded: true);
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 'stroke-1',
         color: '#FFFFFF',
         width: 3.0,
-        points: const [
-          CanvasPoint(x: 0.1, y: 0.2),
-          CanvasPoint(x: 0.3, y: 0.4),
-        ],
+        points: [CanvasPoint(x: 0.1, y: 0.2), CanvasPoint(x: 0.3, y: 0.4)],
       );
 
       // Simulate what handleCanvasEvent("stroke") does.
@@ -36,20 +33,20 @@ void main() {
 
   group('handleCanvasEvent – clear', () {
     test('removes all strokes', () {
-      var state = CanvasState(
+      var state = const CanvasState(
         isLoaded: true,
         strokes: [
           CanvasStroke(
             id: 'a',
             color: '#FF0000',
             width: 2.0,
-            points: const [CanvasPoint(x: 0.0, y: 0.0)],
+            points: [CanvasPoint(x: 0.0, y: 0.0)],
           ),
           CanvasStroke(
             id: 'b',
             color: '#00FF00',
             width: 2.0,
-            points: const [CanvasPoint(x: 0.5, y: 0.5)],
+            points: [CanvasPoint(x: 0.5, y: 0.5)],
           ),
         ],
       );
@@ -90,7 +87,7 @@ void main() {
         width: 0.25,
         height: 0.2,
       );
-      var state = CanvasState(isLoaded: true, images: [original]);
+      var state = const CanvasState(isLoaded: true, images: [original]);
 
       // Simulate image_move
       final updated = original.copyWith(x: 0.5, y: 0.6);
@@ -121,7 +118,7 @@ void main() {
         width: 0.1,
         height: 0.1,
       );
-      var state = CanvasState(isLoaded: true, images: [img1, img2]);
+      var state = const CanvasState(isLoaded: true, images: [img1, img2]);
 
       final newImages = state.images.where((img) => img.id != 'img-1').toList();
       state = state.copyWith(images: newImages);

--- a/apps/client/test/providers/channels_provider_test.dart
+++ b/apps/client/test/providers/channels_provider_test.dart
@@ -46,10 +46,10 @@ void main() {
     });
 
     test('copyWith preserves unchanged fields', () {
-      final state = ChannelsState(
+      final state = const ChannelsState(
         channelsByConversation: {
           'conv-1': [
-            const GroupChannel(
+            GroupChannel(
               id: 'ch-1',
               conversationId: 'conv-1',
               name: 'general',
@@ -59,7 +59,7 @@ void main() {
             ),
           ],
         },
-        loadingConversations: const {'conv-2'},
+        loadingConversations: {'conv-2'},
       );
 
       final copied = state.copyWith(error: 'test error');

--- a/apps/client/test/providers/chat_notifier_test.dart
+++ b/apps/client/test/providers/chat_notifier_test.dart
@@ -344,7 +344,7 @@ void main() {
       final notifier = _createNotifier();
       notifier.addMessage(_msg1);
 
-      final reaction = Reaction(
+      final reaction = const Reaction(
         messageId: 'msg-1',
         userId: 'user-2',
         username: 'bob',
@@ -361,7 +361,7 @@ void main() {
       final notifier = _createNotifier();
       notifier.addMessage(_msg1);
 
-      final reaction = Reaction(
+      final reaction = const Reaction(
         messageId: 'msg-1',
         userId: 'user-2',
         username: 'bob',

--- a/apps/client/test/providers/chat_provider_state_test.dart
+++ b/apps/client/test/providers/chat_provider_state_test.dart
@@ -29,7 +29,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final state = ChatState(
+      final state = const ChatState(
         messagesByConversation: {
           'conv-1': [msg],
         },
@@ -69,7 +69,7 @@ void main() {
         isMine: false,
       );
 
-      final state = ChatState(
+      final state = const ChatState(
         messagesByConversation: {
           'conv-1': [msg1, msg2, msg3],
         },
@@ -92,13 +92,13 @@ void main() {
     });
 
     test('isLoadingHistory returns correct value', () {
-      final state = ChatState(loadingHistory: {'conv-1:': true});
+      final state = const ChatState(loadingHistory: {'conv-1:': true});
       expect(state.isLoadingHistory('conv-1'), isTrue);
       expect(state.isLoadingHistory('conv-2'), isFalse);
     });
 
     test('isLoadingHistory with channel', () {
-      final state = ChatState(loadingHistory: {'conv-1:ch-1': true});
+      final state = const ChatState(loadingHistory: {'conv-1:ch-1': true});
       expect(state.isLoadingHistory('conv-1', channelId: 'ch-1'), isTrue);
       expect(state.isLoadingHistory('conv-1'), isFalse);
     });
@@ -109,7 +109,7 @@ void main() {
     });
 
     test('conversationHasMore returns stored value', () {
-      final state = ChatState(hasMore: {'conv-1:': false});
+      final state = const ChatState(hasMore: {'conv-1:': false});
       expect(state.conversationHasMore('conv-1'), isFalse);
     });
 
@@ -388,7 +388,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final state = ChatState(
+      final state = const ChatState(
         messagesByConversation: {
           'conv-1': [msg],
         },

--- a/apps/client/test/providers/chat_provider_test.dart
+++ b/apps/client/test/providers/chat_provider_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     test('withMessage adds message to correct conversation', () {
       const state = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -28,7 +28,7 @@ void main() {
 
     test('messages for different conversations are isolated', () {
       const state = ChatState();
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -37,7 +37,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'user2',
         fromUsername: 'bob',
@@ -54,7 +54,7 @@ void main() {
 
     test('withMessage deduplicates by id', () {
       const state = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -84,7 +84,7 @@ void main() {
     });
 
     test('Reaction model', () {
-      final r = Reaction(
+      final r = const Reaction(
         messageId: 'm1',
         userId: 'u1',
         username: 'alice',
@@ -101,7 +101,7 @@ void main() {
 
     test('copyWith with replyToMessage sets the reply', () {
       const state = ChatState();
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'reply-1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -117,7 +117,7 @@ void main() {
     });
 
     test('copyWith with clearReply clears the reply', () {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'reply-1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -134,7 +134,7 @@ void main() {
     });
 
     test('clearReply takes precedence over replyToMessage in copyWith', () {
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'r1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -150,7 +150,7 @@ void main() {
     });
 
     test('withMessage preserves replyToMessage', () {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'reply-1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -160,7 +160,7 @@ void main() {
         isMine: false,
       );
       final state = ChatState(replyToMessage: replyMsg);
-      final newMsg = ChatMessage(
+      final newMsg = const ChatMessage(
         id: 'msg-new',
         fromUserId: 'user2',
         fromUsername: 'bob',
@@ -176,7 +176,7 @@ void main() {
 
     test('messages are ordered by insertion (append-only)', () {
       const state = ChatState();
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -185,7 +185,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'u2',
         fromUsername: 'bob',
@@ -194,7 +194,7 @@ void main() {
         timestamp: '2026-01-01T00:00:01Z',
         isMine: false,
       );
-      final msg3 = ChatMessage(
+      final msg3 = const ChatMessage(
         id: 'msg3',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -212,7 +212,7 @@ void main() {
     });
 
     test('ChatMessage pinnedAt and pinnedById via copyWith', () {
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -252,7 +252,7 @@ void main() {
     });
 
     test('updateMessagePin updates pin on correct message', () {
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -261,7 +261,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'u2',
         fromUsername: 'bob',
@@ -301,7 +301,7 @@ void main() {
     });
 
     test('messagesForConversationChannel filters by channelId', () {
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -311,7 +311,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'u2',
         fromUsername: 'bob',

--- a/apps/client/test/providers/contacts_provider_test.dart
+++ b/apps/client/test/providers/contacts_provider_test.dart
@@ -1,6 +1,19 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:echo_app/src/providers/contacts_provider.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:echo_app/src/models/contact.dart';
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/contacts_provider.dart';
+import 'package:echo_app/src/providers/server_url_provider.dart';
+
+import '../helpers/mock_http_client.dart';
 
 void main() {
   group('ContactsState', () {
@@ -13,9 +26,9 @@ void main() {
     });
 
     test('copyWith preserves contacts, pending, and isLoading', () {
-      final state = ContactsState(
+      final state = const ContactsState(
         contacts: [
-          const Contact(
+          Contact(
             id: 'c1',
             userId: 'u1',
             username: 'alice',
@@ -23,12 +36,7 @@ void main() {
           ),
         ],
         pendingRequests: [
-          const Contact(
-            id: 'c2',
-            userId: 'u2',
-            username: 'bob',
-            status: 'pending',
-          ),
+          Contact(id: 'c2', userId: 'u2', username: 'bob', status: 'pending'),
         ],
         isLoading: true,
       );
@@ -39,14 +47,14 @@ void main() {
     });
 
     test('copyWith with no error argument preserves existing error', () {
-      final state = ContactsState(error: 'old error');
+      final state = const ContactsState(error: 'old error');
       // Omitting the error parameter preserves the current value.
       final copied = state.copyWith();
       expect(copied.error, 'old error');
     });
 
     test('copyWith with explicit null clears error', () {
-      final state = ContactsState(error: 'old error');
+      final state = const ContactsState(error: 'old error');
       final cleared = state.copyWith(error: null);
       expect(cleared.error, isNull);
     });
@@ -141,9 +149,9 @@ void main() {
     });
 
     test('contacts and pending lists are independent', () {
-      final state = ContactsState(
+      final state = const ContactsState(
         contacts: [
-          const Contact(
+          Contact(
             id: 'c1',
             userId: 'u1',
             username: 'alice',
@@ -151,12 +159,7 @@ void main() {
           ),
         ],
         pendingRequests: [
-          const Contact(
-            id: 'c2',
-            userId: 'u2',
-            username: 'bob',
-            status: 'pending',
-          ),
+          Contact(id: 'c2', userId: 'u2', username: 'bob', status: 'pending'),
         ],
       );
 
@@ -169,6 +172,166 @@ void main() {
       final updatedPending = state.copyWith(pendingRequests: []);
       expect(updatedPending.contacts, hasLength(1));
       expect(updatedPending.pendingRequests, isEmpty);
+    });
+  });
+
+  // -----------------------------------------------------------------
+  // #599: monotonic-generation guard for loadContacts.
+  // Two concurrent reloads must not let the older response overwrite
+  // the newer one's state.
+  // -----------------------------------------------------------------
+  group('ContactsNotifier.loadContacts stale-guard (#599)', () {
+    late MockHttpClient mockClient;
+    late ProviderContainer container;
+
+    setUpAll(registerHttpFallbackValues);
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      mockClient = MockHttpClient();
+      when(() => mockClient.close()).thenReturn(null);
+
+      container = ProviderContainer(
+        overrides: [
+          authProvider.overrideWith((ref) {
+            final n = AuthNotifier(ref);
+            n.state = const AuthState(
+              isLoggedIn: true,
+              userId: 'me',
+              username: 'testuser',
+              token: 'fake-token',
+              refreshToken: 'fake-refresh',
+            );
+            return n;
+          }),
+          serverUrlProvider.overrideWith((ref) {
+            final n = ServerUrlNotifier();
+            n.state = 'http://localhost:8080';
+            return n;
+          }),
+        ],
+      );
+    });
+
+    tearDown(() => container.dispose());
+
+    Map<String, dynamic> contactFixture(String id, String username) => {
+      'id': id,
+      'user_id': 'uid-$id',
+      'username': username,
+      'status': 'accepted',
+    };
+
+    test('late stale success does not overwrite fresh success', () async {
+      final completers = <Completer<http.Response>>[
+        Completer<http.Response>(),
+        Completer<http.Response>(),
+      ];
+      var callIndex = 0;
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/contacts')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) => completers[callIndex++].future);
+
+      final notifier = container.read(contactsProvider.notifier);
+      await http.runWithClient(() async {
+        // Fire two reloads without awaiting -- second is the "fresh" one.
+        final a = notifier.loadContacts();
+        final b = notifier.loadContacts();
+
+        // Resolve B (fresh) first with [alice], then A (stale) with [bob].
+        completers[1].complete(
+          http.Response(jsonEncode([contactFixture('1', 'alice')]), 200),
+        );
+        await b;
+
+        completers[0].complete(
+          http.Response(jsonEncode([contactFixture('2', 'bob')]), 200),
+        );
+        await a;
+
+        // Latest call (B / alice) must win even though A finished after.
+        expect(notifier.state.contacts, hasLength(1));
+        expect(notifier.state.contacts.first.username, 'alice');
+        expect(notifier.state.isLoading, isFalse);
+      }, () => mockClient);
+    });
+
+    test('late stale error does not clobber fresh success', () async {
+      final completers = <Completer<http.Response>>[
+        Completer<http.Response>(),
+        Completer<http.Response>(),
+      ];
+      var callIndex = 0;
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/contacts')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) => completers[callIndex++].future);
+
+      final notifier = container.read(contactsProvider.notifier);
+      await http.runWithClient(() async {
+        final a = notifier.loadContacts(); // stale -- will throw
+        final b = notifier.loadContacts(); // fresh -- succeeds
+
+        completers[1].complete(
+          http.Response(jsonEncode([contactFixture('1', 'alice')]), 200),
+        );
+        await b;
+
+        completers[0].completeError(const SocketException('boom'));
+        await a;
+
+        // Stale error must NOT overwrite fresh success.
+        expect(notifier.state.contacts, hasLength(1));
+        expect(notifier.state.contacts.first.username, 'alice');
+        expect(notifier.state.error, isNull);
+        expect(notifier.state.isLoading, isFalse);
+      }, () => mockClient);
+    });
+
+    test('isLoading stays true until the latest call completes', () async {
+      final completers = <Completer<http.Response>>[
+        Completer<http.Response>(),
+        Completer<http.Response>(),
+      ];
+      var callIndex = 0;
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/contacts')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) => completers[callIndex++].future);
+
+      final notifier = container.read(contactsProvider.notifier);
+      await http.runWithClient(() async {
+        final a = notifier.loadContacts();
+        final b = notifier.loadContacts();
+
+        expect(notifier.state.isLoading, isTrue);
+
+        // Resolve the stale call first; loading must stay true.
+        completers[0].complete(
+          http.Response(jsonEncode([contactFixture('1', 'bob')]), 200),
+        );
+        await a;
+        expect(
+          notifier.state.isLoading,
+          isTrue,
+          reason: 'stale return must not flip isLoading=false',
+        );
+
+        // Resolve the fresh call -- THIS one clears loading.
+        completers[1].complete(
+          http.Response(jsonEncode([contactFixture('2', 'alice')]), 200),
+        );
+        await b;
+        expect(notifier.state.isLoading, isFalse);
+        expect(notifier.state.contacts.first.username, 'alice');
+      }, () => mockClient);
     });
   });
 

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -159,10 +159,10 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'group-1', name: 'G1', isGroup: true),
-          const Conversation(id: 'group-2', name: 'G2', isGroup: true),
+          Conversation(id: 'group-1', name: 'G1', isGroup: true),
+          Conversation(id: 'group-2', name: 'G2', isGroup: true),
         ],
       );
 
@@ -192,10 +192,8 @@ void main() {
       ).thenAnswer((_) async => http.Response('error', 500));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
-        conversations: [
-          const Conversation(id: 'group-1', name: 'G1', isGroup: true),
-        ],
+      notifier.state = const ConversationsState(
+        conversations: [Conversation(id: 'group-1', name: 'G1', isGroup: true)],
       );
 
       final result = await http.runWithClient(
@@ -225,8 +223,8 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
-        conversations: [const Conversation(id: 'conv-1', isGroup: false)],
+      notifier.state = const ConversationsState(
+        conversations: [Conversation(id: 'conv-1', isGroup: false)],
       );
 
       final result = await http.runWithClient(
@@ -427,9 +425,9 @@ void main() {
   group('ConversationsNotifier.getOrCreateDm', () {
     test('finds existing DM locally without HTTP call', () async {
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(
+          Conversation(
             id: 'dm-1',
             isGroup: false,
             members: [
@@ -566,9 +564,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
+          Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
         ],
       );
 
@@ -595,9 +593,9 @@ void main() {
       ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
+          Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
         ],
       );
 
@@ -630,9 +628,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -663,9 +661,9 @@ void main() {
       ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -698,9 +696,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -732,9 +730,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('Internal Server Error', 500));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -753,9 +751,9 @@ void main() {
 
     test('no-op returns true when already in target state', () async {
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: true),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: true),
         ],
       );
 
@@ -817,9 +815,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('', 204));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: false),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: false),
         ],
       );
 
@@ -849,9 +847,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('Internal Server Error', 500));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: false),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: false),
         ],
       );
 
@@ -885,9 +883,9 @@ void main() {
       });
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: true),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: true),
         ],
       );
 
@@ -918,9 +916,9 @@ void main() {
       ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: true),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: true),
         ],
       );
 
@@ -939,9 +937,9 @@ void main() {
 
     test('no-op returns true when already in target state', () async {
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: true),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: true),
         ],
       );
 

--- a/apps/client/test/providers/conversations_notifier_test.dart
+++ b/apps/client/test/providers/conversations_notifier_test.dart
@@ -161,7 +161,7 @@ void main() {
 
   group('ConversationsState', () {
     test('copyWith preserves conversations when not overridden', () {
-      final state = ConversationsState(
+      final state = const ConversationsState(
         conversations: [_conv1, _conv2],
         isLoading: true,
       );

--- a/apps/client/test/providers/conversations_provider_test.dart
+++ b/apps/client/test/providers/conversations_provider_test.dart
@@ -12,8 +12,8 @@ void main() {
     });
 
     test('copyWith preserves conversations and isLoading', () {
-      final state = ConversationsState(
-        conversations: [const Conversation(id: 'c1', isGroup: false)],
+      final state = const ConversationsState(
+        conversations: [Conversation(id: 'c1', isGroup: false)],
         isLoading: true,
       );
       final copied = state.copyWith();
@@ -23,7 +23,7 @@ void main() {
     });
 
     test('copyWith with no error argument clears error (by design)', () {
-      final state = ConversationsState(error: 'old error');
+      final state = const ConversationsState(error: 'old error');
       // The copyWith uses direct assignment for error (not null-coalesce),
       // so calling copyWith() without error clears it.
       final copied = state.copyWith();
@@ -82,11 +82,11 @@ void main() {
     });
 
     test('removing a conversation updates the list', () {
-      final state = ConversationsState(
+      final state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'c1', isGroup: false),
-          const Conversation(id: 'c2', isGroup: true, name: 'Group'),
-          const Conversation(id: 'c3', isGroup: false),
+          Conversation(id: 'c1', isGroup: false),
+          Conversation(id: 'c2', isGroup: true, name: 'Group'),
+          Conversation(id: 'c3', isGroup: false),
         ],
       );
       final filtered = state.conversations.where((c) => c.id != 'c2').toList();

--- a/apps/client/test/providers/websocket_provider_test.dart
+++ b/apps/client/test/providers/websocket_provider_test.dart
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('copyWith preserves values when no arguments given', () {
-      final state = WebSocketState(
+      final state = const WebSocketState(
         isConnected: true,
         onlineUsers: {'u1', 'u2'},
       );
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('isUserOnline returns true for online users', () {
-      final state = WebSocketState(onlineUsers: {'user-1', 'user-2'});
+      final state = const WebSocketState(onlineUsers: {'user-1', 'user-2'});
       expect(state.isUserOnline('user-1'), isTrue);
       expect(state.isUserOnline('user-2'), isTrue);
       expect(state.isUserOnline('user-3'), isFalse);
@@ -135,7 +135,7 @@ void main() {
     });
 
     test('onlineUsers empty set means no users online', () {
-      final state = WebSocketState(onlineUsers: {'u1'});
+      final state = const WebSocketState(onlineUsers: {'u1'});
       final cleared = state.copyWith(onlineUsers: <String>{});
       expect(cleared.onlineUsers, isEmpty);
       expect(cleared.isUserOnline('u1'), isFalse);
@@ -256,7 +256,7 @@ void main() {
 
   group('WebSocketState disconnect semantics', () {
     test('disconnect clears isConnected but preserves onlineUsers snapshot', () {
-      final state = WebSocketState(
+      final state = const WebSocketState(
         isConnected: true,
         onlineUsers: {'u1', 'u2'},
       );
@@ -269,7 +269,7 @@ void main() {
     });
 
     test('full disconnect clears connection and online users', () {
-      final state = WebSocketState(
+      final state = const WebSocketState(
         isConnected: true,
         onlineUsers: {'u1', 'u2'},
       );

--- a/apps/client/test/widgets/a11y_tap_targets_test.dart
+++ b/apps/client/test/widgets/a11y_tap_targets_test.dart
@@ -11,7 +11,7 @@ import '../helpers/mock_providers.dart';
 import '../helpers/pump_app.dart';
 
 ChatMessage _peerMsg() {
-  return ChatMessage(
+  return const ChatMessage(
     id: 'msg-1',
     fromUserId: 'user-alice',
     fromUsername: 'alice',

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -12,9 +12,9 @@ import '../helpers/pump_app.dart';
 
 class _FakeChannelsNotifier extends ChannelsNotifier {
   _FakeChannelsNotifier(super.ref) : super() {
-    state = ChannelsState(
+    state = const ChannelsState(
       channelsByConversation: {
-        'conv-1': const [
+        'conv-1': [
           GroupChannel(
             id: 'voice-1',
             conversationId: 'conv-1',
@@ -26,7 +26,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
           ),
         ],
       },
-      voiceSessionsByChannel: const {'voice-1': []},
+      voiceSessionsByChannel: {'voice-1': []},
     );
   }
 

--- a/apps/client/test/widgets/chat_input_bar_test.dart
+++ b/apps/client/test/widgets/chat_input_bar_test.dart
@@ -133,7 +133,7 @@ void main() {
     });
 
     testWidgets('reply preview shows when reply is active', (tester) async {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg-reply',
         fromUserId: 'user-alice',
         fromUsername: 'alice',
@@ -156,7 +156,7 @@ void main() {
     });
 
     testWidgets('reply preview has close button', (tester) async {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg-reply',
         fromUserId: 'user-alice',
         fromUsername: 'alice',
@@ -208,7 +208,7 @@ void main() {
     });
 
     testWidgets('escape key clears reply when reply is active', (tester) async {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg-reply',
         fromUserId: 'user-alice',
         fromUsername: 'alice',

--- a/apps/client/test/widgets/chat_panel_live_region_test.dart
+++ b/apps/client/test/widgets/chat_panel_live_region_test.dart
@@ -156,7 +156,7 @@ void main() {
     ) async {
       final holder = _NotifierHolder();
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: const ChatState(), holder: holder),
       );
       await tester.pump();
@@ -178,7 +178,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: initial, holder: holder),
       );
       await tester.pump();
@@ -209,7 +209,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: initial, holder: holder),
       );
       await tester.pump();
@@ -234,7 +234,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: initial, holder: holder),
       );
       await tester.pump();
@@ -277,7 +277,7 @@ void main() {
         );
 
         await tester.pumpApp(
-          ChatPanel(conversation: _conv),
+          const ChatPanel(conversation: _conv),
           overrides: _overrides(initial: initial, holder: holder),
         );
         await tester.pump();
@@ -304,7 +304,7 @@ void main() {
       final holder = _NotifierHolder();
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: const ChatState(), holder: holder),
       );
       await tester.pump();

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -142,7 +142,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -153,7 +153,7 @@ void main() {
 
     testWidgets('shows group name in group conversation', (tester) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _groupConversation),
+        const ChatPanel(conversation: _groupConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -165,7 +165,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -179,7 +179,7 @@ void main() {
 
     testWidgets('message list renders with messages', (tester) async {
       final messages = [
-        ChatMessage(
+        const ChatMessage(
           id: 'msg-1',
           fromUserId: 'user-alice',
           fromUsername: 'alice',
@@ -188,7 +188,7 @@ void main() {
           timestamp: '2026-01-15T10:00:00Z',
           isMine: false,
         ),
-        ChatMessage(
+        const ChatMessage(
           id: 'msg-2',
           fromUserId: 'test-user-id',
           fromUsername: 'testuser',
@@ -204,7 +204,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();
@@ -214,10 +214,10 @@ void main() {
     });
 
     testWidgets('loading indicator shows when loading history', (tester) async {
-      final chatState = ChatState(loadingHistory: {'conv-dm:': true});
+      final chatState = const ChatState(loadingHistory: {'conv-dm:': true});
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();
@@ -229,7 +229,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -241,7 +241,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -255,7 +255,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -310,7 +310,7 @@ void main() {
     testWidgets('optimistic delete removes message from list', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -329,7 +329,7 @@ void main() {
     testWidgets('rollback restores message after failed delete', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -365,7 +365,7 @@ void main() {
     testWidgets('optimistic pin update is reflected in state', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -399,7 +399,7 @@ void main() {
     testWidgets('rollback clears pin on server failure', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -437,10 +437,10 @@ void main() {
     testWidgets('history-key with channel suffix is respected', (tester) async {
       // Key format is '$conversationId:$channelId' — for a DM with no
       // channel the suffix is empty, so the correct key is 'conv-dm:'.
-      final chatState = ChatState(loadingHistory: {'conv-dm:': true});
+      final chatState = const ChatState(loadingHistory: {'conv-dm:': true});
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();
@@ -452,10 +452,10 @@ void main() {
     testWidgets('skeleton loader shown when loading with no messages', (
       tester,
     ) async {
-      final chatState = ChatState(loadingHistory: {'conv-dm:': true});
+      final chatState = const ChatState(loadingHistory: {'conv-dm:': true});
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();

--- a/apps/client/test/widgets/semantics_labels_test.dart
+++ b/apps/client/test/widgets/semantics_labels_test.dart
@@ -507,8 +507,8 @@ void main() {
   group('Semantic labels - ReactionBar', () {
     testWidgets('single reaction shows "1 reaction:" label', (tester) async {
       await tester.pumpApp(
-        ReactionBar(
-          reactions: const [
+        const ReactionBar(
+          reactions: [
             Reaction(
               messageId: 'm1',
               userId: 'u1',
@@ -517,7 +517,7 @@ void main() {
             ),
           ],
           isMine: false,
-          chatBgColor: const Color(0xFF141415),
+          chatBgColor: Color(0xFF141415),
         ),
       );
       await tester.pump();
@@ -529,8 +529,8 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ReactionBar(
-          reactions: const [
+        const ReactionBar(
+          reactions: [
             Reaction(
               messageId: 'm1',
               userId: 'u1',
@@ -545,7 +545,7 @@ void main() {
             ),
           ],
           isMine: false,
-          chatBgColor: const Color(0xFF141415),
+          chatBgColor: Color(0xFF141415),
         ),
       );
       await tester.pump();
@@ -555,8 +555,8 @@ void main() {
 
     testWidgets('reaction bar has button: true', (tester) async {
       await tester.pumpApp(
-        ReactionBar(
-          reactions: const [
+        const ReactionBar(
+          reactions: [
             Reaction(
               messageId: 'm1',
               userId: 'u1',
@@ -565,7 +565,7 @@ void main() {
             ),
           ],
           isMine: false,
-          chatBgColor: const Color(0xFF141415),
+          chatBgColor: Color(0xFF141415),
         ),
       );
       await tester.pump();

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -50,6 +50,12 @@ rand = "0.10"
 # Signal Protocol signature verification
 ed25519-dalek = { version = "2", features = ["std"] }
 
+# Shared wire-format constants (#700). echo-core defines magic bytes,
+# version markers, header_len, KDF info strings, and skip-key bounds in
+# one place; server consumes via `echo_core::signal::protocol::*` so
+# the protocol contract has a single source of truth.
+echo-core = { path = "../../core/rust-core" }
+
 # Tracing
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -183,15 +183,9 @@ pub async fn get_messages(
     requesting_device_id: Option<i32>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
     // Single query handles both cursor and non-cursor cases via optional $3 param.
-    // #557: when the caller passes its own `device_id`, we LEFT JOIN
-    // `message_device_contents` and surface the device-specific ciphertext via
-    // COALESCE so multi-device DM history decrypts on the right ratchet.
-    // When no device_id is provided we preserve the legacy behaviour.
-    // Audit #678: replace correlated `(SELECT COUNT(*) ...)` per-row with a
-    // single LEFT JOIN LATERAL.  Postgres can plan the lateral once per outer
-    // row but still benefit from the partial index `idx_messages_reply_to_id`
-    // -- and importantly the same shape is reused by `search_messages` /
-    // `get_thread_replies` so the planner statistics line up across paths.
+    // #557: when device_id is supplied, COALESCE per-device ciphertext over
+    // the canonical content. reply_count via LEFT JOIN LATERAL matches the
+    // shape used by search_messages / get_thread_replies.
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -236,21 +230,14 @@ pub async fn get_messages(
 /// (#634), while still exercising the ack queue under realistic backlogs.
 pub const UNDELIVERED_PAGE_SIZE: i64 = 200;
 
-/// Fetch undelivered messages for a user, optionally after a `created_at`
-/// cursor.  Caller paginates by passing the last-seen `created_at` from the
-/// previous batch; with `None` this returns the oldest 200.
-///
-/// Audit #689: previously this had no `after_ts` and the caller fetched
-/// once.  Backlogs > 200 silently truncated -- the rest got stuck until the
-/// next reconnect.  Callers now loop with the cursor until the batch
-/// returns < UNDELIVERED_PAGE_SIZE rows.
+/// Fetch undelivered messages, optionally after a `created_at` cursor.
+/// Callers loop with the cursor until the batch returns
+/// < UNDELIVERED_PAGE_SIZE rows.
 pub async fn get_undelivered(
     pool: &PgPool,
     user_id: Uuid,
     after_ts: Option<DateTime<Utc>>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
-    // Audit #638: same LEFT JOIN LATERAL shape as get_messages -- one
-    // sub-query per outer row instead of a correlated COUNT(*).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -39,12 +39,7 @@ async fn main() {
         media_tickets: dashmap::DashMap::new(),
     });
 
-    // Audit #625: each cleanup runs in its own task with per-task cadence
-    // and panic recovery (catch_unwind on the future).  Previously all five
-    // shared one 60s loop, so a panic anywhere killed every cleanup
-    // silently.  Cadences: voice + expired-messages stay tight (60s / 30s)
-    // because their UX impact is immediate; tokens/prekeys/empty-groups
-    // are hygiene tasks at lower frequency.
+    // Per-task cleanup loops with panic recovery; cadence per task.
     spawn_periodic("voice_sessions", std::time::Duration::from_secs(60), {
         let pool = pool.clone();
         let hub = hub.clone();
@@ -127,13 +122,8 @@ async fn main() {
     .expect("Server error");
 }
 
-/// Spawn a periodic cleanup task that recovers from panics.
-///
-/// Each task gets its own `tokio::spawn` so a panic anywhere doesn't kill
-/// the others (audit #625).  `AssertUnwindSafe` is sound here because the
-/// closures we pass are stateless re-creators -- they capture `Arc` clones
-/// of pool/hub and rebuild a fresh future per tick, so any partially-
-/// mutated state from a panicked invocation is dropped on unwind.
+/// Periodic task with panic recovery. `make_fut` is a stateless re-creator;
+/// captured `Arc` clones make `AssertUnwindSafe` sound.
 fn spawn_periodic<F, Fut>(name: &'static str, period: std::time::Duration, mut make_fut: F)
 where
     F: FnMut() -> Fut + Send + 'static,
@@ -302,18 +292,9 @@ async fn cleanup_expired_messages(pool: &PgPool, hub: &ws::hub::Hub) {
 }
 
 /// Delete all dependent rows for a group conversation, then the conversation
-/// itself, atomically (audit #625, H32). Previously this was 9 sequential
-/// pool queries with `if let Err(e) ...` swallows -- a connection drop after
-/// step 4 left the conversation half-deleted and the next sweep picked it up
-/// incompletely. Wrapped in one tx so the database is never observed in a
-/// partially-cleaned state.
-///
-/// Migration 20260412000000 added ON DELETE CASCADE on a subset of child
-/// tables (`messages`, `read_receipts`, `conversation_members`); the others
-/// are still cleaned explicitly here. A follow-up migration that adds
-/// CASCADE to `voice_sessions`, `channels`, `group_keys`,
-/// `group_key_envelopes`, `banned_members`, and `media` would let this
-/// collapse to `DELETE FROM conversations WHERE id = $1`.
+/// itself, atomically. Migration 20260412000000 added ON DELETE CASCADE on
+/// a subset of child tables; the rest are cleaned explicitly until a
+/// follow-up migration extends CASCADE.
 async fn delete_group_dependents(pool: &PgPool, gid: uuid::Uuid) {
     let mut tx = match pool.begin().await {
         Ok(tx) => tx,

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -142,9 +142,6 @@ pub async fn register(
     jar: CookieJar,
     Json(body): Json<AuthRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Audit #685: server-side enforcement of REGISTRATION_OPEN. Without this
-    // gate, any client (including direct curl) could create accounts on a
-    // self-hosted instance whose operator advertises "closed" via /server-info.
     if !crate::config::registration_open() {
         return Err(AppError::forbidden("Registration is closed on this server"));
     }

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -110,10 +110,7 @@ pub async fn upload_group_key(
         ));
     }
 
-    // Audit #686: cap envelope count and reject empty payloads up front so
-    // a hostile admin can't pollute the table with millions of junk entries.
-    // 10 000 is generous -- the largest group on echo-messenger.us is well
-    // below this, and matches the per-conv member ceiling we'd want anyway.
+    // Cap envelope count so a hostile admin can't pollute the table.
     const MAX_ENVELOPES_PER_REQUEST: usize = 10_000;
     if body.envelopes.len() > MAX_ENVELOPES_PER_REQUEST {
         return Err(AppError::bad_request(format!(
@@ -129,19 +126,10 @@ pub async fn upload_group_key(
         }
     }
 
-    // Audit #687: sentinel row + envelopes commit atomically. Previously
-    // these were two separate pool queries -- if the second envelope failed,
-    // the conversation was left with a key_version row but only some members
-    // had envelopes, and those without one could not decrypt anything until
-    // the next rotation.
+    // Sentinel row + envelopes commit atomically; member-set read inside
+    // the same tx so we see the committed view that matches the writes.
     let mut tx = state.pool.begin().await.db_ctx("upload_group_key/begin")?;
 
-    // Audit #686: every envelope.user_id must be a current group member.
-    // Without this, a hostile admin can stage envelopes for arbitrary users
-    // who never were members; future invitees would receive pre-staged
-    // envelopes on join, and banned-then-readded users could be silently
-    // re-keyed.  Read membership inside the same tx so we see the current
-    // committed view (matches the writes that follow).
     let member_ids: std::collections::HashSet<Uuid> =
         db::groups::get_conversation_member_ids(&mut *tx, group_id)
             .await

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -508,8 +508,6 @@ pub async fn join_group(
         return Err(AppError::bad_request("Group not found or is not public"));
     }
 
-    // Audit #692: drop the membership cache so the new member's typing /
-    // presence / fanout requests no longer hit a cached "not a member" miss.
     invalidate_member_cache(group_id);
 
     Ok(Json(serde_json::json!({ "status": "joined" })))

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -167,12 +167,6 @@ pub async fn fetch_preview(
         }));
     }
 
-    // Audit #684: stream the body and abort once the byte cap is reached
-    // instead of buffering the whole response and then truncating. Otherwise
-    // a multi-GB response (or a gzip bomb if compression is ever enabled)
-    // OOMs the server before cap_html ever runs. Also reject obvious size
-    // hints up front via Content-Length so we don't pay the round-trip
-    // for clearly-oversized bodies.
     if let Some(declared_len) = resp.content_length()
         && declared_len > MAX_HTML_BYTES as u64
     {

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -91,6 +91,50 @@ pub struct LastMessageInfo {
     pub created_at: DateTime<Utc>,
 }
 
+/// Message response DTO for GET /api/messages/:conversation_id.
+#[derive(Debug, Serialize)]
+pub struct MessageDto {
+    pub id: Uuid,
+    pub message_id: Uuid,
+    pub conversation_id: Uuid,
+    pub channel_id: Option<Uuid>,
+    pub sender_id: Uuid,
+    pub from_user_id: Uuid,
+    pub from_device_id: Option<i32>,
+    pub sender_username: String,
+    pub from_username: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub edited_at: Option<DateTime<Utc>>,
+    pub reply_to_id: Option<Uuid>,
+    pub reply_to_content: Option<String>,
+    pub reply_to_username: Option<String>,
+    pub reply_count: i64,
+}
+
+impl From<db::messages::MessageWithSender> for MessageDto {
+    fn from(m: db::messages::MessageWithSender) -> Self {
+        Self {
+            id: m.id,
+            message_id: m.id,
+            conversation_id: m.conversation_id,
+            channel_id: m.channel_id,
+            sender_id: m.sender_id,
+            from_user_id: m.sender_id,
+            from_device_id: m.sender_device_id,
+            sender_username: m.sender_username.clone(),
+            from_username: m.sender_username,
+            content: m.content,
+            created_at: m.created_at,
+            edited_at: m.edited_at,
+            reply_to_id: m.reply_to_id,
+            reply_to_content: m.reply_to_content,
+            reply_to_username: m.reply_to_username,
+            reply_count: m.reply_count,
+        }
+    }
+}
+
 /// Raw row returned by the single optimized list_conversations query.
 #[derive(Debug, sqlx::FromRow)]
 struct ConversationFullRow {
@@ -289,34 +333,8 @@ pub async fn get_messages(
     .await
     .db_ctx("get_messages/fetch")?;
 
-    // Re-shape the response to expose `from_user_id` / `from_username` /
-    // `from_device_id` keys the client expects on history (#557). Doing it
-    // here avoids changing every other consumer of `MessageWithSender`.
-    let body: Vec<serde_json::Value> = messages
-        .into_iter()
-        .map(|m| {
-            serde_json::json!({
-                "id": m.id,
-                "message_id": m.id,
-                "conversation_id": m.conversation_id,
-                "channel_id": m.channel_id,
-                "sender_id": m.sender_id,
-                "from_user_id": m.sender_id,
-                "from_device_id": m.sender_device_id,
-                "sender_username": m.sender_username,
-                "from_username": m.sender_username,
-                "content": m.content,
-                "created_at": m.created_at,
-                "edited_at": m.edited_at,
-                "reply_to_id": m.reply_to_id,
-                "reply_to_content": m.reply_to_content,
-                "reply_to_username": m.reply_to_username,
-                "reply_count": m.reply_count,
-            })
-        })
-        .collect();
-
-    Ok(Json(body))
+    let dtos: Vec<MessageDto> = messages.into_iter().map(MessageDto::from).collect();
+    Ok(Json(dtos))
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -199,24 +199,14 @@ pub async fn handle_socket(
     // Broadcast online presence to contacts
     typing_service::broadcast_presence(&state, user_id, &username, "online").await;
 
-    // Forward hub messages to WebSocket sink. Audit #696: previously this
-    // ran as a detached `tokio::spawn` and the receive loop ran serially
-    // afterward, so the two halves had no shared lifecycle -- if the peer's
-    // TCP died but more inbound bytes arrived, the receive loop kept
-    // accepting frames and the hub kept enqueueing into a now-unread mpsc
-    // channel until it filled. Conversely if the receive loop ended first
-    // (ticket expiry), aborting the send task discarded any pending hub
-    // messages. We now wrap both halves in `tokio::select!` so either half
-    // ending tears down both, and we drain `rx` with a brief timeout after
-    // shutdown to flush in-flight frames before the connection drops.
+    // Forward hub -> sink. Both halves are select!-linked below so neither
+    // outlives the other; rx returned for post-shutdown drain.
     let send_fut = async move {
         while let Some(msg) = rx.recv().await {
             if sender.send(msg).await.is_err() {
                 break;
             }
         }
-        // Return ownership of the sink + the receiver so the post-shutdown
-        // drain step can continue using the same socket.
         (sender, rx)
     };
     tokio::pin!(send_fut);

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -13,11 +13,8 @@ use uuid::Uuid;
 
 pub type WsTx = mpsc::Sender<WsMessage>;
 
-/// After this many consecutive `Full` results inside [`SLOW_CONSUMER_WINDOW`],
-/// the hub unregisters the device so the client must reconnect.  Picked
-/// conservatively: a busy public group can produce occasional Full bursts
-/// when a tab is briefly throttled, so we allow short spikes but kill any
-/// connection that consistently can't keep up (audit #634).
+/// Slow-consumer eviction threshold: this many consecutive `Full` results
+/// inside the window unregister the device so the client must reconnect.
 const SLOW_CONSUMER_FULL_THRESHOLD: u32 = 50;
 const SLOW_CONSUMER_WINDOW: Duration = Duration::from_secs(60);
 
@@ -166,11 +163,8 @@ impl Hub {
 }
 
 impl Hub {
-    /// Try to send a message and update the per-(user, device) slow-consumer
-    /// counter.  When a device has had `SLOW_CONSUMER_FULL_THRESHOLD`
-    /// consecutive `Full` results within `SLOW_CONSUMER_WINDOW`, unregister
-    /// it so the client must reconnect (audit #634) -- otherwise a stalled
-    /// tab can starve itself indefinitely with silent drops.
+    /// `try_send` plus slow-consumer tracking. Force-unregisters once the
+    /// threshold trips so a stalled tab can't starve itself indefinitely.
     fn try_send_tracked(&self, user_id: Uuid, device_id: i32, tx: &WsTx, msg: WsMessage) -> bool {
         match tx.try_send(msg) {
             Ok(()) => {
@@ -418,9 +412,6 @@ mod tests {
         assert!(!sent, "send must report failure once receiver is dropped");
     }
 
-    /// Audit #634: a stuck consumer must be force-disconnected after the
-    /// configured threshold of consecutive Full results so the connection
-    /// slot is freed and the client is forced to reconnect.
     #[tokio::test]
     async fn test_slow_consumer_unregisters_after_threshold() {
         let hub = Hub::new();

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -15,9 +15,6 @@ use crate::ws::typing_service::get_member_ids_cached;
 
 pub(super) const MAX_MESSAGE_LENGTH: usize = 10_000;
 
-// Wire-format constants are defined once in `echo_core::signal::protocol`
-// (audit #700). Re-export under the historical local names so the rest of
-// this file reads unchanged.
 use echo_core::signal::protocol::{
     NORMAL_HEADER_LEN as ECHO_NORMAL_HEADER_LEN, WIRE_INITIAL_V1 as ECHO_WIRE_INITIAL_V1,
     WIRE_INITIAL_V2 as ECHO_WIRE_INITIAL_V2, WIRE_MAGIC as ECHO_WIRE_MAGIC,
@@ -901,10 +898,7 @@ pub(super) async fn fanout_message(
 /// used as a fallback when no device-specific row exists (group messages,
 /// unencrypted convs, or messages predating multi-device support).
 pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid, device_id: i32) {
-    // Audit #689: loop with cursor pagination so backlogs >200 messages
-    // (multi-week offline) replay completely instead of leaving the rest
-    // stuck until the next reconnect.  Cap iterations defensively against a
-    // pathological pool error returning the same row over and over.
+    // Cursor-paginated replay; cap iterations against pathological pool errors.
     const MAX_ITERATIONS: usize = 50; // 50 * 200 = 10 000 messages per reconnect
     let mut after_ts: Option<chrono::DateTime<chrono::Utc>> = None;
     for _iter in 0..MAX_ITERATIONS {

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -15,16 +15,13 @@ use crate::ws::typing_service::get_member_ids_cached;
 
 pub(super) const MAX_MESSAGE_LENGTH: usize = 10_000;
 
-/// Echo Messenger wire format magic byte (#591). The first byte of any
-/// initial-message payload identifies the protocol family.
-const ECHO_WIRE_MAGIC: u8 = 0xEC;
-/// Initial-message version 1 (no one-time prekey).
-const ECHO_WIRE_INITIAL_V1: u8 = 0x01;
-/// Initial-message version 2 (with one-time prekey).
-const ECHO_WIRE_INITIAL_V2: u8 = 0x02;
-/// Normal-message wire prefix is a u32 LE header length of 40 bytes
-/// (`header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`).
-const ECHO_NORMAL_HEADER_LEN: u32 = 40;
+// Wire-format constants are defined once in `echo_core::signal::protocol`
+// (audit #700). Re-export under the historical local names so the rest of
+// this file reads unchanged.
+use echo_core::signal::protocol::{
+    NORMAL_HEADER_LEN as ECHO_NORMAL_HEADER_LEN, WIRE_INITIAL_V1 as ECHO_WIRE_INITIAL_V1,
+    WIRE_INITIAL_V2 as ECHO_WIRE_INITIAL_V2, WIRE_MAGIC as ECHO_WIRE_MAGIC,
+};
 
 /// Validate that a base64-encoded payload is shaped like an Echo
 /// ciphertext wire frame. We do NOT decrypt or otherwise validate

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -104,12 +104,9 @@ pub fn invalidate_member_cache(conversation_id: Uuid) {
     MEMBERSHIP_CACHE.retain(|(_, conv_id), _| *conv_id != conversation_id);
 }
 
-/// Periodic sweep that drops cache entries older than 2× their TTL across
-/// all three caches.  Called from the cleanup scheduler in main.rs every
-/// 5 minutes (audit #692).  Without this, entries never expire on a busy
-/// server -- after 24h a `MEMBERSHIP_CACHE` for a public group with 1k
-/// members and 100 typers can hold 100k stale `(user_id, conversation_id)`
-/// pairs that no live read path will ever revisit.
+/// Drop cache entries older than 2× their TTL across all three caches.
+/// Called from the cleanup scheduler so stale entries don't accumulate on
+/// long-running servers.
 pub fn sweep_expired_caches() {
     let cutoff = MEMBERSHIP_CACHE_TTL * 2;
     let mut membership_evicted = 0usize;
@@ -235,20 +232,13 @@ pub(super) async fn broadcast_presence(
     username: &str,
     status: &str,
 ) {
-    // Audit #436: gate presence on first-device-up / last-device-down so
-    // a multi-device user reconnecting after a network blip doesn't make
-    // every contact see online/offline/online/offline once per device.
-    // `register` happens before this call (online) and `unregister` happens
-    // before this call (offline), so:
-    //   online:  device_count == 1 -> first device just connected, broadcast
-    //   online:  device_count >  1 -> already had other devices, no-op
-    //   offline: device_count == 0 -> last device just disconnected, broadcast
-    //   offline: device_count >  0 -> still has other devices, no-op
+    // Gate on first-device-up / last-device-down so multi-device reconnects
+    // don't surface online/offline flapping to contacts.
     let dev_count = state.hub.device_count(&user_id);
     let should_broadcast = match status {
         "online" => dev_count == 1,
         "offline" => dev_count == 0,
-        _ => true, // explicit status changes (away/dnd) always broadcast
+        _ => true,
     };
     if !should_broadcast {
         return;
@@ -303,9 +293,7 @@ pub(super) async fn broadcast_presence(
         Err(_) => return,
     };
 
-    // Audit #690: build the WsMessage once outside the loop. axum's
-    // Message::Text is backed by bytes::Bytes, so msg.clone() inside the
-    // loop is O(1) reference-count bump rather than a fresh String alloc.
+    // Build once; clone is O(1) on Bytes-backed Message::Text.
     let msg = WsMessage::Text(json.into());
     for cid in &contact_ids {
         state.hub.send_to(cid, msg.clone());

--- a/apps/server/tests/api_rate_limit_proxy.rs
+++ b/apps/server/tests/api_rate_limit_proxy.rs
@@ -94,6 +94,58 @@ async fn rate_limit_honours_x_real_ip_from_trusted_proxy() {
 }
 
 // ---------------------------------------------------------------------------
+// Trusted vs untrusted: single combined assertion (#524)
+// ---------------------------------------------------------------------------
+
+/// X-Real-IP is honoured when the peer is in trusted_proxies and ignored when
+/// it is not.  Two servers are started so the two behaviours are tested in the
+/// same function against the same endpoint (login).
+#[tokio::test]
+async fn x_real_ip_trusted_proxy_honoured_untrusted_ignored() {
+    let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+
+    // Server A: loopback is a trusted proxy -- X-Real-IP should be the key.
+    let base_trusted = common::spawn_server_with_trusted_proxies(vec![loopback]).await;
+    // Server B: no trusted proxies -- X-Real-IP must be ignored.
+    let base_untrusted = common::spawn_server().await;
+
+    let client = Client::new();
+
+    // --- trusted path: exhaust the bucket for X-Real-IP 10.1.1.1 ---
+    for _ in 0..5 {
+        let s = try_login(&client, &base_trusted, "x-real-ip", "10.1.1.1").await;
+        assert_ne!(s, 429, "trusted: bucket not full yet");
+    }
+    let s = try_login(&client, &base_trusted, "x-real-ip", "10.1.1.1").await;
+    assert_eq!(
+        s, 429,
+        "trusted: 6th attempt for 10.1.1.1 must be rate-limited"
+    );
+
+    // A fresh X-Real-IP on the trusted server should still be allowed.
+    let s = try_login(&client, &base_trusted, "x-real-ip", "10.2.2.2").await;
+    assert_ne!(
+        s, 429,
+        "trusted: different X-Real-IP must have its own bucket"
+    );
+
+    // --- untrusted path: exhaust the bucket using the peer IP (127.0.0.1) ---
+    // The X-Real-IP header is sent but must not influence the key.
+    for _ in 0..5 {
+        let s = try_login(&client, &base_untrusted, "x-real-ip", "10.3.3.3").await;
+        assert_ne!(s, 429, "untrusted: bucket not full yet");
+    }
+    // Sixth attempt from the same peer (127.0.0.1) must be rate-limited even
+    // though it carries a different X-Real-IP header.
+    let s = try_login(&client, &base_untrusted, "x-real-ip", "10.4.4.4").await;
+    assert_eq!(
+        s, 429,
+        "untrusted: 6th request from 127.0.0.1 must be rate-limited \
+         regardless of X-Real-IP header value"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // With trusted proxy: X-Forwarded-For is honoured as fallback
 // ---------------------------------------------------------------------------
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,23 @@ comment:
   layout: "reach,diff,flags,components"
   behavior: default
 
+component_management:
+  individual_components:
+    - component_id: ratchet
+      name: Ratchet/Signal Protocol
+      paths:
+        - apps/client/lib/src/services/signal_*.dart
+        - apps/client/lib/src/services/crypto_*.dart
+      status:
+        project:
+          target: 60%
+          threshold: 5%
+          informational: true
+        patch:
+          target: 70%
+          threshold: 5%
+          informational: true
+
 flags:
   flutter:
     paths:

--- a/core/rust-core/src/signal/mod.rs
+++ b/core/rust-core/src/signal/mod.rs
@@ -1,12 +1,14 @@
 //! Signal Protocol implementation: X3DH key agreement + Double Ratchet.
 //!
 //! This module provides end-to-end encryption using the Signal Protocol:
+//! - **protocol**: wire-format constants shared with the Rust server (#700)
 //! - **keys**: Key types and generation (identity, signed prekeys, ephemeral)
 //! - **x3dh**: Extended Triple Diffie-Hellman for session establishment
 //! - **ratchet**: Double Ratchet for per-message forward secrecy
 //! - **session**: High-level session management API
 
 pub mod keys;
+pub mod protocol;
 pub mod ratchet;
 pub mod session;
 pub mod x3dh;

--- a/core/rust-core/src/signal/protocol.rs
+++ b/core/rust-core/src/signal/protocol.rs
@@ -1,31 +1,13 @@
-//! Wire-format constants shared by the Rust server, the Rust core, and the
-//! Dart client.
+//! Wire-format constants shared by the Rust server and core. Dart parity
+//! lives in `apps/client/lib/src/services/signal_protocol.dart` and is
+//! enforced by hand until codegen lands.
 //!
-//! Audit #700 (H34): before this module, these constants were re-typed in
-//! at least three places (Rust server, Rust core, Dart client). One typo
-//! silently breaks decryption with no compile-time check. CLAUDE.md
-//! documented the wire format in prose but no schema lived in version
-//! control.
-//!
-//! Phase 1 (this PR): Rust server + Rust core re-export from a single
-//! definition here. Dart parity is Phase 2 — it requires either codegen
-//! from a manifest or a CI test that round-trips a Rust-encrypted
-//! ciphertext through Dart and vice versa with a fixed seed.
-//!
-//! ## Wire format reference
-//!
-//! Every encrypted message frame starts with a magic byte sequence so the
-//! server can distinguish protocol versions and reject malformed payloads
-//! at the edge:
-//!
+//! Wire layout:
 //! ```text
 //! Initial V1 (no OTP): [0xEC, 0x01] || identity_pub(32) || ephemeral_pub(32) || ratchet_wire
 //! Initial V2 (OTP):    [0xEC, 0x02] || identity_pub(32) || ephemeral_pub(32) || otp_id(4 LE) || ratchet_wire
 //! Normal:              header_len(4 LE) || header(40) || nonce(12) || ciphertext || tag(16)
 //! ```
-//!
-//! Where `ratchet_wire` is the canonical `MessageHeader` (see ratchet.rs)
-//! plus AEAD payload.
 
 // -----------------------------------------------------------------------
 // Magic bytes

--- a/core/rust-core/src/signal/protocol.rs
+++ b/core/rust-core/src/signal/protocol.rs
@@ -1,0 +1,91 @@
+//! Wire-format constants shared by the Rust server, the Rust core, and the
+//! Dart client.
+//!
+//! Audit #700 (H34): before this module, these constants were re-typed in
+//! at least three places (Rust server, Rust core, Dart client). One typo
+//! silently breaks decryption with no compile-time check. CLAUDE.md
+//! documented the wire format in prose but no schema lived in version
+//! control.
+//!
+//! Phase 1 (this PR): Rust server + Rust core re-export from a single
+//! definition here. Dart parity is Phase 2 — it requires either codegen
+//! from a manifest or a CI test that round-trips a Rust-encrypted
+//! ciphertext through Dart and vice versa with a fixed seed.
+//!
+//! ## Wire format reference
+//!
+//! Every encrypted message frame starts with a magic byte sequence so the
+//! server can distinguish protocol versions and reject malformed payloads
+//! at the edge:
+//!
+//! ```text
+//! Initial V1 (no OTP): [0xEC, 0x01] || identity_pub(32) || ephemeral_pub(32) || ratchet_wire
+//! Initial V2 (OTP):    [0xEC, 0x02] || identity_pub(32) || ephemeral_pub(32) || otp_id(4 LE) || ratchet_wire
+//! Normal:              header_len(4 LE) || header(40) || nonce(12) || ciphertext || tag(16)
+//! ```
+//!
+//! Where `ratchet_wire` is the canonical `MessageHeader` (see ratchet.rs)
+//! plus AEAD payload.
+
+// -----------------------------------------------------------------------
+// Magic bytes
+// -----------------------------------------------------------------------
+
+/// First byte of every encrypted Echo wire frame. Picked so it lands
+/// outside ASCII printable range to make accidental plaintext-vs-ciphertext
+/// confusion noisy when humans inspect frames.
+pub const WIRE_MAGIC: u8 = 0xEC;
+
+/// Second byte for an "initial" frame using the V1 X3DH flow (no
+/// one-time prekey consumed). Carries identity + ephemeral public keys.
+pub const WIRE_INITIAL_V1: u8 = 0x01;
+
+/// Second byte for an "initial" frame using the V2 X3DH flow (consumes
+/// a one-time prekey identified by the embedded `otp_id`).
+pub const WIRE_INITIAL_V2: u8 = 0x02;
+
+/// Length of the Double Ratchet `MessageHeader` serialised on the wire,
+/// per `MessageHeader::serialize`:
+///   - 32 bytes ratchet_public_key
+///   - 4 bytes prev_chain_length (LE u32)
+///   - 4 bytes message_number (LE u32)
+pub const NORMAL_HEADER_LEN: u32 = 40;
+
+// -----------------------------------------------------------------------
+// HKDF info strings
+// -----------------------------------------------------------------------
+
+/// HKDF info passed into the Double Ratchet KDF for chain-key + message-key
+/// derivation. The byte sequence is part of the protocol contract: changing
+/// it on either side breaks decryption silently.
+pub const RATCHET_KDF_INFO: &[u8] = b"EchoDoubleRatchet";
+
+/// HKDF info for the X3DH shared-secret derivation. Same contract: any
+/// rename or byte-level change breaks new sessions.
+pub const X3DH_HKDF_INFO: &[u8] = b"EchoSignalX3DH";
+
+// -----------------------------------------------------------------------
+// Skip-key bounds (audit CRIT-4)
+// -----------------------------------------------------------------------
+
+/// Maximum number of message keys that can be skipped in a single
+/// `skip_message_keys` call. Without this an attacker that controls
+/// `message_number` can force unbounded key derivation.
+pub const MAX_SKIP: u32 = 1000;
+
+/// Global cap on `skipped_keys` map size across the lifetime of a session.
+/// Prevents an adversary that bumps the DH ratchet repeatedly (each step
+/// resets `recv_counter` to 0) from accumulating skipped keys without
+/// bound.
+pub const MAX_SKIPPED_KEYS: usize = 2000;
+
+// -----------------------------------------------------------------------
+// Compile-time invariants
+// -----------------------------------------------------------------------
+
+// The serializer in MessageHeader::serialize hard-codes a 40-byte layout;
+// this assertion guarantees future contributors who change either side
+// notice immediately.
+const _: () = {
+    assert!(NORMAL_HEADER_LEN == 40);
+};

--- a/core/rust-core/src/signal/ratchet.rs
+++ b/core/rust-core/src/signal/ratchet.rs
@@ -18,16 +18,13 @@ use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::error::CoreError;
 
-/// Maximum number of skipped message keys allowed in a single skip call,
-/// and the global cap on `skipped_keys` size across the lifetime of a session.
-/// Prevents memory exhaustion from a malicious peer sending huge message
-/// numbers or repeatedly bumping the ratchet key (which resets `recv_counter`)
-/// to accumulate skipped keys without bound.
-const MAX_SKIP: u32 = 1000;
-const MAX_SKIPPED_KEYS: usize = 2000;
+/// Re-exports of the protocol-level skip caps; defined once in `protocol.rs`
+/// so the Rust server can refer to the same MAX_SKIP / MAX_SKIPPED_KEYS
+/// (#700, audit CRIT-4 gate).
+use super::protocol::{MAX_SKIP, MAX_SKIPPED_KEYS, RATCHET_KDF_INFO};
 
-/// HKDF info strings for key derivation.
-const RATCHET_KDF_INFO: &[u8] = b"EchoDoubleRatchet";
+/// Local KDF context bytes -- not protocol-shared because they're internal
+/// to the message-key derivation scheme inside this file.
 const CHAIN_KEY_SEED: u8 = 0x02;
 const MESSAGE_KEY_SEED: u8 = 0x01;
 

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
       - traefik
 
   postgres:
-    image: postgres:17
+    image: postgres:17.6
     restart: unless-stopped
     environment:
       POSTGRES_DB: echo_prod
@@ -100,7 +100,7 @@ services:
   #   SERVER_VERSION=v1.2.3 WEB_VERSION=v1.2.3 docker compose pull && docker compose up -d
 
   backup:
-    image: prodrigestivill/postgres-backup-local:17
+    image: prodrigestivill/postgres-backup-local:17.6
     restart: unless-stopped
     environment:
       POSTGRES_HOST: postgres

--- a/infra/docker/docker-compose.test.yml
+++ b/infra/docker/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   postgres-test:
-    image: postgres:17
+    image: postgres:17.6
     environment:
       POSTGRES_DB: echo_test
       POSTGRES_USER: echo

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17
+    image: postgres:17.6
     environment:
       POSTGRES_DB: echo_dev
       POSTGRES_USER: echo

--- a/scripts/demo_two_apps.sh
+++ b/scripts/demo_two_apps.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 SERVER_URL="http://localhost:8080"
-WS_URL="ws://localhost:8080"
 APP_BINARY="apps/client/build/linux/x64/release/bundle/echo_app"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -38,7 +37,7 @@ sleep 1
 echo "[3/6] Starting server..."
 source "$HOME/.cargo/env" 2>/dev/null || true
 DATABASE_URL="postgres://echo:dev_password@localhost:5432/echo_dev" \
-JWT_SECRET="dev-secret" \
+JWT_SECRET="dev-jwt-secret-must-be-at-least-32-chars-long" \
 RUST_LOG="echo_server=info" \
 "$PROJECT_DIR/target/debug/echo-server" &
 SERVER_PID=$!

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -29,7 +29,7 @@ sleep 1
 
 source "$HOME/.cargo/env" 2>/dev/null || true
 export DATABASE_URL="postgres://echo:dev_password@localhost:5432/echo_dev"
-export JWT_SECRET="dev-secret"
+export JWT_SECRET="dev-jwt-secret-must-be-at-least-32-chars-long"
 export RUST_LOG="echo_server=info"
 mkdir -p uploads/avatars
 

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -126,14 +126,20 @@ echo "── WebSocket Messaging ──"
 
 source "$HOME/.cargo/env" 2>/dev/null || true
 
+# Obtain ws-tickets (30-sec single-use; client must use ?ticket= not ?token=)
+ALICE_TICKET=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+BOB_TICKET1=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $BOB_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+
 # Test: Send message while recipient is offline (offline delivery)
 echo '{"type":"send_message","to_user_id":"'"$BOB_ID"'","content":"Hello from alice (offline)"}' \
-  | timeout 3 websocat "ws://localhost:8080/ws?token=$ALICE_TOKEN" > /tmp/e2e_alice1.txt 2>&1 || true
+  | timeout 3 websocat "ws://localhost:8080/ws?ticket=$ALICE_TICKET" > /tmp/e2e_alice1.txt 2>&1 || true
 
 assert_contains "$(cat /tmp/e2e_alice1.txt)" "message_sent" "Alice sends message (bob offline), gets confirmation"
 
 # Bob connects and should receive the offline message
-timeout 3 websocat "ws://localhost:8080/ws?token=$BOB_TOKEN" > /tmp/e2e_bob1.txt 2>&1 || true
+timeout 3 websocat "ws://localhost:8080/ws?ticket=$BOB_TICKET1" > /tmp/e2e_bob1.txt 2>&1 || true
 assert_contains "$(cat /tmp/e2e_bob1.txt)" "Hello from alice" "Bob receives offline message on connect"
 assert_contains "$(cat /tmp/e2e_bob1.txt)" "new_message" "Bob receives correct message type"
 
@@ -142,14 +148,20 @@ assert_contains "$(cat /tmp/e2e_bob1.txt)" "new_message" "Bob receives correct m
 rm -f /tmp/e2e_bob_fifo
 mkfifo /tmp/e2e_bob_fifo
 
+# Fresh tickets for each new connection (single-use)
+ALICE_TICKET2=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+BOB_TICKET2=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $BOB_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+
 # Bob connects via named pipe (stays open)
-cat /tmp/e2e_bob_fifo | timeout 8 websocat "ws://localhost:8080/ws?token=$BOB_TOKEN" > /tmp/e2e_bob2.txt 2>&1 &
+cat /tmp/e2e_bob_fifo | timeout 8 websocat "ws://localhost:8080/ws?ticket=$BOB_TICKET2" > /tmp/e2e_bob2.txt 2>&1 &
 BOB_WS=$!
 sleep 2
 
 # Alice sends while Bob is online
 echo '{"type":"send_message","to_user_id":"'"$BOB_ID"'","content":"Real-time hello!"}' \
-  | timeout 3 websocat "ws://localhost:8080/ws?token=$ALICE_TOKEN" > /tmp/e2e_alice2.txt 2>&1 || true
+  | timeout 3 websocat "ws://localhost:8080/ws?ticket=$ALICE_TICKET2" > /tmp/e2e_alice2.txt 2>&1 || true
 sleep 2
 
 # Close Bob's input to let him finish
@@ -161,8 +173,10 @@ assert_contains "$(cat /tmp/e2e_alice2.txt)" "message_sent" "Alice gets confirma
 assert_contains "$(cat /tmp/e2e_bob2.txt)" "Real-time hello" "Bob receives real-time message"
 
 # Test: Non-contact messaging should fail
+ALICE_TICKET3=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
 echo '{"type":"send_message","to_user_id":"00000000-0000-0000-0000-000000000000","content":"should fail"}' \
-  | timeout 3 websocat "ws://localhost:8080/ws?token=$ALICE_TOKEN" > /tmp/e2e_alice3.txt 2>&1 || true
+  | timeout 3 websocat "ws://localhost:8080/ws?ticket=$ALICE_TICKET3" > /tmp/e2e_alice3.txt 2>&1 || true
 assert_contains "$(cat /tmp/e2e_alice3.txt)" "error" "Non-contact message rejected"
 
 # ─── REST Message History ───


### PR DESCRIPTION
## Summary

Stacked on #710. User-redirected version of Sprint 4 — instead of the god-widget refactors (which need to pair with Riverpod migrations per RIVERPOD_MIGRATION.md), this PR triages 125 open issues, dispatches haiku/sonnet subagents in parallel for quick wins, and self-corrects audit-attribution comment bloat that landed in #703/#709/#710.

## Items shipped (11 commits)

| Commit | Issue(s) | What |
|---|---|---|
| `007933d` | #701 | CLAUDE.md drift: soft-delete column name + `api.rs` known-limitation |
| `21a7152` | #700 (Phase 1) | Wire-format constants single-source in `core/rust-core/src/signal/protocol.rs`, re-exported to server |
| `01c6901` | #713 | Trim 22 audit-attribution comment blocks across server+core (-110 lines of prose) |
| `ca13257` | #583 | Pin `postgres:17` → `17.6` in all three compose files |
| `1e6477e` | #535 | Dev helper scripts: JWT_SECRET ≥ 32 chars, `?token=` → `?ticket=` |
| `05cd377` | #524 | Combined trusted-proxy `X-Real-IP` test (wiring already correct) |
| `6c6937a` | #672, #671, #662 | Codecov token wired with fork-safe guard, ratchet coverage threshold 40%→60%, hide pending-request +badge on desktop |
| `7cdab16` | #585 | Typed `MessageDto` for `get_messages` (replaces 75-line `serde_json::json!` reshape) |
| `444c7a1` | #599, #674 | `contacts_provider` stale-reload race fix + 3 tests; `dart fix prefer_const_constructors` sweep across 24 files (120 fixes); `_kAuthorizationHeader` const-extraction in `chat_header_bar.dart` |

**11 issues closed (or close-on-merge): #701, #700, #713, #583, #535, #524, #672, #671, #662, #585, #599, #674.**

## Items intentionally deferred (filed as their own issues)

| Issue | Why |
|---|---|
| #512, #628 ChatPanel split | Pair with #705 chat_provider Riverpod migration |
| #693 voice_lounge split | Pair with #707 voice cluster Riverpod migration |
| #513 ChatInputBar split | Pair with chat split |
| #352 ws/handler.rs split | Started this PR, reverted per user redirect |
| #514 multipart upload consolidation | Larger client refactor; defer |
| #702 migration consolidation | Needs prod deploy coordination |
| **NEW** #711 crypto_service.dart split (2,170 LoC) | Pair with #705 |
| **NEW** #712 conversations_provider split (628 LoC) | Pair with #704 umbrella |
| **NEW** #713 comment-bloat sweep (Dart side) | This PR shipped the server side; Dart pass is its own |

## Triage outcome

Of ~125 open issues:
- **Already addressed in PRs #703/#709/#710** (auto-close on merge): ~30 issues
- **Quick wins shipped here**: 12 issues across 11 commits
- **New issues filed**: 3 (#711, #712, #713)
- **Remaining after this PR merges**: ~80, most blocked on the deferred god-widget refactors

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (one transient flake in `search_users_returns_results` — documented as #699, parallel-run row-state issue)
- `dart format --set-exit-if-changed` ✓
- `flutter analyze --fatal-infos` ✓ (with `prefer_const_constructors` + `prefer_const_literals_to_create_immutables` now permanently enabled)
- `flutter test` ✓ (1071 passed, 12 skipped)

## Stacking

`sprint4` → `sprint3` → `sprint2` → `audit-sprint1-riverpod` → `dev`. When the chain merges in order, each PR's base auto-retargets.

## Self-correction note (per #713)

Going forward, code comments only when WHY is non-obvious. Fix history belongs in commit messages and issue bodies, not as `// Audit #XXX: <prose>` blocks that ship with every binary forever. The Dart-side comment sweep is on the #713 backlog.

## Test plan

- [ ] Code review the 11 commits in branch order
- [ ] Sanity-check the typed `MessageDto` wire shape against a real client (curl + jq) before this lands in prod
- [ ] Verify the `dart fix` const-constructor sweep didn't change runtime behavior (`flutter test` already passes; widget tests cover the touched files)
- [ ] Decide whether to schedule a Dart-side comment-bloat sweep separately or fold it into the next Sprint