### PR TITLE
chore(scripts): seed any server via REST + WS, themed demo.json

### DIFF
--- a/scripts/seed_assets/demo.json
+++ b/scripts/seed_assets/demo.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "Echo seed dataset. Edit and re-run scripts/seed_full_demo.sh.",
+  "password": "demopass123",
+
+  "users": [
+    {
+      "username": "alice",
+      "bio": "Backend engineer. SQL nerd. Recovering microservices fan.",
+      "status_message": "Refactoring something."
+    },
+    {
+      "username": "bob",
+      "bio": "Game dev. Speedrunner. Mech keyboard hoarder.",
+      "status_message": "Just shipped a build."
+    },
+    {
+      "username": "charlie",
+      "bio": "Music producer by night, frontend dev by day.",
+      "status_message": "On a synth deep-dive."
+    },
+    {
+      "username": "diana",
+      "bio": "Cinephile. Trying to watch every film in the Criterion Collection.",
+      "status_message": "Movie night planning."
+    },
+    {
+      "username": "eve",
+      "bio": "Security researcher. Will absolutely audit your auth flow.",
+      "status_message": "Reading a CVE writeup."
+    },
+    {
+      "username": "frank",
+      "bio": "Marathon runner, weekend tinkerer, dad jokes welcome.",
+      "status_message": "Halfway through a long run."
+    },
+    {
+      "username": "grace",
+      "bio": "Author of three sci-fi novels nobody asked for.",
+      "status_message": "Editing chapter twelve."
+    },
+    {
+      "username": "henry",
+      "bio": "Photographer. Coffee snob. Probably outside.",
+      "status_message": "Chasing golden hour."
+    }
+  ],
+
+  "groups": [
+    {
+      "name": "Tech Talk",
+      "description": "Programming, gadgets, and infra nerdery.",
+      "owner": "alice",
+      "members": ["alice", "bob", "charlie", "diana", "eve"],
+      "messages": [
+        { "from": "alice",   "text": "anyone else moved over to sqlx 0.8 yet? the migration story finally feels solid" },
+        { "from": "charlie", "text": "we did last sprint. the only gotcha was the new query macro hint format" },
+        { "from": "bob",     "text": "I switched a side project, no regrets. their CI is nice now too" },
+        { "from": "eve",     "text": "+1, also the fix for that prepared-statement caching bug landed in 0.8.4" },
+        { "from": "diana",   "text": "tangent: anyone seen the new Tokio scheduler benchmarks?" },
+        { "from": "alice",   "text": "the cooperative scheduling thing? yeah it's a real win for our hot paths" },
+        { "from": "charlie", "text": "we saw a 12% latency drop on the websocket fanout after the upgrade" },
+        { "from": "bob",     "text": "that matches what the post-mortem on their blog claimed" },
+        { "from": "eve",     "text": "I'd love to see a flamegraph before/after if anyone has one handy" },
+        { "from": "alice",   "text": "I'll throw one in here later today" }
+      ],
+      "pin_index": 0,
+      "reactions": [
+        { "message_index": 0, "from": "charlie", "emoji": "👍" },
+        { "message_index": 0, "from": "bob",     "emoji": "🚀" },
+        { "message_index": 6, "from": "alice",   "emoji": "🔥" },
+        { "message_index": 6, "from": "diana",   "emoji": "💯" },
+        { "message_index": 9, "from": "eve",     "emoji": "👀" }
+      ],
+      "replies": [
+        { "from": "diana", "to_index": 1, "text": "the new hint format threw us off too — tracking issue #2347 has the migration steps" }
+      ]
+    },
+
+    {
+      "name": "Gaming Lounge",
+      "description": "LFG, reviews, and esports.",
+      "owner": "bob",
+      "members": ["bob", "charlie", "frank", "grace", "henry"],
+      "messages": [
+        { "from": "bob",     "text": "anyone up for ranked tonight around 9?" },
+        { "from": "frank",   "text": "in. need to climb out of plat" },
+        { "from": "charlie", "text": "I can do 2 games, then need to call it" },
+        { "from": "grace",   "text": "I'll spectate, working on a deadline" },
+        { "from": "henry",   "text": "did anyone finish the new soulslike yet? worth picking up?" },
+        { "from": "bob",     "text": "boss design is top tier, world's a bit empty mid-game" },
+        { "from": "frank",   "text": "the pvp invasions are killing me, in a good way" },
+        { "from": "charlie", "text": "music's incredible, the boss themes alone justify the price" },
+        { "from": "henry",   "text": "sold. picking it up tonight" }
+      ],
+      "pin_index": 0,
+      "reactions": [
+        { "message_index": 0, "from": "frank",   "emoji": "🎉" },
+        { "message_index": 4, "from": "bob",     "emoji": "👀" },
+        { "message_index": 5, "from": "charlie", "emoji": "🔥" },
+        { "message_index": 7, "from": "henry",   "emoji": "❤️" },
+        { "message_index": 8, "from": "bob",     "emoji": "👍" }
+      ],
+      "replies": [
+        { "from": "grace", "to_index": 4, "text": "if you like methodical exploration, yes. don't go in expecting open-world fluff" }
+      ]
+    },
+
+    {
+      "name": "Music Corner",
+      "description": "Share tracks, discover artists, talk theory.",
+      "owner": "charlie",
+      "members": ["alice", "charlie", "diana", "grace"],
+      "messages": [
+        { "from": "charlie", "text": "fell down a rabbit hole on minimal techno from the early 90s last night" },
+        { "from": "alice",   "text": "give me three names to start with" },
+        { "from": "charlie", "text": "Robert Hood, Jeff Mills, Maurizio. start with Hood's Minimal Nation" },
+        { "from": "diana",   "text": "Maurizio is so good. that whole basic channel catalog is pristine" },
+        { "from": "grace",   "text": "anyone been to a Berghain residency? on my bucket list" },
+        { "from": "charlie", "text": "haven't, but a friend went in 2019 and said the soundsystem alone is worth the trip" },
+        { "from": "alice",   "text": "thanks for the recs. queueing them now" },
+        { "from": "diana",   "text": "if you want a softer entry point, try Ricardo Villalobos' Easy Lee" }
+      ],
+      "pin_index": 2,
+      "reactions": [
+        { "message_index": 2, "from": "alice", "emoji": "💯" },
+        { "message_index": 2, "from": "diana", "emoji": "🔥" },
+        { "message_index": 3, "from": "grace", "emoji": "❤️" },
+        { "message_index": 7, "from": "alice", "emoji": "✨" }
+      ],
+      "replies": [
+        { "from": "alice", "to_index": 2, "text": "Minimal Nation is on right now. this is going on every commute playlist" }
+      ]
+    },
+
+    {
+      "name": "Movie Club",
+      "description": "Recommendations, reviews, and watch parties.",
+      "owner": "diana",
+      "members": ["diana", "eve", "frank", "henry"],
+      "messages": [
+        { "from": "diana", "text": "watch party Friday — voting between The Conversation and Memories of Murder" },
+        { "from": "eve",   "text": "Memories of Murder. the tonal shifts are unreal" },
+        { "from": "frank", "text": "Conversation for me, Coppola era is unbeatable" },
+        { "from": "henry", "text": "split vote. flip a coin?" },
+        { "from": "diana", "text": "calling it: Memories of Murder Friday, Conversation the week after. 8pm in the lounge" },
+        { "from": "eve",   "text": "🎉" },
+        { "from": "frank", "text": "I'll bring the wine" },
+        { "from": "henry", "text": "I'll do snacks. anyone gluten free?" }
+      ],
+      "pin_index": 4,
+      "reactions": [
+        { "message_index": 1, "from": "diana", "emoji": "🔥" },
+        { "message_index": 4, "from": "frank", "emoji": "👍" },
+        { "message_index": 4, "from": "henry", "emoji": "👍" },
+        { "message_index": 7, "from": "diana", "emoji": "❤️" }
+      ],
+      "replies": [
+        { "from": "diana", "to_index": 7, "text": "yes, eve is. picking up some rice crackers and dip" }
+      ]
+    },
+
+    {
+      "name": "Random Chat",
+      "description": "Off-topic, memes, and general hangout.",
+      "owner": "alice",
+      "members": ["alice", "bob", "charlie", "diana", "eve", "frank", "grace", "henry"],
+      "messages": [
+        { "from": "frank",   "text": "good morning. who's already on their second coffee" },
+        { "from": "alice",   "text": "third, but who's counting" },
+        { "from": "henry",   "text": "I switched to matcha last week and it's been a journey" },
+        { "from": "bob",     "text": "matcha-pilled. respect" },
+        { "from": "grace",   "text": "fyi, the bookstore on 9th has 30% off all classics this weekend" },
+        { "from": "charlie", "text": "ooh, going on Saturday if anyone wants to make a thing of it" },
+        { "from": "diana",   "text": "in. let's get lunch after?" },
+        { "from": "eve",     "text": "send me the address, will try to swing by" },
+        { "from": "alice",   "text": "anyone seen the bug where the app shows time as 'in 3 minutes' for messages just sent? haunting" },
+        { "from": "bob",     "text": "yes, my client clock was off by 2 minutes. fixed when I synced ntp" },
+        { "from": "alice",   "text": "amazing, thanks. classic clock skew" }
+      ],
+      "pin_index": 4,
+      "reactions": [
+        { "message_index": 0, "from": "alice",   "emoji": "☕" },
+        { "message_index": 4, "from": "diana",   "emoji": "🎉" },
+        { "message_index": 4, "from": "charlie", "emoji": "📚" },
+        { "message_index": 5, "from": "diana",   "emoji": "✨" },
+        { "message_index": 8, "from": "bob",     "emoji": "👀" },
+        { "message_index": 9, "from": "alice",   "emoji": "🙏" },
+        { "message_index": 10, "from": "henry",  "emoji": "😂" }
+      ],
+      "replies": [
+        { "from": "frank",   "to_index": 4, "text": "any cookbook recs? trying to expand the rotation" },
+        { "from": "grace",   "to_index": 4, "text": "the Diana Henry section is huge right now. Salt Sugar Smoke is my pick" }
+      ]
+    },
+
+    {
+      "name": "Book Worms",
+      "description": "Reading lists, reviews, and literary discussion.",
+      "owner": "grace",
+      "members": ["alice", "grace", "henry"],
+      "messages": [
+        { "from": "grace", "text": "currently reading: Piranesi by Susanna Clarke. anyone else?" },
+        { "from": "alice", "text": "I read it last year, the prose is hypnotic" },
+        { "from": "henry", "text": "on my list. is it as weird as Jonathan Strange?" },
+        { "from": "grace", "text": "different weird. shorter, dreamier, more melancholic" },
+        { "from": "alice", "text": "what's next on the list? I want a recommendation" },
+        { "from": "grace", "text": "Stoner by John Williams. quiet but devastating" },
+        { "from": "henry", "text": "I've heard nothing but good things. ordering it now" }
+      ],
+      "pin_index": 0,
+      "reactions": [
+        { "message_index": 0, "from": "alice", "emoji": "❤️" },
+        { "message_index": 3, "from": "henry", "emoji": "✨" },
+        { "message_index": 5, "from": "alice", "emoji": "👀" }
+      ],
+      "replies": [
+        { "from": "henry", "to_index": 5, "text": "putting it next on the queue. love a quiet devastating book" }
+      ]
+    }
+  ]
+}

--- a/scripts/seed_full_demo.sh
+++ b/scripts/seed_full_demo.sh
@@ -1,364 +1,273 @@
 #!/usr/bin/env bash
-# Seed Echo Messenger with users, contacts, public groups, group memberships,
-# and demo messages so the app has something to look at on first run.
+# Seed Echo Messenger with realistic, themed test data using only the public
+# REST + WebSocket API. Works against any reachable server -- localhost,
+# staging, production, anywhere -- with no DB credentials needed.
 #
-# Users are registered via the REST API (so passwords are properly Argon2id-
-# hashed and prekeys land via the normal flow). Contacts, group conversations,
-# memberships, and messages are inserted directly via psql to bypass the WS +
-# E2E-encryption requirements that would otherwise complicate seed data.
-#
-# All seeded groups are created with is_encrypted=false so the inserted plain
-# `content` strings render as-is in the client. Real DMs are auto-encrypted
-# end-to-end by design (#591) and are intentionally NOT seeded here -- when you
-# want to exercise DM flows, use two real client sessions.
+# What gets seeded (driven by scripts/seed_assets/demo.json):
+#   - Users with profile bios + status messages
+#   - All-to-all accepted contacts
+#   - Public groups with thematic descriptions and member lists
+#   - Real-world themed messages, with replies and pins
+#   - Reactions on messages
 #
 # Usage:
-#   ./scripts/seed_full_demo.sh                        # localhost defaults
-#   SERVER_URL=http://localhost:8080 \
-#     DB_URL=postgres://echo:devpass@localhost:5432/echo_dev \
-#     ./scripts/seed_full_demo.sh
+#   ./scripts/seed_full_demo.sh                                    # localhost
+#   SERVER_URL=https://staging.echo-messenger.us ./scripts/seed_full_demo.sh
+#   DATA_FILE=scripts/seed_assets/my_scenario.json ./scripts/seed_full_demo.sh
 #
-# Env overrides:
-#   SERVER_URL  Echo server URL (default http://localhost:8080)
-#   DB_URL      Postgres connection string
-#               (default postgres://echo:devpass@localhost:5432/echo_dev)
-#   PASSWORD    Demo password for every seeded user (default demopass123)
-#   FORCE       1 = wipe seeded users/groups before re-seeding
+# Env:
+#   SERVER_URL  Echo server base URL (default http://localhost:8080)
+#   DATA_FILE   Path to seed JSON  (default scripts/seed_assets/demo.json)
+#   PASSWORD    Override the password from the JSON file
+#   VERBOSE     1 to dump every API request/response
 #
-# Reruns are idempotent. Existing users login instead of register; groups
-# upsert by title; messages append (so re-running grows the timeline).
+# Dependencies: curl, jq, websocat. Install websocat with `cargo install websocat`
+# or grab a static binary from https://github.com/vi/websocat/releases.
+#
+# Reruns are idempotent: existing users login instead of registering, contacts
+# upsert, and groups skip if a same-named public group already exists for the
+# owner. Messages are always appended -- the timeline grows on each rerun.
 
 set -euo pipefail
 
 SERVER_URL="${SERVER_URL:-http://localhost:8080}"
-DB_URL="${DB_URL:-postgres://echo:devpass@localhost:5432/echo_dev}"
-PASSWORD="${PASSWORD:-demopass123}"
-FORCE="${FORCE:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_FILE="${DATA_FILE:-$SCRIPT_DIR/seed_assets/demo.json}"
+VERBOSE="${VERBOSE:-0}"
 
-# ---- Dependency checks ------------------------------------------------------
-for cmd in curl jq psql; do
+# ----- Dependency checks ----------------------------------------------------
+for cmd in curl jq websocat; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "ERROR: '$cmd' is required but not on PATH" >&2
+    [ "$cmd" = "websocat" ] && \
+      echo "       install: cargo install websocat  (or download from github.com/vi/websocat/releases)" >&2
     exit 1
   fi
 done
 
-# ---- Demo cast --------------------------------------------------------------
-USERS=(alice bob charlie diana eve frank grace henry)
-
-# group_title|description|owner|members(comma)
-GROUPS=(
-  "Tech Talk|Programming, gadgets, and infra nerdery|alice|alice,bob,charlie,diana,eve"
-  "Gaming Lounge|LFG, reviews, and esports|bob|bob,charlie,frank,grace,henry"
-  "Music Corner|Share tracks and discover artists|charlie|alice,charlie,diana,grace"
-  "Movie Club|Watch parties and reviews|diana|diana,eve,frank,henry"
-  "Random Chat|Off-topic, memes, and hangout|alice|alice,bob,charlie,diana,eve,frank,grace,henry"
-  "Book Worms|Reading lists and literary discussion|grace|alice,grace,henry"
-)
-
-# Pool of message templates. {user} is substituted at insert time so the
-# message reads naturally regardless of who the sender ends up being.
-MESSAGES=(
-  "hey everyone, what's up"
-  "anyone tried the new beta build?"
-  "lol that's wild"
-  "sounds good"
-  "I'll check it out tonight"
-  "any recommendations for the weekend?"
-  "did you see the announcement?"
-  "ship it"
-  "+1 to that"
-  "we should hop on voice later"
-  "fixed it locally, pushing now"
-  "ngl that was a great call"
-  "anyone else seeing this issue?"
-  "got it working, thanks"
-  "lunch in 10?"
-  "just finished a fun deep dive on this"
-  "this is the way"
-  "back from a walk, what'd I miss"
-  "tldr: it works"
-  "absolute classic"
-)
-
-echo "==> Seeding Echo demo data"
-echo "    server: $SERVER_URL"
-echo "    db:     ${DB_URL%%@*}@***"
-echo "    users:  ${USERS[*]}"
-echo "    groups: ${#GROUPS[@]} public groups"
-
-# ---- Server reachability ----------------------------------------------------
-if ! curl -sf "$SERVER_URL/api/health" >/dev/null 2>&1; then
-  echo "ERROR: server not reachable at $SERVER_URL/api/health" >&2
-  echo "       start it with ./scripts/run.sh and try again" >&2
+if [ ! -f "$DATA_FILE" ]; then
+  echo "ERROR: data file not found: $DATA_FILE" >&2
   exit 1
 fi
 
-# ---- Optional wipe ----------------------------------------------------------
-if [ "$FORCE" = "1" ]; then
-  echo "==> FORCE=1: wiping previously-seeded users, groups, and messages"
-  psql "$DB_URL" -v ON_ERROR_STOP=1 <<SQL >/dev/null
-WITH demo AS (
-  SELECT id FROM users WHERE username = ANY(ARRAY[$(printf "'%s'," "${USERS[@]}" | sed 's/,$//')])
-)
-DELETE FROM messages       WHERE sender_id      IN (SELECT id FROM demo);
-DELETE FROM conversation_members WHERE user_id  IN (SELECT id FROM demo);
-DELETE FROM conversations  WHERE id IN (
-  SELECT id FROM conversations WHERE kind = 'group' AND title = ANY(ARRAY[$(printf "'%s'," "${GROUPS[@]%%|*}" | sed 's/,$//')])
-);
-DELETE FROM contacts       WHERE requester_id   IN (SELECT id FROM demo)
-                              OR target_id      IN (SELECT id FROM demo);
-DELETE FROM users          WHERE id             IN (SELECT id FROM demo);
-SQL
+if ! jq -e . "$DATA_FILE" >/dev/null 2>&1; then
+  echo "ERROR: $DATA_FILE is not valid JSON" >&2
+  exit 1
 fi
 
-# ---- Phase 1: register users via REST --------------------------------------
+PASSWORD="${PASSWORD:-$(jq -r '.password' "$DATA_FILE")}"
+WS_BASE="$(echo "$SERVER_URL" | sed -e 's|^http://|ws://|' -e 's|^https://|wss://|')"
+
+# ----- Logging --------------------------------------------------------------
+log()  { printf '%s\n' "$*"; }
+vlog() { [ "$VERBOSE" = "1" ] && printf '   [v] %s\n' "$*" >&2 || true; }
+
+# ----- Server reachability --------------------------------------------------
+log "==> Echo seed"
+log "    server : $SERVER_URL"
+log "    data   : $DATA_FILE"
+if ! curl -sf -m 5 "$SERVER_URL/api/health" >/dev/null 2>&1; then
+  echo "ERROR: server not reachable at $SERVER_URL/api/health" >&2
+  exit 1
+fi
+
+# ----- Helpers --------------------------------------------------------------
+api() {
+  local method="$1" path="$2" token="${3:-}" body="${4:-}"
+  local args=(-sS -X "$method" "$SERVER_URL$path" -H 'Content-Type: application/json')
+  [ -n "$token" ] && args+=(-H "Authorization: Bearer $token")
+  [ -n "$body" ]  && args+=(-d "$body")
+  vlog "$method $path"
+  curl "${args[@]}"
+}
+
+# ----- Phase 1: users -------------------------------------------------------
+log "==> Phase 1: users"
 declare -A USER_ID
 declare -A USER_TOKEN
+USERS=()
+while read -r u; do USERS+=("$u"); done < <(jq -r '.users[].username' "$DATA_FILE")
+
 for u in "${USERS[@]}"; do
-  resp=$(curl -s -X POST "$SERVER_URL/api/auth/register" \
-    -H "Content-Type: application/json" \
-    -d "{\"username\":\"$u\",\"password\":\"$PASSWORD\"}")
+  resp=$(api POST /api/auth/register "" "{\"username\":\"$u\",\"password\":\"$PASSWORD\"}")
   if [ "$(jq -r '.access_token // empty' <<<"$resp")" = "" ]; then
-    # Already exists -> login
-    resp=$(curl -sf -X POST "$SERVER_URL/api/auth/login" \
-      -H "Content-Type: application/json" \
-      -d "{\"username\":\"$u\",\"password\":\"$PASSWORD\"}")
+    resp=$(api POST /api/auth/login "" "{\"username\":\"$u\",\"password\":\"$PASSWORD\"}")
   fi
   uid=$(jq -r '.user_id' <<<"$resp")
   tok=$(jq -r '.access_token' <<<"$resp")
   if [ "$uid" = "null" ] || [ -z "$uid" ]; then
-    echo "ERROR: failed to register/login $u: $resp" >&2
-    exit 1
+    echo "ERROR: register/login failed for $u: $resp" >&2; exit 1
   fi
-  USER_ID[$u]=$uid
-  USER_TOKEN[$u]=$tok
-  printf "   user %-8s %s\n" "$u" "$uid"
+  USER_ID[$u]="$uid"
+  USER_TOKEN[$u]="$tok"
+  printf "    user %-8s %s\n" "$u" "$uid"
 done
 
-# ---- Phase 2: contacts (everyone with everyone) ----------------------------
-echo "==> Linking contacts (all-to-all, accepted)"
+# Update profile (bio + status) for each user.
+log "==> Phase 1b: profiles"
+for u in "${USERS[@]}"; do
+  bio=$(jq -r --arg u "$u" '.users[]|select(.username==$u).bio // empty' "$DATA_FILE")
+  status=$(jq -r --arg u "$u" '.users[]|select(.username==$u).status_message // empty' "$DATA_FILE")
+  body=$(jq -nc --arg b "$bio" --arg s "$status" '{bio:$b, status_message:$s}')
+  api PATCH /api/users/me/profile "${USER_TOKEN[$u]}" "$body" >/dev/null
+done
+
+# ----- Phase 2: all-to-all contacts -----------------------------------------
+log "==> Phase 2: contacts (all-to-all)"
 for a in "${USERS[@]}"; do
   for b in "${USERS[@]}"; do
     [ "$a" = "$b" ] && continue
-    psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-INSERT INTO contacts (requester_id, target_id, status)
-VALUES ('${USER_ID[$a]}', '${USER_ID[$b]}', 'accepted')
-ON CONFLICT (requester_id, target_id) DO UPDATE SET status = 'accepted', updated_at = now();
-SQL
+    req=$(api POST /api/contacts/request "${USER_TOKEN[$a]}" "{\"username\":\"$b\"}")
+    contact_id=$(jq -r '.contact_id // .id // empty' <<<"$req")
+    [ -z "$contact_id" ] && continue   # already contacts (request rejected)
+    api POST /api/contacts/accept "${USER_TOKEN[$b]}" "{\"contact_id\":\"$contact_id\"}" >/dev/null || true
   done
 done
 
-# ---- Phase 3: groups (idempotent upsert by title) --------------------------
-echo "==> Creating ${#GROUPS[@]} public groups"
+# ----- Phase 3: groups ------------------------------------------------------
+log "==> Phase 3: groups"
 declare -A GROUP_ID
-for spec in "${GROUPS[@]}"; do
-  IFS='|' read -r title desc owner members_csv <<<"$spec"
-  oid=${USER_ID[$owner]}
-  cid=$(psql "$DB_URL" -v ON_ERROR_STOP=1 -At <<SQL
-WITH ins AS (
-  INSERT INTO conversations (kind, title, description, is_public, is_encrypted)
-  SELECT 'group', '$title', '$desc', true, false
-  WHERE NOT EXISTS (SELECT 1 FROM conversations WHERE kind = 'group' AND title = '$title')
-  RETURNING id
-)
-SELECT id FROM ins
-UNION ALL
-SELECT id FROM conversations WHERE kind = 'group' AND title = '$title'
-LIMIT 1;
-SQL
-)
-  if [ -z "$cid" ]; then
-    echo "ERROR: failed to upsert group '$title'" >&2
-    exit 1
-  fi
-  GROUP_ID[$title]=$cid
-  printf "   group %-16s %s (owner=%s)\n" "$title" "$cid" "$owner"
+group_count=$(jq '.groups | length' "$DATA_FILE")
+for i in $(seq 0 $((group_count - 1))); do
+  name=$(jq -r ".groups[$i].name" "$DATA_FILE")
+  desc=$(jq -r ".groups[$i].description" "$DATA_FILE")
+  owner=$(jq -r ".groups[$i].owner" "$DATA_FILE")
 
-  # Owner first (admin role).
-  psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-INSERT INTO conversation_members (conversation_id, user_id, role, is_removed)
-VALUES ('$cid', '$oid', 'admin', false)
-ON CONFLICT (conversation_id, user_id) DO UPDATE SET role = 'admin', is_removed = false, removed_at = NULL;
-SQL
-
-  # Other members.
-  IFS=',' read -r -a member_arr <<<"$members_csv"
-  for m in "${member_arr[@]}"; do
+  members=()
+  while read -r m; do
     [ "$m" = "$owner" ] && continue
-    mid=${USER_ID[$m]}
-    psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-INSERT INTO conversation_members (conversation_id, user_id, role, is_removed)
-VALUES ('$cid', '$mid', 'member', false)
-ON CONFLICT (conversation_id, user_id) DO UPDATE SET is_removed = false, removed_at = NULL;
-SQL
-  done
+    members+=("\"${USER_ID[$m]}\"")
+  done < <(jq -r ".groups[$i].members[]" "$DATA_FILE")
+  members_json="[$(IFS=,; echo "${members[*]}")]"
 
-  # Refresh denormalized member_count to match active members (#701).
-  psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-UPDATE conversations SET member_count = (
-  SELECT COUNT(*) FROM conversation_members
-  WHERE conversation_id = '$cid' AND is_removed = false
-) WHERE id = '$cid';
-SQL
+  body=$(jq -nc \
+    --arg name "$name" \
+    --arg desc "$desc" \
+    --argjson members "$members_json" \
+    '{name:$name, description:$desc, is_public:true, member_ids:$members}')
+  resp=$(api POST /api/groups "${USER_TOKEN[$owner]}" "$body")
+  gid=$(jq -r '.id // empty' <<<"$resp")
+  if [ -z "$gid" ]; then
+    # Fallback: search public groups by name (idempotent rerun path).
+    enc_name=$(jq -rn --arg n "$name" '$n|@uri')
+    existing=$(api GET "/api/groups/public?search=$enc_name" "${USER_TOKEN[$owner]}")
+    gid=$(jq -r --arg n "$name" '.[]|select(.title==$n)|.id' <<<"$existing" | head -1)
+  fi
+  if [ -z "$gid" ] || [ "$gid" = "null" ]; then
+    echo "WARN: could not resolve group id for '$name': $resp" >&2
+    continue
+  fi
+  GROUP_ID["$name"]="$gid"
+  printf "    group %-16s %s\n" "$name" "$gid"
 done
 
-# ---- Phase 4: messages (8-12 per group, time-ordered) ----------------------
-echo "==> Seeding messages"
+# ----- Phase 4: messages over WS, capture in-order ids via /messages fetch --
+log "==> Phase 4: messages, replies, reactions, pins"
 total_msgs=0
 total_replies=0
-total_pins=0
 total_reactions=0
-declare -a UPLOAD_DIR_CANDIDATES=("./uploads" "./apps/server/uploads")
-UPLOADS_DIR=""
-for cand in "${UPLOAD_DIR_CANDIDATES[@]}"; do
-  if [ -d "$cand" ] && [ -w "$cand" ]; then UPLOADS_DIR="$cand"; break; fi
-done
-EMOJIS=("👍" "❤️" "😂" "🔥" "🎉" "👀" "🚀" "💯" "🤔" "✨")
+total_pins=0
 
-for spec in "${GROUPS[@]}"; do
-  IFS='|' read -r title _ owner members_csv <<<"$spec"
-  cid=${GROUP_ID[$title]}
-  oid=${USER_ID[$owner]}
-  IFS=',' read -r -a member_arr <<<"$members_csv"
-  msg_count=$((8 + RANDOM % 5))
+# Send a single WS payload as $1=user_token, $2=NDJSON line. Returns once
+# the server has had a moment to ingest the frame.
+ws_send_one() {
+  local token="$1" payload="$2"
+  local ticket
+  ticket=$(api POST /api/auth/ws-ticket "$token" '' | jq -r '.ticket // empty')
+  if [ -z "$ticket" ]; then
+    echo "WARN: failed to mint WS ticket; skipping send" >&2
+    return 1
+  fi
+  # `--no-close` keeps the socket open after stdin EOF so the server can
+  # actually process the frame; we kill the client after a short wait.
+  printf '%s' "$payload" \
+    | websocat --no-close -E "$WS_BASE/ws?ticket=$ticket" >/dev/null 2>&1 &
+  local pid=$!
+  sleep 0.5
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
 
-  # Build a multi-row INSERT for one round-trip per group, return new ids.
-  values=""
-  declare -a senders=()
-  for i in $(seq 1 "$msg_count"); do
-    sender="${member_arr[$((RANDOM % ${#member_arr[@]}))]}"
-    sid=${USER_ID[$sender]}
-    senders+=("$sid")
-    template="${MESSAGES[$((RANDOM % ${#MESSAGES[@]}))]}"
-    body=${template//\'/\'\'}
-    offset=$((msg_count - i))
-    sep=","; [ -z "$values" ] && sep=""
-    values+="$sep('$cid', '$sid', '$body', now() - (interval '1 minute' * $offset))"
+for i in $(seq 0 $((group_count - 1))); do
+  name=$(jq -r ".groups[$i].name" "$DATA_FILE")
+  owner=$(jq -r ".groups[$i].owner" "$DATA_FILE")
+  cid="${GROUP_ID[$name]:-}"
+  [ -z "$cid" ] && continue
+
+  msg_count=$(jq ".groups[$i].messages | length" "$DATA_FILE")
+
+  # Send each message as the listed sender.
+  for j in $(seq 0 $((msg_count - 1))); do
+    sender=$(jq -r ".groups[$i].messages[$j].from" "$DATA_FILE")
+    text=$(jq -r ".groups[$i].messages[$j].text" "$DATA_FILE")
+    payload=$(jq -nc --arg cid "$cid" --arg t "$text" \
+      '{type:"send_message", conversation_id:$cid, content:$t}')
+    ws_send_one "${USER_TOKEN[$sender]}" "$payload" || true
+    total_msgs=$((total_msgs + 1))
   done
-  mapfile -t MSG_IDS < <(psql "$DB_URL" -v ON_ERROR_STOP=1 -At <<SQL
-INSERT INTO messages (conversation_id, sender_id, content, created_at)
-VALUES $values
-RETURNING id;
-SQL
-)
-  total_msgs=$((total_msgs + msg_count))
 
-  # 4a. Replies: pick 1-2 messages and have a different sender reply to one
-  # of the earliest messages, threaded.
-  if [ ${#MSG_IDS[@]} -ge 4 ]; then
-    parent_idx=1
-    parent_id="${MSG_IDS[$parent_idx]}"
-    reply_sender="${member_arr[$((RANDOM % ${#member_arr[@]}))]}"
-    reply_sid=${USER_ID[$reply_sender]}
-    reply_body="${MESSAGES[$((RANDOM % ${#MESSAGES[@]}))]}"
-    reply_body=${reply_body//\'/\'\'}
-    psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-INSERT INTO messages (conversation_id, sender_id, content, reply_to_id, created_at)
-VALUES ('$cid', '$reply_sid', '$reply_body', '$parent_id', now() - interval '30 seconds');
-SQL
+  # Pull message IDs in chronological order.
+  msgs_resp=$(api GET "/api/conversations/$cid/messages?limit=200" "${USER_TOKEN[$owner]}")
+  mapfile -t MSG_IDS < <(jq -r '.[].id' <<<"$msgs_resp" | tac)
+
+  # Replies: we resolve the parent id from the just-captured array.
+  reply_count=$(jq ".groups[$i].replies | length // 0" "$DATA_FILE")
+  for r in $(seq 0 $((reply_count - 1))); do
+    [ "$reply_count" -eq 0 ] && break
+    rfrom=$(jq -r ".groups[$i].replies[$r].from" "$DATA_FILE")
+    rto=$(jq -r ".groups[$i].replies[$r].to_index" "$DATA_FILE")
+    rtext=$(jq -r ".groups[$i].replies[$r].text" "$DATA_FILE")
+    parent_id="${MSG_IDS[$rto]:-}"
+    [ -z "$parent_id" ] && continue
+    payload=$(jq -nc --arg cid "$cid" --arg t "$rtext" --arg p "$parent_id" \
+      '{type:"send_message", conversation_id:$cid, content:$t, reply_to_id:$p}')
+    ws_send_one "${USER_TOKEN[$rfrom]}" "$payload" || true
     total_replies=$((total_replies + 1))
-    total_msgs=$((total_msgs + 1))
+  done
+
+  # Reactions (REST, idempotent on duplicate emoji).
+  rx_count=$(jq ".groups[$i].reactions | length // 0" "$DATA_FILE")
+  for r in $(seq 0 $((rx_count - 1))); do
+    [ "$rx_count" -eq 0 ] && break
+    rfrom=$(jq -r ".groups[$i].reactions[$r].from" "$DATA_FILE")
+    ridx=$(jq -r ".groups[$i].reactions[$r].message_index" "$DATA_FILE")
+    remoji=$(jq -r ".groups[$i].reactions[$r].emoji" "$DATA_FILE")
+    target_id="${MSG_IDS[$ridx]:-}"
+    [ -z "$target_id" ] && continue
+    body=$(jq -nc --arg e "$remoji" '{emoji:$e}')
+    api POST "/api/messages/$target_id/reactions" "${USER_TOKEN[$rfrom]}" "$body" >/dev/null || true
+    total_reactions=$((total_reactions + 1))
+  done
+
+  # Pin (REST).
+  pin_idx=$(jq -r ".groups[$i].pin_index // empty" "$DATA_FILE")
+  pinned=0
+  if [ -n "$pin_idx" ] && [ "$pin_idx" != "null" ]; then
+    pin_id="${MSG_IDS[$pin_idx]:-}"
+    if [ -n "$pin_id" ]; then
+      api POST "/api/messages/$pin_id/pin" "${USER_TOKEN[$owner]}" "" >/dev/null || true
+      total_pins=$((total_pins + 1))
+      pinned=1
+    fi
   fi
 
-  # 4b. Pin: pin the second message (a slightly older, more interesting one).
-  if [ ${#MSG_IDS[@]} -ge 2 ]; then
-    pin_id="${MSG_IDS[1]}"
-    psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-UPDATE messages SET pinned_at = now(), pinned_by_id = '$oid' WHERE id = '$pin_id';
-SQL
-    total_pins=$((total_pins + 1))
-  fi
-
-  # 4c. Reactions: 5-9 reactions distributed over a few messages.
-  rx_count=$((5 + RANDOM % 5))
-  rx_values=""
-  for r in $(seq 1 "$rx_count"); do
-    target_idx=$((RANDOM % ${#MSG_IDS[@]}))
-    target_id="${MSG_IDS[$target_idx]}"
-    reactor="${member_arr[$((RANDOM % ${#member_arr[@]}))]}"
-    reactor_id=${USER_ID[$reactor]}
-    emoji="${EMOJIS[$((RANDOM % ${#EMOJIS[@]}))]}"
-    sep=","; [ -z "$rx_values" ] && sep=""
-    rx_values+="$sep('$target_id', '$reactor_id', '$emoji')"
-  done
-  psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-INSERT INTO reactions (message_id, user_id, emoji)
-VALUES $rx_values
-ON CONFLICT (message_id, user_id, emoji) DO NOTHING;
-SQL
-  # Count actual unique reactions (some collisions on (message,user,emoji)).
-  applied=$(psql "$DB_URL" -At -v ON_ERROR_STOP=1 <<SQL
-SELECT COUNT(*) FROM reactions
-WHERE message_id IN ($(printf "'%s'," "${MSG_IDS[@]}" | sed 's/,$//'));
-SQL
-)
-  total_reactions=$((total_reactions + ${applied:-0}))
-
-  printf "   %-16s +%d msgs (+1 reply, +1 pin, +%s reactions)\n" \
-    "$title" "$msg_count" "${applied:-0}"
+  printf "    %-16s %d msgs (+%s replies, +%s reactions, +%d pin)\n" \
+    "$name" "$msg_count" "$reply_count" "$rx_count" "$pinned"
 done
-
-# ---- Phase 5: group avatars (icon_url -> stable identicon) -----------------
-echo "==> Setting group icons (dicebear identicons)"
-for spec in "${GROUPS[@]}"; do
-  IFS='|' read -r title _ _ _ <<<"$spec"
-  cid=${GROUP_ID[$title]}
-  # URL-encode the title for the dicebear seed.
-  seed=$(printf '%s' "$title" | jq -sRr @uri)
-  icon="https://api.dicebear.com/7.x/identicon/svg?seed=$seed&backgroundColor=transparent"
-  psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-UPDATE conversations SET icon_url = '$icon' WHERE id = '$cid';
-SQL
-done
-
-# ---- Phase 6: attachment (one image-message per group) ---------------------
-# Drops a 1x1 transparent PNG into the server's uploads dir, registers a
-# media row, and posts a message whose content links to the media.  The
-# Flutter client treats /api/media/<uuid> URLs in content as attachments
-# (apps/client/lib/src/widgets/message_item.dart:381).
-total_attachments=0
-if [ -n "$UPLOADS_DIR" ]; then
-  echo "==> Seeding attachments (uploads dir: $UPLOADS_DIR)"
-  PNG_B64="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-  for spec in "${GROUPS[@]}"; do
-    IFS='|' read -r title _ _ members_csv <<<"$spec"
-    cid=${GROUP_ID[$title]}
-    IFS=',' read -r -a member_arr <<<"$members_csv"
-    sender="${member_arr[$((RANDOM % ${#member_arr[@]}))]}"
-    sid=${USER_ID[$sender]}
-    media_uuid=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
-    media_path="$UPLOADS_DIR/${media_uuid}.png"
-    printf '%s' "$PNG_B64" | base64 -d > "$media_path"
-    size=$(stat -c%s "$media_path" 2>/dev/null || stat -f%z "$media_path")
-    psql "$DB_URL" -v ON_ERROR_STOP=1 -q <<SQL >/dev/null
-INSERT INTO media (id, uploader_id, filename, mime_type, size_bytes, conversation_id)
-VALUES ('$media_uuid', '$sid', 'demo.png', 'image/png', $size, '$cid');
-
-INSERT INTO messages (conversation_id, sender_id, content, created_at)
-VALUES ('$cid', '$sid', '/api/media/$media_uuid', now() - interval '5 seconds');
-SQL
-    total_attachments=$((total_attachments + 1))
-    total_msgs=$((total_msgs + 1))
-  done
-else
-  echo "==> Skipping attachments (no writable ./uploads dir found; run from repo root or apps/server/)"
-fi
 
 cat <<EOF
 
 ==> Done!
 
    ${#USERS[@]} users         : ${USERS[*]}
-   ${#GROUPS[@]} public groups: ${!GROUP_ID[@]}
+   ${#GROUP_ID[@]} groups        : ${!GROUP_ID[@]}
    ${total_msgs} messages
-   ${total_replies} reply chains
-   ${total_pins} pinned messages
+   ${total_replies} replies
    ${total_reactions} reactions
-   ${total_attachments} attachments
+   ${total_pins} pinned messages
 
-Login credentials (any user):
+Login with any seeded user:
    password: $PASSWORD
 
-Re-run with FORCE=1 to wipe and re-seed.
+Edit $DATA_FILE to change the scenario, then re-run.
 EOF


### PR DESCRIPTION
## Why

Earlier `seed_full_demo.sh` shelled directly into psql, which made it hard to point at anything but localhost. This rewrite makes seeding **any reachable server** (localhost, staging, your prod box) a one-liner. Tester can edit a JSON data file to change the scenario without touching the script.

## What changed

- **`scripts/seed_assets/demo.json`** (new) — single editable data file. 8 named users with bios + status messages, 6 themed groups (Tech Talk, Gaming Lounge, Music Corner, Movie Club, Random Chat, Book Worms) with real-feel conversations covering 53 base messages, replies, pins, and reactions.
- **`scripts/seed_full_demo.sh`** (rewrite) — REST + WebSocket only. **No DB credentials needed.**
  - Phase 1: register/login users via REST, set bio + status via `PATCH /api/users/me/profile`.
  - Phase 2: all-to-all contacts via `POST /api/contacts/request` + `POST /api/contacts/accept`.
  - Phase 3: groups via `POST /api/groups` with `member_ids`. Idempotent — falls back to `GET /api/groups/public?search=` on rerun.
  - Phase 4: messages over WebSocket (`/ws?ticket=`) using `websocat`. Replies use the `reply_to_id` field. Reactions via `POST /api/messages/{id}/reactions`. Pins via `POST /api/messages/{id}/pin`. Message IDs are recovered from `GET /api/conversations/{id}/messages` so reactions/pins/replies can target by data-file index.

## Usage

```bash
# Localhost (after ./scripts/run.sh):
./scripts/seed_full_demo.sh

# Any other server:
SERVER_URL=https://staging.echo-messenger.us ./scripts/seed_full_demo.sh

# Custom scenario:
DATA_FILE=scripts/seed_assets/my_scenario.json \
  SERVER_URL=https://echo-messenger.us \
  ./scripts/seed_full_demo.sh

# Verbose (logs every API call):
VERBOSE=1 ./scripts/seed_full_demo.sh
```

## Dependencies

- `curl` — REST
- `jq` — JSON parsing
- `websocat` — WS message send. Install with `cargo install websocat` or grab a static binary from <https://github.com/vi/websocat/releases>.

The script's preflight rejects with a clear install hint if any are missing.

## What testers see after seeding

Login as any of `alice`, `bob`, `charlie`, `diana`, `eve`, `frank`, `grace`, `henry` with the password from `demo.json` (default `demopass123`):

- Profile bio + status visible on each user
- 6 public groups with descriptions, all visible in Discover
- Realistic threaded conversations (Tech Talk discusses sqlx 0.8, Music Corner debates minimal techno, Movie Club picks Friday's screening, etc.)
- One pinned message + several reactions + one reply chain per group

## What this drops vs. the previous psql version

- **Direct DB writes** — gone. Only the public API is used. No DB password needed.
- **Group avatars** — set via the previous version's direct UPDATE; this version doesn't touch them yet (avatar upload is multipart and benefits from a separate PR).
- **Inline attachment seeding** — same reason. The previous version dropped a 1x1 PNG into `./uploads/` directly; doing it through the API means a multipart upload that's nicer to handle in a follow-up.

## Out of scope

- DM seeding (auto-encrypted by design — needs a real Signal session).
- Voice/LiveKit channels.
- Multi-device (every seeded user uses one device).

## Test plan

- `bash -n scripts/seed_full_demo.sh` — syntax clean.
- `jq -e .` validates `demo.json`.
- Manual against a running stack (`./scripts/run.sh`):
  1. `./scripts/seed_full_demo.sh` — confirm the summary at the end shows 8 users, 6 groups, 53+ messages, replies, reactions, pins.
  2. Log in as alice, confirm Tech Talk shows the threaded sqlx conversation with diana's reply on message 1, the pinned first message, and reactions on messages 0/6/9.
  3. `SERVER_URL=https://staging... ./scripts/seed_full_demo.sh` succeeds against a remote.

## Notes

- `scripts/seed_demo_data.sh` (the older `admin_tester` + 10 empty groups script) is left untouched.
- This is a non-production tool — running it against your live host will create 8 demo users and a stack of public groups visible in Discover. Use a staging URL or accept the cleanup work.