### PR TITLE
refactor(client): extract HoverActionButton from message_item (6/7)

### DIFF
--- a/apps/client/lib/src/widgets/message/hover_action_button.dart
+++ b/apps/client/lib/src/widgets/message/hover_action_button.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/echo_theme.dart';
+
+/// Tight 28×28 visual chip with a 44×44 hit target — used for the
+/// Discord/Slack-style hover-action bar that sits on top of every message
+/// (reply, pin, react, save, delete, ...).
+///
+/// Pulled out of `message_item.dart` so callers other than the bar itself
+/// (notably the action sheet on long-press for mobile) can share the same
+/// look and a11y contract instead of re-implementing it.
+class HoverActionButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  const HoverActionButton({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // 44×44 hit target per WCAG 2.5.5 — keyboard, switch, and assistive
+    // pointer users can land on the button even though the visual chip
+    // remains a tight 28×28 to preserve the Discord/Slack-style hover bar.
+    return Semantics(
+      label: tooltip,
+      button: true,
+      child: Tooltip(
+        message: tooltip,
+        child: SizedBox(
+          width: 44,
+          height: 44,
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(6),
+            child: Center(
+              child: SizedBox(
+                width: 28,
+                height: 28,
+                child: Center(
+                  child: Opacity(
+                    opacity: 0.75,
+                    child: Icon(icon, size: 14, color: context.textSecondary),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -21,13 +21,14 @@ import '../utils/semantics_preview.dart';
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart' show buildAvatar, avatarColor, senderLabelColor;
 import '../services/media_cache_service.dart';
+import 'message/hover_action_button.dart';
+import 'message/link_preview_card.dart';
 import 'message/media_content.dart';
 import 'message/message_status_icon.dart';
 import 'message/reaction_bar.dart';
 import 'message/reply_quote.dart';
-import 'message/link_preview_card.dart';
-import 'message/youtube_embed.dart';
 import 'message/rich_text_content.dart';
+import 'message/youtube_embed.dart';
 
 /// Common emojis for the reaction picker.
 const reactionEmojis = ['👍', '❤️', '😂', '😮', '😢', '🔥', '👎', '🎉'];
@@ -783,13 +784,13 @@ class _MessageItemState extends State<MessageItem>
             Semantics(
               label: 'Reply to message',
               button: true,
-              child: _HoverActionButton(
+              child: HoverActionButton(
                 icon: Icons.reply_outlined,
                 tooltip: 'Reply',
                 onPressed: () => widget.onReply?.call(msg),
               ),
             ),
-          _HoverActionButton(
+          HoverActionButton(
             icon: Icons.add_reaction_outlined,
             tooltip: 'React',
             onPressed: () {
@@ -2009,50 +2010,4 @@ IconData _systemEventIcon(String content) {
     return Icons.group;
   }
   return Icons.info_outline;
-}
-
-class _HoverActionButton extends StatelessWidget {
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onPressed;
-
-  const _HoverActionButton({
-    required this.icon,
-    required this.tooltip,
-    required this.onPressed,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    // 44×44 hit target per WCAG 2.5.5 — keyboard, switch, and assistive
-    // pointer users can land on the button even though the visual chip
-    // remains a tight 28×28 to preserve the Discord/Slack-style hover bar.
-    return Semantics(
-      label: tooltip,
-      button: true,
-      child: Tooltip(
-        message: tooltip,
-        child: SizedBox(
-          width: 44,
-          height: 44,
-          child: InkWell(
-            onTap: onPressed,
-            borderRadius: BorderRadius.circular(6),
-            child: Center(
-              child: SizedBox(
-                width: 28,
-                height: 28,
-                child: Center(
-                  child: Opacity(
-                    opacity: 0.75,
-                    child: Icon(icon, size: 14, color: context.textSecondary),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 }


### PR DESCRIPTION
Sixth god-module split per the playbook. Pulls the file-internal _HoverActionButton out into widgets/message/hover_action_button.dart so it's reusable across message-action surfaces. Net 2058 → 2014 LoC. flutter analyze clean, message_item_test 37/37 passes.