### PR TITLE
release: client UX fixes (#795 #794 #796 #725 #738 #790 #792 #739)

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -713,13 +713,37 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               border: Border(top: BorderSide(color: context.border, width: 1)),
             ),
             child: Center(
-              child: IconButton(
-                icon: const Icon(Icons.settings_outlined, size: 18),
-                color: context.textSecondary,
-                tooltip: 'Settings',
-                onPressed: _openSettings,
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              child: Builder(
+                builder: (context) {
+                  final updateState = ref.watch(updateProvider);
+                  final showUpdateDot =
+                      updateState.updateAvailable && !updateState.dismissed;
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.settings_outlined, size: 18),
+                        color: context.textSecondary,
+                        tooltip: 'Settings',
+                        onPressed: _openSettings,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(
+                          minWidth: 44,
+                          minHeight: 44,
+                        ),
+                      ),
+                      if (showUpdateDot)
+                        Positioned(
+                          top: 10,
+                          right: 10,
+                          child: _DotBadge(
+                            ringColor: context.mainBg,
+                            bgColor: context.accent,
+                          ),
+                        ),
+                    ],
+                  );
+                },
               ),
             ),
           ),
@@ -1244,6 +1268,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         .watch(conversationsProvider)
         .conversations
         .fold<int>(0, (s, c) => s + c.unreadCount);
+    final updateState = ref.watch(updateProvider);
+    final showUpdateDot = updateState.updateAvailable && !updateState.dismissed;
 
     final tabs = <_MobileTabSpec>[
       _MobileTabSpec(
@@ -1262,10 +1288,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         outlinedIcon: Icons.people_outline,
         filledIcon: Icons.people,
       ),
-      const _MobileTabSpec(
+      _MobileTabSpec(
         label: 'Settings',
         outlinedIcon: Icons.settings_outlined,
         filledIcon: Icons.settings,
+        showDot: showUpdateDot,
       ),
     ];
 
@@ -1319,6 +1346,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                                 right: -8,
                                 child: _UnreadBadge(
                                   count: tab.badge,
+                                  ringColor: context.sidebarBg,
+                                  bgColor: context.accent,
+                                ),
+                              )
+                            else if (tab.showDot)
+                              Positioned(
+                                top: -2,
+                                right: -2,
+                                child: _DotBadge(
                                   ringColor: context.sidebarBg,
                                   bgColor: context.accent,
                                 ),
@@ -1661,11 +1697,18 @@ class _MobileTabSpec {
   final IconData outlinedIcon;
   final IconData filledIcon;
   final int badge;
+
+  /// Show a small accent-coloured dot (no count) on top of the icon. Used to
+  /// surface low-frequency, non-critical signals — e.g. an available update
+  /// (#792). [badge] takes precedence when both are set.
+  final bool showDot;
+
   const _MobileTabSpec({
     required this.label,
     required this.outlinedIcon,
     required this.filledIcon,
     this.badge = 0,
+    this.showDot = false,
   });
 }
 
@@ -1699,6 +1742,30 @@ class _UnreadBadge extends StatelessWidget {
             fontWeight: FontWeight.w700,
             height: 1.0,
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Small dot indicator (no count). Used for low-frequency, non-critical
+/// signals like an available update on the Settings icon (#792).
+class _DotBadge extends StatelessWidget {
+  final Color ringColor;
+  final Color bgColor;
+  const _DotBadge({required this.ringColor, required this.bgColor});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'update available',
+      child: Container(
+        width: 10,
+        height: 10,
+        decoration: BoxDecoration(
+          color: bgColor,
+          shape: BoxShape.circle,
+          border: Border.all(color: ringColor, width: 1.5),
         ),
       ),
     );

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -90,6 +90,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   double _sidebarWidth = 350;
   static const _sidebarMinWidth = 200.0;
   static const _sidebarMaxWidth = 500.0;
+
+  /// Lower clamp during a resize drag — below `_sidebarMinWidth` so the
+  /// drag-end handler can detect a pull-through and snap into compact mode
+  /// (#739). Stays above 0 so the sidebar never visually vanishes mid-drag.
+  static const _sidebarPullThroughWidth = 100.0;
   static const _sidebarCollapsedWidth = 60.0;
   static const _sidebarDefaultWidth = 350.0;
 
@@ -1034,17 +1039,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         child: GestureDetector(
           onHorizontalDragUpdate: (details) {
             if (_sidebarCollapsed) return;
+            // Allow dragging below `_sidebarMinWidth` so users can pull the
+            // handle through to compact mode and the drag-end handler can
+            // snap to collapsed. The lower clamp keeps the sidebar from
+            // disappearing entirely mid-drag (#739).
             setState(() {
               _sidebarWidth = (_sidebarWidth + details.delta.dx).clamp(
-                _sidebarMinWidth,
+                _sidebarPullThroughWidth,
                 _sidebarMaxWidth,
               );
             });
           },
           onHorizontalDragEnd: (details) {
-            if (_sidebarWidth < 150) {
-              setState(() => _sidebarCollapsed = true);
-            }
+            setState(() {
+              if (_sidebarWidth < _sidebarMinWidth) {
+                // User pulled past the min — snap to compact and restore the
+                // expanded default for the next expand-from-compact toggle.
+                _sidebarCollapsed = true;
+                _sidebarWidth = _sidebarDefaultWidth;
+              }
+            });
           },
           onDoubleTap: () {
             setState(() {

--- a/apps/client/lib/src/widgets/avatar_crop_dialog.dart
+++ b/apps/client/lib/src/widgets/avatar_crop_dialog.dart
@@ -1,8 +1,84 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
+
+/// Decodes [bytes] into an [img.Image] suitable for cropping.
+///
+/// The `image` package handles JPEG, PNG, GIF, WebP, BMP and TIFF directly.
+/// On iOS the gallery often hands back HEIC, which `image` does not support
+/// — that produced the "could not decode image" failure in #796. When the
+/// fast path fails we sniff for HEIC / HEIF / AVIF magic bytes and fall
+/// back to Flutter's platform decoder via [ui.instantiateImageCodec], which
+/// uses the iOS native HEIC decoder. The first frame is re-encoded as PNG
+/// and fed back through the `image` package so cropping can proceed.
+///
+/// Returns null when both decoders fail.
+Future<img.Image?> decodeAvatarImage(Uint8List bytes) {
+  if (bytes.isEmpty) return Future.value(null);
+
+  // image's decodeImage can throw on truncated/garbage input rather than
+  // returning null, so wrap the fast path defensively.
+  img.Image? direct;
+  try {
+    direct = img.decodeImage(bytes);
+  } catch (_) {
+    direct = null;
+  }
+  if (direct != null) return Future.value(direct);
+
+  // Only try the platform decoder for formats `image` legitimately can't
+  // handle. Falling back unconditionally would hide truly malformed input
+  // and stall the dialog when the platform decoder isn't available
+  // (notably in widget tests, where instantiateImageCodec doesn't resolve).
+  if (_looksLikeHeifFamily(bytes)) {
+    return _decodeViaPlatformCodec(bytes);
+  }
+  return Future.value(null);
+}
+
+// Detect HEIC / HEIF / AVIF by looking at the ISOBMFF `ftyp` box brand at
+// offset 8-11. Returns false on anything that isn't an ISOBMFF container.
+bool _looksLikeHeifFamily(Uint8List bytes) {
+  if (bytes.length < 12) return false;
+  if (bytes[4] != 0x66 ||
+      bytes[5] != 0x74 ||
+      bytes[6] != 0x79 ||
+      bytes[7] != 0x70) {
+    return false; // bytes 4-7 != "ftyp"
+  }
+  const heifBrands = {
+    'heic',
+    'heix',
+    'heim',
+    'heis',
+    'mif1',
+    'msf1',
+    'avif',
+    'avis',
+    'avi1',
+  };
+  final brand = String.fromCharCodes(bytes.sublist(8, 12));
+  return heifBrands.contains(brand);
+}
+
+Future<img.Image?> _decodeViaPlatformCodec(Uint8List bytes) async {
+  try {
+    final codec = await ui.instantiateImageCodec(bytes);
+    final frame = await codec.getNextFrame();
+    final pngData = await frame.image.toByteData(
+      format: ui.ImageByteFormat.png,
+    );
+    frame.image.dispose();
+    codec.dispose();
+    if (pngData == null) return null;
+    return img.decodePng(pngData.buffer.asUint8List());
+  } catch (_) {
+    return null;
+  }
+}
 
 /// Shows a modal crop dialog for an avatar image.
 ///
@@ -88,9 +164,8 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
     }
   }
 
-  static Future<img.Image?> _decodeAsync(Uint8List bytes) async {
-    return img.decodeImage(bytes);
-  }
+  static Future<img.Image?> _decodeAsync(Uint8List bytes) =>
+      decodeAvatarImage(bytes);
 
   // Clamp offset so the crop square (previewSize×previewSize) is always
   // fully covered by the image — no empty space inside the circle.

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -313,17 +313,86 @@ class ChatHeaderBar extends ConsumerWidget {
         padding: EdgeInsets.zero,
         constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
       ),
-      _buildOverflowMenu(context, ref, conv, pinnedCount),
+      _buildOverflowMenu(context, ref, conv, pinnedCount, isWide: false),
     ];
   }
 
-  /// Overflow 3-dot menu for narrow layouts.
+  /// Overflow 3-dot menu.
+  ///
+  /// In wide layout the inline action row already exposes pins, search, media,
+  /// safety-number (DMs) and members (groups), so the overflow only carries
+  /// the advanced actions that don't have inline equivalents. When wide and
+  /// no advanced actions apply (e.g. unencrypted group), the menu is hidden
+  /// entirely (#738).
   Widget _buildOverflowMenu(
     BuildContext context,
     WidgetRef ref,
     Conversation conv,
-    int pinnedCount,
-  ) {
+    int pinnedCount, {
+    required bool isWide,
+  }) {
+    final items = <PopupMenuEntry<String>>[
+      if (!isWide && !conv.isGroup)
+        PopupMenuItem<String>(
+          value: 'safety',
+          child: _overflowItem(
+            context,
+            icon: Icons.lock_outlined,
+            label: 'Verify safety number',
+            color: EchoTheme.online,
+          ),
+        ),
+      if (!conv.isGroup && conv.isEncrypted)
+        PopupMenuItem<String>(
+          value: 'reset_keys',
+          child: _overflowItem(
+            context,
+            icon: Icons.healing,
+            label: 'Fix encryption issues',
+          ),
+        ),
+      if (!isWide)
+        PopupMenuItem<String>(
+          value: 'pins',
+          child: _overflowItem(
+            context,
+            icon: Icons.push_pin_outlined,
+            label: pinnedCount > 0
+                ? 'Pinned ($pinnedCount)'
+                : 'Pinned messages',
+          ),
+        ),
+      if (!isWide)
+        PopupMenuItem<String>(
+          value: 'media',
+          child: _overflowItem(
+            context,
+            icon: Icons.photo_library_outlined,
+            label: 'Shared media',
+          ),
+        ),
+      if (!isWide && conv.isGroup && onMembersToggle != null)
+        PopupMenuItem<String>(
+          value: 'members',
+          child: _overflowItem(
+            context,
+            icon: Icons.people_outline,
+            label: 'Members',
+          ),
+        ),
+      if (!conv.isGroup)
+        PopupMenuItem<String>(
+          value: 'disappearing',
+          child: _overflowItem(
+            context,
+            icon: Icons.timer_outlined,
+            label: _disappearingMessagesLabel,
+          ),
+        ),
+    ];
+
+    if (items.isEmpty) return const SizedBox.shrink();
+
     return PopupMenuButton<String>(
       icon: Icon(Icons.more_vert, size: 20, color: context.textSecondary),
       tooltip: 'More options',
@@ -348,63 +417,7 @@ class ChatHeaderBar extends ConsumerWidget {
             _showDisappearingDialog(context, ref, conv);
         }
       },
-      itemBuilder: (ctx) => [
-        if (!conv.isGroup)
-          PopupMenuItem<String>(
-            value: 'safety',
-            child: _overflowItem(
-              ctx,
-              icon: Icons.lock_outlined,
-              label: 'Verify safety number',
-              color: EchoTheme.online,
-            ),
-          ),
-        if (!conv.isGroup && conv.isEncrypted)
-          PopupMenuItem<String>(
-            value: 'reset_keys',
-            child: _overflowItem(
-              ctx,
-              icon: Icons.healing,
-              label: 'Fix encryption issues',
-            ),
-          ),
-        PopupMenuItem<String>(
-          value: 'pins',
-          child: _overflowItem(
-            ctx,
-            icon: Icons.push_pin_outlined,
-            label: pinnedCount > 0
-                ? 'Pinned ($pinnedCount)'
-                : 'Pinned messages',
-          ),
-        ),
-        PopupMenuItem<String>(
-          value: 'media',
-          child: _overflowItem(
-            ctx,
-            icon: Icons.photo_library_outlined,
-            label: 'Shared media',
-          ),
-        ),
-        if (conv.isGroup && onMembersToggle != null)
-          PopupMenuItem<String>(
-            value: 'members',
-            child: _overflowItem(
-              ctx,
-              icon: Icons.people_outline,
-              label: 'Members',
-            ),
-          ),
-        if (!conv.isGroup)
-          PopupMenuItem<String>(
-            value: 'disappearing',
-            child: _overflowItem(
-              ctx,
-              icon: Icons.timer_outlined,
-              label: _disappearingMessagesLabel,
-            ),
-          ),
-      ],
+      itemBuilder: (_) => items,
     );
   }
 
@@ -468,7 +481,7 @@ class ChatHeaderBar extends ConsumerWidget {
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
         ),
-      _buildOverflowMenu(context, ref, conv, pinnedCount),
+      _buildOverflowMenu(context, ref, conv, pinnedCount, isWide: true),
     ];
   }
 

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -427,15 +427,7 @@ class ChatHeaderBar extends ConsumerWidget {
           constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
         ),
       IconButton(
-        icon: Badge(
-          isLabelVisible: pinnedCount > 0,
-          label: Text(
-            '$pinnedCount',
-            style: const TextStyle(fontSize: 9, color: Colors.white),
-          ),
-          backgroundColor: context.accent,
-          child: const Icon(Icons.push_pin_outlined, size: 20),
-        ),
+        icon: const Icon(Icons.push_pin_outlined, size: 20),
         color: context.textSecondary,
         tooltip: 'Pinned messages',
         onPressed: () => _showPinnedMessagesDialog(context, ref, conv),

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -14,17 +14,22 @@ import '../../theme/echo_theme.dart';
 import '../../utils/download_helper.dart';
 import 'voice_message_widget.dart';
 
+// Markers may be followed by a newline + caption (the seed script and the
+// chat input both produce `[img:URL]\nCaption`), so the regex is anchored at
+// the start, uses a lazy capture, and does NOT require the closing `]` to
+// be at end-of-string. See #795.
+
 /// Regex for detecting image markers: [img:URL]
-final _imgRegex = RegExp(r'^\[img:(.+)\]$');
+final _imgRegex = RegExp(r'^\[img:([^\]\n]+)\]');
 
 /// Regex for detecting video markers: [video:URL]
-final _videoRegex = RegExp(r'^\[video:(.+)\]$');
+final _videoRegex = RegExp(r'^\[video:([^\]\n]+)\]');
 
 /// Regex for detecting generic file markers: [file:URL]
-final _fileRegex = RegExp(r'^\[file:(.+)\]$');
+final _fileRegex = RegExp(r'^\[file:([^\]\n]+)\]');
 
 /// Regex for detecting audio markers: [audio:URL]
-final _audioRegex = RegExp(r'^\[audio:(.+)\]$');
+final _audioRegex = RegExp(r'^\[audio:([^\]\n]+)\]');
 
 /// Regex for detecting standalone URL messages.
 final _standaloneUrlRegex = RegExp(r'^https?://[^\s]+$', caseSensitive: false);
@@ -149,6 +154,22 @@ String? extractMediaUrl(String content) {
     return content.trim();
   }
 
+  return null;
+}
+
+/// Extracts the caption that follows a media marker on the first line.
+///
+/// Returns the trimmed text after the closing `]` of an `[img:]` / `[video:]`
+/// / `[file:]` / `[audio:]` marker, or `null` if there is no marker or no
+/// caption. Used so messages of the form `[img:URL]\nCaption` render both the
+/// inline media and the caption text below it.
+String? extractMediaCaption(String content) {
+  for (final regex in [_imgRegex, _videoRegex, _fileRegex, _audioRegex]) {
+    final match = regex.firstMatch(content);
+    if (match == null) continue;
+    final rest = content.substring(match.end).trim();
+    return rest.isEmpty ? null : rest;
+  }
   return null;
 }
 

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1455,8 +1455,15 @@ class _MessageItemState extends State<MessageItem>
       padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
     }
 
+    // Compact / Plain layouts (#794) flow to the full chat-pane width like
+    // Discord/Slack — no centered-bubble cap. Bubble layout keeps 520px so
+    // bubbles don't stretch awkwardly on wide windows.
+    final bubbleConstraints = widget.compactLayout
+        ? const BoxConstraints()
+        : const BoxConstraints(maxWidth: 520);
+
     return Container(
-      constraints: const BoxConstraints(maxWidth: 520),
+      constraints: bubbleConstraints,
       padding: padding,
       decoration: BoxDecoration(
         color: _bubbleColor(isMine: isMine, isFailed: isFailed),

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1185,13 +1185,30 @@ class _MessageItemState extends State<MessageItem>
     required bool hasMedia,
   }) {
     if (hasMedia) {
-      return MediaContent(
+      final mediaWidget = MediaContent(
         content: msg.content,
         isMine: isMine,
         serverUrl: widget.serverUrl,
         authToken: widget.authToken,
         mediaTicket: widget.mediaTicket,
         onImageTap: widget.onImageTap,
+      );
+      final caption = extractMediaCaption(msg.content);
+      if (caption == null) return mediaWidget;
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          mediaWidget,
+          const SizedBox(height: 4),
+          RichTextContent(
+            text: caption,
+            textColor: _contentTextColor(isMine: isMine, isFailed: isFailed),
+            accentHoverColor: context.accentHover,
+            textSecondaryColor: context.textSecondary,
+            compact: widget.compactLayout,
+          ),
+        ],
       );
     }
     if (_isDecryptFailure(msg.content)) {

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1171,6 +1171,11 @@ class _MessageItemState extends State<MessageItem>
   /// Resolve text color for message content.
   Color _contentTextColor({required bool isMine, required bool isFailed}) {
     if (isFailed) return EchoTheme.danger;
+    // Plain (Slack) layout drops the bubble fill (#564) so the message sits
+    // directly on the chat background. The primary's onColor would be picked
+    // for an accent-coloured bubble that no longer exists, so use textPrimary
+    // for readable contrast on every theme (#790).
+    if (widget._isPlain) return context.textPrimary;
     if (isMine) return Theme.of(context).colorScheme.onPrimary;
     return context.textPrimary;
   }

--- a/apps/client/test/widgets/avatar_crop_decode_test.dart
+++ b/apps/client/test/widgets/avatar_crop_decode_test.dart
@@ -1,0 +1,67 @@
+// Direct tests for [decodeAvatarImage], the decoder behind the avatar
+// crop dialog (#796).
+//
+// The fast path (PNG/JPEG via the `image` package) is exercised here.
+// The platform-decoder fallback for HEIC requires real HEIC bytes and a
+// device codec, which Skia in widget tests does not provide — the
+// fallback branch is covered manually on iOS hardware.
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+import 'package:echo_app/src/widgets/avatar_crop_dialog.dart';
+
+void main() {
+  group('decodeAvatarImage (#796)', () {
+    test('decodes a PNG via the fast path', () async {
+      final pngBytes = Uint8List.fromList(
+        img.encodePng(img.Image(width: 4, height: 4)),
+      );
+      final image = await decodeAvatarImage(pngBytes);
+      expect(image, isNotNull);
+      expect(image!.width, 4);
+      expect(image.height, 4);
+    });
+
+    test('decodes a JPEG via the fast path', () async {
+      final jpegBytes = Uint8List.fromList(
+        img.encodeJpg(img.Image(width: 4, height: 4)),
+      );
+      final image = await decodeAvatarImage(jpegBytes);
+      expect(image, isNotNull);
+      expect(image!.width, 4);
+    });
+
+    test('returns null for empty bytes', () async {
+      expect(await decodeAvatarImage(Uint8List(0)), isNull);
+    });
+
+    test('returns null for non-image garbage', () async {
+      final bytes = Uint8List.fromList([0x01, 0x02, 0x03, 0x04, 0x05]);
+      expect(await decodeAvatarImage(bytes), isNull);
+    });
+
+    test('HEIC-shaped bytes route through the platform fallback', () async {
+      // Minimal ISOBMFF ftyp box with brand 'heic'. The platform decoder
+      // can't actually decode this stub, but the fallback must fail-safe
+      // (return null) instead of hanging — that's the regression #796 was
+      // catching, and the matching guard is verified here.
+      final fakeHeic = Uint8List.fromList([
+        0x00, 0x00, 0x00, 0x18, // box size
+        0x66, 0x74, 0x79, 0x70, // 'ftyp'
+        0x68, 0x65, 0x69, 0x63, // brand 'heic'
+        0x00, 0x00, 0x00, 0x00, // minor version
+        0x68, 0x65, 0x69, 0x63, // compat brand
+        0x6D, 0x69, 0x66, 0x31, // compat brand 'mif1'
+      ]);
+      // Bound the await so a non-resolving codec future fails the test
+      // loudly instead of timing out the whole runner.
+      final result = await decodeAvatarImage(fakeHeic).timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => throw StateError('platform fallback never resolved'),
+      );
+      expect(result, isNull);
+    });
+  });
+}

--- a/apps/client/test/widgets/media_content_caption_test.dart
+++ b/apps/client/test/widgets/media_content_caption_test.dart
@@ -1,0 +1,71 @@
+// Unit tests for marker + caption parsing in media_content.dart (#795).
+// Messages of the form `[img:URL]\nCaption` must extract the URL and the
+// caption separately so the renderer can show both inline media and the
+// caption text underneath.
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/message/media_content.dart';
+
+void main() {
+  group('extractMediaUrl with caption (#795)', () {
+    test('returns URL when content is a bare [img:] marker', () {
+      expect(extractMediaUrl('[img:/api/media/abc-123]'), '/api/media/abc-123');
+    });
+
+    test('returns URL when [img:] marker is followed by a caption', () {
+      expect(
+        extractMediaUrl('[img:/api/media/abc-123]\nLook at this'),
+        '/api/media/abc-123',
+      );
+    });
+
+    test('returns URL for [video:] marker with caption', () {
+      expect(
+        extractMediaUrl('[video:/api/media/v]\nClip from yesterday'),
+        '/api/media/v',
+      );
+    });
+
+    test('returns URL for [file:] marker with caption', () {
+      expect(
+        extractMediaUrl('[file:/api/media/f]\nslides.pdf'),
+        '/api/media/f',
+      );
+    });
+
+    test('returns URL for [audio:] marker with caption', () {
+      expect(
+        extractMediaUrl('[audio:/api/media/a]\nvoice memo'),
+        '/api/media/a',
+      );
+    });
+
+    test('returns null for plain text', () {
+      expect(extractMediaUrl('hello world'), isNull);
+    });
+  });
+
+  group('extractMediaCaption (#795)', () {
+    test('returns null when there is no caption', () {
+      expect(extractMediaCaption('[img:/api/media/x]'), isNull);
+    });
+
+    test('returns caption text after a marker', () {
+      expect(extractMediaCaption('[img:/x]\nLook'), 'Look');
+    });
+
+    test('trims whitespace around the caption', () {
+      expect(extractMediaCaption('[img:/x]\n  Hello  '), 'Hello');
+    });
+
+    test('returns null when content is plain text', () {
+      expect(extractMediaCaption('just a sentence'), isNull);
+    });
+
+    test('handles each marker type', () {
+      expect(extractMediaCaption('[video:/v]\ncap'), 'cap');
+      expect(extractMediaCaption('[file:/f]\ncap'), 'cap');
+      expect(extractMediaCaption('[audio:/a]\ncap'), 'cap');
+    });
+  });
+}

--- a/apps/client/test/widgets/message_item_compact_width_test.dart
+++ b/apps/client/test/widgets/message_item_compact_width_test.dart
@@ -1,0 +1,82 @@
+// Verifies the bubble Container's max-width constraint differs between
+// the bubble layout (capped at 520) and compact/plain layouts (uncapped),
+// so Compact/Plain flow to the chat-pane width like Discord/Slack (#794).
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/providers/theme_provider.dart';
+import 'package:echo_app/src/widgets/message_item.dart';
+
+import '../helpers/pump_app.dart';
+
+ChatMessage _msg() => const ChatMessage(
+  id: 'm1',
+  fromUserId: 'u-other',
+  fromUsername: 'alice',
+  conversationId: 'c1',
+  content: 'A reasonably long message that would otherwise hit the bubble cap.',
+  timestamp: '2026-05-06T10:00:00Z',
+  isMine: false,
+  status: MessageStatus.sent,
+);
+
+// Find the message bubble Container — uniquely identified as the Container
+// that has a BoxDecoration AND wraps its child in MergeSemantics (the avatar
+// column / hover overlay containers don't share that structure).
+Container _bubble(WidgetTester tester) {
+  return tester
+      .widgetList<Container>(find.byType(Container))
+      .firstWhere(
+        (c) => c.decoration is BoxDecoration && c.child is MergeSemantics,
+      );
+}
+
+void main() {
+  group('Bubble width constraint by layout (#794)', () {
+    testWidgets('bubble layout caps width at 520', (tester) async {
+      await tester.pumpApp(
+        MessageItem(
+          message: _msg(),
+          showHeader: true,
+          isLastInGroup: true,
+          myUserId: 'me',
+          // default: MessageLayout.bubbles
+        ),
+      );
+      await tester.pump();
+
+      expect(_bubble(tester).constraints!.maxWidth, 520);
+    });
+
+    testWidgets('compact layout removes the 520 cap', (tester) async {
+      await tester.pumpApp(
+        MessageItem(
+          message: _msg(),
+          showHeader: true,
+          isLastInGroup: true,
+          myUserId: 'me',
+          layout: MessageLayout.compact,
+        ),
+      );
+      await tester.pump();
+
+      expect(_bubble(tester).constraints!.maxWidth, double.infinity);
+    });
+
+    testWidgets('plain layout removes the 520 cap', (tester) async {
+      await tester.pumpApp(
+        MessageItem(
+          message: _msg(),
+          showHeader: true,
+          isLastInGroup: true,
+          myUserId: 'me',
+          layout: MessageLayout.plain,
+        ),
+      );
+      await tester.pump();
+
+      expect(_bubble(tester).constraints!.maxWidth, double.infinity);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Bundles client UX/bug fixes for `dev → main`. Each fix is its own commit with focused tests where possible.

### Bug fixes

- **#795** `fix(client): render media-marker messages with captions` — relax `[img/video/file/audio:URL]` regexes so they match when followed by a caption (`[img:URL]\nCaption`, the form the seed script and chat input produce). Add `extractMediaCaption`; render the caption below inline media in `_buildBubbleContent`.
- **#794** `fix(client): use full chat-pane width in compact/plain layouts` — make the bubble's `maxWidth: 520` cap conditional. Compact / Plain flow to chat-pane width like Discord/Slack; Bubble keeps the cap.
- **#796** `fix(client,mobile): fall back to platform decoder for HEIC avatars` — when `image.decodeImage` returns null and the bytes' `ftyp` brand looks like HEIC/HEIF/AVIF, decode via `ui.instantiateImageCodec` (iOS native), re-encode as PNG, and feed it back through `image` so cropping can proceed.
- **#790** `fix(client): use textPrimary in plain message layout` — Plain layout drops the bubble fill; the previous `colorScheme.onPrimary` was unreadable on light themes when the bubble disappeared. Switch to `textPrimary` in plain mode.
- **#738** `fix(client): suppress redundant overflow menu on wide chat header` — In wide layout the inline action row already exposes pins/search/media/safety/members; filter the 3-dot menu to advanced-only items (reset keys, disappearing timer) and hide it entirely when none apply.
- **#739** `fix(client): pull sidebar through to compact via drag` — drag handler clamped to `_sidebarMinWidth` so the snap-to-compact threshold (150) was unreachable; lower the drag-time clamp and snap to compact when released below the min width.

### Style

- **#725** `style(client): remove pin-count badge from chat header` — Drop the Badge wrapper around the pin icon; pinned panel already surfaces the count.

### Feat

- **#792** `feat(client): show update-available dot on Settings icon` — small accent dot on the mobile bottom-tab Settings icon and desktop sidebar Settings icon when `updateProvider` reports an available, undismissed update.

## Closes

- Closes #795, #794, #796, #790, #738, #739, #725, #792
- Closes #722 (banner already gone — verified, commented in-thread)

## Not in this PR

- **#791 (i18n)** — moved to its own branch `feature/localizations` so it can sit until we're ready for the call-site sweep + a translation pass before public release. Branch: https://github.com/NC1107/echo-messenger/tree/feature/localizations.

## Test plan

- [x] `flutter test` (1332 passed, 8 skipped) on every commit
- [x] `dart format --set-exit-if-changed .` clean
- [x] `flutter analyze --fatal-infos` clean
- [ ] Manual verification on iOS hardware for the HEIC avatar path (test only covers fast path + magic-byte branching; HEIC decoding requires a device codec)