### PR TITLE
chore: cleanup batch — unnecessary_async + channels_provider Riverpod migration (#770)

### DIFF
--- a/apps/client/analysis_options.yaml
+++ b/apps/client/analysis_options.yaml
@@ -30,9 +30,10 @@ linter:
     # Catch BuildContext usage after an `await` (post-async-gap), a classic
     # Flutter footgun that crashes when the widget is unmounted mid-await.
     use_build_context_synchronously: true
-    # `unnecessary_async` is a logical follow-up but currently flags 27
-    # call sites across providers/services/tests; cleaning those is its
-    # own focused PR.
+    # Catch async functions with no await — usually means a sync expression
+    # was wrapped in async/await unnecessarily, or someone meant to await
+    # something inside but forgot.
+    unnecessary_async: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -19,7 +19,7 @@ import 'src/services/sound_service.dart';
 import 'src/services/user_data_dir.dart';
 import 'src/utils/platform_shutdown.dart';
 
-void main() async {
+void main() {
   WidgetsFlutterBinding.ensureInitialized();
   // Initialize media_kit's libmpv backend so video playback works on every
   // platform — including Linux desktop, where Flutter's default video_player

--- a/apps/client/lib/src/providers/auth/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.dart
@@ -333,7 +333,7 @@ class AuthNotifier extends StateNotifier<AuthState>
   /// clears the in-state refresh token so the caller can simulate the web path
   /// (no body) using the standard mock infrastructure.
   @visibleForTesting
-  Future<bool> refreshAccessTokenForTest({bool sendBody = true}) async {
+  Future<bool> refreshAccessTokenForTest({bool sendBody = true}) {
     if (!sendBody) {
       // Temporarily null out the refresh token in state so _doRefreshAccessToken
       // takes the kIsWeb-equivalent branch where no body field is included.

--- a/apps/client/lib/src/providers/channels_provider.dart
+++ b/apps/client/lib/src/providers/channels_provider.dart
@@ -64,7 +64,7 @@ class ChannelsNotifier extends StateNotifier<ChannelsState> {
 
   Future<http.Response> _authenticatedRequest(
     Future<http.Response> Function(String token) requestFn,
-  ) async {
+  ) {
     return ref.read(authProvider.notifier).authenticatedRequest(requestFn);
   }
 

--- a/apps/client/lib/src/providers/channels_provider.dart
+++ b/apps/client/lib/src/providers/channels_provider.dart
@@ -1,12 +1,14 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/channel.dart';
 import 'auth_provider.dart';
 import 'server_url_provider.dart';
+
+part 'channels_provider.g.dart';
 
 class ChannelsState {
   final Map<String, List<GroupChannel>> channelsByConversation;
@@ -50,10 +52,10 @@ class ChannelsState {
   }
 }
 
-class ChannelsNotifier extends StateNotifier<ChannelsState> {
-  final Ref ref;
-
-  ChannelsNotifier(this.ref) : super(const ChannelsState());
+@Riverpod(keepAlive: true)
+class Channels extends _$Channels {
+  @override
+  ChannelsState build() => const ChannelsState();
 
   String get _serverUrl => ref.read(serverUrlProvider);
 
@@ -289,9 +291,3 @@ class ChannelsNotifier extends StateNotifier<ChannelsState> {
     }
   }
 }
-
-final channelsProvider = StateNotifierProvider<ChannelsNotifier, ChannelsState>(
-  (ref) {
-    return ChannelsNotifier(ref);
-  },
-);

--- a/apps/client/lib/src/providers/channels_provider.g.dart
+++ b/apps/client/lib/src/providers/channels_provider.g.dart
@@ -1,25 +1,25 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'privacy_provider.dart';
+part of 'channels_provider.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$privacyHash() => r'68bd1ada98140fdd9a0f9c2d0c84d2b66df6b5eb';
+String _$channelsHash() => r'09add42a68bc9404a3a2e5e291f515de37dfaaf7';
 
-/// See also [Privacy].
-@ProviderFor(Privacy)
-final privacyProvider = NotifierProvider<Privacy, PrivacyState>.internal(
-  Privacy.new,
-  name: r'privacyProvider',
+/// See also [Channels].
+@ProviderFor(Channels)
+final channelsProvider = NotifierProvider<Channels, ChannelsState>.internal(
+  Channels.new,
+  name: r'channelsProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$privacyHash,
+      : _$channelsHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-typedef _$Privacy = Notifier<PrivacyState>;
+typedef _$Channels = Notifier<ChannelsState>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/contacts_provider.dart
+++ b/apps/client/lib/src/providers/contacts_provider.dart
@@ -85,7 +85,7 @@ class Contacts extends _$Contacts {
   /// Make an authenticated request with automatic 401 refresh-and-retry.
   Future<http.Response> _authenticatedRequest(
     Future<http.Response> Function(String token) requestFn,
-  ) async {
+  ) {
     return ref.read(authProvider.notifier).authenticatedRequest(requestFn);
   }
 

--- a/apps/client/lib/src/providers/contacts_provider.g.dart
+++ b/apps/client/lib/src/providers/contacts_provider.g.dart
@@ -6,7 +6,7 @@ part of 'contacts_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$contactsHash() => r'bd95d695d094aeb06b4687266277077cd9232603';
+String _$contactsHash() => r'43b765ee9db3c4e16ed2eabb70ddadb8222a5906';
 
 /// See also [Contacts].
 @ProviderFor(Contacts)

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -113,7 +113,7 @@ class ConversationsNotifier extends StateNotifier<ConversationsState>
   @override
   Future<http.Response> _authenticatedRequest(
     Future<http.Response> Function(String token) requestFn,
-  ) async {
+  ) {
     return ref.read(authProvider.notifier).authenticatedRequest(requestFn);
   }
 

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -308,7 +308,7 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
   Future<int?> rotateGroupKey(
     String conversationId,
     List<Map<String, dynamic>> members,
-  ) async {
+  ) {
     final groupCrypto = ref.read(groupCryptoServiceProvider);
     final token = ref.read(authProvider).token ?? '';
     groupCrypto.setToken(token);
@@ -316,7 +316,7 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
   }
 
   /// Fetch the latest group key from the server and cache it locally.
-  Future<(int, String)?> fetchGroupKey(String conversationId) async {
+  Future<(int, String)?> fetchGroupKey(String conversationId) {
     final groupCrypto = ref.read(groupCryptoServiceProvider);
     final token = ref.read(authProvider).token ?? '';
     groupCrypto.setToken(token);
@@ -334,7 +334,7 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
   // -----------------------------------------------------------------------
 
   /// Check whether a peer's identity key has changed since first contact.
-  Future<bool> hasPeerIdentityKeyChanged(String peerUserId) async {
+  Future<bool> hasPeerIdentityKeyChanged(String peerUserId) {
     final crypto = ref.read(cryptoServiceProvider);
     return crypto.hasPeerIdentityKeyChanged(peerUserId);
   }
@@ -361,7 +361,7 @@ class CryptoNotifier extends StateNotifier<CryptoState> {
 
   /// Compute the safety-number fingerprint for [peerUserId], or `null`
   /// if either identity key is unavailable.
-  Future<String?> safetyNumberFor(String peerUserId) async {
+  Future<String?> safetyNumberFor(String peerUserId) {
     final crypto = ref.read(cryptoServiceProvider);
     return crypto.safetyNumberFor(peerUserId);
   }

--- a/apps/client/lib/src/providers/privacy_provider.dart
+++ b/apps/client/lib/src/providers/privacy_provider.dart
@@ -71,7 +71,7 @@ class Privacy extends _$Privacy {
 
   Future<http.Response> _authenticatedRequest(
     Future<http.Response> Function(String token) requestFn,
-  ) async {
+  ) {
     return ref.read(authProvider.notifier).authenticatedRequest(requestFn);
   }
 

--- a/apps/client/lib/src/services/crypto/init_extension.dart
+++ b/apps/client/lib/src/services/crypto/init_extension.dart
@@ -114,7 +114,7 @@ extension CryptoServiceInit on CryptoService {
     String storedPrivate, {
     Future<String?> Function(String key)? readKey,
   }) async {
-    Future<String?> read(String key) async =>
+    Future<String?> read(String key) =>
         readKey != null ? readKey(key) : store.read(key);
 
     final privateBytes = base64Decode(storedPrivate);

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -645,7 +645,7 @@ class CryptoService {
     String peerUserId,
     String ciphertextB64,
     int? fromDeviceId,
-  ) async {
+  ) {
     final sessionKey = _sessionKeyFor(peerUserId, fromDeviceId);
     final fullWire = Uint8List.fromList(base64Decode(ciphertextB64));
 

--- a/apps/client/lib/src/services/message_cache.dart
+++ b/apps/client/lib/src/services/message_cache.dart
@@ -290,7 +290,7 @@ class MessageCache {
   }
 
   /// Open a Hive box (encrypted if a key is available, plain otherwise).
-  static Future<Box<Map>> _openBox(String name) async {
+  static Future<Box<Map>> _openBox(String name) {
     final keyBytes = _encKeyBytes;
     if (keyBytes != null) {
       return _openEncryptedBox(name, keyBytes);

--- a/apps/client/lib/src/utils/clipboard_image_helper_io.dart
+++ b/apps/client/lib/src/utils/clipboard_image_helper_io.dart
@@ -49,7 +49,7 @@ bool _isWaylandSession() {
       xdgSessionType == 'wayland';
 }
 
-Future<ClipboardImageData?> _readLinuxClipboard() async {
+Future<ClipboardImageData?> _readLinuxClipboard() {
   if (_isWaylandSession()) {
     return _readWaylandClipboard();
   }
@@ -264,7 +264,7 @@ Future<bool> writeImageToClipboard(Uint8List bytes, String mimeType) async {
   return false;
 }
 
-Future<bool> _writeLinuxClipboard(Uint8List bytes, String mimeType) async {
+Future<bool> _writeLinuxClipboard(Uint8List bytes, String mimeType) {
   if (_isWaylandSession()) {
     return _writeWaylandClipboard(bytes, mimeType);
   }

--- a/apps/client/test/group_crypto_test.dart
+++ b/apps/client/test/group_crypto_test.dart
@@ -109,7 +109,7 @@ void main() {
       );
     });
 
-    test('decryption without prefix throws FormatException', () async {
+    test('decryption without prefix throws FormatException', () {
       final key = GroupCryptoService.generateGroupKey();
 
       expect(
@@ -118,7 +118,7 @@ void main() {
       );
     });
 
-    test('decryption with truncated ciphertext throws', () async {
+    test('decryption with truncated ciphertext throws', () {
       final key = GroupCryptoService.generateGroupKey();
       // Valid prefix but too short payload
       final shortPayload = '${groupEncryptedPrefix}AAAA';

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -495,7 +495,7 @@ void main() {
       expect(result.id, 'new-dm-1');
     });
 
-    test('throws DmException when server returns 400', () async {
+    test('throws DmException when server returns 400', () {
       when(
         () => mockClient.post(
           any(that: predicate<Uri>((u) => u.path == '/api/conversations/dm')),
@@ -517,7 +517,7 @@ void main() {
       );
     });
 
-    test('throws DmException on network error', () async {
+    test('throws DmException on network error', () {
       when(
         () => mockClient.post(
           any(that: predicate<Uri>((u) => u.path == '/api/conversations/dm')),

--- a/apps/client/test/providers/websocket_send_test.dart
+++ b/apps/client/test/providers/websocket_send_test.dart
@@ -547,7 +547,7 @@ class _PreKeyErrorCryptoService extends CryptoService {
   Future<Map<String, String>> encryptForAllDevices(
     String peerUserId,
     String plaintext,
-  ) async {
+  ) {
     throw Exception('No PreKey bundle found for user');
   }
 
@@ -560,7 +560,7 @@ class _PreKeyErrorCryptoService extends CryptoService {
   }
 
   @override
-  Future<String> encryptMessage(String peerUserId, String plaintext) async {
+  Future<String> encryptMessage(String peerUserId, String plaintext) {
     throw Exception('No PreKey bundle found for user');
   }
 

--- a/apps/client/test/providers/ws_message_handler_test.dart
+++ b/apps/client/test/providers/ws_message_handler_test.dart
@@ -48,11 +48,12 @@ class _FakeGroupCryptoService extends GroupCryptoService {
   Future<(int, String)?> fetchGroupKey(String conversationId) async => null;
 }
 
-class _FakeChannelsNotifier extends ChannelsNotifier {
+class _FakeChannelsNotifier extends Channels {
   final List<String> loadedChannels = [];
   final List<String> loadedVoiceSessions = [];
 
-  _FakeChannelsNotifier(super.ref);
+  @override
+  ChannelsState build() => const ChannelsState();
 
   @override
   Future<void> loadChannels(String conversationId) async {
@@ -173,8 +174,8 @@ void _setup() {
       conversationsProvider.overrideWith(
         (ref) => _FakeConversationsNotifier(ref),
       ),
-      channelsProvider.overrideWith((ref) {
-        fakeChannels = _FakeChannelsNotifier(ref);
+      channelsProvider.overrideWith(() {
+        fakeChannels = _FakeChannelsNotifier();
         return fakeChannels;
       }),
     ],

--- a/apps/client/test/providers/ws_message_handler_test.dart
+++ b/apps/client/test/providers/ws_message_handler_test.dart
@@ -187,7 +187,7 @@ const _myUserId = 'my-user-id';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  setUp(() async {
+  setUp(() {
     SharedPreferences.setMockInitialValues({});
     _setup();
   });

--- a/apps/client/test/services/crypto_service_encrypt_decrypt_test.dart
+++ b/apps/client/test/services/crypto_service_encrypt_decrypt_test.dart
@@ -222,19 +222,16 @@ void main() {
       },
     );
 
-    test(
-      'decryptMessage throws for unknown peer with normal message',
-      () async {
-        // Construct a fake "normal" (non-X3DH) ciphertext — just random bytes.
-        final fakeWire = base64Encode(
-          Uint8List.fromList(List.generate(100, (i) => i)),
-        );
-        expect(
-          () => asBob(() => bob.decryptMessage('unknown-peer', fakeWire)),
-          throwsA(isA<Exception>()),
-        );
-      },
-    );
+    test('decryptMessage throws for unknown peer with normal message', () {
+      // Construct a fake "normal" (non-X3DH) ciphertext — just random bytes.
+      final fakeWire = base64Encode(
+        Uint8List.fromList(List.generate(100, (i) => i)),
+      );
+      expect(
+        () => asBob(() => bob.decryptMessage('unknown-peer', fakeWire)),
+        throwsA(isA<Exception>()),
+      );
+    });
 
     test('session persists across CryptoService re-init', () async {
       // Establish session: Alice -> Bob

--- a/apps/client/test/services/group_crypto_service_test.dart
+++ b/apps/client/test/services/group_crypto_service_test.dart
@@ -93,7 +93,7 @@ void main() {
       );
     });
 
-    test('decryption without prefix throws FormatException', () async {
+    test('decryption without prefix throws FormatException', () {
       final key = GroupCryptoService.generateGroupKey();
       expect(
         () => GroupCryptoService.decryptGroupMessage('no-prefix-data', key),

--- a/apps/client/test/utils/clipboard_image_helper_test.dart
+++ b/apps/client/test/utils/clipboard_image_helper_test.dart
@@ -4,7 +4,7 @@ void main() {
   group('readImageFromClipboard', () {
     test(
       'Wayland: uses wl-paste when WAYLAND_DISPLAY is set',
-      () async {
+      () {
         // Bug: _readLinuxClipboard() always calls xclip, which is X11-only.
         // On Wayland sessions (WAYLAND_DISPLAY set or XDG_SESSION_TYPE=wayland),
         // xclip is unavailable and the paste silently returns null.
@@ -19,7 +19,7 @@ void main() {
 
     test(
       'iOS: readImageFromClipboard logs and returns null instead of silently falling through',
-      () async {
+      () {
         // Bug: readImageFromClipboard() has no Platform.isIOS branch.
         // On iOS the function falls through the if/else chain and returns null
         // without any log, giving the user no indication of why paste fails.
@@ -36,7 +36,7 @@ void main() {
   group('writeImageToClipboard', () {
     test(
       'Wayland: uses wl-copy when WAYLAND_DISPLAY is set',
-      () async {
+      () {
         // Bug: _writeLinuxClipboard() always calls xclip, which is X11-only.
         // On Wayland xclip fails silently.
         // Expected fix: detect Wayland env vars and use wl-copy instead.

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -10,28 +10,27 @@ import 'package:echo_app/src/widgets/channel_bar.dart';
 import '../helpers/mock_providers.dart';
 import '../helpers/pump_app.dart';
 
-class _FakeChannelsNotifier extends ChannelsNotifier {
-  _FakeChannelsNotifier(super.ref) : super() {
-    state = const ChannelsState(
-      channelsByConversation: {
-        'conv-1': [
-          GroupChannel(
-            id: 'voice-1',
-            conversationId: 'conv-1',
-            name: 'lounge',
-            kind: 'voice',
-            position: 0,
-            category: 'Voice Channels',
-            createdAt: '2026-01-01T00:00:00Z',
-          ),
-        ],
-      },
-      voiceSessionsByChannel: {'voice-1': []},
-    );
-  }
-
+class _FakeChannelsNotifier extends Channels {
   int joinCalls = 0;
   int leaveCalls = 0;
+
+  @override
+  ChannelsState build() => const ChannelsState(
+    channelsByConversation: {
+      'conv-1': [
+        GroupChannel(
+          id: 'voice-1',
+          conversationId: 'conv-1',
+          name: 'lounge',
+          kind: 'voice',
+          position: 0,
+          category: 'Voice Channels',
+          createdAt: '2026-01-01T00:00:00Z',
+        ),
+      ],
+    },
+    voiceSessionsByChannel: {'voice-1': []},
+  );
 
   @override
   Future<bool> joinVoiceChannel(String conversationId, String channelId) async {
@@ -125,8 +124,8 @@ void main() {
         overrides: [
           authOverride(loggedInAuthState),
           webSocketOverride(),
-          channelsProvider.overrideWith((ref) {
-            fakeChannels = _FakeChannelsNotifier(ref);
+          channelsProvider.overrideWith(() {
+            fakeChannels = _FakeChannelsNotifier();
             return fakeChannels;
           }),
           voiceRtcProvider.overrideWith((ref) {
@@ -167,8 +166,8 @@ void main() {
         overrides: [
           authOverride(loggedInAuthState),
           webSocketOverride(),
-          channelsProvider.overrideWith((ref) {
-            fakeChannels = _FakeChannelsNotifier(ref);
+          channelsProvider.overrideWith(() {
+            fakeChannels = _FakeChannelsNotifier();
             return fakeChannels;
           }),
           voiceRtcProvider.overrideWith((ref) {
@@ -211,8 +210,8 @@ void main() {
         overrides: [
           authOverride(loggedInAuthState),
           webSocketOverride(),
-          channelsProvider.overrideWith((ref) {
-            fakeChannels = _FakeChannelsNotifier(ref);
+          channelsProvider.overrideWith(() {
+            fakeChannels = _FakeChannelsNotifier();
             return fakeChannels;
           }),
           voiceRtcProvider.overrideWith((ref) {

--- a/apps/client/test/widgets/chat_panel_live_region_test.dart
+++ b/apps/client/test/widgets/chat_panel_live_region_test.dart
@@ -45,10 +45,9 @@ class _FakeChatNotifier extends ChatNotifier {
   }
 }
 
-class _FakeChannelsNotifier extends ChannelsNotifier {
-  _FakeChannelsNotifier(super.ref) {
-    state = const ChannelsState();
-  }
+class _FakeChannelsNotifier extends Channels {
+  @override
+  ChannelsState build() => const ChannelsState();
 
   @override
   Future<void> loadChannels(String conversationId) async {}
@@ -129,7 +128,7 @@ List<Override> _overrides({
       holder.notifier = n;
       return n;
     }),
-    channelsProvider.overrideWith((ref) => _FakeChannelsNotifier(ref)),
+    channelsProvider.overrideWith(_FakeChannelsNotifier.new),
     privacyProvider.overrideWith(_FakePrivacy.new),
     voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
     voiceRtcProvider.overrideWith((ref) => _FakeVoiceRtcNotifier(ref)),

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -43,10 +43,9 @@ class _FakeChatNotifier extends ChatNotifier {
   }
 }
 
-class _FakeChannelsNotifier extends ChannelsNotifier {
-  _FakeChannelsNotifier(super.ref) {
-    state = const ChannelsState();
-  }
+class _FakeChannelsNotifier extends Channels {
+  @override
+  ChannelsState build() => const ChannelsState();
 
   @override
   Future<void> loadChannels(String conversationId) async {}
@@ -71,7 +70,7 @@ List<Override> _chatPanelOverrides({ChatState chatState = const ChatState()}) {
   return [
     ...standardOverrides(),
     chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, chatState)),
-    channelsProvider.overrideWith((ref) => _FakeChannelsNotifier(ref)),
+    channelsProvider.overrideWith(_FakeChannelsNotifier.new),
     privacyProvider.overrideWith(_FakePrivacy.new),
     voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
     voiceRtcProvider.overrideWith((ref) => _FakeVoiceRtcNotifier(ref)),

--- a/apps/client/test/widgets/voice_footer_test.dart
+++ b/apps/client/test/widgets/voice_footer_test.dart
@@ -35,24 +35,23 @@ class _FakeLiveKitNotifier extends LiveKitVoiceNotifier {
   }) async {}
 }
 
-class _FakeChannelsNotifier extends ChannelsNotifier {
-  _FakeChannelsNotifier(super.ref) {
-    state = const ChannelsState(
-      channelsByConversation: {
-        'conv-1': [
-          GroupChannel(
-            id: 'voice-1',
-            conversationId: 'conv-1',
-            name: 'General',
-            kind: 'voice',
-            position: 0,
-            category: 'Voice Channels',
-            createdAt: '2026-01-01T00:00:00Z',
-          ),
-        ],
-      },
-    );
-  }
+class _FakeChannelsNotifier extends Channels {
+  @override
+  ChannelsState build() => const ChannelsState(
+    channelsByConversation: {
+      'conv-1': [
+        GroupChannel(
+          id: 'voice-1',
+          conversationId: 'conv-1',
+          name: 'General',
+          kind: 'voice',
+          position: 0,
+          category: 'Voice Channels',
+          createdAt: '2026-01-01T00:00:00Z',
+        ),
+      ],
+    },
+  );
 
   @override
   Future<void> loadChannels(String conversationId) async {}
@@ -94,7 +93,7 @@ List<Override> _overrides({required LiveKitVoiceState voiceState}) {
     livekitVoiceProvider.overrideWith(
       (ref) => _FakeLiveKitNotifier(ref, initial: voiceState),
     ),
-    channelsProvider.overrideWith((ref) => _FakeChannelsNotifier(ref)),
+    channelsProvider.overrideWith(_FakeChannelsNotifier.new),
   ];
 }
 
@@ -141,7 +140,7 @@ void main() {
             fakeVoice = _FakeLiveKitNotifier(ref, initial: _activeVoiceState);
             return fakeVoice;
           }),
-          channelsProvider.overrideWith((ref) => _FakeChannelsNotifier(ref)),
+          channelsProvider.overrideWith(_FakeChannelsNotifier.new),
         ],
       );
       await tester.pump();


### PR DESCRIPTION
## Summary

Two more cleanup items, picked from the audit's queued list.

### 1. Enable `unnecessary_async` lint rule (`13dc5d4`)

The third lint rule deferred from PR #802. Drops the redundant `async` keyword from 27 functions whose body never awaits — usually wrappers that forward a Future from a delegate (e.g. all the \`_authenticatedRequest\` helpers in providers, plus a handful of \`test()\` blocks whose bodies are purely sync expectations).

No behaviour change: the Future return type is preserved in every case because the body already returned a Future expression directly. The lint is now active project-wide.

### 2. `channels_provider` Riverpod migration (`d75b7fc`, #770)

Second of 9 remaining unmigrated providers per the #770 audit. Convert `ChannelsNotifier` from `StateNotifier` to `@Riverpod`-class codegen.

- `channels_provider.dart`: switch to `@Riverpod(keepAlive: true) class Channels extends _\$Channels` with `ChannelsState build() => const ChannelsState();`. Drop the manual `ref` field, the `StateNotifier` base, and the bottom-of-file `StateNotifierProvider` declaration (codegen replaces it).
- The generated provider name (`channelsProvider`) is unchanged, so all `ref.watch` / `ref.read(p.notifier).method()` call sites stay the same — only the notifier class name (`ChannelsNotifier` → `Channels`) changes.
- 5 test files needed updates (`chat_panel_test`, `chat_panel_live_region_test`, `voice_footer_test`, `channel_bar_test`, `ws_message_handler_test`): renamed fakes from `extends ChannelsNotifier` → `extends Channels`; moved state-seeding from constructor body to `build()` override; switched overrides from `(ref) => _Fake(ref)` to `_Fake.new` or a `() { fakeChannels = _Fake(); return fakeChannels; }` thunk where the test needs to capture the instance.

## Closes / addresses

- Partially addresses #770 (now 2 of 10 originally-unmigrated providers complete).

## Test plan

- [x] `flutter test` — 1332 passed, 8 skipped.
- [x] `flutter analyze --fatal-infos` clean (with the new rule on).
- [x] `dart format --set-exit-if-changed .` clean.
- [x] `dart run build_runner build --delete-conflicting-outputs` succeeds.

## Out of scope

- The remaining 8 unmigrated providers (`auth_provider`, `crypto_provider`, `conversations_provider`, `livekit_voice_provider`, `websocket_provider`, `chat_provider`, `server_url_provider`, `conversations_provider`) — each is its own focused PR per the audit's recommended order.