### PR TITLE
fix(server,client): allow self-origin img/media in CSP, add favicon.ico alias

### DIFF
--- a/apps/client/Dockerfile.web
+++ b/apps/client/Dockerfile.web
@@ -20,3 +20,8 @@ RUN chown -R nginx:nginx \
 
 USER nginx
 EXPOSE 80
+
+# Hit the silent /healthz path (nginx.conf disables access logging for it)
+# so the healthcheck doesn't spam the access log every interval.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost/healthz || exit 1

--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -1,7 +1,28 @@
+log_format echo_combined '$remote_addr - $remote_user [$time_local] '
+                         '"$request" $status $body_bytes_sent '
+                         '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+
+# Silence in-container probes (host healthcheck, docker HEALTHCHECK, uptime
+# checkers) so 30-second pings don't drown real traffic in the access log.
+map $http_user_agent $loggable {
+    default                 1;
+    "~*^(Wget|curl|kube-probe|Docker-HealthCheck|GoogleHC)" 0;
+}
+
 server {
     listen 80;
     root /usr/share/nginx/html;
     index index.html;
+
+    access_log /var/log/nginx/access.log echo_combined if=$loggable;
+
+    # Dedicated healthcheck: returns 200 with no logging.  Use this for
+    # docker HEALTHCHECK, Traefik backend probes, and external uptime tests.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
 
     # Allow camera, microphone, and screen-share for WebRTC voice/video.
     # Without this, some browsers/proxies silently deny getUserMedia and

--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -24,6 +24,18 @@ server {
         return 200 "ok\n";
     }
 
+    # Browsers (Firefox especially) still hit /favicon.ico as a fallback even
+    # when <link rel="icon"> tags point at favicon.png.  Without this map,
+    # the request falls through to /index.html (SPA fallback) which the
+    # browser then tries to render as an image and fails with a 404 + CSP
+    # noise (#732).  Serve favicon.png for the legacy .ico path.
+    location = /favicon.ico {
+        alias /usr/share/nginx/html/favicon.png;
+        access_log off;
+        log_not_found off;
+        add_header Cache-Control "public, max-age=86400";
+    }
+
     # Allow camera, microphone, and screen-share for WebRTC voice/video.
     # Without this, some browsers/proxies silently deny getUserMedia and
     # getDisplayMedia without ever prompting the user.

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -379,11 +379,16 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
         ))
         .layer(SetResponseHeaderLayer::overriding(
             header::CONTENT_SECURITY_POLICY,
-            // API responses are JSON only -- no HTML, scripts, or styles are
-            // ever rendered from these endpoints. Lock everything down; the
-            // Flutter web client is served by nginx with its own CSP.
+            // API responses are JSON or binary (avatars, media files served
+            // via /api/{users,groups}/.../avatar and /api/media/{id}).
+            // Allow self-origin img + media so Firefox does not block their
+            // use in <img>/<video> embeds with the page's CSP fallback
+            // (#732, #733).  Everything else stays locked to 'none'.
+            // The Flutter web client (HTML+JS) is served by nginx with its
+            // own broader CSP that covers script/style/font/connect.
             header::HeaderValue::from_static(
-                "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+                "default-src 'none'; img-src 'self'; media-src 'self'; \
+                 frame-ancestors 'none'; base-uri 'none'",
             ),
         ))
         .with_state(state)


### PR DESCRIPTION
## Summary

Two related browser-rendering bugs collapse to one root cause: the **server's API CSP** middleware sends `default-src 'none'; frame-ancestors 'none'; base-uri 'none'` on every API response, including binary media (`/api/media/{id}`) and avatars (`/api/users/{id}/avatar`, `/api/groups/{id}/avatar`). With `default-src 'none'` and no explicit `img-src`/`media-src`, browsers (Firefox in particular) refuse to use those responses for `<img>`/`<video>` rendering — yielding the user's reported errors:

- `(media-src) at https://echo-messenger.us/api/media/<uuid>?ticket=… because it violates default-src 'none'`
- `Media resource … could not be decoded. NS_ERROR_DOM_MEDIA_METADATA_ERR` (downstream symptom — Firefox can't read the moov atom because the fetch was blocked)
- `(img-src) at https://echo-messenger.us/favicon.ico because it violates default-src 'none'` (the favicon path falls through SPA `try_files` to `/index.html` on builds without a `favicon.ico`, but Firefox still flags the same restrictive CSP from a stale deploy)

## Changes

### `apps/server/src/routes/mod.rs`
API CSP now opens **only** `img-src 'self'` and `media-src 'self'`. Everything else stays `'none'`. Comment updated.

```diff
- "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+ "default-src 'none'; img-src 'self'; media-src 'self'; \
+  frame-ancestors 'none'; base-uri 'none'"
```

### `apps/client/nginx.conf`
- Add `location = /favicon.ico` that aliases to `/favicon.png`. Stops Firefox's automatic `/favicon.ico` request from falling through SPA `try_files` to `/index.html`, which the browser then (correctly) refuses to render as an image.
- Cherry-picked the orphan `/healthz` + access-log silencer for in-container probes from earlier work, so the prior healthcheck access-log spam fix lands here too.

## Why MP4 metadata error is bundled

The `NS_ERROR_DOM_MEDIA_METADATA_ERR` is the second-order effect of the CSP block: Firefox can't finish reading the MP4 moov atom because the resource fetch was rejected. With `media-src 'self'` allowed, the fetch completes and the existing range-request support in `routes/media.rs` lets Firefox seek the moov atom from the end of the file. If a user still hits this on legacy uploads where moov is at file-end, the next move is `-movflags +faststart` on the upload pipeline — tracked separately, not in scope here.

## Test plan

- `cargo fmt --check` + `cargo clippy -D warnings` — clean.
- `cargo test -p echo-server --lib` — 122 passed.
- nginx config validated via `nginx -t` in a clean nginx:alpine container — syntax ok.
- Manual after deploy:
  1. Hard-refresh `https://echo-messenger.us/` and confirm `/favicon.ico` returns 200 with image/png.
  2. Open a conversation with a video attachment, hit play in Firefox; expect playback (no CSP error, no metadata error).
  3. Confirm avatars render in chat list.

## Out of scope

- ffmpeg-based MP4 faststart re-mux on upload (track separately if metadata errors persist on legacy files).
- Tightening nginx CSP further (current `connect-src 'self' wss: https:` is broader than ideal for the Echo deployment but covers WebSocket + LiveKit + link previews; needs separate audit).

Closes #732
Closes #733