### PR TITLE
refactor(client): migrate contacts_provider to @Riverpod (12/22)

### DIFF
--- a/apps/client/lib/src/providers/contacts_provider.dart
+++ b/apps/client/lib/src/providers/contacts_provider.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/blocked_user.dart';
 import '../models/contact.dart';
@@ -10,6 +10,8 @@ import '../services/debug_log_service.dart';
 import 'auth_provider.dart';
 import 'conversations_provider.dart';
 import 'server_url_provider.dart';
+
+part 'contacts_provider.g.dart';
 
 /// Sentinel used by [ContactsState.copyWith] to distinguish "not provided"
 /// from an explicit `null` (which clears the error).
@@ -51,8 +53,8 @@ class ContactsState {
   }
 }
 
-class ContactsNotifier extends StateNotifier<ContactsState> {
-  final Ref ref;
+@Riverpod(keepAlive: true)
+class Contacts extends _$Contacts {
   bool _isPendingLoadInFlight = false;
   DateTime? _lastPendingLoadedAt;
 
@@ -62,7 +64,16 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
   /// overwriting fresh state when two reloads overlap.
   int _loadGen = 0;
 
-  ContactsNotifier(this.ref) : super(const ContactsState());
+  /// True after the provider has been disposed; gates state writes from
+  /// async callbacks (the StateNotifier `mounted` check has no equivalent
+  /// on Notifier so we track it manually).
+  bool _disposed = false;
+
+  @override
+  ContactsState build() {
+    ref.onDispose(() => _disposed = true);
+    return const ContactsState();
+  }
 
   String get _serverUrl => ref.read(serverUrlProvider);
 
@@ -90,7 +101,7 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
       );
       // Drop a stale response -- a newer call has been issued or the notifier
       // was disposed while awaiting.
-      if (gen != _loadGen || !mounted) return;
+      if (gen != _loadGen || _disposed) return;
 
       if (response.statusCode == 200) {
         final list = (jsonDecode(response.body) as List)
@@ -104,7 +115,7 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
         );
       }
     } catch (e) {
-      if (gen != _loadGen || !mounted) return;
+      if (gen != _loadGen || _disposed) return;
       state = state.copyWith(isLoading: false, error: e.toString());
     }
   }
@@ -288,9 +299,3 @@ class ContactsNotifier extends StateNotifier<ContactsState> {
     }
   }
 }
-
-final contactsProvider = StateNotifierProvider<ContactsNotifier, ContactsState>(
-  (ref) {
-    return ContactsNotifier(ref);
-  },
-);

--- a/apps/client/lib/src/providers/contacts_provider.g.dart
+++ b/apps/client/lib/src/providers/contacts_provider.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contacts_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$contactsHash() => r'8ab36e1f6f8f177f06762941098074d83f805bb7';
+
+/// See also [Contacts].
+@ProviderFor(Contacts)
+final contactsProvider = NotifierProvider<Contacts, ContactsState>.internal(
+  Contacts.new,
+  name: r'contactsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$contactsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$Contacts = Notifier<ContactsState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/test/helpers/mock_providers.dart
+++ b/apps/client/test/helpers/mock_providers.dart
@@ -153,13 +153,12 @@ class _FakeConversationsNotifier extends ConversationsNotifier {
 
 /// Override [contactsProvider] with an empty state.
 Override contactsOverride() {
-  return contactsProvider.overrideWith((ref) => _FakeContactsNotifier(ref));
+  return contactsProvider.overrideWith(_FakeContacts.new);
 }
 
-class _FakeContactsNotifier extends ContactsNotifier {
-  _FakeContactsNotifier(super.ref) {
-    state = const ContactsState();
-  }
+class _FakeContacts extends Contacts {
+  @override
+  ContactsState build() => const ContactsState();
 
   @override
   Future<void> loadContacts() async {}


### PR DESCRIPTION
Migrate Contacts from legacy StateNotifier to Notifier+@Riverpod. 296 LoC. mounted check replaced by manual _disposed bool wired through ref.onDispose. Updated mock_providers.dart helper to use overrideWith(NewClass.new) pattern. Analyzer clean, contacts_provider_test 15/15 pass.