### PR TITLE
refactor(client): extract upload helpers from chat_input_bar.dart

### DIFF
--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -36,6 +36,7 @@ import 'chat_input_bar/media_marker_helpers.dart';
 import 'chat_input_bar/media_picker_toggle.dart';
 import 'chat_input_bar/recording_row.dart';
 import 'chat_input_bar/send_button.dart';
+import 'chat_input_bar/upload_helpers.dart';
 import 'input/markdown_toolbar.dart';
 import 'input/pending_attachments_strip.dart';
 import 'input/input_status_bar.dart';
@@ -44,36 +45,8 @@ import 'input/reply_preview_bar.dart';
 import 'media_picker_panel.dart';
 import 'mobile_media_picker_panel.dart';
 
-const _kOctetStream = 'octet-stream';
-
-/// Mirror of `MAX_FILE_SIZE` in `apps/server/src/routes/media.rs`. Both must
-/// be bumped together. Cloudflare Free also caps request bodies at 100 MB,
-/// so going higher than this without proxy work will 502 on prod.
-const _kMaxUploadBytes = 100 * 1024 * 1024;
-
-/// Strip the original name and return `media.{ext}` (or just `media` if the
-/// filename had no extension). Used by the "preserve original filenames"
-/// privacy toggle.
-String _genericFilename(String original) {
-  final dot = original.lastIndexOf('.');
-  if (dot <= 0 || dot == original.length - 1) return 'media';
-  final ext = original.substring(dot + 1).toLowerCase();
-  return 'media.$ext';
-}
-
-/// Format a byte count as a human-readable string (1024-based, 1 decimal).
-String _formatBytes(int bytes) {
-  if (bytes < 1024) return '$bytes B';
-  const units = ['KB', 'MB', 'GB'];
-  var v = bytes / 1024.0;
-  var i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return '${v.toStringAsFixed(1)} ${units[i]}';
-}
-
+// Upload constants + pure-Dart helpers (kOctetStream, kMaxUploadBytes,
+// genericFilename, formatBytes) live in chat_input_bar/upload_helpers.dart.
 // Marker / MIME helpers live in chat_input_bar/media_marker_helpers.dart.
 // Local alias preserves the `_kImageGif` symbol used at three call sites
 // in this file without touching them.
@@ -316,7 +289,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       'm4a': ['audio', 'mp4'],
       'aac': ['audio', 'aac'],
     };
-    final mime = mimeTypes[ext] ?? ['application', _kOctetStream];
+    final mime = mimeTypes[ext] ?? ['application', kOctetStream];
 
     _setPendingAttachment(
       bytes: fileBytes,
@@ -725,7 +698,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     // upload the file under a generic name keyed off the extension. The file
     // contents are unchanged.
     final preserve = await readPreserveOriginalFilenames();
-    final uploadFileName = preserve ? fileName : _genericFilename(fileName);
+    final uploadFileName = preserve ? fileName : genericFilename(fileName);
 
     final uploader = UploadClient(ref.read(authProvider.notifier));
     final result = await uploader.uploadFile(
@@ -873,12 +846,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
 
       var sentCount = 0;
       for (final file in result.files) {
-        if (file.size > _kMaxUploadBytes) {
+        if (file.size > kMaxUploadBytes) {
           if (mounted) {
             ToastService.show(
               context,
-              '${file.name} is ${_formatBytes(file.size)} — limit is '
-              '${_formatBytes(_kMaxUploadBytes)}',
+              '${file.name} is ${formatBytes(file.size)} — limit is '
+              '${formatBytes(kMaxUploadBytes)}',
               type: ToastType.error,
             );
           }
@@ -908,7 +881,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         }
 
         final ext = (file.extension ?? '').toLowerCase();
-        final mime = _kMimeTypes[ext] ?? ['application', _kOctetStream];
+        final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
         final mimeType = '${mime[0]}/${mime[1]}';
 
         if (isMulti) {
@@ -1283,12 +1256,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
 
       var sentCount = 0;
       for (final file in result.files) {
-        if (file.size > _kMaxUploadBytes) {
+        if (file.size > kMaxUploadBytes) {
           if (mounted) {
             ToastService.show(
               context,
-              '${file.name} is ${_formatBytes(file.size)} — limit is '
-              '${_formatBytes(_kMaxUploadBytes)}',
+              '${file.name} is ${formatBytes(file.size)} — limit is '
+              '${formatBytes(kMaxUploadBytes)}',
               type: ToastType.error,
             );
           }
@@ -1304,7 +1277,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         if (bytes == null) continue;
 
         final ext = (file.extension ?? '').toLowerCase();
-        final mime = _kMimeTypes[ext] ?? ['application', _kOctetStream];
+        final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
         final mimeType = '${mime[0]}/${mime[1]}';
 
         if (isMulti) {

--- a/apps/client/lib/src/widgets/chat_input_bar/upload_helpers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/upload_helpers.dart
@@ -1,0 +1,39 @@
+/// Constants and pure-Dart helpers shared by the file picker, image picker,
+/// camera picker, and clipboard-paste paths in `chat_input_bar.dart`.
+///
+/// Extracted so the three picker methods don't each redeclare their own
+/// copies, and so other widgets (e.g. avatar pickers, settings file pickers)
+/// can reuse the same caps and formatting without depending on the chat
+/// input bar's internals.
+library;
+
+/// Default MIME subtype when we can't infer the file type.
+const kOctetStream = 'octet-stream';
+
+/// Mirror of `MAX_FILE_SIZE` in `apps/server/src/routes/media.rs`. Both must
+/// be bumped together. Cloudflare Free also caps request bodies at 100 MB,
+/// so going higher than this without proxy work will 502 on prod.
+const kMaxUploadBytes = 100 * 1024 * 1024;
+
+/// Strip the original name and return `media.{ext}` (or just `media` if the
+/// filename had no extension). Used by the "preserve original filenames"
+/// privacy toggle.
+String genericFilename(String original) {
+  final dot = original.lastIndexOf('.');
+  if (dot <= 0 || dot == original.length - 1) return 'media';
+  final ext = original.substring(dot + 1).toLowerCase();
+  return 'media.$ext';
+}
+
+/// Format a byte count as a human-readable string (1024-based, 1 decimal).
+String formatBytes(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  const units = ['KB', 'MB', 'GB'];
+  var v = bytes / 1024.0;
+  var i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return '${v.toStringAsFixed(1)} ${units[i]}';
+}


### PR DESCRIPTION
## Why

`chat_input_bar.dart` has been the largest god module in the tree at 2030 LOC. The audit identified clean extraction targets (media picker, emoji/GIF picker, keyboard shortcuts, drafts), but they all reference private state of the parent `ChatInputBarState` class — so any of those splits would require making fields public or factoring the state into a separate object. That's its own focused refactor.

This PR does the **one** mechanical extraction with bounded coupling: a handful of upload constants and pure-Dart helpers that don't touch state at all but are used by three picker code paths plus the clipboard-paste flow.

## What moved

New file `lib/src/widgets/chat_input_bar/upload_helpers.dart` (joins the existing `chat_input_bar/` subdirectory of small extracted widgets):
- `kOctetStream` — default MIME subtype fallback.
- `kMaxUploadBytes` — mirrors `MAX_FILE_SIZE` in `apps/server/src/routes/media.rs`.
- `genericFilename(String)` — used by the privacy "preserve original filenames" toggle.
- `formatBytes(int)` — human-readable byte counts.

Renamed from leading-underscore private to public symbols. Six call sites in `chat_input_bar.dart` updated to use the public names.

## Scope honesty

This is a small extraction (~30 LOC actually moved). The bigger god-module split work for `chat_input_bar.dart` (extracting the file picker, image picker, recording state, edit-mode helpers, etc.) requires real state-object refactoring that's out of scope for a single mechanical-PR.

The audit's other large god modules (`message_item.dart` 2045, `chat_panel.dart` 1951, `home_screen.dart` 1787) have similar entanglement and are queued for individual focused PRs.

## Test plan

- [x] `flutter test` — 1332 passed, 8 skipped.
- [x] `flutter analyze --fatal-infos` clean.
- [x] `dart format --set-exit-if-changed .` clean.