### PR TITLE
release: critical user bugs (#763) — export chats, pinned msgs decrypt, canvas dup

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -330,12 +330,13 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
 
   void _addImageByUrl(String url) {
     if (!mounted) return;
-    final token = ref.read(authProvider).token;
-    final headers = <String, String>{};
-    if (token != null) {
-      headers['Authorization'] = 'Bearer $token';
-    }
-    _canvas?.addImageFromUrl(url, headers: headers);
+    // Broadcast via canvasProvider so every participant (including this
+    // one, via VoiceCanvas's ref.watch on canvas state) renders the image.
+    // Previously also called _canvas?.addImageFromUrl(...) which placed a
+    // SECOND copy at canvas-center inside LoungeDrawingCanvas's local
+    // _images list -- that copy never broadcast and never moved when the
+    // shared one was dragged, producing the "stuck twin" the user
+    // reported in #752.
     final img = CanvasImage(
       id: newCanvasId(),
       url: url,

--- a/apps/client/lib/src/services/export_service.dart
+++ b/apps/client/lib/src/services/export_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' show File;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
@@ -43,13 +44,28 @@ class ExportService {
         .substring(0, 19);
     final fileName = 'echo_chat_export_$ts.json';
 
-    return FilePicker.saveFile(
+    // On web, file_picker writes the bytes itself (browser download).
+    // On native (desktop, Android, iOS), saveFile() only returns the
+    // user-chosen path -- the caller must write the file (#740).
+    if (kIsWeb) {
+      return FilePicker.saveFile(
+        dialogTitle: 'Save chat export',
+        fileName: fileName,
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+        bytes: Uint8List.fromList(bytes),
+      );
+    }
+
+    final path = await FilePicker.saveFile(
       dialogTitle: 'Save chat export',
       fileName: fileName,
       type: FileType.custom,
       allowedExtensions: ['json'],
-      bytes: kIsWeb ? Uint8List.fromList(bytes) : null,
     );
+    if (path == null) return null; // user cancelled
+    await File(path).writeAsBytes(bytes, flush: true);
+    return path;
   }
 
   /// Build the export map without touching the filesystem.

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -16,6 +16,7 @@ import '../providers/websocket_provider.dart';
 import '../screens/safety_number_screen.dart';
 import '../screens/user_profile_screen.dart';
 import '../providers/livekit_voice_provider.dart';
+import '../services/message_cache.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
@@ -1043,14 +1044,27 @@ class _PinnedMessagesDialogState extends ConsumerState<_PinnedMessagesDialog> {
         final list = decoded is List
             ? decoded
             : (decoded['messages'] as List? ?? []);
-        final messages = list
-            .map(
-              (e) => ChatMessage.fromServerJson(
-                e as Map<String, dynamic>,
-                widget.myUserId,
-              ),
-            )
-            .toList();
+        // The /pinned endpoint returns the raw stored content, which is
+        // ciphertext for encrypted DMs.  Re-hydrate from the per-conversation
+        // message cache (which stores the decrypted view) so users see the
+        // plaintext they expect.  Falls back to the server payload if the
+        // message isn't in the cache (e.g. pinned before this device joined
+        // the conversation) -- in that case the user still sees something is
+        // pinned, just as ciphertext, which matches the prior behavior (#724).
+        final messages = <ChatMessage>[];
+        for (final e in list) {
+          final raw = ChatMessage.fromServerJson(
+            e as Map<String, dynamic>,
+            widget.myUserId,
+          );
+          final cached = await MessageCache.getCachedMessage(
+            widget.conversationId,
+            raw.id,
+            widget.myUserId,
+          );
+          messages.add(cached ?? raw);
+        }
+        if (!mounted) return;
         setState(() {
           _pinnedMessages = messages;
           _isLoading = false;


### PR DESCRIPTION
## Summary

Promotes 3 high-impact P1 user-facing bug fixes from `dev` to `main`.

## Included

- **#763 — fix(client): write export file on native, decrypt pinned msgs, drop dup canvas image**
  - Closes **#740** — `Settings → Data & Storage → Export chats` now actually writes the file on native platforms (Linux desktop, Android, iOS). Previously `FilePicker.saveFile()` was called with `bytes: null` on native, which only returns the chosen path; the caller has to write the file.
  - Closes **#724** — Pinned messages in DMs now display decrypted plaintext. The `/pinned` endpoint returns raw stored content (ciphertext for encrypted DMs); the client now hydrates from `MessageCache` (which has the decrypted view) before rendering.
  - Refs **#752** (image-dup half) — voice lounge image-add no longer creates a stuck "twin" image at canvas-center. The duplicate was caused by `drawing_tools_menu._addImageByUrl` calling both `LoungeDrawingCanvas.addImageFromUrl()` (local-only, never broadcasts, never moves) AND `canvasProvider.addImage()` (broadcasts + moves correctly). Dropped the local call. Stroke-sync portion of #752 needs a separate architectural change and is tracked.

## Test plan

All gates green on dev:
- `dart format --check` clean
- `flutter analyze --fatal-infos` clean  
- `flutter test` 1302 passed / 8 skipped (identical baseline)
- All CI smoke tests green (Linux Desktop, Android, Web)

## Manual verification after deploy

1. Settings → Data & Storage → Export chats → pick a path → file appears with proper JSON.
2. Pin a message in a DM, open the pinned panel, see plaintext (not raw ciphertext).
3. In a voice lounge, attach an image, see exactly one image (not two), drag it freely.

Closes #740
Closes #724
Refs #752