### PR TITLE
refactor(client): migrate screen_share_provider to @Riverpod (10/22)

### DIFF
--- a/apps/client/lib/src/providers/screen_share_provider.dart
+++ b/apps/client/lib/src/providers/screen_share_provider.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugPrint, defaultTargetPlatform, kIsWeb;
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'screen_share_provider.g.dart';
 
 /// State for screen sharing capture and local preview.
 class ScreenShareState {
@@ -22,9 +24,15 @@ class ScreenShareState {
   static const empty = ScreenShareState();
 }
 
-class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
+@Riverpod(keepAlive: true)
+class ScreenShare extends _$ScreenShare {
   MediaStream? _screenStream;
   RTCVideoRenderer? _screenRenderer;
+
+  /// True after the provider is disposed; gates state writes from
+  /// async callbacks (the StateNotifier `mounted` check has no
+  /// equivalent on Notifier so we track it manually).
+  bool _disposed = false;
 
   /// Expose the screen share stream for peer connection integration.
   MediaStream? get screenStream => _screenStream;
@@ -32,7 +40,15 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
   /// Expose the renderer so the UI can display a local preview.
   RTCVideoRenderer? get screenRenderer => _screenRenderer;
 
-  ScreenShareNotifier() : super(ScreenShareState.empty);
+  @override
+  ScreenShareState build() {
+    ref.onDispose(() {
+      _disposed = true;
+      // Fire-and-forget cleanup when the provider is torn down.
+      unawaited(stopScreenShare());
+    });
+    return ScreenShareState.empty;
+  }
 
   /// Begin capturing the user's screen via `getDisplayMedia`.
   ///
@@ -48,38 +64,25 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
         'audio': false,
       });
 
-      // Initialize the renderer for local preview.
-      final renderer = RTCVideoRenderer();
-      await renderer.initialize();
-      renderer.srcObject = stream;
-
       _screenStream = stream;
-      _screenRenderer = renderer;
+      _screenRenderer = RTCVideoRenderer();
+      await _screenRenderer!.initialize();
+      _screenRenderer!.srcObject = stream;
+
+      // Auto-stop on user-cancellation via browser native UI.
+      stream.getVideoTracks().firstOrNull?.onEnded = () {
+        debugPrint('[ScreenShare] track ended (user cancelled)');
+        unawaited(stopScreenShare());
+      };
 
       state = state.copyWith(isScreenSharing: true, error: null);
-
-      // Listen for the user stopping the share via the browser/OS UI
-      // (e.g. clicking "Stop sharing" in Chrome's native bar).
-      final videoTracks = stream.getVideoTracks();
-      if (videoTracks.isNotEmpty) {
-        videoTracks.first.onEnded = () {
-          stopScreenShare();
-        };
-      }
     } catch (e) {
-      // getDisplayMedia can throw for many reasons:
-      // - User cancelled the picker dialog
-      // - Platform does not support screen capture
-      // - HTTPS required but not available
-      final message = _friendlyError(e);
-      state = state.copyWith(isScreenSharing: false, error: message);
       debugPrint('[ScreenShare] getDisplayMedia failed: $e');
+      state = state.copyWith(isScreenSharing: false, error: _friendlyError(e));
     }
   }
 
-  /// Stop screen sharing and release all resources.
-  ///
-  /// Safe to call even if no screen share is active — silently no-ops.
+  /// Stop the active capture, dispose the renderer, and clear state.
   Future<void> stopScreenShare() async {
     final stream = _screenStream;
     final renderer = _screenRenderer;
@@ -87,30 +90,27 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
     _screenStream = null;
     _screenRenderer = null;
 
-    if (stream != null) {
-      try {
-        for (final track in stream.getTracks()) {
-          track.stop();
-        }
-        await stream.dispose();
-      } catch (e) {
-        // Platform may throw "No active stream to cancel" if the capture
-        // was already released (e.g. getDisplayMedia failed on Linux).
-        debugPrint('[ScreenShare] Error disposing stream: $e');
-      }
-    }
-
     if (renderer != null) {
       try {
         renderer.srcObject = null;
         await renderer.dispose();
       } catch (e) {
-        // Renderer may already be disposed.
-        debugPrint('[ScreenShare] Error disposing renderer: $e');
+        debugPrint('[ScreenShare] renderer dispose failed: $e');
       }
     }
 
-    if (mounted) {
+    if (stream != null) {
+      try {
+        for (final track in stream.getTracks()) {
+          await track.stop();
+        }
+        await stream.dispose();
+      } catch (e) {
+        debugPrint('[ScreenShare] stream dispose failed: $e');
+      }
+    }
+
+    if (!_disposed) {
       state = state.copyWith(isScreenSharing: false, error: null);
     }
   }
@@ -120,13 +120,13 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
   /// Used when LiveKit SDK manages the capture internally via
   /// [LocalParticipant.setScreenShareEnabled].
   void setLiveKitScreenShareActive(bool active) {
-    if (mounted) {
+    if (!_disposed) {
       state = state.copyWith(isScreenSharing: active, error: null);
     }
   }
 
-  /// Map common exceptions to user-readable messages.
-  static String _friendlyError(Object error) {
+  /// Translate platform errors into actionable user-facing strings.
+  String _friendlyError(Object error) {
     final msg = error.toString().toLowerCase();
     if (msg.contains('notallowederror') || msg.contains('permission')) {
       return 'Screen sharing was cancelled or denied.';
@@ -147,16 +147,4 @@ class ScreenShareNotifier extends StateNotifier<ScreenShareState> {
     }
     return 'Could not start screen sharing: $error';
   }
-
-  @override
-  void dispose() {
-    // Fire-and-forget cleanup; the notifier is being torn down.
-    unawaited(stopScreenShare());
-    super.dispose();
-  }
 }
-
-final screenShareProvider =
-    StateNotifierProvider<ScreenShareNotifier, ScreenShareState>(
-      (ref) => ScreenShareNotifier(),
-    );

--- a/apps/client/lib/src/providers/screen_share_provider.g.dart
+++ b/apps/client/lib/src/providers/screen_share_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'screen_share_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$screenShareHash() => r'2aba7f83789a88d37543ddddf5a55ee439a448f9';
+
+/// See also [ScreenShare].
+@ProviderFor(ScreenShare)
+final screenShareProvider =
+    NotifierProvider<ScreenShare, ScreenShareState>.internal(
+      ScreenShare.new,
+      name: r'screenShareProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$screenShareHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ScreenShare = Notifier<ScreenShareState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/test/providers/screen_share_provider_test.dart
+++ b/apps/client/test/providers/screen_share_provider_test.dart
@@ -1,6 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:echo_app/src/providers/screen_share_provider.dart';
+
+ProviderContainer _container() {
+  final c = ProviderContainer();
+  addTearDown(c.dispose);
+  return c;
+}
 
 void main() {
   group('ScreenShareState', () {
@@ -25,44 +32,38 @@ void main() {
     });
   });
 
-  group('ScreenShareNotifier', () {
+  group('ScreenShare notifier', () {
     test('setLiveKitScreenShareActive(true) sets isScreenSharing', () {
-      final notifier = ScreenShareNotifier();
-      expect(notifier.state.isScreenSharing, isFalse);
+      final container = _container();
+      final notifier = container.read(screenShareProvider.notifier);
+      expect(container.read(screenShareProvider).isScreenSharing, isFalse);
 
       notifier.setLiveKitScreenShareActive(true);
-      expect(notifier.state.isScreenSharing, isTrue);
-      expect(notifier.state.error, isNull);
+      expect(container.read(screenShareProvider).isScreenSharing, isTrue);
+      expect(container.read(screenShareProvider).error, isNull);
     });
 
     test('setLiveKitScreenShareActive(false) clears isScreenSharing', () {
-      final notifier = ScreenShareNotifier();
+      final container = _container();
+      final notifier = container.read(screenShareProvider.notifier);
       notifier.setLiveKitScreenShareActive(true);
       notifier.setLiveKitScreenShareActive(false);
-      expect(notifier.state.isScreenSharing, isFalse);
+      expect(container.read(screenShareProvider).isScreenSharing, isFalse);
     });
 
     test('setLiveKitScreenShareActive clears any previous error', () {
-      final notifier = ScreenShareNotifier();
-      // Simulate an error state
+      final container = _container();
+      final notifier = container.read(screenShareProvider.notifier);
       notifier.setLiveKitScreenShareActive(true);
-      expect(notifier.state.error, isNull);
+      expect(container.read(screenShareProvider).error, isNull);
     });
 
     test('stopScreenShare when not sharing is a no-op', () async {
-      final notifier = ScreenShareNotifier();
+      final container = _container();
+      final notifier = container.read(screenShareProvider.notifier);
       // Should not throw
       await notifier.stopScreenShare();
-      expect(notifier.state.isScreenSharing, isFalse);
-    });
-  });
-
-  group('ScreenShareNotifier._friendlyError', () {
-    // _friendlyError is static -- access via the public class
-    test('maps NotAllowedError to user-friendly message', () {
-      // We can't call the private method directly, but we verify the state
-      // patterns it handles by testing the error messages indirectly.
-      // The method is static and private, so this is covered by integration.
+      expect(container.read(screenShareProvider).isScreenSharing, isFalse);
     });
   });
 }


### PR DESCRIPTION
Smallest leaf riverpod migration (#770). 162 LoC, leaf provider, no Ref ref. StateNotifier → Notifier shape with mounted → `_disposed` flag wired through ref.onDispose. setLiveKitScreenShareActive and stopScreenShare keep their disposed guards. Test rewritten to ProviderContainer + provider.notifier. Analyzer clean, 7/7 tests pass.