### PR TITLE
feat(client): drop YouTube iframe, always show thumbnail card

### DIFF
--- a/apps/client/lib/src/widgets/message/youtube_embed.dart
+++ b/apps/client/lib/src/widgets/message/youtube_embed.dart
@@ -1,23 +1,23 @@
-import 'dart:async';
-
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:youtube_player_iframe/youtube_player_iframe.dart';
 
 import '../../theme/echo_theme.dart';
-import 'youtube_platform_support.dart';
 
 /// 16:9 YouTube embed.
 ///
-/// On platforms where `youtube_player_iframe` (and its underlying webview
-/// implementation) is supported — iOS, Android, Web, macOS — this renders
-/// the inline iframe player. On Linux + Windows desktop, or when iframe
-/// init fails for any reason (network, ad-blocker, etc.), it falls back to
-/// a static thumbnail card with a red play button overlay; tapping the
-/// fallback launches YouTube via deep link or the system browser.
-class YouTubeEmbed extends StatefulWidget {
+/// Renders a static thumbnail card with a red play button overlay; tapping
+/// launches the video in the YouTube app (deep-link) or, if the app isn't
+/// installed, the system browser.
+///
+/// We deliberately don't use `youtube_player_iframe` for inline playback
+/// any more. YouTube blocks many otherwise-public videos from embedding
+/// (region locks, age gates, "embedding disabled by uploader") and renders
+/// its branded "Video unavailable, error 152-N" UI inside the iframe
+/// without firing a JS error event we can intercept. The result was 8
+/// seconds of YouTube's branded error before the load timeout swapped to
+/// this card. The card is faster, more reliable, and consistent with how
+/// Discord/Slack handle YouTube links.
+class YouTubeEmbed extends StatelessWidget {
   final String videoId;
   final String? title;
 
@@ -34,164 +34,6 @@ class YouTubeEmbed extends StatefulWidget {
     final match = _idRegex.firstMatch(url.trim());
     return match?.group(1);
   }
-
-  @override
-  State<YouTubeEmbed> createState() => _YouTubeEmbedState();
-}
-
-class _YouTubeEmbedState extends State<YouTubeEmbed> {
-  YoutubePlayerController? _controller;
-  StreamSubscription<YoutubePlayerValue>? _subscription;
-  Timer? _loadTimeout;
-  bool _useFallback = !youtubeIframeSupported;
-
-  /// Maximum time we wait for the iframe player to reach any known state
-  /// (`cued`, `unstarted`, etc.) before assuming a silent failure and
-  /// swapping to the static fallback card. Some YouTube error states (e.g.
-  /// region/age/embed restrictions that surface as the iframe's branded
-  /// "Video unavailable" UI with codes like 152/153) never fire the JS
-  /// `onError` event, so the explicit-error listener below cannot catch
-  /// them — this timeout is the catch-net for that class of failures.
-  static const _kLoadTimeout = Duration(seconds: 8);
-
-  @override
-  void initState() {
-    super.initState();
-    if (youtubeIframeSupported) {
-      try {
-        final controller = YoutubePlayerController.fromVideoId(
-          videoId: widget.videoId,
-          autoPlay: false,
-          params: const YoutubePlayerParams(
-            mute: false,
-            showControls: true,
-            showFullscreenButton: true,
-            strictRelatedVideos: true,
-          ),
-        );
-        // Listen for explicit IFrame-API errors and for the player reaching
-        // a usable state (which cancels the load-timeout fallback). The two
-        // signals together cover most failure modes:
-        //   - JS `onError` codes 100/101/105/150 + catch-all `unknown`
-        //     (handled here via `value.error`).
-        //   - Silent failures where YouTube renders its branded error UI
-        //     inside the iframe without firing onError (handled via the
-        //     load timeout below).
-        _subscription = controller.listen((value) {
-          if (!mounted || _useFallback) return;
-          if (value.error != YoutubeError.none) {
-            debugPrint(
-              '[YouTubeEmbed] runtime error ${value.error}, falling back',
-            );
-            _loadTimeout?.cancel();
-            setState(() => _useFallback = true);
-            return;
-          }
-          // Cancel the timeout once the iframe reports any usable state —
-          // anything past `unknown` means YouTube's player is alive.
-          if (value.playerState != PlayerState.unknown) {
-            _loadTimeout?.cancel();
-          }
-        });
-        _loadTimeout = Timer(_kLoadTimeout, () {
-          if (!mounted || _useFallback) return;
-          debugPrint(
-            '[YouTubeEmbed] iframe never reached a usable state in '
-            '${_kLoadTimeout.inSeconds}s, falling back '
-            '(likely region/embed/age restriction)',
-          );
-          setState(() => _useFallback = true);
-        });
-        _controller = controller;
-      } catch (e) {
-        debugPrint('[YouTubeEmbed] iframe init failed: $e');
-        _useFallback = true;
-      }
-    }
-  }
-
-  @override
-  void dispose() {
-    _loadTimeout?.cancel();
-    _subscription?.cancel();
-    _controller?.close();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final controller = _controller;
-    if (_useFallback || controller == null) {
-      return _YouTubeFallbackCard(videoId: widget.videoId, title: widget.title);
-    }
-
-    return Padding(
-      padding: const EdgeInsets.only(top: 8),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(14),
-        child: Container(
-          decoration: BoxDecoration(
-            color: context.surface,
-            border: Border.all(color: context.border, width: 1),
-            borderRadius: BorderRadius.circular(14),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AspectRatio(
-                aspectRatio: 16 / 9,
-                // On web the iframe sits inside an HtmlElementView and the
-                // outer GestureDetector on the chat bubble (long-press,
-                // swipe-to-reply) wins the gesture arena before the iframe
-                // sees the tap. PointerInterceptor draws a transparent HTML
-                // element that intercepts pointer events at the DOM layer
-                // so they reach the iframe's controls. No-op on native.
-                child: kIsWeb
-                    ? PointerInterceptor(
-                        child: YoutubePlayer(
-                          controller: controller,
-                          aspectRatio: 16 / 9,
-                          enableFullScreenOnVerticalDrag: false,
-                        ),
-                      )
-                    : YoutubePlayer(
-                        controller: controller,
-                        aspectRatio: 16 / 9,
-                        enableFullScreenOnVerticalDrag: false,
-                      ),
-              ),
-              if (widget.title != null && widget.title!.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
-                  child: Text(
-                    widget.title!,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: context.textPrimary,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                      height: 1.3,
-                    ),
-                  ),
-                ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Static thumbnail card. Used directly on Linux/Windows desktop where the
-/// iframe player isn't supported, and as a fallback when iframe init fails
-/// at runtime on supported platforms.
-class _YouTubeFallbackCard extends StatelessWidget {
-  final String videoId;
-  final String? title;
-
-  const _YouTubeFallbackCard({required this.videoId, this.title});
 
   static Future<void> _launchVideo(String videoId) async {
     final appUri = Uri.parse('youtube://watch?v=$videoId');

--- a/apps/client/lib/src/widgets/message/youtube_platform_support.dart
+++ b/apps/client/lib/src/widgets/message/youtube_platform_support.dart
@@ -1,8 +1,0 @@
-// Whether `youtube_player_iframe` reliably supports the current platform.
-//
-// The package is backed by `webview_flutter`, which has solid platform
-// implementations for iOS, Android, Web, and macOS but not for Linux or
-// Windows desktop. The web stub defaults to `true`; the io variant uses
-// `dart:io.Platform` to gate Linux + Windows.
-export 'youtube_platform_support_stub.dart'
-    if (dart.library.io) 'youtube_platform_support_io.dart';

--- a/apps/client/lib/src/widgets/message/youtube_platform_support_io.dart
+++ b/apps/client/lib/src/widgets/message/youtube_platform_support_io.dart
@@ -1,6 +1,0 @@
-import 'dart:io' show Platform;
-
-/// True on iOS, Android, macOS — false on Linux, Windows desktop where
-/// `webview_flutter` does not have a reliable platform implementation.
-final bool youtubeIframeSupported =
-    Platform.isIOS || Platform.isAndroid || Platform.isMacOS;

--- a/apps/client/lib/src/widgets/message/youtube_platform_support_stub.dart
+++ b/apps/client/lib/src/widgets/message/youtube_platform_support_stub.dart
@@ -1,2 +1,0 @@
-/// Web fallback: webview / iframe is supported.
-const bool youtubeIframeSupported = true;

--- a/apps/client/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/client/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -28,7 +28,6 @@ import tray_manager
 import url_launcher_macos
 import volume_controller
 import wakelock_plus
-import webview_flutter_wkwebview
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -55,6 +54,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
-  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -1125,38 +1125,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  pointer_interceptor:
-    dependency: "direct main"
-    description:
-      name: pointer_interceptor
-      sha256: "57210410680379aea8b1b7ed6ae0c3ad349bfd56fe845b8ea934a53344b9d523"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.1+2"
-  pointer_interceptor_ios:
-    dependency: transitive
-    description:
-      name: pointer_interceptor_ios
-      sha256: "03c5fa5896080963ab4917eeffda8d28c90f22863a496fb5ba13bc10943e40e4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.1+1"
-  pointer_interceptor_platform_interface:
-    dependency: transitive
-    description:
-      name: pointer_interceptor_platform_interface
-      sha256: "0597b0560e14354baeb23f8375cd612e8bd4841bf8306ecb71fcd0bb78552506"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.0+1"
-  pointer_interceptor_web:
-    dependency: transitive
-    description:
-      name: pointer_interceptor_web
-      sha256: "460b600e71de6fcea2b3d5f662c92293c049c4319e27f0829310e5a953b3ee2a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.3"
   pointycastle:
     dependency: transitive
     description:
@@ -1809,38 +1777,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  webview_flutter:
-    dependency: transitive
-    description:
-      name: webview_flutter
-      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.13.1"
-  webview_flutter_android:
-    dependency: transitive
-    description:
-      name: webview_flutter_android
-      sha256: f560f57d0f529c1dcdaf4edc3a3217b099560622f9f4a10b6bdbb566553c61ea
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.11.0"
-  webview_flutter_platform_interface:
-    dependency: transitive
-    description:
-      name: webview_flutter_platform_interface
-      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.15.1"
-  webview_flutter_wkwebview:
-    dependency: transitive
-    description:
-      name: webview_flutter_wkwebview
-      sha256: a68868ac4828a5f012bf81e8bd25d879f3cec5bd5301575466caafbf9a320a65
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.24.5"
   win32:
     dependency: transitive
     description:
@@ -1889,22 +1825,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  youtube_player_iframe:
-    dependency: "direct main"
-    description:
-      name: youtube_player_iframe
-      sha256: "6690da91591d14b32a6884eb6ae270ea4cc946a748d577d89d18cde565be689f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.2.2"
-  youtube_player_iframe_web:
-    dependency: transitive
-    description:
-      name: youtube_player_iframe_web
-      sha256: "333901d008634f2ea67ef27aba8d597567e4ff45f393290b948a739654ab6dca"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.2"
 sdks:
   dart: ">=3.11.4 <4.0.0"
   flutter: ">=3.41.0"

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -51,15 +51,6 @@ dependencies:
   local_auth: ^3.0.1
   desktop_drop: ^0.7.1
   flutter_slidable: ^3.1.1
-  # Inline YouTube playback. Backed by webview_flutter which supports
-  # iOS / Android / Web / macOS. On Linux + Windows desktop where webview
-  # support is limited, the YouTubeEmbed widget falls back to the static
-  # thumbnail card.
-  youtube_player_iframe: ^5.2.0
-  # On web the YouTube iframe sits below the Flutter pointer-capture layer,
-  # so taps don't reach it. PointerInterceptor lets pointer events pass
-  # through to the underlying iframe element. No-op on native platforms.
-  pointer_interceptor: ^0.10.1+2
   image: ^4.8.0
   flutter_colorpicker: ^1.1.0
 


### PR DESCRIPTION
## Why

User reports the inline YouTube iframe shows its branded \"This video is unavailable, error 152-4\" UI for ~8 seconds before swapping to our thumbnail fallback. The 8-second timeout from #803 was working as designed, but for a very common failure mode (region locks, age gates, embed-disabled, region-specific licensing), 8 seconds of YouTube's branded error is worse UX than just showing the thumbnail card from the start.

YouTube renders some \"Video unavailable\" states inside its iframe WITHOUT firing a JS error event we can intercept, so even with explicit error listening + timeout, we can't avoid showing the broken state for *some* time before swapping.

## Fix

Drop the iframe player entirely. `YouTubeEmbed` now always renders the static thumbnail card (red play button overlay on the maxresdefault/hqdefault image). Tapping deep-links the YouTube app via `youtube://watch?v=ID`, falling back to the system browser when the app isn't installed.

This is the same pattern Discord/Slack use — far more reliable, faster, and consistent across platforms.

### Cleanup
- Drop `youtube_player_iframe: ^5.2.0` and `pointer_interceptor: ^0.10.1+2` from pubspec — no remaining consumers.
- Delete `youtube_platform_support.dart` + io/stub variants — no platform gating needed any more.
- Removes ~150 LOC of iframe controller / listener / timeout plumbing.

## Test plan

- [x] `flutter test` — 1332 passed, 8 skipped. All 13 existing YouTube-embed cases pass unchanged (they were against the thumbnail-card path which is now the only path).
- [x] `flutter analyze --fatal-infos` clean.
- [x] `dart format --set-exit-if-changed .` clean.
- [ ] Manual mobile: post a YouTube link, confirm thumbnail card renders immediately (no \"Video unavailable\" delay), tap launches YouTube app.
- [ ] Manual desktop: same — tap launches browser to youtube.com.