### PR TITLE
fix(client): export-chats writes file, pinned-msgs decrypt, canvas image dup

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -330,12 +330,13 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
 
   void _addImageByUrl(String url) {
     if (!mounted) return;
-    final token = ref.read(authProvider).token;
-    final headers = <String, String>{};
-    if (token != null) {
-      headers['Authorization'] = 'Bearer $token';
-    }
-    _canvas?.addImageFromUrl(url, headers: headers);
+    // Broadcast via canvasProvider so every participant (including this
+    // one, via VoiceCanvas's ref.watch on canvas state) renders the image.
+    // Previously also called _canvas?.addImageFromUrl(...) which placed a
+    // SECOND copy at canvas-center inside LoungeDrawingCanvas's local
+    // _images list -- that copy never broadcast and never moved when the
+    // shared one was dragged, producing the "stuck twin" the user
+    // reported in #752.
     final img = CanvasImage(
       id: newCanvasId(),
       url: url,

--- a/apps/client/lib/src/services/export_service.dart
+++ b/apps/client/lib/src/services/export_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' show File;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
@@ -43,13 +44,28 @@ class ExportService {
         .substring(0, 19);
     final fileName = 'echo_chat_export_$ts.json';
 
-    return FilePicker.saveFile(
+    // On web, file_picker writes the bytes itself (browser download).
+    // On native (desktop, Android, iOS), saveFile() only returns the
+    // user-chosen path -- the caller must write the file (#740).
+    if (kIsWeb) {
+      return FilePicker.saveFile(
+        dialogTitle: 'Save chat export',
+        fileName: fileName,
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+        bytes: Uint8List.fromList(bytes),
+      );
+    }
+
+    final path = await FilePicker.saveFile(
       dialogTitle: 'Save chat export',
       fileName: fileName,
       type: FileType.custom,
       allowedExtensions: ['json'],
-      bytes: kIsWeb ? Uint8List.fromList(bytes) : null,
     );
+    if (path == null) return null; // user cancelled
+    await File(path).writeAsBytes(bytes, flush: true);
+    return path;
   }
 
   /// Build the export map without touching the filesystem.

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -16,6 +16,7 @@ import '../providers/websocket_provider.dart';
 import '../screens/safety_number_screen.dart';
 import '../screens/user_profile_screen.dart';
 import '../providers/livekit_voice_provider.dart';
+import '../services/message_cache.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
@@ -1043,14 +1044,27 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
         final list = decoded is List
             ? decoded
             : (decoded['messages'] as List? ?? []);
-        final messages = list
-            .map(
-              (e) => ChatMessage.fromServerJson(
-                e as Map<String, dynamic>,
-                widget.myUserId,
-              ),
-            )
-            .toList();
+        // The /pinned endpoint returns the raw stored content, which is
+        // ciphertext for encrypted DMs.  Re-hydrate from the per-conversation
+        // message cache (which stores the decrypted view) so users see the
+        // plaintext they expect.  Falls back to the server payload if the
+        // message isn't in the cache (e.g. pinned before this device joined
+        // the conversation) -- in that case the user still sees something is
+        // pinned, just as ciphertext, which matches the prior behavior (#724).
+        final messages = <ChatMessage>[];
+        for (final e in list) {
+          final raw = ChatMessage.fromServerJson(
+            e as Map<String, dynamic>,
+            widget.myUserId,
+          );
+          final cached = await MessageCache.getCachedMessage(
+            widget.conversationId,
+            raw.id,
+            widget.myUserId,
+          );
+          messages.add(cached ?? raw);
+        }
+        if (!mounted) return;
         setState(() {
           _pinnedMessages = messages;
           _isLoading = false;


### PR DESCRIPTION
## Summary

Three high-impact P1 user-facing bugs fixed in one focused PR.

## #740 — export chats produces no file

**Root cause**: `export_service.dart:51` passed `bytes: kIsWeb ? Uint8List.fromList(bytes) : null` to `FilePicker.saveFile()`. On web, file_picker writes the bytes to a browser download. On **native** (Linux desktop, Android, iOS), `bytes: null` means file_picker only returns the chosen path — the caller has to write the file. We never did, so the user picked a destination, the dialog closed, and nothing happened.

**Fix**: branch on `kIsWeb`. Web keeps the existing path (file_picker writes it). Native now does `await File(path).writeAsBytes(bytes, flush: true)` after the picker returns a non-null path. Cancellation still returns null cleanly.

## #724 — pinned messages display as encrypted in DMs

**Root cause**: `chat_header_bar.dart` `_fetchPinnedMessages` calls `GET /api/conversations/{id}/pinned`, which returns the raw stored `messages.content` — for encrypted DMs that's the wire-format ciphertext. The pinned-messages list rendered the ciphertext directly, never running it through the decrypt path that the live chat uses.

**Fix**: after parsing each `ChatMessage` from the server response, look it up in `MessageCache` (the per-conversation Hive box that stores decrypted content). If found, use the cached decrypted version; otherwise fall back to the server payload (so users still see _that_ a message is pinned even if it pre-dates this device joining the conversation, matching prior behavior).

## #752 — voice lounge image places duplicate twin

**Root cause** (the dup half of #752): `drawing_tools_menu.dart::_addImageByUrl` called BOTH:
1. `_canvas?.addImageFromUrl(url, headers: headers)` — adds to `LoungeDrawingCanvas`'s local `_images` (rendered by its private `_DrawingPainter` overlay) at canvas-center.
2. `canvasProvider.notifier.addImage(img)` — adds to provider state at random 20-50% position; broadcasts `image_add` to other participants; `VoiceCanvas` (which `ref.watch`es the provider) renders it.

Both canvases are mounted in the lounge stack. The first copy is at canvas-center, has bitmap data, and **never broadcasts** — that's the "stuck twin" the user reported. The second is at a different position, has the URL, and is the only one that responds to drag (`canvasProvider.moveImage` operates on provider state).

**Fix**: drop the `_canvas?.addImageFromUrl(...)` call. Provider is the single source of truth; `VoiceCanvas` renders, `LoungeDrawingCanvas` no longer keeps a parallel image list for shared content.

**NOT in this PR** (separate fix): drawings (strokes) not syncing to other participants. Same architectural cause — `LoungeDrawingCanvas._onPointerUp` writes to its own `_strokes` list and never goes through `canvasProvider`. Tracked in #752; needs a structural change (route stroke events through the provider and stop rendering local `_strokes` in `LoungeDrawingCanvas`). Out of scope for this focused bug-fix PR.

## Test plan

- `dart format --set-exit-if-changed .` clean
- `flutter analyze --fatal-infos` clean
- `flutter test` 1302 passed / 8 skipped / 0 failed (identical baseline)
- Manual:
  - Settings → Data & Storage → Export chats → pick a path → file appears at the chosen path with proper JSON content
  - Pin a message in a DM, open the pinned panel, see plaintext (not ciphertext)
  - In a voice lounge, click attach-image, pick an image, see exactly one image (not two), drag it freely

Closes #740
Closes #724
Refs #752 (image-dup half closed; stroke-sync half tracked separately)