### PR TITLE
release: bundle of audit + sprints 1-4 (42 commits)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,66 @@
+# Audit H26 (#356): without a .dockerignore, `docker build .` shipped
+# the entire ~2GB workspace to the docker daemon on every build.  This
+# bloats CI runner disk, slows local builds, and risks accidental
+# inclusion of secrets in image layers if a future COPY is sloppy.
+#
+# Minimal exclusion list -- prefer explicit COPY directives in
+# Dockerfiles over implicit "include everything except ...".
+
+# Build artefacts
+target/
+node_modules/
+build/
+dist/
+coverage/
+test-results/
+.playwright-mcp/
+
+# VCS
+.git/
+.gitignore
+
+# Local env / secrets (never ship into images)
+.env
+.env.*
+!.env.example
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# Flutter client artefacts (the web image copies build/web explicitly
+# from a stage; never bundle the source tree into the server image).
+apps/client/build/
+apps/client/.dart_tool/
+apps/client/.flutter-plugins
+apps/client/.flutter-plugins-dependencies
+apps/client/.packages
+apps/client/ios/Pods/
+apps/client/macos/Pods/
+
+# Distribution-only files
+*.AppImage
+*.AppImage.zsync
+*.dmg
+*.exe
+*.apk
+*.aab
+*.ipa
+
+# Docs / research / planning -- not runtime artefacts
+docs/
+research/
+RESEARCH.md
+TECHNICAL_DEBT.md
+SPRINT_PLAN.md
+RIVERPOD_MIGRATION.md
+
+# Claude / agent state
+.claude/
+
+# QA scratch
+qa/
+uploads/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -133,13 +133,13 @@ jobs:
 
       - name: Run smoke tests
         # Smoke lane: local_full.spec.ts exercises the full feature surface
-        # in a single end-to-end flow.  Documented as smoke coverage only.
-        # Soft-failed on CI because the CanvasKit login selector is brittle
-        # and prone to 10-min timeouts; the maintained lane below provides
-        # the required per-feature regression signal.
-        continue-on-error: true
+        # in a single end-to-end flow.  Audit H33 (#357): the assertion
+        # antipatterns (console.log instead of expect) and forbidden ws
+        # `?token=` seed step were fixed in CRIT-2/3, so this lane now
+        # gates strictly. `--retries=1` absorbs single-flake noise without
+        # masking real failures.
         working-directory: tests/e2e
-        run: npx playwright test --project=smoke
+        run: npx playwright test --project=smoke --retries=1
         env:
           DATABASE_URL: postgres://echo:test_password@localhost:5432/echo_test
           JWT_SECRET: ci-e2e-secret-do-not-use-in-production
@@ -147,13 +147,14 @@ jobs:
       - name: Run maintained E2E suite
         # Maintained lane: targeted UI and protocol specs (semantics_e2e,
         # group_create_ui, group_messaging_ui, hover_then_type, crypto_dm_test).
-        # Soft-failed pending #673: login/register selectors fixed via
-        # Semantics labels, but deeper widgets (chatsTab, createGroupBtn,
-        # etc.) still hit the same CanvasKit `getByRole` brittleness.
-        # Sweep across all maintained specs is a separate effort.
+        # Still soft-failed pending #673: login/register selectors fixed
+        # via Semantics labels, but deeper widgets (chatsTab, createGroupBtn,
+        # etc.) still hit CanvasKit `getByRole` brittleness.  The sweep
+        # across all maintained specs is its own effort tracked there.
+        # `--retries=2` reduces noise once the gate flips on.
         continue-on-error: true
         working-directory: tests/e2e
-        run: npx playwright test --project=maintained
+        run: npx playwright test --project=maintained --retries=2
         env:
           DATABASE_URL: postgres://echo:test_password@localhost:5432/echo_test
           JWT_SECRET: ci-e2e-secret-do-not-use-in-production

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -75,13 +75,11 @@ jobs:
           print(f"Coverage {pct:.1f}% meets the required {threshold:.0f}% threshold.")
           EOF
       - name: Upload Flutter coverage
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: apps/client/coverage/lcov.info
           flags: flutter
-          # Codecov rejects tokenless uploads on protected branches; the
-          # coverage threshold check above is already enforced separately,
-          # so let the upload fail soft until CODECOV_TOKEN is wired up.
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
+      # On pull_request, trufflehog auto-detects base/head from the event
+      # context.  On push the action's defaults can fall back to scanning the
+      # working tree only, missing historical secrets in a single squash
+      # commit.  Pass the explicit range so push events scan the new commits.
+      - name: Scan for secrets (pull_request)
+        if: github.event_name == 'pull_request'
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
+          extra_args: --only-verified
+      - name: Scan for secrets (push)
+        if: github.event_name == 'push'
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
+        with:
+          base: ${{ github.event.before }}
+          head: ${{ github.event.after }}
           extra_args: --only-verified

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,9 +1,16 @@
 name: SonarCloud
 
+# Security: do NOT run on `pull_request` -- the head-of-PR code executes the
+# `cargo test` and `flutter test` build steps with `SONAR_TOKEN` in env, so a
+# malicious PR could exfiltrate the token via a modified `build.rs`, test, or
+# any third-party action.  Restrict to push events on protected branches; PR
+# code goes through review on `dev` before reaching `main`.  If PR-level
+# Sonar feedback is needed later, split into a `pull_request` job that
+# produces artifacts (no token) and a `workflow_run` job that consumes them
+# with the token in a clean environment.
 on:
-  pull_request:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -11,7 +18,9 @@ permissions:
 
 concurrency:
   group: sonar-${{ github.ref }}
-  cancel-in-progress: true
+  # SonarCloud analysis is not idempotent across cancellations -- a partial
+  # upload can leave the project in a confused state.
+  cancel-in-progress: false
 
 env:
   FLUTTER_VERSION: '3.41.x'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - **Server required env**: `DATABASE_URL` and `JWT_SECRET` (≥32 chars, panics without them). Optional: `SERVER_HOST` (default `0.0.0.0`), `SERVER_PORT` (default `8080`), `CORS_ORIGINS` for allowed origins, `RUST_LOG` for log filtering (e.g. `echo_server=debug`). Legacy `HOST`/`PORT` are still accepted but emit a deprecation warning at startup (#532).
 - **Traefik routing**: API priority 100, Web priority 1 (API routes must take precedence).
 - **Message wire format**: Initial V2 (with OTP) = `[0xEC, 0x02] + identity_pub(32) + ephemeral_pub(32) + otp_id(4 LE) + ratchet_wire`; Initial V1 (no OTP) = `[0xEC, 0x01] + identity_pub(32) + ephemeral_pub(32) + ratchet_wire`; Normal = `header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`. All base64-wrapped over WebSocket.
-- **Soft deletes**: Messages use `is_deleted` flag, not hard deletes.
+- **Soft deletes**: Messages use a `deleted_at TIMESTAMPTZ NULL` column; queries filter with `deleted_at IS NULL`. Hard deletes only happen during `cleanup_expired_messages` (disappearing TTL) and `delete_group_dependents`.
 - **Refresh tokens (web)**: HttpOnly + Secure + SameSite=Strict cookie scoped to `/api/auth`; mobile/desktop continue to use the JSON body. `/refresh` accepts either; cookie wins. CORS requires explicit origins (not `*`) when cookie auth is enabled.
 
 ## Commit Style
@@ -155,5 +155,5 @@ Three compose files in `infra/docker/`:
 
 1. Session keys cached in memory with 24h idle TTL + 200-entry LRU cap; evicted entries have key material zeroed and reload from secure storage on demand.
 2. Multi-device: key-level revoke + last_seen + platform metadata work end-to-end; refresh tokens are not yet bound per device, so "logout all others" only kicks connected sessions via WS and truly offline sessions get blocked at next key operation.
-3. `core/rust-core/src/api.rs` has `todo!()` stubs (FFI bridge not integrated)
+3. `core/rust-core` ships Signal Protocol primitives only (X3DH, Double Ratchet, key types). The originally-planned FFI bridge to a Dart-side runtime never landed; the Dart client re-implements the protocol in pure Dart and the rust-core code path is exercised only by Rust integration tests. A few transitive deps (`rusqlite`, `tokio-tungstenite`, `reqwest`) sit in `Cargo.toml` from that abandoned design and could be pruned.
 4. Rate limiting is in-memory only (resets on server restart)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "dotenvy",
+ "echo-core",
  "ed25519-dalek",
  "futures-util",
  "infer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64",
+ "bytes",
  "chrono",
  "criterion",
  "dashmap",
@@ -2378,12 +2379,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3669,6 +3672,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/RIVERPOD_MIGRATION.md
+++ b/RIVERPOD_MIGRATION.md
@@ -1,0 +1,217 @@
+# Riverpod modernization — migration playbook
+
+Status: **5 of 22 providers migrated** in this PR. The remaining 17 are
+deliberately deferred — they pair with Sprint 4 widget refactors (#512,
+#628, #693) so each consumer surface is edited only once.
+
+## What this is
+
+Echo was already on `flutter_riverpod ^2.6.0` but every stateful provider
+used the legacy `StateNotifier` API. This PR adopts:
+
+- `@Riverpod` annotation + `riverpod_generator` (codegen)
+- `Notifier` / `AsyncNotifier` API instead of `StateNotifier`
+- `ref.onDispose` for lifecycle cleanup instead of overridden `dispose()`
+- `keepAlive: true` for singletons that need to outlive transient
+  un-watch periods (auto-dispose is the default for `@riverpod`)
+
+## Done in this PR
+
+| Provider | Class name | Generated provider | Alias kept? | Notes |
+|---|---|---|---|---|
+| `accessibility_provider` | `Accessibility` | `accessibilityProvider` | n/a — same name | first migrated, simplest |
+| `gif_playback_provider` | `GifPlayback` | `gifPlaybackProvider` | n/a | callback `WidgetsBindingObserver` via `ref.onDispose` |
+| `theme_provider` | `AppTheme` | `appThemeProvider` | `themeProvider` | renamed to avoid colliding with Material `Theme` |
+| `theme_provider` (layout) | `MessageLayoutNotifier` | `messageLayoutNotifierProvider` | `messageLayoutProvider` | `MessageLayout` enum already taken |
+| `biometric_provider` | `Biometric` | `biometricProvider` | n/a | keepAlive for lock-session timer |
+| `media_ticket_provider` | `MediaTicket` | `mediaTicketProvider` | n/a | refresh `Timer` cancelled via `ref.onDispose` |
+
+## Not yet migrated (17 providers)
+
+### Defer to Sprint 4 — coupled to god-widget refactors
+
+These should land in the same PRs that split their consumer widgets, so the
+call-site sweep happens once:
+
+| Provider | Coupled refactor | Reason |
+|---|---|---|
+| `chat_provider` | #512 ChatPanel split | 600+ LoC, 30+ consumer widgets, biggest blast radius |
+| `livekit_voice_provider` | #693 voice_lounge split | Consumer is `voice_lounge_screen.dart` (2683 LoC) |
+| `voice_rtc_provider` | #693 | Same consumer |
+| `voice_settings_provider` | #693 | Same consumer + persistence layer |
+| `screen_share_provider` | #693 | Same consumer |
+| `ws_message_handler` | #352 ws/handler.rs split (server-side) + chat split | 901-line god orchestrator; cross-touches every state-mutation surface |
+
+### Defer to Sprint 2/3 — stable but high call-site count
+
+These are mechanically straightforward but touch many consumers, so batch
+them with related work:
+
+| Provider | Defer reason |
+|---|---|
+| `auth_provider` | 32 KB file; touches every authenticated request site |
+| `crypto_provider` | Foundation for chat_provider — migrate together |
+| `server_url_provider` | Cross-talks with auth + websocket; multi-step transactions |
+| `conversations_provider` | 628 LoC, list rendering hot path |
+| `contacts_provider` | Already noted in #599 for stale-reload race; do alongside that fix |
+| `channels_provider` | Tied to ws_message_handler events |
+| `canvas_provider` | Tied to ws CanvasEvent dispatch |
+| `websocket_provider` | Lifecycle-heavy; coordinate with #696 follow-up |
+
+### Defer to Sprint 4 (medium-priority leaves)
+
+| Provider | Reason |
+|---|---|
+| `privacy_provider` | 224 LoC, persistence-heavy; pairs with settings UI refactors |
+| `update_provider` | 293 LoC; checks for app updates, has its own retry loop |
+
+## Migration recipe
+
+For each provider:
+
+### 1. Edit the file
+
+```dart
+// BEFORE
+class FooNotifier extends StateNotifier<FooState> {
+  FooNotifier() : super(const FooState()) {
+    _load();
+  }
+  Future<void> _load() async { ... }
+  Future<void> setBar(bool v) async { state = state.copyWith(bar: v); ... }
+}
+
+final fooProvider = StateNotifierProvider<FooNotifier, FooState>((ref) {
+  return FooNotifier();
+});
+```
+
+```dart
+// AFTER
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'foo_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class Foo extends _$Foo {
+  @override
+  FooState build() {
+    _load();
+    return const FooState();
+  }
+
+  Future<void> _load() async { ... }
+  Future<void> setBar(bool v) async { state = state.copyWith(bar: v); ... }
+}
+```
+
+### 2. If the class name collides with something else in importing files
+
+Rename the class and add an alias for the historical provider symbol:
+
+```dart
+@Riverpod(keepAlive: true)
+class AppFoo extends _$AppFoo {
+  // ...
+}
+
+/// Back-compat: existing call sites still refer to `fooProvider`.
+final fooProvider = appFooProvider;
+```
+
+### 3. Lifecycle hooks
+
+Replace any of these:
+
+| Old | New |
+|---|---|
+| `super.dispose()` override | `ref.onDispose(() { ... })` inside `build()` |
+| `WidgetsBindingObserver` mixin | callback-based observer + `ref.onDispose(() => removeObserver(...))` |
+| Constructor that calls `_load()` | Call `_load()` from inside `build()` before returning the initial value |
+
+### 4. Run codegen
+
+```bash
+cd apps/client
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Commit the generated `.g.dart` file alongside the edit.
+
+### 5. Update tests
+
+The override pattern changes:
+
+```dart
+// BEFORE
+fooProvider.overrideWith((ref) => _FakeFooNotifier())
+
+class _FakeFooNotifier extends FooNotifier {
+  _FakeFooNotifier() {
+    state = const FooState(bar: true);   // mutate from constructor
+  }
+}
+```
+
+```dart
+// AFTER
+fooProvider.overrideWith(_FakeFoo.new)   // pass the class constructor
+
+class _FakeFoo extends Foo {
+  @override
+  FooState build() => const FooState(bar: true);  // override build()
+}
+```
+
+Test code that used to do:
+
+```dart
+final notifier = FooNotifier();
+await Future<void>.delayed(...);
+expect(notifier.state, ...);
+```
+
+Becomes:
+
+```dart
+final container = ProviderContainer();
+addTearDown(container.dispose);
+container.read(fooProvider);     // triggers build()
+await _flushLoad();              // wait for async _load() to settle
+expect(container.read(fooProvider), ...);
+```
+
+## Common gotchas
+
+- **`@riverpod` defaults to auto-dispose**. Use `@Riverpod(keepAlive: true)`
+  for any provider that holds state that should survive moments without
+  watchers (timers, accumulators, anything cached from disk).
+- **Class name → provider name is mechanical**: `class Foo` → `fooProvider`,
+  `class AppFoo` → `appFooProvider`. There is no way to override this in
+  the annotation, so pick the class name carefully.
+- **Don't shadow Flutter built-ins**: `class Theme` collides with Material's
+  `Theme` widget; `class Notifier` would shadow Riverpod's own; etc. The
+  analyzer catches these but only after consumers import the provider.
+- **`ref` is available inside Notifier methods** — no need to inject it
+  through a constructor parameter like StateNotifier did. `ref.read`,
+  `ref.watch`, `ref.listen` all work the same.
+- **`state` is the state of THIS notifier**, not the wrapped value's
+  property. `state = state.copyWith(...)` is unchanged from StateNotifier.
+- **`build()` runs once per provider instantiation**, including any side
+  effects like `_load()` or `ref.listen(...)`. Subsequent `state = ...`
+  mutations don't re-run `build()`.
+
+## Validation per migrated provider
+
+For each PR that migrates a provider:
+
+1. `dart format --set-exit-if-changed apps/client/lib/src/providers/foo_provider.dart`
+2. `flutter analyze --fatal-infos` (full project — catches consumer breakage)
+3. `flutter test test/providers/foo_provider_test.dart`
+4. Spot-check at least one consumer widget test that watches the provider
+
+## Related issues
+
+- audit recommendations: SPRINT_PLAN.md "Riverpod modernization" section
+- coupled refactors: #512 (ChatPanel), #693 (voice_lounge), #628 (god widgets)
+- ws_message_handler god orchestrator: #352

--- a/SPRINT_PLAN.md
+++ b/SPRINT_PLAN.md
@@ -1,0 +1,190 @@
+# Sprint Plan — 4 sprints (8 weeks)
+
+Last updated: 2026-04-30
+Source: 2026-04-30 multi-agent audit (`TECHNICAL_DEBT.md`, 124 open findings) + existing GitHub backlog (116 open issues prior, 19 added by this audit).
+
+## Conventions
+
+- **Sprint length**: 2 weeks each, ~10 working days.
+- **Capacity assumption**: one engineer full-time, or two engineers ~60% on roadmap items + ~40% on user-reported bugs. Adjust if your team is different — the relative ordering still applies.
+- **Rule of thumb**: each sprint mixes one big-rock effort, several mediums, and a clutch of small-but-mechanical fixes so reviews stay manageable and merges flow steadily to `dev`.
+- **Out of scope**: anything in `severity:low` or `ux:visual` polish backlog (#403/#404/#405) unless explicitly pulled in. The 8 audit criticals are already shipped on `dev` (see commits `b3d5eb9..417ad34`).
+
+## Sprint themes
+
+```
+Sprint 1 — Beta-blocker correctness   (delivery semantics, crypto integrity)
+Sprint 2 — Server reliability + perf  (hot-path allocs, list LIMIT, auth context)
+Sprint 3 — Test infra + release pipe  (cascade tests, e2e cleanup, Docker hardening)
+Sprint 4 — Architecture refactors     (god-widget split, WS handler split, Riverpod modernization)
+```
+
+---
+
+## Sprint 1 — Beta-blocker correctness (weeks 1–2)
+
+**Theme**: stop messages from getting silently dropped, lock down the remaining auth/crypto holes the audit found. Nothing here can wait for after launch.
+
+| # | Issue | Severity | Effort | Notes |
+|---|---|---|---|---|
+| 1 | #521 + #634 | high (combined) | medium | Bundle the fix: introduce a per-connection ack queue so `delivered=true` only flips after client ack, AND when mpsc(256) is Full, count failures and force-disconnect the slow consumer. These two compound; one fix touches both surfaces. |
+| 2 | #696 (H2) | high | medium | Wrap WS receive/send halves in `tokio::select!` so either ending tears both down. Drain `rx` with a short timeout before drop. |
+| 3 | #689 (H11) | high | small | Paginate `get_undelivered` with cursor (`created_at > last_seen`). Re-arm on WS reconnect. |
+| 4 | #687 (H4) | high | small | Wrap `upload_group_key` envelope storage in one tx. `ON CONFLICT DO UPDATE` for sentinel row. |
+| 5 | #686 (H5) | high (sec) | small | Validate envelope `user_id`s against current group members. Cap envelope count. |
+| 6 | #685 (H7) | high (sec) | small | Enforce `REGISTRATION_OPEN=false` in `register()`. Default closed. |
+| 7 | #684 (H6) | high (sec) | medium | Stream `link_preview` body, abort at 256 KB, disable auto-decompression. |
+| 8 | #697 (H3) | high | small | `change_password` Argon2 → `spawn_blocking`. Audit `reset_keys` for same. |
+
+**Sprint 1 size**: ~8.5 days of medium work. Leaves ~1.5 days of slack for rework on rejected PRs.
+
+**Exit criteria**:
+- Cargo + Flutter test suites green; new ack-queue + concurrency tests added for #521/#634
+- `gh issue close` on all 8 issues
+- Soak `dev` for 48h with the new delivery semantics before merging to `main`
+
+---
+
+## Sprint 2 — Server reliability + perf foundations (weeks 3–4)
+
+**Theme**: address the audit's perf findings before they bite at scale, and pay down the highest-leverage code-quality debt.
+
+| # | Issue | Severity | Effort | Notes |
+|---|---|---|---|---|
+| 1 | #694 (H18) | high (cq) | medium | `DbErrCtx` extension trait. ~370 lines deleted across routes, +1 small util. Mechanical sweep — do this *first* in the sprint so other PRs use the new pattern. |
+| 2 | #688 (H8) | high | medium | `LIMIT $N OFFSET $M` on contacts/groups list endpoints. Pagination params at route layer. |
+| 3 | #678 + #638 | high+medium | small | Convert reply-count subqueries in `get_messages`/`get_undelivered` to `LEFT JOIN LATERAL`. Drop duplicate `idx_messages_reply_to` partial index in same migration. |
+| 4 | #690 (H12) | high | small (loops) + medium (per-device) | `WsMessage::Text` once, clone the Bytes-backed message inside the loop. Per-device send loop: prefix-suffix prebuild instead of full re-serialize. |
+| 5 | #691 (H14) | high | medium | `db::groups::get_conversation_auth_context` returning kind/role/is_public in one query. Sweep route handlers to the new helper. |
+| 6 | #692 (H15) | high | small | Periodic 5-min eviction sweep on the three caches. Add `invalidate_member_cache` to add/ban/role-change paths. |
+| 7 | #625 | high | medium | Tasks-of-spawn + JoinSet panic recovery. Replace 9-statement teardown with cascade-relying single DELETE in tx. Per-task cadence. |
+| 8 | #680 + media download | high | medium | Stream uploads + downloads via `ReaderStream` / `bytes_stream`. Drops 100MB→8KB resident per request. Title rename per audit comment. |
+| 9 | #436 (M64) | medium | small | Presence flap fix: gate "offline" on last-device-disconnect, "online" on first-device-register. |
+
+**Sprint 2 size**: ~10 days. Tight; if H18 (#694) gets bikeshedded on naming, defer to Sprint 3.
+
+**Exit criteria**:
+- All `area:performance` issues from this list closed
+- Latency on a 50k-row `list_contacts` benchmark drops by ≥80% (validate with `cargo bench` against a seeded test DB)
+- `git grep "DB error in"` returns 0 hits in `apps/server/src/routes/`
+
+---
+
+## Sprint 3 — Test infrastructure + release pipeline (weeks 5–6)
+
+**Theme**: fix the systemic test-quality issues the audit surfaced, harden the release pipeline, get the e2e suite trustworthy.
+
+| # | Issue | Severity | Effort | Notes |
+|---|---|---|---|---|
+| 1 | #699 (H21) | high | large | Per-test transaction-rollback isolation in `tests/common/mod.rs`. Add `apps/server/tests/migrations.rs` that runs all 33 migrations against a fresh DB. Single biggest unlock for reliable Rust tests. |
+| 2 | #698 (H20) | high | medium | `db_cascade.rs` integration test asserting CASCADE behavior on every child table. |
+| 3 | #695 (H19) | high | medium | Sweep 32 sites of `tokio::time::sleep(200ms)` → explicit `recv_until(predicate)` waits. Add helper. |
+| 4 | #670 (H22) | low | medium | Resolve `#670` (riverpod state-mutation propagation in widget tests). Unskip 6 optimistic-update tests. |
+| 5 | #673 + #674-style sweep (H23/H24) | high | medium | Replace `waitForTimeout(5000-8000)` → `waitForSelector('flt-semantics')`. Replace pixel clicks with `getByRole`. Sweep all 58 occurrences. |
+| 6 | #356 + #357 batch | high (devops) | medium | Pin Docker base images by digest, add root `.dockerignore`, add HEALTHCHECK to server image, add `mem_limit`/`cpus`/log rotation to compose, drop `e2e.yml continue-on-error`, fix Dockerfile migrations path, add SBOM + cosign keyless sign. Big batch but each item is small — do as one PR per concern. |
+| 7 | #594 | low (sec) | small | GitHub tag ruleset restricting `v*` tags to github-actions[bot]. |
+
+**Sprint 3 size**: ~10 days; H21 alone is ~3 days. Pull H19 forward if H21 spills.
+
+**Exit criteria**:
+- `cargo test --workspace` runs with per-test isolation; flake rate measured before/after
+- `e2e.yml` returns real pass/fail (no more `continue-on-error: true`)
+- Dependabot can bump pinned digests; one such PR exists and merges cleanly
+
+---
+
+## Sprint 4 — Architecture refactors + Riverpod modernization (weeks 7–8)
+
+**Theme**: pay down the largest structural debt items the audit (and prior audits) keep flagging. This sprint is mostly Dart refactors, so it pairs naturally with the Riverpod question below.
+
+| # | Issue | Severity | Effort | Notes |
+|---|---|---|---|---|
+| 1 | #512 + #628 | high (cq) | large | ChatPanel split. Move first-frame side effects out of `build`. Extract `ChatMessageList` widget. Pairs with Riverpod migration if approved. |
+| 2 | #693 (H17) | high (cq) | large | `voice_lounge_screen.dart` split into `widgets/voice_lounge/`. |
+| 3 | #513 | high (cq) | medium | `ChatInputBar` controller-driven feature modules. |
+| 4 | #352 | high | medium | `ws/handler.rs` split: extract `voice_signal.rs`, `canvas_event.rs`, `broadcast_events.rs`. |
+| 5 | #514 | medium | medium | Consolidate multipart upload paths behind one authenticated upload client. |
+| 6 | #700 (H34) | high (cq) | medium | Wire-format constants single source in `core/rust-core/src/signal/protocol.rs`, re-exported to server. Phase 1 only — Dart parity test in a later sprint. |
+| 7 | #702 (M40) | medium | medium-large | Migration consolidation: snapshot v2 baseline, archive historical, drop duplicate index. Coordinate with prod deploy window. |
+| 8 | #701 | low (docs) | small | CLAUDE.md drift fixes (`is_deleted`, `api.rs`). One PR. |
+
+**Sprint 4 size**: ~12 days of medium-to-large work. This sprint will likely **slip by 3-5 days**; that's OK because god-widget refactors are review-heavy and should not be rushed.
+
+**Exit criteria**:
+- ChatPanel and voice_lounge each have a `build` ≤80 lines
+- `apps/server/src/ws/handler.rs` ≤400 lines
+- Wire-format constants exist in exactly one place in Rust (Dart parity tracked separately)
+
+---
+
+## Items intentionally NOT in this 4-sprint plan
+
+These are tracked but defer for now:
+
+- **User-reported feature requests** (#449/#450/#451/#452/#454/#456 — rich text, threads, mentions, scheduled send, stickers): all `severity:high` user-reported but they are *features*, not debt. Slot one feature per sprint into the slack — likely **#451 (mentions)** in Sprint 1, **#449 (threads)** in Sprint 4 if Riverpod work doesn't fully consume.
+- **Voice/UX refresh** (#210, #614, #613, #615): defer to a "polish" sprint after Sprint 4.
+- **Encrypted groups full enforcement** (#591, #228, #658): blocked on Sprint 1 #686 + #687 landing first; pull into a Sprint 5.
+- **Forgot password** (#476), **data export** (#398): both important but can wait until reliability is solid.
+- **DevOps low-severity batch** (#358) and **UX polish backlogs** (#403/#404/#405): drip-feed via small PRs between sprint pulls.
+
+## Risks & dependencies
+
+- **Sprint 1 → Sprint 2** is hard-dependent: H14 (auth context) and H18 (DbErrCtx) need a stable route module first — Sprint 1 doesn't touch route shape.
+- **Sprint 3 H21 (per-test isolation)** is the *biggest* schedule risk. If it slips, push H20/H19 into Sprint 4. Don't compromise H21 — it unblocks every future test reliability win.
+- **Sprint 4 god-widget refactors** are the highest-conflict PRs (other branches touching same files). Plan a 2-day "no other PRs to chat_panel.dart" window per refactor.
+- **Riverpod migration (see below)**: orthogonal to all four sprints; plug into Sprint 4 if the user opts in.
+
+---
+
+## Riverpod modernization (decision needed)
+
+### Current state
+
+- **Package**: `flutter_riverpod ^2.6.0` — already on Riverpod 2.x.
+- **Style**: all 22 stateful providers use the legacy `StateNotifier` API (the original Riverpod 1.x pattern, kept around in 2.x for backwards compatibility but **soft-deprecated** in favor of `Notifier`/`AsyncNotifier`).
+- **Codegen**: not in use. `build_runner` is already a dev dep, but neither `riverpod_generator` nor `riverpod_annotation` are pulled in.
+- **Dart SDK**: `^3.11.4` (recent — supports all modern Riverpod 2.x and 3.x APIs).
+
+> When the user asked about "switching to Riverpod" — the codebase is already there. The realistic interpretations are migrating *within* Riverpod.
+
+### Three migration options
+
+#### Option A — `StateNotifier` → `Notifier` / `AsyncNotifier` (modern Riverpod 2.x API)
+
+- **Why**: The new `Notifier` API removes `StateNotifierProvider<MyNotifier, MyState>` boilerplate, supports `ref` directly inside the notifier (no constructor injection), composes better with `AsyncNotifier` for async state, and is the path Riverpod is steering toward. `StateNotifier` is functional but increasingly second-class.
+- **Audit synergy**: H16 (#512), H17 (#693), and #628 (god-widget refactor) all extract smaller widgets/controllers. The new pieces are a natural place to drop the new API. Co-locating the refactor + API migration avoids touching the same files twice.
+- **Workload**: 22 providers ranging from ~50 LoC (`server_url_provider`, `theme_provider`) to ~600 LoC (`chat_provider`). Estimate **~12-15 working days** for one engineer (4 days for the simple ones, 7-9 for the complex ones — `chat_provider`, `crypto_provider`, `livekit_voice_provider`, `ws_message_handler` — plus call-site sweep). Tests need updating; can migrate one provider at a time and ship incrementally on `dev`.
+- **Risk**: low. Existing tests guard behavior. New API can coexist with old during the migration.
+
+#### Option B — Add `@riverpod` codegen on top
+
+- **Why**: Eliminates manual `Provider<...>` declarations. Provider name + type derived from method/class. Reduces the `final myProvider = Provider<MyType>((ref) => ...)` boilerplate by ~70% per provider. Pairs naturally with Option A — many teams do A and B together.
+- **Workload**: an additional **~3-5 days** on top of Option A (mechanical: add annotations, run `build_runner`, update imports). Adds `riverpod_generator`, `riverpod_annotation`, `custom_lint`, `riverpod_lint` dev deps.
+- **Risk**: low–medium. Codegen adds a build step (`flutter pub run build_runner build`); CI needs to handle `.g.dart` file freshness. Adds ~1-2s to incremental builds.
+
+#### Option C — Bump to Riverpod 3.x (`flutter_riverpod ^3.0.0`)
+
+- **Why**: 3.x is the current major. Some breaking changes from 2.x (mostly removing already-deprecated APIs and tightening types). Future-proofing.
+- **Workload**: **~2-3 days** for the bump itself. Most breaking changes are minor; `StateNotifier` paths still work in 3.x but the `legacy_provider` path is being phased out. Best done **before** Option A so you're targeting the modern API directly.
+- **Risk**: medium. Behavioral edge cases around `ref.invalidate` and `keepAlive` semantics changed slightly. Need a soak window.
+
+### Recommendation
+
+**Do A + B together, in Sprint 4, after the god-widget refactors land** (or interleaved with them). Skip C for now unless you hit a 3.x-only feature you need; `StateNotifier` legacy support in 3.x is unlikely to be removed before 4.x.
+
+Concretely for Sprint 4:
+- After splitting ChatPanel (#512), migrate `chat_provider` to `AsyncNotifier` *as part of the split PR*, since the consumer surface is changing anyway.
+- Same pattern for voice_lounge (#693) → `livekit_voice_provider`, `voice_rtc_provider`, `voice_settings_provider`, `screen_share_provider`.
+- Leftover providers (auth, theme, contacts, etc.) become a Sprint 5 sweep.
+
+Total **incremental workload over Sprint 4**: roughly **+5 days** if interleaved with the refactors (the base refactor work was already there; the API change is mostly mechanical), or **+12-18 days** as a separate dedicated sprint.
+
+### Why not "swap state management entirely"
+
+The audit doesn't flag any state-management *concept* problems — the issues are:
+- Provider granularity (#578: `ref.watch` whole map instead of `select`)
+- Side effects in `build` (H16 / #512)
+- God orchestrators (#693, ws_message_handler.dart 901 lines)
+- Set rebuilds (#676)
+
+None of these are solved by switching to Bloc, signals, or any other library — they're discipline issues that hurt under any state-mgmt system. Riverpod is a fine choice; the modernization is about API ergonomics, not correctness.

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -1,0 +1,199 @@
+# Technical Debt
+
+Last updated: 2026-04-30 (multi-agent audit on `dev`)
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| Critical | 8 |
+| High | 34 |
+| Medium | 68 |
+| Low | 22 |
+| **Total** | **132** |
+
+Findings come from a multi-agent review (security, backend, frontend, devops, code-quality, test-quality, performance, architecture) of the full repo on the `dev` branch. Full per-finding evidence including code excerpts and exact file:line refs lives in `.claude/state/audit-project/review-queue-20260430-161802.md`.
+
+Security findings are intentionally tracked here rather than as public GitHub issues until fixes land or a coordinated disclosure plan is in place.
+
+---
+
+## Critical
+
+### CRIT-1 — LiveKit voice token IDOR
+**File**: `apps/server/src/routes/voice.rs:86-130`
+The `room` claim minted into the LiveKit JWT is taken from `body.room.or(body.channel_id).or(body.conversation_id)`, but the membership check at line 117 runs against `body.conversation_id.or(body.channel_id)`. An attacker who is a member of any conversation can request `{room: "<victim-room>", conversation_id: "<their-own>"}` and receive a token granting `roomJoin/canPublish/canSubscribe` on the victim's room.
+**Fix**: derive `room` from the validated `conversation_id`/`channel_id` only; drop or canonicalize `body.room`.
+**Effort**: small.
+
+### CRIT-2 — e2e specs use `console.log` in place of assertions
+**Files**: `tests/e2e/local_full.spec.ts:9-11,115`, `tests/e2e/crypto_dm_test.spec.ts:254-259`
+Both specs report PASS/FAIL via `console.log` calls; the suite reports green even when the assertions would have failed. The crypto-error detector in particular logs detected errors and continues.
+**Fix**: replace each `check(name, ok)` and error-`console.log` with `expect(...).toBe(true)` / `expect(errors).toEqual([])`.
+**Effort**: small.
+
+### CRIT-3 — Test seed uses forbidden `?token=` WS query param
+**File**: `tests/e2e/local_full.spec.ts:148-149`
+CLAUDE.md mandates ticket-based WS auth (`?ticket=` only). Test uses `?token=...` and `|| true` swallows any failure.
+**Fix**: `POST /api/auth/ws-ticket` then `?ticket=`. Drop `|| true`.
+**Effort**: small.
+
+### CRIT-4 — Double-Ratchet `MAX_SKIP=1000` cap is not tested + `skipped_keys` map can grow unbounded
+**Files**: `core/rust-core/src/signal/ratchet.rs:363,510`, `apps/client/lib/src/services/signal_session.dart:289`
+The DoS guard against a malicious peer sending `message_number = u32::MAX` exists but has zero coverage in either Rust or Dart. The deserialize-side `num_skipped > MAX_SKIP` gate is also untested. Across DH-ratchet steps `skipped_keys` has no global cap, and the comparison `recv_counter + MAX_SKIP < until` can panic in debug builds on overflow.
+**Fix**: add `test_skip_limit_exceeded_rejects` and `test_deserialize_rejects_oversized_skipped_keys`; mirror in Dart `crypto_test.dart`. Cap `skipped_keys.len()` globally (e.g. 2000 entries with oldest-evict). Switch to `saturating_add`.
+**Effort**: small.
+
+### CRIT-5 — JWT expiry rejection has no unit test
+**File**: `apps/server/src/auth/jwt.rs:87`
+Existing tests cover wrong-secret and roundtrip, but no test mints a `Claims { exp: now-1 }` and asserts `validate_token` rejects it. A regression that accepts expired tokens would not be caught by the unit suite.
+**Fix**: add `test_expired_token_is_rejected`.
+**Effort**: small.
+
+### CRIT-6 — LiveKit signaling port 7880 published on 0.0.0.0
+**File**: `infra/docker/docker-compose.prod.yml:66-77`
+Port 7880 (LiveKit HTTP/WebSocket signaling) is bound to all interfaces, bypassing Traefik and TLS termination. Direct access lets anyone hit the API-key-protected endpoint.
+**Fix**: bind to `127.0.0.1` (or `echo-internal` network) and proxy via Traefik with TLS. Document required host firewall rules for the media UDP ports (50000-50200).
+**Effort**: medium.
+
+### CRIT-7 — trufflehog secret scan misconfigured for `push` events
+**File**: `.github/workflows/security.yml:33-42`
+The action defaults to scanning a single commit (or the working tree) on `push` events without explicit `base`/`head`. Historical secrets added in a single squash commit can be missed.
+**Fix**: pass `base: ${{ github.event.before }}` and `head: ${{ github.event.after }}` for push events.
+**Effort**: small.
+
+### CRIT-8 — SonarCloud workflow exposes `SONAR_TOKEN` to PR head code
+**File**: `.github/workflows/sonarcloud.yml:3-6,23`
+`pull_request` (not `pull_request_target`) runs the head's `cargo test` and the SonarCloud scanner with `SONAR_TOKEN` in env. A malicious PR can dump the token via `build.rs`, modified test code, or any third-party action.
+**Fix**: split into a `pull_request` job that produces coverage artifacts (no token) and a `workflow_run`-triggered job that consumes them with the token; or restrict to `push` only.
+**Effort**: medium.
+
+---
+
+## High
+
+### Server / API / Database
+- **HIGH-1** WS message marked `delivered=true` before client confirms — `apps/server/src/ws/message_service.rs:978-1009`. Mid-air loss window if TCP dies between `tx.send` and socket flush.
+- **HIGH-2** WS receive/send loops not linked by `tokio::select!` — `apps/server/src/ws/handler.rs:202-209,258-263`. Half can outlive the other.
+- **HIGH-3** `change_password` runs Argon2 on async runtime — `apps/server/src/routes/users.rs:462,468`. Stalls Tokio worker for 50-150ms.
+- **HIGH-4** `upload_group_key` is non-transactional — `apps/server/src/routes/group_keys.rs:126-161`. Partial state leaves some members unable to decrypt.
+- **HIGH-5** `upload_group_key` doesn't verify envelope recipients are members — `apps/server/src/routes/group_keys.rs:85-186`. Hostile admin can pollute the table for arbitrary user IDs.
+- **HIGH-6** `link_preview` reads body unbounded — `apps/server/src/routes/link_preview.rs:170-174`. OOM / gzip-bomb DoS.
+- **HIGH-7** `REGISTRATION_OPEN` advertised but never enforced — `apps/server/src/routes/auth.rs:140-167`. Closed self-hosted instances still accept registrations.
+- **HIGH-8** List endpoints lack `LIMIT` — `db/contacts.rs:86-103,118-138,181-195`, `db/groups.rs:180-194,268-278`. Unbounded responses.
+- **HIGH-9** `delete_group_dependents` is 9-statement non-transactional — `apps/server/src/main.rs:224-241`. Use `force_delete_conversation` + cascade FKs.
+- **HIGH-10** `mpsc(256)` outbound queue silently drops on full — `ws/hub.rs:109-129`, `handler.rs:194`. Stuck consumer never disconnected.
+- **HIGH-11** `get_undelivered LIMIT 200` truncates large offline backlogs — `db/messages.rs:226-252`. No continuation cursor.
+
+### Performance
+- **HIGH-12** Per-recipient JSON re-serialization clones full body N times in fanout — `ws/message_service.rs:704-738,756`, `ws/typing_service.rs:246`, `main.rs:128,217`. `WsMessage::Text` is `Bytes`-backed; clone the message, not the String.
+- **HIGH-13** Reply-count correlated subquery O(N·M) in `get_messages` and `get_undelivered` — `db/messages.rs:198,237,732`. Convert to `LEFT JOIN LATERAL`.
+- **HIGH-14** `is_member` + `get_conversation_kind` + `get_member_role` triple round-trip per group route. Add `get_conversation_auth_context` returning all three in one query.
+- **HIGH-15** Membership/typing/conv-kind caches never evict — `ws/typing_service.rs:20-30`. Periodic sweep + invalidate on add/ban/role-change paths.
+
+### Client
+- **HIGH-16** `ChatPanel.build` is 249 lines with side effects in `addPostFrameCallback` from `build` — `widgets/chat_panel.dart:2233`. Move to `initState`/`didUpdateWidget`; replace `ref.watch(chatProvider)` with `select`.
+- **HIGH-17** `voice_lounge_screen.dart` is 2,683 lines with two `build` methods of 195 + 193 lines — extract `_VoiceDock`, `_VoiceParticipantGrid`, `_VoiceFocusedTile` into `widgets/voice_lounge/`.
+
+### Code quality
+- **HIGH-18** 123 copies of identical "DB error → AppError::internal" closure across `routes/*.rs`. Add `trait DbErrCtx` extension.
+
+### Tests
+- **HIGH-19** 32 sites use `tokio::time::sleep(200ms)` for "drain pending" — `ws_messaging.rs:30`, `ws_events.rs:78`, +30 more. Use `tokio::time::timeout` waiting on specific events.
+- **HIGH-20** FK CASCADE migration has no integration test — `migrations/20260412000000_cascade_conversation_fks.sql`. Add `delete_conversation_cascades_to_children`.
+- **HIGH-21** Migrations run once per process; tests share DB row state — `tests/common/mod.rs:23-49`. Per-test transaction or per-test schema.
+- **HIGH-22** 6 skipped optimistic-update tests in `chat_panel_test.dart` (#670). Resolve or rewrite without widget pump.
+- **HIGH-23** e2e tests use viewport-relative pixel clicks for login — `crypto_dm_test.spec.ts:88,131`. Use `getByRole`.
+- **HIGH-24** e2e specs use 5-8s `waitForTimeout` for Flutter boot (58 occurrences). Use `waitForSelector('flt-semantics')`.
+
+### DevOps
+- **HIGH-25** Server Dockerfile copies migrations from wrong path — `apps/server/Dockerfile:37` says `apps/server/src/migrations`; real path is `apps/server/migrations/`. The `src/migrations/` dir contains stale `001_initial.sql` etc. Either fix the path or drop the COPY (`sqlx::migrate!` embeds at compile time) and remove the stale dir.
+- **HIGH-26** No `.dockerignore` files anywhere — multi-GB build contexts and risk of copying secrets.
+- **HIGH-27** No `HEALTHCHECK` in server Docker image and no `healthcheck:` in compose — Traefik routes to dead containers until TCP refuses.
+- **HIGH-28** Web Docker base `nginx:alpine` not pinned by digest. Pin all base images by `@sha256:...`.
+- **HIGH-29** No SBOM, no provenance attestation, no artifact signing in release pipeline.
+- **HIGH-30** No resource limits on any production service in `docker-compose.prod.yml`. Add `mem_limit`, `cpus`, `logging` rotation.
+- **HIGH-31** Postgres has no WAL/PITR; backups are local-only. Add WAL archiving + off-host target + restore test.
+- **HIGH-32** `delete_group_dependents` swallows `Err` silently — `apps/server/src/main.rs:141,224-241`. Log every Err arm.
+- **HIGH-33** `e2e.yml` soft-fails both test lanes (`continue-on-error: true`) — 60 CPU-min/run for zero signal.
+
+### Contract / cross-language
+- **HIGH-34** Wire-format magic constants duplicated across Rust core, Rust server, Dart client. Single source manifest + codegen.
+
+---
+
+## Medium
+
+68 medium-severity items spanning input validation, secret rotation, cache invalidation, file-streaming, primitive-obsession enums, regex hoisting, presence broadcast hygiene, missing service layer, migration consolidation, secret-in-env vs docker secrets, etc. Full list with file:line references in the review queue file.
+
+Highlights:
+- Filesystem error details leak via `format!("...: {e}")` (security-expert #8) — `routes/{media,groups,users}.rs`
+- Disappearing-TTL conversation default not clamped (security-expert #6) — `routes/messages.rs:711`
+- Push-token registration unbounded (security-expert #5)
+- Search wildcards `%`/`_` not escaped in `list_public_groups` (security-expert #9)
+- Membership cache invalidation missing on add/ban/role paths (backend #10)
+- `media::download` reads full file into memory (backend #15) — use `ReaderStream`
+- `ice_config` returns static long-lived TURN credentials (backend #16) — should be HMAC-time-limited
+- `update_profile` unbounded email/phone/website/timezone (backend #17)
+- 5 inline regex-in-loop sites in client widgets (perf #13-15)
+- 33 schema migrations with no consolidation (arch #5)
+- REST handlers reach into `db::*` directly — no service layer (arch #1)
+- `core/rust-core/src/api.rs` referenced by CLAUDE.md doesn't exist (arch #3) — VERIFIED. Update CLAUDE.md known-limitations.
+- `ws/handler.rs` (851 lines) mixes lifecycle, parse, dispatch, voice signaling, canvas (arch #7)
+- `ws_message_handler.dart` (901 lines) is god orchestrator (arch #8)
+- 30+ duplicated `is_member` + role-check pairs across routes (arch #20)
+- Soft-delete docs say `is_deleted` but code uses `deleted_at` (CLAUDE.md drift) — VERIFIED
+- Negative-input tests missing for unicode/oversized/null on every REST endpoint (test-quality #23)
+- WS-ticket race not concurrency-tested (test-quality #17)
+- cargo-deny `multiple-versions = "warn"` not "deny"; RUSTSEC ignore lists drift between deny.toml and CI (devops #12-13)
+- No CodeQL workflow (devops #14)
+- lefthook missing pre-push deny check + light secret scan (devops #18)
+
+---
+
+## Low
+
+22 nits including:
+- `WsTicketRequest::device_id` defaults to 0 — collides with first-real-device id (backend #23)
+- `RatchetState`'s 11 private fields with implicit invariants (code-quality #29)
+- `push.rs` `unwrap()` on `SystemTime::now().duration_since(UNIX_EPOCH)` (code-quality #15)
+- `lib.rs` no crate-level `//!` doc (code-quality #23)
+- `valid_url_returns_preview` is `#[ignore]` and never runs (test-quality #26)
+- `scripts/run.sh:32` `JWT_SECRET="dev-secret"` (10 chars; CLAUDE.md panics ≥32) — VERIFIED (devops #29)
+- Forward-secrecy ratchet test conflates two properties (test-quality #24)
+- nginx CSP `connect-src wss: https:` overly broad (devops #27)
+- AppState lumps everything; should use `FromRef` (arch #12)
+- SignalSession serialization not interop with Rust core (arch #18)
+
+---
+
+## Frontend audit gap
+
+The dedicated frontend reviewer agent stalled. Code-quality and perf+arch agents covered Dart code at the file-size, regex, rebuild, and lifecycle levels, but the following remain unexamined:
+- Full Riverpod provider lifecycle (scoping, ref.read in build, dispose ordering)
+- BuildContext use after async gaps
+- A11y semantics labels / 44x44 tap targets (some covered by recent #495-498 batch)
+- Theme `ThemeExtension` dark/light parity
+- GoRouter redirect loops, deep-link auth gaps
+- Hive box lifecycle / schema drift
+- WS reconnect backoff specifics
+- Web `?server=` query-param handling
+
+A focused frontend re-run is recommended before GA.
+
+---
+
+## Progress Tracking
+
+- [ ] CRIT-1: LiveKit voice token IDOR
+- [ ] CRIT-2: e2e specs `console.log` instead of assertions
+- [ ] CRIT-3: WS `?token=` in test seed
+- [ ] CRIT-4: Double-Ratchet MAX_SKIP cap untested + unbounded skipped_keys
+- [ ] CRIT-5: JWT expiry unit test missing
+- [ ] CRIT-6: LiveKit 7880 public bind
+- [ ] CRIT-7: trufflehog push misconfig
+- [ ] CRIT-8: SonarCloud token exposure to PR head
+- [ ] HIGH-1..34: see above
+- [ ] MEDIUM (68 items)
+- [ ] LOW (22 items)
+- [ ] Frontend audit re-run

--- a/apps/client/analysis_options.yaml
+++ b/apps/client/analysis_options.yaml
@@ -23,6 +23,8 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    prefer_const_constructors: true
+    prefer_const_literals_to_create_immutables: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/apps/client/lib/src/providers/accessibility_provider.dart
+++ b/apps/client/lib/src/providers/accessibility_provider.dart
@@ -1,5 +1,7 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+part 'accessibility_provider.g.dart';
 
 const kAccessibilityFontScale = 'accessibility_font_scale';
 const kAccessibilityReducedMotion = 'accessibility_reduced_motion';
@@ -29,9 +31,22 @@ class AccessibilityState {
   }
 }
 
-class AccessibilityNotifier extends StateNotifier<AccessibilityState> {
-  AccessibilityNotifier() : super(const AccessibilityState()) {
+/// Migrated from `StateNotifier` to `@riverpod`-annotated `Notifier` (audit
+/// 2026-04-30, Riverpod modernization slice). The exported provider symbol
+/// `accessibilityProvider` is preserved so the ~12 existing call sites do
+/// not change.
+///
+/// `keepAlive: true` matches the original `StateNotifierProvider` semantics
+/// -- the singleton lives for the whole app session so we don't re-run
+/// `_load()` (a SharedPreferences read) every time a widget re-watches.
+@Riverpod(keepAlive: true)
+class Accessibility extends _$Accessibility {
+  @override
+  AccessibilityState build() {
+    // Fire and forget: load persisted prefs and overwrite `state` once
+    // the future resolves. Matches the legacy StateNotifier behaviour.
     _load();
+    return const AccessibilityState();
   }
 
   Future<void> _load() async {
@@ -61,8 +76,3 @@ class AccessibilityNotifier extends StateNotifier<AccessibilityState> {
     await prefs.setBool(kAccessibilityHighContrast, value);
   }
 }
-
-final accessibilityProvider =
-    StateNotifierProvider<AccessibilityNotifier, AccessibilityState>((ref) {
-      return AccessibilityNotifier();
-    });

--- a/apps/client/lib/src/providers/accessibility_provider.g.dart
+++ b/apps/client/lib/src/providers/accessibility_provider.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'accessibility_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$accessibilityHash() => r'1d490869342809e9bcd9c32d2e786afe404d2be5';
+
+/// Migrated from `StateNotifier` to `@riverpod`-annotated `Notifier` (audit
+/// 2026-04-30, Riverpod modernization slice). The exported provider symbol
+/// `accessibilityProvider` is preserved so the ~12 existing call sites do
+/// not change.
+///
+/// `keepAlive: true` matches the original `StateNotifierProvider` semantics
+/// -- the singleton lives for the whole app session so we don't re-run
+/// `_load()` (a SharedPreferences read) every time a widget re-watches.
+///
+/// Copied from [Accessibility].
+@ProviderFor(Accessibility)
+final accessibilityProvider =
+    NotifierProvider<Accessibility, AccessibilityState>.internal(
+      Accessibility.new,
+      name: r'accessibilityProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$accessibilityHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$Accessibility = Notifier<AccessibilityState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/biometric_provider.dart
+++ b/apps/client/lib/src/providers/biometric_provider.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:local_auth/local_auth.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+part 'biometric_provider.g.dart';
 
 const _kBiometricLockKey = 'biometric_lock_enabled';
 
@@ -25,15 +27,12 @@ class BiometricState {
   }
 }
 
-class BiometricNotifier extends StateNotifier<BiometricState> {
-  BiometricNotifier() : super(const BiometricState()) {
-    _init();
-  }
-
-  /// Named constructor for tests: sets initial state without running [_init].
-  @visibleForTesting
-  BiometricNotifier.forTest(super.initial);
-
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// Singleton lifetime via `keepAlive: true` because the lock-session timer
+/// (`_lastAuthTime` + `_lockTimeout`) lives on the notifier instance and
+/// the auto-dispose default would lose it whenever no widget is watching.
+@Riverpod(keepAlive: true)
+class Biometric extends _$Biometric {
   final _auth = LocalAuthentication();
 
   bool _authenticatedThisSession = false;
@@ -44,6 +43,12 @@ class BiometricNotifier extends StateNotifier<BiometricState> {
   bool get isSessionValid {
     if (!_authenticatedThisSession || _lastAuthTime == null) return false;
     return DateTime.now().difference(_lastAuthTime!) < _lockTimeout;
+  }
+
+  @override
+  BiometricState build() {
+    _init();
+    return const BiometricState();
   }
 
   Future<void> _init() async {
@@ -103,8 +108,3 @@ class BiometricNotifier extends StateNotifier<BiometricState> {
     }
   }
 }
-
-final biometricProvider =
-    StateNotifierProvider<BiometricNotifier, BiometricState>(
-      (_) => BiometricNotifier(),
-    );

--- a/apps/client/lib/src/providers/biometric_provider.g.dart
+++ b/apps/client/lib/src/providers/biometric_provider.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'biometric_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$biometricHash() => r'67c498962f61c6ab6f9994b667f14206fb883d1e';
+
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// Singleton lifetime via `keepAlive: true` because the lock-session timer
+/// (`_lastAuthTime` + `_lockTimeout`) lives on the notifier instance and
+/// the auto-dispose default would lose it whenever no widget is watching.
+///
+/// Copied from [Biometric].
+@ProviderFor(Biometric)
+final biometricProvider = NotifierProvider<Biometric, BiometricState>.internal(
+  Biometric.new,
+  name: r'biometricProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$biometricHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$Biometric = Notifier<BiometricState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/contacts_provider.dart
+++ b/apps/client/lib/src/providers/contacts_provider.dart
@@ -56,6 +56,12 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
   bool _isPendingLoadInFlight = false;
   DateTime? _lastPendingLoadedAt;
 
+  /// Monotonic generation counter for [loadContacts] (#599). Each call
+  /// captures `++_loadGen` and bails before mutating state when the captured
+  /// value no longer matches -- guards against a stale in-flight response
+  /// overwriting fresh state when two reloads overlap.
+  int _loadGen = 0;
+
   ContactsNotifier(this.ref) : super(const ContactsState());
 
   String get _serverUrl => ref.read(serverUrlProvider);
@@ -74,6 +80,7 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
 
   Future<void> loadContacts() async {
     state = state.copyWith(isLoading: true, error: null);
+    final gen = ++_loadGen;
     try {
       final response = await _authenticatedRequest(
         (token) => http.get(
@@ -81,6 +88,10 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
           headers: _headersWithToken(token),
         ),
       );
+      // Drop a stale response -- a newer call has been issued or the notifier
+      // was disposed while awaiting.
+      if (gen != _loadGen || !mounted) return;
+
       if (response.statusCode == 200) {
         final list = (jsonDecode(response.body) as List)
             .map((e) => Contact.fromJson(e as Map<String, dynamic>))
@@ -93,6 +104,7 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
         );
       }
     } catch (e) {
+      if (gen != _loadGen || !mounted) return;
       state = state.copyWith(isLoading: false, error: e.toString());
     }
   }

--- a/apps/client/lib/src/providers/gif_playback_provider.dart
+++ b/apps/client/lib/src/providers/gif_playback_provider.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../screens/settings/appearance_section.dart' show kGifAutoplayKey;
+
+part 'gif_playback_provider.g.dart';
 
 /// Combined GIF playback gate: animated GIFs only animate when the user has
 /// the autoplay preference on AND the window/app is currently focused. The
@@ -27,12 +29,40 @@ class GifPlaybackState {
   }
 }
 
-class GifPlaybackNotifier extends StateNotifier<GifPlaybackState>
-    with WidgetsBindingObserver {
-  GifPlaybackNotifier()
-    : super(const GifPlaybackState(autoplayEnabled: true, appFocused: true)) {
-    WidgetsBinding.instance.addObserver(this);
+/// A `WidgetsBindingObserver` lives outside the notifier so we can register
+/// it in [GifPlayback.build] and detach via `ref.onDispose`. Riverpod's
+/// Notifier lifecycle ties cleanup to the provider being disposed (or
+/// invalidated), not to a class instance, so we use a callback observer
+/// instead of `class GifPlayback ... with WidgetsBindingObserver` to make
+/// the listener removal symmetrical with attachment.
+class _GifFocusObserver with WidgetsBindingObserver {
+  _GifFocusObserver(this._onFocusChanged);
+  final void Function(bool focused) _onFocusChanged;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState lifecycle) {
+    _onFocusChanged(lifecycle == AppLifecycleState.resumed);
+  }
+}
+
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// `keepAlive: true` matches the singleton lifetime of the original
+/// `StateNotifierProvider`. Lifecycle-observer detach happens through
+/// `ref.onDispose` instead of an overridden `dispose()`.
+@Riverpod(keepAlive: true)
+class GifPlayback extends _$GifPlayback {
+  @override
+  GifPlaybackState build() {
+    final observer = _GifFocusObserver(
+      (focused) => state = state.copyWith(appFocused: focused),
+    );
+    WidgetsBinding.instance.addObserver(observer);
+    ref.onDispose(() {
+      WidgetsBinding.instance.removeObserver(observer);
+    });
+
     _loadPref();
+    return const GifPlaybackState(autoplayEnabled: true, appFocused: true);
   }
 
   Future<void> _loadPref() async {
@@ -49,22 +79,4 @@ class GifPlaybackNotifier extends StateNotifier<GifPlaybackState>
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(kGifAutoplayKey, value);
   }
-
-  @override
-  // ignore: avoid_renaming_method_parameters
-  void didChangeAppLifecycleState(AppLifecycleState lifecycle) {
-    final focused = lifecycle == AppLifecycleState.resumed;
-    state = state.copyWith(appFocused: focused);
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
 }
-
-final gifPlaybackProvider =
-    StateNotifierProvider<GifPlaybackNotifier, GifPlaybackState>(
-      (ref) => GifPlaybackNotifier(),
-    );

--- a/apps/client/lib/src/providers/gif_playback_provider.g.dart
+++ b/apps/client/lib/src/providers/gif_playback_provider.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'gif_playback_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$gifPlaybackHash() => r'fd304afc6963d832d34add4f41bf8af55f062e53';
+
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// `keepAlive: true` matches the singleton lifetime of the original
+/// `StateNotifierProvider`. Lifecycle-observer detach happens through
+/// `ref.onDispose` instead of an overridden `dispose()`.
+///
+/// Copied from [GifPlayback].
+@ProviderFor(GifPlayback)
+final gifPlaybackProvider =
+    NotifierProvider<GifPlayback, GifPlaybackState>.internal(
+      GifPlayback.new,
+      name: r'gifPlaybackProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$gifPlaybackHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$GifPlayback = Notifier<GifPlaybackState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/media_ticket_provider.dart
+++ b/apps/client/lib/src/providers/media_ticket_provider.dart
@@ -1,27 +1,34 @@
 import 'dart:async';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'auth_provider.dart';
 import 'server_url_provider.dart';
+
+part 'media_ticket_provider.g.dart';
 
 /// Provides a reusable media ticket for authenticating web `<img>` requests.
 ///
 /// The ticket is fetched once after login and refreshed every 4 minutes
 /// (server TTL is 5 minutes).  On native platforms the Authorization header
 /// is used instead, so this provider is only consumed on web.
-final mediaTicketProvider = StateNotifierProvider<MediaTicketNotifier, String?>(
-  (ref) {
-    return MediaTicketNotifier(ref);
-  },
-);
-
-class MediaTicketNotifier extends StateNotifier<String?> {
-  final Ref ref;
+///
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// Singleton lifetime via `keepAlive: true` because the refresh timer must
+/// survive moments when no widget is watching the ticket.
+@Riverpod(keepAlive: true)
+class MediaTicket extends _$MediaTicket {
   Timer? _refreshTimer;
 
-  MediaTicketNotifier(this.ref) : super(null) {
+  @override
+  String? build() {
+    // Cancel the refresh timer when the provider is disposed (provider
+    // lifecycle ties the timer to the notifier's lifetime cleanly).
+    ref.onDispose(() {
+      _refreshTimer?.cancel();
+    });
+
     ref.listen<AuthState>(authProvider, (prev, next) {
       if (next.isLoggedIn && next.token != null) {
         _fetch();
@@ -29,11 +36,14 @@ class MediaTicketNotifier extends StateNotifier<String?> {
         _clear();
       }
     });
+
     // Fetch immediately if already logged in.
     final auth = ref.read(authProvider);
     if (auth.isLoggedIn && auth.token != null) {
       _fetch();
     }
+
+    return null;
   }
 
   Future<void> _fetch() async {
@@ -70,10 +80,9 @@ class MediaTicketNotifier extends StateNotifier<String?> {
     _refreshTimer?.cancel();
     state = null;
   }
-
-  @override
-  void dispose() {
-    _refreshTimer?.cancel();
-    super.dispose();
-  }
 }
+
+/// Alias preserving the legacy `mediaTicketProvider` symbol for existing
+/// call sites; codegen produces `mediaTicketProvider` directly here so the
+/// alias is purely defensive against future renames.
+// (No alias needed -- generated provider name matches.)

--- a/apps/client/lib/src/providers/media_ticket_provider.g.dart
+++ b/apps/client/lib/src/providers/media_ticket_provider.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'media_ticket_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$mediaTicketHash() => r'34afad4bbeb8a7e46a64b9afd6771a2313517019';
+
+/// Provides a reusable media ticket for authenticating web `<img>` requests.
+///
+/// The ticket is fetched once after login and refreshed every 4 minutes
+/// (server TTL is 5 minutes).  On native platforms the Authorization header
+/// is used instead, so this provider is only consumed on web.
+///
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// Singleton lifetime via `keepAlive: true` because the refresh timer must
+/// survive moments when no widget is watching the ticket.
+///
+/// Copied from [MediaTicket].
+@ProviderFor(MediaTicket)
+final mediaTicketProvider = NotifierProvider<MediaTicket, String?>.internal(
+  MediaTicket.new,
+  name: r'mediaTicketProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$mediaTicketHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$MediaTicket = Notifier<String?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+part 'theme_provider.g.dart';
 
 enum AppThemeSelection {
   system,
@@ -13,16 +15,24 @@ enum AppThemeSelection {
   aurora,
 }
 
-class ThemeNotifier extends StateNotifier<AppThemeSelection> {
-  static const _key = 'echo_theme_mode';
+const _kThemeKey = 'echo_theme_mode';
+const _kMessageLayoutKey = 'echo_message_layout';
 
-  ThemeNotifier() : super(AppThemeSelection.dark) {
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// Class is named `AppTheme` (not `Theme`) to avoid colliding with Flutter's
+/// `Theme` widget in importing files; `themeProvider` is preserved via an
+/// alias below so call sites are unchanged.
+@Riverpod(keepAlive: true)
+class AppTheme extends _$AppTheme {
+  @override
+  AppThemeSelection build() {
     _load();
+    return AppThemeSelection.dark;
   }
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
-    final value = prefs.getString(_key);
+    final value = prefs.getString(_kThemeKey);
     state = switch (value) {
       'light' => AppThemeSelection.light,
       'dark' => AppThemeSelection.dark,
@@ -39,10 +49,10 @@ class ThemeNotifier extends StateNotifier<AppThemeSelection> {
   Future<void> setTheme(AppThemeSelection selection) async {
     state = selection;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, selection.name);
+    await prefs.setString(_kThemeKey, selection.name);
   }
 
-  // Keep this for existing callers that still use ThemeMode.
+  /// Backwards-compat surface for callers that still pass [ThemeMode].
   Future<void> setThemeMode(ThemeMode mode) async {
     final selection = switch (mode) {
       ThemeMode.system => AppThemeSelection.system,
@@ -53,28 +63,23 @@ class ThemeNotifier extends StateNotifier<AppThemeSelection> {
   }
 }
 
-final themeProvider = StateNotifierProvider<ThemeNotifier, AppThemeSelection>((
-  ref,
-) {
-  return ThemeNotifier();
-});
-
 // ---------------------------------------------------------------------------
 // Message layout: compact (Discord-style, default), bubbles, or plain (Slack)
 // ---------------------------------------------------------------------------
 
 enum MessageLayout { bubbles, compact, plain }
 
-class MessageLayoutNotifier extends StateNotifier<MessageLayout> {
-  static const _key = 'echo_message_layout';
-
-  MessageLayoutNotifier() : super(MessageLayout.compact) {
+@Riverpod(keepAlive: true)
+class MessageLayoutNotifier extends _$MessageLayoutNotifier {
+  @override
+  MessageLayout build() {
     _load();
+    return MessageLayout.compact;
   }
 
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
-    final value = prefs.getString(_key);
+    final value = prefs.getString(_kMessageLayoutKey);
     state = switch (value) {
       'bubbles' => MessageLayout.bubbles,
       'compact' => MessageLayout.compact,
@@ -86,11 +91,15 @@ class MessageLayoutNotifier extends StateNotifier<MessageLayout> {
   Future<void> setLayout(MessageLayout layout) async {
     state = layout;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, layout.name);
+    await prefs.setString(_kMessageLayoutKey, layout.name);
   }
 }
 
-final messageLayoutProvider =
-    StateNotifierProvider<MessageLayoutNotifier, MessageLayout>((ref) {
-      return MessageLayoutNotifier();
-    });
+/// Aliases preserving the legacy provider symbols used by existing call
+/// sites and tests. Riverpod codegen derives the provider name from the
+/// notifier class name; we keep `class AppTheme` (not `Theme`, which would
+/// collide with Flutter's Material `Theme`) and `class MessageLayoutNotifier`
+/// (not `MessageLayout`, which is the enum), then re-export the historical
+/// short names.
+final themeProvider = appThemeProvider;
+final messageLayoutProvider = messageLayoutNotifierProvider;

--- a/apps/client/lib/src/providers/theme_provider.g.dart
+++ b/apps/client/lib/src/providers/theme_provider.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'theme_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$appThemeHash() => r'ded610d070442924290afae9634d3b5792b06845';
+
+/// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
+/// Class is named `AppTheme` (not `Theme`) to avoid colliding with Flutter's
+/// `Theme` widget in importing files; `themeProvider` is preserved via an
+/// alias below so call sites are unchanged.
+///
+/// Copied from [AppTheme].
+@ProviderFor(AppTheme)
+final appThemeProvider = NotifierProvider<AppTheme, AppThemeSelection>.internal(
+  AppTheme.new,
+  name: r'appThemeProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appThemeHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$AppTheme = Notifier<AppThemeSelection>;
+String _$messageLayoutNotifierHash() =>
+    r'bcd897f43c8b6b3f3657d9d2ade5c33b997357c8';
+
+/// See also [MessageLayoutNotifier].
+@ProviderFor(MessageLayoutNotifier)
+final messageLayoutNotifierProvider =
+    NotifierProvider<MessageLayoutNotifier, MessageLayout>.internal(
+      MessageLayoutNotifier.new,
+      name: r'messageLayoutNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$messageLayoutNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$MessageLayoutNotifier = Notifier<MessageLayout>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -13,10 +13,12 @@ import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../providers/auth_provider.dart';
 import '../providers/channels_provider.dart';
+import '../models/contact.dart';
 import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/media_ticket_provider.dart';
 import '../providers/server_url_provider.dart';
+import '../utils/fuzzy_score.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
 
 const _kJsonHeaders = {'Content-Type': 'application/json'};
@@ -130,17 +132,24 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
         final searchController = TextEditingController();
         return StatefulBuilder(
           builder: (ctx, setDialogState) {
-            final query = searchController.text.trim().toLowerCase();
-            final filtered = query.isEmpty
-                ? available
-                : available
-                      .where(
-                        (c) =>
-                            c.username.toLowerCase().contains(query) ||
-                            (c.displayName?.toLowerCase().contains(query) ??
-                                false),
-                      )
-                      .toList();
+            final query = searchController.text.trim();
+            List<Contact> filtered;
+            if (query.isEmpty) {
+              filtered = available;
+            } else {
+              final scored = <({Contact contact, double score})>[];
+              for (final c in available) {
+                final nameScore = fuzzyScore(
+                  query,
+                  c.displayName ?? c.username,
+                );
+                final handleScore = fuzzyScore(query, c.username);
+                final best = nameScore > handleScore ? nameScore : handleScore;
+                if (best > 0.2) scored.add((contact: c, score: best));
+              }
+              scored.sort((a, b) => b.score.compareTo(a.score));
+              filtered = scored.map((e) => e.contact).toList();
+            }
             final serverUrl = ref.read(serverUrlProvider);
             return SimpleDialog(
               title: Column(

--- a/apps/client/lib/src/screens/new_message_screen.dart
+++ b/apps/client/lib/src/screens/new_message_screen.dart
@@ -8,6 +8,7 @@ import '../providers/conversations_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../theme/echo_theme.dart';
+import '../utils/fuzzy_score.dart';
 import '../widgets/avatar_utils.dart';
 import '../widgets/settings/section_header.dart';
 
@@ -81,13 +82,17 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
   }
 
   List<Contact> _filtered(List<Contact> source) {
-    final q = _query.trim().toLowerCase();
+    final q = _query.trim();
     if (q.isEmpty) return source;
-    return source.where((c) {
-      final name = (c.displayName ?? c.username).toLowerCase();
-      final handle = c.username.toLowerCase();
-      return name.contains(q) || handle.contains(q);
-    }).toList();
+    final scored = <({Contact contact, double score})>[];
+    for (final c in source) {
+      final nameScore = fuzzyScore(q, c.displayName ?? c.username);
+      final handleScore = fuzzyScore(q, c.username);
+      final best = nameScore > handleScore ? nameScore : handleScore;
+      if (best > 0.2) scored.add((contact: c, score: best));
+    }
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    return scored.map((e) => e.contact).toList();
   }
 
   @override

--- a/apps/client/lib/src/screens/settings/privacy_section.dart
+++ b/apps/client/lib/src/screens/settings/privacy_section.dart
@@ -586,11 +586,11 @@ class _PrivacySectionState extends ConsumerState<PrivacySection> {
         ),
         if (crypto.isInitialized && !crypto.keysUploadFailed) ...[
           const SizedBox(height: 12),
-          Row(
+          const Row(
             children: [
-              const Icon(Icons.verified_user, color: Colors.green, size: 18),
-              const SizedBox(width: 8),
-              const Text(
+              Icon(Icons.verified_user, color: Colors.green, size: 18),
+              SizedBox(width: 8),
+              Text(
                 'Encryption keys active',
                 style: TextStyle(
                   color: Colors.green,

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -24,6 +24,7 @@ import 'avatar_utils.dart' show buildAvatar, groupAvatarColor, resolveAvatarUrl;
 import 'shared_media_gallery.dart';
 
 const _disappearingMessagesLabel = 'Disappearing messages';
+const _kAuthorizationHeader = 'Authorization';
 
 class ChatHeaderBar extends ConsumerWidget {
   final Conversation conversation;
@@ -721,7 +722,7 @@ class ChatHeaderBar extends ConsumerWidget {
             (token) => http.put(
               Uri.parse('$serverUrl/api/conversations/${conv.id}/disappearing'),
               headers: {
-                'Authorization': 'Bearer $token',
+                _kAuthorizationHeader: 'Bearer $token',
                 'Content-Type': 'application/json',
               },
               body: jsonEncode({'ttl_seconds': ttl}),
@@ -905,7 +906,7 @@ class _IdentityChangedBadgeState extends ConsumerState<_IdentityChangedBadge> {
       padding: const EdgeInsets.only(left: 4),
       child: Semantics(
         label: 'identity changed warning',
-        child: Tooltip(
+        child: const Tooltip(
           message: "Identity changed -- verify safety number",
           child: Icon(
             Icons.warning_amber_rounded,
@@ -1089,7 +1090,7 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                 '/${widget.conversationId}/pinned',
               ),
               headers: {
-                'Authorization': 'Bearer $token',
+                _kAuthorizationHeader: 'Bearer $token',
                 'Content-Type': 'application/json',
               },
             ),
@@ -1140,7 +1141,7 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
                 '/${widget.conversationId}'
                 '/messages/${message.id}/pin',
               ),
-              headers: {'Authorization': 'Bearer $token'},
+              headers: {_kAuthorizationHeader: 'Bearer $token'},
             ),
           );
 

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -724,12 +724,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'chat',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.person_add_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.person_add_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text('New Chat', overflow: TextOverflow.ellipsis),
                     ),
                   ],
@@ -742,12 +742,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'group',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.group_add_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.group_add_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text('New Group', overflow: TextOverflow.ellipsis),
                     ),
                   ],
@@ -760,12 +760,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'discover',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.explore_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.explore_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text(
                         'Discover Groups',
                         overflow: TextOverflow.ellipsis,
@@ -781,12 +781,12 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               value: 'saved',
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minWidth: 200),
-                child: Row(
+                child: const Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.bookmark_border_outlined, size: 18),
-                    const SizedBox(width: 10),
-                    const Flexible(
+                    Icon(Icons.bookmark_border_outlined, size: 18),
+                    SizedBox(width: 10),
+                    Flexible(
                       child: Text(
                         'Saved Messages',
                         overflow: TextOverflow.ellipsis,

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform;
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -798,7 +798,10 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
             ),
           ],
         ),
-        if (pendingCount > 0)
+        if (pendingCount > 0 &&
+            (kIsWeb ||
+                defaultTargetPlatform == TargetPlatform.android ||
+                defaultTargetPlatform == TargetPlatform.iOS))
           Positioned(
             // Re-center the badge on the larger 44×44 button.
             top: 6,

--- a/apps/client/lib/src/widgets/crypto_degraded_banner.dart
+++ b/apps/client/lib/src/widgets/crypto_degraded_banner.dart
@@ -37,7 +37,7 @@ class CryptoDegradedBanner extends ConsumerWidget {
                     Flexible(
                       child: Text(
                         cryptoState.error!,
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 12,
                           color: EchoTheme.warning,
                           fontWeight: FontWeight.w500,

--- a/apps/client/lib/src/widgets/identity_key_changed_banner.dart
+++ b/apps/client/lib/src/widgets/identity_key_changed_banner.dart
@@ -147,7 +147,7 @@ class _IdentityKeyChangedBannerState
                       child: Text(
                         "Security alert: $_peerUsername's identity key "
                         'has changed. Verify their safety number.',
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 12,
                           color: EchoTheme.warning,
                           fontWeight: FontWeight.w500,
@@ -203,7 +203,7 @@ class _IdentityKeyChangedBannerState
                               width: 1,
                             ),
                           ),
-                          child: Text(
+                          child: const Text(
                             'Trust new key',
                             style: TextStyle(
                               fontSize: 11,

--- a/apps/client/lib/src/widgets/quick_switcher_overlay.dart
+++ b/apps/client/lib/src/widgets/quick_switcher_overlay.dart
@@ -152,7 +152,7 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
       child: GestureDetector(
         onTap: () => Navigator.of(context).pop(),
         child: Material(
-          color: Colors.black54,
+          color: context.mainBg.withValues(alpha: 0.54),
           child: Center(
             child: GestureDetector(
               onTap: () {}, // prevent backdrop tap
@@ -165,7 +165,7 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
                   border: Border.all(color: context.border),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.4),
+                      color: context.mainBg.withValues(alpha: 0.4),
                       blurRadius: 24,
                       offset: const Offset(0, 8),
                     ),

--- a/apps/client/lib/src/widgets/quick_switcher_overlay.dart
+++ b/apps/client/lib/src/widgets/quick_switcher_overlay.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/conversation.dart';
 import '../providers/conversations_provider.dart';
 import '../theme/echo_theme.dart';
+import '../utils/fuzzy_score.dart';
 
 /// A Ctrl+K quick-switcher overlay for searching conversations, contacts,
 /// and groups. Shows as a centered floating card with a search input.
@@ -35,12 +36,19 @@ class _QuickSwitcherOverlayState extends ConsumerState<QuickSwitcherOverlay> {
     final conversations = ref.read(conversationsProvider).conversations;
     if (_query.isEmpty) return conversations.take(8).toList();
 
-    final q = _query.toLowerCase();
-    return conversations.where((c) {
-      final title = (c.name ?? '').toLowerCase();
-      final members = c.members.map((m) => m.username.toLowerCase()).join(' ');
-      return title.contains(q) || members.contains(q);
-    }).toList();
+    final q = _query;
+    final scored = <({Conversation conv, double score})>[];
+    for (final c in conversations) {
+      final title = c.name ?? '';
+      double best = fuzzyScore(q, title);
+      for (final m in c.members) {
+        final s = fuzzyScore(q, m.username);
+        if (s > best) best = s;
+      }
+      if (best > 0.2) scored.add((conv: c, score: best));
+    }
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    return scored.map((e) => e.conv).toList();
   }
 
   void _selectCurrent(List<Conversation> results) {

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -657,7 +657,9 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
       height: _kAvatarSize,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: hasVideo ? Colors.black : Colors.black.withValues(alpha: 0.45),
+        color: hasVideo
+            ? context.chatBg
+            : context.chatBg.withValues(alpha: 0.45),
       ),
       clipBehavior: Clip.antiAlias,
       child: hasVideo
@@ -684,7 +686,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
           border: Border.all(color: speakRingColor, width: ringWidth),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.35),
+              color: context.mainBg.withValues(alpha: 0.35),
               blurRadius: 8,
               offset: const Offset(0, 3),
             ),
@@ -703,13 +705,13 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
           decoration: BoxDecoration(
-            color: Colors.black54,
+            color: context.surface.withValues(alpha: 0.54),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Text(
             info.name,
-            style: const TextStyle(
-              color: Colors.white,
+            style: TextStyle(
+              color: context.textPrimary,
               fontSize: 11,
               fontWeight: FontWeight.w500,
             ),
@@ -750,8 +752,8 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
   Widget _initialsWidget(String initial) => Center(
     child: Text(
       initial,
-      style: const TextStyle(
-        color: Colors.white,
+      style: TextStyle(
+        color: context.textPrimary,
         fontSize: 18,
         fontWeight: FontWeight.bold,
       ),
@@ -802,7 +804,7 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                 borderRadius: BorderRadius.circular(4),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.4),
+                    color: context.mainBg.withValues(alpha: 0.4),
                     blurRadius: 8,
                     offset: const Offset(0, 2),
                   ),
@@ -815,11 +817,8 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                   httpHeaders: widget.httpHeaders ?? const {},
                   fit: BoxFit.cover,
                   errorWidget: (_, _, _) => Container(
-                    color: Colors.grey[800],
-                    child: const Icon(
-                      Icons.broken_image,
-                      color: Colors.white54,
-                    ),
+                    color: context.surfaceHover,
+                    child: Icon(Icons.broken_image, color: context.textMuted),
                   ),
                 ),
               ),
@@ -833,15 +832,15 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                   child: Container(
                     width: 32,
                     height: 32,
-                    decoration: const BoxDecoration(
-                      color: Colors.black54,
+                    decoration: BoxDecoration(
+                      color: context.surface.withValues(alpha: 0.54),
                       shape: BoxShape.circle,
                     ),
                     alignment: Alignment.center,
-                    child: const Icon(
+                    child: Icon(
                       Icons.close,
                       size: 16,
-                      color: Colors.white,
+                      color: context.textPrimary,
                     ),
                   ),
                 ),

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -5,18 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "85.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "7.6.0"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.4"
   args:
     dependency: transitive
     description:
@@ -101,18 +109,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: aadd943f4f8cc946882c954c187e6115a84c98c81ad1d9c6cbf0895a8c85da9c
+      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.5"
+    version: "2.5.4"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
@@ -121,14 +129,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
+      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.5.4"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.2"
   built_collection:
     dependency: transitive
     description:
@@ -185,6 +209,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  ci:
+    dependency: transitive
+    description:
+      name: ci
+      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -273,6 +313,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  custom_lint:
+    dependency: "direct dev"
+    description:
+      name: custom_lint
+      sha256: "9656925637516c5cf0f5da018b33df94025af2088fe09c8ae2ca54c53f2d9a84"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.6"
+  custom_lint_builder:
+    dependency: transitive
+    description:
+      name: custom_lint_builder
+      sha256: "6cdc8e87e51baaaba9c43e283ed8d28e59a0c4732279df62f66f7b5984655414"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.6"
+  custom_lint_core:
+    dependency: transitive
+    description:
+      name: custom_lint_core
+      sha256: "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.5"
+  custom_lint_visitor:
+    dependency: transitive
+    description:
+      name: custom_lint_visitor
+      sha256: "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+7.7.0"
   dart_jsonwebtoken:
     dependency: transitive
     description:
@@ -285,10 +357,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.1"
   dart_webrtc:
     dependency: "direct main"
     description:
@@ -390,11 +462,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
-  flutter_driver:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -525,11 +592,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  fuchsia_remote_debug_protocol:
+  freezed_annotation:
     dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -586,6 +664,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  hotreloader:
+    dependency: transitive
+    description:
+      name: hotreloader
+      sha256: "66871df468fc24eee81f1a0a7cb98acc104716f9b7376d355437b48d633c4ebf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   html:
     dependency: transitive
     description:
@@ -618,11 +704,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  integration_test:
-    dependency: "direct dev"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   intl:
     dependency: transitive
     description:
@@ -803,10 +884,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
+      sha256: "4546eac99e8967ea91bae633d2ca7698181d008e95fa4627330cf903d573277a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.4"
+    version: "5.4.6"
   mocktail:
     dependency: "direct dev"
     description:
@@ -999,14 +1080,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.5"
   protobuf:
     dependency: transitive
     description:
@@ -1118,6 +1191,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  riverpod_analyzer_utils:
+    dependency: transitive
+    description:
+      name: riverpod_analyzer_utils
+      sha256: "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.10"
+  riverpod_annotation:
+    dependency: "direct main"
+    description:
+      name: riverpod_annotation
+      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  riverpod_generator:
+    dependency: "direct dev"
+    description:
+      name: riverpod_generator
+      sha256: "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.5"
+  riverpod_lint:
+    dependency: "direct dev"
+    description:
+      name: riverpod_lint
+      sha256: "89a52b7334210dbff8605c3edf26cfe69b15062beed5cbfeff2c3812c33c9e35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.5"
   rxdart:
     dependency: transitive
     description:
@@ -1263,10 +1368,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "732792cfd197d2161a65bb029606a46e0a18ff30ef9e141a7a82172b05ea8ecd"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "2.0.0"
   source_span:
     dependency: transitive
     description:
@@ -1355,14 +1460,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  sync_http:
-    dependency: transitive
-    description:
-      name: sync_http
-      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1395,6 +1492,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.0"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   tray_manager:
     dependency: "direct main"
     description:
@@ -1579,14 +1684,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  webdriver:
-    dependency: transitive
-    description:
-      name: webdriver
-      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   webrtc_interface:
     dependency: transitive
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.6.0
+  riverpod_annotation: ^2.6.0
   go_router: ^17.2.2
   http: ^1.3.0
   http_parser: ^4.1.0
@@ -60,6 +61,9 @@ dev_dependencies:
   mockito: ^5.4.4
   mocktail: ^1.0.4
   build_runner: ^2.4.8
+  riverpod_generator: ^2.6.0
+  custom_lint: ^0.7.0
+  riverpod_lint: ^2.6.0
   network_image_mock: ^2.1.1
   path_provider_platform_interface: ^2.1.0
   plugin_platform_interface: ^2.1.0

--- a/apps/client/test/audit_logic_flaws_test.dart
+++ b/apps/client/test/audit_logic_flaws_test.dart
@@ -30,7 +30,7 @@ void main() {
       const state = ChatState();
 
       // Add 3 pending messages
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'pending_1000',
         fromUserId: 'me',
         fromUsername: 'Me',
@@ -40,7 +40,7 @@ void main() {
         isMine: true,
         status: MessageStatus.sending,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'pending_2000',
         fromUserId: 'me',
         fromUsername: 'Me',
@@ -50,7 +50,7 @@ void main() {
         isMine: true,
         status: MessageStatus.sending,
       );
-      final msg3 = ChatMessage(
+      final msg3 = const ChatMessage(
         id: 'pending_3000',
         fromUserId: 'me',
         fromUsername: 'Me',
@@ -234,7 +234,7 @@ void main() {
       // BEFORE the server call. No rollback on failure.
 
       const conv = Conversation(id: 'conv1', isGroup: false, unreadCount: 5);
-      final state = ConversationsState(conversations: [conv]);
+      final state = const ConversationsState(conversations: [conv]);
       expect(state.conversations.first.unreadCount, 5);
 
       // After markAsRead, count is 0 regardless of server response
@@ -263,7 +263,7 @@ void main() {
       // Stale messages remain in memory.
 
       const chatState = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -334,7 +334,7 @@ void main() {
       // chat_provider.dart:79 — replyToMessage is a global field in ChatState,
       // not scoped to a conversation. Switching conversations doesn't clear it.
 
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg_in_conv1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -365,7 +365,7 @@ void main() {
       'ConversationsState supports restoring unread count after failure',
       () {
         const conv = Conversation(id: 'conv1', isGroup: false, unreadCount: 5);
-        final state = ConversationsState(conversations: [conv]);
+        final state = const ConversationsState(conversations: [conv]);
 
         // Optimistically clear
         final updated = List<Conversation>.from(state.conversations);
@@ -392,7 +392,7 @@ void main() {
   group('H3 fix: clearConversation removes cached messages', () {
     test('ChatState can remove all messages for a conversation', () {
       const state = ChatState();
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -401,7 +401,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'bob',
         fromUsername: 'bob',
@@ -462,7 +462,7 @@ void main() {
   group('H6 fix: reaction guard on deleted messages', () {
     test('message existence check prevents reaction on deleted message', () {
       const state = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',
@@ -537,7 +537,7 @@ void main() {
   // =========================================================================
   group('M2 fix: edit mode clears reply state', () {
     test('entering edit should clear replyToMessage', () {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'alice',
         fromUsername: 'alice',

--- a/apps/client/test/helpers/mock_providers.dart
+++ b/apps/client/test/helpers/mock_providers.dart
@@ -227,16 +227,22 @@ class FakeCryptoNotifier extends CryptoNotifier {
 
 /// Override [biometricProvider] with a fixed state (unavailable by default in
 /// tests since [LocalAuthentication] is not available on host machines).
+///
+/// After the @riverpod migration the `Biometric` class extends a generated
+/// `_$Biometric` parent, so the test fake overrides `build()` to return the
+/// fixed state instead of mutating `state` from a constructor.
 Override biometricOverride([
   BiometricState initialState = const BiometricState(isLoading: false),
 ]) {
-  return biometricProvider.overrideWith(
-    (_) => _FakeBiometricNotifier(initialState),
-  );
+  return biometricProvider.overrideWith(() => _FakeBiometric(initialState));
 }
 
-class _FakeBiometricNotifier extends BiometricNotifier {
-  _FakeBiometricNotifier(super.initial) : super.forTest();
+class _FakeBiometric extends Biometric {
+  _FakeBiometric(this._initial);
+  final BiometricState _initial;
+
+  @override
+  BiometricState build() => _initial;
 
   @override
   Future<void> setEnabled(bool value) async {

--- a/apps/client/test/models/canvas_models_test.dart
+++ b/apps/client/test/models/canvas_models_test.dart
@@ -21,14 +21,11 @@ void main() {
 
   group('CanvasStroke', () {
     test('pen stroke round-trips through JSON', () {
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 'stroke-1',
         color: '#FF0000',
         width: 4.0,
-        points: const [
-          CanvasPoint(x: 0.1, y: 0.2),
-          CanvasPoint(x: 0.3, y: 0.4),
-        ],
+        points: [CanvasPoint(x: 0.1, y: 0.2), CanvasPoint(x: 0.3, y: 0.4)],
         kind: StrokeKind.pen,
       );
 
@@ -43,11 +40,11 @@ void main() {
     });
 
     test('eraser stroke preserves kind', () {
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 'e-1',
         color: '#00000000',
         width: 10.0,
-        points: const [CanvasPoint(x: 0.5, y: 0.5)],
+        points: [CanvasPoint(x: 0.5, y: 0.5)],
         kind: StrokeKind.eraser,
       );
       final json = stroke.toJson();
@@ -135,7 +132,7 @@ void main() {
       final updated = state.copyWith(
         isLoaded: true,
         selectedTool: CanvasTool.eraser,
-        currentColor: Color(0xFFFF0000),
+        currentColor: const Color(0xFFFF0000),
         strokeWidth: 8.0,
       );
       expect(updated.isLoaded, isTrue);
@@ -152,11 +149,11 @@ void main() {
 
     test('copyWith strokes appends correctly', () {
       const state = CanvasState();
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 's1',
         color: '#00FF00',
         width: 3.0,
-        points: const [CanvasPoint(x: 0.0, y: 0.0)],
+        points: [CanvasPoint(x: 0.0, y: 0.0)],
       );
       final updated = state.copyWith(strokes: [stroke]);
       expect(updated.strokes.length, 1);

--- a/apps/client/test/models/conversation_test.dart
+++ b/apps/client/test/models/conversation_test.dart
@@ -52,11 +52,11 @@ void main() {
     });
 
     test('displayName shows group name for groups', () {
-      final conv = Conversation(
+      final conv = const Conversation(
         id: 'conv-1',
         name: 'Team Chat',
         isGroup: true,
-        members: const [
+        members: [
           ConversationMember(userId: 'user-1', username: 'alice'),
           ConversationMember(userId: 'user-2', username: 'bob'),
         ],
@@ -66,10 +66,10 @@ void main() {
     });
 
     test('displayName shows peer name for 1:1', () {
-      final conv = Conversation(
+      final conv = const Conversation(
         id: 'conv-1',
         isGroup: false,
-        members: const [
+        members: [
           ConversationMember(userId: 'user-1', username: 'alice'),
           ConversationMember(userId: 'user-2', username: 'bob'),
         ],
@@ -80,7 +80,7 @@ void main() {
     });
 
     test('copyWith updates specified fields', () {
-      final conv = Conversation(
+      final conv = const Conversation(
         id: 'conv-1',
         name: 'Old Name',
         isGroup: true,

--- a/apps/client/test/providers/accessibility_provider_test.dart
+++ b/apps/client/test/providers/accessibility_provider_test.dart
@@ -1,7 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:echo_app/src/providers/accessibility_provider.dart';
+
+/// Pump enough microtasks for the build()-fired _load() to settle.
+Future<void> _flushLoad() =>
+    Future<void>.delayed(const Duration(milliseconds: 100));
 
 void main() {
   group('AccessibilityState', () {
@@ -32,20 +37,22 @@ void main() {
     });
   });
 
-  group('AccessibilityNotifier', () {
+  group('Accessibility (Notifier)', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
     test('loads defaults from empty SharedPreferences', () async {
-      final notifier = AccessibilityNotifier();
-      // Allow async _load() to complete.
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-
-      expect(notifier.state.fontScale, 1.0);
-      expect(notifier.state.reducedMotion, isFalse);
-      expect(notifier.state.highContrast, isFalse);
-      notifier.dispose();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final state = container.read(accessibilityProvider);
+      expect(state.fontScale, 1.0);
+      expect(state.reducedMotion, isFalse);
+      expect(state.highContrast, isFalse);
+      // After _load() resolves, state stays at defaults (no persisted values).
+      await _flushLoad();
+      final after = container.read(accessibilityProvider);
+      expect(after.fontScale, 1.0);
     });
 
     test('loads persisted values from SharedPreferences', () async {
@@ -55,52 +62,59 @@ void main() {
         kAccessibilityHighContrast: true,
       });
 
-      final notifier = AccessibilityNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      // Trigger build().
+      container.read(accessibilityProvider);
+      await _flushLoad();
 
-      expect(notifier.state.fontScale, 1.5);
-      expect(notifier.state.reducedMotion, isTrue);
-      expect(notifier.state.highContrast, isTrue);
-      notifier.dispose();
+      final after = container.read(accessibilityProvider);
+      expect(after.fontScale, 1.5);
+      expect(after.reducedMotion, isTrue);
+      expect(after.highContrast, isTrue);
     });
 
     test('setFontScale updates state and persists', () async {
-      SharedPreferences.setMockInitialValues({});
-      final notifier = AccessibilityNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(accessibilityProvider);
+      await _flushLoad();
 
-      await notifier.setFontScale(1.75);
-      expect(notifier.state.fontScale, 1.75);
+      await container.read(accessibilityProvider.notifier).setFontScale(1.75);
+      expect(container.read(accessibilityProvider).fontScale, 1.75);
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getDouble(kAccessibilityFontScale), 1.75);
-      notifier.dispose();
     });
 
     test('setReducedMotion updates state and persists', () async {
-      SharedPreferences.setMockInitialValues({});
-      final notifier = AccessibilityNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(accessibilityProvider);
+      await _flushLoad();
 
-      await notifier.setReducedMotion(true);
-      expect(notifier.state.reducedMotion, isTrue);
+      await container
+          .read(accessibilityProvider.notifier)
+          .setReducedMotion(true);
+      expect(container.read(accessibilityProvider).reducedMotion, isTrue);
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getBool(kAccessibilityReducedMotion), isTrue);
-      notifier.dispose();
     });
 
     test('setHighContrast updates state and persists', () async {
-      SharedPreferences.setMockInitialValues({});
-      final notifier = AccessibilityNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(accessibilityProvider);
+      await _flushLoad();
 
-      await notifier.setHighContrast(true);
-      expect(notifier.state.highContrast, isTrue);
+      await container
+          .read(accessibilityProvider.notifier)
+          .setHighContrast(true);
+      expect(container.read(accessibilityProvider).highContrast, isTrue);
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getBool(kAccessibilityHighContrast), isTrue);
-      notifier.dispose();
     });
   });
 }

--- a/apps/client/test/providers/canvas_provider_test.dart
+++ b/apps/client/test/providers/canvas_provider_test.dart
@@ -15,14 +15,11 @@ void main() {
   group('handleCanvasEvent – stroke', () {
     test('appends stroke to state', () {
       var state = const CanvasState(isLoaded: true);
-      final stroke = CanvasStroke(
+      final stroke = const CanvasStroke(
         id: 'stroke-1',
         color: '#FFFFFF',
         width: 3.0,
-        points: const [
-          CanvasPoint(x: 0.1, y: 0.2),
-          CanvasPoint(x: 0.3, y: 0.4),
-        ],
+        points: [CanvasPoint(x: 0.1, y: 0.2), CanvasPoint(x: 0.3, y: 0.4)],
       );
 
       // Simulate what handleCanvasEvent("stroke") does.
@@ -36,20 +33,20 @@ void main() {
 
   group('handleCanvasEvent – clear', () {
     test('removes all strokes', () {
-      var state = CanvasState(
+      var state = const CanvasState(
         isLoaded: true,
         strokes: [
           CanvasStroke(
             id: 'a',
             color: '#FF0000',
             width: 2.0,
-            points: const [CanvasPoint(x: 0.0, y: 0.0)],
+            points: [CanvasPoint(x: 0.0, y: 0.0)],
           ),
           CanvasStroke(
             id: 'b',
             color: '#00FF00',
             width: 2.0,
-            points: const [CanvasPoint(x: 0.5, y: 0.5)],
+            points: [CanvasPoint(x: 0.5, y: 0.5)],
           ),
         ],
       );
@@ -90,7 +87,7 @@ void main() {
         width: 0.25,
         height: 0.2,
       );
-      var state = CanvasState(isLoaded: true, images: [original]);
+      var state = const CanvasState(isLoaded: true, images: [original]);
 
       // Simulate image_move
       final updated = original.copyWith(x: 0.5, y: 0.6);
@@ -121,7 +118,7 @@ void main() {
         width: 0.1,
         height: 0.1,
       );
-      var state = CanvasState(isLoaded: true, images: [img1, img2]);
+      var state = const CanvasState(isLoaded: true, images: [img1, img2]);
 
       final newImages = state.images.where((img) => img.id != 'img-1').toList();
       state = state.copyWith(images: newImages);

--- a/apps/client/test/providers/channels_provider_test.dart
+++ b/apps/client/test/providers/channels_provider_test.dart
@@ -46,10 +46,10 @@ void main() {
     });
 
     test('copyWith preserves unchanged fields', () {
-      final state = ChannelsState(
+      final state = const ChannelsState(
         channelsByConversation: {
           'conv-1': [
-            const GroupChannel(
+            GroupChannel(
               id: 'ch-1',
               conversationId: 'conv-1',
               name: 'general',
@@ -59,7 +59,7 @@ void main() {
             ),
           ],
         },
-        loadingConversations: const {'conv-2'},
+        loadingConversations: {'conv-2'},
       );
 
       final copied = state.copyWith(error: 'test error');

--- a/apps/client/test/providers/chat_notifier_test.dart
+++ b/apps/client/test/providers/chat_notifier_test.dart
@@ -344,7 +344,7 @@ void main() {
       final notifier = _createNotifier();
       notifier.addMessage(_msg1);
 
-      final reaction = Reaction(
+      final reaction = const Reaction(
         messageId: 'msg-1',
         userId: 'user-2',
         username: 'bob',
@@ -361,7 +361,7 @@ void main() {
       final notifier = _createNotifier();
       notifier.addMessage(_msg1);
 
-      final reaction = Reaction(
+      final reaction = const Reaction(
         messageId: 'msg-1',
         userId: 'user-2',
         username: 'bob',

--- a/apps/client/test/providers/chat_provider_state_test.dart
+++ b/apps/client/test/providers/chat_provider_state_test.dart
@@ -29,7 +29,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final state = ChatState(
+      final state = const ChatState(
         messagesByConversation: {
           'conv-1': [msg],
         },
@@ -69,7 +69,7 @@ void main() {
         isMine: false,
       );
 
-      final state = ChatState(
+      final state = const ChatState(
         messagesByConversation: {
           'conv-1': [msg1, msg2, msg3],
         },
@@ -92,13 +92,13 @@ void main() {
     });
 
     test('isLoadingHistory returns correct value', () {
-      final state = ChatState(loadingHistory: {'conv-1:': true});
+      final state = const ChatState(loadingHistory: {'conv-1:': true});
       expect(state.isLoadingHistory('conv-1'), isTrue);
       expect(state.isLoadingHistory('conv-2'), isFalse);
     });
 
     test('isLoadingHistory with channel', () {
-      final state = ChatState(loadingHistory: {'conv-1:ch-1': true});
+      final state = const ChatState(loadingHistory: {'conv-1:ch-1': true});
       expect(state.isLoadingHistory('conv-1', channelId: 'ch-1'), isTrue);
       expect(state.isLoadingHistory('conv-1'), isFalse);
     });
@@ -109,7 +109,7 @@ void main() {
     });
 
     test('conversationHasMore returns stored value', () {
-      final state = ChatState(hasMore: {'conv-1:': false});
+      final state = const ChatState(hasMore: {'conv-1:': false});
       expect(state.conversationHasMore('conv-1'), isFalse);
     });
 
@@ -388,7 +388,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final state = ChatState(
+      final state = const ChatState(
         messagesByConversation: {
           'conv-1': [msg],
         },

--- a/apps/client/test/providers/chat_provider_test.dart
+++ b/apps/client/test/providers/chat_provider_test.dart
@@ -12,7 +12,7 @@ void main() {
 
     test('withMessage adds message to correct conversation', () {
       const state = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -28,7 +28,7 @@ void main() {
 
     test('messages for different conversations are isolated', () {
       const state = ChatState();
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -37,7 +37,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'user2',
         fromUsername: 'bob',
@@ -54,7 +54,7 @@ void main() {
 
     test('withMessage deduplicates by id', () {
       const state = ChatState();
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -84,7 +84,7 @@ void main() {
     });
 
     test('Reaction model', () {
-      final r = Reaction(
+      final r = const Reaction(
         messageId: 'm1',
         userId: 'u1',
         username: 'alice',
@@ -101,7 +101,7 @@ void main() {
 
     test('copyWith with replyToMessage sets the reply', () {
       const state = ChatState();
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'reply-1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -117,7 +117,7 @@ void main() {
     });
 
     test('copyWith with clearReply clears the reply', () {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'reply-1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -134,7 +134,7 @@ void main() {
     });
 
     test('clearReply takes precedence over replyToMessage in copyWith', () {
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'r1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -150,7 +150,7 @@ void main() {
     });
 
     test('withMessage preserves replyToMessage', () {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'reply-1',
         fromUserId: 'user1',
         fromUsername: 'alice',
@@ -160,7 +160,7 @@ void main() {
         isMine: false,
       );
       final state = ChatState(replyToMessage: replyMsg);
-      final newMsg = ChatMessage(
+      final newMsg = const ChatMessage(
         id: 'msg-new',
         fromUserId: 'user2',
         fromUsername: 'bob',
@@ -176,7 +176,7 @@ void main() {
 
     test('messages are ordered by insertion (append-only)', () {
       const state = ChatState();
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -185,7 +185,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'u2',
         fromUsername: 'bob',
@@ -194,7 +194,7 @@ void main() {
         timestamp: '2026-01-01T00:00:01Z',
         isMine: false,
       );
-      final msg3 = ChatMessage(
+      final msg3 = const ChatMessage(
         id: 'msg3',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -212,7 +212,7 @@ void main() {
     });
 
     test('ChatMessage pinnedAt and pinnedById via copyWith', () {
-      final msg = ChatMessage(
+      final msg = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -252,7 +252,7 @@ void main() {
     });
 
     test('updateMessagePin updates pin on correct message', () {
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -261,7 +261,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'u2',
         fromUsername: 'bob',
@@ -301,7 +301,7 @@ void main() {
     });
 
     test('messagesForConversationChannel filters by channelId', () {
-      final msg1 = ChatMessage(
+      final msg1 = const ChatMessage(
         id: 'msg1',
         fromUserId: 'u1',
         fromUsername: 'alice',
@@ -311,7 +311,7 @@ void main() {
         timestamp: '2026-01-01T00:00:00Z',
         isMine: false,
       );
-      final msg2 = ChatMessage(
+      final msg2 = const ChatMessage(
         id: 'msg2',
         fromUserId: 'u2',
         fromUsername: 'bob',

--- a/apps/client/test/providers/contacts_provider_test.dart
+++ b/apps/client/test/providers/contacts_provider_test.dart
@@ -1,6 +1,19 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:echo_app/src/providers/contacts_provider.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import 'package:echo_app/src/models/contact.dart';
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/contacts_provider.dart';
+import 'package:echo_app/src/providers/server_url_provider.dart';
+
+import '../helpers/mock_http_client.dart';
 
 void main() {
   group('ContactsState', () {
@@ -13,9 +26,9 @@ void main() {
     });
 
     test('copyWith preserves contacts, pending, and isLoading', () {
-      final state = ContactsState(
+      final state = const ContactsState(
         contacts: [
-          const Contact(
+          Contact(
             id: 'c1',
             userId: 'u1',
             username: 'alice',
@@ -23,12 +36,7 @@ void main() {
           ),
         ],
         pendingRequests: [
-          const Contact(
-            id: 'c2',
-            userId: 'u2',
-            username: 'bob',
-            status: 'pending',
-          ),
+          Contact(id: 'c2', userId: 'u2', username: 'bob', status: 'pending'),
         ],
         isLoading: true,
       );
@@ -39,14 +47,14 @@ void main() {
     });
 
     test('copyWith with no error argument preserves existing error', () {
-      final state = ContactsState(error: 'old error');
+      final state = const ContactsState(error: 'old error');
       // Omitting the error parameter preserves the current value.
       final copied = state.copyWith();
       expect(copied.error, 'old error');
     });
 
     test('copyWith with explicit null clears error', () {
-      final state = ContactsState(error: 'old error');
+      final state = const ContactsState(error: 'old error');
       final cleared = state.copyWith(error: null);
       expect(cleared.error, isNull);
     });
@@ -141,9 +149,9 @@ void main() {
     });
 
     test('contacts and pending lists are independent', () {
-      final state = ContactsState(
+      final state = const ContactsState(
         contacts: [
-          const Contact(
+          Contact(
             id: 'c1',
             userId: 'u1',
             username: 'alice',
@@ -151,12 +159,7 @@ void main() {
           ),
         ],
         pendingRequests: [
-          const Contact(
-            id: 'c2',
-            userId: 'u2',
-            username: 'bob',
-            status: 'pending',
-          ),
+          Contact(id: 'c2', userId: 'u2', username: 'bob', status: 'pending'),
         ],
       );
 
@@ -169,6 +172,166 @@ void main() {
       final updatedPending = state.copyWith(pendingRequests: []);
       expect(updatedPending.contacts, hasLength(1));
       expect(updatedPending.pendingRequests, isEmpty);
+    });
+  });
+
+  // -----------------------------------------------------------------
+  // #599: monotonic-generation guard for loadContacts.
+  // Two concurrent reloads must not let the older response overwrite
+  // the newer one's state.
+  // -----------------------------------------------------------------
+  group('ContactsNotifier.loadContacts stale-guard (#599)', () {
+    late MockHttpClient mockClient;
+    late ProviderContainer container;
+
+    setUpAll(registerHttpFallbackValues);
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      mockClient = MockHttpClient();
+      when(() => mockClient.close()).thenReturn(null);
+
+      container = ProviderContainer(
+        overrides: [
+          authProvider.overrideWith((ref) {
+            final n = AuthNotifier(ref);
+            n.state = const AuthState(
+              isLoggedIn: true,
+              userId: 'me',
+              username: 'testuser',
+              token: 'fake-token',
+              refreshToken: 'fake-refresh',
+            );
+            return n;
+          }),
+          serverUrlProvider.overrideWith((ref) {
+            final n = ServerUrlNotifier();
+            n.state = 'http://localhost:8080';
+            return n;
+          }),
+        ],
+      );
+    });
+
+    tearDown(() => container.dispose());
+
+    Map<String, dynamic> contactFixture(String id, String username) => {
+      'id': id,
+      'user_id': 'uid-$id',
+      'username': username,
+      'status': 'accepted',
+    };
+
+    test('late stale success does not overwrite fresh success', () async {
+      final completers = <Completer<http.Response>>[
+        Completer<http.Response>(),
+        Completer<http.Response>(),
+      ];
+      var callIndex = 0;
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/contacts')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) => completers[callIndex++].future);
+
+      final notifier = container.read(contactsProvider.notifier);
+      await http.runWithClient(() async {
+        // Fire two reloads without awaiting -- second is the "fresh" one.
+        final a = notifier.loadContacts();
+        final b = notifier.loadContacts();
+
+        // Resolve B (fresh) first with [alice], then A (stale) with [bob].
+        completers[1].complete(
+          http.Response(jsonEncode([contactFixture('1', 'alice')]), 200),
+        );
+        await b;
+
+        completers[0].complete(
+          http.Response(jsonEncode([contactFixture('2', 'bob')]), 200),
+        );
+        await a;
+
+        // Latest call (B / alice) must win even though A finished after.
+        expect(notifier.state.contacts, hasLength(1));
+        expect(notifier.state.contacts.first.username, 'alice');
+        expect(notifier.state.isLoading, isFalse);
+      }, () => mockClient);
+    });
+
+    test('late stale error does not clobber fresh success', () async {
+      final completers = <Completer<http.Response>>[
+        Completer<http.Response>(),
+        Completer<http.Response>(),
+      ];
+      var callIndex = 0;
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/contacts')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) => completers[callIndex++].future);
+
+      final notifier = container.read(contactsProvider.notifier);
+      await http.runWithClient(() async {
+        final a = notifier.loadContacts(); // stale -- will throw
+        final b = notifier.loadContacts(); // fresh -- succeeds
+
+        completers[1].complete(
+          http.Response(jsonEncode([contactFixture('1', 'alice')]), 200),
+        );
+        await b;
+
+        completers[0].completeError(const SocketException('boom'));
+        await a;
+
+        // Stale error must NOT overwrite fresh success.
+        expect(notifier.state.contacts, hasLength(1));
+        expect(notifier.state.contacts.first.username, 'alice');
+        expect(notifier.state.error, isNull);
+        expect(notifier.state.isLoading, isFalse);
+      }, () => mockClient);
+    });
+
+    test('isLoading stays true until the latest call completes', () async {
+      final completers = <Completer<http.Response>>[
+        Completer<http.Response>(),
+        Completer<http.Response>(),
+      ];
+      var callIndex = 0;
+      when(
+        () => mockClient.get(
+          any(that: predicate<Uri>((u) => u.path == '/api/contacts')),
+          headers: any(named: 'headers'),
+        ),
+      ).thenAnswer((_) => completers[callIndex++].future);
+
+      final notifier = container.read(contactsProvider.notifier);
+      await http.runWithClient(() async {
+        final a = notifier.loadContacts();
+        final b = notifier.loadContacts();
+
+        expect(notifier.state.isLoading, isTrue);
+
+        // Resolve the stale call first; loading must stay true.
+        completers[0].complete(
+          http.Response(jsonEncode([contactFixture('1', 'bob')]), 200),
+        );
+        await a;
+        expect(
+          notifier.state.isLoading,
+          isTrue,
+          reason: 'stale return must not flip isLoading=false',
+        );
+
+        // Resolve the fresh call -- THIS one clears loading.
+        completers[1].complete(
+          http.Response(jsonEncode([contactFixture('2', 'alice')]), 200),
+        );
+        await b;
+        expect(notifier.state.isLoading, isFalse);
+        expect(notifier.state.contacts.first.username, 'alice');
+      }, () => mockClient);
     });
   });
 

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -159,10 +159,10 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'group-1', name: 'G1', isGroup: true),
-          const Conversation(id: 'group-2', name: 'G2', isGroup: true),
+          Conversation(id: 'group-1', name: 'G1', isGroup: true),
+          Conversation(id: 'group-2', name: 'G2', isGroup: true),
         ],
       );
 
@@ -192,10 +192,8 @@ void main() {
       ).thenAnswer((_) async => http.Response('error', 500));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
-        conversations: [
-          const Conversation(id: 'group-1', name: 'G1', isGroup: true),
-        ],
+      notifier.state = const ConversationsState(
+        conversations: [Conversation(id: 'group-1', name: 'G1', isGroup: true)],
       );
 
       final result = await http.runWithClient(
@@ -225,8 +223,8 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
-        conversations: [const Conversation(id: 'conv-1', isGroup: false)],
+      notifier.state = const ConversationsState(
+        conversations: [Conversation(id: 'conv-1', isGroup: false)],
       );
 
       final result = await http.runWithClient(
@@ -427,9 +425,9 @@ void main() {
   group('ConversationsNotifier.getOrCreateDm', () {
     test('finds existing DM locally without HTTP call', () async {
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(
+          Conversation(
             id: 'dm-1',
             isGroup: false,
             members: [
@@ -566,9 +564,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
+          Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
         ],
       );
 
@@ -595,9 +593,9 @@ void main() {
       ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
+          Conversation(id: 'conv-1', isGroup: false, unreadCount: 5),
         ],
       );
 
@@ -630,9 +628,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -663,9 +661,9 @@ void main() {
       ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -698,9 +696,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('{}', 200));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -732,9 +730,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('Internal Server Error', 500));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: false),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: false),
         ],
       );
 
@@ -753,9 +751,9 @@ void main() {
 
     test('no-op returns true when already in target state', () async {
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isMuted: true),
+          Conversation(id: 'conv-1', isGroup: false, isMuted: true),
         ],
       );
 
@@ -817,9 +815,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('', 204));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: false),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: false),
         ],
       );
 
@@ -849,9 +847,9 @@ void main() {
       ).thenAnswer((_) async => http.Response('Internal Server Error', 500));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: false),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: false),
         ],
       );
 
@@ -885,9 +883,9 @@ void main() {
       });
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: true),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: true),
         ],
       );
 
@@ -918,9 +916,9 @@ void main() {
       ).thenThrow(const SocketException('Connection refused'));
 
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: true),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: true),
         ],
       );
 
@@ -939,9 +937,9 @@ void main() {
 
     test('no-op returns true when already in target state', () async {
       final notifier = container.read(conversationsProvider.notifier);
-      notifier.state = ConversationsState(
+      notifier.state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'conv-1', isGroup: false, isPinned: true),
+          Conversation(id: 'conv-1', isGroup: false, isPinned: true),
         ],
       );
 

--- a/apps/client/test/providers/conversations_notifier_test.dart
+++ b/apps/client/test/providers/conversations_notifier_test.dart
@@ -161,7 +161,7 @@ void main() {
 
   group('ConversationsState', () {
     test('copyWith preserves conversations when not overridden', () {
-      final state = ConversationsState(
+      final state = const ConversationsState(
         conversations: [_conv1, _conv2],
         isLoading: true,
       );

--- a/apps/client/test/providers/conversations_provider_test.dart
+++ b/apps/client/test/providers/conversations_provider_test.dart
@@ -12,8 +12,8 @@ void main() {
     });
 
     test('copyWith preserves conversations and isLoading', () {
-      final state = ConversationsState(
-        conversations: [const Conversation(id: 'c1', isGroup: false)],
+      final state = const ConversationsState(
+        conversations: [Conversation(id: 'c1', isGroup: false)],
         isLoading: true,
       );
       final copied = state.copyWith();
@@ -23,7 +23,7 @@ void main() {
     });
 
     test('copyWith with no error argument clears error (by design)', () {
-      final state = ConversationsState(error: 'old error');
+      final state = const ConversationsState(error: 'old error');
       // The copyWith uses direct assignment for error (not null-coalesce),
       // so calling copyWith() without error clears it.
       final copied = state.copyWith();
@@ -82,11 +82,11 @@ void main() {
     });
 
     test('removing a conversation updates the list', () {
-      final state = ConversationsState(
+      final state = const ConversationsState(
         conversations: [
-          const Conversation(id: 'c1', isGroup: false),
-          const Conversation(id: 'c2', isGroup: true, name: 'Group'),
-          const Conversation(id: 'c3', isGroup: false),
+          Conversation(id: 'c1', isGroup: false),
+          Conversation(id: 'c2', isGroup: true, name: 'Group'),
+          Conversation(id: 'c3', isGroup: false),
         ],
       );
       final filtered = state.conversations.where((c) => c.id != 'c2').toList();

--- a/apps/client/test/providers/theme_provider_test.dart
+++ b/apps/client/test/providers/theme_provider_test.dart
@@ -1,29 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:echo_app/src/providers/theme_provider.dart';
 
+/// Pump enough microtasks for the build()-fired _load() to settle.
+Future<void> _flushLoad() =>
+    Future<void>.delayed(const Duration(milliseconds: 100));
+
 void main() {
-  group('ThemeNotifier', () {
+  group('AppTheme (Notifier)', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
     test('default theme is dark', () async {
-      final notifier = ThemeNotifier();
-      // Allow async _load to run.
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, AppThemeSelection.dark);
-      notifier.dispose();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(appThemeProvider);
+      await _flushLoad();
+      expect(container.read(appThemeProvider), AppThemeSelection.dark);
     });
 
     test('loads persisted theme from SharedPreferences', () async {
       SharedPreferences.setMockInitialValues({'echo_theme_mode': 'light'});
-      final notifier = ThemeNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, AppThemeSelection.light);
-      notifier.dispose();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(appThemeProvider);
+      await _flushLoad();
+      expect(container.read(appThemeProvider), AppThemeSelection.light);
     });
 
     test('loads all theme variants', () async {
@@ -38,95 +44,126 @@ void main() {
         'aurora': AppThemeSelection.aurora,
       }.entries) {
         SharedPreferences.setMockInitialValues({'echo_theme_mode': entry.key});
-        final notifier = ThemeNotifier();
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.read(appThemeProvider);
+        await _flushLoad();
         expect(
-          notifier.state,
+          container.read(appThemeProvider),
           entry.value,
           reason: '${entry.key} should map to ${entry.value}',
         );
-        notifier.dispose();
       }
     });
 
     test('unknown theme value falls back to dark', () async {
       SharedPreferences.setMockInitialValues({'echo_theme_mode': 'unknown'});
-      final notifier = ThemeNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, AppThemeSelection.dark);
-      notifier.dispose();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(appThemeProvider);
+      await _flushLoad();
+      expect(container.read(appThemeProvider), AppThemeSelection.dark);
     });
 
     test('setTheme updates state and persists', () async {
-      final notifier = ThemeNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(appThemeProvider);
+      await _flushLoad();
 
-      await notifier.setTheme(AppThemeSelection.ember);
-      expect(notifier.state, AppThemeSelection.ember);
+      await container
+          .read(appThemeProvider.notifier)
+          .setTheme(AppThemeSelection.ember);
+      expect(container.read(appThemeProvider), AppThemeSelection.ember);
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getString('echo_theme_mode'), 'ember');
-      notifier.dispose();
     });
 
     test('setThemeMode maps ThemeMode to AppThemeSelection', () async {
-      final notifier = ThemeNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(appThemeProvider);
+      await _flushLoad();
 
+      final notifier = container.read(appThemeProvider.notifier);
       await notifier.setThemeMode(ThemeMode.light);
-      expect(notifier.state, AppThemeSelection.light);
+      expect(container.read(appThemeProvider), AppThemeSelection.light);
 
       await notifier.setThemeMode(ThemeMode.dark);
-      expect(notifier.state, AppThemeSelection.dark);
+      expect(container.read(appThemeProvider), AppThemeSelection.dark);
 
       await notifier.setThemeMode(ThemeMode.system);
-      expect(notifier.state, AppThemeSelection.system);
-      notifier.dispose();
+      expect(container.read(appThemeProvider), AppThemeSelection.system);
+    });
+
+    test('legacy themeProvider alias points at the same provider', () {
+      // The historical symbol is kept for back-compat; assert it resolves to
+      // the same generated provider so call sites can be migrated lazily.
+      expect(themeProvider, same(appThemeProvider));
     });
   });
 
-  group('MessageLayoutNotifier', () {
+  group('MessageLayoutNotifier (Notifier)', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
     test('default layout is compact (Discord-style)', () async {
-      final notifier = MessageLayoutNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, MessageLayout.compact);
-      notifier.dispose();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(messageLayoutNotifierProvider);
+      await _flushLoad();
+      expect(
+        container.read(messageLayoutNotifierProvider),
+        MessageLayout.compact,
+      );
     });
 
     test('loads persisted bubbles layout', () async {
       SharedPreferences.setMockInitialValues({
         'echo_message_layout': 'bubbles',
       });
-      final notifier = MessageLayoutNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, MessageLayout.bubbles);
-      notifier.dispose();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(messageLayoutNotifierProvider);
+      await _flushLoad();
+      expect(
+        container.read(messageLayoutNotifierProvider),
+        MessageLayout.bubbles,
+      );
     });
 
     test('unknown layout value falls back to compact default', () async {
       SharedPreferences.setMockInitialValues({
         'echo_message_layout': 'unknown',
       });
-      final notifier = MessageLayoutNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-      expect(notifier.state, MessageLayout.compact);
-      notifier.dispose();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(messageLayoutNotifierProvider);
+      await _flushLoad();
+      expect(
+        container.read(messageLayoutNotifierProvider),
+        MessageLayout.compact,
+      );
     });
 
     test('setLayout updates state and persists', () async {
-      final notifier = MessageLayoutNotifier();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(messageLayoutNotifierProvider);
+      await _flushLoad();
 
-      await notifier.setLayout(MessageLayout.bubbles);
-      expect(notifier.state, MessageLayout.bubbles);
+      await container
+          .read(messageLayoutNotifierProvider.notifier)
+          .setLayout(MessageLayout.bubbles);
+      expect(
+        container.read(messageLayoutNotifierProvider),
+        MessageLayout.bubbles,
+      );
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getString('echo_message_layout'), 'bubbles');
-      notifier.dispose();
     });
   });
 }

--- a/apps/client/test/providers/websocket_provider_test.dart
+++ b/apps/client/test/providers/websocket_provider_test.dart
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('copyWith preserves values when no arguments given', () {
-      final state = WebSocketState(
+      final state = const WebSocketState(
         isConnected: true,
         onlineUsers: {'u1', 'u2'},
       );
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('isUserOnline returns true for online users', () {
-      final state = WebSocketState(onlineUsers: {'user-1', 'user-2'});
+      final state = const WebSocketState(onlineUsers: {'user-1', 'user-2'});
       expect(state.isUserOnline('user-1'), isTrue);
       expect(state.isUserOnline('user-2'), isTrue);
       expect(state.isUserOnline('user-3'), isFalse);
@@ -135,7 +135,7 @@ void main() {
     });
 
     test('onlineUsers empty set means no users online', () {
-      final state = WebSocketState(onlineUsers: {'u1'});
+      final state = const WebSocketState(onlineUsers: {'u1'});
       final cleared = state.copyWith(onlineUsers: <String>{});
       expect(cleared.onlineUsers, isEmpty);
       expect(cleared.isUserOnline('u1'), isFalse);
@@ -256,7 +256,7 @@ void main() {
 
   group('WebSocketState disconnect semantics', () {
     test('disconnect clears isConnected but preserves onlineUsers snapshot', () {
-      final state = WebSocketState(
+      final state = const WebSocketState(
         isConnected: true,
         onlineUsers: {'u1', 'u2'},
       );
@@ -269,7 +269,7 @@ void main() {
     });
 
     test('full disconnect clears connection and online users', () {
-      final state = WebSocketState(
+      final state = const WebSocketState(
         isConnected: true,
         onlineUsers: {'u1', 'u2'},
       );

--- a/apps/client/test/widgets/a11y_tap_targets_test.dart
+++ b/apps/client/test/widgets/a11y_tap_targets_test.dart
@@ -11,7 +11,7 @@ import '../helpers/mock_providers.dart';
 import '../helpers/pump_app.dart';
 
 ChatMessage _peerMsg() {
-  return ChatMessage(
+  return const ChatMessage(
     id: 'msg-1',
     fromUserId: 'user-alice',
     fromUsername: 'alice',

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -12,9 +12,9 @@ import '../helpers/pump_app.dart';
 
 class _FakeChannelsNotifier extends ChannelsNotifier {
   _FakeChannelsNotifier(super.ref) : super() {
-    state = ChannelsState(
+    state = const ChannelsState(
       channelsByConversation: {
-        'conv-1': const [
+        'conv-1': [
           GroupChannel(
             id: 'voice-1',
             conversationId: 'conv-1',
@@ -26,7 +26,7 @@ class _FakeChannelsNotifier extends ChannelsNotifier {
           ),
         ],
       },
-      voiceSessionsByChannel: const {'voice-1': []},
+      voiceSessionsByChannel: {'voice-1': []},
     );
   }
 

--- a/apps/client/test/widgets/chat_input_bar_test.dart
+++ b/apps/client/test/widgets/chat_input_bar_test.dart
@@ -133,7 +133,7 @@ void main() {
     });
 
     testWidgets('reply preview shows when reply is active', (tester) async {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg-reply',
         fromUserId: 'user-alice',
         fromUsername: 'alice',
@@ -156,7 +156,7 @@ void main() {
     });
 
     testWidgets('reply preview has close button', (tester) async {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg-reply',
         fromUserId: 'user-alice',
         fromUsername: 'alice',
@@ -208,7 +208,7 @@ void main() {
     });
 
     testWidgets('escape key clears reply when reply is active', (tester) async {
-      final replyMsg = ChatMessage(
+      final replyMsg = const ChatMessage(
         id: 'msg-reply',
         fromUserId: 'user-alice',
         fromUsername: 'alice',

--- a/apps/client/test/widgets/chat_panel_live_region_test.dart
+++ b/apps/client/test/widgets/chat_panel_live_region_test.dart
@@ -70,16 +70,14 @@ class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
   _FakeVoiceRtcNotifier(super.ref);
 }
 
-class _FakeThemeNotifier extends ThemeNotifier {
-  _FakeThemeNotifier() {
-    state = AppThemeSelection.dark;
-  }
+class _FakeTheme extends AppTheme {
+  @override
+  AppThemeSelection build() => AppThemeSelection.dark;
 }
 
 class _FakeMessageLayoutNotifier extends MessageLayoutNotifier {
-  _FakeMessageLayoutNotifier() {
-    state = MessageLayout.bubbles;
-  }
+  @override
+  MessageLayout build() => MessageLayout.bubbles;
 }
 
 const _conv = Conversation(
@@ -137,8 +135,8 @@ List<Override> _overrides({
     privacyProvider.overrideWith((ref) => _FakePrivacyNotifier(ref)),
     voiceSettingsProvider.overrideWith((ref) => _FakeVoiceSettingsNotifier()),
     voiceRtcProvider.overrideWith((ref) => _FakeVoiceRtcNotifier(ref)),
-    themeProvider.overrideWith((ref) => _FakeThemeNotifier()),
-    messageLayoutProvider.overrideWith((ref) => _FakeMessageLayoutNotifier()),
+    appThemeProvider.overrideWith(_FakeTheme.new),
+    messageLayoutNotifierProvider.overrideWith(_FakeMessageLayoutNotifier.new),
   ];
 }
 

--- a/apps/client/test/widgets/chat_panel_live_region_test.dart
+++ b/apps/client/test/widgets/chat_panel_live_region_test.dart
@@ -156,7 +156,7 @@ void main() {
     ) async {
       final holder = _NotifierHolder();
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: const ChatState(), holder: holder),
       );
       await tester.pump();
@@ -178,7 +178,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: initial, holder: holder),
       );
       await tester.pump();
@@ -209,7 +209,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: initial, holder: holder),
       );
       await tester.pump();
@@ -234,7 +234,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: initial, holder: holder),
       );
       await tester.pump();
@@ -277,7 +277,7 @@ void main() {
         );
 
         await tester.pumpApp(
-          ChatPanel(conversation: _conv),
+          const ChatPanel(conversation: _conv),
           overrides: _overrides(initial: initial, holder: holder),
         );
         await tester.pump();
@@ -304,7 +304,7 @@ void main() {
       final holder = _NotifierHolder();
 
       await tester.pumpApp(
-        ChatPanel(conversation: _conv),
+        const ChatPanel(conversation: _conv),
         overrides: _overrides(initial: const ChatState(), holder: holder),
       );
       await tester.pump();

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -78,21 +78,22 @@ List<Override> _chatPanelOverrides({ChatState chatState = const ChatState()}) {
     privacyProvider.overrideWith((ref) => _FakePrivacyNotifier(ref)),
     voiceSettingsProvider.overrideWith((ref) => _FakeVoiceSettingsNotifier()),
     voiceRtcProvider.overrideWith((ref) => _FakeVoiceRtcNotifier(ref)),
-    themeProvider.overrideWith((ref) => _FakeThemeNotifier()),
-    messageLayoutProvider.overrideWith((ref) => _FakeMessageLayoutNotifier()),
+    appThemeProvider.overrideWith(_FakeTheme.new),
+    messageLayoutNotifierProvider.overrideWith(_FakeMessageLayoutNotifier.new),
   ];
 }
 
-class _FakeThemeNotifier extends ThemeNotifier {
-  _FakeThemeNotifier() {
-    state = AppThemeSelection.dark;
-  }
+/// `@riverpod` Notifier fakes override `build()` instead of mutating
+/// `state` from a constructor -- the generated parent class initialises
+/// `state` from the value `build()` returns.
+class _FakeTheme extends AppTheme {
+  @override
+  AppThemeSelection build() => AppThemeSelection.dark;
 }
 
 class _FakeMessageLayoutNotifier extends MessageLayoutNotifier {
-  _FakeMessageLayoutNotifier() {
-    state = MessageLayout.bubbles;
-  }
+  @override
+  MessageLayout build() => MessageLayout.bubbles;
 }
 
 /// A 1:1 DM conversation.

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -142,7 +142,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -153,7 +153,7 @@ void main() {
 
     testWidgets('shows group name in group conversation', (tester) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _groupConversation),
+        const ChatPanel(conversation: _groupConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -165,7 +165,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -179,7 +179,7 @@ void main() {
 
     testWidgets('message list renders with messages', (tester) async {
       final messages = [
-        ChatMessage(
+        const ChatMessage(
           id: 'msg-1',
           fromUserId: 'user-alice',
           fromUsername: 'alice',
@@ -188,7 +188,7 @@ void main() {
           timestamp: '2026-01-15T10:00:00Z',
           isMine: false,
         ),
-        ChatMessage(
+        const ChatMessage(
           id: 'msg-2',
           fromUserId: 'test-user-id',
           fromUsername: 'testuser',
@@ -204,7 +204,7 @@ void main() {
       );
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();
@@ -214,10 +214,10 @@ void main() {
     });
 
     testWidgets('loading indicator shows when loading history', (tester) async {
-      final chatState = ChatState(loadingHistory: {'conv-dm:': true});
+      final chatState = const ChatState(loadingHistory: {'conv-dm:': true});
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();
@@ -229,7 +229,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -241,7 +241,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -255,7 +255,7 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(),
       );
       await tester.pump();
@@ -310,7 +310,7 @@ void main() {
     testWidgets('optimistic delete removes message from list', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -329,7 +329,7 @@ void main() {
     testWidgets('rollback restores message after failed delete', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -365,7 +365,7 @@ void main() {
     testWidgets('optimistic pin update is reflected in state', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -399,7 +399,7 @@ void main() {
     testWidgets('rollback clears pin on server failure', skip: true, (
       tester,
     ) async {
-      final chatState = ChatState(
+      final chatState = const ChatState(
         messagesByConversation: {
           'conv-dm': [testMsg],
         },
@@ -437,10 +437,10 @@ void main() {
     testWidgets('history-key with channel suffix is respected', (tester) async {
       // Key format is '$conversationId:$channelId' — for a DM with no
       // channel the suffix is empty, so the correct key is 'conv-dm:'.
-      final chatState = ChatState(loadingHistory: {'conv-dm:': true});
+      final chatState = const ChatState(loadingHistory: {'conv-dm:': true});
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();
@@ -452,10 +452,10 @@ void main() {
     testWidgets('skeleton loader shown when loading with no messages', (
       tester,
     ) async {
-      final chatState = ChatState(loadingHistory: {'conv-dm:': true});
+      final chatState = const ChatState(loadingHistory: {'conv-dm:': true});
 
       await tester.pumpApp(
-        ChatPanel(conversation: _dmConversation),
+        const ChatPanel(conversation: _dmConversation),
         overrides: _chatPanelOverrides(chatState: chatState),
       );
       await tester.pump();

--- a/apps/client/test/widgets/semantics_labels_test.dart
+++ b/apps/client/test/widgets/semantics_labels_test.dart
@@ -507,8 +507,8 @@ void main() {
   group('Semantic labels - ReactionBar', () {
     testWidgets('single reaction shows "1 reaction:" label', (tester) async {
       await tester.pumpApp(
-        ReactionBar(
-          reactions: const [
+        const ReactionBar(
+          reactions: [
             Reaction(
               messageId: 'm1',
               userId: 'u1',
@@ -517,7 +517,7 @@ void main() {
             ),
           ],
           isMine: false,
-          chatBgColor: const Color(0xFF141415),
+          chatBgColor: Color(0xFF141415),
         ),
       );
       await tester.pump();
@@ -529,8 +529,8 @@ void main() {
       tester,
     ) async {
       await tester.pumpApp(
-        ReactionBar(
-          reactions: const [
+        const ReactionBar(
+          reactions: [
             Reaction(
               messageId: 'm1',
               userId: 'u1',
@@ -545,7 +545,7 @@ void main() {
             ),
           ],
           isMine: false,
-          chatBgColor: const Color(0xFF141415),
+          chatBgColor: Color(0xFF141415),
         ),
       );
       await tester.pump();
@@ -555,8 +555,8 @@ void main() {
 
     testWidgets('reaction bar has button: true', (tester) async {
       await tester.pumpApp(
-        ReactionBar(
-          reactions: const [
+        const ReactionBar(
+          reactions: [
             Reaction(
               messageId: 'm1',
               userId: 'u1',
@@ -565,7 +565,7 @@ void main() {
             ),
           ],
           isMine: false,
-          chatBgColor: const Color(0xFF141415),
+          chatBgColor: Color(0xFF141415),
         ),
       );
       await tester.pump();

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -50,6 +50,12 @@ rand = "0.10"
 # Signal Protocol signature verification
 ed25519-dalek = { version = "2", features = ["std"] }
 
+# Shared wire-format constants (#700). echo-core defines magic bytes,
+# version markers, header_len, KDF info strings, and skip-key bounds in
+# one place; server consumes via `echo_core::signal::protocol::*` so
+# the protocol contract has a single source of truth.
+echo-core = { path = "../../core/rust-core" }
+
 # Tracing
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -50,11 +50,8 @@ rand = "0.10"
 # Signal Protocol signature verification
 ed25519-dalek = { version = "2", features = ["std"] }
 
-# Shared wire-format constants (#700). echo-core defines magic bytes,
-# version markers, header_len, KDF info strings, and skip-key bounds in
-# one place; server consumes via `echo_core::signal::protocol::*` so
-# the protocol contract has a single source of truth.
-echo-core = { path = "../../core/rust-core" }
+# Shared wire-format constants (#700).
+echo-core = { version = "0.1.0", path = "../../core/rust-core" }
 
 # Tracing
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -30,6 +30,9 @@ argon2 = "0.5"
 
 # WebSocket / async
 futures-util = "0.3"
+# Used by link_preview streaming body cap (#684) -- reqwest bytes_stream
+# yields bytes::Bytes, but it's not re-exported, so we depend directly.
+bytes = "1"
 
 # Connection hub
 dashmap = "6"
@@ -51,7 +54,9 @@ ed25519-dalek = { version = "2", features = ["std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # HTTP client (link previews)
-reqwest = { version = "0.13", features = ["json"] }
+# `stream` feature exposes Response::bytes_stream() for incremental body
+# reads with a hard cap (#684).
+reqwest = { version = "0.13", features = ["json", "stream"] }
 
 # File type detection (magic bytes)
 infer = "0.19"

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -27,6 +27,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    curl \
     tini \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/* \
@@ -34,12 +35,24 @@ RUN apt-get update && apt-get install -y \
     && useradd --uid 1000 --gid echo --shell /bin/sh echo
 
 COPY --from=builder /app/target/release/echo-server /usr/local/bin/echo-server
-COPY apps/server/src/migrations /opt/echo/migrations
+# Audit H25 (#356): the original COPY pointed at apps/server/src/migrations
+# which holds stale 001_/002_/003_ files unused since the 20250101000000
+# baseline consolidated migration. The runtime sqlx::migrate!() macro
+# embeds migrations from apps/server/migrations/ at compile time, so this
+# COPY is purely defensive (operators who ever shell into the image to
+# inspect schema history).  Point it at the right directory.
+COPY apps/server/migrations /opt/echo/migrations
 
 RUN mkdir -p /app/uploads/avatars
 
 USER echo
 EXPOSE 8080
+
+# Audit H27 (#356): healthcheck so traefik / docker-compose stop routing
+# to the container before tcp accepts refuse.  /api/health is a cheap
+# unauthenticated endpoint that returns {"status": "ok", ...}.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl -fsS http://localhost:8080/api/health || exit 1
 
 ENTRYPOINT ["tini", "--"]
 CMD ["echo-server"]

--- a/apps/server/migrations/20260501000000_drop_duplicate_reply_to_index.sql
+++ b/apps/server/migrations/20260501000000_drop_duplicate_reply_to_index.sql
@@ -1,0 +1,13 @@
+-- Audit perf #6 / #678: drop the duplicate partial index on messages.reply_to_id.
+--
+-- The baseline migration created `idx_messages_reply_to ON messages (reply_to_id)
+-- WHERE reply_to_id IS NOT NULL` and 20260423000000 added an identical
+-- index named `idx_messages_reply_to_id` covering the same column with the
+-- same predicate. Postgres maintains both on every insert/update/delete that
+-- touches `reply_to_id`, doubling the write amplification for zero query
+-- benefit (the planner only ever uses one of them).
+--
+-- Keep `idx_messages_reply_to_id` because the LEFT JOIN LATERAL added in
+-- 2026-04-30 (#678) deliberately uses that name in EXPLAIN traces and code
+-- comments; drop the older `idx_messages_reply_to`.
+DROP INDEX IF EXISTS idx_messages_reply_to;

--- a/apps/server/src/auth/jwt.rs
+++ b/apps/server/src/auth/jwt.rs
@@ -135,4 +135,32 @@ mod tests {
         let h2 = hash_refresh_token("token_b");
         assert_ne!(h1, h2);
     }
+
+    #[test]
+    fn test_expired_token_is_rejected() {
+        // Mint a token whose exp is in the past and confirm validate_token
+        // rejects it.  Guards against regressions that disable expiry checks
+        // (e.g. flipping `validation.validate_exp` off).
+        let user_id = Uuid::new_v4();
+        let now = chrono::Utc::now().timestamp() as usize;
+        // jsonwebtoken's Validation::default() has a 60-second clock-skew
+        // leeway, so the expiry must be more than 60s in the past for the
+        // assertion to be meaningful.
+        let expired = Claims {
+            sub: user_id.to_string(),
+            exp: now - 3600,
+            iat: now - 7200,
+            iss: "echo-messenger".to_string(),
+            aud: "echo-app".to_string(),
+        };
+        let token = encode(
+            &Header::default(),
+            &expired,
+            &EncodingKey::from_secret(TEST_SECRET.as_bytes()),
+        )
+        .unwrap();
+
+        let result = validate_token(&token, TEST_SECRET);
+        assert!(result.is_err(), "expired token should be rejected");
+    }
 }

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -58,6 +58,30 @@ impl Config {
     }
 }
 
+/// Returns whether registration is open on this server.
+///
+/// Read once per call so operators can change the env without a restart in
+/// development.  Defaults to `true` (open) for backwards compatibility with
+/// existing self-hosted instances; set `REGISTRATION_OPEN=false` (or `0`,
+/// `no`, `off`) to lock down a server.  Used by both `GET /api/server-info`
+/// (which advertises the policy) and `POST /api/auth/register` (which
+/// enforces it -- #685).
+pub fn registration_open() -> bool {
+    parse_registration_open(std::env::var("REGISTRATION_OPEN").ok())
+}
+
+/// Parser split out so tests can exercise the truthiness rules without
+/// touching the process-wide env (which would race with parallel tests).
+fn parse_registration_open(raw: Option<String>) -> bool {
+    match raw {
+        Some(v) => !matches!(
+            v.trim().to_lowercase().as_str(),
+            "false" | "0" | "no" | "off"
+        ),
+        None => true,
+    }
+}
+
 /// Resolve the bind host, preferring `SERVER_HOST` and falling back to the
 /// legacy `HOST` (with a deprecation warning) so existing self-hosters using
 /// the bare `HOST=` form keep booting cleanly while new deployments adopt
@@ -211,5 +235,40 @@ mod tests {
         // diverges the two paths.
         let port = resolve_port(fake_env(&[("PORT", "garbage")]));
         assert_eq!(port, 8080);
+    }
+
+    // -----------------------------------------------------------------
+    // #685: REGISTRATION_OPEN parsing rules.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn registration_open_defaults_true_when_unset() {
+        assert!(parse_registration_open(None));
+    }
+
+    #[test]
+    fn registration_open_false_for_falsy_strings() {
+        for v in ["false", "FALSE", "False", "0", "no", "NO", "off", "Off"] {
+            assert!(
+                !parse_registration_open(Some(v.into())),
+                "{v} should parse as closed"
+            );
+        }
+    }
+
+    #[test]
+    fn registration_open_true_for_truthy_strings() {
+        for v in ["true", "1", "yes", "on", "open", "anything-else"] {
+            assert!(
+                parse_registration_open(Some(v.into())),
+                "{v} should parse as open"
+            );
+        }
+    }
+
+    #[test]
+    fn registration_open_trims_whitespace() {
+        assert!(!parse_registration_open(Some("  false  ".into())));
+        assert!(!parse_registration_open(Some("\tno\n".into())));
     }
 }

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -265,14 +265,20 @@ pub async fn remove_member(
 }
 
 /// Get all member user IDs for a conversation (works for both DMs and groups).
-pub async fn get_conversation_member_ids(
-    pool: &PgPool,
+///
+/// Generic over `Executor` so callers can reuse the existing tx during
+/// upload_group_key validation (#686).
+pub async fn get_conversation_member_ids<'e, E>(
+    executor: E,
     conversation_id: Uuid,
-) -> Result<Vec<Uuid>, sqlx::Error> {
+) -> Result<Vec<Uuid>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
     let rows: Vec<(Uuid,)> =
         sqlx::query_as("SELECT user_id FROM conversation_members WHERE conversation_id = $1 AND is_removed = false")
             .bind(conversation_id)
-            .fetch_all(pool)
+            .fetch_all(executor)
             .await?;
     Ok(rows.into_iter().map(|(id,)| id).collect())
 }

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -93,7 +93,11 @@ pub async fn list_public_groups(
 ) -> Result<Vec<PublicGroupRow>, sqlx::Error> {
     match search {
         Some(term) => {
-            let pattern = format!("%{}%", term);
+            let escaped = term
+                .replace('\\', "\\\\")
+                .replace('%', "\\%")
+                .replace('_', "\\_");
+            let pattern = format!("%{escaped}%");
             sqlx::query_as::<_, PublicGroupRow>(
                 "SELECT c.id, c.title, \
                  COUNT(cm.user_id) AS member_count, c.created_at, \
@@ -104,7 +108,7 @@ pub async fn list_public_groups(
                  LEFT JOIN conversation_members cm \
                    ON cm.conversation_id = c.id AND cm.is_removed = false \
                  WHERE c.is_public = true AND c.kind = 'group' \
-                   AND c.title ILIKE $1 \
+                   AND c.title ILIKE $1 ESCAPE '\\' \
                  GROUP BY c.id \
                  ORDER BY c.created_at DESC \
                  LIMIT $3 OFFSET $4",

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -468,13 +468,20 @@ pub struct GroupKeyRow {
 }
 
 /// Insert a new group key version.
-pub async fn store_group_key(
-    pool: &PgPool,
+///
+/// Generic over `Executor` so callers can run this against either the pool
+/// or an in-flight transaction.  `upload_group_key` (#687) needs the latter
+/// so the sentinel row + per-member envelopes commit atomically.
+pub async fn store_group_key<'e, E>(
+    executor: E,
     conversation_id: Uuid,
     key_version: i32,
     encrypted_key: &str,
     created_by: Uuid,
-) -> Result<GroupKeyRow, sqlx::Error> {
+) -> Result<GroupKeyRow, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
     sqlx::query_as::<_, GroupKeyRow>(
         "INSERT INTO group_keys \
              (conversation_id, key_version, encrypted_key, created_by) \
@@ -486,7 +493,7 @@ pub async fn store_group_key(
     .bind(key_version)
     .bind(encrypted_key)
     .bind(created_by)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await
 }
 
@@ -542,13 +549,19 @@ pub struct GroupKeyEnvelopeRow {
 }
 
 /// Store an encrypted group key envelope for a specific recipient.
-pub async fn store_group_key_envelope(
-    pool: &PgPool,
+///
+/// Generic over `Executor` so callers can run this against a transaction
+/// alongside `store_group_key` (#687).
+pub async fn store_group_key_envelope<'e, E>(
+    executor: E,
     conversation_id: Uuid,
     key_version: i32,
     recipient_user_id: Uuid,
     encrypted_key: &str,
-) -> Result<GroupKeyEnvelopeRow, sqlx::Error> {
+) -> Result<GroupKeyEnvelopeRow, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
     sqlx::query_as::<_, GroupKeyEnvelopeRow>(
         "INSERT INTO group_key_envelopes \
              (conversation_id, key_version, recipient_user_id, encrypted_key) \
@@ -562,7 +575,7 @@ pub async fn store_group_key_envelope(
     .bind(key_version)
     .bind(recipient_user_id)
     .bind(encrypted_key)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await
 }
 

--- a/apps/server/src/db/media.rs
+++ b/apps/server/src/db/media.rs
@@ -1,5 +1,7 @@
 //! Media metadata database queries.
 
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -47,6 +49,13 @@ pub async fn get_media(pool: &PgPool, id: Uuid) -> Result<Option<MediaRow>, sqlx
     .bind(id)
     .fetch_optional(pool)
     .await
+}
+
+pub async fn all_media_ids(pool: &PgPool) -> Result<HashSet<Uuid>, sqlx::Error> {
+    let rows: Vec<(Uuid,)> = sqlx::query_as("SELECT id FROM media")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
 /// Check whether a user can access a media file.

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -223,9 +223,23 @@ pub async fn get_messages(
     .await
 }
 
+/// Page size for offline-replay batches.  Picked so a single batch fits
+/// comfortably in the WS outbound mpsc(256) without immediate backpressure
+/// (#634), while still exercising the ack queue under realistic backlogs.
+pub const UNDELIVERED_PAGE_SIZE: i64 = 200;
+
+/// Fetch undelivered messages for a user, optionally after a `created_at`
+/// cursor.  Caller paginates by passing the last-seen `created_at` from the
+/// previous batch; with `None` this returns the oldest 200.
+///
+/// Audit #689: previously this had no `after_ts` and the caller fetched
+/// once.  Backlogs > 200 silently truncated -- the rest got stuck until the
+/// next reconnect.  Callers now loop with the cursor until the batch
+/// returns < UNDELIVERED_PAGE_SIZE rows.
 pub async fn get_undelivered(
     pool: &PgPool,
     user_id: Uuid,
+    after_ts: Option<DateTime<Utc>>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
@@ -243,10 +257,13 @@ pub async fn get_undelivered(
          JOIN conversation_members cm ON cm.conversation_id = m.conversation_id AND cm.user_id = $1 \
                   AND cm.is_removed = false \
          WHERE m.sender_id != $1 AND m.delivered = false AND m.deleted_at IS NULL \
+                  AND ($2::timestamptz IS NULL OR m.created_at > $2) \
          ORDER BY m.created_at ASC \
-         LIMIT 200",
+         LIMIT $3",
     )
     .bind(user_id)
+    .bind(after_ts)
+    .bind(UNDELIVERED_PAGE_SIZE)
     .fetch_all(pool)
     .await
 }

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -183,15 +183,9 @@ pub async fn get_messages(
     requesting_device_id: Option<i32>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
     // Single query handles both cursor and non-cursor cases via optional $3 param.
-    // #557: when the caller passes its own `device_id`, we LEFT JOIN
-    // `message_device_contents` and surface the device-specific ciphertext via
-    // COALESCE so multi-device DM history decrypts on the right ratchet.
-    // When no device_id is provided we preserve the legacy behaviour.
-    // Audit #678: replace correlated `(SELECT COUNT(*) ...)` per-row with a
-    // single LEFT JOIN LATERAL.  Postgres can plan the lateral once per outer
-    // row but still benefit from the partial index `idx_messages_reply_to_id`
-    // -- and importantly the same shape is reused by `search_messages` /
-    // `get_thread_replies` so the planner statistics line up across paths.
+    // #557: when device_id is supplied, COALESCE per-device ciphertext over
+    // the canonical content. reply_count via LEFT JOIN LATERAL matches the
+    // shape used by search_messages / get_thread_replies.
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -236,21 +230,14 @@ pub async fn get_messages(
 /// (#634), while still exercising the ack queue under realistic backlogs.
 pub const UNDELIVERED_PAGE_SIZE: i64 = 200;
 
-/// Fetch undelivered messages for a user, optionally after a `created_at`
-/// cursor.  Caller paginates by passing the last-seen `created_at` from the
-/// previous batch; with `None` this returns the oldest 200.
-///
-/// Audit #689: previously this had no `after_ts` and the caller fetched
-/// once.  Backlogs > 200 silently truncated -- the rest got stuck until the
-/// next reconnect.  Callers now loop with the cursor until the batch
-/// returns < UNDELIVERED_PAGE_SIZE rows.
+/// Fetch undelivered messages, optionally after a `created_at` cursor.
+/// Callers loop with the cursor until the batch returns
+/// < UNDELIVERED_PAGE_SIZE rows.
 pub async fn get_undelivered(
     pool: &PgPool,
     user_id: Uuid,
     after_ts: Option<DateTime<Utc>>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
-    // Audit #638: same LEFT JOIN LATERAL shape as get_messages -- one
-    // sub-query per outer row instead of a correlated COUNT(*).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -257,14 +257,20 @@ pub async fn get_messages(
 /// (#634), while still exercising the ack queue under realistic backlogs.
 pub const UNDELIVERED_PAGE_SIZE: i64 = 200;
 
-/// Fetch undelivered messages, optionally after a `created_at` cursor.
+/// Fetch undelivered messages, optionally after a `(created_at, id)` cursor.
+/// Composite cursor handles ties when multiple messages share a timestamp;
+/// using `created_at` alone would skip same-tick siblings on the next page.
 /// Callers loop with the cursor until the batch returns
 /// < UNDELIVERED_PAGE_SIZE rows.
 pub async fn get_undelivered(
     pool: &PgPool,
     user_id: Uuid,
-    after_ts: Option<DateTime<Utc>>,
+    after_cursor: Option<(DateTime<Utc>, Uuid)>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
+    let (after_ts, after_id): (Option<DateTime<Utc>>, Option<Uuid>) = match after_cursor {
+        Some((ts, id)) => (Some(ts), Some(id)),
+        None => (None, None),
+    };
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -284,12 +290,13 @@ pub async fn get_undelivered(
          JOIN conversation_members cm ON cm.conversation_id = m.conversation_id AND cm.user_id = $1 \
                   AND cm.is_removed = false \
          WHERE m.sender_id != $1 AND m.delivered = false AND m.deleted_at IS NULL \
-                  AND ($2::timestamptz IS NULL OR m.created_at > $2) \
-         ORDER BY m.created_at ASC \
-         LIMIT $3",
+                  AND ($2::timestamptz IS NULL OR (m.created_at, m.id) > ($2, $3)) \
+         ORDER BY m.created_at ASC, m.id ASC \
+         LIMIT $4",
     )
     .bind(user_id)
     .bind(after_ts)
+    .bind(after_id)
     .bind(UNDELIVERED_PAGE_SIZE)
     .fetch_all(pool)
     .await

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -73,9 +73,36 @@ pub async fn find_or_create_dm_conversation(
     }
 
     // Slow path: create the conversation and claim the canonical slot.
-    // Two concurrent requests may both reach this point; the ON CONFLICT
-    // clause ensures only one conversation survives per user pair.
+    // Acquire a transaction-scoped advisory lock keyed on the canonical
+    // (lo, hi) pair so concurrent creators for the same user pair serialize
+    // here rather than contending at the UNIQUE constraint level.  We
+    // concatenate the lexicographically smaller UUID first so both argument
+    // orderings hash to the same i64.  `pg_advisory_xact_lock` (not the
+    // `try_` variant) blocks until the lock is available and releases
+    // automatically when the transaction ends.
     let mut tx = pool.begin().await?;
+
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1::text || $2::text))")
+        .bind(lo)
+        .bind(hi)
+        .execute(&mut *tx)
+        .await?;
+
+    // Re-check inside the tx: another creator may have committed while we
+    // were waiting for the lock, in which case we can take the fast path.
+    let existing_in_tx: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT conversation_id FROM direct_conversations \
+         WHERE user_lo = $1 AND user_hi = $2",
+    )
+    .bind(lo)
+    .bind(hi)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if let Some(row) = existing_in_tx {
+        tx.rollback().await?;
+        return Ok(row.0);
+    }
 
     // Create the conversation row.
     let conv: (Uuid,) = sqlx::query_as(

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -187,6 +187,11 @@ pub async fn get_messages(
     // `message_device_contents` and surface the device-specific ciphertext via
     // COALESCE so multi-device DM history decrypts on the right ratchet.
     // When no device_id is provided we preserve the legacy behaviour.
+    // Audit #678: replace correlated `(SELECT COUNT(*) ...)` per-row with a
+    // single LEFT JOIN LATERAL.  Postgres can plan the lateral once per outer
+    // row but still benefit from the partial index `idx_messages_reply_to_id`
+    // -- and importantly the same shape is reused by `search_messages` /
+    // `get_thread_replies` so the planner statistics line up across paths.
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -195,12 +200,15 @@ pub async fn get_messages(
                 m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                (SELECT COUNT(*) FROM messages r \
-                 WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL) AS reply_count \
+                COALESCE(rc.cnt, 0) AS reply_count \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
+         LEFT JOIN LATERAL ( \
+             SELECT COUNT(*) AS cnt FROM messages r \
+             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
+         ) rc ON true \
          LEFT JOIN message_device_contents mdc \
                 ON $5::int IS NOT NULL \
                AND mdc.message_id = m.id \
@@ -241,6 +249,8 @@ pub async fn get_undelivered(
     user_id: Uuid,
     after_ts: Option<DateTime<Utc>>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
+    // Audit #638: same LEFT JOIN LATERAL shape as get_messages -- one
+    // sub-query per outer row instead of a correlated COUNT(*).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -248,12 +258,15 @@ pub async fn get_undelivered(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                (SELECT COUNT(*) FROM messages r \
-                 WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL) AS reply_count \
+                COALESCE(rc.cnt, 0) AS reply_count \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
+         LEFT JOIN LATERAL ( \
+             SELECT COUNT(*) AS cnt FROM messages r \
+             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
+         ) rc ON true \
          JOIN conversation_members cm ON cm.conversation_id = m.conversation_id AND cm.user_id = $1 \
                   AND cm.is_removed = false \
          WHERE m.sender_id != $1 AND m.delivered = false AND m.deleted_at IS NULL \

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -128,11 +128,10 @@ pub async fn search_users(
     exclude_user_id: Uuid,
 ) -> Result<Vec<UserProfileRow>, sqlx::Error> {
     let escaped = query
-        .to_lowercase()
         .replace('\\', "\\\\")
         .replace('%', "\\%")
         .replace('_', "\\_");
-    let pattern = format!("{escaped}%");
+    let pattern = format!("%{escaped}%");
     sqlx::query_as::<_, UserProfileRow>(
         "SELECT id, username, display_name, avatar_url, bio, status_message, \
          timezone, pronouns, website, \
@@ -141,9 +140,9 @@ pub async fn search_users(
          created_at \
          FROM users \
          WHERE id != $2 AND searchable = true AND ( \
-           LOWER(username) LIKE $1 ESCAPE '\\' \
-           OR (email_discoverable AND LOWER(email) LIKE $1 ESCAPE '\\') \
-           OR (phone_discoverable AND phone LIKE $1 ESCAPE '\\') \
+           username ILIKE $1 ESCAPE '\\' \
+           OR (email_discoverable AND email ILIKE $1 ESCAPE '\\') \
+           OR (phone_discoverable AND phone ILIKE $1 ESCAPE '\\') \
          ) \
          ORDER BY username \
          LIMIT 10",

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -56,6 +56,14 @@ impl AppError {
         }
     }
 
+    pub fn forbidden(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            message: msg.into(),
+            body: None,
+        }
+    }
+
     /// 409 Conflict that carries a structured JSON body. Used for the
     /// per-device identity-key conflict so the client can extract `device_id`
     /// + expected/actual fingerprints without parsing English error strings.

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -126,6 +126,36 @@ impl From<argon2::password_hash::Error> for AppError {
     }
 }
 
+/// Extension trait deduplicating the `Result<_, sqlx::Error>` → `AppError`
+/// boilerplate that previously appeared 120+ times across `routes/*.rs`
+/// (#694).  Callers that need richer error mapping (e.g. distinguishing
+/// 23505 unique-violation conflicts from generic failures) keep using the
+/// explicit `match` form -- this trait is for the dominant case where the
+/// route just wants to log + return 500.
+///
+/// Usage:
+/// ```ignore
+/// let row = db::users::find_by_id(&state.pool, user_id)
+///     .await
+///     .db_ctx("find_by_id")?;
+/// ```
+pub trait DbErrCtx<T> {
+    /// Convert a `Result<_, sqlx::Error>` into `Result<_, AppError>` while
+    /// logging the operation's identifying context.  The label is captured
+    /// as a structured tracing field so observability tools can group
+    /// occurrences without parsing the message string.
+    fn db_ctx(self, ctx: &'static str) -> Result<T, AppError>;
+}
+
+impl<T> DbErrCtx<T> for Result<T, sqlx::Error> {
+    fn db_ctx(self, ctx: &'static str) -> Result<T, AppError> {
+        self.map_err(|e| {
+            tracing::error!(error = ?e, db_ctx = ctx, "DB error");
+            AppError::internal("Database error")
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,5 +216,22 @@ mod tests {
             debug_str.contains("debug me"),
             "Debug output should contain message"
         );
+    }
+
+    #[test]
+    fn db_ctx_passes_through_ok() {
+        let result: Result<i32, sqlx::Error> = Ok(42);
+        let mapped = result.db_ctx("test_ctx").unwrap();
+        assert_eq!(mapped, 42);
+    }
+
+    #[test]
+    fn db_ctx_maps_err_to_internal() {
+        // Use a synthesised RowNotFound -- the cheapest sqlx::Error variant
+        // that doesn't require touching a real connection.
+        let result: Result<i32, sqlx::Error> = Err(sqlx::Error::RowNotFound);
+        let err = result.db_ctx("test_ctx").unwrap_err();
+        assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.message, "Database error");
     }
 }

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -79,6 +79,13 @@ async fn main() {
             async move { cleanup_empty_groups(&pool).await }
         }
     });
+    spawn_periodic("orphan_media", std::time::Duration::from_secs(3600), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { cleanup_orphan_media_files(&pool).await }
+        }
+    });
 
     // Cache eviction sweep on the membership/typing/conv-kind caches in
     // typing_service.  Bounded growth without this -- the audit (#692) found
@@ -288,6 +295,102 @@ async fn cleanup_expired_messages(pool: &PgPool, hub: &ws::hub::Hub) {
                 hub.send_to(member_id, msg.clone());
             }
         }
+    }
+}
+
+/// Scan `./uploads/` and remove files whose name UUID is absent from the
+/// `media` table. Files younger than 5 minutes are skipped so in-flight
+/// uploads not yet committed to the DB are never reaped.
+async fn cleanup_orphan_media_files(pool: &PgPool) {
+    let known_ids = match db::media::all_media_ids(pool).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!("Orphan media reaper: failed to fetch media IDs: {e}");
+            return;
+        }
+    };
+
+    let mut dir = match tokio::fs::read_dir("./uploads").await {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::warn!("Orphan media reaper: cannot read uploads dir: {e}");
+            return;
+        }
+    };
+
+    let cutoff = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(300))
+        .unwrap_or(std::time::UNIX_EPOCH);
+
+    const KNOWN_EXTENSIONS: &[&str] = &[
+        "jpg", "png", "gif", "webp", "heic", "mp4", "mov", "webm", "avi", "mp3", "ogg", "wav",
+        "m4a", "aac", "flac", "pdf", "txt", "doc", "docx", "xls", "xlsx", "zip", "7z", "tar", "gz",
+        "bin",
+    ];
+
+    let mut reaped: u32 = 0;
+
+    loop {
+        let entry = match dir.next_entry().await {
+            Ok(Some(e)) => e,
+            Ok(None) => break,
+            Err(e) => {
+                tracing::warn!("Orphan media reaper: read_dir entry error: {e}");
+                continue;
+            }
+        };
+
+        let path = entry.path();
+
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+
+        if !KNOWN_EXTENSIONS.contains(&ext.as_str()) {
+            continue;
+        }
+
+        let stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        // Thumbnails are stored as `{uuid}.thumb.jpg`; strip the `.thumb` suffix
+        // to resolve back to the owning UUID.
+        let uuid_str = stem.trim_end_matches(".thumb");
+
+        let file_uuid = match uuid::Uuid::parse_str(uuid_str) {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+
+        if known_ids.contains(&file_uuid) {
+            continue;
+        }
+
+        // Skip files that may still be part of an in-flight upload.
+        let too_new = entry
+            .metadata()
+            .await
+            .and_then(|m| m.modified())
+            .map(|mtime| mtime > cutoff)
+            .unwrap_or(true);
+
+        if too_new {
+            continue;
+        }
+
+        if let Err(e) = tokio::fs::remove_file(&path).await {
+            tracing::warn!("Orphan media reaper: failed to delete {:?}: {e}", path);
+        } else {
+            reaped += 1;
+        }
+    }
+
+    if reaped > 0 {
+        tracing::info!("Orphan media reaper: deleted {reaped} file(s)");
     }
 }
 

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -39,22 +39,62 @@ async fn main() {
         media_tickets: dashmap::DashMap::new(),
     });
 
-    // Background task: clean up stale voice sessions every 60 seconds.
-    // Sessions not updated within 2 minutes are removed and leave events
-    // are broadcast to group members.
-    let cleanup_pool = pool.clone();
-    let cleanup_hub = hub.clone();
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-        loop {
-            interval.tick().await;
-            cleanup_stale_voice_sessions(&cleanup_pool, &cleanup_hub).await;
-            cleanup_empty_groups(&cleanup_pool).await;
-            cleanup_expired_tokens(&cleanup_pool).await;
-            cleanup_used_prekeys(&cleanup_pool).await;
-            cleanup_expired_messages(&cleanup_pool, &cleanup_hub).await;
+    // Audit #625: each cleanup runs in its own task with per-task cadence
+    // and panic recovery (catch_unwind on the future).  Previously all five
+    // shared one 60s loop, so a panic anywhere killed every cleanup
+    // silently.  Cadences: voice + expired-messages stay tight (60s / 30s)
+    // because their UX impact is immediate; tokens/prekeys/empty-groups
+    // are hygiene tasks at lower frequency.
+    spawn_periodic("voice_sessions", std::time::Duration::from_secs(60), {
+        let pool = pool.clone();
+        let hub = hub.clone();
+        move || {
+            let pool = pool.clone();
+            let hub = hub.clone();
+            async move { cleanup_stale_voice_sessions(&pool, &hub).await }
         }
     });
+    spawn_periodic("expired_messages", std::time::Duration::from_secs(30), {
+        let pool = pool.clone();
+        let hub = hub.clone();
+        move || {
+            let pool = pool.clone();
+            let hub = hub.clone();
+            async move { cleanup_expired_messages(&pool, &hub).await }
+        }
+    });
+    spawn_periodic("expired_tokens", std::time::Duration::from_secs(600), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { cleanup_expired_tokens(&pool).await }
+        }
+    });
+    spawn_periodic("used_prekeys", std::time::Duration::from_secs(600), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { cleanup_used_prekeys(&pool).await }
+        }
+    });
+    spawn_periodic("empty_groups", std::time::Duration::from_secs(300), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move { cleanup_empty_groups(&pool).await }
+        }
+    });
+
+    // Cache eviction sweep on the membership/typing/conv-kind caches in
+    // typing_service.  Bounded growth without this -- the audit (#692) found
+    // entries never expire after 24h on a busy server.
+    spawn_periodic(
+        "cache_sweep",
+        std::time::Duration::from_secs(300),
+        || async {
+            ws::typing_service::sweep_expired_caches();
+        },
+    );
 
     let app = routes::create_router(state, config.trusted_proxies);
 
@@ -85,6 +125,47 @@ async fn main() {
     })
     .await
     .expect("Server error");
+}
+
+/// Spawn a periodic cleanup task that recovers from panics.
+///
+/// Each task gets its own `tokio::spawn` so a panic anywhere doesn't kill
+/// the others (audit #625).  `AssertUnwindSafe` is sound here because the
+/// closures we pass are stateless re-creators -- they capture `Arc` clones
+/// of pool/hub and rebuild a fresh future per tick, so any partially-
+/// mutated state from a panicked invocation is dropped on unwind.
+fn spawn_periodic<F, Fut>(name: &'static str, period: std::time::Duration, mut make_fut: F)
+where
+    F: FnMut() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    use futures_util::FutureExt;
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(period);
+        // Skip the immediate-fire first tick so we don't pile work onto
+        // server boot, when the pool may still be warming.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let fut = make_fut();
+            // catch_unwind requires Unpin; box-pin the future so we can
+            // call AssertUnwindSafe + catch_unwind on it.
+            let result = std::panic::AssertUnwindSafe(Box::pin(fut))
+                .catch_unwind()
+                .await;
+            if let Err(panic) = result {
+                tracing::error!(
+                    task = name,
+                    "cleanup task panicked: {:?}",
+                    panic
+                        .downcast_ref::<&str>()
+                        .copied()
+                        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                        .unwrap_or("(non-string panic payload)")
+                );
+            }
+        }
+    });
 }
 
 /// Remove voice sessions not updated within 2 minutes and broadcast leave events.
@@ -220,22 +301,75 @@ async fn cleanup_expired_messages(pool: &PgPool, hub: &ws::hub::Hub) {
     }
 }
 
-/// Delete all dependent rows for a group conversation, then delete the conversation itself.
+/// Delete all dependent rows for a group conversation, then the conversation
+/// itself, atomically (audit #625, H32). Previously this was 9 sequential
+/// pool queries with `if let Err(e) ...` swallows -- a connection drop after
+/// step 4 left the conversation half-deleted and the next sweep picked it up
+/// incompletely. Wrapped in one tx so the database is never observed in a
+/// partially-cleaned state.
+///
+/// Migration 20260412000000 added ON DELETE CASCADE on a subset of child
+/// tables (`messages`, `read_receipts`, `conversation_members`); the others
+/// are still cleaned explicitly here. A follow-up migration that adds
+/// CASCADE to `voice_sessions`, `channels`, `group_keys`,
+/// `group_key_envelopes`, `banned_members`, and `media` would let this
+/// collapse to `DELETE FROM conversations WHERE id = $1`.
 async fn delete_group_dependents(pool: &PgPool, gid: uuid::Uuid) {
-    let tables = [
-        "DELETE FROM voice_sessions WHERE channel_id IN (SELECT id FROM channels WHERE conversation_id = $1)",
-        "DELETE FROM channels WHERE conversation_id = $1",
-        "DELETE FROM messages WHERE conversation_id = $1",
-        "DELETE FROM group_key_envelopes WHERE conversation_id = $1",
-        "DELETE FROM group_keys WHERE conversation_id = $1",
-        "DELETE FROM banned_members WHERE conversation_id = $1",
-        "DELETE FROM read_receipts WHERE conversation_id = $1",
-        "DELETE FROM media WHERE conversation_id = $1",
-        "DELETE FROM conversations WHERE id = $1",
-    ];
-    for sql in tables {
-        if let Err(e) = sqlx::query(sql).bind(gid).execute(pool).await {
-            tracing::error!("Failed to clean up group {gid}: {e} (query: {sql})");
+    let mut tx = match pool.begin().await {
+        Ok(tx) => tx,
+        Err(e) => {
+            tracing::error!(group_id = %gid, "begin tx for group cleanup failed: {e}");
+            return;
         }
+    };
+
+    let tables = [
+        (
+            "voice_sessions",
+            "DELETE FROM voice_sessions WHERE channel_id IN (SELECT id FROM channels WHERE conversation_id = $1)",
+        ),
+        (
+            "channels",
+            "DELETE FROM channels WHERE conversation_id = $1",
+        ),
+        (
+            "messages",
+            "DELETE FROM messages WHERE conversation_id = $1",
+        ),
+        (
+            "group_key_envelopes",
+            "DELETE FROM group_key_envelopes WHERE conversation_id = $1",
+        ),
+        (
+            "group_keys",
+            "DELETE FROM group_keys WHERE conversation_id = $1",
+        ),
+        (
+            "banned_members",
+            "DELETE FROM banned_members WHERE conversation_id = $1",
+        ),
+        (
+            "read_receipts",
+            "DELETE FROM read_receipts WHERE conversation_id = $1",
+        ),
+        ("media", "DELETE FROM media WHERE conversation_id = $1"),
+        ("conversations", "DELETE FROM conversations WHERE id = $1"),
+    ];
+    for (table, sql) in tables {
+        if let Err(e) = sqlx::query(sql).bind(gid).execute(&mut *tx).await {
+            tracing::error!(
+                group_id = %gid,
+                table = table,
+                "group cleanup failed at {table}: {e} -- rolling back"
+            );
+            if let Err(rb) = tx.rollback().await {
+                tracing::error!(group_id = %gid, "rollback failed: {rb}");
+            }
+            return;
+        }
+    }
+
+    if let Err(e) = tx.commit().await {
+        tracing::error!(group_id = %gid, "commit group cleanup failed: {e}");
     }
 }

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -39,12 +39,7 @@ async fn main() {
         media_tickets: dashmap::DashMap::new(),
     });
 
-    // Audit #625: each cleanup runs in its own task with per-task cadence
-    // and panic recovery (catch_unwind on the future).  Previously all five
-    // shared one 60s loop, so a panic anywhere killed every cleanup
-    // silently.  Cadences: voice + expired-messages stay tight (60s / 30s)
-    // because their UX impact is immediate; tokens/prekeys/empty-groups
-    // are hygiene tasks at lower frequency.
+    // Per-task cleanup loops with panic recovery; cadence per task.
     spawn_periodic("voice_sessions", std::time::Duration::from_secs(60), {
         let pool = pool.clone();
         let hub = hub.clone();
@@ -127,13 +122,8 @@ async fn main() {
     .expect("Server error");
 }
 
-/// Spawn a periodic cleanup task that recovers from panics.
-///
-/// Each task gets its own `tokio::spawn` so a panic anywhere doesn't kill
-/// the others (audit #625).  `AssertUnwindSafe` is sound here because the
-/// closures we pass are stateless re-creators -- they capture `Arc` clones
-/// of pool/hub and rebuild a fresh future per tick, so any partially-
-/// mutated state from a panicked invocation is dropped on unwind.
+/// Periodic task with panic recovery. `make_fut` is a stateless re-creator;
+/// captured `Arc` clones make `AssertUnwindSafe` sound.
 fn spawn_periodic<F, Fut>(name: &'static str, period: std::time::Duration, mut make_fut: F)
 where
     F: FnMut() -> Fut + Send + 'static,
@@ -302,18 +292,9 @@ async fn cleanup_expired_messages(pool: &PgPool, hub: &ws::hub::Hub) {
 }
 
 /// Delete all dependent rows for a group conversation, then the conversation
-/// itself, atomically (audit #625, H32). Previously this was 9 sequential
-/// pool queries with `if let Err(e) ...` swallows -- a connection drop after
-/// step 4 left the conversation half-deleted and the next sweep picked it up
-/// incompletely. Wrapped in one tx so the database is never observed in a
-/// partially-cleaned state.
-///
-/// Migration 20260412000000 added ON DELETE CASCADE on a subset of child
-/// tables (`messages`, `read_receipts`, `conversation_members`); the others
-/// are still cleaned explicitly here. A follow-up migration that adds
-/// CASCADE to `voice_sessions`, `channels`, `group_keys`,
-/// `group_key_envelopes`, `banned_members`, and `media` would let this
-/// collapse to `DELETE FROM conversations WHERE id = $1`.
+/// itself, atomically. Migration 20260412000000 added ON DELETE CASCADE on
+/// a subset of child tables; the rest are cleaned explicitly until a
+/// follow-up migration extends CASCADE.
 async fn delete_group_dependents(pool: &PgPool, gid: uuid::Uuid) {
     let mut tx = match pool.begin().await {
         Ok(tx) => tx,

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -8,13 +8,43 @@ use axum::response::{IntoResponse, Response};
 use dashmap::DashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
+
+/// How often (in seconds) expired buckets are swept from the map.
+/// Between sweeps the hot path pays only a single atomic load.
+const SWEEP_INTERVAL_SECS: u64 = 60;
 
 /// Tracks request count and window start per IP.
 #[derive(Debug, Clone)]
 struct RateBucket {
     count: u32,
     window_start: Instant,
+}
+
+/// Periodic-sweep state shared across all clones of a `RateLimiter`.
+struct SweepState {
+    /// Process-relative epoch used to convert `Instant::now()` to u64 nanos.
+    epoch: Instant,
+    /// Nanos since `epoch` at which the last sweep completed (0 = never).
+    ///
+    /// Relaxed ordering: the only consequence of a stale read is that two
+    /// threads concurrently believe the sweep is due.  The CAS below ensures
+    /// only one of them actually runs `retain`; the other reads the updated
+    /// value and skips.  No happens-before relationship with the DashMap
+    /// shards is required here because DashMap manages its own shard locks.
+    last_sweep_nanos: AtomicU64,
+}
+
+impl std::fmt::Debug for SweepState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SweepState")
+            .field(
+                "last_sweep_nanos",
+                &self.last_sweep_nanos.load(Ordering::Relaxed),
+            )
+            .finish()
+    }
 }
 
 /// Shared rate limit state using lock-free concurrent map.
@@ -27,15 +57,24 @@ pub struct RateLimiter {
     /// headers we trust.  When empty, proxy headers are ignored and the
     /// peer (ConnectInfo) IP is used directly.
     trusted_proxies: Arc<Vec<IpAddr>>,
+    sweep: Arc<SweepState>,
 }
 
 impl RateLimiter {
+    fn new_sweep() -> Arc<SweepState> {
+        Arc::new(SweepState {
+            epoch: Instant::now(),
+            last_sweep_nanos: AtomicU64::new(0),
+        })
+    }
+
     pub fn new(max_requests: u32, window_secs: u64) -> Self {
         Self {
             entries: Arc::new(DashMap::new()),
             max_requests,
             window_secs,
             trusted_proxies: Arc::new(Vec::new()),
+            sweep: Self::new_sweep(),
         }
     }
 
@@ -46,6 +85,7 @@ impl RateLimiter {
             max_requests,
             window_secs,
             trusted_proxies: Arc::new(proxies),
+            sweep: Self::new_sweep(),
         }
     }
 
@@ -62,18 +102,41 @@ impl RateLimiter {
             max_requests,
             window_secs,
             trusted_proxies: proxies,
+            sweep: Self::new_sweep(),
         }
     }
 
     /// Check rate limit for an IP. Returns true if the request should be allowed.
+    ///
+    /// Expired-bucket cleanup is **periodic** (at most once every
+    /// [`SWEEP_INTERVAL_SECS`]), not per-request.  On the hot path the only
+    /// overhead vs. the old code is a single `AtomicU64` load.
+    ///
+    /// Sweep contention: `last_sweep_nanos` is updated via compare-and-exchange
+    /// so that at most one thread runs `retain` when the interval expires.
+    /// All other concurrent threads lose the CAS, see the updated timestamp,
+    /// and skip immediately -- they never block waiting for the sweeper.
     fn check(&self, ip: IpAddr) -> bool {
         let now = Instant::now();
+        let now_nanos = now.duration_since(self.sweep.epoch).as_nanos() as u64;
 
-        // Opportunistic cleanup: remove entries older than 2x window
-        let cleanup_threshold = self.window_secs * 2;
-        self.entries.retain(|_, bucket| {
-            now.duration_since(bucket.window_start).as_secs() < cleanup_threshold
-        });
+        // Lazy periodic sweep: skip the O(N) retain unless the interval has elapsed.
+        let last = self.sweep.last_sweep_nanos.load(Ordering::Relaxed);
+        let interval_nanos = SWEEP_INTERVAL_SECS * 1_000_000_000;
+        if now_nanos.saturating_sub(last) >= interval_nanos {
+            // Only the thread that wins the CAS runs retain(); losers skip.
+            if self
+                .sweep
+                .last_sweep_nanos
+                .compare_exchange(last, now_nanos, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                let cleanup_threshold = self.window_secs * 2;
+                self.entries.retain(|_, bucket| {
+                    now.duration_since(bucket.window_start).as_secs() < cleanup_threshold
+                });
+            }
+        }
 
         let mut bucket = self.entries.entry(ip).or_insert(RateBucket {
             count: 0,
@@ -216,6 +279,11 @@ pub fn revoke_others_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(3, 60, trusted_proxies)
 }
 
+/// Edit message rate limiter: 30 edits per 60 seconds per IP.
+pub fn edit_message_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+    RateLimiter::with_shared_proxies(30, 60, trusted_proxies)
+}
+
 /// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
 fn is_private(ip: IpAddr) -> bool {
     match ip {
@@ -290,6 +358,13 @@ mod tests {
     fn test_link_preview_limiter_config() {
         let limiter = link_preview_limiter(Arc::new(vec![]));
         assert_eq!(limiter.max_requests, 20);
+        assert_eq!(limiter.window_secs, 60);
+    }
+
+    #[test]
+    fn test_edit_message_limiter_config() {
+        let limiter = edit_message_limiter(Arc::new(vec![]));
+        assert_eq!(limiter.max_requests, 30);
         assert_eq!(limiter.window_secs, 60);
     }
 
@@ -422,5 +497,63 @@ mod tests {
         assert_eq!(limiter.max_requests, 5);
         assert_eq!(limiter.window_secs, 60);
         assert_eq!(*limiter.trusted_proxies, proxies);
+    }
+
+    /// With 1000 expired buckets already in the map, a `check()` for a fresh
+    /// IP must complete in under 5 ms.  A per-request retain() on 1000 entries
+    /// typically takes 1-10 ms in debug builds; the periodic sweep approach
+    /// skips it entirely on this call because the interval has not elapsed.
+    #[test]
+    fn test_check_does_not_sweep_on_hot_path_with_expired_buckets() {
+        // Use a very long window so nothing counts as active, and a large
+        // sweep interval so no sweep fires during this test.
+        let limiter = RateLimiter::new(100, 3600);
+
+        // Pre-fill 1000 distinct IPs with expired buckets (window_start = epoch,
+        // which is far in the past relative to any real Instant).  We can't
+        // directly set window_start to an "ancient" Instant from outside, so we
+        // insert at address-space level via the DashMap.
+        let ancient = limiter.sweep.epoch; // epoch itself: 0 nanos since epoch
+        for i in 0u32..1000 {
+            let ip = IpAddr::V4(std::net::Ipv4Addr::from(0x0A00_0001 + i));
+            limiter.entries.insert(
+                ip,
+                RateBucket {
+                    count: 0,
+                    window_start: ancient,
+                },
+            );
+        }
+
+        // The sweep timer starts at 0 (never swept).  SWEEP_INTERVAL_SECS is 60 s.
+        // Set last_sweep_nanos to "right now" so the 60-second interval has NOT
+        // elapsed -- no sweep will be triggered during check().
+        let now_nanos = Instant::now()
+            .duration_since(limiter.sweep.epoch)
+            .as_nanos() as u64;
+        limiter
+            .sweep
+            .last_sweep_nanos
+            .store(now_nanos, Ordering::Relaxed);
+
+        let fresh_ip = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8));
+        let deadline_ns: u64 = 5_000_000; // 5 ms
+
+        let t0 = Instant::now();
+        let allowed = limiter.check(fresh_ip);
+        let elapsed_ns = t0.elapsed().as_nanos() as u64;
+
+        assert!(allowed, "fresh IP should be allowed");
+        assert!(
+            elapsed_ns < deadline_ns,
+            "check() took {elapsed_ns} ns with 1000 expired buckets (limit {deadline_ns} ns / 5 ms); \
+             per-request sweep was not eliminated"
+        );
+        // Stale entries still present -- sweep did NOT run.
+        assert_eq!(
+            limiter.entries.len(),
+            1001, // 1000 pre-filled + 1 for fresh_ip
+            "stale entries should not have been removed during the hot-path check"
+        );
     }
 }

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -537,19 +537,14 @@ mod tests {
             .store(now_nanos, Ordering::Relaxed);
 
         let fresh_ip = IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8));
-        let deadline_ns: u64 = 5_000_000; // 5 ms
 
-        let t0 = Instant::now();
         let allowed = limiter.check(fresh_ip);
-        let elapsed_ns = t0.elapsed().as_nanos() as u64;
 
         assert!(allowed, "fresh IP should be allowed");
-        assert!(
-            elapsed_ns < deadline_ns,
-            "check() took {elapsed_ns} ns with 1000 expired buckets (limit {deadline_ns} ns / 5 ms); \
-             per-request sweep was not eliminated"
-        );
-        // Stale entries still present -- sweep did NOT run.
+        // Stale entries still present -- sweep did NOT run on this hot path.
+        // Deterministic check; the wall-clock perf claim is covered by the
+        // sweep-gate logic itself (verified by the entries.len() == 1001
+        // invariant, which only holds if retain() was never called).
         assert_eq!(
             limiter.entries.len(),
             1001, // 1000 pre-filled + 1 for fresh_ip

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -142,6 +142,13 @@ pub async fn register(
     jar: CookieJar,
     Json(body): Json<AuthRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    // Audit #685: server-side enforcement of REGISTRATION_OPEN. Without this
+    // gate, any client (including direct curl) could create accounts on a
+    // self-hosted instance whose operator advertises "closed" via /server-info.
+    if !crate::config::registration_open() {
+        return Err(AppError::forbidden("Registration is closed on this server"));
+    }
+
     validate_username(&body.username)?;
     validate_password(&body.password)?;
 

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -142,9 +142,6 @@ pub async fn register(
     jar: CookieJar,
     Json(body): Json<AuthRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Audit #685: server-side enforcement of REGISTRATION_OPEN. Without this
-    // gate, any client (including direct curl) could create accounts on a
-    // self-hosted instance whose operator advertises "closed" via /server-info.
     if !crate::config::registration_open() {
         return Err(AppError::forbidden("Registration is closed on this server"));
     }

--- a/apps/server/src/routes/channels.rs
+++ b/apps/server/src/routes/channels.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::{ChannelKind, ConversationKind, Role};
 
 use super::AppState;
@@ -78,10 +78,7 @@ async fn ensure_group_member(
 ) -> Result<(), AppError> {
     let kind = db::groups::get_conversation_kind(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_group_member/get_kind: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ensure_group_member/get_kind")?
         .ok_or_else(|| AppError::bad_request("Group not found"))?;
 
     if ConversationKind::from_str_opt(&kind) != Some(ConversationKind::Group) {
@@ -90,10 +87,7 @@ async fn ensure_group_member(
 
     let is_member = db::groups::is_member(&state.pool, group_id, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_group_member/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("ensure_group_member/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -110,10 +104,7 @@ async fn ensure_group_admin(
 ) -> Result<(), AppError> {
     let role = db::groups::get_member_role(&state.pool, group_id, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_group_admin/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("ensure_group_admin/get_role")?;
     match role.as_deref().and_then(Role::from_str_opt) {
         Some(r) if r.is_admin_or_above() => Ok(()),
         _ => Err(AppError::unauthorized(
@@ -129,10 +120,7 @@ async fn ensure_channel_in_group(
 ) -> Result<db::channels::ChannelRow, AppError> {
     let channel = db::channels::get_channel(&state.pool, channel_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ensure_channel_in_group/get_channel: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ensure_channel_in_group/get_channel")?
         .ok_or_else(|| AppError::bad_request("Channel not found"))?;
 
     if channel.conversation_id != group_id {
@@ -163,10 +151,7 @@ pub async fn list_channels(
 
     let rows = db::channels::list_channels(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_channels: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_channels")?;
 
     let channels: Vec<ChannelResponse> = rows
         .into_iter()
@@ -214,10 +199,7 @@ pub async fn create_channel(
         Some(_) => return Err(AppError::bad_request("Position must be non-negative")),
         None => db::channels::next_channel_position(&state.pool, group_id, &kind)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in create_channel/next_position: {e:?}");
-                AppError::internal("Database error")
-            })?,
+            .db_ctx("create_channel/next_position")?,
     };
 
     let created = db::channels::create_channel(
@@ -374,10 +356,7 @@ pub async fn list_voice_sessions(
 
     let rows = db::channels::list_voice_sessions(&state.pool, channel.id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_voice_sessions: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_voice_sessions")?;
 
     let sessions: Vec<VoiceSessionResponse> = rows
         .into_iter()

--- a/apps/server/src/routes/contacts.rs
+++ b/apps/server/src/routes/contacts.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -96,10 +96,7 @@ pub async fn list_contacts(
 ) -> Result<impl IntoResponse, AppError> {
     let contacts = db::contacts::list_contacts(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_contacts: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_contacts")?;
 
     Ok(Json(contacts))
 }
@@ -110,10 +107,7 @@ pub async fn list_pending(
 ) -> Result<impl IntoResponse, AppError> {
     let pending = db::contacts::list_pending_requests(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_pending: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_pending")?;
 
     Ok(Json(pending))
 }
@@ -138,10 +132,7 @@ pub async fn block_user(
 
     db::contacts::block_user(&state.pool, auth.user_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in block_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("block_user")?;
 
     Ok((
         StatusCode::CREATED,
@@ -156,10 +147,7 @@ pub async fn unblock_user(
 ) -> Result<impl IntoResponse, AppError> {
     let removed = db::contacts::unblock_user(&state.pool, auth.user_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unblock_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("unblock_user")?;
 
     if !removed {
         return Err(AppError::bad_request("User is not blocked"));
@@ -174,10 +162,7 @@ pub async fn list_blocked(
 ) -> Result<impl IntoResponse, AppError> {
     let blocked = db::contacts::list_blocked_users(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in list_blocked: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("list_blocked")?;
 
     Ok(Json(blocked))
 }

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -113,6 +113,17 @@ pub async fn upload_group_key(
         ));
     }
 
+    // Audit #686: cap envelope count and reject empty payloads up front so
+    // a hostile admin can't pollute the table with millions of junk entries.
+    // 10 000 is generous -- the largest group on echo-messenger.us is well
+    // below this, and matches the per-conv member ceiling we'd want anyway.
+    const MAX_ENVELOPES_PER_REQUEST: usize = 10_000;
+    if body.envelopes.len() > MAX_ENVELOPES_PER_REQUEST {
+        return Err(AppError::bad_request(format!(
+            "Too many envelopes (max {MAX_ENVELOPES_PER_REQUEST})"
+        )));
+    }
+
     for envelope in &body.envelopes {
         if envelope.encrypted_key.is_empty() {
             return Err(AppError::bad_request(
@@ -121,10 +132,45 @@ pub async fn upload_group_key(
         }
     }
 
+    // Audit #687: sentinel row + envelopes commit atomically. Previously
+    // these were two separate pool queries -- if the second envelope failed,
+    // the conversation was left with a key_version row but only some members
+    // had envelopes, and those without one could not decrypt anything until
+    // the next rotation.
+    let mut tx = state.pool.begin().await.map_err(|e| {
+        tracing::error!("DB error in upload_group_key/begin: {e:?}");
+        AppError::internal("Database error")
+    })?;
+
+    // Audit #686: every envelope.user_id must be a current group member.
+    // Without this, a hostile admin can stage envelopes for arbitrary users
+    // who never were members; future invitees would receive pre-staged
+    // envelopes on join, and banned-then-readded users could be silently
+    // re-keyed.  Read membership inside the same tx so we see the current
+    // committed view (matches the writes that follow).
+    let member_ids: std::collections::HashSet<Uuid> =
+        db::groups::get_conversation_member_ids(&mut *tx, group_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("DB error in upload_group_key/members: {e:?}");
+                AppError::internal("Database error")
+            })?
+            .into_iter()
+            .collect();
+
+    for envelope in &body.envelopes {
+        if !member_ids.contains(&envelope.user_id) {
+            return Err(AppError::bad_request(format!(
+                "envelope user_id {} is not a member of this group",
+                envelope.user_id
+            )));
+        }
+    }
+
     // Store a sentinel row in group_keys for version tracking (encrypted_key
     // is a placeholder -- the real per-member keys live in group_key_envelopes).
     let row = db::keys::store_group_key(
-        &state.pool,
+        &mut *tx,
         group_id,
         body.key_version,
         "__envelope__",
@@ -141,10 +187,10 @@ pub async fn upload_group_key(
         }
     })?;
 
-    // Store per-member envelopes
+    // Store per-member envelopes inside the same tx.
     for envelope in &body.envelopes {
         db::keys::store_group_key_envelope(
-            &state.pool,
+            &mut *tx,
             group_id,
             body.key_version,
             envelope.user_id,
@@ -159,6 +205,11 @@ pub async fn upload_group_key(
             AppError::internal("Failed to store group key envelope")
         })?;
     }
+
+    tx.commit().await.map_err(|e| {
+        tracing::error!("DB error in upload_group_key/commit: {e:?}");
+        AppError::internal("Database error")
+    })?;
 
     // Broadcast key_rotated event to all group members
     let member_ids = db::groups::get_conversation_member_ids(&state.pool, group_id)

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::Role;
 
 use super::AppState;
@@ -91,10 +91,7 @@ pub async fn upload_group_key(
     // Verify membership and role
     let role_str = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in upload_group_key/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("upload_group_key/get_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
@@ -137,10 +134,7 @@ pub async fn upload_group_key(
     // the conversation was left with a key_version row but only some members
     // had envelopes, and those without one could not decrypt anything until
     // the next rotation.
-    let mut tx = state.pool.begin().await.map_err(|e| {
-        tracing::error!("DB error in upload_group_key/begin: {e:?}");
-        AppError::internal("Database error")
-    })?;
+    let mut tx = state.pool.begin().await.db_ctx("upload_group_key/begin")?;
 
     // Audit #686: every envelope.user_id must be a current group member.
     // Without this, a hostile admin can stage envelopes for arbitrary users
@@ -151,10 +145,7 @@ pub async fn upload_group_key(
     let member_ids: std::collections::HashSet<Uuid> =
         db::groups::get_conversation_member_ids(&mut *tx, group_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in upload_group_key/members: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("upload_group_key/members")?
             .into_iter()
             .collect();
 
@@ -206,10 +197,7 @@ pub async fn upload_group_key(
         })?;
     }
 
-    tx.commit().await.map_err(|e| {
-        tracing::error!("DB error in upload_group_key/commit: {e:?}");
-        AppError::internal("Database error")
-    })?;
+    tx.commit().await.db_ctx("upload_group_key/commit")?;
 
     // Broadcast key_rotated event to all group members
     let member_ids = db::groups::get_conversation_member_ids(&state.pool, group_id)
@@ -247,10 +235,7 @@ pub async fn get_latest_group_key(
 ) -> Result<impl IntoResponse, AppError> {
     let is_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_latest_group_key/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_latest_group_key/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -259,10 +244,7 @@ pub async fn get_latest_group_key(
     // Try envelope-based lookup first (new E2E scheme)
     let envelope = db::keys::get_my_group_key_envelope(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_latest_group_key/envelope: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_latest_group_key/envelope")?;
 
     if let Some(env) = envelope {
         return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
@@ -271,10 +253,7 @@ pub async fn get_latest_group_key(
     // Fallback: legacy group_keys table (for groups that haven't rotated yet)
     let row = db::keys::get_latest_group_key(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_latest_group_key/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_latest_group_key/fetch")?
         .ok_or_else(|| AppError::bad_request("No group key found for this conversation"))?;
 
     Ok(Json(GroupKeyResponse::from_row(row)).into_response())
@@ -291,10 +270,7 @@ pub async fn get_group_key_version(
 ) -> Result<impl IntoResponse, AppError> {
     let is_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_key_version/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group_key_version/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -304,10 +280,7 @@ pub async fn get_group_key_version(
     let envelope =
         db::keys::get_my_group_key_envelope_version(&state.pool, group_id, auth.user_id, version)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_group_key_version/envelope: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("get_group_key_version/envelope")?;
 
     if let Some(env) = envelope {
         return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
@@ -316,10 +289,7 @@ pub async fn get_group_key_version(
     // Fallback: legacy group_keys table
     let row = db::keys::get_group_key(&state.pool, group_id, version)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_key_version/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group_key_version/fetch")?
         .ok_or_else(|| AppError::bad_request("Group key version not found"))?;
 
     Ok(Json(GroupKeyResponse::from_row(row)).into_response())

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -110,10 +110,7 @@ pub async fn upload_group_key(
         ));
     }
 
-    // Audit #686: cap envelope count and reject empty payloads up front so
-    // a hostile admin can't pollute the table with millions of junk entries.
-    // 10 000 is generous -- the largest group on echo-messenger.us is well
-    // below this, and matches the per-conv member ceiling we'd want anyway.
+    // Cap envelope count so a hostile admin can't pollute the table.
     const MAX_ENVELOPES_PER_REQUEST: usize = 10_000;
     if body.envelopes.len() > MAX_ENVELOPES_PER_REQUEST {
         return Err(AppError::bad_request(format!(
@@ -129,19 +126,10 @@ pub async fn upload_group_key(
         }
     }
 
-    // Audit #687: sentinel row + envelopes commit atomically. Previously
-    // these were two separate pool queries -- if the second envelope failed,
-    // the conversation was left with a key_version row but only some members
-    // had envelopes, and those without one could not decrypt anything until
-    // the next rotation.
+    // Sentinel row + envelopes commit atomically; member-set read inside
+    // the same tx so we see the committed view that matches the writes.
     let mut tx = state.pool.begin().await.db_ctx("upload_group_key/begin")?;
 
-    // Audit #686: every envelope.user_id must be a current group member.
-    // Without this, a hostile admin can stage envelopes for arbitrary users
-    // who never were members; future invitees would receive pre-staged
-    // envelopes on join, and banned-then-readded users could be silently
-    // re-keyed.  Read membership inside the same tx so we see the current
-    // committed view (matches the writes that follow).
     let member_ids: std::collections::HashSet<Uuid> =
         db::groups::get_conversation_member_ids(&mut *tx, group_id)
             .await

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -508,8 +508,6 @@ pub async fn join_group(
         return Err(AppError::bad_request("Group not found or is not public"));
     }
 
-    // Audit #692: drop the membership cache so the new member's typing /
-    // presence / fanout requests no longer hit a cached "not a member" miss.
     invalidate_member_cache(group_id);
 
     Ok(Json(serde_json::json!({ "status": "joined" })))

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::{ConversationKind, Role};
 use crate::ws::typing_service::invalidate_member_cache;
 
@@ -237,10 +237,7 @@ pub async fn get_group(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this group"));
@@ -248,18 +245,12 @@ pub async fn get_group(
 
     let group = db::groups::get_group(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group/fetch")?
         .ok_or_else(|| AppError::bad_request("Group not found"))?;
 
     let members = db::groups::get_group_members(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group/get_members: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group/get_members")?;
 
     let response = GroupResponse {
         id: group.id,
@@ -291,19 +282,13 @@ pub async fn add_member(
     // Verify caller is a member and get their role
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("add_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     // Verify it's a group conversation
     let kind = db::groups::get_conversation_kind(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/get_conversation_kind: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/get_conversation_kind")?;
 
     if kind.as_deref().and_then(ConversationKind::from_str_opt) != Some(ConversationKind::Group) {
         return Err(AppError::bad_request("Not a group conversation"));
@@ -312,10 +297,7 @@ pub async fn add_member(
     // For private groups, only owner or admin can add members
     let is_public = db::groups::is_public(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/is_public: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/is_public")?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
     if !is_public && !caller_role_enum.is_admin_or_above() {
@@ -327,10 +309,7 @@ pub async fn add_member(
     // Verify target user exists
     let user_exists = db::users::find_by_id(&state.pool, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/find_user")?;
 
     if user_exists.is_none() {
         return Err(AppError::bad_request("User not found"));
@@ -339,10 +318,7 @@ pub async fn add_member(
     // Check if target user is banned
     let banned = db::groups::is_banned(&state.pool, group_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/is_banned: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/is_banned")?;
     if banned {
         return Err(AppError::bad_request("User is banned from this group"));
     }
@@ -350,10 +326,7 @@ pub async fn add_member(
     // Check if already an active member
     let already_member = db::groups::is_member(&state.pool, group_id, body.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_member/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_member/is_member")?;
     if already_member {
         return Err(AppError::conflict("User is already a member"));
     }
@@ -379,10 +352,7 @@ pub async fn remove_member(
     // Verify caller is a member and get their role
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("remove_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     // If removing someone else, must be owner or admin
@@ -397,10 +367,7 @@ pub async fn remove_member(
     if target_user_id != auth.user_id {
         let target_role = db::groups::get_member_role(&state.pool, group_id, target_user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in remove_member/get_target_role: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("remove_member/get_target_role")?;
         if target_role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
             return Err(AppError::bad_request("Cannot remove the group owner"));
         }
@@ -484,18 +451,12 @@ pub async fn get_group_preview(
 ) -> Result<impl IntoResponse, AppError> {
     let preview = db::groups::get_group_preview(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_preview: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group_preview")?
         .ok_or_else(|| AppError::not_found("Group not found"))?;
 
     let members = db::groups::get_group_member_previews(&state.pool, group_id, 5)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_preview/members: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_group_preview/members")?;
 
     Ok(Json(json!({
         "id": preview.id,
@@ -523,10 +484,7 @@ pub async fn join_group(
     // Check if user is banned
     let banned = db::groups::is_banned(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in join_group/is_banned: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("join_group/is_banned")?;
     if banned {
         return Err(AppError::bad_request("You are banned from this group"));
     }
@@ -534,10 +492,7 @@ pub async fn join_group(
     // Check if already a member
     let already_member = db::groups::is_member(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in join_group/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("join_group/is_member")?;
     if already_member {
         return Err(AppError::conflict("Already a member of this group"));
     }
@@ -565,10 +520,7 @@ pub async fn leave_group(
     // Owners must transfer ownership before leaving (unless they're the last member)
     let role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in leave_group/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("leave_group/get_role")?;
     if role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
         let members = db::groups::get_conversation_member_ids(&state.pool, group_id)
             .await
@@ -688,10 +640,7 @@ pub async fn ban_member(
 ) -> Result<impl IntoResponse, AppError> {
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ban_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ban_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
@@ -704,10 +653,7 @@ pub async fn ban_member(
     // Prevent banning the owner or peers of equal rank
     let target_role = db::groups::get_member_role(&state.pool, group_id, target_user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ban_member/get_target_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("ban_member/get_target_role")?;
     let target_role_enum = target_role
         .as_deref()
         .and_then(Role::from_str_opt)
@@ -755,10 +701,7 @@ pub async fn unban_member(
 ) -> Result<impl IntoResponse, AppError> {
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unban_member/get_caller_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("unban_member/get_caller_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
@@ -824,10 +767,7 @@ pub async fn upload_group_avatar(
     // Verify caller is owner or admin
     let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in upload_group_avatar/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("upload_group_avatar/get_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
     let caller_role_enum = Role::from_str_opt(&caller_role).unwrap_or(Role::Member);
@@ -919,10 +859,7 @@ pub async fn get_group_avatar(
 ) -> Result<Response, AppError> {
     let icon_url = db::groups::get_group_icon_url(&state.pool, group_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_group_avatar/icon_url: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_group_avatar/icon_url")?
         .ok_or_else(|| AppError {
             status: StatusCode::NOT_FOUND,
             message: "No avatar set for this group".to_string(),

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -508,6 +508,10 @@ pub async fn join_group(
         return Err(AppError::bad_request("Group not found or is not public"));
     }
 
+    // Audit #692: drop the membership cache so the new member's typing /
+    // presence / fanout requests no longer hit a cached "not a member" miss.
+    invalidate_member_cache(group_id);
+
     Ok(Json(serde_json::json!({ "status": "joined" })))
 }
 

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -2,6 +2,7 @@
 
 use axum::Json;
 use axum::extract::State;
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -166,12 +167,38 @@ pub async fn fetch_preview(
         }));
     }
 
-    // Limit body size to 256KB to prevent abuse
-    let html = resp
-        .text()
-        .await
-        .map_err(|_| AppError::bad_request("Failed to read response"))?;
-    let html = cap_html(&html);
+    // Audit #684: stream the body and abort once the byte cap is reached
+    // instead of buffering the whole response and then truncating. Otherwise
+    // a multi-GB response (or a gzip bomb if compression is ever enabled)
+    // OOMs the server before cap_html ever runs. Also reject obvious size
+    // hints up front via Content-Length so we don't pay the round-trip
+    // for clearly-oversized bodies.
+    if let Some(declared_len) = resp.content_length()
+        && declared_len > MAX_HTML_BYTES as u64
+    {
+        return Err(AppError::bad_request(
+            "URL response declares Content-Length above the size cap",
+        ));
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut buf: Vec<u8> = Vec::with_capacity(8 * 1024);
+    while let Some(chunk_result) = stream.next().await {
+        let chunk: bytes::Bytes =
+            chunk_result.map_err(|_| AppError::bad_request("Failed to read response"))?;
+        // Cap hard; we don't even copy the tail of an oversized chunk.
+        let remaining = MAX_HTML_BYTES.saturating_sub(buf.len());
+        if remaining == 0 {
+            break;
+        }
+        let take = chunk.len().min(remaining);
+        buf.extend_from_slice(&chunk[..take]);
+        if buf.len() >= MAX_HTML_BYTES {
+            break;
+        }
+    }
+    let html_owned = String::from_utf8_lossy(&buf).into_owned();
+    let html = cap_html(&html_owned);
 
     // Extract Open Graph tags with simple regex (no HTML parser dependency)
     let title = extract_og_content(html, "og:title").or_else(|| extract_tag_content(html, "title"));

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -167,12 +167,6 @@ pub async fn fetch_preview(
         }));
     }
 
-    // Audit #684: stream the body and abort once the byte cap is reached
-    // instead of buffering the whole response and then truncating. Otherwise
-    // a multi-GB response (or a gzip bomb if compression is ever enabled)
-    // OOMs the server before cap_html ever runs. Also reject obvious size
-    // hints up front via Content-Length so we don't pay the round-trip
-    // for clearly-oversized bodies.
     if let Some(declared_len) = resp.content_length()
         && declared_len > MAX_HTML_BYTES as u64
     {

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 
 use crate::auth::{jwt, middleware::AuthUser};
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -195,10 +195,7 @@ pub async fn upload(
             // Verify the uploader is a member of this conversation
             let is_member = db::groups::is_member(&state.pool, cid, auth.user_id)
                 .await
-                .map_err(|e| {
-                    tracing::error!("DB error in upload_media/is_member: {e:?}");
-                    AppError::internal("Database error")
-                })?;
+                .db_ctx("upload_media/is_member")?;
             if !is_member {
                 return Err(AppError {
                     status: StatusCode::FORBIDDEN,

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::types::{ConversationKind, Role};
 use crate::ws::typing_service::invalidate_member_cache;
 
@@ -240,10 +240,7 @@ pub async fn get_messages(
     // Verify the user is a member of this conversation
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_messages/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_messages/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -252,10 +249,7 @@ pub async fn get_messages(
     if let Some(channel_id) = params.channel_id {
         let conversation_kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_messages/get_conversation_kind: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("get_messages/get_conversation_kind")?
             .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
 
         if ConversationKind::from_str_opt(&conversation_kind) != Some(ConversationKind::Group) {
@@ -266,10 +260,7 @@ pub async fn get_messages(
 
         let channel = db::channels::get_channel(&state.pool, channel_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_messages/get_channel: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("get_messages/get_channel")?
             .ok_or_else(|| AppError::bad_request("Channel not found"))?;
 
         if channel.conversation_id != conversation_id {
@@ -296,10 +287,7 @@ pub async fn get_messages(
         params.device_id,
     )
     .await
-    .map_err(|e| {
-        tracing::error!("DB error in get_messages/fetch: {e:?}");
-        AppError::internal("Database error")
-    })?;
+    .db_ctx("get_messages/fetch")?;
 
     // Re-shape the response to expose `from_user_id` / `from_username` /
     // `from_device_id` keys the client expects on history (#557). Doing it
@@ -343,10 +331,7 @@ pub async fn create_dm(
 ) -> Result<impl IntoResponse, AppError> {
     let are_contacts = db::contacts::are_contacts(&state.pool, auth.user_id, req.peer_user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in create_dm/are_contacts: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("create_dm/are_contacts")?;
     if !are_contacts {
         return Err(AppError::bad_request("Not a contact"));
     }
@@ -373,10 +358,7 @@ pub async fn delete_message(
 ) -> Result<impl IntoResponse, AppError> {
     let conversation_id = db::messages::delete_message(&state.pool, message_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in delete_message: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("delete_message")?
         .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
 
     // Broadcast to conversation members via WebSocket
@@ -428,10 +410,7 @@ pub async fn edit_message(
     let convo_meta =
         db::messages::get_message_conversation_security(&state.pool, message_id, auth.user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in edit_message/security lookup: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("edit_message/security lookup")?
             .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
     if convo_meta.is_encrypted {
         tracing::warn!(
@@ -448,10 +427,7 @@ pub async fn edit_message(
     let (conversation_id, edited_at) =
         db::messages::edit_message(&state.pool, message_id, auth.user_id, &body.content)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in edit_message: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("edit_message")?
             .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
 
     // Broadcast to conversation members via WebSocket
@@ -498,10 +474,7 @@ pub async fn get_thread_replies(
             .bind(message_id)
             .fetch_optional(&state.pool)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in get_thread_replies/lookup: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("get_thread_replies/lookup")?;
 
     let conversation_id = parent
         .map(|(cid,)| cid)
@@ -509,10 +482,7 @@ pub async fn get_thread_replies(
 
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_thread_replies/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_thread_replies/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -523,10 +493,7 @@ pub async fn get_thread_replies(
     // replies (or any future regression) cannot leak content across DMs.
     let replies = db::messages::get_thread_replies(&state.pool, message_id, conversation_id, limit)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_thread_replies/fetch: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_thread_replies/fetch")?;
 
     Ok(Json(replies))
 }
@@ -554,10 +521,7 @@ pub async fn search_messages(
 ) -> Result<impl IntoResponse, AppError> {
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in search_messages/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("search_messages/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
@@ -622,10 +586,7 @@ pub async fn leave_conversation(
     // Owners must transfer ownership before leaving (unless they're the last member)
     let role = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in leave_conversation/get_role: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("leave_conversation/get_role")?;
     if role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
         let members = db::groups::get_conversation_member_ids(&state.pool, conversation_id)
             .await
@@ -681,10 +642,7 @@ pub async fn toggle_mute(
     let updated =
         db::messages::set_mute_status(&state.pool, conversation_id, auth.user_id, body.is_muted)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in toggle_mute: {e:?}");
-                AppError::internal("Database error")
-            })?;
+            .db_ctx("toggle_mute")?;
 
     if !updated {
         return Err(AppError::bad_request("Not a member of this conversation"));
@@ -767,10 +725,7 @@ pub async fn pin_message(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_message/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("pin_message/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
@@ -778,19 +733,13 @@ pub async fn pin_message(
     // For groups, only admins/owners can pin
     let kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_message/get_kind: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("pin_message/get_kind")?
         .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
 
     if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group) {
         let role_str = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in pin_message/get_role: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("pin_message/get_role")?
             .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
         let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
@@ -805,10 +754,7 @@ pub async fn pin_message(
     let _conv_id =
         db::messages::pin_message(&state.pool, message_id, auth.user_id, conversation_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in pin_message: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("pin_message")?
             .ok_or_else(|| {
                 AppError::bad_request("Message not found or does not belong to this conversation")
             })?;
@@ -816,10 +762,7 @@ pub async fn pin_message(
     // Look up pinner's username for the broadcast event
     let pinner = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_message/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("pin_message/find_user")?;
     let pinned_by_username = pinner
         .map(|u| u.username)
         .unwrap_or_else(|| "unknown".to_string());
@@ -861,10 +804,7 @@ pub async fn unpin_message(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_message/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("unpin_message/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
@@ -872,19 +812,13 @@ pub async fn unpin_message(
     // For groups, only admins/owners can unpin
     let kind = db::groups::get_conversation_kind(&state.pool, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_message/get_kind: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("unpin_message/get_kind")?
         .ok_or_else(|| AppError::bad_request("Conversation not found"))?;
 
     if ConversationKind::from_str_opt(&kind) == Some(ConversationKind::Group) {
         let role_str = db::groups::get_member_role(&state.pool, conversation_id, auth.user_id)
             .await
-            .map_err(|e| {
-                tracing::error!("DB error in unpin_message/get_role: {e:?}");
-                AppError::internal("Database error")
-            })?
+            .db_ctx("unpin_message/get_role")?
             .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
 
         let role = Role::from_str_opt(&role_str).unwrap_or(Role::Member);
@@ -898,10 +832,7 @@ pub async fn unpin_message(
     // Unpin the message (atomically verified against the correct conversation)
     let _conv_id = db::messages::unpin_message(&state.pool, message_id, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_message: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("unpin_message")?
         .ok_or_else(|| {
             AppError::bad_request("Message not found, not pinned, or wrong conversation")
         })?;
@@ -936,20 +867,14 @@ pub async fn get_pinned_messages(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_pinned_messages/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_pinned_messages/is_member")?;
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
     }
 
     let pinned = db::messages::get_pinned_messages(&state.pool, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_pinned_messages: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("get_pinned_messages")?;
 
     Ok(Json(pinned))
 }
@@ -965,10 +890,7 @@ pub async fn pin_conversation(
 ) -> Result<impl IntoResponse, AppError> {
     db::users::pin_conversation(&state.pool, auth.user_id, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in pin_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("pin_conversation")?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -983,9 +905,6 @@ pub async fn unpin_conversation(
 ) -> Result<impl IntoResponse, AppError> {
     db::users::unpin_conversation(&state.pool, auth.user_id, conversation_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in unpin_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("unpin_conversation")?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -91,6 +91,50 @@ pub struct LastMessageInfo {
     pub created_at: DateTime<Utc>,
 }
 
+/// Message response DTO for GET /api/messages/:conversation_id.
+#[derive(Debug, Serialize)]
+pub struct MessageDto {
+    pub id: Uuid,
+    pub message_id: Uuid,
+    pub conversation_id: Uuid,
+    pub channel_id: Option<Uuid>,
+    pub sender_id: Uuid,
+    pub from_user_id: Uuid,
+    pub from_device_id: Option<i32>,
+    pub sender_username: String,
+    pub from_username: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+    pub edited_at: Option<DateTime<Utc>>,
+    pub reply_to_id: Option<Uuid>,
+    pub reply_to_content: Option<String>,
+    pub reply_to_username: Option<String>,
+    pub reply_count: i64,
+}
+
+impl From<db::messages::MessageWithSender> for MessageDto {
+    fn from(m: db::messages::MessageWithSender) -> Self {
+        Self {
+            id: m.id,
+            message_id: m.id,
+            conversation_id: m.conversation_id,
+            channel_id: m.channel_id,
+            sender_id: m.sender_id,
+            from_user_id: m.sender_id,
+            from_device_id: m.sender_device_id,
+            sender_username: m.sender_username.clone(),
+            from_username: m.sender_username,
+            content: m.content,
+            created_at: m.created_at,
+            edited_at: m.edited_at,
+            reply_to_id: m.reply_to_id,
+            reply_to_content: m.reply_to_content,
+            reply_to_username: m.reply_to_username,
+            reply_count: m.reply_count,
+        }
+    }
+}
+
 /// Raw row returned by the single optimized list_conversations query.
 #[derive(Debug, sqlx::FromRow)]
 struct ConversationFullRow {
@@ -289,34 +333,8 @@ pub async fn get_messages(
     .await
     .db_ctx("get_messages/fetch")?;
 
-    // Re-shape the response to expose `from_user_id` / `from_username` /
-    // `from_device_id` keys the client expects on history (#557). Doing it
-    // here avoids changing every other consumer of `MessageWithSender`.
-    let body: Vec<serde_json::Value> = messages
-        .into_iter()
-        .map(|m| {
-            serde_json::json!({
-                "id": m.id,
-                "message_id": m.id,
-                "conversation_id": m.conversation_id,
-                "channel_id": m.channel_id,
-                "sender_id": m.sender_id,
-                "from_user_id": m.sender_id,
-                "from_device_id": m.sender_device_id,
-                "sender_username": m.sender_username,
-                "from_username": m.sender_username,
-                "content": m.content,
-                "created_at": m.created_at,
-                "edited_at": m.edited_at,
-                "reply_to_id": m.reply_to_id,
-                "reply_to_content": m.reply_to_content,
-                "reply_to_username": m.reply_to_username,
-                "reply_count": m.reply_count,
-            })
-        })
-        .collect();
-
-    Ok(Json(body))
+    let dtos: Vec<MessageDto> = messages.into_iter().map(MessageDto::from).collect();
+    Ok(Json(dtos))
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -109,7 +109,9 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
     let key_reset_device_limit =
         rate_limit::make_rate_limit_layer(rate_limit::key_reset_limiter(Arc::clone(&proxies)));
     let revoke_others_limit =
-        rate_limit::make_rate_limit_layer(rate_limit::revoke_others_limiter(proxies));
+        rate_limit::make_rate_limit_layer(rate_limit::revoke_others_limiter(Arc::clone(&proxies)));
+    let edit_message_limit =
+        rate_limit::make_rate_limit_layer(rate_limit::edit_message_limiter(proxies));
 
     let auth_routes = Router::new()
         .route(
@@ -180,7 +182,8 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
             "/messages/{id}",
             get(messages::get_messages)
                 .delete(messages::delete_message)
-                .put(messages::edit_message),
+                .put(messages::edit_message)
+                .layer(middleware::from_fn(edit_message_limit)),
         )
         .route("/messages/{id}/replies", get(messages::get_thread_replies))
         .route("/messages/{id}/reactions", post(reactions::add_reaction))

--- a/apps/server/src/routes/reactions.rs
+++ b/apps/server/src/routes/reactions.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -48,19 +48,13 @@ pub async fn add_reaction(
     // Get conversation for this message
     let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_reaction/get_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("add_reaction/get_conversation")?
         .ok_or_else(|| AppError::bad_request("Message not found"))?;
 
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_reaction/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("add_reaction/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -76,10 +70,7 @@ pub async fn add_reaction(
     // Look up username for broadcast
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in add_reaction/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("add_reaction/find_user")?
         .ok_or_else(|| AppError::internal("User not found"))?;
 
     // Broadcast to conversation members
@@ -110,19 +101,13 @@ pub async fn remove_reaction(
     // Get conversation for this message
     let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_reaction/get_conversation: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("remove_reaction/get_conversation")?
         .ok_or_else(|| AppError::bad_request("Message not found"))?;
 
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_reaction/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("remove_reaction/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -142,10 +127,7 @@ pub async fn remove_reaction(
     // Look up username for broadcast
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in remove_reaction/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("remove_reaction/find_user")?
         .ok_or_else(|| AppError::internal("User not found"))?;
 
     // Broadcast removal to conversation members
@@ -173,10 +155,7 @@ pub async fn mark_read(
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in mark_read/is_member: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("mark_read/is_member")?;
 
     if !is_member {
         return Err(AppError::unauthorized("Not a member of this conversation"));
@@ -184,10 +163,7 @@ pub async fn mark_read(
 
     let privacy = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in mark_read/get_privacy: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("mark_read/get_privacy")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     if !privacy.read_receipts_enabled {

--- a/apps/server/src/routes/server_info.rs
+++ b/apps/server/src/routes/server_info.rs
@@ -11,6 +11,7 @@ use axum::response::IntoResponse;
 use serde::Serialize;
 use std::sync::Arc;
 
+use crate::config::registration_open;
 use crate::error::AppError;
 use crate::routes::AppState;
 
@@ -46,20 +47,11 @@ pub async fn server_info(
             .await
             .map_err(|_| AppError::internal("Database error"))?;
 
-    let registration_open = std::env::var("REGISTRATION_OPEN")
-        .map(|v| {
-            !matches!(
-                v.trim().to_lowercase().as_str(),
-                "false" | "0" | "no" | "off"
-            )
-        })
-        .unwrap_or(true);
-
     Ok(Json(ServerInfoResponse {
         name: env!("CARGO_PKG_NAME"),
         version: env!("CARGO_PKG_VERSION"),
         server_id: server_id.to_string(),
-        registration_open,
+        registration_open: registration_open(),
         federation_capable: false,
     }))
 }

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 
 use super::AppState;
 
@@ -77,10 +77,7 @@ pub async fn get_my_privacy(
 ) -> Result<impl IntoResponse, AppError> {
     let privacy = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_my_privacy: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_my_privacy")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     Ok(Json(PrivacyPreferencesResponse {
@@ -102,10 +99,7 @@ pub async fn update_my_privacy(
 ) -> Result<impl IntoResponse, AppError> {
     let current = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_my_privacy/get_current: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("update_my_privacy/get_current")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     let prefs = db::users::PrivacyUpdate {
@@ -151,10 +145,7 @@ pub async fn get_profile(
 ) -> Result<impl IntoResponse, AppError> {
     let profile = db::users::find_public_profile(&state.pool, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in get_profile: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("get_profile")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     Ok(Json(UserProfile {
@@ -268,10 +259,7 @@ pub async fn update_profile(
     };
     let profile = db::users::update_profile(&state.pool, auth.user_id, &fields)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_profile: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("update_profile")?;
 
     Ok(Json(UserProfile {
         user_id: profile.id,
@@ -310,10 +298,7 @@ pub async fn update_presence_status(
 
     db::users::update_presence_status(&state.pool, auth.user_id, &body.status)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_presence_status: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("update_presence_status")?;
 
     // Broadcast to contacts.  Invisible users appear offline to others.
     let broadcast_status = if body.status == "invisible" {
@@ -509,10 +494,7 @@ pub async fn online_users(
 ) -> Result<impl IntoResponse, AppError> {
     let contact_ids = db::contacts::list_contact_user_ids(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in online_users/list_contacts: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("online_users/list_contacts")?;
     let all_online = state.hub.get_online_user_ids();
     let online_contacts: Vec<_> = all_online
         .into_iter()
@@ -538,10 +520,7 @@ pub async fn search_users(
 
     let results = db::users::search_users(&state.pool, query, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in search_users: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("search_users")?;
 
     let users: Vec<_> = results
         .into_iter()
@@ -591,10 +570,7 @@ pub async fn resolve_username_invite(
 
     let resolved = db::users::resolve_username_invite(&state.pool, auth.user_id, candidate)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in resolve_username_invite: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("resolve_username_invite")?
         .ok_or_else(|| AppError::not_found("User not found"))?;
 
     let discoverable = resolved.searchable
@@ -792,9 +768,6 @@ pub async fn update_status_text(
     }
     db::users::update_status_text(&state.pool, auth.user_id, text)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in update_status_text: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("update_status_text")?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -459,13 +459,25 @@ pub async fn change_password(
         .map_err(|_| AppError::internal("Database error"))?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
-    let valid = password::verify_password(&body.current_password, &user.password_hash)?;
+    // Argon2 verify takes ~50-150ms of pure CPU. Without spawn_blocking it
+    // stalls a tokio worker for the whole duration -- login/register already
+    // do this; change_password was missing it (#697).
+    let stored_hash = user.password_hash.clone();
+    let current_password = body.current_password.clone();
+    let valid = tokio::task::spawn_blocking(move || {
+        password::verify_password(&current_password, &stored_hash)
+    })
+    .await
+    .map_err(|e| AppError::internal(format!("argon2 join error: {e}")))??;
     if !valid {
         return Err(AppError::unauthorized("Current password is incorrect"));
     }
 
-    // Hash and store new password
-    let new_hash = password::hash_password(&body.new_password)?;
+    // Hash and store new password (also spawn_blocking, same reason).
+    let new_password = body.new_password.clone();
+    let new_hash = tokio::task::spawn_blocking(move || password::hash_password(&new_password))
+        .await
+        .map_err(|e| AppError::internal(format!("argon2 join error: {e}")))??;
     db::users::update_password(&state.pool, auth.user_id, &new_hash)
         .await
         .map_err(|e| {

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use crate::auth::middleware::AuthUser;
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::routes::AppState;
 
 #[derive(Debug, Deserialize)]
@@ -64,10 +64,7 @@ pub async fn generate_token(
     // longer has to race a post-connect `setName` call.
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error looking up user for voice token: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("looking up user for voice token")?
         .ok_or_else(|| AppError::bad_request("User not found"))?;
 
     let username = user.username;
@@ -97,10 +94,7 @@ pub async fn generate_token(
 
     let is_member = db::groups::is_member(&state.pool, conv_uuid, auth.user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error checking voice token membership: {e:?}");
-            AppError::internal("Database error")
-        })?;
+        .db_ctx("checking voice token membership")?;
     if !is_member {
         return Err(AppError::bad_request("Not a member of this conversation"));
     }

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -14,11 +14,12 @@ use crate::routes::AppState;
 
 #[derive(Debug, Deserialize)]
 pub struct TokenRequest {
-    pub room: Option<String>,
     pub identity: Option<String>,
     /// Alternative field name used by some mobile clients.
     pub channel_id: Option<String>,
-    /// Conversation context -- used to derive room name when `room` is absent.
+    /// Conversation context -- the room name is derived from this so the
+    /// LiveKit grant cannot be steered to a conversation the caller is not
+    /// a member of (CRIT-1, audit 2026-04-30).
     pub conversation_id: Option<String>,
 }
 
@@ -81,53 +82,32 @@ pub async fn generate_token(
         ));
     }
 
-    // Resolve room: prefer explicit `room`, fall back to channel_id or
-    // conversation_id so mobile clients that send either field still work.
-    let room = body
-        .room
-        .or(body.channel_id.clone())
-        .or(body.conversation_id.clone())
-        .unwrap_or_default();
+    // Security: derive the LiveKit room name from the conversation the caller
+    // claims membership of, then check membership against THAT same value.
+    // Earlier code accepted a separate `body.room` that was used as the JWT
+    // claim while membership was checked against `conversation_id`, so a
+    // member of conv A could request `{room: "<victim>", conversation_id: "<A>"}`
+    // and receive a token granting access to the victim's room (CRIT-1).
+    let conversation_id_str = body.conversation_id.or(body.channel_id).ok_or_else(|| {
+        AppError::bad_request("conversation_id or channel_id is required for voice token")
+    })?;
 
-    if room.is_empty() {
-        return Err(AppError::bad_request("Room name is required"));
+    let conv_uuid = uuid::Uuid::parse_str(&conversation_id_str)
+        .map_err(|_| AppError::bad_request("Invalid conversation_id or channel_id"))?;
+
+    let is_member = db::groups::is_member(&state.pool, conv_uuid, auth.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("DB error checking voice token membership: {e:?}");
+            AppError::internal("Database error")
+        })?;
+    if !is_member {
+        return Err(AppError::bad_request("Not a member of this conversation"));
     }
 
-    // Validate room name: alphanumeric, hyphens, underscores, colons only.
-    // Prevents injection into LiveKit room names that could break tenant
-    // isolation or cause unexpected behavior in the LiveKit server.
-    if room.len() > 128
-        || !room
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == ':')
-    {
-        return Err(AppError::bad_request(
-            "Room name must be alphanumeric with hyphens, underscores, or colons (max 128 chars)",
-        ));
-    }
-
-    // Security: verify the user is a member of the conversation they are
-    // requesting a voice token for.  Without this check any authenticated
-    // user could generate a token for an arbitrary room and eavesdrop on
-    // voice channels they should not have access to.
-    let conversation_id_str = body.conversation_id.or(body.channel_id);
-    if let Some(ref cid) = conversation_id_str {
-        let conv_uuid = uuid::Uuid::parse_str(cid)
-            .map_err(|_| AppError::bad_request("Invalid conversation_id or channel_id"))?;
-        let is_member = db::groups::is_member(&state.pool, conv_uuid, auth.user_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("DB error checking voice token membership: {e:?}");
-                AppError::internal("Database error")
-            })?;
-        if !is_member {
-            return Err(AppError::bad_request("Not a member of this conversation"));
-        }
-    } else {
-        return Err(AppError::bad_request(
-            "conversation_id or channel_id is required for voice token",
-        ));
-    }
+    // Use the conversation UUID (canonical, hyphenated) as the LiveKit room
+    // name -- safe by construction (alphanumeric + hyphens, <= 36 chars).
+    let room = conv_uuid.to_string();
 
     let api_key = std::env::var("LIVEKIT_API_KEY").map_err(|_| {
         AppError::bad_request(

--- a/apps/server/src/routes/ws.rs
+++ b/apps/server/src/routes/ws.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::db;
-use crate::error::AppError;
+use crate::error::{AppError, DbErrCtx};
 use crate::ws::handler;
 
 use super::AppState;
@@ -52,10 +52,7 @@ pub async fn ws_upgrade(
 
     let user = db::users::find_by_id(&state.pool, user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("DB error in ws_upgrade/find_user: {e:?}");
-            AppError::internal("Database error")
-        })?
+        .db_ctx("ws_upgrade/find_user")?
         .ok_or_else(|| AppError::unauthorized("User not found"))?;
 
     tracing::info!(

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -199,14 +199,27 @@ pub async fn handle_socket(
     // Broadcast online presence to contacts
     typing_service::broadcast_presence(&state, user_id, &username, "online").await;
 
-    // Task: forward hub messages to WebSocket sink
-    let send_task = tokio::spawn(async move {
+    // Forward hub messages to WebSocket sink. Audit #696: previously this
+    // ran as a detached `tokio::spawn` and the receive loop ran serially
+    // afterward, so the two halves had no shared lifecycle -- if the peer's
+    // TCP died but more inbound bytes arrived, the receive loop kept
+    // accepting frames and the hub kept enqueueing into a now-unread mpsc
+    // channel until it filled. Conversely if the receive loop ended first
+    // (ticket expiry), aborting the send task discarded any pending hub
+    // messages. We now wrap both halves in `tokio::select!` so either half
+    // ending tears down both, and we drain `rx` with a brief timeout after
+    // shutdown to flush in-flight frames before the connection drops.
+    let send_fut = async move {
         while let Some(msg) = rx.recv().await {
             if sender.send(msg).await.is_err() {
                 break;
             }
         }
-    });
+        // Return ownership of the sink + the receiver so the post-shutdown
+        // drain step can continue using the same socket.
+        (sender, rx)
+    };
+    tokio::pin!(send_fut);
 
     // Task: send heartbeat every 30 seconds to keep the connection alive
     // through reverse-proxy (Traefik/Cloudflare) idle timeouts.
@@ -255,11 +268,39 @@ pub async fn handle_socket(
 
     message_service::deliver_undelivered_messages(&state, user_id, device_id).await;
 
-    run_receive_loop(&mut receiver, user_id, device_id, &username, &state).await;
+    // Run receive + send concurrently. Whichever finishes first triggers the
+    // tear-down; the other half is awaited (or dropped) in the cleanup arm.
+    let recv_fut = run_receive_loop(&mut receiver, user_id, device_id, &username, &state);
+    tokio::pin!(recv_fut);
 
-    // Cleanup
-    state.hub.unregister(user_id, device_id);
-    send_task.abort();
+    let leftover_rx: Option<mpsc::Receiver<WsMessage>> = tokio::select! {
+        _ = &mut recv_fut => {
+            // Receive loop ended -- the send half might still have pending
+            // frames in `rx`. Unregister so no new ones land, then attempt a
+            // brief drain (50ms) to flush what's already buffered.
+            state.hub.unregister(user_id, device_id);
+            // Pull the sink + rx back out of the send future by polling
+            // it once with a tight timeout. If the channel was already
+            // closed by `unregister` (which dropped the tx) the future
+            // resolves immediately; otherwise the timeout caps it.
+            match tokio::time::timeout(Duration::from_millis(50), &mut send_fut).await {
+                Ok((_sender, rx)) => Some(rx),
+                Err(_) => None,
+            }
+        }
+        (_sender, rx) = &mut send_fut => {
+            // Send half ended (peer TCP died, or rx was closed). Stop
+            // accepting new inbound frames by unregistering, then let the
+            // recv future complete naturally as the underlying socket
+            // surfaces the error.
+            state.hub.unregister(user_id, device_id);
+            // Best-effort: give the recv loop a moment to observe the
+            // socket close before we drop it.
+            let _ = tokio::time::timeout(Duration::from_millis(50), &mut recv_fut).await;
+            Some(rx)
+        }
+    };
+    drop(leftover_rx);
     ping_task.abort();
 
     cleanup_user_voice_sessions(&state, user_id).await;

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -199,24 +199,14 @@ pub async fn handle_socket(
     // Broadcast online presence to contacts
     typing_service::broadcast_presence(&state, user_id, &username, "online").await;
 
-    // Forward hub messages to WebSocket sink. Audit #696: previously this
-    // ran as a detached `tokio::spawn` and the receive loop ran serially
-    // afterward, so the two halves had no shared lifecycle -- if the peer's
-    // TCP died but more inbound bytes arrived, the receive loop kept
-    // accepting frames and the hub kept enqueueing into a now-unread mpsc
-    // channel until it filled. Conversely if the receive loop ended first
-    // (ticket expiry), aborting the send task discarded any pending hub
-    // messages. We now wrap both halves in `tokio::select!` so either half
-    // ending tears down both, and we drain `rx` with a brief timeout after
-    // shutdown to flush in-flight frames before the connection drops.
+    // Forward hub -> sink. Both halves are select!-linked below so neither
+    // outlives the other; rx returned for post-shutdown drain.
     let send_fut = async move {
         while let Some(msg) = rx.recv().await {
             if sender.send(msg).await.is_err() {
                 break;
             }
         }
-        // Return ownership of the sink + the receiver so the post-shutdown
-        // drain step can continue using the same socket.
         (sender, rx)
     };
     tokio::pin!(send_fut);

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -5,53 +5,87 @@
 
 use axum::extract::ws::Message as WsMessage;
 use dashmap::DashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use uuid::Uuid;
 
 pub type WsTx = mpsc::Sender<WsMessage>;
 
+/// After this many consecutive `Full` results inside [`SLOW_CONSUMER_WINDOW`],
+/// the hub unregisters the device so the client must reconnect.  Picked
+/// conservatively: a busy public group can produce occasional Full bursts
+/// when a tab is briefly throttled, so we allow short spikes but kill any
+/// connection that consistently can't keep up (audit #634).
+const SLOW_CONSUMER_FULL_THRESHOLD: u32 = 50;
+const SLOW_CONSUMER_WINDOW: Duration = Duration::from_secs(60);
+
 #[derive(Debug, Default, Clone)]
 pub struct Hub {
+    inner: std::sync::Arc<HubInner>,
+}
+
+#[derive(Debug, Default)]
+struct HubInner {
     /// user_id -> (device_id -> sender channel)
     connections: DashMap<Uuid, DashMap<i32, WsTx>>,
+    /// Per-(user, device) counter of consecutive `try_send` Full results.
+    /// Reset on any successful send.  When the counter exceeds the threshold
+    /// inside the rolling window, the device is unregistered.
+    full_counters: DashMap<(Uuid, i32), FullCounter>,
+}
+
+#[derive(Debug, Default)]
+struct FullCounter {
+    consecutive: AtomicU32,
+    first_failure_at: std::sync::Mutex<Option<Instant>>,
 }
 
 impl Hub {
     pub fn new() -> Self {
-        Self {
-            connections: DashMap::new(),
-        }
+        Self::default()
     }
 
     /// Register a device connection. Multiple devices per user are supported.
     pub fn register(&self, user_id: Uuid, device_id: i32, tx: WsTx) {
-        self.connections
+        self.inner
+            .connections
             .entry(user_id)
             .or_default()
             .insert(device_id, tx);
+        // Wipe any stale slow-consumer counter from a previous session.
+        self.inner.full_counters.remove(&(user_id, device_id));
     }
 
     /// Unregister a specific device. Cleans up the user entry if no devices remain.
     pub fn unregister(&self, user_id: Uuid, device_id: i32) {
-        if let Some(devices) = self.connections.get(&user_id) {
+        if let Some(devices) = self.inner.connections.get(&user_id) {
             devices.remove(&device_id);
             if devices.is_empty() {
                 drop(devices);
                 // Re-check after dropping the ref to avoid race
-                self.connections
+                self.inner
+                    .connections
                     .remove_if(&user_id, |_, devs| devs.is_empty());
             }
         }
+        // Drop the slow-consumer counter alongside the connection so a future
+        // reconnect from the same device gets a clean slate.
+        self.inner.full_counters.remove(&(user_id, device_id));
     }
 
     /// Unregister ALL devices for a user (e.g., account deletion).
     pub fn unregister_all(&self, user_id: Uuid) {
-        self.connections.remove(&user_id);
+        self.inner.connections.remove(&user_id);
     }
 
     pub fn get_online_user_ids(&self) -> Vec<Uuid> {
-        self.connections.iter().map(|entry| *entry.key()).collect()
+        self.inner
+            .connections
+            .iter()
+            .map(|entry| *entry.key())
+            .collect()
     }
 
     /// Send a message to ALL connected devices of a user.
@@ -59,29 +93,41 @@ impl Hub {
     /// message. Full/closed queues are logged separately so beta-test
     /// telemetry distinguishes saturation from disconnect cleanup.
     pub fn send_to_user(&self, user_id: &Uuid, msg: WsMessage) -> bool {
-        if let Some(devices) = self.connections.get(user_id) {
-            let mut any_sent = false;
-            for entry in devices.iter() {
-                if try_send_logged(entry.value(), msg.clone(), user_id, *entry.key()) {
-                    any_sent = true;
-                }
+        // Snapshot the device IDs while holding the read ref so we can
+        // mutate `connections` (via `unregister`) without re-entrant locks
+        // on the slow-consumer eviction path below.
+        let device_ids: Vec<(i32, WsTx)> = {
+            let Some(devices) = self.inner.connections.get(user_id) else {
+                return false;
+            };
+            devices
+                .iter()
+                .map(|e| (*e.key(), e.value().clone()))
+                .collect()
+        };
+
+        let mut any_sent = false;
+        for (device_id, tx) in device_ids {
+            if self.try_send_tracked(*user_id, device_id, &tx, msg.clone()) {
+                any_sent = true;
             }
-            any_sent
-        } else {
-            false
         }
+        any_sent
     }
 
     /// Send a message to a specific device of a user. Returns true only when
     /// the message was actually enqueued — callers in the replay path rely
     /// on this to avoid prematurely marking messages as delivered (#523).
     pub fn send_to_device(&self, user_id: &Uuid, device_id: i32, msg: WsMessage) -> bool {
-        if let Some(devices) = self.connections.get(user_id)
-            && let Some(tx) = devices.get(&device_id)
-        {
-            return try_send_logged(tx.value(), msg, user_id, device_id);
+        let tx_opt: Option<WsTx> = self
+            .inner
+            .connections
+            .get(user_id)
+            .and_then(|devices| devices.get(&device_id).map(|e| e.value().clone()));
+        match tx_opt {
+            Some(tx) => self.try_send_tracked(*user_id, device_id, &tx, msg),
+            None => false,
         }
-        false
     }
 
     /// Backward-compatible: send to user (all devices). Alias for `send_to_user`.
@@ -106,24 +152,82 @@ impl Hub {
     }
 }
 
-fn try_send_logged(tx: &WsTx, msg: WsMessage, user_id: &Uuid, device_id: i32) -> bool {
-    match tx.try_send(msg) {
-        Ok(()) => true,
-        Err(TrySendError::Full(_)) => {
-            tracing::warn!(
-                user_id = %user_id,
-                device_id = device_id,
-                "WS outbound queue full — message not delivered"
-            );
-            false
+impl Hub {
+    /// Try to send a message and update the per-(user, device) slow-consumer
+    /// counter.  When a device has had `SLOW_CONSUMER_FULL_THRESHOLD`
+    /// consecutive `Full` results within `SLOW_CONSUMER_WINDOW`, unregister
+    /// it so the client must reconnect (audit #634) -- otherwise a stalled
+    /// tab can starve itself indefinitely with silent drops.
+    fn try_send_tracked(&self, user_id: Uuid, device_id: i32, tx: &WsTx, msg: WsMessage) -> bool {
+        match tx.try_send(msg) {
+            Ok(()) => {
+                // Reset the counter on any success.
+                self.inner.full_counters.remove(&(user_id, device_id));
+                true
+            }
+            Err(TrySendError::Full(_)) => {
+                let kick = self.record_full(user_id, device_id);
+                tracing::warn!(
+                    %user_id,
+                    device_id,
+                    "WS outbound queue full -- message not delivered"
+                );
+                if kick {
+                    tracing::warn!(
+                        %user_id,
+                        device_id,
+                        threshold = SLOW_CONSUMER_FULL_THRESHOLD,
+                        window_secs = SLOW_CONSUMER_WINDOW.as_secs(),
+                        "slow consumer threshold reached -- forcing reconnect"
+                    );
+                    self.unregister(user_id, device_id);
+                }
+                false
+            }
+            Err(TrySendError::Closed(_)) => {
+                tracing::debug!(
+                    %user_id,
+                    device_id,
+                    "WS outbound queue closed -- recipient disconnected"
+                );
+                // Closed (rather than Full) indicates the receiver is gone --
+                // no point keeping the counter.
+                self.inner.full_counters.remove(&(user_id, device_id));
+                false
+            }
         }
-        Err(TrySendError::Closed(_)) => {
-            tracing::debug!(
-                user_id = %user_id,
-                device_id = device_id,
-                "WS outbound queue closed — recipient disconnected"
-            );
-            false
+    }
+
+    /// Increment the failure counter for `(user_id, device_id)`.  Returns
+    /// `true` when the threshold has just been reached and the caller should
+    /// unregister the device.  The window is rolling: if the first failure
+    /// is older than `SLOW_CONSUMER_WINDOW`, the counter resets.
+    fn record_full(&self, user_id: Uuid, device_id: i32) -> bool {
+        let counter = self
+            .inner
+            .full_counters
+            .entry((user_id, device_id))
+            .or_default();
+
+        // Rolling-window reset: if the first failure was longer ago than the
+        // window, treat this Full as a fresh start.
+        let now = Instant::now();
+        let mut first_failure_at = counter.first_failure_at.lock().unwrap();
+        match *first_failure_at {
+            Some(t) if now.duration_since(t) > SLOW_CONSUMER_WINDOW => {
+                *first_failure_at = Some(now);
+                counter.consecutive.store(1, Ordering::Relaxed);
+                false
+            }
+            None => {
+                *first_failure_at = Some(now);
+                counter.consecutive.store(1, Ordering::Relaxed);
+                false
+            }
+            Some(_) => {
+                let n = counter.consecutive.fetch_add(1, Ordering::Relaxed) + 1;
+                n >= SLOW_CONSUMER_FULL_THRESHOLD
+            }
         }
     }
 }
@@ -299,6 +403,61 @@ mod tests {
 
         let sent = hub.send_to_device(&user_id, 1, WsMessage::Text("dropped".into()));
         assert!(!sent, "send must report failure once receiver is dropped");
+    }
+
+    /// Audit #634: a stuck consumer must be force-disconnected after the
+    /// configured threshold of consecutive Full results so the connection
+    /// slot is freed and the client is forced to reconnect.
+    #[tokio::test]
+    async fn test_slow_consumer_unregisters_after_threshold() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel(1);
+        hub.register(user_id, 1, tx);
+
+        // First send fits in the cap-1 queue.
+        assert!(hub.send_to_device(&user_id, 1, WsMessage::Text("first".into())));
+        // Subsequent sends fail (queue is full and we're not consuming) but
+        // the device stays registered until the threshold is crossed.
+        for i in 0..(SLOW_CONSUMER_FULL_THRESHOLD - 1) {
+            assert!(
+                !hub.send_to_device(&user_id, 1, WsMessage::Text("blocked".into())),
+                "iteration {i}: send should fail while queue is full"
+            );
+            assert!(
+                hub.inner.connections.contains_key(&user_id),
+                "iteration {i}: device should still be registered"
+            );
+        }
+        // The next failure trips the threshold and unregisters the device.
+        assert!(!hub.send_to_device(&user_id, 1, WsMessage::Text("kicker".into())));
+        assert!(
+            !hub.inner.connections.contains_key(&user_id),
+            "device must be unregistered after slow-consumer threshold"
+        );
+    }
+
+    /// Successful sends reset the consecutive-Full counter so a brief burst
+    /// of contention doesn't accumulate toward eviction.
+    #[tokio::test]
+    async fn test_full_counter_resets_on_success() {
+        let hub = Hub::new();
+        let user_id = Uuid::new_v4();
+        let (tx, mut rx) = mpsc::channel(1);
+        hub.register(user_id, 1, tx);
+
+        // Half-fill the failure budget without consuming.
+        assert!(hub.send_to_device(&user_id, 1, WsMessage::Text("ok".into())));
+        for _ in 0..10 {
+            assert!(!hub.send_to_device(&user_id, 1, WsMessage::Text("full".into())));
+        }
+        // Drain the receiver and send again -- counter must reset.
+        let _ = rx.recv().await;
+        assert!(hub.send_to_device(&user_id, 1, WsMessage::Text("recovered".into())));
+        assert!(
+            hub.inner.full_counters.get(&(user_id, 1)).is_none(),
+            "successful send must clear the counter"
+        );
     }
 
     #[tokio::test]

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -88,6 +88,19 @@ impl Hub {
             .collect()
     }
 
+    /// Number of devices currently registered for `user_id`.  Used by the
+    /// presence broadcaster (#436) to gate `online`/`offline` events on
+    /// first-device-up / last-device-down so a user with three devices
+    /// reconnecting after a flaky network blip doesn't make contacts see
+    /// online/offline/online/offline per device.
+    pub fn device_count(&self, user_id: &Uuid) -> usize {
+        self.inner
+            .connections
+            .get(user_id)
+            .map(|devices| devices.len())
+            .unwrap_or(0)
+    }
+
     /// Send a message to ALL connected devices of a user.
     /// Returns true if at least one device's outbound queue accepted the
     /// message. Full/closed queues are logged separately so beta-test

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -13,11 +13,8 @@ use uuid::Uuid;
 
 pub type WsTx = mpsc::Sender<WsMessage>;
 
-/// After this many consecutive `Full` results inside [`SLOW_CONSUMER_WINDOW`],
-/// the hub unregisters the device so the client must reconnect.  Picked
-/// conservatively: a busy public group can produce occasional Full bursts
-/// when a tab is briefly throttled, so we allow short spikes but kill any
-/// connection that consistently can't keep up (audit #634).
+/// Slow-consumer eviction threshold: this many consecutive `Full` results
+/// inside the window unregister the device so the client must reconnect.
 const SLOW_CONSUMER_FULL_THRESHOLD: u32 = 50;
 const SLOW_CONSUMER_WINDOW: Duration = Duration::from_secs(60);
 
@@ -166,11 +163,8 @@ impl Hub {
 }
 
 impl Hub {
-    /// Try to send a message and update the per-(user, device) slow-consumer
-    /// counter.  When a device has had `SLOW_CONSUMER_FULL_THRESHOLD`
-    /// consecutive `Full` results within `SLOW_CONSUMER_WINDOW`, unregister
-    /// it so the client must reconnect (audit #634) -- otherwise a stalled
-    /// tab can starve itself indefinitely with silent drops.
+    /// `try_send` plus slow-consumer tracking. Force-unregisters once the
+    /// threshold trips so a stalled tab can't starve itself indefinitely.
     fn try_send_tracked(&self, user_id: Uuid, device_id: i32, tx: &WsTx, msg: WsMessage) -> bool {
         match tx.try_send(msg) {
             Ok(()) => {
@@ -418,9 +412,6 @@ mod tests {
         assert!(!sent, "send must report failure once receiver is dropped");
     }
 
-    /// Audit #634: a stuck consumer must be force-disconnected after the
-    /// configured threshold of consecutive Full results so the connection
-    /// slot is freed and the client is forced to reconnect.
     #[tokio::test]
     async fn test_slow_consumer_unregisters_after_threshold() {
         let hub = Hub::new();

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -15,9 +15,6 @@ use crate::ws::typing_service::get_member_ids_cached;
 
 pub(super) const MAX_MESSAGE_LENGTH: usize = 10_000;
 
-// Wire-format constants are defined once in `echo_core::signal::protocol`
-// (audit #700). Re-export under the historical local names so the rest of
-// this file reads unchanged.
 use echo_core::signal::protocol::{
     NORMAL_HEADER_LEN as ECHO_NORMAL_HEADER_LEN, WIRE_INITIAL_V1 as ECHO_WIRE_INITIAL_V1,
     WIRE_INITIAL_V2 as ECHO_WIRE_INITIAL_V2, WIRE_MAGIC as ECHO_WIRE_MAGIC,
@@ -901,10 +898,7 @@ pub(super) async fn fanout_message(
 /// used as a fallback when no device-specific row exists (group messages,
 /// unencrypted convs, or messages predating multi-device support).
 pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid, device_id: i32) {
-    // Audit #689: loop with cursor pagination so backlogs >200 messages
-    // (multi-week offline) replay completely instead of leaving the rest
-    // stuck until the next reconnect.  Cap iterations defensively against a
-    // pathological pool error returning the same row over and over.
+    // Cursor-paginated replay; cap iterations against pathological pool errors.
     const MAX_ITERATIONS: usize = 50; // 50 * 200 = 10 000 messages per reconnect
     let mut after_ts: Option<chrono::DateTime<chrono::Utc>> = None;
     for _iter in 0..MAX_ITERATIONS {

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -899,10 +899,11 @@ pub(super) async fn fanout_message(
 /// unencrypted convs, or messages predating multi-device support).
 pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid, device_id: i32) {
     // Cursor-paginated replay; cap iterations against pathological pool errors.
+    // Composite (created_at, id) cursor handles same-tick ties.
     const MAX_ITERATIONS: usize = 50; // 50 * 200 = 10 000 messages per reconnect
-    let mut after_ts: Option<chrono::DateTime<chrono::Utc>> = None;
+    let mut after_cursor: Option<(chrono::DateTime<chrono::Utc>, Uuid)> = None;
     for _iter in 0..MAX_ITERATIONS {
-        let batch = match db::messages::get_undelivered(&state.pool, user_id, after_ts).await {
+        let batch = match db::messages::get_undelivered(&state.pool, user_id, after_cursor).await {
             Ok(msgs) => msgs,
             Err(e) => {
                 tracing::error!(?e, %user_id, "deliver_undelivered: db error -- aborting replay loop");
@@ -916,13 +917,13 @@ pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid
 
         // Advance cursor before processing so a continue-on-error inside the
         // loop body can't infinitely re-fetch the same rows.
-        let last_ts = batch.last().map(|m| m.created_at);
+        let last_cursor = batch.last().map(|m| (m.created_at, m.id));
         let was_full = batch.len() as i64 == db::messages::UNDELIVERED_PAGE_SIZE;
         deliver_one_batch(state, user_id, device_id, batch).await;
         if !was_full {
             return; // last page
         }
-        after_ts = last_ts;
+        after_cursor = last_cursor;
     }
     tracing::warn!(%user_id, "deliver_undelivered: hit MAX_ITERATIONS, deferring remainder to next reconnect");
 }

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -904,15 +904,44 @@ pub(super) async fn fanout_message(
 /// used as a fallback when no device-specific row exists (group messages,
 /// unencrypted convs, or messages predating multi-device support).
 pub(super) async fn deliver_undelivered_messages(state: &AppState, user_id: Uuid, device_id: i32) {
-    let undelivered = match db::messages::get_undelivered(&state.pool, user_id).await {
-        Ok(msgs) => msgs,
-        Err(_) => return,
-    };
+    // Audit #689: loop with cursor pagination so backlogs >200 messages
+    // (multi-week offline) replay completely instead of leaving the rest
+    // stuck until the next reconnect.  Cap iterations defensively against a
+    // pathological pool error returning the same row over and over.
+    const MAX_ITERATIONS: usize = 50; // 50 * 200 = 10 000 messages per reconnect
+    let mut after_ts: Option<chrono::DateTime<chrono::Utc>> = None;
+    for _iter in 0..MAX_ITERATIONS {
+        let batch = match db::messages::get_undelivered(&state.pool, user_id, after_ts).await {
+            Ok(msgs) => msgs,
+            Err(e) => {
+                tracing::error!(?e, %user_id, "deliver_undelivered: db error -- aborting replay loop");
+                return;
+            }
+        };
 
-    if undelivered.is_empty() {
-        return;
+        if batch.is_empty() {
+            return;
+        }
+
+        // Advance cursor before processing so a continue-on-error inside the
+        // loop body can't infinitely re-fetch the same rows.
+        let last_ts = batch.last().map(|m| m.created_at);
+        let was_full = batch.len() as i64 == db::messages::UNDELIVERED_PAGE_SIZE;
+        deliver_one_batch(state, user_id, device_id, batch).await;
+        if !was_full {
+            return; // last page
+        }
+        after_ts = last_ts;
     }
+    tracing::warn!(%user_id, "deliver_undelivered: hit MAX_ITERATIONS, deferring remainder to next reconnect");
+}
 
+async fn deliver_one_batch(
+    state: &AppState,
+    user_id: Uuid,
+    device_id: i32,
+    undelivered: Vec<db::messages::MessageWithSender>,
+) {
     let all_ids: Vec<Uuid> = undelivered.iter().map(|m| m.id).collect();
 
     // Batch-fetch all per-device ciphertexts in a single query to avoid N+1.

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -15,16 +15,13 @@ use crate::ws::typing_service::get_member_ids_cached;
 
 pub(super) const MAX_MESSAGE_LENGTH: usize = 10_000;
 
-/// Echo Messenger wire format magic byte (#591). The first byte of any
-/// initial-message payload identifies the protocol family.
-const ECHO_WIRE_MAGIC: u8 = 0xEC;
-/// Initial-message version 1 (no one-time prekey).
-const ECHO_WIRE_INITIAL_V1: u8 = 0x01;
-/// Initial-message version 2 (with one-time prekey).
-const ECHO_WIRE_INITIAL_V2: u8 = 0x02;
-/// Normal-message wire prefix is a u32 LE header length of 40 bytes
-/// (`header_len(4 LE) + header(40) + nonce(12) + ciphertext + tag(16)`).
-const ECHO_NORMAL_HEADER_LEN: u32 = 40;
+// Wire-format constants are defined once in `echo_core::signal::protocol`
+// (audit #700). Re-export under the historical local names so the rest of
+// this file reads unchanged.
+use echo_core::signal::protocol::{
+    NORMAL_HEADER_LEN as ECHO_NORMAL_HEADER_LEN, WIRE_INITIAL_V1 as ECHO_WIRE_INITIAL_V1,
+    WIRE_INITIAL_V2 as ECHO_WIRE_INITIAL_V2, WIRE_MAGIC as ECHO_WIRE_MAGIC,
+};
 
 /// Validate that a base64-encoded payload is shaped like an Echo
 /// ciphertext wire frame. We do NOT decrypt or otherwise validate

--- a/apps/server/src/ws/mod.rs
+++ b/apps/server/src/ws/mod.rs
@@ -1,4 +1,4 @@
 pub mod handler;
 pub mod hub;
 pub(crate) mod message_service;
-pub(crate) mod typing_service;
+pub mod typing_service;

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -284,7 +284,11 @@ pub(super) async fn broadcast_presence(
         Err(_) => return,
     };
 
+    // Audit #690: build the WsMessage once outside the loop. axum's
+    // Message::Text is backed by bytes::Bytes, so msg.clone() inside the
+    // loop is O(1) reference-count bump rather than a fresh String alloc.
+    let msg = WsMessage::Text(json.into());
     for cid in &contact_ids {
-        state.hub.send_to(cid, WsMessage::Text(json.clone().into()));
+        state.hub.send_to(cid, msg.clone());
     }
 }

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -235,6 +235,25 @@ pub(super) async fn broadcast_presence(
     username: &str,
     status: &str,
 ) {
+    // Audit #436: gate presence on first-device-up / last-device-down so
+    // a multi-device user reconnecting after a network blip doesn't make
+    // every contact see online/offline/online/offline once per device.
+    // `register` happens before this call (online) and `unregister` happens
+    // before this call (offline), so:
+    //   online:  device_count == 1 -> first device just connected, broadcast
+    //   online:  device_count >  1 -> already had other devices, no-op
+    //   offline: device_count == 0 -> last device just disconnected, broadcast
+    //   offline: device_count >  0 -> still has other devices, no-op
+    let dev_count = state.hub.device_count(&user_id);
+    let should_broadcast = match status {
+        "online" => dev_count == 1,
+        "offline" => dev_count == 0,
+        _ => true, // explicit status changes (away/dnd) always broadcast
+    };
+    if !should_broadcast {
+        return;
+    }
+
     let contact_ids = match db::contacts::list_contact_user_ids(&state.pool, user_id).await {
         Ok(ids) => ids,
         Err(e) => {

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -104,12 +104,9 @@ pub fn invalidate_member_cache(conversation_id: Uuid) {
     MEMBERSHIP_CACHE.retain(|(_, conv_id), _| *conv_id != conversation_id);
 }
 
-/// Periodic sweep that drops cache entries older than 2× their TTL across
-/// all three caches.  Called from the cleanup scheduler in main.rs every
-/// 5 minutes (audit #692).  Without this, entries never expire on a busy
-/// server -- after 24h a `MEMBERSHIP_CACHE` for a public group with 1k
-/// members and 100 typers can hold 100k stale `(user_id, conversation_id)`
-/// pairs that no live read path will ever revisit.
+/// Drop cache entries older than 2× their TTL across all three caches.
+/// Called from the cleanup scheduler so stale entries don't accumulate on
+/// long-running servers.
 pub fn sweep_expired_caches() {
     let cutoff = MEMBERSHIP_CACHE_TTL * 2;
     let mut membership_evicted = 0usize;
@@ -235,20 +232,13 @@ pub(super) async fn broadcast_presence(
     username: &str,
     status: &str,
 ) {
-    // Audit #436: gate presence on first-device-up / last-device-down so
-    // a multi-device user reconnecting after a network blip doesn't make
-    // every contact see online/offline/online/offline once per device.
-    // `register` happens before this call (online) and `unregister` happens
-    // before this call (offline), so:
-    //   online:  device_count == 1 -> first device just connected, broadcast
-    //   online:  device_count >  1 -> already had other devices, no-op
-    //   offline: device_count == 0 -> last device just disconnected, broadcast
-    //   offline: device_count >  0 -> still has other devices, no-op
+    // Gate on first-device-up / last-device-down so multi-device reconnects
+    // don't surface online/offline flapping to contacts.
     let dev_count = state.hub.device_count(&user_id);
     let should_broadcast = match status {
         "online" => dev_count == 1,
         "offline" => dev_count == 0,
-        _ => true, // explicit status changes (away/dnd) always broadcast
+        _ => true,
     };
     if !should_broadcast {
         return;
@@ -303,9 +293,7 @@ pub(super) async fn broadcast_presence(
         Err(_) => return,
     };
 
-    // Audit #690: build the WsMessage once outside the loop. axum's
-    // Message::Text is backed by bytes::Bytes, so msg.clone() inside the
-    // loop is O(1) reference-count bump rather than a fresh String alloc.
+    // Build once; clone is O(1) on Bytes-backed Message::Text.
     let msg = WsMessage::Text(json.into());
     for cid in &contact_ids {
         state.hub.send_to(cid, msg.clone());

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -104,6 +104,48 @@ pub fn invalidate_member_cache(conversation_id: Uuid) {
     MEMBERSHIP_CACHE.retain(|(_, conv_id), _| *conv_id != conversation_id);
 }
 
+/// Periodic sweep that drops cache entries older than 2× their TTL across
+/// all three caches.  Called from the cleanup scheduler in main.rs every
+/// 5 minutes (audit #692).  Without this, entries never expire on a busy
+/// server -- after 24h a `MEMBERSHIP_CACHE` for a public group with 1k
+/// members and 100 typers can hold 100k stale `(user_id, conversation_id)`
+/// pairs that no live read path will ever revisit.
+pub fn sweep_expired_caches() {
+    let cutoff = MEMBERSHIP_CACHE_TTL * 2;
+    let mut membership_evicted = 0usize;
+    MEMBERSHIP_CACHE.retain(|_, last_seen| {
+        let keep = last_seen.elapsed() < cutoff;
+        if !keep {
+            membership_evicted += 1;
+        }
+        keep
+    });
+    let mut member_ids_evicted = 0usize;
+    MEMBER_IDS_CACHE.retain(|_, (_, fetched_at)| {
+        let keep = fetched_at.elapsed() < cutoff;
+        if !keep {
+            member_ids_evicted += 1;
+        }
+        keep
+    });
+    let mut kind_evicted = 0usize;
+    CONV_KIND_CACHE.retain(|_, (_, fetched_at)| {
+        let keep = fetched_at.elapsed() < cutoff;
+        if !keep {
+            kind_evicted += 1;
+        }
+        keep
+    });
+    if membership_evicted > 0 || member_ids_evicted > 0 || kind_evicted > 0 {
+        tracing::debug!(
+            membership_evicted,
+            member_ids_evicted,
+            kind_evicted,
+            "ws cache sweep"
+        );
+    }
+}
+
 pub(super) async fn handle_typing(
     state: &AppState,
     sender_id: Uuid,

--- a/apps/server/tests/api_messages.rs
+++ b/apps/server/tests/api_messages.rs
@@ -64,10 +64,11 @@ async fn setup_dm_with_message(
             .await
             .expect("WS connect failed");
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Drain presence events
-    while let Ok(Some(Ok(_))) = tokio::time::timeout(Duration::from_millis(100), ws.next()).await {}
+    // Audit #695: replace the 200ms wall-clock sleep with the bounded-idle
+    // drain helper.  Alice has no contacts here so no `presence` echoes
+    // reach her socket; the drain just absorbs anything that does arrive
+    // within 150ms of the last frame and returns immediately when idle.
+    common::drain_pending(&mut ws).await;
 
     let canonical = common::dummy_ciphertext("pin_canonical");
     let bob_ct = common::dummy_ciphertext("pin_bob");

--- a/apps/server/tests/api_messages_extra.rs
+++ b/apps/server/tests/api_messages_extra.rs
@@ -61,8 +61,6 @@ async fn setup_dm_with_message(
         .await
         .expect("WS connect failed");
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
     // Drain initial events
     while let Ok(Some(Ok(_))) = tokio::time::timeout(Duration::from_millis(100), ws.next()).await {}
 
@@ -209,7 +207,6 @@ async fn edit_message_on_unencrypted_group_succeeds() {
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("{ws_url}/ws?ticket={ticket}"))
         .await
         .expect("WS connect failed");
-    tokio::time::sleep(Duration::from_millis(200)).await;
     while let Ok(Some(Ok(_))) = tokio::time::timeout(Duration::from_millis(100), ws.next()).await {}
 
     ws.send(Message::Text(

--- a/apps/server/tests/api_messages_extra.rs
+++ b/apps/server/tests/api_messages_extra.rs
@@ -576,12 +576,12 @@ async fn create_dm_idempotent() {
     );
 }
 
-/// Concurrent DM creation must not produce duplicate conversations.
+/// Concurrent DM creation must not produce duplicate conversations (#525).
 ///
-/// Before the fix, two simultaneous POST /api/conversations/dm requests for the
-/// same user pair could both pass the "not found" check and each insert a new
-/// conversation, violating the one-DM-per-pair invariant.  After the fix, both
-/// requests must return the same conversation_id.
+/// Five simultaneous POST /api/conversations/dm requests for the same user pair
+/// are fired with no prior DM existing.  The `pg_advisory_xact_lock` added to
+/// `find_or_create_dm_conversation` serializes slow-path creators at the DB
+/// level, so all five must return the identical conversation_id.
 #[tokio::test]
 async fn create_dm_concurrent_no_duplicate() {
     let base = common::spawn_server().await;
@@ -610,34 +610,53 @@ async fn create_dm_concurrent_no_duplicate() {
         .await
         .unwrap();
 
-    // Fire two concurrent DM-create requests from Alice toward Bob.
-    let (r1, r2) = tokio::join!(
-        client
-            .post(format!("{base}/api/conversations/dm"))
-            .header("Authorization", format!("Bearer {alice_token}"))
-            .json(&serde_json::json!({ "peer_user_id": bob_id }))
-            .send(),
-        client
-            .post(format!("{base}/api/conversations/dm"))
-            .header("Authorization", format!("Bearer {alice_token}"))
-            .json(&serde_json::json!({ "peer_user_id": bob_id }))
-            .send(),
-    );
+    // Fire 5 concurrent DM-create requests; all must return the same id.
+    const CONCURRENCY: usize = 5;
+    let mut handles = Vec::with_capacity(CONCURRENCY);
+    for _ in 0..CONCURRENCY {
+        let c = client.clone();
+        let b = base.clone();
+        let tok = alice_token.clone();
+        let peer = bob_id.clone();
+        handles.push(tokio::spawn(async move {
+            let resp = c
+                .post(format!("{b}/api/conversations/dm"))
+                .header("Authorization", format!("Bearer {tok}"))
+                .json(&serde_json::json!({ "peer_user_id": peer }))
+                .send()
+                .await
+                .expect("request failed");
+            let status = resp.status().as_u16();
+            let body: Value = resp.json().await.unwrap_or(Value::Null);
+            (status, body)
+        }));
+    }
 
-    let r1 = r1.unwrap();
-    let r2 = r2.unwrap();
-    assert_eq!(r1.status().as_u16(), 200);
-    assert_eq!(r2.status().as_u16(), 200);
+    let results: Vec<_> = futures_util::future::join_all(handles)
+        .await
+        .into_iter()
+        .map(|r| r.expect("task panicked"))
+        .collect();
 
-    let b1: Value = r1.json().await.unwrap();
-    let b2: Value = r2.json().await.unwrap();
-    let id1 = b1["conversation_id"].as_str().unwrap();
-    let id2 = b2["conversation_id"].as_str().unwrap();
+    let conv_ids: Vec<String> = results
+        .iter()
+        .enumerate()
+        .map(|(i, (status, body))| {
+            assert_eq!(*status, 200, "request {i} returned {status}: {body}");
+            body["conversation_id"]
+                .as_str()
+                .unwrap_or_else(|| panic!("request {i} missing conversation_id: {body}"))
+                .to_string()
+        })
+        .collect();
 
-    assert_eq!(
-        id1, id2,
-        "Concurrent DM creation must return the same conversation_id, got {id1} and {id2}"
-    );
+    let first = &conv_ids[0];
+    for (i, id) in conv_ids.iter().enumerate() {
+        assert_eq!(
+            id, first,
+            "request {i} returned {id} but request 0 returned {first} -- duplicate DM created"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_messages_reply_scope.rs
+++ b/apps/server/tests/api_messages_reply_scope.rs
@@ -150,7 +150,6 @@ async fn reply_to_message_in_other_conversation_is_rejected() {
 
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
-    tokio::time::sleep(Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // Alice posts a message in conv_ab.
@@ -218,7 +217,6 @@ async fn thread_replies_does_not_return_cross_conversation_replies() {
     let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
-    tokio::time::sleep(Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
 

--- a/apps/server/tests/api_rate_limit_proxy.rs
+++ b/apps/server/tests/api_rate_limit_proxy.rs
@@ -94,6 +94,58 @@ async fn rate_limit_honours_x_real_ip_from_trusted_proxy() {
 }
 
 // ---------------------------------------------------------------------------
+// Trusted vs untrusted: single combined assertion (#524)
+// ---------------------------------------------------------------------------
+
+/// X-Real-IP is honoured when the peer is in trusted_proxies and ignored when
+/// it is not.  Two servers are started so the two behaviours are tested in the
+/// same function against the same endpoint (login).
+#[tokio::test]
+async fn x_real_ip_trusted_proxy_honoured_untrusted_ignored() {
+    let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+
+    // Server A: loopback is a trusted proxy -- X-Real-IP should be the key.
+    let base_trusted = common::spawn_server_with_trusted_proxies(vec![loopback]).await;
+    // Server B: no trusted proxies -- X-Real-IP must be ignored.
+    let base_untrusted = common::spawn_server().await;
+
+    let client = Client::new();
+
+    // --- trusted path: exhaust the bucket for X-Real-IP 10.1.1.1 ---
+    for _ in 0..5 {
+        let s = try_login(&client, &base_trusted, "x-real-ip", "10.1.1.1").await;
+        assert_ne!(s, 429, "trusted: bucket not full yet");
+    }
+    let s = try_login(&client, &base_trusted, "x-real-ip", "10.1.1.1").await;
+    assert_eq!(
+        s, 429,
+        "trusted: 6th attempt for 10.1.1.1 must be rate-limited"
+    );
+
+    // A fresh X-Real-IP on the trusted server should still be allowed.
+    let s = try_login(&client, &base_trusted, "x-real-ip", "10.2.2.2").await;
+    assert_ne!(
+        s, 429,
+        "trusted: different X-Real-IP must have its own bucket"
+    );
+
+    // --- untrusted path: exhaust the bucket using the peer IP (127.0.0.1) ---
+    // The X-Real-IP header is sent but must not influence the key.
+    for _ in 0..5 {
+        let s = try_login(&client, &base_untrusted, "x-real-ip", "10.3.3.3").await;
+        assert_ne!(s, 429, "untrusted: bucket not full yet");
+    }
+    // Sixth attempt from the same peer (127.0.0.1) must be rate-limited even
+    // though it carries a different X-Real-IP header.
+    let s = try_login(&client, &base_untrusted, "x-real-ip", "10.4.4.4").await;
+    assert_eq!(
+        s, 429,
+        "untrusted: 6th request from 127.0.0.1 must be rate-limited \
+         regardless of X-Real-IP header value"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // With trusted proxy: X-Forwarded-For is honoured as fallback
 // ---------------------------------------------------------------------------
 

--- a/apps/server/tests/api_reactions.rs
+++ b/apps/server/tests/api_reactions.rs
@@ -60,8 +60,6 @@ async fn setup_dm_with_message(base: &str) -> (Client, String, String, String, S
         .await
         .expect("WS connect failed");
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
     // Drain initial presence/contact events so they don't interfere with the
     // message_sent assertion below. The 100ms timeout means we stop draining
     // once there are no more pending messages.

--- a/apps/server/tests/api_voice.rs
+++ b/apps/server/tests/api_voice.rs
@@ -165,9 +165,14 @@ async fn voice_token_without_conversation_id_rejected() {
     );
 }
 
-/// Voice token with empty room is rejected.
+/// Voice token with empty body is rejected (no room can be derived).
+///
+/// After CRIT-1 the `room` field was removed from the request: rooms are
+/// always derived from a verified-membership conversation_id/channel_id, so
+/// the canonical "missing room" failure now surfaces as the missing
+/// conversation_id error.
 #[tokio::test]
-async fn voice_token_empty_room_rejected() {
+async fn voice_token_empty_body_rejected() {
     let base = common::spawn_server().await;
     let client = Client::new();
 
@@ -189,6 +194,39 @@ async fn voice_token_empty_room_rejected() {
         body["error"]
             .as_str()
             .unwrap_or("")
-            .contains("Room name is required")
+            .contains("conversation_id or channel_id is required"),
+        "expected conversation-id error, got: {}",
+        body
+    );
+}
+
+/// CRIT-1 regression test: the `room` field on the request is silently
+/// dropped now -- the LiveKit grant must always be derived from the
+/// validated conversation_id, never an attacker-supplied value.  We assert
+/// the request reaches the LIVEKIT-config error (i.e. validation passed)
+/// even though we tried to set a different `room` than `conversation_id`.
+#[tokio::test]
+async fn voice_token_ignores_attacker_supplied_room() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _, conv_id) = setup_voice_test(&client, &base).await;
+
+    let resp = client
+        .post(format!("{base}/api/voice/token"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({
+            // An attacker tries to steer the room claim to a victim conv id.
+            "room": "00000000-0000-0000-0000-000000000000",
+            "conversation_id": conv_id,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let body: Value = resp.json().await.unwrap();
+    let error = body["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("Voice chat is not configured"),
+        "expected LIVEKIT config error (validation passed), got: {error}"
     );
 }

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -198,6 +198,62 @@ pub fn unique_username(prefix: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// WebSocket helpers (audit #695)
+// ---------------------------------------------------------------------------
+//
+// 32 integration tests sat on a `tokio::time::sleep(200ms); drain_pending()`
+// pattern to wait for chatter to arrive before reading a specific frame.
+// Under CI load (cargo running 250+ tests in parallel) the 200ms became
+// brittle and tests flaked intermittently. These helpers replace the
+// wall-clock waits with predicate-based reads bounded by an explicit
+// timeout, mirroring the pattern that already worked in
+// `api_messages_reply_scope.rs::wait_for_event`.
+
+/// WebSocket stream type used by the integration suite.
+pub type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// Read frames until one whose `type` field is in `wanted` arrives, or fail
+/// after `Duration::from_secs(5)`.  Skips presence/typing/echo chatter the
+/// caller didn't ask about.
+///
+/// Use this in place of `tokio::time::sleep(200ms); drain_pending()` when
+/// you know the next interesting frame's type.
+pub async fn recv_until_event(ws: &mut WsStream, wanted: &[&str]) -> serde_json::Value {
+    use futures_util::StreamExt;
+    use std::time::Duration;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let next = tokio::time::timeout_at(deadline, ws.next())
+            .await
+            .expect("timed out waiting for event");
+        let frame = next.expect("WS stream closed").expect("WS error");
+        if let tokio_tungstenite::tungstenite::Message::Text(text) = frame
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&text)
+            && let Some(t) = v["type"].as_str()
+            && wanted.contains(&t)
+        {
+            return v;
+        }
+    }
+}
+
+/// Read every immediately-available frame and discard.  Returns once 150ms
+/// pass without a new frame.  Use after a write to swallow chatter when no
+/// specific reply is expected.
+///
+/// Prefer `recv_until_event` when you know the expected event type --
+/// `drain_pending` accepts the lossy "best effort" model that the audit
+/// flagged as flaky, but kept here as an escape hatch for tests where the
+/// next interesting frame depends on inputs the test deliberately doesn't
+/// know.
+pub async fn drain_pending(ws: &mut WsStream) {
+    use futures_util::StreamExt;
+    use std::time::Duration;
+    while let Ok(Some(Ok(_))) = tokio::time::timeout(Duration::from_millis(150), ws.next()).await {}
+}
+
+// ---------------------------------------------------------------------------
 // Convenience helpers
 // ---------------------------------------------------------------------------
 

--- a/apps/server/tests/db_cascade.rs
+++ b/apps/server/tests/db_cascade.rs
@@ -1,0 +1,101 @@
+//! Audit #698: assert ON DELETE CASCADE behaviour on every child of
+//! `conversations` at the database level.
+//!
+//! Migration 20260412000000 added CASCADE to a subset of FKs that were
+//! missing it; the rest were declared with CASCADE in their original
+//! creation migrations (group_keys, group_key_envelopes, channels,
+//! direct_conversations, pinned_conversations, banned_members). Without a
+//! test asserting end-to-end CASCADE behaviour, a future migration could
+//! revert one of these silently and the resulting orphan rows would only
+//! surface as confusing app-level bugs months later.
+//!
+//! This test does not exercise per-test isolation (audit #699 still open);
+//! it relies on the suite's shared test database and uses a unique group
+//! per assertion so concurrent test runs don't interfere.
+
+mod common;
+
+use sqlx::Row;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn delete_conversation_cascades_to_children() {
+    let base = common::spawn_server().await;
+    let client = reqwest::Client::new();
+
+    // Create owner + member, group, and seed every child table that should
+    // cascade-delete with the parent conversation.
+    let (owner_token, _owner_id, owner_username) =
+        common::register_and_login(&client, &base, "casc_owner").await;
+    let (_member_token, member_id, _member_username) =
+        common::register_and_login(&client, &base, "casc_member").await;
+    let _ = owner_username; // captured for parity with similar helpers
+
+    let group_id = common::create_group(&client, &base, &owner_token, "cascade-test").await;
+    let group_uuid = Uuid::parse_str(&group_id).expect("group id is a UUID");
+    common::add_member_to_group(&client, &base, &owner_token, &group_id, &member_id).await;
+
+    // Open a direct DB pool for the assertion phase.  The integration server
+    // already migrated the database, so we just observe.
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("TEST_DATABASE_URL or DATABASE_URL must be set for integration tests");
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("connect to test db");
+
+    // Tables that should be empty for the group_uuid after cascade.
+    // group_keys + group_key_envelopes only get rows when keys are uploaded;
+    // they're included so future migrations can't silently drop CASCADE.
+    let tables = [
+        "conversation_members",
+        "channels",
+        "messages",
+        "read_receipts",
+        "group_keys",
+        "group_key_envelopes",
+        "banned_members",
+        "media",
+        "direct_conversations",
+        "pinned_conversations",
+    ];
+
+    // Sanity-check that conversation_members at least is non-empty before
+    // delete -- otherwise we'd be asserting on a vacuous truth.
+    let pre: i64 =
+        sqlx::query("SELECT COUNT(*) FROM conversation_members WHERE conversation_id = $1")
+            .bind(group_uuid)
+            .fetch_one(&pool)
+            .await
+            .expect("pre-delete conversation_members count")
+            .get(0);
+    assert!(
+        pre >= 1,
+        "expected at least one conversation_members row before delete (got {pre})"
+    );
+
+    // Delete the conversation directly to test the FK cascades end-to-end.
+    sqlx::query("DELETE FROM conversations WHERE id = $1")
+        .bind(group_uuid)
+        .execute(&pool)
+        .await
+        .expect("DELETE FROM conversations failed -- check FK cascades");
+
+    for table in tables {
+        let sql = format!("SELECT COUNT(*) FROM {table} WHERE conversation_id = $1");
+        let count: i64 = sqlx::query(&sql)
+            .bind(group_uuid)
+            .fetch_one(&pool)
+            .await
+            .unwrap_or_else(|e| panic!("count query for {table} failed: {e}"))
+            .get(0);
+        assert_eq!(
+            count, 0,
+            "{table} should cascade-delete when its parent conversation is removed (had {count} orphans)"
+        );
+    }
+
+    pool.close().await;
+}

--- a/apps/server/tests/migrations.rs
+++ b/apps/server/tests/migrations.rs
@@ -1,0 +1,103 @@
+//! Audit #699 (partial): exercise the full migration sequence against a
+//! freshly created schema, asserting each migration succeeds.
+//!
+//! The rest of the integration suite shares a single long-lived database
+//! (with `OnceCell<MIGRATIONS>` ensuring a one-shot apply per process), so
+//! a migration that breaks on an empty schema is invisible until a fresh
+//! production deploy. This test isolates that path.
+//!
+//! Approach: create a unique temporary schema in the existing test database
+//! (no CREATE DATABASE permission needed), set `search_path` so all tables
+//! land inside it, run `sqlx::migrate!` against a pool pinned to that
+//! schema, then drop the schema on teardown.
+//!
+//! NOTE: this exercises only schema-creation idempotency. The harder gap --
+//! per-test row-state isolation across the rest of the suite -- is still
+//! open and tracked separately in #699.
+
+use sqlx::Connection;
+use sqlx::Executor;
+use sqlx::postgres::PgConnection;
+use uuid::Uuid;
+
+/// Build a connection string with the same parameters as `TEST_DATABASE_URL`
+/// but `?options=-csearch_path%3D<schema>` appended so all queries scope
+/// to the fresh schema.
+fn url_with_search_path(base: &str, schema: &str) -> String {
+    let separator = if base.contains('?') { '&' } else { '?' };
+    // %3D is "=", %2C is ","; sqlx forwards the options to libpq verbatim.
+    format!("{base}{separator}options=-csearch_path%3D{schema}")
+}
+
+#[tokio::test]
+async fn migrations_apply_cleanly_to_empty_schema() {
+    let database_url =
+        match std::env::var("TEST_DATABASE_URL").or_else(|_| std::env::var("DATABASE_URL")) {
+            Ok(url) => url,
+            Err(_) => {
+                eprintln!(
+                    "skipping: TEST_DATABASE_URL or DATABASE_URL must be set for integration tests"
+                );
+                return;
+            }
+        };
+
+    let schema = format!("test_migrations_{}", Uuid::new_v4().simple());
+
+    // Open a single admin connection on the default search path to create +
+    // (later) drop the test schema.  Held for the duration of the test so
+    // the schema can be dropped even if the migration step panics.
+    let mut admin = PgConnection::connect(&database_url)
+        .await
+        .expect("connect for schema setup");
+    admin
+        .execute(format!(r#"CREATE SCHEMA "{schema}""#).as_str())
+        .await
+        .expect("CREATE SCHEMA failed");
+
+    // Run the migration in a separate scope so we can drop the schema
+    // unconditionally afterwards. `catch_unwind` would be safer in a real
+    // suite, but for a single-test smoke check we accept the leak risk on
+    // panic and drop the schema in the success path.
+    let result = std::panic::AssertUnwindSafe(run_migrations_into_schema(&database_url, &schema));
+    use futures_util::FutureExt;
+    let migration_outcome = result.catch_unwind().await;
+
+    // Always drop the schema, regardless of success.
+    let drop_sql = format!(r#"DROP SCHEMA IF EXISTS "{schema}" CASCADE"#);
+    if let Err(e) = admin.execute(drop_sql.as_str()).await {
+        eprintln!("warning: failed to drop test schema {schema}: {e}");
+    }
+
+    // Now surface migration failures.
+    match migration_outcome {
+        Ok(Ok(applied)) => {
+            assert!(
+                applied >= 1,
+                "expected at least 1 migration to apply against empty schema"
+            );
+        }
+        Ok(Err(e)) => panic!("migrations failed against empty schema: {e}"),
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+async fn run_migrations_into_schema(base_url: &str, schema: &str) -> Result<usize, sqlx::Error> {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&url_with_search_path(base_url, schema))
+        .await?;
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .map_err(|e| sqlx::Error::Migrate(Box::new(e)))?;
+
+    // Count applied migrations from sqlx's tracking table inside the schema.
+    let (count,): (i64,) = sqlx::query_as(r#"SELECT COUNT(*) FROM _sqlx_migrations"#)
+        .fetch_one(&pool)
+        .await?;
+
+    pool.close().await;
+    Ok(count as usize)
+}

--- a/apps/server/tests/ws_events.rs
+++ b/apps/server/tests/ws_events.rs
@@ -32,7 +32,10 @@ async fn drain_pending(ws: &mut WsStream) {
     {}
 }
 
-/// Read text frames, skipping presence events, until a non-presence frame arrives.
+/// Read text frames, skipping `presence` and `new_message` events.
+/// `new_message` arrives asynchronously when the server replays undelivered
+/// messages on WS connect; tests that exercise reactions/deletes/edits don't
+/// care about it and would otherwise race with `drain_pending`.
 async fn read_text_skipping_noise(ws: &mut WsStream) -> String {
     let timeout = std::time::Duration::from_secs(5);
     loop {
@@ -40,7 +43,7 @@ async fn read_text_skipping_noise(ws: &mut WsStream) -> String {
             Ok(Some(Ok(Message::Text(text)))) => {
                 let s = text.to_string();
                 if let Ok(v) = serde_json::from_str::<Value>(&s)
-                    && v["type"] == "presence"
+                    && matches!(v["type"].as_str(), Some("presence") | Some("new_message"))
                 {
                     continue;
                 }

--- a/apps/server/tests/ws_events.rs
+++ b/apps/server/tests/ws_events.rs
@@ -75,7 +75,6 @@ async fn setup_dm_with_message(
     let alice_ticket = common::get_ws_ticket(&client, base, &alice_token).await;
     let mut alice_ws = connect_ws(base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // DMs are auto-encrypted, so the ciphertext-shape gate (#591) requires
@@ -135,7 +134,6 @@ async fn add_reaction_broadcasts_ws_event_to_peer() {
     // Bob connects via WS to receive the reaction broadcast.
     let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut bob_ws).await;
 
     // Alice adds a reaction via REST.
@@ -181,7 +179,6 @@ async fn remove_reaction_broadcasts_ws_event_to_peer() {
     // Bob connects.
     let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut bob_ws).await;
 
     // Alice removes the reaction.
@@ -219,7 +216,6 @@ async fn delete_message_broadcasts_ws_event_to_peer() {
     // Bob connects to receive the broadcast.
     let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut bob_ws).await;
 
     // Alice deletes the message via REST.
@@ -257,7 +253,6 @@ async fn edit_message_on_encrypted_dm_rejected_no_broadcast() {
     // Bob connects.
     let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut bob_ws).await;
 
     // Alice attempts to edit on an encrypted DM — rejected with 409.
@@ -316,7 +311,6 @@ async fn connecting_broadcasts_online_presence_to_peer() {
     // Alice connects first.
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // Bob connects — Alice should receive a presence event for Bob.

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -27,7 +27,6 @@ async fn alice_sends_bob_receives() {
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
 
@@ -97,7 +96,6 @@ async fn typing_indicator_broadcast() {
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
 
@@ -144,7 +142,6 @@ async fn read_receipt_broadcast() {
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
 
@@ -166,7 +163,6 @@ async fn read_receipt_broadcast() {
         .expect("Alice send failed");
 
     // Drain the message_sent and new_message events
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
 
@@ -217,7 +213,6 @@ async fn key_reset_broadcast() {
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
 
@@ -270,7 +265,6 @@ async fn group_message_fanout() {
     let mut bob_ws = connect_ws(&base, &bob_ticket).await;
     let mut charlie_ws = connect_ws(&base, &charlie_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_ws).await;
     drain_pending(&mut charlie_ws).await;
@@ -325,7 +319,6 @@ async fn invalid_json_returns_error() {
 
     let mut ws = connect_ws(&base, &ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut ws).await;
 
     // Send invalid JSON
@@ -353,7 +346,6 @@ async fn message_to_noncontact_returns_error() {
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // Alice tries to message Eve (not a contact)
@@ -407,7 +399,6 @@ async fn offline_delivery_marks_unknown_device_undecryptable() {
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // Bob has device_id=42 in this simulation; the test WS path uses device_id=0
@@ -490,7 +481,6 @@ async fn device_content_db_roundtrip() {
     // Alice sends a message that stores a device-specific ciphertext.
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // Both alice and bob use device_id=1 — this is the exact collision case
@@ -586,7 +576,6 @@ async fn test_dm_fanout_delivers_to_all_recipient_devices() {
     let mut bob_d1_ws = connect_ws(&base, &bob_d1_ticket).await;
     let mut bob_d2_ws = connect_ws(&base, &bob_d2_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_d1_ws).await;
     drain_pending(&mut bob_d2_ws).await;
@@ -685,7 +674,6 @@ async fn test_group_fanout_delivers_to_all_devices_of_all_members() {
     let mut charlie_d1_ws = connect_ws(&base, &charlie_d1_ticket).await;
     let mut charlie_d2_ws = connect_ws(&base, &charlie_d2_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
     drain_pending(&mut bob_d1_ws).await;
     drain_pending(&mut bob_d2_ws).await;
@@ -806,7 +794,6 @@ async fn encrypted_dm_rejects_plaintext_send() {
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     let send_msg = serde_json::json!({
@@ -855,7 +842,6 @@ async fn encrypted_dm_rejects_nonciphertext_device_payload() {
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // The per-device value is plain ASCII (no 0xEC magic, not normal-msg shape).
@@ -903,7 +889,6 @@ async fn encrypted_dm_rejects_plaintext_canonical_content_with_valid_per_device(
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     // Per-device value is valid ciphertext (passes the per-device check)
@@ -962,7 +947,6 @@ async fn encrypted_group_rejects_plaintext_send() {
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     let send_msg = serde_json::json!({
@@ -1012,7 +996,6 @@ async fn encrypted_group_accepts_ciphertext_shaped_content() {
     let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
     let mut alice_ws = connect_ws(&base, &alice_ticket).await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     drain_pending(&mut alice_ws).await;
 
     let ct = common::dummy_ciphertext("encgrp_ok");

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -110,7 +110,7 @@ async fn typing_indicator_broadcast() {
         .expect("Alice typing send failed");
 
     // Bob should receive typing event
-    let bob_event = read_text_with_timeout(&mut bob_ws).await;
+    let bob_event = read_text_skipping_chatter(&mut bob_ws).await;
     let event: Value = serde_json::from_str(&bob_event).expect("Bob typing JSON parse failed");
     assert_eq!(event["type"], "typing", "Bob should get typing event");
     assert_eq!(event["conversation_id"], conv_id);
@@ -177,7 +177,7 @@ async fn read_receipt_broadcast() {
         .expect("Bob read_receipt send failed");
 
     // Alice should receive read_receipt
-    let alice_event = read_text_with_timeout(&mut alice_ws).await;
+    let alice_event = read_text_skipping_chatter(&mut alice_ws).await;
     let event: Value =
         serde_json::from_str(&alice_event).expect("Alice read_receipt JSON parse failed");
     assert_eq!(
@@ -227,7 +227,7 @@ async fn key_reset_broadcast() {
         .expect("Alice key_reset send failed");
 
     // Bob should receive key_reset
-    let bob_event = read_text_with_timeout(&mut bob_ws).await;
+    let bob_event = read_text_skipping_chatter(&mut bob_ws).await;
     let event: Value = serde_json::from_str(&bob_event).expect("Bob key_reset JSON parse failed");
     assert_eq!(event["type"], "key_reset", "Bob should get key_reset");
     assert_eq!(event["conversation_id"], conv_id);
@@ -1061,10 +1061,8 @@ async fn drain_pending(ws: &mut WsStream) {
     {}
 }
 
-/// Read frames from the socket, skipping any `presence` events, until a
-/// non-presence text frame arrives. Presence events can race in late under
-/// slower runtimes (tarpaulin coverage instrumentation, CI pressure) and
-/// should not cause flakes in tests that assert other event types.
+/// Read frames, skipping `presence` events. Use when the test expects a
+/// non-presence non-new_message frame.
 async fn read_text_skipping_presence(ws: &mut WsStream) -> String {
     loop {
         let text = read_text_with_timeout(ws).await;
@@ -1073,6 +1071,27 @@ async fn read_text_skipping_presence(ws: &mut WsStream) -> String {
             Err(_) => return text,
         };
         if parsed["type"] == "presence" {
+            continue;
+        }
+        return text;
+    }
+}
+
+/// Read frames, skipping `presence`, `new_message`, and `message_sent`.
+/// Use when the test exercises a downstream event (typing, read_receipt,
+/// key_reset) and the message-fanout chatter would race in late under
+/// tarpaulin/CI pressure.
+async fn read_text_skipping_chatter(ws: &mut WsStream) -> String {
+    loop {
+        let text = read_text_with_timeout(ws).await;
+        let parsed: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(v) => v,
+            Err(_) => return text,
+        };
+        if matches!(
+            parsed["type"].as_str(),
+            Some("presence") | Some("new_message") | Some("message_sent")
+        ) {
             continue;
         }
         return text;

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,23 @@ comment:
   layout: "reach,diff,flags,components"
   behavior: default
 
+component_management:
+  individual_components:
+    - component_id: ratchet
+      name: Ratchet/Signal Protocol
+      paths:
+        - apps/client/lib/src/services/signal_*.dart
+        - apps/client/lib/src/services/crypto_*.dart
+      status:
+        project:
+          target: 60%
+          threshold: 5%
+          informational: true
+        patch:
+          target: 70%
+          threshold: 5%
+          informational: true
+
 flags:
   flutter:
     paths:

--- a/core/rust-core/src/signal/mod.rs
+++ b/core/rust-core/src/signal/mod.rs
@@ -1,12 +1,14 @@
 //! Signal Protocol implementation: X3DH key agreement + Double Ratchet.
 //!
 //! This module provides end-to-end encryption using the Signal Protocol:
+//! - **protocol**: wire-format constants shared with the Rust server (#700)
 //! - **keys**: Key types and generation (identity, signed prekeys, ephemeral)
 //! - **x3dh**: Extended Triple Diffie-Hellman for session establishment
 //! - **ratchet**: Double Ratchet for per-message forward secrecy
 //! - **session**: High-level session management API
 
 pub mod keys;
+pub mod protocol;
 pub mod ratchet;
 pub mod session;
 pub mod x3dh;

--- a/core/rust-core/src/signal/protocol.rs
+++ b/core/rust-core/src/signal/protocol.rs
@@ -1,31 +1,13 @@
-//! Wire-format constants shared by the Rust server, the Rust core, and the
-//! Dart client.
+//! Wire-format constants shared by the Rust server and core. Dart parity
+//! lives in `apps/client/lib/src/services/signal_protocol.dart` and is
+//! enforced by hand until codegen lands.
 //!
-//! Audit #700 (H34): before this module, these constants were re-typed in
-//! at least three places (Rust server, Rust core, Dart client). One typo
-//! silently breaks decryption with no compile-time check. CLAUDE.md
-//! documented the wire format in prose but no schema lived in version
-//! control.
-//!
-//! Phase 1 (this PR): Rust server + Rust core re-export from a single
-//! definition here. Dart parity is Phase 2 — it requires either codegen
-//! from a manifest or a CI test that round-trips a Rust-encrypted
-//! ciphertext through Dart and vice versa with a fixed seed.
-//!
-//! ## Wire format reference
-//!
-//! Every encrypted message frame starts with a magic byte sequence so the
-//! server can distinguish protocol versions and reject malformed payloads
-//! at the edge:
-//!
+//! Wire layout:
 //! ```text
 //! Initial V1 (no OTP): [0xEC, 0x01] || identity_pub(32) || ephemeral_pub(32) || ratchet_wire
 //! Initial V2 (OTP):    [0xEC, 0x02] || identity_pub(32) || ephemeral_pub(32) || otp_id(4 LE) || ratchet_wire
 //! Normal:              header_len(4 LE) || header(40) || nonce(12) || ciphertext || tag(16)
 //! ```
-//!
-//! Where `ratchet_wire` is the canonical `MessageHeader` (see ratchet.rs)
-//! plus AEAD payload.
 
 // -----------------------------------------------------------------------
 // Magic bytes

--- a/core/rust-core/src/signal/protocol.rs
+++ b/core/rust-core/src/signal/protocol.rs
@@ -1,0 +1,91 @@
+//! Wire-format constants shared by the Rust server, the Rust core, and the
+//! Dart client.
+//!
+//! Audit #700 (H34): before this module, these constants were re-typed in
+//! at least three places (Rust server, Rust core, Dart client). One typo
+//! silently breaks decryption with no compile-time check. CLAUDE.md
+//! documented the wire format in prose but no schema lived in version
+//! control.
+//!
+//! Phase 1 (this PR): Rust server + Rust core re-export from a single
+//! definition here. Dart parity is Phase 2 — it requires either codegen
+//! from a manifest or a CI test that round-trips a Rust-encrypted
+//! ciphertext through Dart and vice versa with a fixed seed.
+//!
+//! ## Wire format reference
+//!
+//! Every encrypted message frame starts with a magic byte sequence so the
+//! server can distinguish protocol versions and reject malformed payloads
+//! at the edge:
+//!
+//! ```text
+//! Initial V1 (no OTP): [0xEC, 0x01] || identity_pub(32) || ephemeral_pub(32) || ratchet_wire
+//! Initial V2 (OTP):    [0xEC, 0x02] || identity_pub(32) || ephemeral_pub(32) || otp_id(4 LE) || ratchet_wire
+//! Normal:              header_len(4 LE) || header(40) || nonce(12) || ciphertext || tag(16)
+//! ```
+//!
+//! Where `ratchet_wire` is the canonical `MessageHeader` (see ratchet.rs)
+//! plus AEAD payload.
+
+// -----------------------------------------------------------------------
+// Magic bytes
+// -----------------------------------------------------------------------
+
+/// First byte of every encrypted Echo wire frame. Picked so it lands
+/// outside ASCII printable range to make accidental plaintext-vs-ciphertext
+/// confusion noisy when humans inspect frames.
+pub const WIRE_MAGIC: u8 = 0xEC;
+
+/// Second byte for an "initial" frame using the V1 X3DH flow (no
+/// one-time prekey consumed). Carries identity + ephemeral public keys.
+pub const WIRE_INITIAL_V1: u8 = 0x01;
+
+/// Second byte for an "initial" frame using the V2 X3DH flow (consumes
+/// a one-time prekey identified by the embedded `otp_id`).
+pub const WIRE_INITIAL_V2: u8 = 0x02;
+
+/// Length of the Double Ratchet `MessageHeader` serialised on the wire,
+/// per `MessageHeader::serialize`:
+///   - 32 bytes ratchet_public_key
+///   - 4 bytes prev_chain_length (LE u32)
+///   - 4 bytes message_number (LE u32)
+pub const NORMAL_HEADER_LEN: u32 = 40;
+
+// -----------------------------------------------------------------------
+// HKDF info strings
+// -----------------------------------------------------------------------
+
+/// HKDF info passed into the Double Ratchet KDF for chain-key + message-key
+/// derivation. The byte sequence is part of the protocol contract: changing
+/// it on either side breaks decryption silently.
+pub const RATCHET_KDF_INFO: &[u8] = b"EchoDoubleRatchet";
+
+/// HKDF info for the X3DH shared-secret derivation. Same contract: any
+/// rename or byte-level change breaks new sessions.
+pub const X3DH_HKDF_INFO: &[u8] = b"EchoSignalX3DH";
+
+// -----------------------------------------------------------------------
+// Skip-key bounds (audit CRIT-4)
+// -----------------------------------------------------------------------
+
+/// Maximum number of message keys that can be skipped in a single
+/// `skip_message_keys` call. Without this an attacker that controls
+/// `message_number` can force unbounded key derivation.
+pub const MAX_SKIP: u32 = 1000;
+
+/// Global cap on `skipped_keys` map size across the lifetime of a session.
+/// Prevents an adversary that bumps the DH ratchet repeatedly (each step
+/// resets `recv_counter` to 0) from accumulating skipped keys without
+/// bound.
+pub const MAX_SKIPPED_KEYS: usize = 2000;
+
+// -----------------------------------------------------------------------
+// Compile-time invariants
+// -----------------------------------------------------------------------
+
+// The serializer in MessageHeader::serialize hard-codes a 40-byte layout;
+// this assertion guarantees future contributors who change either side
+// notice immediately.
+const _: () = {
+    assert!(NORMAL_HEADER_LEN == 40);
+};

--- a/core/rust-core/src/signal/ratchet.rs
+++ b/core/rust-core/src/signal/ratchet.rs
@@ -18,16 +18,13 @@ use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::error::CoreError;
 
-/// Maximum number of skipped message keys allowed in a single skip call,
-/// and the global cap on `skipped_keys` size across the lifetime of a session.
-/// Prevents memory exhaustion from a malicious peer sending huge message
-/// numbers or repeatedly bumping the ratchet key (which resets `recv_counter`)
-/// to accumulate skipped keys without bound.
-const MAX_SKIP: u32 = 1000;
-const MAX_SKIPPED_KEYS: usize = 2000;
+/// Re-exports of the protocol-level skip caps; defined once in `protocol.rs`
+/// so the Rust server can refer to the same MAX_SKIP / MAX_SKIPPED_KEYS
+/// (#700, audit CRIT-4 gate).
+use super::protocol::{MAX_SKIP, MAX_SKIPPED_KEYS, RATCHET_KDF_INFO};
 
-/// HKDF info strings for key derivation.
-const RATCHET_KDF_INFO: &[u8] = b"EchoDoubleRatchet";
+/// Local KDF context bytes -- not protocol-shared because they're internal
+/// to the message-key derivation scheme inside this file.
 const CHAIN_KEY_SEED: u8 = 0x02;
 const MESSAGE_KEY_SEED: u8 = 0x01;
 

--- a/core/rust-core/src/signal/ratchet.rs
+++ b/core/rust-core/src/signal/ratchet.rs
@@ -18,9 +18,13 @@ use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::error::CoreError;
 
-/// Maximum number of skipped message keys to store (prevents memory exhaustion
-/// from a malicious peer sending huge message numbers).
+/// Maximum number of skipped message keys allowed in a single skip call,
+/// and the global cap on `skipped_keys` size across the lifetime of a session.
+/// Prevents memory exhaustion from a malicious peer sending huge message
+/// numbers or repeatedly bumping the ratchet key (which resets `recv_counter`)
+/// to accumulate skipped keys without bound.
 const MAX_SKIP: u32 = 1000;
+const MAX_SKIPPED_KEYS: usize = 2000;
 
 /// HKDF info strings for key derivation.
 const RATCHET_KDF_INFO: &[u8] = b"EchoDoubleRatchet";
@@ -361,7 +365,9 @@ impl RatchetState {
     ///
     /// Stores the skipped keys so out-of-order messages can still be decrypted.
     fn skip_message_keys(&mut self, until: u32) -> Result<(), CoreError> {
-        if self.recv_counter + MAX_SKIP < until {
+        // saturating_add avoids debug-build overflow panics when `until` is
+        // close to u32::MAX (a malicious peer can pick the message_number).
+        if self.recv_counter.saturating_add(MAX_SKIP) < until {
             return Err(CoreError::Crypto(format!(
                 "Too many skipped messages (recv_counter={}, target={})",
                 self.recv_counter, until,
@@ -370,6 +376,14 @@ impl RatchetState {
 
         if let Some(ref mut chain_key) = self.receiving_chain_key {
             while self.recv_counter < until {
+                // Global cap across DH-ratchet steps: each step resets
+                // `recv_counter` to 0, so without this an adversary could
+                // accumulate skipped_keys across many steps unbounded.
+                if self.skipped_keys.len() >= MAX_SKIPPED_KEYS {
+                    return Err(CoreError::Crypto(format!(
+                        "Skipped-keys map full ({MAX_SKIPPED_KEYS}); refusing to grow"
+                    )));
+                }
                 let (new_ck, mk) = kdf_ck(chain_key)?;
                 let rk = self
                     .receiving_ratchet_key
@@ -720,5 +734,69 @@ mod tests {
         let (ct, hdr) = alice.encrypt(&big_msg).unwrap();
         let pt = bob.decrypt(&hdr, &ct).unwrap();
         assert_eq!(pt, big_msg);
+    }
+
+    #[test]
+    fn test_skip_limit_exceeded_rejects() {
+        // A malicious peer that puts an outsized message_number in the header
+        // must be rejected before the skip loop allocates `until` keys.
+        let (mut alice, mut bob) = setup_ratchet_pair();
+
+        // Push Bob's recv_counter forward by decrypting one in-order message.
+        let (ct0, hdr0) = alice.encrypt(b"first").unwrap();
+        bob.decrypt(&hdr0, &ct0).unwrap();
+
+        // Forge a header claiming we're far past the cap.
+        let bad_hdr = MessageHeader {
+            ratchet_public_key: hdr0.ratchet_public_key,
+            prev_chain_length: 0,
+            message_number: MAX_SKIP + 5,
+        };
+        // The ciphertext value doesn't matter -- skip_message_keys runs first.
+        let result = bob.decrypt(&bad_hdr, b"ignored");
+        assert!(
+            result.is_err(),
+            "headers exceeding MAX_SKIP must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_skip_with_max_msg_number_does_not_overflow() {
+        // Guards against debug-build overflow on `recv_counter + MAX_SKIP`.
+        let (mut alice, mut bob) = setup_ratchet_pair();
+        let (ct0, hdr0) = alice.encrypt(b"first").unwrap();
+        bob.decrypt(&hdr0, &ct0).unwrap();
+
+        let bad_hdr = MessageHeader {
+            ratchet_public_key: hdr0.ratchet_public_key,
+            prev_chain_length: 0,
+            message_number: u32::MAX,
+        };
+        // Must be a clean Err, not a panic.
+        let result = bob.decrypt(&bad_hdr, b"ignored");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_rejects_oversized_skipped_keys() {
+        // Hand-craft a serialized blob whose num_skipped exceeds MAX_SKIP and
+        // confirm deserialize() rejects it before allocating.
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&[0u8; 32]); // root_key
+        blob.extend_from_slice(&[0u8; 32]); // sending_chain_key
+        blob.push(0); // has_receiving_chain_key = false
+        blob.extend_from_slice(&[0u8; 32]); // sending_ratchet_private
+        blob.extend_from_slice(&[0u8; 32]); // sending_ratchet_public
+        blob.push(0); // has_receiving_ratchet_key = false
+        blob.extend_from_slice(&0u32.to_le_bytes()); // send_counter
+        blob.extend_from_slice(&0u32.to_le_bytes()); // recv_counter
+        blob.extend_from_slice(&0u32.to_le_bytes()); // prev_send_counter
+        blob.extend_from_slice(&(MAX_SKIP + 1).to_le_bytes()); // num_skipped
+
+        let result = RatchetState::deserialize(&blob);
+        assert!(
+            result.is_err(),
+            "oversized num_skipped must be rejected before allocation"
+        );
     }
 }

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,63 @@
+# Release process
+
+Echo's release workflow auto-increments the patch version when a tag matching
+`v*` is pushed to `main`. The release pipeline (`.github/workflows/release.yml`)
+then runs the security gate, builds artifacts for every platform (Linux
+AppImage, Windows .exe, macOS, Android, iOS, Web, Server, Docker images), and
+publishes a GitHub Release.
+
+## Tag ruleset (audit #594)
+
+The release pipeline's `version` job creates `v*` tags from `github-actions[bot]`
+during the auto-increment step. Without a ruleset restricting who can push
+those tags, any collaborator with write access can push a tag manually and
+trigger an unintended release of arbitrary content.
+
+The protection lives in GitHub's tag-ruleset UI, not in code. To configure:
+
+1. **Repo → Settings → Rules → Rulesets → New ruleset**.
+2. **Name**: `release-tags`.
+3. **Enforcement**: `Active`.
+4. **Target**: `Tags` → `Include by pattern` → `v*`.
+5. **Bypass list**: add `Repository admin` and the GitHub Actions app
+   (search for "Actions" — the bot ID for our auto-tag step). Verify by
+   checking `release.yml`: the `version` job uses `github.token` which the
+   actions bot wraps. With the actions app on the bypass list, the bot can
+   still push tags during the release flow.
+6. **Restrictions** (apply to everyone *not* on the bypass list):
+   - `Restrict creations` — on
+   - `Restrict updates` — on
+   - `Restrict deletions` — on
+   - `Block force pushes` — on (defense in depth, even though tags don't
+     normally accept force pushes)
+7. **Save**.
+
+After saving, attempt to push a `v*` tag from a non-admin account to verify
+the restriction takes effect. Successful release tags from
+`github-actions[bot]` should continue to work.
+
+## Operator runbook
+
+Routine release (no operator action needed):
+
+1. Merge a `dev` → `main` PR with the changes you want to ship.
+2. The release workflow's `version` job auto-bumps the patch version,
+   creates the tag, and triggers downstream artifact builds.
+
+Hotfix:
+
+1. Branch off `main` (not `dev`) for the fix.
+2. PR to `main` with the conventional-commit subject prefixed `fix:`.
+3. Merge — the auto-tagger handles the rest.
+
+Manual force release (rare; e.g. re-running a failed release after
+infra fix):
+
+1. Repo admin pushes the tag manually from the bypass-listed account.
+2. Document the reason in the GitHub Release notes.
+
+## Related
+
+- `.github/workflows/release.yml` — the pipeline this protects.
+- Audit issue: #594.
+- Security model: docs/SECURITY.md.

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
       - traefik
 
   postgres:
-    image: postgres:17
+    image: postgres:17.6
     restart: unless-stopped
     environment:
       POSTGRES_DB: echo_prod
@@ -100,7 +100,7 @@ services:
   #   SERVER_VERSION=v1.2.3 WEB_VERSION=v1.2.3 docker compose pull && docker compose up -d
 
   backup:
-    image: prodrigestivill/postgres-backup-local:17
+    image: prodrigestivill/postgres-backup-local:17.6
     restart: unless-stopped
     environment:
       POSTGRES_HOST: postgres

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -63,8 +63,18 @@ services:
   livekit:
     image: livekit/livekit-server:v1.10.1
     restart: unless-stopped
+    # Signaling (7880) is bound to localhost only -- public access must go
+    # through Traefik with TLS via the labels below.  Direct 0.0.0.0 binding
+    # bypassed TLS termination and let anyone hit the API-key surface.
+    # Media TURN/UDP ports remain public; deploy docs must require
+    # `ufw allow 7881/tcp,7882/udp,50000:50200/udp` on the host.
+    #
+    # DEPLOY NOTE: this requires a DNS A record for livekit.echo-messenger.us
+    # pointing at this host *and* the client's LiveKit URL configured to
+    # `wss://livekit.echo-messenger.us`.  Until both are in place, voice/video
+    # connectivity will fail.  Reverting to public 7880 must not be done.
     ports:
-      - "7880:7880"
+      - "127.0.0.1:7880:7880"
       - "7881:7881"
       - "7882:7882/udp"
       - "50000-50200:50000-50200/udp"
@@ -73,7 +83,14 @@ services:
     volumes:
       - ./livekit.yaml:/etc/livekit.yaml
     command: ["--config", "/etc/livekit.yaml"]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.echo-livekit.rule=Host(`livekit.echo-messenger.us`)"
+      - "traefik.http.routers.echo-livekit.tls=true"
+      - "traefik.http.routers.echo-livekit.tls.certresolver=cloudflare"
+      - "traefik.http.services.echo-livekit.loadbalancer.server.port=7880"
     networks:
+      - traefik
       - echo-internal
 
   # Watchtower removed: auto-pulling `latest` every 5 minutes risks deploying

--- a/infra/docker/docker-compose.test.yml
+++ b/infra/docker/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   postgres-test:
-    image: postgres:17
+    image: postgres:17.6
     environment:
       POSTGRES_DB: echo_test
       POSTGRES_USER: echo

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17
+    image: postgres:17.6
     environment:
       POSTGRES_DB: echo_dev
       POSTGRES_USER: echo

--- a/scripts/demo_two_apps.sh
+++ b/scripts/demo_two_apps.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 SERVER_URL="http://localhost:8080"
-WS_URL="ws://localhost:8080"
 APP_BINARY="apps/client/build/linux/x64/release/bundle/echo_app"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -38,7 +37,7 @@ sleep 1
 echo "[3/6] Starting server..."
 source "$HOME/.cargo/env" 2>/dev/null || true
 DATABASE_URL="postgres://echo:dev_password@localhost:5432/echo_dev" \
-JWT_SECRET="dev-secret" \
+JWT_SECRET="dev-jwt-secret-must-be-at-least-32-chars-long" \
 RUST_LOG="echo_server=info" \
 "$PROJECT_DIR/target/debug/echo-server" &
 SERVER_PID=$!

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -29,7 +29,7 @@ sleep 1
 
 source "$HOME/.cargo/env" 2>/dev/null || true
 export DATABASE_URL="postgres://echo:dev_password@localhost:5432/echo_dev"
-export JWT_SECRET="dev-secret"
+export JWT_SECRET="dev-jwt-secret-must-be-at-least-32-chars-long"
 export RUST_LOG="echo_server=info"
 mkdir -p uploads/avatars
 

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -126,14 +126,20 @@ echo "── WebSocket Messaging ──"
 
 source "$HOME/.cargo/env" 2>/dev/null || true
 
+# Obtain ws-tickets (30-sec single-use; client must use ?ticket= not ?token=)
+ALICE_TICKET=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+BOB_TICKET1=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $BOB_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+
 # Test: Send message while recipient is offline (offline delivery)
 echo '{"type":"send_message","to_user_id":"'"$BOB_ID"'","content":"Hello from alice (offline)"}' \
-  | timeout 3 websocat "ws://localhost:8080/ws?token=$ALICE_TOKEN" > /tmp/e2e_alice1.txt 2>&1 || true
+  | timeout 3 websocat "ws://localhost:8080/ws?ticket=$ALICE_TICKET" > /tmp/e2e_alice1.txt 2>&1 || true
 
 assert_contains "$(cat /tmp/e2e_alice1.txt)" "message_sent" "Alice sends message (bob offline), gets confirmation"
 
 # Bob connects and should receive the offline message
-timeout 3 websocat "ws://localhost:8080/ws?token=$BOB_TOKEN" > /tmp/e2e_bob1.txt 2>&1 || true
+timeout 3 websocat "ws://localhost:8080/ws?ticket=$BOB_TICKET1" > /tmp/e2e_bob1.txt 2>&1 || true
 assert_contains "$(cat /tmp/e2e_bob1.txt)" "Hello from alice" "Bob receives offline message on connect"
 assert_contains "$(cat /tmp/e2e_bob1.txt)" "new_message" "Bob receives correct message type"
 
@@ -142,14 +148,20 @@ assert_contains "$(cat /tmp/e2e_bob1.txt)" "new_message" "Bob receives correct m
 rm -f /tmp/e2e_bob_fifo
 mkfifo /tmp/e2e_bob_fifo
 
+# Fresh tickets for each new connection (single-use)
+ALICE_TICKET2=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+BOB_TICKET2=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $BOB_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
+
 # Bob connects via named pipe (stays open)
-cat /tmp/e2e_bob_fifo | timeout 8 websocat "ws://localhost:8080/ws?token=$BOB_TOKEN" > /tmp/e2e_bob2.txt 2>&1 &
+cat /tmp/e2e_bob_fifo | timeout 8 websocat "ws://localhost:8080/ws?ticket=$BOB_TICKET2" > /tmp/e2e_bob2.txt 2>&1 &
 BOB_WS=$!
 sleep 2
 
 # Alice sends while Bob is online
 echo '{"type":"send_message","to_user_id":"'"$BOB_ID"'","content":"Real-time hello!"}' \
-  | timeout 3 websocat "ws://localhost:8080/ws?token=$ALICE_TOKEN" > /tmp/e2e_alice2.txt 2>&1 || true
+  | timeout 3 websocat "ws://localhost:8080/ws?ticket=$ALICE_TICKET2" > /tmp/e2e_alice2.txt 2>&1 || true
 sleep 2
 
 # Close Bob's input to let him finish
@@ -161,8 +173,10 @@ assert_contains "$(cat /tmp/e2e_alice2.txt)" "message_sent" "Alice gets confirma
 assert_contains "$(cat /tmp/e2e_bob2.txt)" "Real-time hello" "Bob receives real-time message"
 
 # Test: Non-contact messaging should fail
+ALICE_TICKET3=$(curl -s "$SERVER_URL/api/auth/ws-ticket" -X POST \
+  -H "Authorization: Bearer $ALICE_TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)['ticket'])")
 echo '{"type":"send_message","to_user_id":"00000000-0000-0000-0000-000000000000","content":"should fail"}' \
-  | timeout 3 websocat "ws://localhost:8080/ws?token=$ALICE_TOKEN" > /tmp/e2e_alice3.txt 2>&1 || true
+  | timeout 3 websocat "ws://localhost:8080/ws?ticket=$ALICE_TICKET3" > /tmp/e2e_alice3.txt 2>&1 || true
 assert_contains "$(cat /tmp/e2e_alice3.txt)" "error" "Non-contact message rejected"
 
 # ─── REST Message History ───

--- a/tests/e2e/crypto_dm_test.spec.ts
+++ b/tests/e2e/crypto_dm_test.spec.ts
@@ -252,38 +252,38 @@ test.describe('Encrypted DM Tests', () => {
       await ss(alicePage, '02_alice_sent');
 
       const aliceErrors = await hasCryptoErrors(alicePage);
-      if (aliceErrors.length > 0) {
-        console.log(`  ⚠️ Alice send errors: ${aliceErrors.join(', ')}`);
-      } else {
-        console.log('  ✓ Alice sent message without errors');
-      }
+      expect(
+        aliceErrors,
+        `Alice surfaced crypto errors after sending: ${aliceErrors.join(', ')}`,
+      ).toEqual([]);
 
       // Bob opens the conversation
       await bobPage.waitForTimeout(2000);
       const bobOpened = await openConversation(bobPage, ALICE);
-      if (bobOpened) {
-        await bobPage.waitForTimeout(2000);
-        await ss(bobPage, '03_bob_received');
-        const bobSees = await pageContains(bobPage, 'Hello Bob from Alice');
-        console.log(`  Bob sees Alice's message: ${bobSees ? '✓' : '✗'}`);
+      expect(bobOpened, 'Bob could not open conversation with Alice').toBe(true);
 
-        // Bob replies
-        const msg2 = `Reply from Bob [${ts}]`;
-        await sendMessage(bobPage, msg2);
-        await ss(bobPage, '04_bob_replied');
-        const bobErrors = await hasCryptoErrors(bobPage);
-        console.log(`  Bob reply errors: ${bobErrors.length === 0 ? '✓ none' : bobErrors.join(', ')}`);
+      await bobPage.waitForTimeout(2000);
+      await ss(bobPage, '03_bob_received');
+      const bobSees = await pageContains(bobPage, 'Hello Bob from Alice');
+      expect(bobSees, "Bob did not see Alice's encrypted message").toBe(true);
 
-        // Alice sees the reply
-        await alicePage.waitForTimeout(3000);
-        const aliceSees = await pageContains(alicePage, 'Reply from Bob');
-        console.log(`  Alice sees Bob's reply: ${aliceSees ? '✓' : '✗'}`);
-        await ss(alicePage, '05_alice_sees_reply');
-      } else {
-        console.log('  ✗ Bob could not open conversation with Alice');
-      }
+      // Bob replies
+      const msg2 = `Reply from Bob [${ts}]`;
+      await sendMessage(bobPage, msg2);
+      await ss(bobPage, '04_bob_replied');
+      const bobErrors = await hasCryptoErrors(bobPage);
+      expect(
+        bobErrors,
+        `Bob surfaced crypto errors after replying: ${bobErrors.join(', ')}`,
+      ).toEqual([]);
+
+      // Alice sees the reply
+      await alicePage.waitForTimeout(3000);
+      const aliceSees = await pageContains(alicePage, 'Reply from Bob');
+      expect(aliceSees, "Alice did not see Bob's reply").toBe(true);
+      await ss(alicePage, '05_alice_sees_reply');
     } else {
-      console.log('  ✗ Could not open DM conversation');
+      expect(aliceOpened, 'Could not open DM conversation as Alice').toBe(true);
     }
 
     await aliceCtx.close();

--- a/tests/e2e/local_full.spec.ts
+++ b/tests/e2e/local_full.spec.ts
@@ -271,14 +271,16 @@ test('Full feature test', async ({ browser }) => {
   await p1.waitForTimeout(1500);
   await ss(p1, '17-back-from-settings');
 
-  // DB encryption check
-  try {
-    const db = execSync('docker exec docker-postgres-1 psql -U echo -d echo_dev -t -c "SELECT content FROM messages ORDER BY created_at DESC LIMIT 3;"').toString().trim();
-    const lines = db.split('\n').map(l => l.trim()).filter(l => l.length > 0);
-    const allEncrypted = lines.every(l => /^[A-Za-z0-9+/=]{20,}$/.test(l));
-    // Note: messages sent via websocat are plaintext, UI messages may be encrypted
-    check('DB messages exist', lines.length > 0, `${lines.length} messages`);
-  } catch (_) { check('DB check', false, 'docker exec failed'); }
+  // DB encryption check via the local docker-compose container. CI runs
+  // postgres as a GitHub Actions service (no docker-compose container by
+  // that name), so this check is local-only.
+  if (!process.env.CI) {
+    try {
+      const db = execSync('docker exec docker-postgres-1 psql -U echo -d echo_dev -t -c "SELECT content FROM messages ORDER BY created_at DESC LIMIT 3;"').toString().trim();
+      const lines = db.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+      check('DB messages exist', lines.length > 0, `${lines.length} messages`);
+    } catch (_) { check('DB check', false, 'docker exec failed'); }
+  }
 
   // Final
   await ss(p1, '18-final-u1');

--- a/tests/e2e/local_full.spec.ts
+++ b/tests/e2e/local_full.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 
 const LOCAL = 'http://localhost:8080';
 const APP_BASE = 'http://localhost:8081';
@@ -159,14 +159,26 @@ test('Full feature test', async ({ browser }) => {
     return body.ticket as string;
   }
 
+  // Use spawnSync with argv arrays so user_ids and tickets pass as program
+  // arguments, never shell-interpolated (CodeQL js/shell-command-injected-with-input).
+  function seedViaWebsocat(toUserId: string, content: string, ticket: string): boolean {
+    const payload = JSON.stringify({ type: 'send_message', to_user_id: toUserId, content });
+    const wsUrl = `ws://localhost:8080/ws?ticket=${ticket}`;
+    const r = spawnSync('timeout', ['3', 'websocat', wsUrl], {
+      input: payload,
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    return r.status === 0 || r.status === 124; // 124 = timeout exit, but the message was sent
+  }
+
   let seedOk = false;
   try {
     const t1 = await mintTicket(r1.access_token);
     const t2 = await mintTicket(r2.access_token);
-    execSync(`echo '{"type":"send_message","to_user_id":"${r2.user_id}","content":"Hello from setup!"}' | timeout 3 websocat "ws://localhost:8080/ws?ticket=${t1}"`, { timeout: 5000 });
-    execSync(`echo '{"type":"send_message","to_user_id":"${r1.user_id}","content":"Reply from setup!"}' | timeout 3 websocat "ws://localhost:8080/ws?ticket=${t2}"`, { timeout: 5000 });
-    seedOk = true;
-  } catch (e) {
+    seedOk = seedViaWebsocat(r2.user_id, 'Hello from setup!', t1)
+      && seedViaWebsocat(r1.user_id, 'Reply from setup!', t2);
+  } catch (_) {
     seedOk = false;
   }
   check('Seed messages', seedOk, seedOk ? '' : 'websocat or ws-ticket failed');

--- a/tests/e2e/local_full.spec.ts
+++ b/tests/e2e/local_full.spec.ts
@@ -1,4 +1,4 @@
-import { test, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { execSync } from 'child_process';
 
 const LOCAL = 'http://localhost:8080';
@@ -7,7 +7,10 @@ const APP = `${APP_BASE}/?server=${encodeURIComponent(LOCAL)}`;
 const SS = 'tests/e2e/test-results/local-full';
 
 function check(name: string, ok: boolean, note = '') {
+  // Console line is for human-readable test output; the assertion is what
+  // actually fails the spec when something is wrong.
   console.log(`${ok ? '✅' : '❌'} ${name}${note ? ` -- ${note}` : ''}`);
+  expect(ok, `${name}${note ? ` -- ${note}` : ''}`).toBe(true);
 }
 
 async function ss(page: Page, name: string) {
@@ -143,12 +146,30 @@ test('Full feature test', async ({ browser }) => {
   });
   check('Contacts', true);
 
-  // Pre-send messages via websocat so conversations exist
+  // Pre-send messages via websocat so conversations exist.  WS auth is
+  // ticket-based (see CLAUDE.md): mint a single-use ticket, then connect
+  // with `?ticket=`.  Earlier `?token=` form is forbidden.
+  async function mintTicket(accessToken: string): Promise<string> {
+    const r = await fetch(`${LOCAL}/api/auth/ws-ticket`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${accessToken}` },
+    });
+    if (!r.ok) throw new Error(`ws-ticket HTTP ${r.status}`);
+    const body = await r.json();
+    return body.ticket as string;
+  }
+
+  let seedOk = false;
   try {
-    execSync(`echo '{"type":"send_message","to_user_id":"${r2.user_id}","content":"Hello from setup!"}' | timeout 3 websocat "ws://localhost:8080/ws?token=${r1.access_token}" || true`, { timeout: 5000 });
-    execSync(`echo '{"type":"send_message","to_user_id":"${r1.user_id}","content":"Reply from setup!"}' | timeout 3 websocat "ws://localhost:8080/ws?token=${r2.access_token}" || true`, { timeout: 5000 });
-    check('Seed messages', true);
-  } catch (_) { check('Seed messages', false, 'websocat failed'); }
+    const t1 = await mintTicket(r1.access_token);
+    const t2 = await mintTicket(r2.access_token);
+    execSync(`echo '{"type":"send_message","to_user_id":"${r2.user_id}","content":"Hello from setup!"}' | timeout 3 websocat "ws://localhost:8080/ws?ticket=${t1}"`, { timeout: 5000 });
+    execSync(`echo '{"type":"send_message","to_user_id":"${r1.user_id}","content":"Reply from setup!"}' | timeout 3 websocat "ws://localhost:8080/ws?ticket=${t2}"`, { timeout: 5000 });
+    seedOk = true;
+  } catch (e) {
+    seedOk = false;
+  }
+  check('Seed messages', seedOk, seedOk ? '' : 'websocat or ws-ticket failed');
 
   // Health
   const health = await fetch(`${LOCAL}/api/health`).then(r => r.json()).catch(() => null);


### PR DESCRIPTION
## Summary

This PR rolls up four sprints of audit-driven work that was previously stacked across PRs #703 → #709 → #710 → #714. With sprint4 fast-forward-merged into `dev`, this becomes the single bundle ready for `main`.

**42 commits, ~50 issues addressed.**

## Issues closed-on-merge

### Critical fixes (Sprint 1, audit follow-ups)
CRIT-1 voice IDOR · CRIT-2/3 e2e assertion gaps · CRIT-4 ratchet MAX_SKIP cap · CRIT-5 JWT expiry test · CRIT-6 LiveKit bind · CRIT-7 trufflehog config · CRIT-8 SonarCloud token exposure · #685 REGISTRATION_OPEN · #686/#687 group key envelope tx + member validation · #689 get_undelivered cursor pagination · #684 link_preview streaming · #696 WS tokio::select! · #697 change_password spawn_blocking · #634 mpsc slow consumer eviction

### Reliability + perf (Sprint 2)
#694 DbErrCtx (91 closure dedup) · #678 + #638 reply_count LATERAL joins · #625 + #692 panic recovery + cache sweep · #690 fanout JSON allocation · #436 presence flap

### Test infra + CI (Sprint 3)
#699 fresh-DB migration smoke · #698 CASCADE integration test · #695 sleep(200ms) sweep · #356/#357 Docker hardening · #594 tag-ruleset runbook

### Architecture + quick-wins (Sprint 4)
#700 wire-format constants single source · #713 server-side comment-bloat sweep · #701 CLAUDE.md drift · #583 postgres pin · #535 dev script refresh · #524 trusted-proxy test · #672 codecov token · #671 ratchet coverage threshold · #662 pending-badge gate · #585 typed MessageDto · #599 contacts stale-reload race · #674 dart fix const-constructor sweep · #624 edit_message rate limit · #525 advisory_xact_lock DM race · #622 lazy rate-limiter sweep · #421 fuzzy search · #635 orphan media reaper · #626 verified covered

### Riverpod modernization (slice)
5 of 22 providers migrated to `@riverpod` codegen: accessibility, gif_playback, theme, biometric, media_ticket. Remaining 17 documented with sequencing in RIVERPOD_MIGRATION.md and tracked in #704–#708, #711, #712.

### Documentation added
- TECHNICAL_DEBT.md — 132-finding catalog from 2026-04-30 audit
- SPRINT_PLAN.md — 4-sprint plan + Riverpod analysis
- RIVERPOD_MIGRATION.md — playbook for the 17 deferred providers
- docs/release-process.md — tag-ruleset runbook (#594)

## Issues filed for follow-up

#704 Riverpod umbrella · #705 chat_provider · #706 auth_provider · #707 voice cluster · #708 ws_message_handler · #711 crypto_service split · #712 conversations_provider split · #713 comment-bloat sweep (Dart side outstanding)

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ (one transient parallel-run flake in `search_users_returns_results`, documented as #699)
- `dart format --set-exit-if-changed` ✓
- `flutter analyze --fatal-infos` ✓
- `flutter test` ✓ (1071 passed, 12 skipped)

## Deploy callouts

1. **CRIT-6 LiveKit bind** requires DNS A record for `livekit.echo-messenger.us` + client config update before next prod redeploy. Compose file comments and sprint1 commit message both flag this.
2. **#702 migration consolidation** still open and needs prod deploy coordination — not in this PR.
3. **`idx_messages_reply_to` drop** in migration `20260501000000_drop_duplicate_reply_to_index.sql` is idempotent (`IF EXISTS`); safe to apply on staging first.

## Test plan

- [ ] CI green on all gates (rust-ci, flutter-ci, security, sonarcloud, e2e smoke)
- [ ] Spot-check the per-task cleanup loop comes up after deploy (look for the `task=voice_sessions/expired_messages/...` log lines)
- [ ] Verify the LiveKit bind change works with the operator's DNS update before declaring voice/video healthy
- [ ] Soak `dev` for 24h before fast-forwarding `main`

## Not merging from this PR

User instruction: open and stop. The earlier stacked PRs (#703, #709, #710, #714) become redundant once this lands and should be closed.