### PR TITLE
fix(server,client): return configurable LIVEKIT_URL on voice token

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice_provider.dart
@@ -155,6 +155,7 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
       peerConnectionStates: const {},
     );
 
+    String? attemptedUrl;
     try {
       // 1. Fetch a LiveKit JWT from the Echo server.
       final tokenResult = await _fetchLiveKitToken(conversationId, channelId);
@@ -168,6 +169,12 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
 
       final livekitUrl = tokenResult.url;
       final livekitToken = tokenResult.token;
+      attemptedUrl = livekitUrl;
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'Connecting to $livekitUrl (token len=${livekitToken.length})',
+      );
 
       // 2. Create and connect a LiveKit Room.
       final voiceSettings = ref.read(voiceSettingsProvider);
@@ -228,11 +235,14 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
         'Joined room for channel $channelId',
       );
     } catch (e) {
-      debugPrint('[LiveKitVoice] join failed: $e');
+      // Surface the URL we tried so a 404 / DNS failure points ops at the
+      // exact subdomain that needs DNS or Traefik attention (#721).
+      final tried = attemptedUrl ?? '<token-fetch>';
+      debugPrint('[LiveKitVoice] join failed at $tried: $e');
       DebugLogService.instance.log(
         LogLevel.error,
         'LiveKitVoice',
-        'Join failed: $e',
+        'Join failed at $tried: $e',
       );
       await _cleanupRoom();
       state = state.copyWith(

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -26,6 +26,12 @@ pub struct TokenRequest {
 #[derive(Debug, Serialize)]
 pub struct TokenResponse {
     pub token: String,
+    /// LiveKit signaling URL the client should connect to.  Returned only
+    /// when `LIVEKIT_URL` is configured on the server, so ops can point the
+    /// client at a managed LiveKit (e.g. `wss://*.livekit.cloud`) or a
+    /// non-default subdomain without a client release (#721).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 /// LiveKit video grant claims.
@@ -140,7 +146,14 @@ pub async fn generate_token(
         AppError::internal("Failed to generate voice token")
     })?;
 
-    Ok(Json(TokenResponse { token }))
+    // Optional explicit URL — lets ops redirect to a managed LiveKit or a
+    // non-default subdomain without a client release.  When unset the client
+    // falls back to deriving `wss://livekit.<server-host>`.
+    let url = std::env::var("LIVEKIT_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty());
+
+    Ok(Json(TokenResponse { token, url }))
 }
 
 #[cfg(test)]
@@ -198,5 +211,26 @@ mod tests {
         assert_eq!(json["video"]["roomJoin"], true);
         assert_eq!(json["video"]["canPublish"], true);
         assert_eq!(json["video"]["canSubscribe"], true);
+    }
+
+    #[test]
+    fn token_response_omits_url_when_none() {
+        let resp = TokenResponse {
+            token: "jwt".into(),
+            url: None,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["token"], "jwt");
+        assert!(json.get("url").is_none(), "url must be omitted when None");
+    }
+
+    #[test]
+    fn token_response_includes_url_when_set() {
+        let resp = TokenResponse {
+            token: "jwt".into(),
+            url: Some("wss://livekit.example.com".into()),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["url"], "wss://livekit.example.com");
     }
 }

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -10,6 +10,11 @@ services:
       SERVER_PORT: 8080
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY}
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET}
+      # Optional: explicit LiveKit signaling URL returned to clients on
+      # `POST /api/voice/token`.  When set, clients use this instead of
+      # deriving `wss://livekit.<server-host>`.  Set to your livekit
+      # subdomain or a managed LiveKit Cloud endpoint (#721).
+      LIVEKIT_URL: ${LIVEKIT_URL:-}
       APNS_KEY_ID: ${APNS_KEY_ID}
       APNS_TEAM_ID: ${APNS_TEAM_ID}
       APNS_AUTH_KEY_BASE64: ${APNS_AUTH_KEY_BASE64}
@@ -73,6 +78,11 @@ services:
     # pointing at this host *and* the client's LiveKit URL configured to
     # `wss://livekit.echo-messenger.us`.  Until both are in place, voice/video
     # connectivity will fail.  Reverting to public 7880 must not be done.
+    #
+    # Set `LIVEKIT_URL=wss://livekit.echo-messenger.us` in `.env` so the
+    # echo-server returns it on `POST /api/voice/token` and the client uses
+    # the configured URL instead of deriving `wss://livekit.<host>`.  Override
+    # to a managed LiveKit Cloud endpoint if self-hosting becomes a chore (#721).
     ports:
       - "127.0.0.1:7880:7880"
       - "7881:7881"


### PR DESCRIPTION
## Summary

The LiveKit voice lounge fails to join with `livekit exception: [ConnectionException] 404 page not found` (#721). The 404 body is Go's default `http.NotFound` response, which means the request is reaching *something* HTTP-aware (LiveKit, Traefik 404 page, or Cloudflare 404) but not the LiveKit `/rtc` signaling endpoint behind the right host. Most likely cause: DNS / Traefik routing for `livekit.echo-messenger.us` is not in place on the deployed host. That is an ops fix — but the **code currently makes it impossible to redirect without a client release** because the client hard-derives `wss://livekit.<server-host>` and the server never returns a URL.

This PR doesn't promise to fix the deployed infrastructure. It gives ops a knob: set `LIVEKIT_URL=wss://livekit.echo-messenger.us` (or a managed LiveKit Cloud endpoint) and the server returns it on `POST /api/voice/token`; the client already prefers `data['url']` over its derived fallback.

## Changes

- **Server** (`apps/server/src/routes/voice.rs`): `TokenResponse` now optionally carries `url`. Read from `LIVEKIT_URL` env; absent → field omitted (`#[serde(skip_serializing_if = "Option::is_none")]`) so old clients keep working unchanged.
- **Client** (`apps/client/lib/src/providers/livekit_voice_provider.dart`): log the URL we attempt to connect to, and include it in the failure log so ops can see at a glance which subdomain needs DNS / cert work. No behavior change otherwise.
- **Compose** (`infra/docker/docker-compose.prod.yml`): pass `LIVEKIT_URL` through to the server service; document it next to the existing `livekit.echo-messenger.us` deploy note.

## Test plan

- `cargo test -p echo-server --lib` — 122 passed (incl. two new tests covering `TokenResponse { url: None }` omission and `Some(...)` inclusion).
- `cargo fmt --check` + `cargo clippy -D warnings` — clean.
- `flutter analyze --fatal-infos` + `flutter test` — clean, 1302 passed, 8 skipped.
- Manual deploy steps for ops (after merge):
  1. Set `LIVEKIT_URL=wss://livekit.echo-messenger.us` in prod `.env`.
  2. Confirm DNS A record for `livekit.echo-messenger.us` resolves to the host running Traefik.
  3. Verify Cloudflare cert is provisioned (Traefik logs).
  4. Restart `server` container; tap "Join voice" and confirm connection.

## Out of scope

- Diagnosing the actual production DNS / cert state (ops). The error logging change is the bridge to make that diagnosable from client logs.
- Switching to LiveKit Cloud entirely.
- Voice-server-side healthcheck or readiness probe.

Refs #721