### PR TITLE
refactor(client): extract full reaction picker from chat_panel (4/7)

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:desktop_drop/desktop_drop.dart';
-import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
@@ -35,6 +34,7 @@ import 'chat/session_corrupted_banner.dart';
 import 'chat_panel/chat_message_list.dart';
 import 'chat_panel/drop_overlay.dart';
 import 'chat_panel/floating_date_pill.dart';
+import 'chat_panel/full_reaction_picker.dart';
 import 'chat_panel/new_messages_pill.dart';
 import 'chat_panel/no_conversation_placeholder.dart';
 import 'connection_status_banner.dart';
@@ -972,59 +972,12 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   }
 
   void _showFullReactionPicker(ChatMessage message, String myUserId) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: context.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (sheetContext) => SizedBox(
-        height: 380,
-        child: EmojiPicker(
-          onEmojiSelected: (_, emoji) {
-            Navigator.of(sheetContext).pop();
-            final alreadyReacted = message.reactions.any(
-              (r) => r.emoji == emoji.emoji && r.userId == myUserId,
-            );
-            _toggleReaction(message, emoji.emoji, alreadyReacted);
-          },
-          config: Config(
-            height: 380,
-            checkPlatformCompatibility: true,
-            emojiViewConfig: EmojiViewConfig(
-              backgroundColor: context.surface,
-              columns: 9,
-              emojiSizeMax: 28,
-              verticalSpacing: 0,
-              horizontalSpacing: 0,
-              noRecents: Text(
-                'No recents yet.',
-                style: TextStyle(fontSize: 12, color: context.textMuted),
-              ),
-            ),
-            categoryViewConfig: CategoryViewConfig(
-              initCategory: Category.SMILEYS,
-              recentTabBehavior: RecentTabBehavior.RECENT,
-              backgroundColor: context.surface,
-              indicatorColor: context.accent,
-              iconColorSelected: context.accent,
-              iconColor: context.textMuted,
-            ),
-            skinToneConfig: SkinToneConfig(
-              enabled: true,
-              dialogBackgroundColor: context.surface,
-              indicatorColor: context.accent,
-            ),
-            bottomActionBarConfig: const BottomActionBarConfig(enabled: false),
-            searchViewConfig: SearchViewConfig(
-              backgroundColor: context.surface,
-              buttonIconColor: context.textSecondary,
-              hintText: 'Find an emoji...',
-            ),
-          ),
-        ),
-      ),
+    showFullReactionPicker(
+      context,
+      message: message,
+      myUserId: myUserId,
+      onPick: (emoji, alreadyReacted) =>
+          _toggleReaction(message, emoji, alreadyReacted),
     );
   }
 

--- a/apps/client/lib/src/widgets/chat_panel/full_reaction_picker.dart
+++ b/apps/client/lib/src/widgets/chat_panel/full_reaction_picker.dart
@@ -1,0 +1,76 @@
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+
+/// Show the full emoji-picker bottom sheet for adding a reaction to a message.
+///
+/// Pulled out of `chat_panel.dart` so the picker is reusable from other
+/// surfaces (thread view, search results, etc.) without dragging the
+/// 232-line reaction-overlay machinery along with it.
+///
+/// `onPick` receives the chosen emoji and the boolean of whether the user
+/// already had that reaction (so the caller can flip add ↔ remove without
+/// re-deriving it).
+Future<void> showFullReactionPicker(
+  BuildContext context, {
+  required ChatMessage message,
+  required String myUserId,
+  required void Function(String emoji, bool alreadyReacted) onPick,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: context.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (sheetContext) => SizedBox(
+      height: 380,
+      child: EmojiPicker(
+        onEmojiSelected: (_, emoji) {
+          Navigator.of(sheetContext).pop();
+          final alreadyReacted = message.reactions.any(
+            (r) => r.emoji == emoji.emoji && r.userId == myUserId,
+          );
+          onPick(emoji.emoji, alreadyReacted);
+        },
+        config: Config(
+          height: 380,
+          checkPlatformCompatibility: true,
+          emojiViewConfig: EmojiViewConfig(
+            backgroundColor: context.surface,
+            columns: 9,
+            emojiSizeMax: 28,
+            verticalSpacing: 0,
+            horizontalSpacing: 0,
+            noRecents: Text(
+              'No recents yet.',
+              style: TextStyle(fontSize: 12, color: context.textMuted),
+            ),
+          ),
+          categoryViewConfig: CategoryViewConfig(
+            initCategory: Category.SMILEYS,
+            recentTabBehavior: RecentTabBehavior.RECENT,
+            backgroundColor: context.surface,
+            indicatorColor: context.accent,
+            iconColorSelected: context.accent,
+            iconColor: context.textMuted,
+          ),
+          skinToneConfig: SkinToneConfig(
+            enabled: true,
+            dialogBackgroundColor: context.surface,
+            indicatorColor: context.accent,
+          ),
+          bottomActionBarConfig: const BottomActionBarConfig(enabled: false),
+          searchViewConfig: SearchViewConfig(
+            backgroundColor: context.surface,
+            buttonIconColor: context.textSecondary,
+            hintText: 'Find an emoji...',
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Fourth god-module split per `.claude/plans/generic-growing-bentley.md`. Continues the existing `chat_panel/` folder pattern.

## What

Extract the 60-line modal-bottom-sheet emoji picker (`_showFullReactionPicker`) out of `chat_panel.dart` into a reusable `chat_panel/full_reaction_picker.dart` helper.

```
widgets/chat_panel/
├── chat_message_list.dart        # existing
├── date_divider.dart             # existing
├── drop_overlay.dart             # existing
├── empty_message_placeholder.dart  # existing
├── floating_date_pill.dart       # existing
├── full_reaction_picker.dart     # NEW (76 LoC)
├── new_messages_pill.dart        # existing
├── no_conversation_placeholder.dart  # existing
├── system_timeline_message.dart  # existing
└── unread_divider.dart           # existing
```

Net `chat_panel.dart` reduction: 1998 → 1952 LoC. Also drops the `emoji_picker_flutter` import from the main file since it's now only needed by the helper.

## Why this scope

The remaining big clusters in `chat_panel.dart` (message-action handlers, scroll machinery, reaction-overlay state) require careful design to mixin or co-class — they share private fields (`_reactionOverlay`, scroll controllers, message keys) heavily with the state class. Those are explicitly deferred to follow-up PRs so this one stays a pure-pull, zero-risk extraction.

## Test plan

- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test test/widgets/chat_panel_test.dart` — all 15 pass
- [ ] CI lanes