### PR TITLE
ci: skip presence_list in ws_events helper, gate codecov fail on token

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           files: apps/client/coverage/lcov.info
           flags: flutter
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   smoke-linux:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           files: coverage/rust/lcov.info
           flags: rust
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # ------------------------------------------------------------------

--- a/apps/server/tests/ws_events.rs
+++ b/apps/server/tests/ws_events.rs
@@ -43,7 +43,10 @@ async fn read_text_skipping_noise(ws: &mut WsStream) -> String {
             Ok(Some(Ok(Message::Text(text)))) => {
                 let s = text.to_string();
                 if let Ok(v) = serde_json::from_str::<Value>(&s)
-                    && matches!(v["type"].as_str(), Some("presence") | Some("new_message"))
+                    && matches!(
+                        v["type"].as_str(),
+                        Some("presence") | Some("presence_list") | Some("new_message")
+                    )
                 {
                     continue;
                 }


### PR DESCRIPTION
Two CI breaks on PR #720:
1. add_reaction_broadcasts_ws_event_to_peer flaked when the presence_list snapshot from #436 raced past drain_pending. The read_text_skipping_noise helper in ws_events.rs only skipped presence + new_message — added presence_list.
2. Codecov upload was hard-failing CI even when CODECOV_TOKEN was missing or rate-limited. Made fail_ci_if_error conditional on the token being set so unauthenticated/anon uploads don't break the gate.

## What does this PR do?

<!-- Concise description of the change. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] CI/CD or infrastructure
- [ ] Documentation

## How was this tested?

- [ ] Unit tests pass
- [ ] Manual testing performed

## Security checklist

- [ ] No secrets or credentials included
- [ ] No new `unsafe` blocks (or justified and documented)
