### PR TITLE
fix(client): route lounge drawing strokes through canvasProvider for sync

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -15,11 +15,9 @@ import '../../providers/server_url_provider.dart';
 import '../../services/upload_client.dart';
 import '../../theme/echo_theme.dart';
 import '../../utils/canvas_utils.dart';
-import '../../widgets/lounge_drawing_canvas.dart' hide CanvasImage;
 
 /// Popup content for the drawing tools menu.
 class DrawingToolsMenu extends ConsumerStatefulWidget {
-  final GlobalKey<LoungeDrawingCanvasState> drawingCanvasKey;
   final VoidCallback onToggleDrawing;
   final bool isDrawing;
   final String conversationId;
@@ -27,7 +25,6 @@ class DrawingToolsMenu extends ConsumerStatefulWidget {
 
   const DrawingToolsMenu({
     super.key,
-    required this.drawingCanvasKey,
     required this.onToggleDrawing,
     required this.isDrawing,
     required this.conversationId,
@@ -39,7 +36,11 @@ class DrawingToolsMenu extends ConsumerStatefulWidget {
 }
 
 class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
-  DrawingTool _selectedTool = DrawingTool.pen;
+  // The menu mirrors a slice of `canvasProvider` state for its own
+  // selected-chip highlighting.  The provider is the source of truth for
+  // actual drawing values; these locals just cache the latest selection
+  // so the chips render synchronously without an extra ref.watch.
+  CanvasTool _selectedTool = CanvasTool.pen;
   Color _selectedColor = Colors.white;
   double _selectedSize = 4.0;
 
@@ -59,17 +60,16 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
 
   static const _penSizes = [2.0, 4.0, 6.0, 10.0, 16.0];
 
-  LoungeDrawingCanvasState? get _canvas => widget.drawingCanvasKey.currentState;
-
   @override
   void initState() {
     super.initState();
-    final canvas = _canvas;
-    if (canvas != null) {
-      _selectedTool = canvas.tool;
-      _selectedColor = canvas.penColor;
-      _selectedSize = canvas.penSize;
-    }
+    // Hydrate from the provider so the menu opens with the current selection.
+    final canvas = ref.read(canvasProvider);
+    _selectedTool = canvas.selectedTool == CanvasTool.eraser
+        ? CanvasTool.eraser
+        : CanvasTool.pen;
+    _selectedColor = canvas.currentColor;
+    _selectedSize = canvas.strokeWidth;
   }
 
   @override
@@ -85,18 +85,18 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
             padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
             child: Row(
               children: [
-                _toolChip(context, Icons.edit, 'Draw', DrawingTool.pen),
+                _toolChip(context, Icons.edit, 'Draw', CanvasTool.pen),
                 const SizedBox(width: 8),
                 _toolChip(
                   context,
                   Icons.auto_fix_high,
                   'Erase',
-                  DrawingTool.eraser,
+                  CanvasTool.eraser,
                 ),
               ],
             ),
           ),
-          if (_selectedTool == DrawingTool.pen) ...[
+          if (_selectedTool == CanvasTool.pen) ...[
             const Divider(height: 1),
             // Color picker
             Padding(
@@ -121,7 +121,6 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
                     onTap: () {
                       HapticFeedback.selectionClick();
                       setState(() => _selectedColor = c);
-                      _canvas?.setPenColor(c);
                       ref.read(canvasProvider.notifier).setColor(c);
                     },
                     child: SizedBox(
@@ -182,7 +181,6 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
                       onTap: () {
                         HapticFeedback.selectionClick();
                         setState(() => _selectedSize = s);
-                        _canvas?.setPenSize(s);
                         ref.read(canvasProvider.notifier).setStrokeWidth(s);
                       },
                       child: AnimatedContainer(
@@ -247,7 +245,6 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
                   child: TextButton.icon(
                     onPressed: () {
                       HapticFeedback.mediumImpact();
-                      _canvas?.clearMyDrawings();
                       ref.read(canvasProvider.notifier).clearDrawing();
                       widget.onRequestClose?.call();
                     },
@@ -285,8 +282,16 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
       if (bytes == null) return;
 
       if (conversationId.isEmpty) {
-        // No conversation — display locally only.
-        _canvas?.addImageFromBytes(bytes);
+        // No conversation — image add requires a conversation context for
+        // the upload + broadcast.  Show a snackbar instead of a local-only
+        // preview that wouldn't sync to anyone.
+        if (ctx.mounted) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(
+              content: Text('Open a conversation before adding images'),
+            ),
+          );
+        }
         return;
       }
 
@@ -308,12 +313,13 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
         final absUrl = relUrl.startsWith('http') ? relUrl : '$serverUrl$relUrl';
         _addImageByUrl(absUrl);
       } else {
-        // Upload failed — display locally via bytes only.
-        _canvas?.addImageFromBytes(bytes);
+        // Upload failed — surface the error so the user can retry.  We no
+        // longer fall back to a local-only preview because that copy never
+        // synced to other participants and led to a confusing experience.
         if (ctx.mounted) {
           ScaffoldMessenger.of(ctx).showSnackBar(
             const SnackBar(
-              content: Text('Image upload failed; shown locally only'),
+              content: Text('Image upload failed; please try again'),
             ),
           );
         }
@@ -366,7 +372,7 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
     BuildContext context,
     IconData icon,
     String label,
-    DrawingTool tool,
+    CanvasTool tool,
   ) {
     final isSelected = _selectedTool == tool;
     return Expanded(
@@ -374,12 +380,7 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
         onTap: () {
           HapticFeedback.selectionClick();
           setState(() => _selectedTool = tool);
-          _canvas?.setTool(tool);
-          ref
-              .read(canvasProvider.notifier)
-              .setTool(
-                tool == DrawingTool.eraser ? CanvasTool.eraser : CanvasTool.pen,
-              );
+          ref.read(canvasProvider.notifier).setTool(tool);
         },
         child: Container(
           padding: const EdgeInsets.symmetric(vertical: 8),

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -12,7 +12,7 @@ import '../providers/server_url_provider.dart';
 import '../providers/voice_settings_provider.dart';
 import '../theme/echo_theme.dart';
 import '../utils/canvas_utils.dart';
-import '../widgets/lounge_drawing_canvas.dart' hide CanvasImage;
+import '../widgets/lounge_drawing_canvas.dart';
 import '../widgets/vertex_mesh_background.dart';
 import '../widgets/voice_canvas.dart';
 import 'voice_lounge/dock_submenus.dart';
@@ -42,9 +42,6 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
 
   /// Whether the drawing canvas overlay is active.
   bool _isDrawing = false;
-
-  /// Global key for the drawing canvas to access its state.
-  final _drawingCanvasKey = GlobalKey<LoungeDrawingCanvasState>();
 
   /// Anchors for dock submenu panels.
   final LayerLink _drawingToolsLayerLink = LayerLink();
@@ -432,7 +429,6 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       case DockSubmenu.draw:
         link = _drawingToolsLayerLink;
         content = DrawingToolsMenu(
-          drawingCanvasKey: _drawingCanvasKey,
           onToggleDrawing: () => setState(() => _isDrawing = !_isDrawing),
           isDrawing: _isDrawing,
           conversationId: conversationId,
@@ -528,10 +524,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       },
     );
 
-    final drawingOverlay = LoungeDrawingCanvas(
-      key: _drawingCanvasKey,
-      isActive: _isDrawing,
-    );
+    final drawingOverlay = LoungeDrawingCanvas(isActive: _isDrawing);
 
     return OrientationBuilder(
       builder: (context, orientation) {

--- a/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
+++ b/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
@@ -1,381 +1,85 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:http/http.dart' as http;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../theme/echo_theme.dart';
+import '../models/canvas_models.dart';
+import '../providers/canvas_provider.dart';
 
-/// A single stroke drawn on the canvas.
-class DrawingStroke {
-  final List<Offset> points;
-  final Color color;
-  final double width;
-  final bool isEraser;
-
-  DrawingStroke({
-    required this.points,
-    required this.color,
-    required this.width,
-    this.isEraser = false,
-  });
-}
-
-/// An image pinned onto the canvas.
-class CanvasImage {
-  Offset position;
-  Size size;
-  final ui.Image image;
-
-  CanvasImage({
-    required this.position,
-    required this.size,
-    required this.image,
-  });
-}
-
-/// Drawing tool mode.
-enum DrawingTool { pen, eraser }
-
-/// Transparent overlay canvas for freehand drawing in the voice lounge.
+/// Transparent pointer-capture overlay for freehand drawing in the voice
+/// lounge.
 ///
-/// Captures pointer events and renders smoothed strokes using quadratic
-/// Bezier interpolation.
-class LoungeDrawingCanvas extends StatefulWidget {
+/// All stroke state (in-progress + committed) is owned by [canvasProvider]
+/// so it broadcasts to other participants and persists.  This widget is
+/// purely a pointer router: when [isActive] is true it sits above the voice
+/// canvas, captures pointer events that would otherwise hit avatars or
+/// shared-screen tiles, and forwards them to the provider as normalized
+/// `CanvasPoint`s.
+///
+/// Rendering of strokes (committed and in-progress) happens in
+/// `widgets/voice_canvas.dart`'s `_DrawingLayer`, which subscribes to the
+/// same provider state.  Without this overlay, drawing-mode pointer events
+/// would race with avatar drag handlers and stroke broadcast was previously
+/// not happening at all (#752).
+class LoungeDrawingCanvas extends ConsumerStatefulWidget {
   final bool isActive;
 
   const LoungeDrawingCanvas({super.key, required this.isActive});
 
   @override
-  State<LoungeDrawingCanvas> createState() => LoungeDrawingCanvasState();
+  ConsumerState<LoungeDrawingCanvas> createState() =>
+      LoungeDrawingCanvasState();
 }
 
-class LoungeDrawingCanvasState extends State<LoungeDrawingCanvas> {
-  final List<DrawingStroke> _strokes = [];
-  final List<CanvasImage> _images = [];
+class LoungeDrawingCanvasState extends ConsumerState<LoungeDrawingCanvas> {
+  Size _canvasSize = Size.zero;
 
-  /// Active stroke points accumulated during a drag. Mutable for performance
-  /// (avoids O(n) list copy on every pointer move). Wrapped in a DrawingStroke
-  /// only when the stroke is finalized on pointer up.
-  List<Offset>? _activePoints;
-  Color _activeColor = EchoTheme.textPrimary;
-  double _activeWidth = 3.0;
-  bool _activeIsEraser = false;
-
-  /// Index of image being dragged, or -1.
-  int _draggingIndex = -1;
-  Offset _dragStart = Offset.zero;
-
-  DrawingTool _tool = DrawingTool.pen;
-  Color _penColor = EchoTheme.textPrimary;
-  double _penSize = 3.0;
-  static const double _eraserSize = 20.0;
-
-  DrawingTool get tool => _tool;
-  Color get penColor => _penColor;
-  double get penSize => _penSize;
-
-  void setTool(DrawingTool tool) => setState(() => _tool = tool);
-  void setPenColor(Color color) => setState(() => _penColor = color);
-  void setPenSize(double size) => setState(() => _penSize = size);
-
-  void clearMyDrawings() {
-    setState(() {
-      _strokes.clear();
-      _images.clear();
-      _activePoints = null;
-    });
-  }
-
-  /// Load image from raw bytes and pin it to the canvas center.
-  Future<void> addImageFromBytes(Uint8List bytes) async {
-    await _addImageFromBytes(bytes);
-  }
-
-  /// Load an image from a URL and pin it to the canvas center.
-  Future<void> addImageFromUrl(
-    String url, {
-    Map<String, String>? headers,
-  }) async {
-    try {
-      final response = await http.get(Uri.parse(url), headers: headers);
-      if (response.statusCode != 200) {
-        debugPrint(
-          '[DrawingCanvas] Image fetch failed: ${response.statusCode}',
-        );
-        return;
-      }
-      await _addImageFromBytes(response.bodyBytes);
-    } catch (e) {
-      debugPrint('[DrawingCanvas] Failed to load image from URL: $e');
-    }
-  }
-
-  /// Read image data from the system clipboard and pin it to the canvas.
-  Future<void> addImageFromClipboard() async {
-    try {
-      final data = await Clipboard.getData('text/plain');
-      // Check if clipboard contains a URL
-      final text = data?.text?.trim() ?? '';
-      if (text.startsWith('http://') || text.startsWith('https://')) {
-        final uri = Uri.tryParse(text);
-        if (uri != null) {
-          await addImageFromUrl(text);
-          return;
-        }
-      }
-    } catch (e) {
-      debugPrint('[DrawingCanvas] Clipboard read failed: $e');
-    }
-  }
-
-  Future<void> _addImageFromBytes(Uint8List bytes) async {
-    final codec = await ui.instantiateImageCodec(bytes);
-    final frame = await codec.getNextFrame();
-    final image = frame.image;
-
-    // Scale to fit within 200px max dimension
-    final scale = 200.0 / image.width.toDouble().clamp(1, double.infinity);
-    final w = image.width * scale;
-    final h = image.height * scale;
-
-    if (!mounted) return;
-    final canvasSize = context.size ?? const Size(400, 400);
-    setState(() {
-      _images.add(
-        CanvasImage(
-          position: Offset(
-            (canvasSize.width - w) / 2,
-            (canvasSize.height - h) / 2,
-          ),
-          size: Size(w, h),
-          image: image,
-        ),
-      );
-    });
-  }
-
-  /// Check if pointer hits an image (top-most first).
-  int _hitTestImage(Offset pos) {
-    for (int i = _images.length - 1; i >= 0; i--) {
-      final img = _images[i];
-      final rect = Rect.fromLTWH(
-        img.position.dx,
-        img.position.dy,
-        img.size.width,
-        img.size.height,
-      );
-      if (rect.contains(pos)) return i;
-    }
-    return -1;
+  CanvasPoint _toNormalized(Offset pixel) {
+    final w = _canvasSize.width;
+    final h = _canvasSize.height;
+    if (w <= 0 || h <= 0) return const CanvasPoint(x: 0, y: 0);
+    return CanvasPoint(
+      x: (pixel.dx / w).clamp(0.0, 1.0),
+      y: (pixel.dy / h).clamp(0.0, 1.0),
+    );
   }
 
   void _onPointerDown(PointerDownEvent event) {
-    if (!widget.isActive) return;
     if (event.buttons != kPrimaryButton) return;
-
-    // Check if tapping on an image (drag to reposition)
-    final imgIdx = _hitTestImage(event.localPosition);
-    if (imgIdx >= 0) {
-      _draggingIndex = imgIdx;
-      _dragStart = event.localPosition - _images[imgIdx].position;
-      return;
-    }
-
-    setState(() {
-      _activePoints = [event.localPosition];
-      _activeColor = _tool == DrawingTool.eraser
-          ? Colors.transparent
-          : _penColor;
-      _activeWidth = _tool == DrawingTool.eraser ? _eraserSize : _penSize;
-      _activeIsEraser = _tool == DrawingTool.eraser;
-    });
+    ref
+        .read(canvasProvider.notifier)
+        .startStroke(_toNormalized(event.localPosition));
   }
 
   void _onPointerMove(PointerMoveEvent event) {
-    if (!widget.isActive) return;
-
-    if (_draggingIndex >= 0) {
-      setState(() {
-        _images[_draggingIndex].position = event.localPosition - _dragStart;
-      });
-      return;
-    }
-
-    if (_activePoints == null) return;
-    setState(() {
-      _activePoints!.add(event.localPosition);
-    });
+    if (event.buttons != kPrimaryButton) return;
+    ref
+        .read(canvasProvider.notifier)
+        .continueStroke(_toNormalized(event.localPosition));
   }
 
   void _onPointerUp(PointerUpEvent event) {
-    if (_draggingIndex >= 0) {
-      _draggingIndex = -1;
-      return;
-    }
-    if (_activePoints == null) return;
-    setState(() {
-      _strokes.add(
-        DrawingStroke(
-          points: List.from(_activePoints!),
-          color: _activeColor,
-          width: _activeWidth,
-          isEraser: _activeIsEraser,
-        ),
-      );
-      _activePoints = null;
-    });
+    ref.read(canvasProvider.notifier).endStroke();
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    ref.read(canvasProvider.notifier).endStroke();
   }
 
   @override
   Widget build(BuildContext context) {
-    final hasContent =
-        _strokes.isNotEmpty || _activePoints != null || _images.isNotEmpty;
-
-    // Always render strokes/images; only capture pointer events when active.
-    if (!widget.isActive && !hasContent) return const SizedBox.shrink();
-
-    // Build a temporary DrawingStroke for the active points so the painter
-    // can render the in-progress stroke. This is the only allocation per
-    // frame and is O(1) since we share the same list reference.
-    final activeStroke = _activePoints != null
-        ? DrawingStroke(
-            points: _activePoints!,
-            color: _activeColor,
-            width: _activeWidth,
-            isEraser: _activeIsEraser,
-          )
-        : null;
-
-    final painter = RepaintBoundary(
-      child: CustomPaint(
-        size: Size.infinite,
-        painter: _DrawingPainter(
-          strokes: _strokes,
-          currentStroke: activeStroke,
-          images: _images,
-        ),
-      ),
-    );
-
-    if (!widget.isActive) {
-      return IgnorePointer(child: painter);
-    }
-
-    return Listener(
-      onPointerDown: _onPointerDown,
-      onPointerMove: _onPointerMove,
-      onPointerUp: _onPointerUp,
-      behavior: HitTestBehavior.translucent,
-      child: painter,
-    );
-  }
-}
-
-class _DrawingPainter extends CustomPainter {
-  final List<DrawingStroke> strokes;
-  final DrawingStroke? currentStroke;
-  final List<CanvasImage> images;
-
-  _DrawingPainter({
-    required this.strokes,
-    this.currentStroke,
-    this.images = const [],
-  });
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    // saveLayer so BlendMode.clear (eraser) works on the stroke layer
-    canvas.saveLayer(Offset.zero & size, Paint());
-
-    // Draw pinned images first (below strokes)
-    for (final img in images) {
-      final dst = Rect.fromLTWH(
-        img.position.dx,
-        img.position.dy,
-        img.size.width,
-        img.size.height,
-      );
-      final src = Rect.fromLTWH(
-        0,
-        0,
-        img.image.width.toDouble(),
-        img.image.height.toDouble(),
-      );
-      canvas.drawImageRect(img.image, src, dst, Paint());
-    }
-
-    for (final stroke in strokes) {
-      _drawStroke(canvas, stroke);
-    }
-    if (currentStroke != null) {
-      _drawStroke(canvas, currentStroke!);
-    }
-
-    canvas.restore();
-  }
-
-  void _drawStroke(Canvas canvas, DrawingStroke stroke) {
-    if (stroke.points.isEmpty) return;
-
-    final paint = Paint()
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round
-      ..strokeWidth = stroke.width
-      ..style = PaintingStyle.stroke;
-
-    if (stroke.isEraser) {
-      // BlendMode.clear punches out alpha; the color value doesn't affect the
-      // result, but an explicit fully-transparent color avoids a warning on
-      // some Flutter build configurations where a missing color may fall back
-      // to opaque black and render unexpectedly on non-isolated layers.
-      paint
-        ..blendMode = ui.BlendMode.clear
-        ..color = const Color(0x00000000);
-    } else {
-      paint.color = stroke.color;
-    }
-
-    final pts = stroke.points;
-
-    // Single-point tap: draw a dot.
-    if (pts.length == 1) {
-      canvas.drawCircle(
-        pts[0],
-        stroke.width / 2,
-        paint..style = PaintingStyle.fill,
-      );
-      return;
-    }
-
-    // Build a smoothed path using quadratic Bezier curves
-    final path = ui.Path();
-
-    path.moveTo(pts[0].dx, pts[0].dy);
-
-    if (pts.length == 2) {
-      path.lineTo(pts[1].dx, pts[1].dy);
-    } else {
-      // Use midpoints as control anchors for smooth curves
-      for (int i = 1; i < pts.length - 1; i++) {
-        final mid = Offset(
-          (pts[i].dx + pts[i + 1].dx) / 2,
-          (pts[i].dy + pts[i + 1].dy) / 2,
+    if (!widget.isActive) return const SizedBox.shrink();
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        _canvasSize = Size(constraints.maxWidth, constraints.maxHeight);
+        return Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: _onPointerDown,
+          onPointerMove: _onPointerMove,
+          onPointerUp: _onPointerUp,
+          onPointerCancel: _onPointerCancel,
+          child: const SizedBox.expand(),
         );
-        path.quadraticBezierTo(pts[i].dx, pts[i].dy, mid.dx, mid.dy);
-      }
-      // Final segment
-      final last = pts.last;
-      path.lineTo(last.dx, last.dy);
-    }
-
-    canvas.drawPath(path, paint..style = PaintingStyle.stroke);
+      },
+    );
   }
-
-  @override
-  bool shouldRepaint(covariant _DrawingPainter oldDelegate) =>
-      currentStroke != null ||
-      strokes.length != oldDelegate.strokes.length ||
-      images.length != oldDelegate.images.length;
 }


### PR DESCRIPTION
## Summary

Closes the stroke-sync half of #752. Voice-lounge drawings now broadcast to other participants in real time. Previously each user could only see their own strokes — strokes were stored in a local `_strokes` list on `LoungeDrawingCanvas` and never went through `canvasProvider`, so they never broadcast.

The image-dup half of #752 closed in #763. With this PR, #752 is fully resolved.

## Root cause

`LoungeDrawingCanvas` was a stateful overlay widget that captured pointer events when drawing mode was active and tracked **its own** `_strokes` list. Meanwhile `VoiceCanvas` already had a `_DrawingLayer` that routes pointer events through `canvasProvider.startStroke/continueStroke/endStroke` (which broadcasts via WebSocket). But `LoungeDrawingCanvas` sat on top of `VoiceCanvas` in the stack and intercepted all pointer events when active. So pointers never reached the broadcasting layer.

## Fix

Slim `LoungeDrawingCanvas` down to a **pure pointer-capture overlay**:

- It's still positioned above `VoiceCanvas` so drawing-mode pointer events don't get stolen by avatar drag handlers (its original purpose).
- But pointer events now route to `canvasProvider.startStroke/continueStroke/endStroke` (in normalized canvas coordinates).
- Local `_strokes` / `_images` / `_DrawingPainter` removed — `VoiceCanvas`'s `_DrawingLayer` already renders all strokes from `canvasProvider.state`.
- `DrawingStroke`, the legacy `CanvasImage`, and `DrawingTool` types removed (the model layer's `CanvasImage` and `CanvasTool` are now used everywhere).
- Public widget-state methods (`addImageFromBytes`, `addImageFromUrl`, `addImageFromClipboard`, `setTool`, `setPenColor`, `setPenSize`, `clearMyDrawings`) removed — all of these manipulated the now-removed local state. Calls flow through `canvasProvider` directly.

`drawing_tools_menu.dart` simplified accordingly:
- Drops `drawingCanvasKey` parameter and the `_canvas` getter.
- Replaces the `_canvas?.X(...)` calls with `ref.read(canvasProvider.notifier).X(...)`.
- `DrawingTool` enum replaced with `CanvasTool` from `canvas_models.dart`.
- `_pickAndAddImage` no-conv and upload-failed branches now show a snackbar instead of a local-only image preview that wouldn't sync.

`voice_lounge_screen.dart`:
- Drops the `_drawingCanvasKey` field and the `key:`/`drawingCanvasKey:` plumbing.

## What gets fixed

- ✅ User A draws a stroke → User B sees it in real time (broadcast via existing `canvas_event` WS path).
- ✅ Sender no longer renders strokes from two widgets simultaneously (was visual-only doubling on the sender's screen).
- ✅ Existing image-dup fix from #763 stays intact (provider is still the single source of truth for image add).

## What's NOT in this PR

- The pre-existing `chat_panel.dart:1945` GlobalKey reach-in (`_chatInputBarKey.currentState!.buildMediaPickerPanel()`) — separate coupling smell.
- `_pickAndAddImage`'s no-conv / upload-failed snackbars previously had a "shown locally only" fallback that displayed the image bytes locally without syncing. That fallback is gone (it produced confusing UX where the local user saw an image other participants didn't). The error toasts are clearer now.

## Verification

- `dart format --set-exit-if-changed .` clean
- `flutter analyze --fatal-infos` clean
- `flutter test` 1302 passed / 8 skipped / 0 failed (identical baseline)

## Manual test

1. Two users join the same voice lounge.
2. User A: tap drawing tools → pick pen + color → draw a stroke on the canvas.
3. **Expected**: User B sees the stroke appear within ~100ms.
4. User A drops an image → exactly one image, draggable, position syncs to User B.
5. User A clicks Clear → strokes + images vanish on both sides.

## Diff stat

3 files changed, 87 insertions(+), 389 deletions(−). Most of the deletion is the removed local `_DrawingPainter`, `DrawingStroke`, `CanvasImage`, and the public mutation methods.

Closes #752