### PR TITLE
refactor(client): migrate canvas_provider to @Riverpod (13/22)

### DIFF
--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart' show Color;
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/canvas_models.dart';
 import '../services/debug_log_service.dart';
@@ -12,13 +12,14 @@ import 'auth_provider.dart';
 import 'server_url_provider.dart';
 import 'websocket_provider.dart';
 
+part 'canvas_provider.g.dart';
+
 // ---------------------------------------------------------------------------
 // Notifier
 // ---------------------------------------------------------------------------
 
-class CanvasNotifier extends StateNotifier<CanvasState> {
-  final Ref ref;
-
+@Riverpod(keepAlive: true)
+class CanvasController extends _$CanvasController {
   /// The channel this canvas is attached to.
   String? _channelId;
 
@@ -33,7 +34,14 @@ class CanvasNotifier extends StateNotifier<CanvasState> {
   /// Events buffered while [_channelId] is not yet set (attach race window).
   final List<Map<String, dynamic>> _pendingEvents = [];
 
-  CanvasNotifier(this.ref) : super(const CanvasState());
+  @override
+  CanvasState build() {
+    ref.onDispose(() {
+      _avatarThrottle?.cancel();
+      _imageThrottle?.cancel();
+    });
+    return const CanvasState();
+  }
 
   // -------------------------------------------------------------------------
   // Lifecycle
@@ -338,19 +346,9 @@ class CanvasNotifier extends StateNotifier<CanvasState> {
         .read(websocketProvider.notifier)
         .sendCanvasEvent(channelId: cid, kind: kind, payload: payload);
   }
-
-  @override
-  void dispose() {
-    _avatarThrottle?.cancel();
-    _imageThrottle?.cancel();
-    super.dispose();
-  }
 }
 
-// ---------------------------------------------------------------------------
-// Provider
-// ---------------------------------------------------------------------------
-
-final canvasProvider = StateNotifierProvider<CanvasNotifier, CanvasState>(
-  (ref) => CanvasNotifier(ref),
-);
+/// Back-compat alias: existing call sites still refer to `canvasProvider`.
+/// The class is named `CanvasController` to avoid shadowing dart:ui.Canvas
+/// inside this library.
+final canvasProvider = canvasControllerProvider;

--- a/apps/client/lib/src/providers/canvas_provider.g.dart
+++ b/apps/client/lib/src/providers/canvas_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'canvas_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$canvasControllerHash() => r'63bd641d1dcd98d6cc6bbcad3811594079aad7f4';
+
+/// See also [CanvasController].
+@ProviderFor(CanvasController)
+final canvasControllerProvider =
+    NotifierProvider<CanvasController, CanvasState>.internal(
+      CanvasController.new,
+      name: r'canvasControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$canvasControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$CanvasController = Notifier<CanvasState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
Migrate Canvas notifier from legacy StateNotifier to Notifier+@Riverpod. 356 LoC. **Class renamed to CanvasController** to avoid shadowing dart:ui.Canvas; back-compat alias `final canvasProvider = canvasControllerProvider;` preserves all import paths. dispose() override replaced by ref.onDispose() that cancels avatar+image throttle timers. Analyzer clean, canvas_provider_test 13/13 pass.