### PR TITLE
release: hover symmetry, update-check TTL, signup avatar crop (#723 #793 #728)

### DIFF
--- a/apps/client/lib/src/providers/update_provider.dart
+++ b/apps/client/lib/src/providers/update_provider.dart
@@ -89,7 +89,13 @@ const _cacheTimeKey = 'update_check_time';
 const _dismissedVersionKey = 'update_dismissed_version';
 const _downloadedFileKey = 'update_downloaded_file';
 const _downloadedVersionKey = 'update_downloaded_version';
-const _cacheTtl = Duration(hours: 24);
+
+/// How long an update-check result is reused before re-fetching from the
+/// GitHub releases API. Previously 24h, which meant a release landing a few
+/// hours after the user's first launch of the day was suppressed until the
+/// next day (#793). One hour balances API politeness against freshness for
+/// users who keep the app open all day.
+const _cacheTtl = Duration(hours: 1);
 
 const _releaseApiUrl =
     'https://api.github.com/repos/NC1107/echo-messenger/releases/latest';
@@ -110,7 +116,10 @@ class Update extends _$Update {
   }
 
   Future<void> check({bool force = false}) async {
-    if (appVersion == 'dev') return;
+    if (appVersion == 'dev') {
+      debugPrint('[UpdateProvider] check skipped — running dev build');
+      return;
+    }
     state = state.copyWith(status: UpdateStatus.checking);
 
     try {
@@ -118,9 +127,17 @@ class Update extends _$Update {
 
       if (!force) {
         final usedCache = await _tryLoadFromCache(prefs);
-        if (usedCache) return;
+        if (usedCache) {
+          debugPrint(
+            '[UpdateProvider] check served from cache (TTL ${_cacheTtl.inMinutes}m)',
+          );
+          return;
+        }
       }
 
+      debugPrint(
+        '[UpdateProvider] check fetching from GitHub releases (force=$force)',
+      );
       await _fetchLatestRelease(prefs);
     } catch (e) {
       debugPrint('[UpdateProvider] Error checking for updates: $e');

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -16,6 +16,7 @@ import '../services/toast_service.dart';
 import '../services/upload_client.dart';
 import '../theme/echo_theme.dart';
 import '../utils/friendly_error.dart';
+import '../widgets/avatar_crop_dialog.dart';
 import '../widgets/echo_logo_icon.dart';
 
 /// Shared preferences key that gates whether onboarding has been completed.
@@ -154,8 +155,20 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
     final file = result.files.first;
     if (file.bytes == null) return;
 
-    setState(() => _pickedAvatar = file);
-    await _uploadAvatar(file);
+    // Show the same crop dialog the Settings → Profile flow uses (#728) so
+    // signup users get an aspect-correct avatar instead of whatever shape
+    // their gallery handed back. Dialog returns null on cancel.
+    if (!mounted) return;
+    final croppedBytes = await showAvatarCropDialog(context, file.bytes!);
+    if (croppedBytes == null) return;
+
+    final croppedFile = PlatformFile(
+      name: 'avatar.jpg',
+      size: croppedBytes.length,
+      bytes: croppedBytes,
+    );
+    setState(() => _pickedAvatar = croppedFile);
+    await _uploadAvatar(croppedFile);
   }
 
   Future<void> _uploadAvatar(PlatformFile file) async {

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1712,8 +1712,14 @@ class _MessageItemState extends State<MessageItem>
   }) {
     return Positioned(
       top: -28,
+      // Anchor only the side closest to the bubble so the overlay sizes to
+      // its child action row (#723). Setting both left & right would force
+      // it to span the entire chat width — sent (right-aligned) bubbles set
+      // `right: 0`, but received bubbles previously also set `right: 8`,
+      // which is what produced the asymmetric full-width hover bar on
+      // left-side messages.
       left: isMine ? null : 36,
-      right: isMine ? 0 : 8,
+      right: isMine ? 0 : null,
       child: ExcludeSemantics(
         excluding: !_isHovered,
         child: IgnorePointer(

--- a/apps/client/test/widgets/message_item_hover_overlay_test.dart
+++ b/apps/client/test/widgets/message_item_hover_overlay_test.dart
@@ -1,0 +1,80 @@
+// Verifies the hover-actions overlay sizes to its child instead of
+// stretching across the chat pane on left-side received bubbles (#723).
+//
+// The overlay is a Positioned widget at top:-28. Anchoring only the side
+// closest to the bubble (left for received, right for sent) lets the inner
+// action row determine the overlay's width. Setting both `left` and `right`
+// would force the overlay to span the full chat width, which is the bug
+// #723 reported.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/widgets/message_item.dart';
+
+import '../helpers/pump_app.dart';
+
+ChatMessage _msg({required bool isMine}) => ChatMessage(
+  id: isMine ? 'm-mine' : 'm-other',
+  fromUserId: isMine ? 'me' : 'u-other',
+  fromUsername: isMine ? 'me' : 'alice',
+  conversationId: 'c1',
+  content: 'short',
+  timestamp: '2026-05-06T10:00:00Z',
+  isMine: isMine,
+  status: MessageStatus.sent,
+);
+
+// Find the hover-overlay Positioned widget — uniquely identified by its
+// top: -28 placement (the affordance bar floats just above the bubble).
+Positioned _hoverPositioned(WidgetTester tester) {
+  return tester
+      .widgetList<Positioned>(find.byType(Positioned))
+      .firstWhere((p) => p.top == -28);
+}
+
+void main() {
+  group('Hover overlay anchoring (#723)', () {
+    testWidgets(
+      'received (left-side) overlay anchors only at left so it sizes to child',
+      (tester) async {
+        await tester.pumpApp(
+          MessageItem(
+            message: _msg(isMine: false),
+            showHeader: true,
+            isLastInGroup: true,
+            myUserId: 'me',
+          ),
+        );
+        await tester.pump();
+
+        final overlay = _hoverPositioned(tester);
+        expect(overlay.left, 36);
+        expect(
+          overlay.right,
+          isNull,
+          reason: 'received bubble overlay must not pin its right edge',
+        );
+      },
+    );
+
+    testWidgets(
+      'sent (right-side) overlay anchors only at right so it sizes to child',
+      (tester) async {
+        await tester.pumpApp(
+          MessageItem(
+            message: _msg(isMine: true),
+            showHeader: true,
+            isLastInGroup: true,
+            myUserId: 'me',
+          ),
+        );
+        await tester.pump();
+
+        final overlay = _hoverPositioned(tester);
+        expect(overlay.left, isNull);
+        expect(overlay.right, 0);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Three independent client fixes for `dev → main`. Each is its own commit; reviewer can read them in any order.

- **#723** `fix(client): anchor hover overlay to the bubble side, not full chat width` — hover affordance bar on left-side received bubbles spanned the entire chat pane because the Positioned wrapper set both `left: 36` and `right: 8`. Drop the right anchor on the received branch so the overlay sizes to its child action row, mirroring the sent-side behavior. Locked in with a widget test that asserts `left == 36, right == null` for received and `left == null, right == 0` for sent.
- **#793** `fix(client): drop update-check cache TTL from 24h to 1h` — a release landing hours after the user's first launch was suppressed until the next day because every subsequent `check()` served a stale cached "no update" hit. Reduce to 1 hour so continuously-running sessions pick up new releases within the hour, still polite to GitHub's API. Added `debugPrint` for cache hit / network fetch / dev-build skip so the issue's diagnosis loop has something to grep.
- **#728** `fix(client): show avatar crop dialog during signup` — the Settings → Profile avatar flow shows the cropper before upload, but the onboarding wizard handed the picked file straight to the uploader. Wire `showAvatarCropDialog` into the same spot so the two flows match.

## Closes

- Closes #723
- Closes #793
- Closes #728

## Test plan

- [x] `flutter test` (1334 passed including 2 new hover-overlay tests, 8 skipped)
- [x] `dart format --set-exit-if-changed .` clean
- [x] `flutter analyze --fatal-infos` clean

## Not in this PR

- **#727 (Linux video playback)** is on `feature/media-kit-migration` (PR #799). Replacing the entire `video_player` stack with `media_kit` deserved its own focused review and a Linux-hardware verification before it ships.