### PR TITLE
refactor(client): migrate voice_settings_provider to @Riverpod (11/22)

### DIFF
--- a/apps/client/lib/src/providers/voice_settings_provider.dart
+++ b/apps/client/lib/src/providers/voice_settings_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+part 'voice_settings_provider.g.dart';
 
 class VoiceSettingsState {
   final String inputDeviceId;
@@ -71,9 +73,12 @@ class VoiceSettingsState {
   }
 }
 
-class VoiceSettingsNotifier extends StateNotifier<VoiceSettingsState> {
-  VoiceSettingsNotifier() : super(const VoiceSettingsState()) {
+@Riverpod(keepAlive: true)
+class VoiceSettings extends _$VoiceSettings {
+  @override
+  VoiceSettingsState build() {
     _load();
+    return const VoiceSettingsState();
   }
 
   static const _keyInputDevice = 'voice_input_device_id';
@@ -221,8 +226,3 @@ class VoiceSettingsNotifier extends StateNotifier<VoiceSettingsState> {
     await _persist(next);
   }
 }
-
-final voiceSettingsProvider =
-    StateNotifierProvider<VoiceSettingsNotifier, VoiceSettingsState>((ref) {
-      return VoiceSettingsNotifier();
-    });

--- a/apps/client/lib/src/providers/voice_settings_provider.g.dart
+++ b/apps/client/lib/src/providers/voice_settings_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'voice_settings_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$voiceSettingsHash() => r'8203f11dc2ce3fd687eddedf83c71a7b848b6ad2';
+
+/// See also [VoiceSettings].
+@ProviderFor(VoiceSettings)
+final voiceSettingsProvider =
+    NotifierProvider<VoiceSettings, VoiceSettingsState>.internal(
+      VoiceSettings.new,
+      name: r'voiceSettingsProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$voiceSettingsHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$VoiceSettings = Notifier<VoiceSettingsState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/screens/settings/notification_section.dart
+++ b/apps/client/lib/src/screens/settings/notification_section.dart
@@ -732,7 +732,7 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
     }
   }
 
-  Future<void> _capturePushToTalkKey(VoiceSettingsNotifier notifier) async {
+  Future<void> _capturePushToTalkKey(VoiceSettings notifier) async {
     final result = await showDialog<Map<String, String>>(
       context: context,
       builder: (dialogContext) {

--- a/apps/client/test/providers/voice_settings_provider_test.dart
+++ b/apps/client/test/providers/voice_settings_provider_test.dart
@@ -1,7 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:echo_app/src/providers/voice_settings_provider.dart';
+
+ProviderContainer _container() {
+  final c = ProviderContainer();
+  addTearDown(c.dispose);
+  return c;
+}
 
 void main() {
   group('VoiceSettingsState', () {
@@ -53,19 +60,21 @@ void main() {
     });
   });
 
-  group('VoiceSettingsNotifier', () {
+  group('VoiceSettings notifier', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
     test('loads defaults from empty SharedPreferences', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      // Trigger build() then wait for async _load.
+      container.read(voiceSettingsProvider);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
-      expect(notifier.state.inputDeviceId, 'default');
-      expect(notifier.state.outputVolume, 1.0);
-      expect(notifier.state.noiseSuppression, isTrue);
-      notifier.dispose();
+      final state = container.read(voiceSettingsProvider);
+      expect(state.inputDeviceId, 'default');
+      expect(state.outputVolume, 1.0);
+      expect(state.noiseSuppression, isTrue);
     });
 
     test('loads persisted values', () async {
@@ -76,84 +85,86 @@ void main() {
         'voice_noise_suppression': false,
       });
 
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      container.read(voiceSettingsProvider);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
-      expect(notifier.state.inputDeviceId, 'mic-custom');
-      expect(notifier.state.outputVolume, 0.7);
-      expect(notifier.state.selfMuted, isTrue);
-      expect(notifier.state.noiseSuppression, isFalse);
-      notifier.dispose();
+      final state = container.read(voiceSettingsProvider);
+      expect(state.inputDeviceId, 'mic-custom');
+      expect(state.outputVolume, 0.7);
+      expect(state.selfMuted, isTrue);
+      expect(state.noiseSuppression, isFalse);
     });
 
     test('setInputDevice updates state and persists', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      final notifier = container.read(voiceSettingsProvider.notifier);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await notifier.setInputDevice('mic-new');
-      expect(notifier.state.inputDeviceId, 'mic-new');
+      expect(container.read(voiceSettingsProvider).inputDeviceId, 'mic-new');
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getString('voice_input_device_id'), 'mic-new');
-      notifier.dispose();
     });
 
     test('setOutputVolume updates state and persists', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      final notifier = container.read(voiceSettingsProvider.notifier);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await notifier.setOutputVolume(0.3);
-      expect(notifier.state.outputVolume, 0.3);
+      expect(container.read(voiceSettingsProvider).outputVolume, 0.3);
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getDouble('voice_output_volume'), 0.3);
-      notifier.dispose();
     });
 
     test('setSelfMuted updates state and persists', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      final notifier = container.read(voiceSettingsProvider.notifier);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await notifier.setSelfMuted(true);
-      expect(notifier.state.selfMuted, isTrue);
-      notifier.dispose();
+      expect(container.read(voiceSettingsProvider).selfMuted, isTrue);
     });
 
     test('setSelfDeafened updates state and persists', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      final notifier = container.read(voiceSettingsProvider.notifier);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await notifier.setSelfDeafened(true);
-      expect(notifier.state.selfDeafened, isTrue);
-      notifier.dispose();
+      expect(container.read(voiceSettingsProvider).selfDeafened, isTrue);
     });
 
     test('setNoiseSuppression updates state and persists', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      final notifier = container.read(voiceSettingsProvider.notifier);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await notifier.setNoiseSuppression(false);
-      expect(notifier.state.noiseSuppression, isFalse);
-      notifier.dispose();
+      expect(container.read(voiceSettingsProvider).noiseSuppression, isFalse);
     });
 
     test('setEchoCancellation updates state and persists', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      final notifier = container.read(voiceSettingsProvider.notifier);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await notifier.setEchoCancellation(false);
-      expect(notifier.state.echoCancellation, isFalse);
-      notifier.dispose();
+      expect(container.read(voiceSettingsProvider).echoCancellation, isFalse);
     });
 
     test('setPushToTalkKey updates both id and label', () async {
-      final notifier = VoiceSettingsNotifier();
+      final container = _container();
+      final notifier = container.read(voiceSettingsProvider.notifier);
       await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await notifier.setPushToTalkKey(keyId: '65', keyLabel: 'A');
-      expect(notifier.state.pushToTalkKeyId, '65');
-      expect(notifier.state.pushToTalkKeyLabel, 'A');
-      notifier.dispose();
+      final state = container.read(voiceSettingsProvider);
+      expect(state.pushToTalkKeyId, '65');
+      expect(state.pushToTalkKeyLabel, 'A');
     });
   });
 }

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -98,15 +98,16 @@ class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
   }
 }
 
-class _FakeVoiceSettingsNotifier extends VoiceSettingsNotifier {
-  _FakeVoiceSettingsNotifier();
+class _FakeVoiceSettings extends VoiceSettings {
+  @override
+  VoiceSettingsState build() => const VoiceSettingsState();
 }
 
 /// Fake that has confirmBeforeJoinVoice = true so confirmation-dialog tests work.
-class _FakeVoiceSettingsNotifierConfirm extends VoiceSettingsNotifier {
-  _FakeVoiceSettingsNotifierConfirm() {
-    state = state.copyWith(confirmBeforeJoinVoice: true);
-  }
+class _FakeVoiceSettingsConfirm extends VoiceSettings {
+  @override
+  VoiceSettingsState build() =>
+      const VoiceSettingsState(confirmBeforeJoinVoice: true);
 }
 
 void main() {
@@ -132,9 +133,7 @@ void main() {
             fakeVoiceRtc = _FakeVoiceRtcNotifier(ref);
             return fakeVoiceRtc;
           }),
-          voiceSettingsProvider.overrideWith(
-            (ref) => _FakeVoiceSettingsNotifierConfirm(),
-          ),
+          voiceSettingsProvider.overrideWith(_FakeVoiceSettingsConfirm.new),
         ],
       );
       await tester.pumpAndSettle();
@@ -176,9 +175,7 @@ void main() {
             fakeVoiceRtc = _FakeVoiceRtcNotifier(ref);
             return fakeVoiceRtc;
           }),
-          voiceSettingsProvider.overrideWith(
-            (ref) => _FakeVoiceSettingsNotifierConfirm(),
-          ),
+          voiceSettingsProvider.overrideWith(_FakeVoiceSettingsConfirm.new),
         ],
       );
       await tester.pumpAndSettle();
@@ -222,9 +219,7 @@ void main() {
             fakeVoiceRtc = _FakeVoiceRtcNotifier(ref);
             return fakeVoiceRtc;
           }),
-          voiceSettingsProvider.overrideWith(
-            (ref) => _FakeVoiceSettingsNotifier(),
-          ),
+          voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
         ],
       );
       await tester.pumpAndSettle();

--- a/apps/client/test/widgets/chat_input_bar_test.dart
+++ b/apps/client/test/widgets/chat_input_bar_test.dart
@@ -45,15 +45,12 @@ class _FakeChatNotifier extends ChatNotifier {
 
 /// Override [voiceSettingsProvider] with default state.
 Override voiceSettingsOverride() {
-  return voiceSettingsProvider.overrideWith(
-    (ref) => _FakeVoiceSettingsNotifier(),
-  );
+  return voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new);
 }
 
-class _FakeVoiceSettingsNotifier extends VoiceSettingsNotifier {
-  _FakeVoiceSettingsNotifier() {
-    state = const VoiceSettingsState();
-  }
+class _FakeVoiceSettings extends VoiceSettings {
+  @override
+  VoiceSettingsState build() => const VoiceSettingsState();
 }
 
 /// Standard overrides for ChatInputBar tests.

--- a/apps/client/test/widgets/chat_panel_live_region_test.dart
+++ b/apps/client/test/widgets/chat_panel_live_region_test.dart
@@ -59,10 +59,9 @@ class _FakePrivacy extends Privacy {
   PrivacyState build() => const PrivacyState();
 }
 
-class _FakeVoiceSettingsNotifier extends VoiceSettingsNotifier {
-  _FakeVoiceSettingsNotifier() {
-    state = const VoiceSettingsState();
-  }
+class _FakeVoiceSettings extends VoiceSettings {
+  @override
+  VoiceSettingsState build() => const VoiceSettingsState();
 }
 
 class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
@@ -132,7 +131,7 @@ List<Override> _overrides({
     }),
     channelsProvider.overrideWith((ref) => _FakeChannelsNotifier(ref)),
     privacyProvider.overrideWith(_FakePrivacy.new),
-    voiceSettingsProvider.overrideWith((ref) => _FakeVoiceSettingsNotifier()),
+    voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
     voiceRtcProvider.overrideWith((ref) => _FakeVoiceRtcNotifier(ref)),
     appThemeProvider.overrideWith(_FakeTheme.new),
     messageLayoutNotifierProvider.overrideWith(_FakeMessageLayoutNotifier.new),

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -57,10 +57,9 @@ class _FakePrivacy extends Privacy {
   PrivacyState build() => const PrivacyState();
 }
 
-class _FakeVoiceSettingsNotifier extends VoiceSettingsNotifier {
-  _FakeVoiceSettingsNotifier() {
-    state = const VoiceSettingsState();
-  }
+class _FakeVoiceSettings extends VoiceSettings {
+  @override
+  VoiceSettingsState build() => const VoiceSettingsState();
 }
 
 class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
@@ -74,7 +73,7 @@ List<Override> _chatPanelOverrides({ChatState chatState = const ChatState()}) {
     chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, chatState)),
     channelsProvider.overrideWith((ref) => _FakeChannelsNotifier(ref)),
     privacyProvider.overrideWith(_FakePrivacy.new),
-    voiceSettingsProvider.overrideWith((ref) => _FakeVoiceSettingsNotifier()),
+    voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
     voiceRtcProvider.overrideWith((ref) => _FakeVoiceRtcNotifier(ref)),
     appThemeProvider.overrideWith(_FakeTheme.new),
     messageLayoutNotifierProvider.overrideWith(_FakeMessageLayoutNotifier.new),

--- a/apps/client/test/widgets/slash_commands_widget_test.dart
+++ b/apps/client/test/widgets/slash_commands_widget_test.dart
@@ -45,15 +45,12 @@ class _FakeChatNotifier extends ChatNotifier {
 }
 
 Override _voiceSettingsOverride() {
-  return voiceSettingsProvider.overrideWith(
-    (ref) => _FakeVoiceSettingsNotifier(),
-  );
+  return voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new);
 }
 
-class _FakeVoiceSettingsNotifier extends VoiceSettingsNotifier {
-  _FakeVoiceSettingsNotifier() {
-    state = const VoiceSettingsState();
-  }
+class _FakeVoiceSettings extends VoiceSettings {
+  @override
+  VoiceSettingsState build() => const VoiceSettingsState();
 }
 
 List<Override> _overrides() => [


### PR DESCRIPTION
Migrate VoiceSettings from legacy StateNotifier to Notifier+@Riverpod. 228 LoC, persistence-heavy leaf. _load() called inside build() per playbook. Updated 6 test files to ProviderContainer + Notifier-style fakes. notification_section.dart's typed param VoiceSettingsNotifier renamed to VoiceSettings. Analyzer clean, all touched tests pass.