### PR TITLE
release: locale popup fix + LiveKit URL config (#743 #744)

### DIFF
--- a/apps/client/lib/src/app.dart
+++ b/apps/client/lib/src/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'providers/accessibility_provider.dart';
@@ -85,6 +86,14 @@ class EchoApp extends ConsumerWidget {
       title: 'Echo',
       locale: locale,
       supportedLocales: supportedFlutterLocales,
+      // When app-specific delegates (e.g. AppLocalizations.delegate from
+      // gen_l10n) are added later, they MUST come BEFORE the Global* entries
+      // so user-supplied strings can override Flutter defaults.
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       theme: lightTheme,
       darkTheme: darkTheme,
       themeMode: themeMode,

--- a/apps/client/lib/src/providers/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice_provider.dart
@@ -155,6 +155,7 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
       peerConnectionStates: const {},
     );
 
+    String? attemptedUrl;
     try {
       // 1. Fetch a LiveKit JWT from the Echo server.
       final tokenResult = await _fetchLiveKitToken(conversationId, channelId);
@@ -168,6 +169,12 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
 
       final livekitUrl = tokenResult.url;
       final livekitToken = tokenResult.token;
+      attemptedUrl = livekitUrl;
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'Connecting to $livekitUrl (token len=${livekitToken.length})',
+      );
 
       // 2. Create and connect a LiveKit Room.
       final voiceSettings = ref.read(voiceSettingsProvider);
@@ -228,11 +235,14 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState> {
         'Joined room for channel $channelId',
       );
     } catch (e) {
-      debugPrint('[LiveKitVoice] join failed: $e');
+      // Surface the URL we tried so a 404 / DNS failure points ops at the
+      // exact subdomain that needs DNS or Traefik attention (#721).
+      final tried = attemptedUrl ?? '<token-fetch>';
+      debugPrint('[LiveKitVoice] join failed at $tried: $e');
       DebugLogService.instance.log(
         LogLevel.error,
         'LiveKitVoice',
-        'Join failed: $e',
+        'Join failed at $tried: $e',
       );
       await _cleanupRoom();
       state = state.copyWith(

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -518,6 +518,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^2.6.0
   riverpod_annotation: ^2.6.0
   go_router: ^17.2.2

--- a/apps/client/test/widgets/locale_popup_regression_test.dart
+++ b/apps/client/test/widgets/locale_popup_regression_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/providers/locale_provider.dart';
+
+/// Regression test for issues #736 / #741.
+///
+/// Without `GlobalMaterialLocalizations.delegate` in the app's
+/// `localizationsDelegates`, `PopupMenuButton` (and other Material widgets)
+/// crash under non-English locales because they dereference
+/// `MaterialLocalizations.of(context)!`, which returns `null` when only the
+/// default English fallback is registered.
+///
+/// This test mirrors the production `MaterialApp` configuration and verifies
+/// that opening a `PopupMenuButton` under `Locale('fr')` does not throw.
+Widget _harness(Locale locale) {
+  return MaterialApp(
+    locale: locale,
+    supportedLocales: supportedFlutterLocales,
+    localizationsDelegates: const [
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    home: Scaffold(
+      body: Center(
+        child: PopupMenuButton<String>(
+          itemBuilder: (_) => const [
+            PopupMenuItem<String>(value: 'a', child: Text('A')),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('PopupMenuButton opens under fr locale without crashing', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_harness(const Locale('fr')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(PopupMenuItem<String>), findsWidgets);
+  });
+
+  testWidgets('PopupMenuButton opens under en baseline (sanity)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_harness(const Locale('en')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(PopupMenuItem<String>), findsWidgets);
+  });
+}

--- a/apps/client/test/widgets/settings/language_section_test.dart
+++ b/apps/client/test/widgets/settings/language_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -12,6 +13,12 @@ Widget _wrap(Widget child, {List<Override> overrides = const []}) {
     overrides: overrides,
     child: MaterialApp(
       theme: EchoTheme.darkTheme,
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: supportedFlutterLocales,
       home: Scaffold(body: child),
     ),
   );

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -26,6 +26,12 @@ pub struct TokenRequest {
 #[derive(Debug, Serialize)]
 pub struct TokenResponse {
     pub token: String,
+    /// LiveKit signaling URL the client should connect to.  Returned only
+    /// when `LIVEKIT_URL` is configured on the server, so ops can point the
+    /// client at a managed LiveKit (e.g. `wss://*.livekit.cloud`) or a
+    /// non-default subdomain without a client release (#721).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 /// LiveKit video grant claims.
@@ -140,7 +146,14 @@ pub async fn generate_token(
         AppError::internal("Failed to generate voice token")
     })?;
 
-    Ok(Json(TokenResponse { token }))
+    // Optional explicit URL — lets ops redirect to a managed LiveKit or a
+    // non-default subdomain without a client release.  When unset the client
+    // falls back to deriving `wss://livekit.<server-host>`.
+    let url = std::env::var("LIVEKIT_URL")
+        .ok()
+        .filter(|u| !u.trim().is_empty());
+
+    Ok(Json(TokenResponse { token, url }))
 }
 
 #[cfg(test)]
@@ -198,5 +211,26 @@ mod tests {
         assert_eq!(json["video"]["roomJoin"], true);
         assert_eq!(json["video"]["canPublish"], true);
         assert_eq!(json["video"]["canSubscribe"], true);
+    }
+
+    #[test]
+    fn token_response_omits_url_when_none() {
+        let resp = TokenResponse {
+            token: "jwt".into(),
+            url: None,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["token"], "jwt");
+        assert!(json.get("url").is_none(), "url must be omitted when None");
+    }
+
+    #[test]
+    fn token_response_includes_url_when_set() {
+        let resp = TokenResponse {
+            token: "jwt".into(),
+            url: Some("wss://livekit.example.com".into()),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["url"], "wss://livekit.example.com");
     }
 }

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -10,6 +10,11 @@ services:
       SERVER_PORT: 8080
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY}
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET}
+      # Optional: explicit LiveKit signaling URL returned to clients on
+      # `POST /api/voice/token`.  When set, clients use this instead of
+      # deriving `wss://livekit.<server-host>`.  Set to your livekit
+      # subdomain or a managed LiveKit Cloud endpoint (#721).
+      LIVEKIT_URL: ${LIVEKIT_URL:-}
       APNS_KEY_ID: ${APNS_KEY_ID}
       APNS_TEAM_ID: ${APNS_TEAM_ID}
       APNS_AUTH_KEY_BASE64: ${APNS_AUTH_KEY_BASE64}
@@ -73,6 +78,11 @@ services:
     # pointing at this host *and* the client's LiveKit URL configured to
     # `wss://livekit.echo-messenger.us`.  Until both are in place, voice/video
     # connectivity will fail.  Reverting to public 7880 must not be done.
+    #
+    # Set `LIVEKIT_URL=wss://livekit.echo-messenger.us` in `.env` so the
+    # echo-server returns it on `POST /api/voice/token` and the client uses
+    # the configured URL instead of deriving `wss://livekit.<host>`.  Override
+    # to a managed LiveKit Cloud endpoint if self-hosting becomes a chore (#721).
     ports:
       - "127.0.0.1:7880:7880"
       - "7881:7881"


### PR DESCRIPTION
## Summary

Promotes recent `dev` work to `main` for release.

## Included

- **#743 — fix(client): add flutter_localizations delegates to fix locale popup crash** (closes #736 + #741). Adds `flutter_localizations` SDK dep + 3 GlobalLocalizations delegates to `MaterialApp.router`. Eliminates the `MaterialLocalizations.of` null-check crash in `PopupMenuButton` that ate the entire UI as a grey overlay on locale switch. New regression test guards the failure mode.
- **#744 — fix(server,client): return configurable LIVEKIT_URL on voice token** (refs #721). Server `TokenResponse` now optionally carries `url` from `LIVEKIT_URL` env; client logs the attempted URL on connect failure. Gives ops a knob to redirect voice without a client release.

## Test plan

- All Flutter tests passing on dev: 1302 / 8 skipped / 0 failed.
- Server unit tests passing: 122 / 0 failed (incl. new `TokenResponse` url tests).
- `cargo fmt --check`, `cargo clippy -D warnings`, `flutter analyze --fatal-infos` all clean.
- Pipeline run on dev (PR #744): all code-quality gates green; the 2 prior E2E lane failures were infra-network only (apt-get DNS to azure.archive.ubuntu.com timing out).

## Deploy notes

After merge:
1. Set `LIVEKIT_URL=wss://livekit.echo-messenger.us` in prod `.env` so the server returns it on `/api/voice/token`.
2. Confirm DNS A record for `livekit.echo-messenger.us` resolves to the host running Traefik and the Cloudflare cert is provisioned.
3. Redeploy server + web. Voice lounge should connect; if not, the new client log line will surface the attempted URL.

Closes #736
Closes #741
Refs #721