### PR TITLE
refactor(client): extract media marker helpers from chat_input_bar (5/7)

### DIFF
--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -32,6 +32,7 @@ import '../theme/responsive.dart';
 import '../utils/clipboard_image_helper.dart';
 import 'chat_input_bar/attach_file_button.dart';
 import 'chat_input_bar/attach_option.dart';
+import 'chat_input_bar/media_marker_helpers.dart';
 import 'chat_input_bar/media_picker_toggle.dart';
 import 'chat_input_bar/recording_row.dart';
 import 'chat_input_bar/send_button.dart';
@@ -73,7 +74,10 @@ String _formatBytes(int bytes) {
   return '${v.toStringAsFixed(1)} ${units[i]}';
 }
 
-const _kImageGif = 'image/gif';
+// Marker / MIME helpers live in chat_input_bar/media_marker_helpers.dart.
+// Local alias preserves the `_kImageGif` symbol used at three call sites
+// in this file without touching them.
+const _kImageGif = kImageGifMimeType;
 
 /// Extracted chat input bar from ChatPanel (~850 lines).
 ///
@@ -407,7 +411,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       _saveDraftImmediate(widget.conversation.id, '');
       for (var i = 0; i < attachments.length; i++) {
         final att = attachments[i];
-        final marker = _buildMediaMarker(
+        final marker = buildMediaMarker(
           extension: att.ext,
           url: att.uploadedUrl!,
         );
@@ -600,51 +604,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   }
 
   // ---------------------------------------------------------------------------
-  // Media marker helpers
-  // ---------------------------------------------------------------------------
-
-  String _buildMediaMarker({required String extension, required String url}) {
-    const imageExts = {'jpg', 'jpeg', 'png', 'gif', 'webp'};
-    const videoExts = {'mp4', 'webm', 'mov'};
-    const audioExts = {'mp3', 'ogg', 'wav', 'm4a', 'aac'};
-
-    final ext = extension.toLowerCase();
-    if (imageExts.contains(ext)) {
-      return '[img:$url]';
-    }
-    if (videoExts.contains(ext)) {
-      return '[video:$url]';
-    }
-    if (audioExts.contains(ext)) {
-      return '[audio:$url]';
-    }
-    return '[file:$url]';
-  }
-
-  String _extensionFromMime(String mimeType) {
-    switch (mimeType.toLowerCase()) {
-      case 'image/jpeg':
-        return 'jpg';
-      case 'image/png':
-        return 'png';
-      case _kImageGif:
-        return 'gif';
-      case 'image/webp':
-        return 'webp';
-      case 'video/mp4':
-        return 'mp4';
-      case 'video/webm':
-        return 'webm';
-      case 'video/quicktime':
-        return 'mov';
-      case 'application/pdf':
-        return 'pdf';
-      default:
-        return 'bin';
-    }
-  }
-
-  // ---------------------------------------------------------------------------
   // Pending attachment helpers (Discord-style preview before send)
   // ---------------------------------------------------------------------------
 
@@ -800,7 +759,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       bytes: image.bytes,
       fileName: image.fileName,
       mimeType: image.mimeType,
-      ext: _extensionFromMime(image.mimeType),
+      ext: extensionFromMime(image.mimeType),
     );
   }
 
@@ -883,7 +842,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       mimeType: mimeType,
     );
     if (!mounted || url == null) return;
-    final marker = _buildMediaMarker(extension: ext, url: url);
+    final marker = buildMediaMarker(extension: ext, url: url);
     await _doSend(marker);
   }
 

--- a/apps/client/lib/src/widgets/chat_input_bar/media_marker_helpers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/media_marker_helpers.dart
@@ -1,0 +1,54 @@
+/// Pure helpers for building the `[img:URL]` / `[video:URL]` / `[audio:URL]`
+/// / `[file:URL]` markers the chat-render pipeline understands, plus a
+/// MIME → extension fallback used when the picker hands over bytes without
+/// a usable filename.
+///
+/// Pulled out of `chat_input_bar.dart` (~50 LoC) so the marker format is
+/// reusable from paste / drop / gif-picker code paths without dragging the
+/// 2071-line state class into scope.
+library;
+
+const String kImageGifMimeType = 'image/gif';
+
+const _imageExts = {'jpg', 'jpeg', 'png', 'gif', 'webp'};
+const _videoExts = {'mp4', 'webm', 'mov'};
+const _audioExts = {'mp3', 'ogg', 'wav', 'm4a', 'aac'};
+
+/// Build the marker string for a media attachment.
+///
+/// `extension` is matched case-insensitively against the image / video /
+/// audio sets; anything else falls back to `[file:URL]` so the receiver
+/// renders a generic-file affordance.
+String buildMediaMarker({required String extension, required String url}) {
+  final ext = extension.toLowerCase();
+  if (_imageExts.contains(ext)) return '[img:$url]';
+  if (_videoExts.contains(ext)) return '[video:$url]';
+  if (_audioExts.contains(ext)) return '[audio:$url]';
+  return '[file:$url]';
+}
+
+/// Best-effort MIME → file-extension lookup for the few types Echo
+/// recognizes natively. Unknown MIMEs return `'bin'` so the marker still
+/// produces a useful `[file:URL]` rather than a broken inline preview.
+String extensionFromMime(String mimeType) {
+  switch (mimeType.toLowerCase()) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case kImageGifMimeType:
+      return 'gif';
+    case 'image/webp':
+      return 'webp';
+    case 'video/mp4':
+      return 'mp4';
+    case 'video/webm':
+      return 'webm';
+    case 'video/quicktime':
+      return 'mov';
+    case 'application/pdf':
+      return 'pdf';
+    default:
+      return 'bin';
+  }
+}


### PR DESCRIPTION
Fifth god-module split per `.claude/plans/generic-growing-bentley.md`. Continues the existing `chat_input_bar/` folder pattern.

## What

Extract the marker-building + MIME→extension fallback (two pure helpers, ~50 LoC) into `chat_input_bar/media_marker_helpers.dart`.

```
widgets/chat_input_bar/
├── attach_file_button.dart       # existing
├── attach_option.dart            # existing
├── live_waveform_bars.dart       # existing
├── media_marker_helpers.dart     # NEW (54 LoC)
├── media_picker_toggle.dart      # existing
├── pulsing_dot.dart              # existing
├── recording_row.dart            # existing
└── send_button.dart              # existing
```

Net `chat_input_bar.dart` reduction: 2071 → 2030 LoC.

## Why this scope

The other large clusters in `chat_input_bar.dart` — text-input state with mention picker / drafts, the 401-retrying upload pipeline, voice-recorder state — share heavy mutable state with `ChatInputBarState`. Pulling them out cleanly requires a stateful split that needs more design care; explicitly deferred to follow-up PRs so this one stays a zero-risk pure-function pull.

## Test plan

- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test test/widgets/chat_input_bar_attachments_test.dart` — 3/3 pass
- [ ] CI lanes