### PR TITLE
feat: @everyone / @here mentions (#451) + ChatInputBar mention controller (#513)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 - Dart production: `apps/client/lib/src/services/signal_protocol.dart`, `signal_x3dh.dart`, `signal_session.dart`
 - 1:1 messages: X3DH key exchange + Double Ratchet (end-to-end encrypted)
 - Group messages: group key envelopes infrastructure exists (`group_crypto_service.dart`, `routes/group_keys.rs`) but not fully wired. When `is_encrypted=true` is enabled on a group, `sendGroupMessage` hard-fails on encryption errors instead of falling back to plaintext (#344) — server-side ciphertext-only enforcement is tracked separately (#591)
+- `@everyone` / `@here` broadcast mentions are surfaced in the group mention autocomplete picker (#451). `@here` causes the server to skip APNs push to offline members (plaintext groups only; encrypted groups are unaffected because the literal text never appears in ciphertext).
 
 **Voice & Video** (LiveKit integration):
 - Server: `routes/voice.rs` handles call signaling and LiveKit token generation

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Get the latest buildw from the [Releases page](https://github.com/NC1107/echo-me
 - **Privacy controls** -- Toggle read receipts
 - **Username DM invites** -- Share `#/u/{username}` deep links and QR codes to add contacts quickly
 - **Per-message encryption indicator** -- Lock icon shows which messages were encrypted
+- **@mentions** -- @username autocomplete in group chats; @everyone notifies all members, @here notifies only online members (plaintext groups)
 - **Typing indicators** -- See when someone is typing
 - **Conversations list** -- Last message preview, unread badges, timestamps
 - **Cross-platform** -- Windows, Linux, Web, iOS, Android

--- a/apps/client/lib/src/models/conversation.dart
+++ b/apps/client/lib/src/models/conversation.dart
@@ -13,6 +13,12 @@ class Conversation {
   final String? lastMessageTimestamp;
   final String? lastMessageSender;
   final int unreadCount;
+
+  /// Number of unread messages that mention the local user (`@username`,
+  /// `@everyone`, or `@here`). Client-side state only — not serialized
+  /// to/from the server. Reset to 0 by [ConversationsNotifier.markAsRead].
+  final int mentionCount;
+
   final bool isMuted;
   final bool isPinned;
 
@@ -32,6 +38,7 @@ class Conversation {
     this.lastMessageTimestamp,
     this.lastMessageSender,
     this.unreadCount = 0,
+    this.mentionCount = 0,
     this.isMuted = false,
     this.isPinned = false,
     this.ttlSeconds,
@@ -112,6 +119,7 @@ class Conversation {
     String? lastMessageTimestamp,
     String? lastMessageSender,
     int? unreadCount,
+    int? mentionCount,
     bool? isMuted,
     bool? isPinned,
     Object? ttlSeconds = _sentinel,
@@ -128,6 +136,7 @@ class Conversation {
       lastMessageTimestamp: lastMessageTimestamp ?? this.lastMessageTimestamp,
       lastMessageSender: lastMessageSender ?? this.lastMessageSender,
       unreadCount: unreadCount ?? this.unreadCount,
+      mentionCount: mentionCount ?? this.mentionCount,
       isMuted: isMuted ?? this.isMuted,
       isPinned: isPinned ?? this.isPinned,
       ttlSeconds: ttlSeconds == _sentinel
@@ -151,6 +160,7 @@ class Conversation {
             lastMessageTimestamp == other.lastMessageTimestamp &&
             lastMessageSender == other.lastMessageSender &&
             unreadCount == other.unreadCount &&
+            mentionCount == other.mentionCount &&
             isMuted == other.isMuted &&
             isPinned == other.isPinned &&
             ttlSeconds == other.ttlSeconds &&
@@ -169,6 +179,7 @@ class Conversation {
     lastMessageTimestamp,
     lastMessageSender,
     unreadCount,
+    mentionCount,
     isMuted,
     isPinned,
     ttlSeconds,

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -198,13 +198,13 @@ class ConversationsNotifier extends StateNotifier<ConversationsState>
     }
   }
 
-  /// Mark a conversation as read (reset unread count).
+  /// Mark a conversation as read (reset unread + mention counts).
   void markAsRead(String conversationId) {
     final updated = List<Conversation>.from(state.conversations);
     final index = updated.indexWhere((c) => c.id == conversationId);
 
     if (index >= 0) {
-      updated[index] = updated[index].copyWith(unreadCount: 0);
+      updated[index] = updated[index].copyWith(unreadCount: 0, mentionCount: 0);
       state = state.copyWith(conversations: updated);
       _updateTabBadge();
     }
@@ -212,13 +212,12 @@ class ConversationsNotifier extends StateNotifier<ConversationsState>
 
   /// Send read receipt to server.
   Future<void> sendReadReceipt(String conversationId) async {
-    // Save old count so we can restore it if the server call fails.
-    final oldCount =
-        state.conversations
-            .where((c) => c.id == conversationId)
-            .firstOrNull
-            ?.unreadCount ??
-        0;
+    // Save old counts so we can restore them if the server call fails.
+    final oldConv = state.conversations
+        .where((c) => c.id == conversationId)
+        .firstOrNull;
+    final oldUnread = oldConv?.unreadCount ?? 0;
+    final oldMention = oldConv?.mentionCount ?? 0;
 
     markAsRead(conversationId);
     final privacy = ref.read(privacyProvider);
@@ -237,12 +236,15 @@ class ConversationsNotifier extends StateNotifier<ConversationsState>
         '[Conversations] sendReadReceipt failed for '
         '$conversationId: $e',
       );
-      // Rollback: restore the previous unread count so the badge reappears.
-      if (oldCount > 0) {
+      // Rollback: restore the previous counts so the badges reappear.
+      if (oldUnread > 0 || oldMention > 0) {
         final rollback = List<Conversation>.from(state.conversations);
         final idx = rollback.indexWhere((c) => c.id == conversationId);
         if (idx >= 0) {
-          rollback[idx] = rollback[idx].copyWith(unreadCount: oldCount);
+          rollback[idx] = rollback[idx].copyWith(
+            unreadCount: oldUnread,
+            mentionCount: oldMention,
+          );
           state = state.copyWith(conversations: rollback);
           _updateTabBadge();
         }

--- a/apps/client/lib/src/providers/conversations_ws_handlers.dart
+++ b/apps/client/lib/src/providers/conversations_ws_handlers.dart
@@ -17,12 +17,16 @@ mixin _ConversationsWsHandlersMixin on StateNotifier<ConversationsState> {
   ///
   /// Set [incrementUnread] to false for the sender's own messages so the
   /// unread badge is not bumped for messages the user just sent.
+  /// Set [isMention] to true when the decrypted message body contains a
+  /// mention of the local user (`@<myUsername>`, `@everyone`, `@here`);
+  /// the mentionCount badge is bumped alongside the unread count.
   void onNewMessage({
     required String conversationId,
     required String content,
     required String timestamp,
     required String senderUsername,
     bool incrementUnread = true,
+    bool isMention = false,
   }) {
     // System sentinel messages (#663) must not appear in the conversation
     // preview or increment the unread badge.
@@ -39,11 +43,15 @@ mixin _ConversationsWsHandlersMixin on StateNotifier<ConversationsState> {
 
     if (index >= 0) {
       final conv = conversations[index];
+      final shouldBumpMention = incrementUnread && isMention;
       final updatedConv = conv.copyWith(
         lastMessage: content,
         lastMessageTimestamp: timestamp,
         lastMessageSender: senderUsername,
         unreadCount: incrementUnread ? conv.unreadCount + 1 : conv.unreadCount,
+        mentionCount: shouldBumpMention
+            ? conv.mentionCount + 1
+            : conv.mentionCount,
       );
 
       // Build new list updating only the changed conversation and moving

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -23,6 +23,7 @@ enum AppThemeSelection {
 
 const _kThemeKey = 'echo_theme_mode';
 const _kMessageLayoutKey = 'echo_message_layout';
+const _kUiDensityKey = 'echo_ui_density';
 
 /// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
 /// Class is named `AppTheme` (not `Theme`) to avoid colliding with Flutter's
@@ -109,6 +110,56 @@ class MessageLayoutNotifier extends _$MessageLayoutNotifier {
 /// short names.
 final themeProvider = appThemeProvider;
 final messageLayoutProvider = messageLayoutNotifierProvider;
+final uiDensityProvider = uIDensityNotifierProvider;
+
+// ---------------------------------------------------------------------------
+// UI density: cozy (spacious) / normal / compact (Discord-style).
+//
+// Independent of [MessageLayout] (which controls bubble style). Phase 2 of
+// docs/ux-roadmap.md.
+// ---------------------------------------------------------------------------
+
+enum UIDensity { cozy, normal, compact }
+
+@Riverpod(keepAlive: true)
+class UIDensityNotifier extends _$UIDensityNotifier {
+  @override
+  UIDensity build() {
+    _load();
+    // Today's effective default is compact: MessageLayoutNotifier defaults
+    // to MessageLayout.compact, which currently shrinks the sidebar.  Match
+    // that here so brand-new users (no prefs at all) see no behavior change.
+    return UIDensity.compact;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_kUiDensityKey);
+    if (raw == null) {
+      // First read after upgrade.  If the user explicitly chose a
+      // non-compact MessageLayout (bubbles or plain), their sidebar
+      // was rendering at the spacious 68px height — preserve that by
+      // setting density to normal.  Otherwise keep the build() default
+      // (compact), matching today's behavior.
+      final legacy = prefs.getString(_kMessageLayoutKey);
+      if (legacy != null && legacy != 'compact') {
+        state = UIDensity.normal;
+      }
+      return;
+    }
+    state = switch (raw) {
+      'cozy' => UIDensity.cozy,
+      'compact' => UIDensity.compact,
+      _ => UIDensity.normal,
+    };
+  }
+
+  Future<void> setDensity(UIDensity density) async {
+    state = density;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kUiDensityKey, density.name);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Custom color overrides: user-selectable primary and accent (issue #613)

--- a/apps/client/lib/src/providers/theme_provider.g.dart
+++ b/apps/client/lib/src/providers/theme_provider.g.dart
@@ -43,6 +43,22 @@ final messageLayoutNotifierProvider =
     );
 
 typedef _$MessageLayoutNotifier = Notifier<MessageLayout>;
+String _$uIDensityNotifierHash() => r'b63be7192710cd7e4854b0c246f87c7a2016742b';
+
+/// See also [UIDensityNotifier].
+@ProviderFor(UIDensityNotifier)
+final uIDensityNotifierProvider =
+    NotifierProvider<UIDensityNotifier, UIDensity>.internal(
+      UIDensityNotifier.new,
+      name: r'uIDensityNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$uIDensityNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$UIDensityNotifier = Notifier<UIDensity>;
 String _$customColorsHash() => r'8c29d77cdeb45748e1dd87e93287d132534582b8';
 
 /// See also [CustomColors].

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -17,6 +17,7 @@ import '../services/notification_service.dart';
 import '../services/sound_service.dart';
 import '../utils/crypto_utils.dart';
 import '../utils/debug_log.dart';
+import '../utils/mention_detection.dart';
 import 'auth_provider.dart';
 import 'canvas_provider.dart';
 import 'channels_provider.dart';
@@ -375,6 +376,15 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
       MessageCache.cacheMessages(conversationId, [msg]);
     }
 
+    // Mention detection runs over the *decrypted* plaintext. Skip the
+    // sender's own messages — we don't want to badge someone for
+    // mentioning themselves. Sentinel-shaped strings (failed decrypt,
+    // placeholders) won't contain real mentions and are filtered by
+    // _decryptedPreviews logic upstream.
+    final isMention =
+        fromUserId != myUserId &&
+        containsMention(decryptedContent, ref.read(authProvider).username);
+
     // Update conversations list with decrypted preview
     ref
         .read(conversationsProvider.notifier)
@@ -383,6 +393,7 @@ mixin WsMessageHandler on StateNotifier<WebSocketState> {
           content: decryptedContent,
           timestamp: timestamp,
           senderUsername: senderUsername,
+          isMention: isMention,
         );
 
     // Notify with decrypted content so users never see ciphertext.

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -257,6 +257,48 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
                   .read(messageLayoutProvider.notifier)
                   .setLayout(MessageLayout.plain),
             ),
+            const SizedBox(height: 32),
+            // Density tier — UX roadmap Phase 2.  Independent of message
+            // layout: density tunes sidebar row spacing without changing
+            // bubble style.
+            Text(
+              'Density',
+              style: TextStyle(
+                color: context.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _LayoutOption(
+              label: 'Cozy',
+              subtitle: 'More breathing room',
+              icon: Icons.density_large,
+              isSelected: ref.watch(uiDensityProvider) == UIDensity.cozy,
+              onTap: () => ref
+                  .read(uiDensityProvider.notifier)
+                  .setDensity(UIDensity.cozy),
+            ),
+            const SizedBox(height: 8),
+            _LayoutOption(
+              label: 'Normal',
+              subtitle: 'Balanced default',
+              icon: Icons.density_medium,
+              isSelected: ref.watch(uiDensityProvider) == UIDensity.normal,
+              onTap: () => ref
+                  .read(uiDensityProvider.notifier)
+                  .setDensity(UIDensity.normal),
+            ),
+            const SizedBox(height: 8),
+            _LayoutOption(
+              label: 'Compact',
+              subtitle: 'Power-user dense, Discord-style',
+              icon: Icons.density_small,
+              isSelected: ref.watch(uiDensityProvider) == UIDensity.compact,
+              onTap: () => ref
+                  .read(uiDensityProvider.notifier)
+                  .setDensity(UIDensity.compact),
+            ),
             const SizedBox(height: 24),
             // GIF autoplay
             SwitchListTile.adaptive(

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -14,6 +14,7 @@ import '../../providers/canvas_provider.dart';
 import '../../providers/server_url_provider.dart';
 import '../../services/upload_client.dart';
 import '../../theme/echo_theme.dart';
+import '../../theme/motion_tokens.dart';
 import '../../utils/canvas_utils.dart';
 
 /// Popup content for the drawing tools menu.
@@ -128,7 +129,7 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
                       height: 44,
                       child: Center(
                         child: AnimatedContainer(
-                          duration: const Duration(milliseconds: 120),
+                          duration: MotionDurations.quick,
                           width: isSelected ? 24 : 20,
                           height: isSelected ? 24 : 20,
                           decoration: BoxDecoration(
@@ -184,7 +185,7 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
                         ref.read(canvasProvider.notifier).setStrokeWidth(s);
                       },
                       child: AnimatedContainer(
-                        duration: const Duration(milliseconds: 120),
+                        duration: MotionDurations.quick,
                         width: 28,
                         height: 28,
                         decoration: BoxDecoration(

--- a/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
+++ b/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
@@ -14,6 +14,7 @@ import '../../providers/livekit_voice_provider.dart';
 import '../../providers/screen_share_provider.dart';
 import '../../providers/voice_settings_provider.dart';
 import '../../theme/echo_theme.dart';
+import '../../theme/motion_tokens.dart';
 import 'lounge_constants.dart';
 
 class FloatingDock extends ConsumerWidget {
@@ -291,7 +292,8 @@ class FloatingDock extends ConsumerWidget {
           },
           borderRadius: BorderRadius.circular(20),
           child: AnimatedContainer(
-            duration: const Duration(milliseconds: 150),
+            duration: MotionDurations.quick,
+            curve: MotionCurves.entrance,
             width: 40,
             height: 40,
             decoration: BoxDecoration(color: bgColor, shape: BoxShape.circle),
@@ -389,7 +391,8 @@ class DockButtonWithSubmenu extends StatelessWidget {
               },
               borderRadius: BorderRadius.circular(20),
               child: AnimatedContainer(
-                duration: const Duration(milliseconds: 150),
+                duration: MotionDurations.quick,
+                curve: MotionCurves.entrance,
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(

--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -9,6 +9,7 @@ import 'package:livekit_client/livekit_client.dart' as lk;
 
 import '../../providers/livekit_voice_provider.dart';
 import '../../theme/echo_theme.dart';
+import '../../theme/motion_tokens.dart';
 import '../../utils/canvas_utils.dart';
 import '../../widgets/voice_speaking_ring.dart';
 
@@ -206,7 +207,8 @@ class ParticipantTile extends StatelessWidget {
           : null,
       onLongPress: !isLocal && onMuteForMe != null ? onMuteForMe : null,
       child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
+        duration: MotionDurations.standard,
+        curve: MotionCurves.entrance,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16),
           border: Border.all(

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -1222,6 +1222,34 @@ extension EchoColors on BuildContext {
   Color get recvBubble => echo.recvBubble;
   Color get cardRowBg => echo.resolvedCardRowBg;
   Gradient? get chatBgGradient => echo.chatBgGradient;
+
+  // ---------------------------------------------------------------------------
+  // Sidebar state hierarchy tokens (UX roadmap Phase 1).
+  // Derived from existing palette so themes don't need per-theme overrides;
+  // promote to ThemeExtension fields if specific themes ever need to retune.
+  // ---------------------------------------------------------------------------
+
+  /// Subtle accent-tinted background applied to a sidebar row when the
+  /// conversation has unread messages. ~6% opacity keeps it readable
+  /// alongside hover and selected states.
+  Color get unreadRowTint => accent.withValues(alpha: 0.06);
+
+  /// Full-saturation accent used for the 4px-wide left edge bar that marks
+  /// the actively-selected conversation. Stronger signal than the existing
+  /// row tint alone.
+  Color get activeRowAccent => accent;
+
+  /// Distinct color for the mention indicator badge (`@`). Reuses the
+  /// shared danger/warning red so unread vs. mention badges read
+  /// differently at a glance — accent for unread count, danger for
+  /// "you were mentioned."
+  Color get mentionBadgeBg => EchoTheme.danger;
+
+  /// Reduced-contrast text color for muted conversations. Darker than
+  /// [textMuted] so the row reads as "present but quiet" rather than
+  /// "secondary." Applied to name, snippet, timestamp, and the presence
+  /// dot when [Conversation.isMuted] is true.
+  Color get mutedSurface => textMuted.withValues(alpha: 0.6);
 }
 
 /// Shared layout tokens for sectioned card lists (e.g. Settings).

--- a/apps/client/lib/src/theme/motion_tokens.dart
+++ b/apps/client/lib/src/theme/motion_tokens.dart
@@ -1,0 +1,75 @@
+/// Centralized motion tokens for Echo's animation language.
+///
+/// Use these instead of inline `Duration(milliseconds: N)` and raw
+/// `Curves.foo` references so tuning the feel of the app is a one-line
+/// edit instead of a sweep across dozens of widgets.
+///
+/// Phase 0 of the UX roadmap (`docs/ux-roadmap.md`).
+///
+/// Naming is semantic, not numeric: a future contributor knows the
+/// *intent* (`pulse`, `gentle`) without needing to remember the
+/// concrete millisecond value.
+library;
+
+import 'package:flutter/animation.dart';
+
+/// Durations for state transitions, hover feedback, and ambient motion.
+///
+/// Six tokens cover the full range Echo uses today.  Don't add a
+/// seventh without justification — more granularity turns the API into
+/// a lookup table.
+class MotionDurations {
+  MotionDurations._();
+
+  /// Hover, micro-feedback, ripple acknowledgement.
+  static const Duration instant = Duration(milliseconds: 80);
+
+  /// Submenu open/close, tap response, dock highlight.
+  static const Duration quick = Duration(milliseconds: 150);
+
+  /// Banner slide, tile state change, default UI feedback.
+  static const Duration standard = Duration(milliseconds: 200);
+
+  /// Panel slide, dialog show/hide, mode switch.
+  static const Duration expressive = Duration(milliseconds: 300);
+
+  /// Presence transitions, status changes — slow enough to read as
+  /// "something happened" without feeling sluggish.
+  static const Duration gentle = Duration(milliseconds: 400);
+
+  /// Ambient breathing — speaking ring pulse, idle indicators.
+  /// Reserved for *continuous* motion, not one-shot transitions.
+  static const Duration pulse = Duration(milliseconds: 700);
+}
+
+/// Curves for state transitions.
+///
+/// Three semantic curves cover entrance / exit / two-way motion, plus
+/// one expressive overshoot for the rare cases that warrant a soft
+/// "bounce" feel.  Don't add `Curves.bounceOut` or `Curves.elasticOut`
+/// — premium ≠ cartoon (per the UX roadmap anti-goals).
+class MotionCurves {
+  MotionCurves._();
+
+  /// Ease-out: starts fast, decelerates.  Use for things appearing on
+  /// screen — tooltips, banners, panels sliding in.
+  static const Curve entrance = Curves.easeOutCubic;
+
+  /// Ease-in: starts slow, accelerates.  Use for things leaving —
+  /// dismissed dialogs, banners sliding out.
+  static const Curve exit = Curves.easeInCubic;
+
+  /// Symmetric ease.  Use for in-place state changes (color shifts,
+  /// border highlights) where there's no spatial origin or destination.
+  static const Curve emphasis = Curves.easeInOutCubic;
+
+  /// Soft overshoot.  Use only for celebratory or attention-pulling
+  /// transitions — most state changes should use [emphasis] instead.
+  /// Tuned so a 300ms expressive transition reads as "confident,"
+  /// not "bouncy."
+  static const Curve expressiveBounce = Cubic(0.34, 1.20, 0.64, 1.0);
+
+  /// Sharp deceleration.  Reserved for drag-release physics where the
+  /// user's gesture sets the initial velocity.
+  static const Curve decelerate = Curves.decelerate;
+}

--- a/apps/client/lib/src/utils/mention_detection.dart
+++ b/apps/client/lib/src/utils/mention_detection.dart
@@ -1,0 +1,63 @@
+/// Word-boundary scanner for `@`-mentions in plaintext message content.
+///
+/// Used by the WS handler to mark a conversation as "mentioned" when an
+/// incoming message contains `@<myUsername>`, `@everyone`, or `@here`.
+/// Mirrors the server-side `mentions_broadcast` helper
+/// (`apps/server/src/ws/message_service.rs`) but stays decoupled — the
+/// client may grow client-only mention features later (e.g., custom
+/// keyword highlights, mute-mentions-from-X).
+///
+/// Boundary rule: `@` is preceded by start-of-string or whitespace /
+/// non-word character, and the keyword is followed by end-of-string or
+/// non-word character.  Word characters are `[A-Za-z0-9_]`.  This
+/// matches what the autocomplete picker treats as a mention trigger
+/// and avoids false positives like `me@host` or `@hereabouts`.
+library;
+
+/// Returns true when [content] contains a mention of [myUsername]
+/// (case-insensitive) or one of the broadcast keywords (`@everyone`,
+/// `@here`).
+///
+/// [myUsername] may be `null` or empty when the user is not yet
+/// authenticated — in that case only broadcast keywords are matched.
+bool containsMention(String content, String? myUsername) {
+  if (content.isEmpty) return false;
+  if (_containsKeyword(content, 'everyone')) return true;
+  if (_containsKeyword(content, 'here')) return true;
+  if (myUsername == null || myUsername.isEmpty) return false;
+  return _containsKeyword(content, myUsername);
+}
+
+/// Returns true when `@<keyword>` appears in [content] as a standalone
+/// token.  Case-insensitive.  Exposed for tests; prefer [containsMention]
+/// for application code.
+bool containsKeywordMention(String content, String keyword) =>
+    _containsKeyword(content, keyword);
+
+bool _containsKeyword(String content, String keyword) {
+  if (keyword.isEmpty) return false;
+  final target = '@${keyword.toLowerCase()}';
+  final lower = content.toLowerCase();
+  var start = 0;
+  while (true) {
+    final rel = lower.indexOf(target, start);
+    if (rel < 0) return false;
+    final after = rel + target.length;
+    final leftOk = rel == 0 || !_isWordChar(lower.codeUnitAt(rel - 1));
+    final rightOk =
+        after == lower.length || !_isWordChar(lower.codeUnitAt(after));
+    if (leftOk && rightOk) return true;
+    start = rel + target.length;
+  }
+}
+
+bool _isWordChar(int codeUnit) {
+  // ASCII alphanumeric or underscore.  Non-ASCII chars (e.g., accented
+  // letters) count as non-word so a username like "café" still matches
+  // when followed by punctuation.  This is consistent with the server
+  // behavior — strict-ASCII boundary checks for the mention path.
+  return (codeUnit >= 0x30 && codeUnit <= 0x39) || // 0-9
+      (codeUnit >= 0x41 && codeUnit <= 0x5A) || // A-Z
+      (codeUnit >= 0x61 && codeUnit <= 0x7A) || // a-z
+      codeUnit == 0x5F; // _
+}

--- a/apps/client/lib/src/utils/mention_detection.dart
+++ b/apps/client/lib/src/utils/mention_detection.dart
@@ -7,11 +7,15 @@
 /// client may grow client-only mention features later (e.g., custom
 /// keyword highlights, mute-mentions-from-X).
 ///
-/// Boundary rule: `@` is preceded by start-of-string or whitespace /
-/// non-word character, and the keyword is followed by end-of-string or
-/// non-word character.  Word characters are `[A-Za-z0-9_]`.  This
-/// matches what the autocomplete picker treats as a mention trigger
-/// and avoids false positives like `me@host` or `@hereabouts`.
+/// Boundary rule: `@` is preceded by start-of-string or any non-word
+/// character (whitespace OR punctuation), and the keyword is followed
+/// by end-of-string or a non-word character.  Word characters are
+/// `[A-Za-z0-9_]`.  This is intentionally *more permissive* than the
+/// autocomplete picker (`extractMentionQuery`), which only fires after
+/// whitespace — the picker stays conservative to avoid surprising the
+/// user, but the detection used to drive notifications/badges should
+/// match anywhere a mention can plausibly appear in plaintext.  Both
+/// rules avoid false positives like `me@host` and `@hereabouts`.
 library;
 
 /// Returns true when [content] contains a mention of [myUsername]

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -1404,7 +1404,10 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     return false; // don't consume -- let other handlers also run
   }
 
-  /// Handles the Escape key. Returns true if the event was consumed.
+  /// Handles the Escape key by dismissing the highest-priority
+  /// composer-modal state (mention picker → inline picker → media
+  /// picker → pending attachments → edit mode → reply state).  Each
+  /// dismissal is a no-op if the corresponding state isn't active.
   void _handleEscapeKey() {
     if (_mentionController.showPicker) {
       _mentionController.dismiss();

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -546,6 +546,11 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     final text = _messageController.text;
     final cursorPos = _messageController.selection.baseOffset;
 
+    // No selection (-1) means the field has never been focused; bail out
+    // before insertMention's no-op path so we don't dismiss the picker
+    // without inserting anything (would be a silent UX failure).
+    if (cursorPos < 0) return;
+
     _messageController.value = insertMention(
       text: text,
       cursorPosition: cursorPos,
@@ -558,7 +563,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
 
   List<ConversationMember> get _filteredMentionMembers {
     final myUserId = ref.read(authProvider).userId ?? '';
-    return _mentionController.filterMembers(
+    return MentionComposerController.filterMembers(
       widget.conversation.members,
       myUserId,
     );

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -28,6 +28,7 @@ import '../services/slash_commands.dart';
 import '../services/toast_service.dart';
 import '../services/upload_client.dart';
 import '../theme/echo_theme.dart';
+import '../theme/motion_tokens.dart';
 import '../theme/responsive.dart';
 import '../utils/clipboard_image_helper.dart';
 import 'chat_input_bar/attach_file_button.dart';
@@ -1890,13 +1891,21 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                       statusText: inputStatusText,
                       onCancelEdit: _cancelEditMode,
                     ),
-                  // Reply preview bar
-                  if (replyToMessage != null)
-                    ReplyPreviewBar(
-                      replyToMessage: replyToMessage,
-                      onDismiss: () =>
-                          ref.read(chatProvider.notifier).clearReplyTo(),
-                    ),
+                  // Reply preview bar — wrap in AnimatedSize so the bar
+                  // slides in/out instead of snapping when reply mode
+                  // is entered or dismissed (UX roadmap motion expansion).
+                  AnimatedSize(
+                    duration: MotionDurations.standard,
+                    curve: MotionCurves.entrance,
+                    alignment: Alignment.topCenter,
+                    child: replyToMessage != null
+                        ? ReplyPreviewBar(
+                            replyToMessage: replyToMessage,
+                            onDismiss: () =>
+                                ref.read(chatProvider.notifier).clearReplyTo(),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
                   // Pending-attachments strip — one chip per staged file
                   // with thumbnail, name, size, progress, and cancel.
                   if (_hasPendingAttachment)

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -41,6 +41,7 @@ import 'input/markdown_toolbar.dart';
 import 'input/pending_attachments_strip.dart';
 import 'input/input_status_bar.dart';
 import 'input/mention_autocomplete.dart';
+import 'input/mention_controller.dart';
 import 'input/reply_preview_bar.dart';
 import 'media_picker_panel.dart';
 import 'mobile_media_picker_panel.dart';
@@ -120,9 +121,10 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   ChatMessage? _editingMessage;
   bool get _isEditing => _editingMessage != null;
 
-  // Mention autocomplete state
-  bool _showMentionPicker = false;
-  String _mentionQuery = '';
+  // Mention autocomplete state — owned by a controller so the logic is
+  // unit-testable without pumping the whole composer (#513).
+  final MentionComposerController _mentionController =
+      MentionComposerController();
 
   // Pending attachments staged for the current send. Single-pick uses one
   // entry (with the caption-and-send flow); multi-pick stages all picked
@@ -160,7 +162,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   void initState() {
     super.initState();
     _messageController.addListener(_onTextChanged);
+    _mentionController.addListener(_onMentionChanged);
     _loadDraft(widget.conversation.id);
+  }
+
+  void _onMentionChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
@@ -171,8 +178,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       _saveDraftImmediate(oldWidget.conversation.id, _messageController.text);
       _draftSaveTimer?.cancel();
 
-      _showMentionPicker = false;
-      _mentionQuery = '';
+      _mentionController.dismiss();
       _searchDebounce?.cancel();
       // Release every staged attachment's ValueNotifier — switching
       // conversations was previously only releasing the last one (#623),
@@ -198,6 +204,8 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _recorder.dispose();
     _messageController.removeListener(_onTextChanged);
     _messageController.dispose();
+    _mentionController.removeListener(_onMentionChanged);
+    _mentionController.dispose();
     _inputFocusNode.dispose();
     // Release every staged attachment's ValueNotifier (#623). Calling
     // setState here would be unsafe during dispose; just walk the list
@@ -527,30 +535,11 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   }
 
   void _detectMention(String text) {
-    final conv = widget.conversation;
-    if (!conv.isGroup) {
-      if (_showMentionPicker) {
-        setState(() {
-          _showMentionPicker = false;
-          _mentionQuery = '';
-        });
-      }
-      return;
-    }
-
-    final query = extractMentionQuery(
-      text,
-      _messageController.selection.baseOffset,
+    _mentionController.detect(
+      text: text,
+      cursorPosition: _messageController.selection.baseOffset,
+      isGroup: widget.conversation.isGroup,
     );
-    if (query == null) {
-      if (_showMentionPicker) setState(() => _showMentionPicker = false);
-      return;
-    }
-
-    setState(() {
-      _showMentionPicker = true;
-      _mentionQuery = query;
-    });
   }
 
   void _handleMentionSelected(String username) {
@@ -563,17 +552,16 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       username: username,
     );
 
-    setState(() {
-      _showMentionPicker = false;
-      _mentionQuery = '';
-    });
+    _mentionController.dismiss();
     _inputFocusNode.requestFocus();
   }
 
   List<ConversationMember> get _filteredMentionMembers {
-    final conv = widget.conversation;
     final myUserId = ref.read(authProvider).userId ?? '';
-    return conv.members.where((m) => m.userId != myUserId).toList();
+    return _mentionController.filterMembers(
+      widget.conversation.members,
+      myUserId,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -1412,11 +1400,8 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
 
   /// Handles the Escape key. Returns true if the event was consumed.
   void _handleEscapeKey() {
-    if (_showMentionPicker) {
-      setState(() {
-        _showMentionPicker = false;
-        _mentionQuery = '';
-      });
+    if (_mentionController.showPicker) {
+      _mentionController.dismiss();
     } else if (_showInlinePicker) {
       setState(() => _showInlinePicker = false);
       _inputFocusNode.requestFocus();
@@ -1881,10 +1866,10 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
           mainAxisSize: MainAxisSize.min,
           children: [
             // Mention autocomplete picker
-            if (_showMentionPicker)
+            if (_mentionController.showPicker)
               MentionAutocomplete(
                 members: _filteredMentionMembers,
-                mentionQuery: _mentionQuery,
+                mentionQuery: _mentionController.query,
                 onMentionSelected: _handleMentionSelected,
               ),
             // Input area

--- a/apps/client/lib/src/widgets/chat_input_bar/send_button.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/send_button.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/crypto_provider.dart';
 import '../../theme/echo_theme.dart';
+import '../../theme/motion_tokens.dart';
 
 /// Round send / mic / confirm-edit button on the right side of the input row.
 class SendButton extends ConsumerWidget {
@@ -35,64 +36,61 @@ class SendButton extends ConsumerWidget {
         cryptoState.isInitialized && !cryptoState.keysUploadFailed;
     final canSend = hasContent && (cryptoReady || !isDm);
 
-    // When there's no content and not editing, show a bordered mic button
-    // (mirrors the design's RoundIcon). It transitions to the filled accent
-    // send button below as soon as content is present.
-    final showMic = !hasContent && !isEditing && !kIsWeb;
-    if (showMic) {
-      return Semantics(
-        label: 'Record voice message',
-        button: true,
-        child: Material(
-          color: Colors.transparent,
-          shape: const CircleBorder(),
-          child: InkWell(
-            customBorder: const CircleBorder(),
-            onTap: onStartRecording,
-            child: Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: context.surface,
-                shape: BoxShape.circle,
-                border: Border.all(color: context.border, width: 1),
-              ),
-              alignment: Alignment.center,
-              child: Icon(
-                Icons.mic_outlined,
-                size: 20,
-                color: context.textSecondary,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
+    // Three visual modes share one container so the transitions between
+    // them animate via AnimatedContainer + AnimatedSwitcher rather than
+    // snapping (mic ↔ send-arrow on first keystroke; send-arrow ↔ check
+    // on edit-mode entry; disabled ↔ enabled fill color).
+    final bool showMic = !hasContent && !isEditing && !kIsWeb;
 
+    final IconData iconData;
+    final Color iconColor;
     final Color fillColor;
-    if (!canSend) {
+    final bool showBorder;
+    final VoidCallback? onTap;
+    final String semanticLabel;
+    final ValueKey<String> iconKey;
+
+    if (showMic) {
+      iconData = Icons.mic_outlined;
+      iconColor = context.textSecondary;
       fillColor = context.surface;
+      showBorder = true;
+      onTap = onStartRecording;
+      semanticLabel = 'Record voice message';
+      iconKey = const ValueKey('mic');
     } else if (isEditing) {
-      fillColor = EchoTheme.online;
+      iconData = Icons.check_rounded;
+      iconColor = canSend ? Colors.white : context.textMuted;
+      fillColor = canSend ? EchoTheme.online : context.surface;
+      showBorder = !canSend;
+      onTap = canSend ? resolveSendAction() : null;
+      semanticLabel = 'Confirm edit';
+      iconKey = const ValueKey('check');
     } else {
-      fillColor = context.accent;
+      iconData = Icons.arrow_upward_rounded;
+      iconColor = canSend ? Colors.white : context.textMuted;
+      fillColor = canSend ? context.accent : context.surface;
+      showBorder = !canSend;
+      onTap = canSend ? resolveSendAction() : null;
+      semanticLabel = 'Send message';
+      iconKey = const ValueKey('send');
     }
-    final iconColor = canSend ? Colors.white : context.textMuted;
-    final showBorder = !canSend;
 
     final cryptoBlocked = isDm && !cryptoReady;
 
     Widget button = Semantics(
-      label: isEditing ? 'Confirm edit' : 'Send message',
+      label: semanticLabel,
       button: true,
-      enabled: canSend,
+      enabled: showMic ? true : canSend,
       child: Material(
         color: Colors.transparent,
         shape: const CircleBorder(),
         child: InkWell(
           customBorder: const CircleBorder(),
-          onTap: canSend ? resolveSendAction() : null,
-          child: Container(
+          onTap: onTap,
+          child: AnimatedContainer(
+            duration: MotionDurations.standard,
+            curve: MotionCurves.emphasis,
             width: 40,
             height: 40,
             decoration: BoxDecoration(
@@ -103,10 +101,15 @@ class SendButton extends ConsumerWidget {
                   : null,
             ),
             alignment: Alignment.center,
-            child: Icon(
-              isEditing ? Icons.check_rounded : Icons.arrow_upward_rounded,
-              size: 20,
-              color: iconColor,
+            child: AnimatedSwitcher(
+              duration: MotionDurations.quick,
+              switchInCurve: MotionCurves.emphasis,
+              switchOutCurve: MotionCurves.exit,
+              transitionBuilder: (child, animation) => ScaleTransition(
+                scale: animation,
+                child: FadeTransition(opacity: animation, child: child),
+              ),
+              child: Icon(iconData, key: iconKey, size: 20, color: iconColor),
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/connection_status_banner.dart
+++ b/apps/client/lib/src/widgets/connection_status_banner.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/websocket_provider.dart';
 import '../theme/echo_theme.dart';
+import '../theme/motion_tokens.dart';
 
 /// Displays a slim banner at the top of the chat area to indicate WebSocket
 /// connection status. Only visible when disconnected or briefly when reconnecting.
@@ -131,8 +132,8 @@ class _ConnectionStatusBannerState
         wsState.wasReplaced;
 
     return AnimatedSize(
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeOut,
+      duration: MotionDurations.standard,
+      curve: MotionCurves.entrance,
       child: Container(
         width: double.infinity,
         color: status.color.withValues(alpha: 0.15),

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -14,6 +14,7 @@ import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
 import 'avatar_utils.dart';
+// Stack + Positioned (active edge bar overlay) come from material.dart.
 
 /// Fixed height of a single conversation list item in normal mode.
 const double kConversationItemHeight = 68.0;
@@ -39,16 +40,22 @@ Color presenceStatusDotColor(
 
 /// Compose the screen-reader announcement for a conversation row (#631).
 ///
-/// Order: name -> unread count -> muted -> last message snippet. Exposed
-/// at top level so widget tests can lock the contract without reaching
-/// into the private state class.
+/// Order: name -> mention -> unread count -> muted -> last message snippet.
+/// Mention is announced first because it implies the user has an
+/// explicit @-callout waiting; unread count alone doesn't.
+/// Exposed at top level so widget tests can lock the contract without
+/// reaching into the private state class.
 String composeConversationItemSemanticsLabel({
   required String displayName,
   required int unreadCount,
   required bool muted,
   required String? snippet,
+  int mentionCount = 0,
 }) {
   final buf = StringBuffer('Conversation with $displayName');
+  if (mentionCount > 0) {
+    buf.write(', mentioned');
+  }
   if (unreadCount > 0) {
     buf.write(', $unreadCount unread');
   }
@@ -319,64 +326,94 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
       label: composeConversationItemSemanticsLabel(
         displayName: displayName,
         unreadCount: conv.unreadCount,
+        mentionCount: conv.mentionCount,
         muted: conv.isMuted,
         snippet: snippet,
       ),
       button: true,
       child: Material(
         type: MaterialType.transparency,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(10),
-          focusColor: context.accentLight,
-          onHover: (hovered) => setState(() => _isHovered = hovered),
-          onTap: widget.onTap,
-          onSecondaryTapUp: (details) {
-            widget.onContextMenu?.call(details.globalPosition);
-          },
-          onLongPress: _enableLongPressMenu ? _showMuteSheet : null,
-          child: Container(
-            height: isCompact
-                ? kConversationItemHeightCompact
-                : kConversationItemHeight,
-            margin: const EdgeInsets.symmetric(vertical: 1),
-            decoration: BoxDecoration(
-              color: _resolveBackgroundColor(context),
+        child: Stack(
+          children: [
+            InkWell(
               borderRadius: BorderRadius.circular(10),
-            ),
-            padding: EdgeInsets.symmetric(horizontal: isCompact ? 10 : 12),
-            // Visual children re-announce muted/unread/timestamp via
-            // their own Semantics nodes; suppress those so the composed
-            // outer label is the single announcement (#631).
-            child: ExcludeSemantics(
-              child: Row(
-                children: [
-                  _buildAvatarStack(
-                    context,
-                    conv,
-                    displayName,
-                    isCompact: isCompact,
+              focusColor: context.accentLight,
+              onHover: (hovered) => setState(() => _isHovered = hovered),
+              onTap: widget.onTap,
+              onSecondaryTapUp: (details) {
+                widget.onContextMenu?.call(details.globalPosition);
+              },
+              onLongPress: _enableLongPressMenu ? _showMuteSheet : null,
+              child: AnimatedContainer(
+                duration: MotionDurations.quick,
+                curve: MotionCurves.emphasis,
+                height: isCompact
+                    ? kConversationItemHeightCompact
+                    : kConversationItemHeight,
+                margin: const EdgeInsets.symmetric(vertical: 1),
+                decoration: BoxDecoration(
+                  color: _resolveBackgroundColor(context, hasUnread),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                padding: EdgeInsets.symmetric(horizontal: isCompact ? 10 : 12),
+                // Visual children re-announce muted/unread/timestamp via
+                // their own Semantics nodes; suppress those so the composed
+                // outer label is the single announcement (#631).
+                child: ExcludeSemantics(
+                  child: Row(
+                    children: [
+                      _buildAvatarStack(
+                        context,
+                        conv,
+                        displayName,
+                        isCompact: isCompact,
+                      ),
+                      SizedBox(width: isCompact ? 8 : 12),
+                      _buildNameAndSnippet(
+                        context,
+                        displayName: displayName,
+                        snippet: snippet,
+                        hasUnread: hasUnread,
+                        conv: conv,
+                        isCompact: isCompact,
+                      ),
+                    ],
                   ),
-                  SizedBox(width: isCompact ? 8 : 12),
-                  _buildNameAndSnippet(
-                    context,
-                    displayName: displayName,
-                    snippet: snippet,
-                    hasUnread: hasUnread,
-                    conv: conv,
-                    isCompact: isCompact,
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
+            // Active-conversation accent bar — 4px wide left edge marker.
+            // Stronger glance signal than the existing tint alone.
+            // IgnorePointer so taps pass through to the InkWell.
+            if (widget.isSelected)
+              Positioned(
+                left: 0,
+                top: 6,
+                bottom: 6,
+                child: IgnorePointer(
+                  child: Container(
+                    width: 4,
+                    decoration: BoxDecoration(
+                      color: context.activeRowAccent,
+                      borderRadius: const BorderRadius.horizontal(
+                        right: Radius.circular(2),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );
   }
 
-  Color _resolveBackgroundColor(BuildContext context) {
+  Color _resolveBackgroundColor(BuildContext context, bool hasUnread) {
     if (widget.isSelected) return context.accentLight;
     if (_isHovered) return context.surfaceHover;
+    if (hasUnread && !widget.conversation.isMuted) {
+      return context.unreadRowTint;
+    }
     return Colors.transparent;
   }
 
@@ -405,19 +442,24 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
           Positioned(
             bottom: 0,
             right: 0,
-            child: AnimatedContainer(
-              duration: MotionDurations.gentle,
-              curve: MotionCurves.emphasis,
-              width: dotSize,
-              height: dotSize,
-              decoration: BoxDecoration(
-                color: presenceStatusDotColor(
-                  context,
-                  widget.peerPresenceStatus,
-                  widget.isPeerOnline,
+            // Dim the presence dot for muted conversations so the row
+            // reads as "present but quiet" overall.
+            child: Opacity(
+              opacity: conv.isMuted ? 0.5 : 1.0,
+              child: AnimatedContainer(
+                duration: MotionDurations.gentle,
+                curve: MotionCurves.emphasis,
+                width: dotSize,
+                height: dotSize,
+                decoration: BoxDecoration(
+                  color: presenceStatusDotColor(
+                    context,
+                    widget.peerPresenceStatus,
+                    widget.isPeerOnline,
+                  ),
+                  shape: BoxShape.circle,
+                  border: Border.all(color: context.sidebarBg, width: 2),
                 ),
-                shape: BoxShape.circle,
-                border: Border.all(color: context.sidebarBg, width: 2),
               ),
             ),
           ),
@@ -522,7 +564,9 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
             overflow: TextOverflow.ellipsis,
             style: GoogleFonts.inter(
               fontSize: 12,
-              color: hasUnread ? context.accent : context.textMuted,
+              color: widget.conversation.isMuted
+                  ? context.mutedSurface
+                  : (hasUnread ? context.accent : context.textMuted),
             ),
           ),
         ],
@@ -551,7 +595,9 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                   style: GoogleFonts.inter(
                     fontSize: isCompact ? 13 : 14,
                     fontWeight: hasUnread ? FontWeight.w700 : FontWeight.w500,
-                    color: context.textPrimary,
+                    color: conv.isMuted
+                        ? context.textMuted
+                        : context.textPrimary,
                   ),
                 ),
               ),
@@ -677,7 +723,9 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                   overflow: TextOverflow.ellipsis,
                   style: GoogleFonts.inter(
                     fontSize: snippetFontSize,
-                    color: context.textMuted,
+                    color: conv.isMuted
+                        ? context.mutedSurface
+                        : context.textMuted,
                     fontWeight: snippetWeight,
                   ),
                 ),
@@ -688,7 +736,36 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
             child: Icon(
               Icons.notifications_off_outlined,
               size: 16,
-              color: context.textMuted,
+              color: context.mutedSurface,
+            ),
+          ),
+        // Mention badge sits to the LEFT of the unread count badge so it
+        // remains visible when the unread count is multi-digit.  Distinct
+        // color (mentionBadgeBg) so "you were mentioned" reads differently
+        // from "X unread."
+        if (conv.mentionCount > 0)
+          Semantics(
+            label: '${conv.mentionCount} mentions',
+            child: Container(
+              margin: const EdgeInsets.only(left: 8),
+              width: 18,
+              height: 18,
+              decoration: BoxDecoration(
+                color: context.mentionBadgeBg,
+                shape: BoxShape.circle,
+              ),
+              alignment: Alignment.center,
+              child: const ExcludeSemantics(
+                child: Text(
+                  '@',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w800,
+                    height: 1,
+                  ),
+                ),
+              ),
             ),
           ),
         if (hasUnread)

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -12,6 +12,7 @@ import '../providers/theme_provider.dart'
     show MessageLayout, messageLayoutProvider;
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import '../theme/motion_tokens.dart';
 import 'avatar_utils.dart';
 
 /// Fixed height of a single conversation list item in normal mode.
@@ -405,7 +406,8 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
             bottom: 0,
             right: 0,
             child: AnimatedContainer(
-              duration: const Duration(milliseconds: 400),
+              duration: MotionDurations.gentle,
+              curve: MotionCurves.emphasis,
               width: dotSize,
               height: dotSize,
               decoration: BoxDecoration(

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -8,19 +8,32 @@ import '../models/chat_message.dart' show ChatMessage, MessageStatus;
 import '../models/conversation.dart';
 import '../providers/chat_provider.dart';
 import '../providers/conversations_provider.dart';
-import '../providers/theme_provider.dart'
-    show MessageLayout, messageLayoutProvider;
+import '../providers/theme_provider.dart' show UIDensity, uiDensityProvider;
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
 import 'avatar_utils.dart';
 // Stack + Positioned (active edge bar overlay) come from material.dart.
 
-/// Fixed height of a single conversation list item in normal mode.
+/// Fixed height of a single conversation list item in the normal density
+/// tier (UX roadmap Phase 2).
 const double kConversationItemHeight = 68.0;
 
-/// Tighter height for compact (Discord-style) layout (#427).
+/// Tighter height for the compact (Discord-style) density tier.
 const double kConversationItemHeightCompact = 52.0;
+
+/// Roomier height for the cozy density tier — power users who want
+/// breathing room on large displays.
+const double kConversationItemHeightCozy = 84.0;
+
+/// Looks up the conversation row height for a given [density]. Used by
+/// `ConversationPanel` and tests so the list-level geometry stays in sync
+/// with `ConversationItem`'s own sizing.
+double conversationItemHeightFor(UIDensity density) => switch (density) {
+  UIDensity.cozy => kConversationItemHeightCozy,
+  UIDensity.normal => kConversationItemHeight,
+  UIDensity.compact => kConversationItemHeightCompact,
+};
 
 /// Return the dot color for a peer presence status.
 Color presenceStatusDotColor(
@@ -320,7 +333,9 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     final displayName = conv.displayName(widget.myUserId);
     final hasUnread = conv.unreadCount > 0;
     final snippet = _resolveSnippet();
-    final isCompact = ref.watch(messageLayoutProvider) == MessageLayout.compact;
+    final density = ref.watch(uiDensityProvider);
+    final isCompact = density == UIDensity.compact;
+    final isCozy = density == UIDensity.cozy;
 
     return Semantics(
       label: composeConversationItemSemanticsLabel(
@@ -347,15 +362,15 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
               child: AnimatedContainer(
                 duration: MotionDurations.quick,
                 curve: MotionCurves.emphasis,
-                height: isCompact
-                    ? kConversationItemHeightCompact
-                    : kConversationItemHeight,
+                height: conversationItemHeightFor(density),
                 margin: const EdgeInsets.symmetric(vertical: 1),
                 decoration: BoxDecoration(
                   color: _resolveBackgroundColor(context, hasUnread),
                   borderRadius: BorderRadius.circular(10),
                 ),
-                padding: EdgeInsets.symmetric(horizontal: isCompact ? 10 : 12),
+                padding: EdgeInsets.symmetric(
+                  horizontal: isCozy ? 14 : (isCompact ? 10 : 12),
+                ),
                 // Visual children re-announce muted/unread/timestamp via
                 // their own Semantics nodes; suppress those so the composed
                 // outer label is the single announcement (#631).
@@ -366,16 +381,16 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                         context,
                         conv,
                         displayName,
-                        isCompact: isCompact,
+                        density: density,
                       ),
-                      SizedBox(width: isCompact ? 8 : 12),
+                      SizedBox(width: isCozy ? 14 : (isCompact ? 8 : 12)),
                       _buildNameAndSnippet(
                         context,
                         displayName: displayName,
                         snippet: snippet,
                         hasUnread: hasUnread,
                         conv: conv,
-                        isCompact: isCompact,
+                        density: density,
                       ),
                     ],
                   ),
@@ -421,12 +436,27 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     BuildContext context,
     Conversation conv,
     String displayName, {
-    bool isCompact = false,
+    UIDensity density = UIDensity.normal,
   }) {
-    // Compact: 14px radius (28px diameter); normal: 20px radius (40px diameter).
-    final double avatarRadius = isCompact ? 14 : 20;
-    final double dotSize = isCompact ? 10 : 12;
-    final double groupIconSize = isCompact ? 14.0 : 18.0;
+    // Density tier sizes (UX roadmap Phase 2):
+    //   compact -> 14px radius (28px diameter), 10px dot, 14px group icon
+    //   normal  -> 20px radius (40px diameter), 12px dot, 18px group icon
+    //   cozy    -> 22px radius (44px diameter), 13px dot, 20px group icon
+    final double avatarRadius = switch (density) {
+      UIDensity.cozy => 22,
+      UIDensity.normal => 20,
+      UIDensity.compact => 14,
+    };
+    final double dotSize = switch (density) {
+      UIDensity.cozy => 13,
+      UIDensity.normal => 12,
+      UIDensity.compact => 10,
+    };
+    final double groupIconSize = switch (density) {
+      UIDensity.cozy => 20,
+      UIDensity.normal => 18,
+      UIDensity.compact => 14,
+    };
     return Stack(
       children: [
         buildAvatar(
@@ -473,38 +503,48 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     required String? snippet,
     required bool hasUnread,
     required Conversation conv,
-    bool isCompact = false,
+    UIDensity density = UIDensity.normal,
   }) {
     final peer = conv.isGroup
         ? null
         : conv.members.where((m) => m.userId != widget.myUserId).firstOrNull;
     final statusText = peer?.statusText;
+    final double statusFontSize = switch (density) {
+      UIDensity.cozy => 12,
+      UIDensity.normal => 11,
+      UIDensity.compact => 10,
+    };
+    final double snippetGap = switch (density) {
+      UIDensity.cozy => 6,
+      UIDensity.normal => 4,
+      UIDensity.compact => 1,
+    };
 
     return Expanded(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          _buildNameRow(context, displayName, hasUnread, isCompact: isCompact),
+          _buildNameRow(context, displayName, hasUnread, density: density),
           if (statusText != null && statusText.isNotEmpty) ...[
             const SizedBox(height: 1),
             Text(
               statusText,
               style: GoogleFonts.inter(
-                fontSize: isCompact ? 10 : 11,
+                fontSize: statusFontSize,
                 color: context.textMuted,
               ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
           ] else if (snippet != null) ...[
-            SizedBox(height: isCompact ? 1 : 4),
+            SizedBox(height: snippetGap),
             _buildSnippetRow(
               context,
               snippet,
               hasUnread,
               conv,
-              isCompact: isCompact,
+              density: density,
             ),
           ],
         ],
@@ -516,7 +556,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     BuildContext context,
     String displayName,
     bool hasUnread, {
-    bool isCompact = false,
+    UIDensity density = UIDensity.normal,
   }) {
     // On desktop (non-web, non-mobile), show a ... button on hover so users
     // who don't right-click can still discover the context menu.
@@ -593,7 +633,11 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,
                   style: GoogleFonts.inter(
-                    fontSize: isCompact ? 13 : 14,
+                    fontSize: switch (density) {
+                      UIDensity.cozy => 15,
+                      UIDensity.normal => 14,
+                      UIDensity.compact => 13,
+                    },
                     fontWeight: hasUnread ? FontWeight.w700 : FontWeight.w500,
                     color: conv.isMuted
                         ? context.textMuted
@@ -684,12 +728,15 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     String snippet,
     bool hasUnread,
     Conversation conv, {
-    bool isCompact = false,
+    UIDensity density = UIDensity.normal,
   }) {
     final showDraft = _draft != null && !hasUnread;
     final snippetWeight = hasUnread ? FontWeight.w500 : FontWeight.normal;
-    // Compact: 11px snippet; normal: 13px.
-    final double snippetFontSize = isCompact ? 11 : 13;
+    final double snippetFontSize = switch (density) {
+      UIDensity.cozy => 14,
+      UIDensity.normal => 13,
+      UIDensity.compact => 11,
+    };
     return Row(
       children: [
         Expanded(

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -17,8 +17,7 @@ import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
-import '../providers/theme_provider.dart'
-    show MessageLayout, messageLayoutProvider;
+import '../providers/theme_provider.dart' show uiDensityProvider;
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart';
 import 'conversation_item.dart';
@@ -1449,11 +1448,9 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           physics: const AlwaysScrollableScrollPhysics(),
           padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
           // Use fixed itemExtent when no section headers/dividers for faster layout.
-          // Compact mode uses tighter rows to match Slack/Discord density (#427).
+          // Three-way density (UX roadmap Phase 2): cozy / normal / compact.
           itemExtent: extraItems == 0
-              ? (ref.watch(messageLayoutProvider) == MessageLayout.compact
-                    ? kConversationItemHeightCompact
-                    : kConversationItemHeight)
+              ? conversationItemHeightFor(ref.watch(uiDensityProvider))
               : null,
           itemCount: sorted.length + extraItems,
           itemBuilder: (context, index) => _buildListItem(

--- a/apps/client/lib/src/widgets/identity_key_changed_banner.dart
+++ b/apps/client/lib/src/widgets/identity_key_changed_banner.dart
@@ -7,6 +7,7 @@ import '../providers/auth_provider.dart';
 import '../providers/crypto_provider.dart';
 import '../screens/safety_number_screen.dart';
 import '../theme/echo_theme.dart';
+import '../theme/motion_tokens.dart';
 
 /// Displays an amber warning banner when a DM peer's identity key has changed
 /// (TOFU violation). Offers "View Safety Number" and "Dismiss" actions.
@@ -123,8 +124,8 @@ class _IdentityKeyChangedBannerState
     final visible = _checked && _changed;
 
     return AnimatedSize(
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeOut,
+      duration: MotionDurations.standard,
+      curve: MotionCurves.entrance,
       child: visible
           ? Semantics(
               label: 'identity key changed warning',

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -6,7 +6,8 @@ import '../../theme/echo_theme.dart';
 /// Displays an autocomplete popup for @-mentioning conversation members.
 ///
 /// Sits above the input bar and filters members based on [mentionQuery].
-/// When a member is tapped, [onMentionSelected] fires with their username.
+/// When a row is tapped, [onMentionSelected] fires with the username
+/// (or the broadcast keyword `everyone` / `here`).
 class MentionAutocomplete extends StatelessWidget {
   final List<ConversationMember> members;
   final String mentionQuery;
@@ -19,6 +20,21 @@ class MentionAutocomplete extends StatelessWidget {
     required this.onMentionSelected,
   });
 
+  /// Broadcast pseudo-mentions surfaced alongside member rows. Phase 1
+  /// ships `@everyone` and `@here`; role mentions are out of scope (#451).
+  static const List<_BroadcastMention> _broadcasts = [
+    _BroadcastMention(
+      keyword: 'everyone',
+      icon: Icons.campaign_outlined,
+      subtitle: 'Notify everyone',
+    ),
+    _BroadcastMention(
+      keyword: 'here',
+      icon: Icons.bolt_outlined,
+      subtitle: 'Notify online members',
+    ),
+  ];
+
   List<ConversationMember> get _filteredMembers {
     if (mentionQuery.isEmpty) return members;
     return members
@@ -26,13 +42,29 @@ class MentionAutocomplete extends StatelessWidget {
         .toList();
   }
 
+  List<_BroadcastMention> get _filteredBroadcasts {
+    if (mentionQuery.isEmpty) return _broadcasts;
+    return _broadcasts
+        .where((b) => b.keyword.startsWith(mentionQuery))
+        .toList();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final filtered = _filteredMembers;
-    if (filtered.isEmpty) return const SizedBox.shrink();
+    final memberRows = _filteredMembers;
+    final broadcastRows = _filteredBroadcasts;
+    if (memberRows.isEmpty && broadcastRows.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    // ListView uses `reverse: true`, so item 0 paints at the bottom (next
+    // to the text field).  Members come first (lower indices) so they sit
+    // closest to the cursor; broadcasts get pushed to the top of the
+    // picker — they're rarer and visually distinct.
+    final total = memberRows.length + broadcastRows.length;
 
     return Container(
-      constraints: const BoxConstraints(maxHeight: 160),
+      constraints: const BoxConstraints(maxHeight: 200),
       margin: const EdgeInsets.symmetric(horizontal: 20),
       decoration: BoxDecoration(
         color: context.surface,
@@ -42,14 +74,77 @@ class MentionAutocomplete extends StatelessWidget {
       child: ListView.builder(
         reverse: true,
         padding: EdgeInsets.zero,
-        itemCount: filtered.length,
+        itemCount: total,
         itemBuilder: (context, i) {
-          final member = filtered[i];
-          return _MentionItem(
-            member: member,
-            onTap: () => onMentionSelected(member.username),
+          if (i < memberRows.length) {
+            final member = memberRows[i];
+            return _MentionItem(
+              member: member,
+              onTap: () => onMentionSelected(member.username),
+            );
+          }
+          final broadcast = broadcastRows[i - memberRows.length];
+          return _BroadcastMentionItem(
+            broadcast: broadcast,
+            onTap: () => onMentionSelected(broadcast.keyword),
           );
         },
+      ),
+    );
+  }
+}
+
+class _BroadcastMention {
+  final String keyword;
+  final IconData icon;
+  final String subtitle;
+
+  const _BroadcastMention({
+    required this.keyword,
+    required this.icon,
+    required this.subtitle,
+  });
+}
+
+class _BroadcastMentionItem extends StatelessWidget {
+  final _BroadcastMention broadcast;
+  final VoidCallback onTap;
+
+  const _BroadcastMentionItem({required this.broadcast, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'mention @${broadcast.keyword}',
+      hint: broadcast.subtitle,
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              Icon(broadcast.icon, size: 14, color: context.accent),
+              const SizedBox(width: 8),
+              Text(
+                '@${broadcast.keyword}',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: context.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  broadcast.subtitle,
+                  style: TextStyle(fontSize: 11, color: context.textMuted),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -43,9 +43,12 @@ class MentionAutocomplete extends StatelessWidget {
 
   List<_BroadcastMention> get _filteredBroadcasts {
     if (mentionQuery.isEmpty) return _broadcasts;
-    return _broadcasts
-        .where((b) => b.keyword.startsWith(mentionQuery))
-        .toList();
+    // Defensive lowercase: callers from this codebase already pass a
+    // lowercased query (extractMentionQuery normalizes it), but the
+    // public API should not silently drop suggestions for a mixed-case
+    // query supplied by a future caller.
+    final q = mentionQuery.toLowerCase();
+    return _broadcasts.where((b) => b.keyword.startsWith(q)).toList();
   }
 
   @override
@@ -189,46 +192,4 @@ class _MentionItem extends StatelessWidget {
       ),
     );
   }
-}
-
-/// Attempts to extract a partial mention query from [text] at the given
-/// [cursorPosition]. Returns the lowercased query string when an active `@`
-/// trigger is found, or `null` when no mention autocomplete should be shown.
-String? extractMentionQuery(String text, int cursorPosition) {
-  if (cursorPosition < 0 || cursorPosition > text.length) return null;
-
-  final beforeCursor = text.substring(0, cursorPosition);
-  final atIndex = beforeCursor.lastIndexOf('@');
-  if (atIndex < 0) return null;
-
-  if (atIndex > 0 && beforeCursor[atIndex - 1] != ' ') return null;
-
-  final partial = beforeCursor.substring(atIndex + 1);
-  if (partial.contains(' ')) return null;
-
-  return partial.toLowerCase();
-}
-
-/// Inserts a completed @mention into [text] at the cursor position, replacing
-/// the partial query. Returns the new [TextEditingValue] with updated cursor.
-TextEditingValue insertMention({
-  required String text,
-  required int cursorPosition,
-  required String username,
-}) {
-  if (cursorPosition < 0) return TextEditingValue(text: text);
-
-  final beforeCursor = text.substring(0, cursorPosition);
-  final atIndex = beforeCursor.lastIndexOf('@');
-  if (atIndex < 0) return TextEditingValue(text: text);
-
-  final afterCursor = text.substring(cursorPosition);
-  final replacement = '@$username ';
-  final newText = text.substring(0, atIndex) + replacement + afterCursor;
-  final newCursorPos = atIndex + replacement.length;
-
-  return TextEditingValue(
-    text: newText,
-    selection: TextSelection.collapsed(offset: newCursorPos),
-  );
 }

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -20,8 +20,7 @@ class MentionAutocomplete extends StatelessWidget {
     required this.onMentionSelected,
   });
 
-  /// Broadcast pseudo-mentions surfaced alongside member rows. Phase 1
-  /// ships `@everyone` and `@here`; role mentions are out of scope (#451).
+  /// Broadcast keywords (`@everyone`, `@here`) surfaced alongside member rows.
   static const List<_BroadcastMention> _broadcasts = [
     _BroadcastMention(
       keyword: 'everyone',

--- a/apps/client/lib/src/widgets/input/mention_controller.dart
+++ b/apps/client/lib/src/widgets/input/mention_controller.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/foundation.dart';
+
+import '../../models/conversation.dart';
+import 'mention_autocomplete.dart' show extractMentionQuery;
+
+/// State holder for the @-mention picker that floats above the chat composer.
+///
+/// Owns picker visibility and the partial `@`-query, plus the keystroke
+/// detection that toggles the picker. Lifted out of `ChatInputBarState`
+/// so it can be unit-tested without rendering the full composer (#513).
+class MentionComposerController extends ChangeNotifier {
+  bool _showPicker = false;
+  String _query = '';
+
+  bool get showPicker => _showPicker;
+  String get query => _query;
+
+  /// Re-evaluate visibility from the latest [text] / [cursorPosition].
+  /// Disabled in 1:1 DMs (the picker is group-only), so [isGroup] forces
+  /// the picker closed regardless of input.
+  void detect({
+    required String text,
+    required int cursorPosition,
+    required bool isGroup,
+  }) {
+    if (!isGroup) {
+      _set(showPicker: false, query: '');
+      return;
+    }
+
+    final next = extractMentionQuery(text, cursorPosition);
+    if (next == null) {
+      _set(showPicker: false, query: '');
+    } else {
+      _set(showPicker: true, query: next);
+    }
+  }
+
+  /// Close the picker (Escape, conversation switch, after a tap).
+  void dismiss() => _set(showPicker: false, query: '');
+
+  /// Filter members eligible for mention suggestions. Excludes the local
+  /// user; broadcast rows (@everyone / @here) are added by the autocomplete
+  /// widget itself, not here.
+  List<ConversationMember> filterMembers(
+    List<ConversationMember> members,
+    String myUserId,
+  ) {
+    return members.where((m) => m.userId != myUserId).toList();
+  }
+
+  void _set({required bool showPicker, required String query}) {
+    if (_showPicker == showPicker && _query == query) return;
+    _showPicker = showPicker;
+    _query = query;
+    notifyListeners();
+  }
+}

--- a/apps/client/lib/src/widgets/input/mention_controller.dart
+++ b/apps/client/lib/src/widgets/input/mention_controller.dart
@@ -3,6 +3,10 @@ import 'package:flutter/widgets.dart' show TextEditingValue, TextSelection;
 
 import '../../models/conversation.dart';
 
+// Reused across [extractMentionQuery] calls to avoid per-keystroke
+// regex allocation in the input hot path.
+final RegExp _whitespace = RegExp(r'\s');
+
 /// Attempts to extract a partial mention query from [text] at the given
 /// [cursorPosition]. Returns the lowercased query string when an active `@`
 /// trigger is found, or `null` when no mention autocomplete should be shown.
@@ -21,12 +25,11 @@ String? extractMentionQuery(String text, int cursorPosition) {
 
   if (atIndex > 0) {
     final prev = beforeCursor[atIndex - 1];
-    final isWhitespace = RegExp(r'\s').hasMatch(prev);
-    if (!isWhitespace) return null;
+    if (!_whitespace.hasMatch(prev)) return null;
   }
 
   final partial = beforeCursor.substring(atIndex + 1);
-  if (RegExp(r'\s').hasMatch(partial)) return null;
+  if (_whitespace.hasMatch(partial)) return null;
 
   return partial.toLowerCase();
 }

--- a/apps/client/lib/src/widgets/input/mention_controller.dart
+++ b/apps/client/lib/src/widgets/input/mention_controller.dart
@@ -1,7 +1,59 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show TextEditingValue, TextSelection;
 
 import '../../models/conversation.dart';
-import 'mention_autocomplete.dart' show extractMentionQuery;
+
+/// Attempts to extract a partial mention query from [text] at the given
+/// [cursorPosition]. Returns the lowercased query string when an active `@`
+/// trigger is found, or `null` when no mention autocomplete should be shown.
+///
+/// The character preceding `@` must be whitespace (space, tab, newline) or
+/// the start of the string — this avoids triggering on email addresses
+/// like `me@host` while still working when a user pastes a multi-line
+/// draft.  The server's broadcast scanner uses a stricter "any non-word
+/// character" rule, but the client picker stays conservative on purpose.
+String? extractMentionQuery(String text, int cursorPosition) {
+  if (cursorPosition < 0 || cursorPosition > text.length) return null;
+
+  final beforeCursor = text.substring(0, cursorPosition);
+  final atIndex = beforeCursor.lastIndexOf('@');
+  if (atIndex < 0) return null;
+
+  if (atIndex > 0) {
+    final prev = beforeCursor[atIndex - 1];
+    final isWhitespace = RegExp(r'\s').hasMatch(prev);
+    if (!isWhitespace) return null;
+  }
+
+  final partial = beforeCursor.substring(atIndex + 1);
+  if (RegExp(r'\s').hasMatch(partial)) return null;
+
+  return partial.toLowerCase();
+}
+
+/// Inserts a completed @mention into [text] at the cursor position, replacing
+/// the partial query. Returns the new [TextEditingValue] with updated cursor.
+TextEditingValue insertMention({
+  required String text,
+  required int cursorPosition,
+  required String username,
+}) {
+  if (cursorPosition < 0) return TextEditingValue(text: text);
+
+  final beforeCursor = text.substring(0, cursorPosition);
+  final atIndex = beforeCursor.lastIndexOf('@');
+  if (atIndex < 0) return TextEditingValue(text: text);
+
+  final afterCursor = text.substring(cursorPosition);
+  final replacement = '@$username ';
+  final newText = text.substring(0, atIndex) + replacement + afterCursor;
+  final newCursorPos = atIndex + replacement.length;
+
+  return TextEditingValue(
+    text: newText,
+    selection: TextSelection.collapsed(offset: newCursorPos),
+  );
+}
 
 /// State holder for the @-mention picker that floats above the chat composer.
 ///
@@ -41,8 +93,9 @@ class MentionComposerController extends ChangeNotifier {
 
   /// Filter members eligible for mention suggestions. Excludes the local
   /// user; broadcast rows (@everyone / @here) are added by the autocomplete
-  /// widget itself, not here.
-  List<ConversationMember> filterMembers(
+  /// widget itself, not here.  Pure transformation — no controller state
+  /// is read or written.
+  static List<ConversationMember> filterMembers(
     List<ConversationMember> members,
     String myUserId,
   ) {

--- a/apps/client/lib/src/widgets/message/message_status_icon.dart
+++ b/apps/client/lib/src/widgets/message/message_status_icon.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../models/chat_message.dart';
 import '../../theme/echo_theme.dart';
+import '../../theme/motion_tokens.dart';
 
 /// Displays a small status icon (sending, sent, delivered, read, failed) with
 /// a tooltip describing the current state.
@@ -43,7 +44,26 @@ class MessageStatusIcon extends StatelessWidget {
       padding: const EdgeInsets.only(left: 4),
       child: Tooltip(
         message: tooltip,
-        child: Icon(icon, size: 12, color: color),
+        // AnimatedSwitcher gives the sending → sent → delivered → read
+        // progression a brief scale transition so each status hand-off
+        // reads as 'something happened' instead of an instant icon swap.
+        // The ValueKey on the icon ensures the switcher detects the
+        // status change (icons of the same type still differ).
+        child: AnimatedSwitcher(
+          duration: MotionDurations.quick,
+          switchInCurve: MotionCurves.emphasis,
+          switchOutCurve: MotionCurves.exit,
+          transitionBuilder: (child, animation) => ScaleTransition(
+            scale: animation,
+            child: FadeTransition(opacity: animation, child: child),
+          ),
+          child: Icon(
+            icon,
+            key: ValueKey<MessageStatus>(status!),
+            size: 12,
+            color: color,
+          ),
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../models/reaction.dart';
 import '../../theme/echo_theme.dart';
+import '../../theme/motion_tokens.dart';
 
 /// Displays per-emoji reaction pills, each showing the emoji and its count.
 /// The chip background matches the parent bubble color (sent or received) with
@@ -70,7 +71,13 @@ class ReactionBar extends StatelessWidget {
   }
 }
 
-class _ReactionPill extends StatelessWidget {
+/// Reaction pill with a one-shot scale-in on first mount.
+///
+/// AnimationController fires once on initState, with a soft overshoot
+/// (`MotionCurves.expressiveBounce`) so a newly-added reaction reads as
+/// "celebratory" without crossing into cartoon territory.  Reduce-motion
+/// users skip the animation entirely.
+class _ReactionPill extends StatefulWidget {
   final String emoji;
   final int count;
   final bool isMine;
@@ -86,41 +93,78 @@ class _ReactionPill extends StatelessWidget {
   });
 
   @override
+  State<_ReactionPill> createState() => _ReactionPillState();
+}
+
+class _ReactionPillState extends State<_ReactionPill>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _entry;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _entry = AnimationController(vsync: this, duration: MotionDurations.quick);
+    _scale = CurvedAnimation(
+      parent: _entry,
+      curve: MotionCurves.expressiveBounce,
+    );
+    // Defer to post-frame so MediaQuery (reduce-motion) is available.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (MediaQuery.of(context).disableAnimations) {
+        _entry.value = 1.0;
+      } else {
+        _entry.forward(from: 0);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _entry.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final bgColor = isMine ? context.sentBubble : context.recvBubble;
-    final textColor = isMine ? Colors.white : context.textPrimary;
+    final bgColor = widget.isMine ? context.sentBubble : context.recvBubble;
+    final textColor = widget.isMine ? Colors.white : context.textPrimary;
 
     return GestureDetector(
-      onTapUp: (details) => onTap?.call(details.globalPosition),
-      child: Container(
-        height: 22,
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        decoration: BoxDecoration(
-          color: bgColor,
-          borderRadius: BorderRadius.circular(11),
-          border: Border.all(color: chatBgColor, width: 1.5),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              emoji,
-              style: const TextStyle(
-                fontSize: 13,
-                decoration: TextDecoration.none,
+      onTapUp: (details) => widget.onTap?.call(details.globalPosition),
+      child: ScaleTransition(
+        scale: _scale,
+        child: Container(
+          height: 22,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          decoration: BoxDecoration(
+            color: bgColor,
+            borderRadius: BorderRadius.circular(11),
+            border: Border.all(color: widget.chatBgColor, width: 1.5),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                widget.emoji,
+                style: const TextStyle(
+                  fontSize: 13,
+                  decoration: TextDecoration.none,
+                ),
               ),
-            ),
-            const SizedBox(width: 3),
-            Text(
-              '$count',
-              style: TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
-                color: textColor.withValues(alpha: 0.75),
-                decoration: TextDecoration.none,
+              const SizedBox(width: 3),
+              Text(
+                '${widget.count}',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: textColor.withValues(alpha: 0.75),
+                  decoration: TextDecoration.none,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -58,6 +58,10 @@ class ReactionBar extends StatelessWidget {
           children: [
             for (final entry in grouped.entries)
               _ReactionPill(
+                // Stable key so reordering this list doesn't let Flutter
+                // recycle a different emoji's _ReactionPillState (whose
+                // entry-scale animation has already played).
+                key: ValueKey('reaction-${entry.key}'),
                 emoji: entry.key,
                 count: entry.value.length,
                 isMine: isMine,
@@ -85,6 +89,7 @@ class _ReactionPill extends StatefulWidget {
   final void Function(Offset globalPosition)? onTap;
 
   const _ReactionPill({
+    super.key,
     required this.emoji,
     required this.count,
     required this.isMine,

--- a/apps/client/lib/src/widgets/puck_trail.dart
+++ b/apps/client/lib/src/widgets/puck_trail.dart
@@ -1,0 +1,104 @@
+import 'dart:ui' show Offset, Size;
+
+import '../models/canvas_models.dart';
+
+/// One historical position of a puck on the voice-lounge canvas.
+class TrailSample {
+  final CanvasPoint pos;
+  final DateTime at;
+
+  const TrailSample({required this.pos, required this.at});
+}
+
+/// One trail sample translated into pixel space, ready for the
+/// painter.  [offset] is the pixel offset from the puck's *current*
+/// position to the historical position.  [opacity] runs from ~1.0
+/// just after the sample is recorded down to 0.0 at [PuckTrail.ttl].
+class RenderedTrailSample {
+  final Offset offset;
+  final double opacity;
+
+  const RenderedTrailSample({required this.offset, required this.opacity});
+}
+
+/// Bounded ring buffer of recent puck positions used to paint a
+/// fading motion trail behind a draggable avatar in the voice lounge.
+///
+/// Pure Dart, no Flutter widget dependencies — unit-testable in
+/// isolation.  Phase 3a sub-slice 2 of `docs/ux-roadmap.md`.
+///
+/// The class is package-public so the widget code in
+/// `voice_canvas.dart` can compose it; it is not part of the app's
+/// stable API surface.  Treat as implementation detail of the
+/// voice lounge canvas.
+class PuckTrail {
+  /// Maximum number of historical samples retained.  Defaults to 6 —
+  /// enough for a visible streak without overdrawing the canvas.
+  final int maxSamples;
+
+  /// How long a sample survives before it falls out of the trail.
+  /// Defaults to 600 ms.
+  final Duration ttl;
+
+  /// Visible-for-testing accessor for the underlying buffer.  Do not
+  /// mutate.
+  List<TrailSample> get samples => List.unmodifiable(_samples);
+
+  final List<TrailSample> _samples = [];
+
+  PuckTrail({this.maxSamples = 6, this.ttl = const Duration(milliseconds: 600)})
+    : assert(maxSamples > 0),
+      assert(ttl > Duration.zero);
+
+  /// True when no samples are present.  When this flips true the
+  /// owning widget should stop its repaint ticker.
+  bool get isEmpty => _samples.isEmpty;
+
+  /// Record a new historical position.  If the buffer is full the
+  /// oldest sample is dropped.
+  void addSample(CanvasPoint pos, DateTime now) {
+    _samples.add(TrailSample(pos: pos, at: now));
+    if (_samples.length > maxSamples) {
+      _samples.removeAt(0);
+    }
+  }
+
+  /// Drop samples older than [ttl] relative to [now].  Call from the
+  /// ticker callback so an idle puck's trail decays naturally.
+  void prune(DateTime now) {
+    _samples.removeWhere((s) => now.difference(s.at) >= ttl);
+  }
+
+  /// Translate the buffered samples into pixel-space rendering data.
+  ///
+  /// [current] is the puck's current normalized position; the
+  /// returned offsets are relative to that point so the painter can
+  /// draw at `Center + offset`.  [canvasSize] converts normalized
+  /// units back to pixels.
+  ///
+  /// Samples older than [ttl] are filtered out (without mutating the
+  /// buffer — call [prune] separately to evict them).
+  List<RenderedTrailSample> render({
+    required CanvasPoint current,
+    required Size canvasSize,
+    required DateTime now,
+  }) {
+    if (_samples.isEmpty) return const [];
+    final ttlMs = ttl.inMilliseconds;
+    final out = <RenderedTrailSample>[];
+    for (final s in _samples) {
+      final ageMs = now.difference(s.at).inMilliseconds;
+      if (ageMs >= ttlMs) continue;
+      // Linear fade.  Older samples vanish first.
+      final opacity = (1.0 - ageMs / ttlMs).clamp(0.0, 1.0);
+      final dx = (s.pos.x - current.x) * canvasSize.width;
+      final dy = (s.pos.y - current.y) * canvasSize.height;
+      out.add(RenderedTrailSample(offset: Offset(dx, dy), opacity: opacity));
+    }
+    return out;
+  }
+
+  /// Drop all buffered samples.  Used when reduce-motion is enabled
+  /// or when the widget is being disposed.
+  void clear() => _samples.clear();
+}

--- a/apps/client/lib/src/widgets/thread_view_panel.dart
+++ b/apps/client/lib/src/widgets/thread_view_panel.dart
@@ -9,6 +9,7 @@ import '../providers/auth_provider.dart';
 import '../providers/chat_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
+import '../theme/motion_tokens.dart';
 import '../theme/responsive.dart';
 import 'message/reply_quote.dart';
 
@@ -127,8 +128,8 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
     if (!_scrollController.hasClients) return;
     _scrollController.animateTo(
       _scrollController.position.maxScrollExtent,
-      duration: const Duration(milliseconds: 250),
-      curve: Curves.easeOut,
+      duration: MotionDurations.expressive,
+      curve: MotionCurves.entrance,
     );
   }
 

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:livekit_client/livekit_client.dart' as lk;
@@ -13,6 +14,7 @@ import '../providers/canvas_provider.dart';
 import '../providers/livekit_voice_provider.dart';
 import '../theme/echo_theme.dart';
 import '../utils/canvas_utils.dart';
+import 'puck_trail.dart';
 import 'voice_speaking_ring.dart';
 
 const double _kAvatarSize = 48.0;
@@ -558,8 +560,74 @@ class _DraggableAvatar extends StatefulWidget {
   State<_DraggableAvatar> createState() => _DraggableAvatarState();
 }
 
-class _DraggableAvatarState extends State<_DraggableAvatar> {
+class _DraggableAvatarState extends State<_DraggableAvatar>
+    with SingleTickerProviderStateMixin {
   CanvasPoint? _localPos;
+
+  /// Buffer of recent positions used to paint the presence trail
+  /// (Phase 3a sub-slice 2 of `docs/ux-roadmap.md`).
+  final PuckTrail _trail = PuckTrail();
+
+  /// Drives a 60Hz repaint of the trail so old samples fade smoothly.
+  /// Only ticks while the buffer holds at least one sample.
+  late final Ticker _trailTicker;
+
+  /// Cached reduce-motion value; refreshed on `didChangeDependencies`
+  /// and `didUpdateWidget` so we don't sample inside `MediaQuery.of`
+  /// during paint.
+  bool _reduceMotion = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _trailTicker = createTicker(_onTrailTick);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _reduceMotion = MediaQuery.of(context).disableAnimations;
+    if (_reduceMotion) _stopTrail();
+  }
+
+  @override
+  void didUpdateWidget(_DraggableAvatar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final prev = oldWidget.currentPos;
+    final next = widget.currentPos;
+    if (!_reduceMotion && (prev.x != next.x || prev.y != next.y)) {
+      // Remote (or post-drag committed) position arrived — record the
+      // *previous* point so the trail starts where the puck just was.
+      _pushTrailSample(prev);
+    }
+  }
+
+  @override
+  void dispose() {
+    _trailTicker.dispose();
+    _trail.clear();
+    super.dispose();
+  }
+
+  void _pushTrailSample(CanvasPoint pos) {
+    if (_reduceMotion) return;
+    _trail.addSample(pos, DateTime.now());
+    if (!_trailTicker.isActive) _trailTicker.start();
+  }
+
+  void _stopTrail() {
+    if (_trailTicker.isActive) _trailTicker.stop();
+    _trail.clear();
+  }
+
+  void _onTrailTick(Duration _) {
+    final now = DateTime.now();
+    _trail.prune(now);
+    if (_trail.isEmpty) {
+      _trailTicker.stop();
+    }
+    if (mounted) setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -634,10 +702,42 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
       ),
     );
 
+    // Phase 3a sub-slice 2: paint the presence trail BEHIND the
+    // avatar circle.  CustomPaint is sized to the avatar but draws
+    // freely (negative offsets) — the surrounding `Stack(Clip.none)`
+    // lets ghost circles render to the left/right/up/down of the
+    // puck without being clipped at the immediate stack bounds.
+    final trailSamples = _reduceMotion
+        ? const <RenderedTrailSample>[]
+        : _trail.render(
+            current: _localPos ?? widget.currentPos,
+            canvasSize: widget.canvasSize,
+            now: DateTime.now(),
+          );
+    final avatarWithTrail = trailSamples.isEmpty
+        ? avatar
+        : Stack(
+            clipBehavior: Clip.none,
+            alignment: Alignment.center,
+            children: [
+              IgnorePointer(
+                child: CustomPaint(
+                  size: const Size(_kAvatarSize, _kAvatarSize),
+                  painter: _TrailPainter(
+                    samples: trailSamples,
+                    color: EchoTheme.online,
+                    radius: _kAvatarHalfSize * 0.45,
+                  ),
+                ),
+              ),
+              avatar,
+            ],
+          );
+
     final content = Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        avatar,
+        avatarWithTrail,
         const SizedBox(height: 4),
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
@@ -674,6 +774,10 @@ class _DraggableAvatarState extends State<_DraggableAvatar> {
             x: (base.x + dx).clamp(0.0, 1.0),
             y: (base.y + dy).clamp(0.0, 1.0),
           );
+          // Record where the puck *was* before this update so the
+          // trail tracks the actual motion path; `_localPos` becomes
+          // the new "current" used by the trail painter.
+          _pushTrailSample(base);
           _localPos = newPos;
           widget.onDrag(newPos);
         },
@@ -783,4 +887,47 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
       ),
     );
   }
+}
+
+/// Paints fading ghost circles at past positions of a puck so motion
+/// reads as "presence" rather than a snapping cursor.
+///
+/// Phase 3a sub-slice 2 of `docs/ux-roadmap.md`.  `samples` is built
+/// fresh each frame by `PuckTrail.render`; the painter just iterates
+/// and draws.  No allocations beyond the per-call `Paint` — and we
+/// reuse a single Paint instance across the loop.
+class _TrailPainter extends CustomPainter {
+  final List<RenderedTrailSample> samples;
+  final Color color;
+
+  /// Radius of each ghost circle.  Smaller than the puck itself so
+  /// trails read as a wake, not a doppelgänger.
+  final double radius;
+
+  const _TrailPainter({
+    required this.samples,
+    required this.color,
+    required this.radius,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (samples.isEmpty) return;
+    final center = Offset(size.width / 2, size.height / 2);
+    final paint = Paint()..style = PaintingStyle.fill;
+    for (final s in samples) {
+      // Trails are subdued — multiply by 0.45 so the puck stays the
+      // visual anchor and the wake stays in the periphery.
+      final alpha = (s.opacity * 0.45).clamp(0.0, 1.0);
+      if (alpha < 0.04) continue;
+      paint.color = color.withValues(alpha: alpha);
+      canvas.drawCircle(center + s.offset, radius, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _TrailPainter old) =>
+      !identical(old.samples, samples) ||
+      old.color != color ||
+      old.radius != radius;
 }

--- a/apps/client/lib/src/widgets/voice_speaking_ring.dart
+++ b/apps/client/lib/src/widgets/voice_speaking_ring.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import '../theme/echo_theme.dart';
@@ -10,12 +12,20 @@ import '../theme/motion_tokens.dart';
 /// Wraps [child] with a green pulsing ring when [audioLevel] exceeds
 /// [threshold] (default 0.05).
 ///
-/// Ring opacity is proportional to the audio level and, unless
-/// [MediaQuery.disableAnimations] is set, pulses at 700 ms intervals so
-/// active speakers are clearly visible at a glance.
+/// Two layers run together while a participant is speaking:
 ///
-/// Reduce-motion: when [MediaQuery.of(context).disableAnimations] is true a
-/// static (non-pulsing) ring is rendered at full levelOpacity.
+/// - **Tight border ring** hugging the avatar — opacity is proportional
+///   to the audio level and oscillates between ~0.55 and that level
+///   peak so the ring stays visible during the breath.
+/// - **Outward audio-radius rings** (Phase 3a of the UX roadmap) — two
+///   concentric rings spawned at the avatar edge that expand outward
+///   and fade as they go, staggered by half a cycle so a new pulse is
+///   always visible. Painted via a single [CustomPainter] on top of
+///   the tight ring layer; no per-frame allocations.
+///
+/// Reduce-motion: when [MediaQuery.of(context).disableAnimations] is
+/// true, only the static tight ring is rendered (no pulse, no
+/// expansion).
 class VoiceSpeakingRing extends StatefulWidget {
   /// The avatar or tile content to decorate.
   final Widget child;
@@ -26,12 +36,17 @@ class VoiceSpeakingRing extends StatefulWidget {
   /// Threshold above which the ring becomes visible. Defaults to 0.05.
   final double threshold;
 
-  /// Width of the ring border. Defaults to 2.5.
+  /// Width of the tight border ring. Defaults to 2.5.
   final double ringWidth;
 
-  /// Duration of one half-cycle of the pulse animation.
-  /// Defaults to [MotionDurations.pulse] (the ambient-breathing token).
+  /// Duration of one half-cycle of the tight-ring pulse animation.
+  /// The audio-radius rings use the same value as the period of one
+  /// outward expansion. Defaults to [MotionDurations.pulse].
   final Duration pulseDuration;
+
+  /// How far each outer audio-radius ring expands beyond the tight
+  /// ring before it fully fades. Defaults to 14 logical pixels.
+  final double radiusReach;
 
   const VoiceSpeakingRing({
     super.key,
@@ -40,6 +55,7 @@ class VoiceSpeakingRing extends StatefulWidget {
     this.threshold = 0.05,
     this.ringWidth = 2.5,
     this.pulseDuration = MotionDurations.pulse,
+    this.radiusReach = 14,
   });
 
   @override
@@ -48,28 +64,41 @@ class VoiceSpeakingRing extends StatefulWidget {
 
 // Exposed for testing (state can be read via tester.state(find.byType(...))).
 class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
+  /// Drives the tight ring's opacity oscillation. Forward / reverse
+  /// pattern (preserves the existing 0→1→0 breath).
   late final AnimationController _pulse;
 
-  /// Whether the pulse animation is currently running. Used in tests.
+  /// Drives the audio-radius rings' outward expansion.  Repeats
+  /// monotonically (no reverse) so the rings always grow outward
+  /// rather than retracting back into the avatar.
+  late final AnimationController _waves;
+
+  /// Whether the tight-ring pulse animation is currently running.
+  /// Used in tests.
   bool get isAnimating => _pulse.isAnimating;
 
   @override
   void initState() {
     super.initState();
     _pulse = AnimationController(vsync: this, duration: widget.pulseDuration)
-      ..addStatusListener(_onStatus);
+      ..addStatusListener(_onPulseStatus);
+    _waves = AnimationController(
+      vsync: this,
+      // Full expansion cycle = one tight-ring pulse half-cycle, so a
+      // wave is born ~every 700ms by default.  Two staggered rings at
+      // half-cycle offset give a continuous radar feel.
+      duration: widget.pulseDuration,
+    );
+
     // Defer the first start so MediaQuery (reduce-motion) is available.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      if (widget.audioLevel > widget.threshold &&
-          !MediaQuery.of(context).disableAnimations) {
-        _pulse.forward();
-      }
+      _syncAnimations();
     });
   }
 
-  void _onStatus(AnimationStatus status) {
+  void _onPulseStatus(AnimationStatus status) {
     if (status == AnimationStatus.completed) {
       _pulse.reverse();
     } else if (status == AnimationStatus.dismissed) {
@@ -77,22 +106,37 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
     }
   }
 
+  /// Start or stop both controllers based on the current speaking
+  /// state and reduce-motion preference.
+  void _syncAnimations() {
+    final isSpeaking = widget.audioLevel > widget.threshold;
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+
+    if (isSpeaking && !reduceMotion) {
+      if (!_pulse.isAnimating) _pulse.forward();
+      if (!_waves.isAnimating) _waves.repeat();
+    } else {
+      if (_pulse.isAnimating) {
+        _pulse.stop();
+        _pulse.value = 0;
+      }
+      if (_waves.isAnimating) {
+        _waves.stop();
+        _waves.value = 0;
+      }
+    }
+  }
+
   @override
   void didUpdateWidget(VoiceSpeakingRing oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final isSpeaking = widget.audioLevel > widget.threshold;
-    final reduceMotion = MediaQuery.of(context).disableAnimations;
-    if (isSpeaking && !_pulse.isAnimating && !reduceMotion) {
-      _pulse.forward();
-    } else if (!isSpeaking && _pulse.isAnimating) {
-      _pulse.stop();
-      _pulse.value = 0;
-    }
+    _syncAnimations();
   }
 
   @override
   void dispose() {
     _pulse.dispose();
+    _waves.dispose();
     super.dispose();
   }
 
@@ -107,7 +151,7 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
     final reduceMotion = MediaQuery.of(context).disableAnimations;
 
     if (reduceMotion) {
-      // Static green ring -- no animation.
+      // Static green tight ring — no pulse, no expansion.
       return _RingDecoration(
         ringOpacity: levelOpacity,
         ringWidth: widget.ringWidth,
@@ -115,15 +159,27 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
       );
     }
 
-    // Animated pulsing ring -- opacity oscillates between 0.35 and levelOpacity.
+    // Tight ring oscillates 0.55 → levelOpacity → 0.55 each pulse cycle.
+    // Outer rings expand outward from the tight ring's edge, staggered.
     return AnimatedBuilder(
-      animation: _pulse,
+      animation: Listenable.merge([_pulse, _waves]),
       builder: (context, child) {
-        final ringOpacity = 0.35 + (_pulse.value * (levelOpacity - 0.35));
-        return _RingDecoration(
-          ringOpacity: ringOpacity,
-          ringWidth: widget.ringWidth,
-          child: child!,
+        final ringOpacity = 0.55 + (_pulse.value * (levelOpacity - 0.55));
+        return CustomPaint(
+          // Behind the child + tight ring, so expanding rings appear to
+          // emanate from the avatar's outer edge without obscuring it.
+          painter: _AudioRadiusPainter(
+            phase: _waves.value,
+            level: levelOpacity,
+            reach: widget.radiusReach,
+            stroke: widget.ringWidth,
+            color: EchoTheme.online,
+          ),
+          child: _RingDecoration(
+            ringOpacity: ringOpacity,
+            ringWidth: widget.ringWidth,
+            child: child!,
+          ),
         );
       },
       child: widget.child,
@@ -155,4 +211,59 @@ class _RingDecoration extends StatelessWidget {
       child: child,
     );
   }
+}
+
+/// Paints the expanding audio-radius rings around a circular avatar.
+///
+/// Two ring "phases" share the same controller via a half-cycle
+/// offset so a new wave is always being born while the previous one
+/// fades out.  Opacity scales with [level] (the speaker's amplitude)
+/// and falls linearly with progress; radius grows linearly from the
+/// child's edge to `edge + reach`.
+class _AudioRadiusPainter extends CustomPainter {
+  final double phase; // [0, 1)
+  final double level; // current peak opacity
+  final double reach; // px to grow beyond the tight ring
+  final double stroke; // line width of each ring
+  final Color color;
+
+  _AudioRadiusPainter({
+    required this.phase,
+    required this.level,
+    required this.reach,
+    required this.stroke,
+    required this.color,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    // Tight ring sits on the child's outer edge; expansion starts there.
+    final innerRadius = math.min(size.width, size.height) / 2;
+
+    void paintWave(double t) {
+      // Skip near-invisible rings to keep the canvas cheap.
+      if (t <= 0 || t >= 1) return;
+      final opacity = (level * (1.0 - t)).clamp(0.0, 1.0);
+      if (opacity < 0.04) return;
+      final radius = innerRadius + reach * t;
+      final paint = Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = stroke * 0.65
+        ..color = color.withValues(alpha: opacity);
+      canvas.drawCircle(center, radius, paint);
+    }
+
+    paintWave(phase);
+    // Second ring, half a cycle out of phase.
+    paintWave((phase + 0.5) % 1.0);
+  }
+
+  @override
+  bool shouldRepaint(covariant _AudioRadiusPainter old) =>
+      old.phase != phase ||
+      old.level != level ||
+      old.reach != reach ||
+      old.stroke != stroke ||
+      old.color != color;
 }

--- a/apps/client/lib/src/widgets/voice_speaking_ring.dart
+++ b/apps/client/lib/src/widgets/voice_speaking_ring.dart
@@ -130,6 +130,14 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
   @override
   void didUpdateWidget(VoiceSpeakingRing oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.pulseDuration != oldWidget.pulseDuration) {
+      // Keep the controllers in sync if the parent retunes the pulse.
+      // AnimationController.duration is a setter that takes effect on
+      // the next tick, so an in-flight animation continues to its
+      // current end state at the new rate.
+      _pulse.duration = widget.pulseDuration;
+      _waves.duration = widget.pulseDuration;
+    }
     _syncAnimations();
   }
 
@@ -159,12 +167,17 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
       );
     }
 
-    // Tight ring oscillates 0.55 → levelOpacity → 0.55 each pulse cycle.
-    // Outer rings expand outward from the tight ring's edge, staggered.
+    // Tight ring oscillates between a floor and the level peak each
+    // pulse cycle.  When the speaker is loud, the floor is 0.55; when
+    // they are quiet (level < 0.55), we collapse the floor to the
+    // level itself so the pulse never *exceeds* the audio-derived
+    // peak (which would make quiet speakers misleadingly opaque).
+    final pulseFloor = math.min(0.55, levelOpacity);
     return AnimatedBuilder(
       animation: Listenable.merge([_pulse, _waves]),
       builder: (context, child) {
-        final ringOpacity = 0.55 + (_pulse.value * (levelOpacity - 0.55));
+        final ringOpacity =
+            pulseFloor + (_pulse.value * (levelOpacity - pulseFloor));
         return CustomPaint(
           // Behind the child + tight ring, so expanding rings appear to
           // emanate from the avatar's outer edge without obscuring it.
@@ -241,16 +254,20 @@ class _AudioRadiusPainter extends CustomPainter {
     // Tight ring sits on the child's outer edge; expansion starts there.
     final innerRadius = math.min(size.width, size.height) / 2;
 
+    // Single Paint reused across both waves — only `color` changes
+    // between calls.  The doc-comment promise of "no per-frame
+    // allocations" depends on this.
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke * 0.65;
+
     void paintWave(double t) {
       // Skip near-invisible rings to keep the canvas cheap.
       if (t <= 0 || t >= 1) return;
       final opacity = (level * (1.0 - t)).clamp(0.0, 1.0);
       if (opacity < 0.04) return;
       final radius = innerRadius + reach * t;
-      final paint = Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = stroke * 0.65
-        ..color = color.withValues(alpha: opacity);
+      paint.color = color.withValues(alpha: opacity);
       canvas.drawCircle(center, radius, paint);
     }
 

--- a/apps/client/lib/src/widgets/voice_speaking_ring.dart
+++ b/apps/client/lib/src/widgets/voice_speaking_ring.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/echo_theme.dart';
+import '../theme/motion_tokens.dart';
 
 // ---------------------------------------------------------------------------
 // VoiceSpeakingRing
@@ -28,7 +29,8 @@ class VoiceSpeakingRing extends StatefulWidget {
   /// Width of the ring border. Defaults to 2.5.
   final double ringWidth;
 
-  /// Duration of one half-cycle of the pulse animation. Defaults to 700 ms.
+  /// Duration of one half-cycle of the pulse animation.
+  /// Defaults to [MotionDurations.pulse] (the ambient-breathing token).
   final Duration pulseDuration;
 
   const VoiceSpeakingRing({
@@ -37,7 +39,7 @@ class VoiceSpeakingRing extends StatefulWidget {
     required this.audioLevel,
     this.threshold = 0.05,
     this.ringWidth = 2.5,
-    this.pulseDuration = const Duration(milliseconds: 700),
+    this.pulseDuration = MotionDurations.pulse,
   });
 
   @override

--- a/apps/client/test/providers/ui_density_test.dart
+++ b/apps/client/test/providers/ui_density_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/providers/theme_provider.dart';
+
+/// Allow the build()-fired async _load() to settle.
+Future<void> _flushLoad() =>
+    Future<void>.delayed(const Duration(milliseconds: 100));
+
+void main() {
+  group('UIDensityNotifier', () {
+    test(
+      'build returns compact synchronously (today\'s effective default)',
+      () {
+        SharedPreferences.setMockInitialValues({});
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        // Read before _load completes — the synchronous build() return value
+        // must match today's effective default so brand-new users see no
+        // behavior change while prefs are loading.
+        final initial = container.read(uiDensityProvider);
+        expect(initial, UIDensity.compact);
+      },
+    );
+
+    test('loads compact when no prefs are set (no regression)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(uiDensityProvider);
+      await _flushLoad();
+      expect(container.read(uiDensityProvider), UIDensity.compact);
+    });
+
+    test(
+      'migrates legacy MessageLayout=compact to UIDensity.compact',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'echo_message_layout': 'compact',
+        });
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.read(uiDensityProvider);
+        await _flushLoad();
+        expect(container.read(uiDensityProvider), UIDensity.compact);
+      },
+    );
+
+    test('migrates legacy MessageLayout=bubbles to UIDensity.normal', () async {
+      SharedPreferences.setMockInitialValues({
+        'echo_message_layout': 'bubbles',
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(uiDensityProvider);
+      await _flushLoad();
+      expect(container.read(uiDensityProvider), UIDensity.normal);
+    });
+
+    test('migrates legacy MessageLayout=plain to UIDensity.normal', () async {
+      SharedPreferences.setMockInitialValues({'echo_message_layout': 'plain'});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(uiDensityProvider);
+      await _flushLoad();
+      expect(container.read(uiDensityProvider), UIDensity.normal);
+    });
+
+    test('reads echo_ui_density when present (cozy)', () async {
+      SharedPreferences.setMockInitialValues({'echo_ui_density': 'cozy'});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(uiDensityProvider);
+      await _flushLoad();
+      expect(container.read(uiDensityProvider), UIDensity.cozy);
+    });
+
+    test('reads echo_ui_density when present (normal)', () async {
+      SharedPreferences.setMockInitialValues({'echo_ui_density': 'normal'});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(uiDensityProvider);
+      await _flushLoad();
+      expect(container.read(uiDensityProvider), UIDensity.normal);
+    });
+
+    test(
+      'explicit echo_ui_density overrides legacy MessageLayout migration',
+      () async {
+        // Once the user picks a density, that wins regardless of the legacy
+        // MessageLayout value.
+        SharedPreferences.setMockInitialValues({
+          'echo_ui_density': 'cozy',
+          'echo_message_layout': 'compact',
+        });
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.read(uiDensityProvider);
+        await _flushLoad();
+        expect(container.read(uiDensityProvider), UIDensity.cozy);
+      },
+    );
+
+    test('setDensity updates state and persists round-trip', () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(uiDensityProvider);
+      await _flushLoad();
+
+      await container
+          .read(uiDensityProvider.notifier)
+          .setDensity(UIDensity.cozy);
+
+      expect(container.read(uiDensityProvider), UIDensity.cozy);
+
+      // Verify persistence: a fresh container reads the saved value.
+      final container2 = ProviderContainer();
+      addTearDown(container2.dispose);
+      container2.read(uiDensityProvider);
+      await _flushLoad();
+      expect(container2.read(uiDensityProvider), UIDensity.cozy);
+    });
+
+    test('unknown saved value falls back to normal', () async {
+      SharedPreferences.setMockInitialValues({'echo_ui_density': 'roomy'});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(uiDensityProvider);
+      await _flushLoad();
+      expect(container.read(uiDensityProvider), UIDensity.normal);
+    });
+  });
+}

--- a/apps/client/test/theme/motion_tokens_test.dart
+++ b/apps/client/test/theme/motion_tokens_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/animation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/theme/motion_tokens.dart';
+
+void main() {
+  group('MotionDurations', () {
+    test('tokens are strictly ordered fastest -> slowest', () {
+      // Catches accidental reordering / typo — if someone edits a
+      // token to a wrong value, this test localizes the regression.
+      const ordered = [
+        MotionDurations.instant,
+        MotionDurations.quick,
+        MotionDurations.standard,
+        MotionDurations.expressive,
+        MotionDurations.gentle,
+        MotionDurations.pulse,
+      ];
+      for (var i = 1; i < ordered.length; i++) {
+        expect(
+          ordered[i].inMilliseconds,
+          greaterThan(ordered[i - 1].inMilliseconds),
+          reason: 'token at index $i must be slower than index ${i - 1}',
+        );
+      }
+    });
+
+    test('all durations are positive', () {
+      const all = [
+        MotionDurations.instant,
+        MotionDurations.quick,
+        MotionDurations.standard,
+        MotionDurations.expressive,
+        MotionDurations.gentle,
+        MotionDurations.pulse,
+      ];
+      for (final d in all) {
+        expect(d.inMilliseconds, greaterThan(0));
+      }
+    });
+
+    test('pulse is suitable for ambient motion (>=500ms)', () {
+      // Pulse is reserved for continuous, breathing motion.  If
+      // someone accidentally aliases it to a faster value, motion
+      // designed against it (speaking ring) will start strobing.
+      expect(MotionDurations.pulse.inMilliseconds, greaterThanOrEqualTo(500));
+    });
+
+    test('instant is fast enough for hover feedback (<=120ms)', () {
+      // Hover responses below ~120ms feel synchronous; above that
+      // they read as "loading."
+      expect(MotionDurations.instant.inMilliseconds, lessThanOrEqualTo(120));
+    });
+  });
+
+  group('MotionCurves', () {
+    test('entrance and exit are distinct curves', () {
+      // Easy regression: collapsing entrance/exit to the same curve
+      // makes UI feel "linear" / robotic.
+      expect(MotionCurves.entrance, isNot(equals(MotionCurves.exit)));
+    });
+
+    test('all curves are non-null Curve instances', () {
+      const curves = <Curve>[
+        MotionCurves.entrance,
+        MotionCurves.exit,
+        MotionCurves.emphasis,
+        MotionCurves.expressiveBounce,
+        MotionCurves.decelerate,
+      ];
+      for (final c in curves) {
+        expect(c, isA<Curve>());
+      }
+    });
+
+    test('expressiveBounce overshoots above 1.0', () {
+      // The whole point of the expressive bounce is that it goes
+      // *past* the target before settling.  If someone "fixes" it to
+      // a non-overshooting curve, this catches the regression.
+      var maxValue = 0.0;
+      for (var t = 0.0; t <= 1.0; t += 0.01) {
+        final v = MotionCurves.expressiveBounce.transform(t);
+        if (v > maxValue) maxValue = v;
+      }
+      expect(maxValue, greaterThan(1.0));
+    });
+
+    test('entrance ends at 1.0 and starts at 0.0', () {
+      expect(MotionCurves.entrance.transform(0.0), closeTo(0.0, 1e-6));
+      expect(MotionCurves.entrance.transform(1.0), closeTo(1.0, 1e-6));
+    });
+  });
+}

--- a/apps/client/test/utils/mention_detection_test.dart
+++ b/apps/client/test/utils/mention_detection_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/utils/mention_detection.dart';
+
+void main() {
+  group('containsMention', () {
+    test('matches @username at start', () {
+      expect(containsMention('@dev hi', 'dev'), isTrue);
+    });
+
+    test('matches @username after whitespace', () {
+      expect(containsMention('hello @dev', 'dev'), isTrue);
+    });
+
+    test('matches @username after punctuation', () {
+      expect(containsMention('great work, @dev!', 'dev'), isTrue);
+    });
+
+    test('does not match email-like x@username', () {
+      expect(containsMention('me@dev', 'dev'), isFalse);
+    });
+
+    test('does not match longer-word @usernameish', () {
+      expect(containsMention('@develop', 'dev'), isFalse);
+    });
+
+    test('matches @everyone broadcast', () {
+      expect(containsMention('@everyone heads up', null), isTrue);
+      expect(containsMention('@everyone heads up', 'someone'), isTrue);
+    });
+
+    test('matches @here broadcast', () {
+      expect(containsMention('@here?', null), isTrue);
+    });
+
+    test('rejects @hereafter', () {
+      expect(containsMention('@hereafter we go', null), isFalse);
+    });
+
+    test('rejects @everyones', () {
+      expect(containsMention('@everyones birthday', null), isFalse);
+    });
+
+    test('case-insensitive on username', () {
+      expect(containsMention('@Dev hi', 'dev'), isTrue);
+      expect(containsMention('@DEV hi', 'dev'), isTrue);
+      expect(containsMention('@dev hi', 'DEV'), isTrue);
+    });
+
+    test('case-insensitive on broadcast keywords', () {
+      expect(containsMention('Yo @Here folks', null), isTrue);
+      expect(containsMention('YO @EVERYONE FOLKS', null), isTrue);
+    });
+
+    test('empty content returns false', () {
+      expect(containsMention('', 'dev'), isFalse);
+    });
+
+    test('null/empty username only matches broadcasts', () {
+      expect(containsMention('@dev', null), isFalse);
+      expect(containsMention('@dev', ''), isFalse);
+      expect(containsMention('@here', null), isTrue);
+    });
+
+    test('username with underscore boundary rejected', () {
+      // `@dev_lounge` is a different identifier; do not fire on @dev.
+      expect(containsMention('@dev_lounge', 'dev'), isFalse);
+    });
+
+    test('multiple mentions still detected', () {
+      expect(containsMention('hi @alice and @dev', 'dev'), isTrue);
+    });
+
+    test('content with @ but no real mention returns false', () {
+      expect(containsMention('email me at user@example.com', 'dev'), isFalse);
+    });
+  });
+
+  group('containsKeywordMention (exposed for tests)', () {
+    test('matches lone keyword', () {
+      expect(containsKeywordMention('@everyone', 'everyone'), isTrue);
+    });
+
+    test('rejects empty keyword', () {
+      expect(containsKeywordMention('@here', ''), isFalse);
+    });
+  });
+}

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:echo_app/src/models/chat_message.dart';
 import 'package:echo_app/src/models/conversation.dart';
 import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/providers/theme_provider.dart';
 import 'package:echo_app/src/theme/echo_theme.dart';
 import 'package:echo_app/src/widgets/conversation_item.dart';
 
@@ -811,6 +812,125 @@ void main() {
       expect(label, contains('4 unread'));
     });
 
+    testWidgets('cozy density renders 84px row + 22px avatar radius', (
+      tester,
+    ) async {
+      final conv = _makeConversation(
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+        overrides: [
+          uiDensityProvider.overrideWith(
+            () => _StaticUIDensity(UIDensity.cozy),
+          ),
+        ],
+      );
+      await tester.pump();
+      expect(
+        conversationItemHeightFor(UIDensity.cozy),
+        kConversationItemHeightCozy,
+      );
+      // Settle one more frame so AnimatedContainer reaches its target.
+      await tester.pumpAndSettle();
+      final container = tester.widget<AnimatedContainer>(
+        find
+            .descendant(
+              of: find.byType(ConversationItem),
+              matching: find.byType(AnimatedContainer),
+            )
+            .first,
+      );
+      expect(
+        container.constraints?.minHeight ?? 0,
+        kConversationItemHeightCozy,
+      );
+    });
+
+    testWidgets('compact density renders 52px row', (tester) async {
+      final conv = _makeConversation(
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+        overrides: [
+          uiDensityProvider.overrideWith(
+            () => _StaticUIDensity(UIDensity.compact),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+      final container = tester.widget<AnimatedContainer>(
+        find
+            .descendant(
+              of: find.byType(ConversationItem),
+              matching: find.byType(AnimatedContainer),
+            )
+            .first,
+      );
+      expect(
+        container.constraints?.minHeight ?? 0,
+        kConversationItemHeightCompact,
+      );
+    });
+
+    testWidgets('normal density renders 68px row (default)', (tester) async {
+      final conv = _makeConversation(
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+        overrides: [
+          uiDensityProvider.overrideWith(
+            () => _StaticUIDensity(UIDensity.normal),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+      final container = tester.widget<AnimatedContainer>(
+        find
+            .descendant(
+              of: find.byType(ConversationItem),
+              matching: find.byType(AnimatedContainer),
+            )
+            .first,
+      );
+      expect(container.constraints?.minHeight ?? 0, kConversationItemHeight);
+    });
+
     testWidgets('muted conversation uses dimmer name color', (tester) async {
       final muted = _makeConversation(
         lastMessage: 'quiet message',
@@ -841,6 +961,18 @@ void main() {
       expect(nameWidget.style?.color, isNot(equals(ctx.textPrimary)));
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Test override that returns a static UIDensity without persisting.
+// Bypasses the SharedPreferences load that the production notifier runs.
+// ---------------------------------------------------------------------------
+class _StaticUIDensity extends UIDensityNotifier {
+  final UIDensity _density;
+  _StaticUIDensity(this._density);
+
+  @override
+  UIDensity build() => _density;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -18,6 +18,7 @@ Conversation _makeConversation({
   String? lastMessageTimestamp,
   String? lastMessageSender,
   int unreadCount = 0,
+  int mentionCount = 0,
   bool isMuted = false,
   List<ConversationMember> members = const [],
 }) {
@@ -29,6 +30,7 @@ Conversation _makeConversation({
     lastMessageTimestamp: lastMessageTimestamp,
     lastMessageSender: lastMessageSender,
     unreadCount: unreadCount,
+    mentionCount: mentionCount,
     isMuted: isMuted,
     members: members,
   );
@@ -687,6 +689,156 @@ void main() {
             'ConversationItem for conv-a rebuilt when only conv-b changed '
             '— selector not applied',
       );
+    });
+  });
+
+  group('ConversationItem state hierarchy (UX roadmap Phase 1)', () {
+    testWidgets('mention badge renders when mentionCount > 0', (tester) async {
+      final conv = _makeConversation(
+        lastMessage: 'hi @me',
+        mentionCount: 2,
+        unreadCount: 5,
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+      expect(find.text('@'), findsOneWidget);
+    });
+
+    testWidgets('mention badge absent when mentionCount is 0', (tester) async {
+      final conv = _makeConversation(
+        lastMessage: 'hello',
+        unreadCount: 3,
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+      expect(find.text('@'), findsNothing);
+    });
+
+    testWidgets('selected conversation renders an active edge bar', (
+      tester,
+    ) async {
+      final conv = _makeConversation(
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+
+      // Render unselected first.
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+      final unselectedPositioned = find
+          .descendant(
+            of: find.byType(ConversationItem),
+            matching: find.byType(Positioned),
+          )
+          .evaluate()
+          .length;
+
+      // Then render selected; the bar adds exactly one more Positioned widget.
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: true,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+      final selectedPositioned = find
+          .descendant(
+            of: find.byType(ConversationItem),
+            matching: find.byType(Positioned),
+          )
+          .evaluate()
+          .length;
+
+      expect(selectedPositioned, equals(unselectedPositioned + 1));
+    });
+
+    testWidgets('semantics label includes "mentioned" when mentionCount > 0', (
+      tester,
+    ) async {
+      final label = composeConversationItemSemanticsLabel(
+        displayName: 'alice',
+        unreadCount: 4,
+        mentionCount: 1,
+        muted: false,
+        snippet: 'hi',
+      );
+      expect(label, contains('mentioned'));
+      expect(label, contains('4 unread'));
+    });
+
+    testWidgets('muted conversation uses dimmer name color', (tester) async {
+      final muted = _makeConversation(
+        lastMessage: 'quiet message',
+        isMuted: true,
+        unreadCount: 1,
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: muted,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:00',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+
+      final ctx = tester.element(find.byType(ConversationItem));
+      final nameWidget = tester.widget<Text>(find.text('alice'));
+      // Muted name should be textMuted, not textPrimary.
+      expect(nameWidget.style?.color, equals(ctx.textMuted));
+      expect(nameWidget.style?.color, isNot(equals(ctx.textPrimary)));
     });
   });
 }

--- a/apps/client/test/widgets/input/mention_autocomplete_test.dart
+++ b/apps/client/test/widgets/input/mention_autocomplete_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:echo_app/src/widgets/input/mention_autocomplete.dart';
+import 'package:echo_app/src/widgets/input/mention_controller.dart';
 
 void main() {
   group('extractMentionQuery', () {
@@ -47,6 +47,18 @@ void main() {
     test('works for broadcast keywords (everyone / here)', () {
       expect(extractMentionQuery('@every', 6), 'every');
       expect(extractMentionQuery('hi @here', 8), 'here');
+    });
+
+    test('accepts tab as left boundary', () {
+      expect(extractMentionQuery('\t@al', 4), 'al');
+    });
+
+    test('accepts newline as left boundary', () {
+      expect(extractMentionQuery('first\n@al', 9), 'al');
+    });
+
+    test('breaks on tab inside the partial', () {
+      expect(extractMentionQuery('@al\tice', 7), isNull);
     });
   });
 

--- a/apps/client/test/widgets/input/mention_autocomplete_test.dart
+++ b/apps/client/test/widgets/input/mention_autocomplete_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/input/mention_autocomplete.dart';
+
+void main() {
+  group('extractMentionQuery', () {
+    test('returns null when no @ in text', () {
+      expect(extractMentionQuery('hello world', 11), isNull);
+    });
+
+    test('returns null when cursor is out of range', () {
+      expect(extractMentionQuery('@al', -1), isNull);
+      expect(extractMentionQuery('@al', 99), isNull);
+    });
+
+    test('returns query when @ at start of string', () {
+      expect(extractMentionQuery('@al', 3), 'al');
+    });
+
+    test('returns lowercased query', () {
+      expect(extractMentionQuery('@AlICe', 6), 'alice');
+    });
+
+    test('returns query when @ follows a space', () {
+      expect(extractMentionQuery('hi @bo', 6), 'bo');
+    });
+
+    test('returns null when @ is mid-word (no leading space)', () {
+      // e.g. an email address
+      expect(extractMentionQuery('me@host', 7), isNull);
+    });
+
+    test('returns null when query contains a space (mention closed)', () {
+      expect(extractMentionQuery('@alice was here', 15), isNull);
+    });
+
+    test('cursor before the @ does not extract', () {
+      // cursor sits BEFORE the @, so beforeCursor has no @
+      expect(extractMentionQuery('hi @bo', 2), isNull);
+    });
+
+    test('returns empty string when only @ has been typed', () {
+      expect(extractMentionQuery('@', 1), '');
+    });
+
+    test('works for broadcast keywords (everyone / here)', () {
+      expect(extractMentionQuery('@every', 6), 'every');
+      expect(extractMentionQuery('hi @here', 8), 'here');
+    });
+  });
+
+  group('insertMention', () {
+    test('replaces partial query with username and trailing space', () {
+      const text = '@al';
+      final result = insertMention(
+        text: text,
+        cursorPosition: 3,
+        username: 'alice',
+      );
+      expect(result.text, '@alice ');
+      expect(result.selection.baseOffset, '@alice '.length);
+    });
+
+    test('preserves text before and after the partial', () {
+      const text = 'hey @bo more';
+      final result = insertMention(
+        text: text,
+        cursorPosition: 7, // right after "@bo"
+        username: 'bob',
+      );
+      expect(result.text, 'hey @bob  more');
+      // Cursor sits right after the inserted "@bob "
+      expect(result.selection.baseOffset, 'hey @bob '.length);
+    });
+
+    test('inserts everyone keyword', () {
+      const text = '@every';
+      final result = insertMention(
+        text: text,
+        cursorPosition: 6,
+        username: 'everyone',
+      );
+      expect(result.text, '@everyone ');
+    });
+
+    test('returns original text when no @ was found', () {
+      const text = 'hello';
+      final result = insertMention(
+        text: text,
+        cursorPosition: 5,
+        username: 'alice',
+      );
+      expect(result.text, 'hello');
+      // No selection set (defaulted) — just confirm no crash and text unchanged.
+    });
+
+    test('returns original text on negative cursor', () {
+      final result = insertMention(
+        text: '@al',
+        cursorPosition: -1,
+        username: 'alice',
+      );
+      expect(result.text, '@al');
+    });
+
+    test('result selection is collapsed', () {
+      final result = insertMention(
+        text: '@al',
+        cursorPosition: 3,
+        username: 'alice',
+      );
+      expect(result.selection, isA<TextSelection>());
+      expect(result.selection.isCollapsed, isTrue);
+    });
+  });
+}

--- a/apps/client/test/widgets/input/mention_autocomplete_widget_test.dart
+++ b/apps/client/test/widgets/input/mention_autocomplete_widget_test.dart
@@ -40,6 +40,7 @@ void main() {
       expect(find.text('@everyone'), findsOneWidget);
       expect(find.text('@here'), findsNothing);
       expect(find.text('alice'), findsNothing);
+      expect(find.text('bob'), findsNothing);
     });
 
     testWidgets('query "he" surfaces only @here', (tester) async {
@@ -48,6 +49,18 @@ void main() {
 
       expect(find.text('@here'), findsOneWidget);
       expect(find.text('@everyone'), findsNothing);
+      expect(find.text('alice'), findsNothing);
+      expect(find.text('bob'), findsNothing);
+    });
+
+    testWidgets('mixed-case query "He" still surfaces @here', (tester) async {
+      // Defensive: extractMentionQuery normalizes to lowercase upstream,
+      // but the public widget API should not silently drop suggestions
+      // for callers that don't pre-normalize.
+      await tester.pumpApp(harness(query: 'He'));
+      await tester.pump();
+
+      expect(find.text('@here'), findsOneWidget);
     });
 
     testWidgets('query that matches nothing renders empty', (tester) async {

--- a/apps/client/test/widgets/input/mention_autocomplete_widget_test.dart
+++ b/apps/client/test/widgets/input/mention_autocomplete_widget_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/widgets/input/mention_autocomplete.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  const members = [
+    ConversationMember(userId: 'u1', username: 'alice'),
+    ConversationMember(userId: 'u2', username: 'bob'),
+  ];
+
+  Widget harness({required String query, ValueChanged<String>? onSelected}) {
+    return MentionAutocomplete(
+      members: members,
+      mentionQuery: query,
+      onMentionSelected: onSelected ?? (_) {},
+    );
+  }
+
+  group('MentionAutocomplete broadcast suggestions', () {
+    testWidgets('empty query shows all members + both broadcasts', (
+      tester,
+    ) async {
+      await tester.pumpApp(harness(query: ''));
+      await tester.pump();
+
+      expect(find.text('alice'), findsOneWidget);
+      expect(find.text('bob'), findsOneWidget);
+      expect(find.text('@everyone'), findsOneWidget);
+      expect(find.text('@here'), findsOneWidget);
+    });
+
+    testWidgets('query "ev" surfaces only @everyone', (tester) async {
+      await tester.pumpApp(harness(query: 'ev'));
+      await tester.pump();
+
+      expect(find.text('@everyone'), findsOneWidget);
+      expect(find.text('@here'), findsNothing);
+      expect(find.text('alice'), findsNothing);
+    });
+
+    testWidgets('query "he" surfaces only @here', (tester) async {
+      await tester.pumpApp(harness(query: 'he'));
+      await tester.pump();
+
+      expect(find.text('@here'), findsOneWidget);
+      expect(find.text('@everyone'), findsNothing);
+    });
+
+    testWidgets('query that matches nothing renders empty', (tester) async {
+      await tester.pumpApp(harness(query: 'zzz'));
+      await tester.pump();
+
+      expect(find.byType(InkWell), findsNothing);
+    });
+
+    testWidgets('tapping @everyone fires onMentionSelected("everyone")', (
+      tester,
+    ) async {
+      String? selected;
+      await tester.pumpApp(
+        harness(query: 'ev', onSelected: (k) => selected = k),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('@everyone'));
+      await tester.pump();
+
+      expect(selected, 'everyone');
+    });
+
+    testWidgets('tapping @here fires onMentionSelected("here")', (
+      tester,
+    ) async {
+      String? selected;
+      await tester.pumpApp(
+        harness(query: 'h', onSelected: (k) => selected = k),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('@here'));
+      await tester.pump();
+
+      expect(selected, 'here');
+    });
+
+    testWidgets('member matches still take precedence near the cursor', (
+      tester,
+    ) async {
+      // The picker is reverse:true; member rows have lower indices, so they
+      // paint at the bottom (closest to text field). Verify both appear.
+      await tester.pumpApp(harness(query: ''));
+      await tester.pump();
+
+      expect(find.text('alice'), findsOneWidget);
+      expect(find.text('@everyone'), findsOneWidget);
+    });
+  });
+}

--- a/apps/client/test/widgets/input/mention_controller_test.dart
+++ b/apps/client/test/widgets/input/mention_controller_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/widgets/input/mention_controller.dart';
+
+void main() {
+  group('MentionComposerController', () {
+    late MentionComposerController controller;
+    late int notifyCount;
+
+    setUp(() {
+      controller = MentionComposerController();
+      notifyCount = 0;
+      controller.addListener(() => notifyCount++);
+    });
+
+    tearDown(() => controller.dispose());
+
+    test('starts hidden with empty query', () {
+      expect(controller.showPicker, isFalse);
+      expect(controller.query, isEmpty);
+    });
+
+    test('detect activates picker on @ in group', () {
+      controller.detect(text: '@al', cursorPosition: 3, isGroup: true);
+      expect(controller.showPicker, isTrue);
+      expect(controller.query, 'al');
+      expect(notifyCount, 1);
+    });
+
+    test('detect is a no-op when state is unchanged', () {
+      controller.detect(text: '@al', cursorPosition: 3, isGroup: true);
+      controller.detect(text: '@al', cursorPosition: 3, isGroup: true);
+      expect(notifyCount, 1, reason: 'second identical call should not notify');
+    });
+
+    test('detect dismisses picker in 1:1 DM regardless of @', () {
+      controller.detect(text: '@al', cursorPosition: 3, isGroup: false);
+      expect(controller.showPicker, isFalse);
+      expect(controller.query, isEmpty);
+      expect(notifyCount, 0, reason: 'starts hidden, no transition fired');
+    });
+
+    test('detect closes picker when query terminator typed', () {
+      controller
+        ..detect(text: '@al', cursorPosition: 3, isGroup: true)
+        ..detect(text: '@al ', cursorPosition: 4, isGroup: true);
+      expect(controller.showPicker, isFalse);
+      expect(controller.query, isEmpty);
+      expect(notifyCount, 2, reason: 'open then close');
+    });
+
+    test('dismiss closes picker and clears query', () {
+      controller.detect(text: '@al', cursorPosition: 3, isGroup: true);
+      controller.dismiss();
+      expect(controller.showPicker, isFalse);
+      expect(controller.query, isEmpty);
+    });
+
+    test('dismiss while already hidden does not notify', () {
+      controller.dismiss();
+      expect(notifyCount, 0);
+    });
+
+    test('filterMembers removes the local user', () {
+      const me = ConversationMember(userId: 'me', username: 'testuser');
+      const other = ConversationMember(userId: 'other', username: 'alice');
+      final filtered = controller.filterMembers([me, other], 'me');
+      expect(filtered, hasLength(1));
+      expect(filtered.first.userId, 'other');
+    });
+  });
+}

--- a/apps/client/test/widgets/input/mention_controller_test.dart
+++ b/apps/client/test/widgets/input/mention_controller_test.dart
@@ -65,7 +65,10 @@ void main() {
     test('filterMembers removes the local user', () {
       const me = ConversationMember(userId: 'me', username: 'testuser');
       const other = ConversationMember(userId: 'other', username: 'alice');
-      final filtered = controller.filterMembers([me, other], 'me');
+      final filtered = MentionComposerController.filterMembers([
+        me,
+        other,
+      ], 'me');
       expect(filtered, hasLength(1));
       expect(filtered.first.userId, 'other');
     });

--- a/apps/client/test/widgets/puck_trail_test.dart
+++ b/apps/client/test/widgets/puck_trail_test.dart
@@ -1,0 +1,124 @@
+import 'dart:ui' show Size;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/canvas_models.dart';
+import 'package:echo_app/src/widgets/puck_trail.dart';
+
+void main() {
+  group('PuckTrail', () {
+    test('starts empty', () {
+      final trail = PuckTrail();
+      expect(trail.isEmpty, isTrue);
+      expect(trail.samples, isEmpty);
+    });
+
+    test('addSample appends to the buffer', () {
+      final trail = PuckTrail();
+      final t0 = DateTime(2026, 1, 1);
+      trail.addSample(const CanvasPoint(x: 0.5, y: 0.5), t0);
+      trail.addSample(
+        const CanvasPoint(x: 0.6, y: 0.5),
+        t0.add(const Duration(milliseconds: 50)),
+      );
+      expect(trail.samples, hasLength(2));
+      expect(trail.isEmpty, isFalse);
+    });
+
+    test('buffer caps at maxSamples (oldest dropped)', () {
+      final trail = PuckTrail(maxSamples: 3);
+      final t0 = DateTime(2026, 1, 1);
+      for (var i = 0; i < 10; i++) {
+        trail.addSample(
+          CanvasPoint(x: i / 10.0, y: 0.5),
+          t0.add(Duration(milliseconds: i * 10)),
+        );
+      }
+      expect(trail.samples, hasLength(3));
+      // The first kept sample is index 7 (i*10 = 70ms).
+      expect(trail.samples.first.at.difference(t0).inMilliseconds, 70);
+      expect(trail.samples.last.at.difference(t0).inMilliseconds, 90);
+    });
+
+    test('prune drops samples older than ttl', () {
+      final trail = PuckTrail(ttl: const Duration(milliseconds: 200));
+      final t0 = DateTime(2026, 1, 1);
+      trail.addSample(const CanvasPoint(x: 0.1, y: 0.5), t0);
+      trail.addSample(
+        const CanvasPoint(x: 0.2, y: 0.5),
+        t0.add(const Duration(milliseconds: 100)),
+      );
+      trail.addSample(
+        const CanvasPoint(x: 0.3, y: 0.5),
+        t0.add(const Duration(milliseconds: 250)),
+      );
+      trail.prune(t0.add(const Duration(milliseconds: 300)));
+      // First two are now > 200ms old; only the last survives.
+      expect(trail.samples, hasLength(1));
+      expect(trail.samples.single.pos.x, closeTo(0.3, 1e-9));
+    });
+
+    test('render returns offsets relative to current in pixel space', () {
+      final trail = PuckTrail();
+      final t0 = DateTime(2026, 1, 1);
+      // Sample at (0.4, 0.5), current is (0.5, 0.5).  Canvas 1000x500.
+      trail.addSample(const CanvasPoint(x: 0.4, y: 0.5), t0);
+      final rendered = trail.render(
+        current: const CanvasPoint(x: 0.5, y: 0.5),
+        canvasSize: const Size(1000, 500),
+        now: t0.add(const Duration(milliseconds: 100)),
+      );
+      expect(rendered, hasLength(1));
+      // dx = (0.4 - 0.5) * 1000 = -100 ; dy = 0.
+      expect(rendered.single.offset.dx, closeTo(-100, 1e-9));
+      expect(rendered.single.offset.dy, closeTo(0, 1e-9));
+    });
+
+    test('render fades opacity linearly toward ttl', () {
+      final trail = PuckTrail(ttl: const Duration(milliseconds: 600));
+      final t0 = DateTime(2026, 1, 1);
+      trail.addSample(const CanvasPoint(x: 0.5, y: 0.5), t0);
+      // Half-life: 300ms in ⇒ ~0.5 opacity.
+      final rendered = trail.render(
+        current: const CanvasPoint(x: 0.5, y: 0.5),
+        canvasSize: const Size(100, 100),
+        now: t0.add(const Duration(milliseconds: 300)),
+      );
+      expect(rendered.single.opacity, closeTo(0.5, 0.01));
+    });
+
+    test(
+      'render filters out samples already past ttl without mutating buffer',
+      () {
+        final trail = PuckTrail(ttl: const Duration(milliseconds: 100));
+        final t0 = DateTime(2026, 1, 1);
+        trail.addSample(const CanvasPoint(x: 0.1, y: 0.5), t0);
+        trail.addSample(
+          const CanvasPoint(x: 0.2, y: 0.5),
+          t0.add(const Duration(milliseconds: 50)),
+        );
+        final rendered = trail.render(
+          current: const CanvasPoint(x: 0.3, y: 0.5),
+          canvasSize: const Size(100, 100),
+          now: t0.add(const Duration(milliseconds: 200)),
+        );
+        expect(rendered, isEmpty, reason: 'all samples expired');
+        // Buffer stays intact for prune() to evict on its own.
+        expect(trail.samples, hasLength(2));
+      },
+    );
+
+    test('clear empties the buffer', () {
+      final trail = PuckTrail();
+      final t0 = DateTime(2026, 1, 1);
+      trail.addSample(const CanvasPoint(x: 0.5, y: 0.5), t0);
+      trail.clear();
+      expect(trail.isEmpty, isTrue);
+    });
+
+    test('asserts non-positive maxSamples and ttl', () {
+      expect(() => PuckTrail(maxSamples: 0), throwsAssertionError);
+      expect(() => PuckTrail(ttl: Duration.zero), throwsAssertionError);
+    });
+  });
+}

--- a/apps/client/test/widgets/voice_speaking_ring_test.dart
+++ b/apps/client/test/widgets/voice_speaking_ring_test.dart
@@ -133,5 +133,80 @@ void main() {
         expect(state2.isAnimating, isTrue);
       },
     );
+
+    // -----------------------------------------------------------------------
+    // Phase 3a — audio-radius (expanding outer rings).
+    // -----------------------------------------------------------------------
+
+    testWidgets(
+      'audio-radius painter is mounted when audioLevel exceeds threshold',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const VoiceSpeakingRing(
+              audioLevel: 0.3,
+              child: SizedBox(width: 48, height: 48),
+            ),
+          ),
+        );
+        await tester.pump();
+        // CustomPaint is the host of the audio-radius painter; appears
+        // only on the animated path.
+        expect(find.byType(CustomPaint), findsWidgets);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'audio-radius painter is NOT mounted below threshold (silent)',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const VoiceSpeakingRing(
+              key: ValueKey('quiet'),
+              audioLevel: 0.01,
+              child: SizedBox(key: ValueKey('child'), width: 48, height: 48),
+            ),
+          ),
+        );
+        await tester.pump();
+        // The widget short-circuits to `child` directly, so neither the
+        // tight-ring DecoratedBox nor the CustomPaint host should be
+        // rendered as descendants of the SpeakingRing.
+        expect(
+          find.descendant(
+            of: find.byKey(const ValueKey('quiet')),
+            matching: find.byType(CustomPaint),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'audio-radius painter is NOT mounted with reduce-motion enabled',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const VoiceSpeakingRing(
+              key: ValueKey('reduced'),
+              audioLevel: 0.3,
+              child: SizedBox(width: 48, height: 48),
+            ),
+            reduceMotion: true,
+          ),
+        );
+        await tester.pump();
+        // Reduce-motion path renders only the static _RingDecoration,
+        // never the CustomPaint host that drives the expanding rings.
+        expect(
+          find.descendant(
+            of: find.byKey(const ValueKey('reduced')),
+            matching: find.byType(CustomPaint),
+          ),
+          findsNothing,
+        );
+      },
+    );
   });
 }

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -337,6 +337,7 @@ pub(super) async fn handle_send_message(
         &deliver,
         stored.id,
         conv_security.is_encrypted,
+        conv_kind == Some(ConversationKind::Group),
         recipient_device_contents,
     )
     .await;
@@ -848,6 +849,7 @@ pub(super) async fn fanout_message(
     message: &ServerMessage,
     stored_id: Uuid,
     is_encrypted: bool,
+    is_group: bool,
     recipient_device_contents: Option<RecipientDeviceContents>,
 ) {
     let Some(fields) = NewMessageFields::extract(message) else {
@@ -952,7 +954,10 @@ pub(super) async fn fanout_message(
     // `@everyone` does NOT suppress offline push: by design it should
     // notify *every* member, online or not, which is exactly what the
     // unmodified fanout already does.
-    let suppress_offline_push = !is_encrypted && mentions_broadcast(&fields.content, "here");
+    // `@here` is a group-only concept; in a 1:1 DM the literal text "@here"
+    // is just a string and must not silently drop the recipient's push.
+    let suppress_offline_push =
+        is_group && !is_encrypted && mentions_broadcast(&fields.content, "here");
 
     if suppress_offline_push && !offline_user_ids.is_empty() {
         // Audit trail for #451: suppressing pushes is observable abuse

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -939,7 +939,13 @@ pub(super) async fn fanout_message(
         send_delivery_confirmation(state, sender_id, sender_device_id, stored_id, conv_id).await;
     }
 
-    if !offline_user_ids.is_empty() {
+    // #451: `@here` only notifies online members.  When the plaintext body
+    // contains a standalone `@here`, drop the offline list so no APNs push
+    // fires.  Encrypted groups are skipped: the server can't read the
+    // ciphertext, and `@here` won't appear literally inside it.
+    let suppress_offline_push = !is_encrypted && mentions_broadcast(&fields.content, "here");
+
+    if !offline_user_ids.is_empty() && !suppress_offline_push {
         spawn_push_notifications(
             state.pool.clone(),
             offline_user_ids,
@@ -950,6 +956,36 @@ pub(super) async fn fanout_message(
             stored_id,
         );
     }
+}
+
+/// Returns true when `content` contains `@<keyword>` as a standalone token.
+///
+/// Boundaries are start/end of string or any non-word character (anything
+/// other than alphanumeric or underscore).  Case-insensitive so users
+/// typing `@Here` or `@HERE` are still routed correctly.
+pub(super) fn mentions_broadcast(content: &str, keyword: &str) -> bool {
+    let target = format!("@{}", keyword.to_lowercase());
+    let lower = content.to_lowercase();
+    let mut start = 0;
+    while let Some(rel) = lower[start..].find(&target) {
+        let abs = start + rel;
+        let after = abs + target.len();
+        let left_ok = abs == 0
+            || !lower[..abs]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        let right_ok = after == lower.len()
+            || !lower[after..]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if left_ok && right_ok {
+            return true;
+        }
+        start = abs + target.len();
+    }
+    false
 }
 
 /// Deliver any messages that were stored while the user was offline, then mark
@@ -1123,5 +1159,63 @@ async fn deliver_one_batch(
                 .hub
                 .send_to(&msg.sender_id, WsMessage::Text(json.into()));
         }
+    }
+}
+
+#[cfg(test)]
+mod broadcast_tests {
+    use super::mentions_broadcast;
+
+    #[test]
+    fn matches_lone_at_here() {
+        assert!(mentions_broadcast("@here", "here"));
+    }
+
+    #[test]
+    fn matches_at_here_with_surrounding_text() {
+        assert!(mentions_broadcast("hi @here please look", "here"));
+    }
+
+    #[test]
+    fn matches_at_here_with_punctuation() {
+        assert!(mentions_broadcast("@here, please", "here"));
+        assert!(mentions_broadcast("psst.@here!", "here"));
+    }
+
+    #[test]
+    fn rejects_at_hereafter() {
+        assert!(!mentions_broadcast("@hereafter we go", "here"));
+    }
+
+    #[test]
+    fn rejects_email_like_x_at_here() {
+        assert!(!mentions_broadcast("x@here", "here"));
+    }
+
+    #[test]
+    fn rejects_underscore_suffix() {
+        assert!(!mentions_broadcast("@here_lounge", "here"));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert!(mentions_broadcast("Yo @Here folks", "here"));
+        assert!(mentions_broadcast("YO @HERE FOLKS", "here"));
+    }
+
+    #[test]
+    fn matches_everyone_too() {
+        assert!(mentions_broadcast("@everyone get in here", "everyone"));
+        assert!(!mentions_broadcast("@everyones", "everyone"));
+    }
+
+    #[test]
+    fn empty_content_is_false() {
+        assert!(!mentions_broadcast("", "here"));
+    }
+
+    #[test]
+    fn no_match_is_false() {
+        assert!(!mentions_broadcast("normal message", "here"));
     }
 }

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -943,7 +943,28 @@ pub(super) async fn fanout_message(
     // contains a standalone `@here`, drop the offline list so no APNs push
     // fires.  Encrypted groups are skipped: the server can't read the
     // ciphertext, and `@here` won't appear literally inside it.
+    //
+    // Privacy trade-off: this is the only path where the server inspects
+    // message body content outside of storage / sender-routing.  We keep
+    // the read narrow (single substring scan, no logging of body bytes)
+    // and gate it on `!is_encrypted` so encrypted groups are unaffected.
+    //
+    // `@everyone` does NOT suppress offline push: by design it should
+    // notify *every* member, online or not, which is exactly what the
+    // unmodified fanout already does.
     let suppress_offline_push = !is_encrypted && mentions_broadcast(&fields.content, "here");
+
+    if suppress_offline_push && !offline_user_ids.is_empty() {
+        // Audit trail for #451: suppressing pushes is observable abuse
+        // surface (any member can silence offline notifications). Log
+        // counts only — no body or recipient identifiers.
+        tracing::info!(
+            %sender_id,
+            %conv_id,
+            suppressed = offline_user_ids.len(),
+            "at_here_suppressed_offline_push"
+        );
+    }
 
     if !offline_user_ids.is_empty() && !suppress_offline_push {
         spawn_push_notifications(
@@ -964,6 +985,11 @@ pub(super) async fn fanout_message(
 /// other than alphanumeric or underscore).  Case-insensitive so users
 /// typing `@Here` or `@HERE` are still routed correctly.
 pub(super) fn mentions_broadcast(content: &str, keyword: &str) -> bool {
+    // Hot path: most messages don't contain '@' at all.  Bail before any
+    // allocation — `str::contains` for a single ASCII byte is SIMD-fast.
+    if !content.contains('@') {
+        return false;
+    }
     let target = format!("@{}", keyword.to_lowercase());
     let lower = content.to_lowercase();
     let mut start = 0;

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -956,10 +956,18 @@ pub(super) async fn fanout_message(
     // unmodified fanout already does.
     // `@here` is a group-only concept; in a 1:1 DM the literal text "@here"
     // is just a string and must not silently drop the recipient's push.
-    let suppress_offline_push =
-        is_group && !is_encrypted && mentions_broadcast(&fields.content, "here");
+    //
+    // Guarded behind `!offline_user_ids.is_empty()` so the body scan
+    // is skipped entirely when no offline recipients exist (the only
+    // path where suppression matters).  `mentions_broadcast` itself
+    // already short-circuits on content with no '@', but this guard
+    // skips even the call setup on the hot path.
+    let suppress_offline_push = !offline_user_ids.is_empty()
+        && is_group
+        && !is_encrypted
+        && mentions_broadcast(&fields.content, "here");
 
-    if suppress_offline_push && !offline_user_ids.is_empty() {
+    if suppress_offline_push {
         // Audit trail for #451: suppressing pushes is observable abuse
         // surface (any member can silence offline notifications). Log
         // counts only — no body or recipient identifiers.

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -306,6 +306,126 @@ async fn group_message_fanout() {
 }
 
 // ---------------------------------------------------------------------------
+// Broadcast mentions (#451)
+// ---------------------------------------------------------------------------
+
+/// Regression: an `@here` message must still deliver to every online member.
+/// (#451 only suppresses the *push* fanout to offline users; the live WS
+/// fanout remains unchanged.)
+#[tokio::test]
+async fn at_here_delivers_to_all_online_members() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "hralice").await;
+    let (bob_token, bob_id, _bob_name) = common::register_and_login(&client, &base, "hrbob").await;
+    let (charlie_token, charlie_id, _charlie_name) =
+        common::register_and_login(&client, &base, "hrcharlie").await;
+
+    let group_id = common::create_group(&client, &base, &alice_token, "HereGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &bob_id).await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &charlie_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+    let charlie_ticket = common::get_ws_ticket(&client, &base, &charlie_token).await;
+
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+    let mut charlie_ws = connect_ws(&base, &charlie_ticket).await;
+
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_ws).await;
+    drain_pending(&mut charlie_ws).await;
+
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group_id,
+        "content": "@here all hands",
+    });
+    alice_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("alice send failed");
+
+    let alice_event = read_text_skipping_presence(&mut alice_ws).await;
+    let alice_msg: Value = serde_json::from_str(&alice_event).unwrap();
+    assert_eq!(alice_msg["type"], "message_sent");
+
+    let bob_event = read_text_skipping_presence(&mut bob_ws).await;
+    let bob_msg: Value = serde_json::from_str(&bob_event).unwrap();
+    assert_eq!(bob_msg["type"], "new_message");
+    assert_eq!(bob_msg["content"], "@here all hands");
+
+    let charlie_event = read_text_skipping_presence(&mut charlie_ws).await;
+    let charlie_msg: Value = serde_json::from_str(&charlie_event).unwrap();
+    assert_eq!(charlie_msg["type"], "new_message");
+    assert_eq!(charlie_msg["content"], "@here all hands");
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+    let _ = charlie_ws.close(None).await;
+}
+
+/// Regression: an `@everyone` message also delivers to every member.  No
+/// special server handling is required for `@everyone` — the existing
+/// fanout already covers all members — but if someone changes that, this
+/// catches it.
+#[tokio::test]
+async fn at_everyone_delivers_to_all_members() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "evalice").await;
+    let (bob_token, bob_id, _bob_name) = common::register_and_login(&client, &base, "evbob").await;
+    let (charlie_token, charlie_id, _charlie_name) =
+        common::register_and_login(&client, &base, "evcharlie").await;
+
+    let group_id = common::create_group(&client, &base, &alice_token, "EveryoneGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &bob_id).await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &charlie_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+    let charlie_ticket = common::get_ws_ticket(&client, &base, &charlie_token).await;
+
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+    let mut charlie_ws = connect_ws(&base, &charlie_ticket).await;
+
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_ws).await;
+    drain_pending(&mut charlie_ws).await;
+
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group_id,
+        "content": "@everyone announce",
+    });
+    alice_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("alice send failed");
+
+    let alice_event = read_text_skipping_presence(&mut alice_ws).await;
+    let alice_msg: Value = serde_json::from_str(&alice_event).unwrap();
+    assert_eq!(alice_msg["type"], "message_sent");
+
+    for ws in [&mut bob_ws, &mut charlie_ws] {
+        let event = read_text_skipping_presence(ws).await;
+        let parsed: Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "new_message");
+        assert_eq!(parsed["content"], "@everyone announce");
+    }
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+    let _ = charlie_ws.close(None).await;
+}
+
+// ---------------------------------------------------------------------------
 // Error handling
 // ---------------------------------------------------------------------------
 

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -368,6 +368,57 @@ async fn at_here_delivers_to_all_online_members() {
     let _ = charlie_ws.close(None).await;
 }
 
+/// Exercises the `@here` suppression branch end-to-end: alice (sender)
+/// is online, bob (group member) is offline.  Alice sends `@here`.  In
+/// fanout_message this hits the `is_group && !is_encrypted &&
+/// mentions_broadcast` path with a non-empty `offline_user_ids` list —
+/// the suppression branch is real, not short-circuited.  Bob then
+/// reconnects and the offline-replay returns the stored message,
+/// confirming that suppression does NOT break message storage / WS
+/// delivery on reconnect.  (Push delivery itself is not observable in
+/// tests — no APNs mock — so this is a wiring regression test.)
+#[tokio::test]
+async fn at_here_with_offline_member_still_stores_and_replays() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "hroflalice").await;
+    let (bob_token, bob_id, _bob_name) =
+        common::register_and_login(&client, &base, "hroflbob").await;
+
+    let group_id = common::create_group(&client, &base, &alice_token, "OfflineGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &bob_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    drain_pending(&mut alice_ws).await;
+
+    // Bob is intentionally offline at send time.
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group_id,
+        "content": "@here urgent",
+    });
+    alice_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("alice send failed");
+
+    let alice_event = read_text_skipping_presence(&mut alice_ws).await;
+    let alice_msg: Value = serde_json::from_str(&alice_event).unwrap();
+    assert_eq!(alice_msg["type"], "message_sent");
+
+    // Bob reconnects; offline replay returns the stored message.
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+    let bob_msg = common::recv_until_event(&mut bob_ws, &["new_message"]).await;
+    assert_eq!(bob_msg["content"], "@here urgent");
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+}
+
 /// Regression: an `@everyone` message also delivers to every member.  No
 /// special server handling is required for `@everyone` — the existing
 /// fanout already covers all members — but if someone changes that, this

--- a/docs/ios-push-setup.md
+++ b/docs/ios-push-setup.md
@@ -74,6 +74,10 @@ The server loads the config once at startup. If any required variable is missing
 | No push attempt in logs | User has no registered push token | Ensure the iOS app requested notification permission and the token was sent to `/api/push/register` |
 | Push sent but app doesn't wake | iOS killed the app or battery saver | Normal iOS behavior -- silent pushes are best-effort. App will reconnect on next foreground. |
 
+## @here Mention Behavior
+
+When a plaintext group message contains a standalone `@here`, the server skips APNs push to offline members for that message — only currently connected members are notified. This is intentional: `@here` is designed for "attention needed now" pings without waking offline users. `@everyone` is unaffected and continues to trigger push for all members as normal. Encrypted group messages are never inspected for mention keywords, so this logic does not apply to them.
+
 ## Self-Hosting Notes
 
 The APNs key is tied to your Apple Developer account. If you self-host and want iOS push:

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -223,8 +223,25 @@ Phase 1 design against three target sizes from the start.
   scaling still works).
 - Toggle persists across app restart.
 
-**Out of scope:**
+**Shipped (sidebar slice):**
 
+- `UIDensity` enum + `uiDensityProvider` with one-shot migration from
+  `MessageLayout.compact` so existing users see no behavior change.
+- Sidebar (`conversation_item.dart`, `conversation_panel.dart`)
+  reads density via `conversationItemHeightFor()`; three-way size
+  tables for row height (84/68/52), avatar radius (22/20/14),
+  presence dot, group icon, fonts, padding, and gaps.
+- Settings UI: new "Density" radio group in
+  `screens/settings/appearance_section.dart` directly below the
+  existing "Message layout" picker.
+
+**Deferred follow-ups (separate PRs):**
+
+- Message item density (line-height, bubble padding tied to
+  `UIDensity` instead of `MessageLayout.compact`). `MessageLayout`
+  still controls bubble compactness today.
+- Channel bar / group list density.
+- Settings rows density.
 - Per-screen density overrides.
 - Mobile density (phones get a single density determined by viewport).
 

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -1,0 +1,358 @@
+# Echo UX Roadmap
+
+This document is the team's reference for the next several months of
+UX work in the Flutter client. It is the strategic complement to
+`docs/style-sheet.md` (visual style) and supersedes
+`research/ui_ux_audit.md` (older April 2026 audit) for direction.
+
+It exists because Echo is at a transition point. The core UI works.
+The visuals are coherent. But shipped polish alone won't move Echo from
+"polished open-source Discord alternative" to "the communication tool
+people emotionally prefer." Closing that gap is the work below.
+
+---
+
+## Vision
+
+> **Persistent, spatial collaboration that feels alive.**
+
+Voice lounge as the centerpiece. Chat as the surface around it. The
+parts of the product that users feel emotionally are the parts where
+Echo isn't competing with Slack, Discord, and Teams on saturated
+territory.
+
+The app should feel:
+
+- **Spatial** — presence, proximity, ambient awareness, "a place" not
+  "a screen."
+- **Alive** — motion that communicates state, not motion that
+  decorates.
+- **Confident** — interactions that respond instantly; transitions that
+  read as "this UI knows what it's doing."
+- **Effortless** — the eye can parse hierarchy in <100ms; muscle
+  memory rewards investment.
+
+---
+
+## Anti-goals
+
+These are easy traps. None of them belong in this roadmap.
+
+- **More glow / gradients / glassmorphism.** Premium ≠ decoration.
+- **Out-Slacking Slack on density visuals.** Slack wins enterprise
+  clarity by going clean and flat. Echo's strength is atmosphere — we
+  shouldn't trade it away.
+- **"Discord for developers" positioning.** That market is saturated
+  and we lose by occupying it.
+- **Cartoon motion.** No `Curves.bounceOut`, no elastic, no
+  attention-grabbing celebration animations. Spring physics is for
+  drag-release, not state tweens.
+- **More features before fixing hierarchy.** The flat sidebar matters
+  more than any new feature we could ship in the same time.
+
+---
+
+## Phase 0 — Motion language foundation
+
+**Status:** in flight (the PR landing this roadmap doc).
+
+**Goal:** Replace scattered inline `Duration(milliseconds: N)` and
+`Curves.foo` calls with a shared semantic vocabulary so future PRs can
+tune the *feel* of the app without sweeping across dozens of widgets.
+
+**Scope:**
+
+- New `apps/client/lib/src/theme/motion_tokens.dart` exporting:
+  - `MotionDurations` — `instant` / `quick` / `standard` / `expressive`
+    / `gentle` / `pulse`.
+  - `MotionCurves` — `entrance` / `exit` / `emphasis` /
+    `expressiveBounce` / `decelerate`.
+- Refresh the 8 most visible animation sites to use the tokens (voice
+  speaking ring, participant tile, dock submenu, drawing tools,
+  conversation presence dot, connection banner, thread panel scroll,
+  identity-key banner).
+
+**Acceptance:**
+
+- `motion_tokens.dart` is the only place token values are defined.
+- Refreshed sites compile, analyze cleanly, and exhibit no visible
+  motion regression.
+- Future PRs reference `MotionDurations` / `MotionCurves`; reviewers
+  flag new inline `Duration(milliseconds: N)` outside `motion_tokens.dart`.
+
+**Out of scope:**
+
+- Sweeping every duration in the codebase. The remaining ~22 inline
+  durations are picked up incrementally as their owning files are
+  touched.
+- Spring physics. `SpringSimulation` is right for Phase 3 voice-lounge
+  drag-release, not for state tweens.
+
+---
+
+## Phase 1 — Sidebar state hierarchy
+
+**Goal:** Unread / muted / mentioned / active conversations are
+distinguishable in <100ms of glance, not after parsing color and font
+weight.
+
+**Why now:** The flattest part of the UI. Every user spends most of
+their time looking at the sidebar. Discord's sidebar is genuinely fast
+to parse; ours is uniform. Closing that gap is high-visibility,
+low-risk, and unblocks every future onboarding / churn discussion.
+
+**Scope:**
+
+- Stronger unread weight (brighter name, accent timestamp, subtle
+  background tint on the row — not just `FontWeight.w700`).
+- Muted conversations visually de-emphasized (currently they're not).
+  Reduced contrast on text + presence dot; muted icon affordance.
+- Mention badge with count — distinct from unread count. Discord has
+  this; we don't.
+- Active-conversation elevation (subtle background, accent left edge
+  bar, or comparable signal — no glow).
+- Hover state: sharper distinction so the eye tracks position during
+  rapid navigation.
+
+**Files:**
+
+- `apps/client/lib/src/widgets/conversation_item.dart` (724 LOC) —
+  primary surface.
+- Possibly `theme/echo_theme.dart` for new state colors (muted text,
+  active row tint).
+
+**Acceptance:**
+
+- A/B screenshots: same conversation list, before vs after, screenshot
+  parsing speed test (5-second glance: which conversations have
+  unread? Which are muted?).
+- Muted conversations read as "present but quiet" — visible, but not
+  pulling attention.
+- Mention badge visible at default density and at compact density
+  (Phase 2 dependency).
+- Tests in `test/widgets/conversation_item_test.dart` cover each state.
+
+**Out of scope:**
+
+- Full sidebar redesign (server list, channel tree).
+- Nav rework (top bar, search, profile menu).
+- Mobile-specific tweaks.
+
+---
+
+## Phase 2 — Density tier (Cozy / Normal / Compact)
+
+**Goal:** Power users get Discord-compact density. New users get the
+current spacious default. Setting persists.
+
+**Why now:** Density is the #1 user-power request in chat apps. Phase 1
+also depends on a notion of "default density" — codifying it here lets
+Phase 1 design against three target sizes from the start.
+
+**Scope:**
+
+- Promote `MessageLayout` (currently bubbles/compact/plain) into a
+  global `UIDensity` provider (`cozy` / `normal` / `compact`) that
+  scales:
+  - Sidebar item height + avatar radius + padding.
+  - Message item line-height + spacing.
+  - Channel/group list density.
+  - Settings rows.
+- Persist to `SharedPreferences` (already the pattern for
+  `messageLayoutProvider`).
+- Settings UI: appearance section gets a Density radio group alongside
+  the existing Layout one.
+- Density-aware widgets pull from `context.density` (extension on
+  `BuildContext`) — same shape as `context.surface`, `context.accent`.
+
+**Files:**
+
+- `apps/client/lib/src/providers/theme_provider.dart` — extend with
+  `UIDensity`.
+- `apps/client/lib/src/screens/settings/appearance_section.dart` —
+  toggle UI.
+- `apps/client/lib/src/widgets/conversation_item.dart` — already takes
+  `MessageLayout`; promote to `UIDensity`.
+- `apps/client/lib/src/theme/responsive.dart` — add density extension.
+
+**Acceptance:**
+
+- Three target sizes documented in `docs/style-sheet.md` once
+  stabilized.
+- Tested at 1280×800 (compact density should fit ≥40 visible
+  conversations) and 1920×1200 (cozy reads as breathable).
+- A11y: density doesn't break dynamic-type compatibility (system font
+  scaling still works).
+- Toggle persists across app restart.
+
+**Out of scope:**
+
+- Per-screen density overrides.
+- Mobile density (phones get a single density determined by viewport).
+
+---
+
+## Phase 3 — Voice lounge depth
+
+The strategic phase. Each sub-phase ships independently and is gated on
+the prior one feeling right.
+
+### 3a — Ambient motion
+
+**Goal:** The voice lounge feels alive, not static.
+
+**Scope:**
+
+- Speaking-ring polish — smoother pulse curve, subtle audio-radius
+  glow, denser feedback at higher amplitude.
+- Presence trails — when a user moves their puck, a soft motion trail
+  fades behind them.
+- Soft audio-radius visualization — concentric rings that pulse with
+  the speaker's audio level (similar to the existing speaking ring,
+  but at room scale, not per-tile).
+- Nearby-mesh ripple — when someone speaks, the canvas vertex mesh
+  near them subtly distorts (low amplitude, no distraction).
+
+**Acceptance:** Gut check — "feels like a place" rather than "feels
+like a screen." Nothing loud. All motion respects
+`MediaQuery.disableAnimations`.
+
+### 3b — Spatial logic
+
+**Goal:** The room itself has structure, not just floating avatars.
+
+**Scope:**
+
+- Conversation circles — pucks naturally cluster when their owners are
+  in the same channel / topic. Soft "gravity" without snapping.
+- Room anchors — fixed regions of the canvas (shared screen, drawing
+  area, current speaker spotlight). Pucks gravitate toward whatever
+  they're attending to.
+- Sticky regions — drag a puck near a region and it lightly snaps in.
+- Speaker attraction — when someone speaks, nearby pucks subtly orient
+  toward them (gaze-direction visual; not a hard zoom).
+- Hover trails — cursors / pucks leave fading trails so motion is
+  legible at low frame rates.
+
+**Acceptance:** A first-time visitor can identify "who is talking to
+whom" without reading text labels.
+
+### 3c — Layer hierarchy
+
+**Goal:** The room guides attention automatically.
+
+**Scope:**
+
+- Active speaker visually elevated (size, contrast, ring intensity).
+- Shared content (screen share window, drawing canvas) elevated above
+  inactive participants.
+- Inactive users fade back — lower opacity, smaller size, less
+  saturated avatar color.
+- Current collaboration target (the thing being discussed / drawn on)
+  elevated above everything else.
+
+**Acceptance:** Screenshot of a busy room communicates the focal
+points to a stranger in <2 seconds.
+
+---
+
+## Phase 4 — Stress-state hardening
+
+**Goal:** Stop feeling mockup-y. Test the UI under chaos and fix what
+breaks.
+
+**Why last:** The earlier phases assume a polished baseline. This
+phase deliberately stress-tests that baseline.
+
+**Scope:**
+
+- Notification overload — what does the sidebar look like at
+  20 unread / 5 mentions / 3 muted-with-mention?
+- Huge servers — group with 500 members, 50 channels.
+- Thread explosions — 200-reply thread, 50 active participants.
+- Bad network — 5s reconnect storm, lossy WebSocket, half-delivered
+  messages.
+- Weird attachments — 10 GIFs in a row, mixed video / audio /
+  document grid.
+- Multi-monitor — does the app behave when dragged between displays
+  with different DPI?
+- Absurd message density — paste a 10 000-character code block.
+- Empty / first-run states — does a brand-new user with zero contacts
+  see something useful, or a black void?
+
+**Process:** A gallery of "hard cases" lives in `research/stress/` (new
+folder). Each case gets a screenshot + a brief note on what's broken.
+Fixes ship as small PRs against this checklist.
+
+**Acceptance:** Each stress case passes a "wouldn't bounce a real
+user" review.
+
+---
+
+## Cross-cutting concerns
+
+These apply to every phase.
+
+### Reduce motion
+
+Every motion addition must respect `MediaQuery.of(context).disableAnimations`.
+Pattern to reuse: `voice_speaking_ring.dart` checks
+`MediaQuery.of(context).disableAnimations` before starting the pulse.
+
+### Density-aware
+
+Once Phase 2 ships `UIDensity`, every new widget should pull from
+`context.density` instead of hard-coding sizes. Phase 1 widgets
+(designed before Phase 2 lands) should be retro-fitted as part of
+Phase 2.
+
+### Documentation
+
+Every stable convention lands in `docs/style-sheet.md`. Examples:
+
+- New motion token added → motion-tokens section in style sheet.
+- New state convention (mention badge, muted dim) → component spec in
+  style sheet.
+
+The roadmap is direction; the style sheet is the contract.
+
+### Accessibility
+
+Every state distinction must work without color alone. Mention badge
+needs a number, muted needs an icon, active-conversation needs more
+than a tint. Test with a color-blindness simulator at minimum.
+
+---
+
+## Success signals
+
+Subjective:
+
+- Returning users prefer Echo's sidebar to Discord's for parsing
+  speed.
+- Voice lounge users describe it as "a place" rather than "a feature."
+- A11y audit doesn't surface motion-driven regressions.
+
+Objective:
+
+- A new Echo user can identify their unread conversations within 3
+  seconds of opening the app (currently: tested anecdotally to be
+  ~6–8 seconds).
+- Voice lounge time-to-first-meaningful-interaction <5 seconds.
+- Render performance: no jank on dense sidebar at 1000 conversations
+  (Compact density target).
+
+---
+
+## How to use this roadmap
+
+- **Picking up Phase N:** read this section + the relevant `Files`
+  list, then write a per-PR plan against the `Acceptance` criteria.
+- **Proposing a new phase:** open an issue with the same shape (Goal /
+  Why now / Scope / Files / Acceptance / Out of scope).
+- **Disagreeing with the direction:** edit the roadmap, propose the
+  change, get sign-off. The roadmap is editable; only the anti-goals
+  should resist amendment.
+
+The roadmap is not a release plan. There are no dates. Phases ship
+when the prior phase feels right, not when a calendar says so.

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -54,7 +54,7 @@ These are easy traps. None of them belong in this roadmap.
 
 ## Phase 0 — Motion language foundation
 
-**Status:** in flight (the PR landing this roadmap doc).
+**Status:** shipped.
 
 **Goal:** Replace scattered inline `Duration(milliseconds: N)` and
 `Curves.foo` calls with a shared semantic vocabulary so future PRs can
@@ -82,7 +82,7 @@ tune the *feel* of the app without sweeping across dozens of widgets.
 
 **Out of scope:**
 
-- Sweeping every duration in the codebase. The remaining ~22 inline
+- Sweeping every duration in the codebase. The remaining inline
   durations are picked up incrementally as their owning files are
   touched.
 - Spring physics. `SpringSimulation` is right for Phase 3 voice-lounge
@@ -90,7 +90,38 @@ tune the *feel* of the app without sweeping across dozens of widgets.
 
 ---
 
+## Phase 0b — Motion expansion (incremental sweep)
+
+**Status:** shipped (Top 5 of 15 candidates).
+
+After the Phase 0 tokens landed, a follow-up sweep mapped 15 more
+animation candidates ranked by ROI. The top 5 were lifted in:
+
+- `widgets/message/message_status_icon.dart` — status progression
+  (sending → sent → delivered → read) animates via `AnimatedSwitcher`
+  + scale.
+- `widgets/chat_input_bar/send_button.dart` — single animated
+  container interpolates fill + border across mic / send / confirm
+  modes; inner `AnimatedSwitcher` scales the icon between them.
+- `widgets/chat_input_bar.dart` — reply preview bar mount/unmount uses
+  `AnimatedSize(entrance)`.
+- `widgets/message/reaction_bar.dart` — new reaction pills enter with
+  a soft overshoot via `expressiveBounce`.
+- `widgets/conversation_item.dart` — covered as part of Phase 1
+  hover/active background animation.
+
+**Remaining tier 2/3 candidates** (e.g., dock submenu scale, voice
+settings switch flash, date/unread dividers, media picker panel)
+intentionally not in this PR. They are picked up incrementally as
+their owning files are touched.
+
+---
+
 ## Phase 1 — Sidebar state hierarchy
+
+**Status:** shipped. Mention badge ships as a *client-side-only* signal
+(see "Out of scope / follow-ups" below); the rest of the deltas land in
+the same PR as Phase 0b.
 
 **Goal:** Unread / muted / mentioned / active conversations are
 distinguishable in <100ms of glance, not after parsing color and font
@@ -132,8 +163,15 @@ low-risk, and unblocks every future onboarding / churn discussion.
   (Phase 2 dependency).
 - Tests in `test/widgets/conversation_item_test.dart` cover each state.
 
-**Out of scope:**
+**Out of scope / follow-ups:**
 
+- **Server-side mention persistence.** The shipped mention badge is
+  derived client-side: when a `new_message` arrives, the WS handler
+  scans the decrypted plaintext for `@<myUsername>`, `@everyone`, or
+  `@here` and increments `Conversation.mentionCount` (a
+  client-state-only field). `markAsRead` clears it. Multi-device sync
+  of "you have mentions waiting" requires a server column + API
+  change — deferred until needed.
 - Full sidebar redesign (server list, channel tree).
 - Nav rework (top bar, search, profile menu).
 - Mobile-specific tweaks.

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -258,9 +258,9 @@ the prior one feeling right.
 
 ### 3a — Ambient motion
 
-**Status:** sub-slice 1 (speaking-ring polish + per-puck audio
-radius) shipped. Sub-slices 2 (presence trails) and 3 (mesh ripple)
-remain open.
+**Status:** sub-slices 1 (speaking-ring polish + per-puck audio
+radius) and 2 (presence trails) shipped. Sub-slice 3 (mesh ripple)
+remains open and is gated on first introducing a vertex-mesh layer.
 
 **Goal:** The voice lounge feels alive, not static.
 
@@ -272,8 +272,12 @@ remain open.
   `_AudioRadiusPainter`; opacity floor raised so the pulse stays
   visible. Reduce-motion fully gated.
   (`apps/client/lib/src/widgets/voice_speaking_ring.dart`)
-- Presence trails — when a user moves their puck, a soft motion trail
-  fades behind them. **Open.**
+- ~~Presence trails~~ — shipped: each draggable puck leaves a short
+  fading wake of ghost circles on local drag and remote position
+  updates. Pure-Dart `PuckTrail` helper, `Ticker`-driven repaint
+  that pauses when the buffer drains, reduce-motion fully gated.
+  (`apps/client/lib/src/widgets/puck_trail.dart`,
+  `apps/client/lib/src/widgets/voice_canvas.dart`)
 - Nearby-mesh ripple — when someone speaks, the canvas vertex mesh
   near them subtly distorts (low amplitude, no distraction).
   **Open** — depends on first introducing a vertex-mesh layer.

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -258,19 +258,28 @@ the prior one feeling right.
 
 ### 3a — Ambient motion
 
+**Status:** sub-slice 1 (speaking-ring polish + per-puck audio
+radius) shipped. Sub-slices 2 (presence trails) and 3 (mesh ripple)
+remain open.
+
 **Goal:** The voice lounge feels alive, not static.
 
 **Scope:**
 
-- Speaking-ring polish — smoother pulse curve, subtle audio-radius
-  glow, denser feedback at higher amplitude.
+- ~~Speaking-ring polish~~ + ~~per-puck audio-radius rings~~ — shipped:
+  each speaking participant now emits two outward-expanding rings
+  on top of the existing tight ring, painted via a single
+  `_AudioRadiusPainter`; opacity floor raised so the pulse stays
+  visible. Reduce-motion fully gated.
+  (`apps/client/lib/src/widgets/voice_speaking_ring.dart`)
 - Presence trails — when a user moves their puck, a soft motion trail
-  fades behind them.
-- Soft audio-radius visualization — concentric rings that pulse with
-  the speaker's audio level (similar to the existing speaking ring,
-  but at room scale, not per-tile).
+  fades behind them. **Open.**
 - Nearby-mesh ripple — when someone speaks, the canvas vertex mesh
   near them subtly distorts (low amplitude, no distraction).
+  **Open** — depends on first introducing a vertex-mesh layer.
+- Room-scale audio-radius visualization (concentric rings at
+  *room* scale rather than per-puck). **Optional follow-up** if the
+  per-puck version proves insufficient in dense rooms.
 
 **Acceptance:** Gut check — "feels like a place" rather than "feels
 like a screen." Nothing loud. All motion respects

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -180,8 +180,12 @@ low-risk, and unblocks every future onboarding / churn discussion.
 
 ## Phase 2 — Density tier (Cozy / Normal / Compact)
 
-**Goal:** Power users get Discord-compact density. New users get the
-current spacious default. Setting persists.
+**Status:** sidebar slice shipped. Message item / channel bar / settings
+row density follow-ups still open.
+
+**Goal:** Power users get Discord-compact density. New users get
+today's effective default (compact, matching the legacy
+`MessageLayout.compact` behavior). Setting persists.
 
 **Why now:** Density is the #1 user-power request in chat apps. Phase 1
 also depends on a notion of "default density" — codifying it here lets


### PR DESCRIPTION
## Summary

Two GitHub issues delivered together because they touch the same code:

- **Closes #451 (Phase 1)** — `@everyone` and `@here` broadcast mentions in group conversations.
- **Progress on #513** — extract mention picker state out of `ChatInputBar` into a `MentionComposerController` (the rest of `chat_input_bar.dart` extractions remain tracked under #513).

Plus the prior commits already on `dev` since the last merge to `main` (upload helpers + video player extractions, channels provider migration to riverpod codegen, YouTube embed cleanup, etc.).

## What changed

### #451 — `@everyone` / `@here`
- Picker now surfaces two pseudo-rows alongside member suggestions in the group composer (`Icons.campaign_outlined` for `@everyone`, `Icons.bolt_outlined` for `@here`, with subtitles).
- **No new wire format**: server scans the plaintext message body for a standalone `@here` and skips APNs push for offline members in that case. `@everyone` continues to use the default fanout (notifies every member) — that's already its semantics.
- **Encrypted groups are excluded**: server can't read ciphertext, and the literal text never appears in it. Documented in code + `CLAUDE.md`.
- Group-only: an unencrypted DM containing literal `@here` text **does not** suppress push (the suppression is gated on `is_group && !is_encrypted`).
- Audit log: when suppression fires the server emits a `tracing::info!` with sender/conv/count (no body bytes), so the abuse vector ("any member can mute offline notifications") is observable.

### #513 — controller extraction
- New `MentionComposerController` (`ChangeNotifier`) owns picker visibility, the partial query, and the keystroke detection. `ChatInputBarState` becomes a thin wrapper.
- `extractMentionQuery` + `insertMention` pure-Dart helpers moved into `mention_controller.dart` so the controller layer no longer transitively depends on `flutter/material` via the widget file.
- `extractMentionQuery` now accepts any whitespace (tab, newline) as a left boundary, not just literal space.
- Behavior preserved on the user-facing path.

## Files

| Area | Files |
|------|-------|
| New | `apps/client/lib/src/widgets/input/mention_controller.dart` |
| Modified | `apps/client/lib/src/widgets/chat_input_bar.dart`, `apps/client/lib/src/widgets/input/mention_autocomplete.dart`, `apps/server/src/ws/message_service.rs`, `apps/server/tests/ws_messaging.rs` |
| Tests | `mention_autocomplete_test.dart` (17), `mention_controller_test.dart` (9), `mention_autocomplete_widget_test.dart` (8), `broadcast_tests` submodule (10), `ws_messaging.rs` (3) |
| Docs | `README.md`, `CLAUDE.md`, `docs/ios-push-setup.md` |

No DB migration. No API surface change.

## Out of scope (deliberate)

- Role-based mentions (`@admin`, custom roles) — Phase 2 of #451; roles don't exist in the model yet.
- `mentions: [...]` field on the `send_message` wire format — content-scan covers the same plaintext path; defer to encrypted-groups follow-up (#591).
- Other `chat_input_bar.dart` extractions (drafts, edit mode, voice, uploads) — tracked under #513 for a follow-up PR.

## Test plan

- [x] `cd apps/client && flutter analyze --fatal-infos` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cd apps/client && flutter test` (1367 passed)
- [x] `cargo test -p echo-server --tests` (all green; new mention tests pass)
- [ ] Manual smoke: `./scripts/run.sh dev devpass123`, type `@every` / `@here` in a group composer, verify rows appear and tap inserts.
- [ ] Manual smoke: send `@here` to a group with one member offline; confirm online member receives WS event and offline member receives the message via offline replay on reconnect.
- [ ] Run full release pipeline once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)