### PR TITLE
UX phase 2 follow-ups + voice lounge attention + production hotfixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,32 @@ jobs:
           chmod +x appimagetool
           mkdir -p Echo.AppDir/usr/bin Echo.AppDir/usr/share/applications Echo.AppDir/usr/share/icons/hicolor/256x256/apps
           cp -r apps/client/build/linux/x64/release/bundle/* Echo.AppDir/usr/bin/
+          # Bundle libmpv.so.2 (and runtime deps) inside the AppImage so it
+          # actually runs on hosts that don't ship libmpv globally.
+          # `media_kit_libs_video` declares a runtime dependency on libmpv
+          # via the dynamic linker but does NOT copy the .so into the
+          # bundle, which left users hitting "libmpv.so.2: cannot open
+          # shared object file" at launch (reported 2026-05-08).  AppRun
+          # already prepends usr/bin/lib to LD_LIBRARY_PATH so the loader
+          # finds these copies.
+          mkdir -p Echo.AppDir/usr/bin/lib
+          LIBMPV_PATH=$(ldconfig -p | awk '/libmpv\.so\.2 / {print $4; exit}')
+          if [ -z "$LIBMPV_PATH" ] || [ ! -e "$LIBMPV_PATH" ]; then
+            echo "::error::libmpv.so.2 not resolvable on the build host; install libmpv2 or libmpv-dev before this step."
+            exit 1
+          fi
+          cp -L "$LIBMPV_PATH" Echo.AppDir/usr/bin/lib/
+          # libmpv pulls in transitive .so deps that some minimal target
+          # hosts also lack (e.g. libplacebo, libmujs).  Resolve via ldd
+          # and copy any that aren't part of glibc / libstdc++ / ld-linux
+          # (those stay host-side per AppImage convention).
+          ldd "$LIBMPV_PATH" | awk '/=>/ {print $3}' \
+            | grep -vE '/(libc|libm|libdl|libpthread|librt|libstdc\+\+|libgcc_s|ld-linux)\.so' \
+            | while read -r dep; do
+                [ -z "$dep" ] || [ ! -e "$dep" ] && continue
+                cp -Ln "$dep" Echo.AppDir/usr/bin/lib/ 2>/dev/null || true
+              done
+          ls Echo.AppDir/usr/bin/lib/libmpv* > /dev/null  # sanity check
           cat > Echo.AppDir/echo.desktop << 'EOF'
           [Desktop Entry]
           Name=Echo

--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -22,6 +22,19 @@ class CanvasPoint {
 
   @override
   String toString() => 'CanvasPoint($x, $y)';
+
+  // Value equality is load-bearing for the voice lounge: every audio
+  // poll (100ms) rebuilds CanvasState.avatarPositions with fresh
+  // CanvasPoint instances, and downstream widgets `select` on them.
+  // Without ==/hashCode every selector fires every tick, dragging the
+  // whole tree into a 10Hz rebuild storm in CanvasKit / web.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CanvasPoint && x == other.x && y == other.y);
+
+  @override
+  int get hashCode => Object.hash(x, y);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -11,6 +11,7 @@ import '../../providers/livekit_voice_provider.dart';
 import '../../theme/echo_theme.dart';
 import '../../theme/motion_tokens.dart';
 import '../../utils/canvas_utils.dart';
+import '../../widgets/voice/participant_attention.dart';
 import '../../widgets/voice_speaking_ring.dart';
 
 class ParticipantGrid extends StatelessWidget {
@@ -35,16 +36,35 @@ class ParticipantGrid extends StatelessWidget {
     this.authToken,
   });
 
+  /// Phase 3c threshold: matches `_ParticipantInfo.isSpeaking` in
+  /// voice_canvas.dart so attention behaves consistently between
+  /// grid and canvas modes.
+  static const double _attentionThreshold = 0.05;
+
+  bool get _anyoneSpeaking {
+    if (voiceState.localAudioLevel > _attentionThreshold) return true;
+    for (final level in voiceState.peerAudioLevels.values) {
+      if (level > _attentionThreshold) return true;
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
     if (room == null) {
       return _buildPlaceholder(context, 'Connecting to voice...');
     }
 
+    // Phase 3c: precompute room attention once per build so each
+    // tile renders fade/scale relative to whoever is on the air.
+    final anyoneSpeaking = _anyoneSpeaking;
+
     final tiles = <Widget>[
       if (room!.localParticipant != null)
-        _buildLocalTile(room!.localParticipant!),
-      ...room!.remoteParticipants.values.map(_buildRemoteTile),
+        _buildLocalTile(room!.localParticipant!, anyoneSpeaking),
+      ...room!.remoteParticipants.values.map(
+        (p) => _buildRemoteTile(p, anyoneSpeaking),
+      ),
     ];
 
     if (tiles.isEmpty) {
@@ -69,7 +89,10 @@ class ParticipantGrid extends StatelessWidget {
     );
   }
 
-  Widget _buildLocalTile(lk.LocalParticipant localParticipant) {
+  Widget _buildLocalTile(
+    lk.LocalParticipant localParticipant,
+    bool anyoneSpeaking,
+  ) {
     final localVideo = localParticipant.videoTrackPublications
         .where(
           (pub) => pub.track != null && pub.source == lk.TrackSource.camera,
@@ -78,6 +101,12 @@ class ParticipantGrid extends StatelessWidget {
 
     final localHasVideo =
         localVideo?.track != null && voiceState.isVideoEnabled;
+
+    final localIsSpeaking = voiceState.localAudioLevel > _attentionThreshold;
+    final attention = attentionFor(
+      isSpeaking: localIsSpeaking,
+      anyoneElseSpeaking: anyoneSpeaking && !localIsSpeaking,
+    );
 
     return ParticipantTile(
       key: const ValueKey('local'),
@@ -89,12 +118,16 @@ class ParticipantGrid extends StatelessWidget {
       audioLevel: voiceState.localAudioLevel,
       isMuted: !voiceState.isCaptureEnabled,
       isLocal: true,
+      attention: attention,
       onTap: onTileTap != null ? () => onTileTap!('local') : null,
       authToken: authToken,
     );
   }
 
-  Widget _buildRemoteTile(lk.RemoteParticipant participant) {
+  Widget _buildRemoteTile(
+    lk.RemoteParticipant participant,
+    bool anyoneSpeaking,
+  ) {
     final displayName = participantDisplayName(participant);
     final videoTrack = participant.videoTrackPublications
         .where(
@@ -110,6 +143,12 @@ class ParticipantGrid extends StatelessWidget {
         : participant.sid.toString();
     final audioLevel = voiceState.peerAudioLevels[identity] ?? 0.0;
 
+    final remoteIsSpeaking = audioLevel > _attentionThreshold;
+    final attention = attentionFor(
+      isSpeaking: remoteIsSpeaking,
+      anyoneElseSpeaking: anyoneSpeaking && !remoteIsSpeaking,
+    );
+
     return ParticipantTile(
       key: ValueKey('remote-${participant.sid}'),
       name: displayName,
@@ -120,6 +159,7 @@ class ParticipantGrid extends StatelessWidget {
       audioLevel: audioLevel,
       isMuted: participant.isMuted,
       connectionState: voiceState.peerConnectionStates[identity],
+      attention: attention,
       onTap: onTileTap != null
           ? () => onTileTap!('remote-${participant.sid}')
           : null,
@@ -180,6 +220,11 @@ class ParticipantTile extends StatelessWidget {
   final VoidCallback? onMuteForMe;
   final String? authToken;
 
+  /// Phase 3c: room-level attention (speaking / faded / idle).
+  /// Drives the tile's scale + opacity so non-speakers fade back when
+  /// someone else is on the air.
+  final ParticipantAttention attention;
+
   const ParticipantTile({
     super.key,
     required this.name,
@@ -191,6 +236,7 @@ class ParticipantTile extends StatelessWidget {
     this.isMuted = false,
     this.connectionState,
     this.isLocal = false,
+    this.attention = ParticipantAttention.idle,
     this.onTap,
     this.onMuteForMe,
     this.authToken,
@@ -199,60 +245,90 @@ class ParticipantTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isSpeaking = audioLevel > 0.01;
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final double targetScale;
+    final double targetOpacity;
+    if (reduceMotion) {
+      targetScale = 1.0;
+      targetOpacity = 1.0;
+    } else {
+      switch (attention) {
+        case ParticipantAttention.speaking:
+          targetScale = 1.04;
+          targetOpacity = 1.0;
+        case ParticipantAttention.faded:
+          targetScale = 0.96;
+          targetOpacity = 0.62;
+        case ParticipantAttention.idle:
+          targetScale = 1.0;
+          targetOpacity = 1.0;
+      }
+    }
 
-    return GestureDetector(
-      onTap: onTap,
-      onSecondaryTapUp: !isLocal && onMuteForMe != null
-          ? (details) => _showParticipantMenu(context, details.globalPosition)
-          : null,
-      onLongPress: !isLocal && onMuteForMe != null ? onMuteForMe : null,
-      child: AnimatedContainer(
-        duration: MotionDurations.standard,
-        curve: MotionCurves.entrance,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: isSpeaking ? EchoTheme.online : context.border,
-            width: isSpeaking ? 2.0 : 1.0,
-          ),
-          boxShadow: isSpeaking
-              ? [
-                  BoxShadow(
-                    color: EchoTheme.online.withValues(alpha: 0.3),
-                    blurRadius: 8,
-                    spreadRadius: 1,
-                  ),
-                ]
+    return AnimatedOpacity(
+      opacity: targetOpacity,
+      duration: MotionDurations.standard,
+      curve: MotionCurves.entrance,
+      child: AnimatedScale(
+        scale: targetScale,
+        duration: MotionDurations.quick,
+        curve: MotionCurves.emphasis,
+        child: GestureDetector(
+          onTap: onTap,
+          onSecondaryTapUp: !isLocal && onMuteForMe != null
+              ? (details) =>
+                    _showParticipantMenu(context, details.globalPosition)
               : null,
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(15),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-            child: Container(
-              color: context.surface.withValues(alpha: 0.30),
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  // Video or avatar
-                  if (hasVideo && videoTrack != null)
-                    lk.VideoTrackRenderer(
-                      videoTrack!,
-                      fit: lk.VideoViewFit.cover,
-                      mirrorMode: mirror
-                          ? lk.VideoViewMirrorMode.mirror
-                          : lk.VideoViewMirrorMode.off,
-                    )
-                  else
-                    AvatarCircle(
-                      name: name,
-                      avatarUrl: avatarUrl,
-                      audioLevel: audioLevel,
-                      authToken: authToken,
-                    ),
-                  _buildNameLabel(context),
-                ],
+          onLongPress: !isLocal && onMuteForMe != null ? onMuteForMe : null,
+          child: AnimatedContainer(
+            duration: MotionDurations.standard,
+            curve: MotionCurves.entrance,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                color: isSpeaking ? EchoTheme.online : context.border,
+                width: isSpeaking ? 2.0 : 1.0,
+              ),
+              boxShadow: isSpeaking
+                  ? [
+                      BoxShadow(
+                        color: EchoTheme.online.withValues(alpha: 0.3),
+                        blurRadius: 8,
+                        spreadRadius: 1,
+                      ),
+                    ]
+                  : null,
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(15),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                child: Container(
+                  color: context.surface.withValues(alpha: 0.30),
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      // Video or avatar
+                      if (hasVideo && videoTrack != null)
+                        lk.VideoTrackRenderer(
+                          videoTrack!,
+                          fit: lk.VideoViewFit.cover,
+                          mirrorMode: mirror
+                              ? lk.VideoViewMirrorMode.mirror
+                              : lk.VideoViewMirrorMode.off,
+                        )
+                      else
+                        AvatarCircle(
+                          name: name,
+                          avatarUrl: avatarUrl,
+                          audioLevel: audioLevel,
+                          authToken: authToken,
+                        ),
+                      _buildNameLabel(context),
+                    ],
+                  ),
+                ),
               ),
             ),
           ),

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -6,6 +6,7 @@ import '../models/channel.dart';
 import '../providers/auth_provider.dart';
 import '../providers/channels_provider.dart';
 import '../providers/livekit_voice_provider.dart';
+import '../providers/theme_provider.dart' show UIDensity, uiDensityProvider;
 import '../providers/voice_settings_provider.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
@@ -160,6 +161,8 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     final voiceSettings = ref.watch(voiceSettingsProvider);
     final authState = ref.watch(authProvider);
     final myUserId = authState.userId ?? '';
+    // Phase 2 follow-up: density drives chip padding / icon / font.
+    final density = ref.watch(uiDensityProvider);
 
     ref.listen<ChannelsState>(channelsProvider, (previous, next) {
       _syncDerivedState(next, myUserId);
@@ -180,6 +183,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
           channelsState,
           voiceSettings,
           activeVoice,
+          density,
         ),
         if (activeVoice != null && voiceRtc.isActive) _buildVideoGrid(voiceRtc),
         if (activeVoice != null && !widget.hideVoiceDock)
@@ -202,8 +206,33 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     return 'No channels yet';
   }
 
-  Widget _buildTextChannelChip(GroupChannel channel) {
+  /// Phase 2 follow-up: per-density chip metrics.  Same shape as the
+  /// switch tables in conversation_item.dart and message_item.dart.
+  ({EdgeInsets padding, double iconSize, double labelSize, double radius})
+  _chipMetrics(UIDensity density) => switch (density) {
+    UIDensity.cozy => (
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
+      iconSize: 16,
+      labelSize: 14,
+      radius: 22,
+    ),
+    UIDensity.normal => (
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      iconSize: 14,
+      labelSize: 12,
+      radius: 20,
+    ),
+    UIDensity.compact => (
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      iconSize: 12,
+      labelSize: 11,
+      radius: 18,
+    ),
+  };
+
+  Widget _buildTextChannelChip(GroupChannel channel, UIDensity density) {
     final isSelected = widget.selectedTextChannelId == channel.id;
+    final m = _chipMetrics(density);
     return Semantics(
       label: 'text channel: ${channel.name}',
       button: true,
@@ -211,15 +240,15 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          borderRadius: BorderRadius.circular(20),
+          borderRadius: BorderRadius.circular(m.radius),
           onTap: () => widget.onTextChannelChanged(channel.id),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            padding: m.padding,
             decoration: BoxDecoration(
               color: isSelected
                   ? context.accent.withValues(alpha: 0.15)
                   : Colors.transparent,
-              borderRadius: BorderRadius.circular(20),
+              borderRadius: BorderRadius.circular(m.radius),
               border: Border.all(
                 color: isSelected
                     ? context.accent.withValues(alpha: 0.4)
@@ -231,7 +260,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
               children: [
                 Icon(
                   Icons.tag,
-                  size: 14,
+                  size: m.iconSize,
                   color: isSelected ? context.accent : context.textMuted,
                 ),
                 const SizedBox(width: 4),
@@ -239,7 +268,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                   channel.name,
                   style: TextStyle(
                     color: isSelected ? context.accent : context.textSecondary,
-                    fontSize: 12,
+                    fontSize: m.labelSize,
                     fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
                   ),
                 ),
@@ -348,24 +377,26 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     List<VoiceSessionMember> participants,
     VoiceSettingsState voiceSettings,
     String? activeVoiceChannelId,
+    UIDensity density,
   ) {
     final participantCount = participants.length;
     final isActive = _isVoiceChannelActive(channel.id, activeVoiceChannelId);
+    final m = _chipMetrics(density);
     return Semantics(
       label: 'voice channel: ${channel.name}',
       button: true,
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          borderRadius: BorderRadius.circular(20),
+          borderRadius: BorderRadius.circular(m.radius),
           onTap: () => _handleVoiceChipTap(channel, isActive, voiceSettings),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            padding: m.padding,
             decoration: BoxDecoration(
               color: isActive
                   ? context.accent.withValues(alpha: 0.15)
                   : Colors.transparent,
-              borderRadius: BorderRadius.circular(20),
+              borderRadius: BorderRadius.circular(m.radius),
               border: Border.all(
                 color: isActive
                     ? context.accent.withValues(alpha: 0.4)
@@ -381,7 +412,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                 children: [
                   Icon(
                     Icons.volume_up_outlined,
-                    size: 14,
+                    size: m.iconSize,
                     color: isActive ? context.accent : context.textMuted,
                   ),
                   const SizedBox(width: 4),
@@ -389,7 +420,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                     channel.name,
                     style: TextStyle(
                       color: isActive ? context.accent : context.textSecondary,
-                      fontSize: 12,
+                      fontSize: m.labelSize,
                       fontWeight: isActive ? FontWeight.w600 : FontWeight.w400,
                     ),
                   ),
@@ -413,6 +444,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     ChannelsState channelsState,
     VoiceSettingsState voiceSettings,
     String? activeVoiceChannelId,
+    UIDensity density,
   ) {
     return Container(
       width: double.infinity,
@@ -434,7 +466,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
               child: Row(
                 children: [
                   for (final channel in textChannels) ...[
-                    _buildTextChannelChip(channel),
+                    _buildTextChannelChip(channel, density),
                     const SizedBox(width: 6),
                   ],
                   if (textChannels.isNotEmpty && voiceChannels.isNotEmpty)
@@ -448,6 +480,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                       channelsState.voiceSessionsFor(channel.id),
                       voiceSettings,
                       activeVoiceChannelId,
+                      density,
                     ),
                     const SizedBox(width: 6),
                   ],

--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -207,6 +207,7 @@ class ChatMessageList extends ConsumerWidget {
             mediaTicket: mediaTicket,
             senderAvatarUrl: senderAvatarUrl,
             layout: ref.watch(messageLayoutProvider),
+            density: ref.watch(uiDensityProvider),
             hideUndecryptable: ref
                 .watch(accessibilityProvider)
                 .hideUndecryptable,

--- a/apps/client/lib/src/widgets/chat_panel/date_divider.dart
+++ b/apps/client/lib/src/widgets/chat_panel/date_divider.dart
@@ -1,15 +1,21 @@
 // Horizontal divider with a localized day label ("Today" / "Yesterday" / date).
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../providers/theme_provider.dart' show UIDensity, uiDensityProvider;
 import '../../theme/echo_theme.dart';
 
-class DateDivider extends StatelessWidget {
+class DateDivider extends ConsumerWidget {
   final String timestamp;
 
-  const DateDivider({super.key, required this.timestamp});
+  /// Optional density override; defaults to the value from
+  /// [uiDensityProvider]. Tests can pin a specific tier via this param.
+  final UIDensity? density;
+
+  const DateDivider({super.key, required this.timestamp, this.density});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     try {
       final dt = DateTime.parse(timestamp).toLocal();
       final now = DateTime.now();
@@ -24,8 +30,11 @@ class DateDivider extends StatelessWidget {
       } else {
         label = '${_fullMonthName(dt.month)} ${dt.day}, ${dt.year}';
       }
+      final UIDensity effectiveDensity =
+          density ?? ref.watch(uiDensityProvider);
+      final m = _DateDividerMetrics.forDensity(effectiveDensity);
       return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+        padding: EdgeInsets.symmetric(vertical: m.vPad, horizontal: 16),
         child: Row(
           children: [
             Expanded(
@@ -35,10 +44,13 @@ class DateDivider extends StatelessWidget {
               ),
             ),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
+              padding: EdgeInsets.symmetric(horizontal: m.hPad),
               child: Text(
                 label,
-                style: TextStyle(fontSize: 11, color: context.textMuted),
+                style: TextStyle(
+                  fontSize: m.fontSize,
+                  color: context.textMuted,
+                ),
               ),
             ),
             Expanded(
@@ -72,5 +84,32 @@ class DateDivider extends StatelessWidget {
       'December',
     ];
     return names[m.clamp(1, 12)];
+  }
+}
+
+class _DateDividerMetrics {
+  final double vPad;
+  final double hPad;
+  final double fontSize;
+
+  const _DateDividerMetrics({
+    required this.vPad,
+    required this.hPad,
+    required this.fontSize,
+  });
+
+  static const cozy = _DateDividerMetrics(vPad: 8, hPad: 12, fontSize: 12);
+  static const normal = _DateDividerMetrics(vPad: 6, hPad: 10, fontSize: 11);
+  static const compact = _DateDividerMetrics(vPad: 4, hPad: 8, fontSize: 11);
+
+  static _DateDividerMetrics forDensity(UIDensity d) {
+    switch (d) {
+      case UIDensity.cozy:
+        return cozy;
+      case UIDensity.normal:
+        return normal;
+      case UIDensity.compact:
+        return compact;
+    }
   }
 }

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../models/reaction.dart';
+import '../../providers/theme_provider.dart' show UIDensity;
 import '../../theme/echo_theme.dart';
 import '../../theme/motion_tokens.dart';
 
@@ -8,6 +9,9 @@ import '../../theme/motion_tokens.dart';
 /// The chip background matches the parent bubble color (sent or received) with
 /// a halo border in the chat background color to visually separate it from
 /// the bubble edge.
+///
+/// Sizing scales with [density] (cozy / normal / compact) so reactions
+/// match the surrounding message-stream density. Phase 2 follow-up.
 class ReactionBar extends StatelessWidget {
   final List<Reaction> reactions;
   final String? currentUserId;
@@ -21,6 +25,9 @@ class ReactionBar extends StatelessWidget {
 
   final void Function(Offset globalPosition)? onTap;
 
+  /// UI density tier; defaults to compact (today's behavior) when omitted.
+  final UIDensity density;
+
   const ReactionBar({
     super.key,
     required this.reactions,
@@ -28,6 +35,7 @@ class ReactionBar extends StatelessWidget {
     required this.isMine,
     required this.chatBgColor,
     this.onTap,
+    this.density = UIDensity.compact,
   });
 
   @override
@@ -67,11 +75,66 @@ class ReactionBar extends StatelessWidget {
                 isMine: isMine,
                 chatBgColor: chatBgColor,
                 onTap: onTap,
+                density: density,
               ),
           ],
         ),
       ),
     );
+  }
+}
+
+class _ReactionMetrics {
+  final double height;
+  final double hPadding;
+  final double radius;
+  final double emojiSize;
+  final double countSize;
+  final double gap;
+
+  const _ReactionMetrics({
+    required this.height,
+    required this.hPadding,
+    required this.radius,
+    required this.emojiSize,
+    required this.countSize,
+    required this.gap,
+  });
+
+  static const cozy = _ReactionMetrics(
+    height: 26,
+    hPadding: 10,
+    radius: 13,
+    emojiSize: 15,
+    countSize: 13,
+    gap: 4,
+  );
+  static const normal = _ReactionMetrics(
+    height: 24,
+    hPadding: 9,
+    radius: 12,
+    emojiSize: 14,
+    countSize: 12,
+    gap: 3,
+  );
+  static const compact = _ReactionMetrics(
+    height: 22,
+    hPadding: 8,
+    radius: 11,
+    emojiSize: 13,
+    countSize: 11,
+    gap: 3,
+  );
+
+  static _ReactionMetrics forDensity(UIDensity d) {
+    switch (d) {
+      case UIDensity.cozy:
+        return cozy;
+      case UIDensity.normal:
+        return normal;
+      case UIDensity.compact:
+        return compact;
+    }
   }
 }
 
@@ -87,6 +150,7 @@ class _ReactionPill extends StatefulWidget {
   final bool isMine;
   final Color chatBgColor;
   final void Function(Offset globalPosition)? onTap;
+  final UIDensity density;
 
   const _ReactionPill({
     super.key,
@@ -95,6 +159,7 @@ class _ReactionPill extends StatefulWidget {
     required this.isMine,
     required this.chatBgColor,
     this.onTap,
+    required this.density,
   });
 
   @override
@@ -135,17 +200,18 @@ class _ReactionPillState extends State<_ReactionPill>
   Widget build(BuildContext context) {
     final bgColor = widget.isMine ? context.sentBubble : context.recvBubble;
     final textColor = widget.isMine ? Colors.white : context.textPrimary;
+    final m = _ReactionMetrics.forDensity(widget.density);
 
     return GestureDetector(
       onTapUp: (details) => widget.onTap?.call(details.globalPosition),
       child: ScaleTransition(
         scale: _scale,
         child: Container(
-          height: 22,
-          padding: const EdgeInsets.symmetric(horizontal: 8),
+          height: m.height,
+          padding: EdgeInsets.symmetric(horizontal: m.hPadding),
           decoration: BoxDecoration(
             color: bgColor,
-            borderRadius: BorderRadius.circular(11),
+            borderRadius: BorderRadius.circular(m.radius),
             border: Border.all(color: widget.chatBgColor, width: 1.5),
           ),
           child: Row(
@@ -153,16 +219,16 @@ class _ReactionPillState extends State<_ReactionPill>
             children: [
               Text(
                 widget.emoji,
-                style: const TextStyle(
-                  fontSize: 13,
+                style: TextStyle(
+                  fontSize: m.emojiSize,
                   decoration: TextDecoration.none,
                 ),
               ),
-              const SizedBox(width: 3),
+              SizedBox(width: m.gap),
               Text(
                 '${widget.count}',
                 style: TextStyle(
-                  fontSize: 11,
+                  fontSize: m.countSize,
                   fontWeight: FontWeight.w600,
                   color: textColor.withValues(alpha: 0.75),
                   decoration: TextDecoration.none,

--- a/apps/client/lib/src/widgets/message/rich_text_content.dart
+++ b/apps/client/lib/src/widgets/message/rich_text_content.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../providers/theme_provider.dart' show UIDensity;
+
 /// Regex for detecting URLs in message text.
 final urlRegex = RegExp(r'https?://[^\s]+');
 
@@ -53,7 +55,18 @@ class RichTextContent extends StatefulWidget {
   /// When true, uses tighter font size (13) and line height (1.35) to match
   /// Slack/Discord compact density. User font-scale from #632 still applies
   /// via MediaQuery.textScaler above this widget.
+  ///
+  /// Honored only when [density] is null.  Most call sites still use
+  /// this; new call sites that thread [UIDensity] should pass it
+  /// instead and leave [compact] at its default.
   final bool compact;
+
+  /// Optional explicit density tier (Phase 2 follow-up).  When set,
+  /// overrides [compact] and selects body font size / line-height
+  /// from a three-tier table (cozy / normal / compact).  When null,
+  /// the legacy [compact] bool drives sizing for back-compat with
+  /// non-message call sites.
+  final UIDensity? density;
 
   const RichTextContent({
     super.key,
@@ -62,6 +75,7 @@ class RichTextContent extends StatefulWidget {
     required this.accentHoverColor,
     required this.textSecondaryColor,
     this.compact = false,
+    this.density,
   });
 
   @override
@@ -79,13 +93,49 @@ class _RichTextContentState extends State<RichTextContent> {
     super.dispose();
   }
 
+  /// Body fontSize.  Three-tier density table when [widget.density] is
+  /// set; otherwise the legacy [widget.compact] bool applies.
+  double get _bodyFontSize {
+    final d = widget.density;
+    if (d != null) {
+      return switch (d) {
+        UIDensity.cozy => 16,
+        UIDensity.normal => 15,
+        UIDensity.compact => 13,
+      };
+    }
+    return widget.compact ? 13 : 15;
+  }
+
+  /// Body line-height.  Same precedence rule as [_bodyFontSize].
+  double get _bodyLineHeight {
+    final d = widget.density;
+    if (d != null) {
+      return switch (d) {
+        UIDensity.cozy => 1.55,
+        UIDensity.normal => 1.47,
+        UIDensity.compact => 1.35,
+      };
+    }
+    return widget.compact ? 1.35 : 1.47;
+  }
+
+  /// Effective "compact" signal for sub-elements (inline code,
+  /// blockquote indents) that don't yet have density-tier values.
+  /// Cozy reads as not-compact; otherwise mirrors density / legacy
+  /// compact bool.
+  bool get _isCompact {
+    final d = widget.density;
+    if (d != null) return d == UIDensity.compact;
+    return widget.compact;
+  }
+
   /// Base text style used throughout message rendering.
   /// Ligatures are disabled ("calt" 0) so user text reads without code ligatures.
-  /// Compact mode shrinks to 13pt / 1.35 line-height (Slack/Discord density).
   TextStyle _baseStyle() => TextStyle(
-    fontSize: widget.compact ? 13 : 15,
+    fontSize: _bodyFontSize,
     color: widget.textColor,
-    height: widget.compact ? 1.35 : 1.47,
+    height: _bodyLineHeight,
     fontFeatures: const [FontFeature.disable('calt')],
   );
 
@@ -123,10 +173,10 @@ class _RichTextContentState extends State<RichTextContent> {
         TextSpan(
           text: match.group(0),
           style: TextStyle(
-            fontSize: widget.compact ? 13 : 15,
+            fontSize: _bodyFontSize,
             color: widget.accentHoverColor,
             fontWeight: FontWeight.w600,
-            height: widget.compact ? 1.35 : 1.47,
+            height: _bodyLineHeight,
           ),
         ),
       );
@@ -208,11 +258,11 @@ class _RichTextContentState extends State<RichTextContent> {
     ({int start, int end, String tag, RegExpMatch match}) e,
   ) {
     final linkStyle = TextStyle(
-      fontSize: widget.compact ? 13 : 15,
+      fontSize: _bodyFontSize,
       color: widget.accentHoverColor,
       decoration: TextDecoration.underline,
       decorationColor: widget.accentHoverColor,
-      height: widget.compact ? 1.35 : 1.47,
+      height: _bodyLineHeight,
     );
     switch (e.tag) {
       case 'bold':
@@ -302,10 +352,10 @@ class _RichTextContentState extends State<RichTextContent> {
             child: Text(
               code,
               style: TextStyle(
-                fontSize: widget.compact ? 12 : 14,
+                fontSize: _isCompact ? 12 : 14,
                 fontFamily: 'monospace',
                 color: widget.textColor,
-                height: widget.compact ? 1.35 : 1.47,
+                height: _bodyLineHeight,
               ),
             ),
           ),

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1713,13 +1713,20 @@ class _MessageItemState extends State<MessageItem>
     return Positioned(
       top: -28,
       // Anchor only the side closest to the bubble so the overlay sizes to
-      // its child action row (#723). Setting both left & right would force
+      // its child action row (#723).  Setting both left & right would force
       // it to span the entire chat width — sent (right-aligned) bubbles set
       // `right: 0`, but received bubbles previously also set `right: 8`,
       // which is what produced the asymmetric full-width hover bar on
       // left-side messages.
       left: isMine ? null : 36,
       right: isMine ? 0 : null,
+      // Defensive `IntrinsicWidth` wrap: in CanvasKit (web) the action
+      // row's `Container > Row(MainAxisSize.min)` was still expanding to
+      // the full Stack width despite the Positioned only setting one
+      // edge — see the production screenshot reported on 2026-05-08.
+      // IntrinsicWidth forces the child subtree to size to its
+      // own intrinsic content regardless of the parent's loose
+      // constraints, giving us the snug action bar everywhere.
       child: ExcludeSemantics(
         excluding: !_isHovered,
         child: IgnorePointer(
@@ -1732,7 +1739,9 @@ class _MessageItemState extends State<MessageItem>
               offset: _isHovered ? Offset.zero : const Offset(0, -0.12),
               duration: const Duration(milliseconds: 140),
               curve: Curves.easeOut,
-              child: _buildHoverActions(msg, isMine, mediaUrl: mediaUrl),
+              child: IntrinsicWidth(
+                child: _buildHoverActions(msg, isMine, mediaUrl: mediaUrl),
+              ),
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -10,7 +10,7 @@ import 'package:http/http.dart' as http;
 import 'package:photo_manager/photo_manager.dart' show PhotoManager;
 
 import '../models/chat_message.dart';
-import '../providers/theme_provider.dart' show MessageLayout;
+import '../providers/theme_provider.dart' show MessageLayout, UIDensity;
 import '../services/message_cache.dart' show MessageCache;
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
@@ -89,6 +89,13 @@ class MessageItem extends StatefulWidget {
   /// (Discord-style all-left with bubble bg), or `plain` (Slack-style all-left, no bg).
   final MessageLayout layout;
 
+  /// User-selected density tier (Phase 2 follow-up).  Drives body
+  /// fontSize / line-height, name + timestamp fontSize, and inter-
+  /// message vertical padding — orthogonal to [layout], which still
+  /// owns bubble shape, alignment, color, and the inline-vs-stacked
+  /// header decision.
+  final UIDensity density;
+
   /// True for any non-bubbles layout — they share alignment + spacing semantics.
   bool get compactLayout => layout != MessageLayout.bubbles;
 
@@ -134,6 +141,7 @@ class MessageItem extends StatefulWidget {
     this.mediaTicket,
     this.senderAvatarUrl,
     this.layout = MessageLayout.bubbles,
+    this.density = UIDensity.compact,
     this.hideUndecryptable = false,
     this.onImageTap,
   });
@@ -1024,10 +1032,25 @@ class _MessageItemState extends State<MessageItem>
     required ChatMessage msg,
     required bool hasMedia,
   }) {
+    // Phase 2 follow-up: density-aware sender + inline-timestamp
+    // sizing.  Layout (bubble style) still controls *whether* the
+    // timestamp is inline vs separate; density controls the font
+    // sizes on whichever side it lands.
+    final double nameFontSize = switch (widget.density) {
+      UIDensity.cozy => 14,
+      UIDensity.normal => 13,
+      UIDensity.compact => 12,
+    };
+    final double timestampFontSize = switch (widget.density) {
+      UIDensity.cozy => 12,
+      UIDensity.normal => 11,
+      UIDensity.compact => 10,
+    };
+
     final nameText = Text(
       msg.fromUsername,
       style: GoogleFonts.inter(
-        fontSize: 13,
+        fontSize: nameFontSize,
         fontWeight: FontWeight.w600,
         color: _getSenderLabelColor(msg.fromUserId),
       ),
@@ -1050,7 +1073,10 @@ class _MessageItemState extends State<MessageItem>
           const SizedBox(width: 6),
           Text(
             formatMessageTimestamp(msg.timestamp),
-            style: GoogleFonts.inter(fontSize: 11, color: context.textMuted),
+            style: GoogleFonts.inter(
+              fontSize: timestampFontSize,
+              color: context.textMuted,
+            ),
           ),
         ],
       ),
@@ -1211,7 +1237,7 @@ class _MessageItemState extends State<MessageItem>
             textColor: _contentTextColor(isMine: isMine, isFailed: isFailed),
             accentHoverColor: context.accentHover,
             textSecondaryColor: context.textSecondary,
-            compact: widget.compactLayout,
+            density: widget.density,
           ),
         ],
       );
@@ -1230,7 +1256,7 @@ class _MessageItemState extends State<MessageItem>
       textColor: textColor,
       accentHoverColor: context.accentHover,
       textSecondaryColor: context.textSecondary,
-      compact: widget.compactLayout,
+      density: widget.density,
     );
 
     final embeddedImages = extractEmbeddedImageUrls(displayContent);
@@ -1940,13 +1966,23 @@ class _MessageItemState extends State<MessageItem>
     final canSwipeToReply =
         _isMobileTouch && widget.onReply != null && !msg.isSystemEvent;
 
-    // In compact mode, the gap between bubbles from the same sender is
-    // reduced so the conversation reads as a single stream.
+    // Phase 2 follow-up: density-driven gap between bubbles from
+    // the same sender, replacing the old MessageLayout-derived
+    // ternary so layout (bubble style) and density (vertical
+    // spacing) are independent knobs.
     final double topPad;
     if (widget.showHeader) {
-      topPad = widget.compactLayout ? 3 : 8;
+      topPad = switch (widget.density) {
+        UIDensity.cozy => 12,
+        UIDensity.normal => 8,
+        UIDensity.compact => 3,
+      };
     } else {
-      topPad = widget.compactLayout ? 1 : 2;
+      topPad = switch (widget.density) {
+        UIDensity.cozy => 4,
+        UIDensity.normal => 2,
+        UIDensity.compact => 1,
+      };
     }
 
     final messageWidget = Container(

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1710,6 +1710,13 @@ class _MessageItemState extends State<MessageItem>
     required ChatMessage msg,
     required bool isMine,
   }) {
+    // Scale font with density so the hover-timestamp matches the
+    // surrounding message-stream sizing.
+    final hoverFontSize = switch (widget.density) {
+      UIDensity.cozy => 12.0,
+      UIDensity.normal => 11.0,
+      UIDensity.compact => 10.0,
+    };
     return AnimatedOpacity(
       opacity: _isHovered ? 1.0 : 0.0,
       duration: const Duration(milliseconds: 140),
@@ -1719,7 +1726,10 @@ class _MessageItemState extends State<MessageItem>
           msg.editedAt != null
               ? '${formatMessageTimestamp(msg.timestamp)} (edited)'
               : formatMessageTimestamp(msg.timestamp),
-          style: GoogleFonts.inter(fontSize: 11, color: context.textMuted),
+          style: GoogleFonts.inter(
+            fontSize: hoverFontSize,
+            color: context.textMuted,
+          ),
         ),
       ),
     );
@@ -1946,6 +1956,7 @@ class _MessageItemState extends State<MessageItem>
       isMine: isMine,
       chatBgColor: context.chatBg,
       onTap: (pos) => widget.onReactionTap?.call(msg, pos),
+      density: widget.density,
     );
 
     final bubble = _buildBubble(

--- a/apps/client/lib/src/widgets/settings/card_row.dart
+++ b/apps/client/lib/src/widgets/settings/card_row.dart
@@ -1,18 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../providers/theme_provider.dart';
 import '../../theme/echo_theme.dart';
 
 /// A grouped card row used by the redesigned Settings list and other
-/// sectioned card layouts. Renders a leading colored icon badge (~36×36
-/// rounded-12), a primary label, an optional trailing summary value, and a
-/// chevron. Use [destructive] for "Log out" / "Delete" style rows — the
-/// chevron is suppressed and the label/icon use [EchoTheme.danger].
-class CardRow extends StatelessWidget {
+/// sectioned card layouts. Renders a leading colored icon badge, a primary
+/// label, an optional trailing summary value, and a chevron. Use
+/// [destructive] for "Log out" / "Delete" style rows -- the chevron is
+/// suppressed and the label/icon use [EchoTheme.danger].
+///
+/// Sizing scales with the global [UIDensity] (cozy / normal / compact),
+/// matching the density tiers used by the channel bar and message stream.
+class CardRow extends ConsumerWidget {
   /// Leading icon shown inside the colored badge.
   final IconData icon;
 
-  /// Tint applied to the icon and to the [iconBadgeBg] (semi-transparent).
-  /// Use [EchoTheme.danger] for destructive rows.
+  /// Tint applied to the icon and to the icon badge background
+  /// (semi-transparent). Use [EchoTheme.danger] for destructive rows.
   final Color iconColor;
 
   /// Primary row label.
@@ -29,6 +34,10 @@ class CardRow extends StatelessWidget {
   /// Tap handler. When null the row renders disabled (40% opacity).
   final VoidCallback? onTap;
 
+  /// Optional density override; defaults to the value from
+  /// [uiDensityProvider]. Tests can pin a specific tier via this param.
+  final UIDensity? density;
+
   const CardRow({
     super.key,
     required this.icon,
@@ -37,15 +46,54 @@ class CardRow extends StatelessWidget {
     this.trailingValue,
     this.destructive = false,
     this.onTap,
+    this.density,
   });
 
-  static const double _rowHeight = 56;
-  static const double _hPadding = 12;
-  static const double _badgeSize = 36;
-  static const double _badgeRadius = 12;
+  static _CardRowMetrics _metricsFor(UIDensity density) {
+    switch (density) {
+      case UIDensity.cozy:
+        return const _CardRowMetrics(
+          rowHeight: 64,
+          hPadding: 14,
+          badgeSize: 40,
+          badgeRadius: 14,
+          iconSize: 20,
+          gap: 14,
+          labelSize: 16,
+          trailingSize: 14,
+          chevronSize: 18,
+        );
+      case UIDensity.compact:
+        return const _CardRowMetrics(
+          rowHeight: 44,
+          hPadding: 10,
+          badgeSize: 28,
+          badgeRadius: 10,
+          iconSize: 16,
+          gap: 10,
+          labelSize: 13,
+          trailingSize: 12,
+          chevronSize: 14,
+        );
+      case UIDensity.normal:
+        return const _CardRowMetrics(
+          rowHeight: 56,
+          hPadding: 12,
+          badgeSize: 36,
+          badgeRadius: 12,
+          iconSize: 18,
+          gap: 12,
+          labelSize: 15,
+          trailingSize: 13,
+          chevronSize: 16,
+        );
+    }
+  }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final UIDensity effectiveDensity = density ?? ref.watch(uiDensityProvider);
+    final m = _metricsFor(effectiveDensity);
     final effectiveIconColor = destructive ? EchoTheme.danger : iconColor;
     final effectiveLabelColor = destructive
         ? EchoTheme.danger
@@ -53,21 +101,20 @@ class CardRow extends StatelessWidget {
 
     final disabled = onTap == null;
     final content = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: _hPadding),
+      padding: EdgeInsets.symmetric(horizontal: m.hPadding),
       child: Row(
         children: [
-          // Leading colored icon badge.
           Container(
-            width: _badgeSize,
-            height: _badgeSize,
+            width: m.badgeSize,
+            height: m.badgeSize,
             decoration: BoxDecoration(
               color: effectiveIconColor.withValues(alpha: 0.16),
-              borderRadius: BorderRadius.circular(_badgeRadius),
+              borderRadius: BorderRadius.circular(m.badgeRadius),
             ),
             alignment: Alignment.center,
-            child: Icon(icon, size: 18, color: effectiveIconColor),
+            child: Icon(icon, size: m.iconSize, color: effectiveIconColor),
           ),
-          const SizedBox(width: 12),
+          SizedBox(width: m.gap),
           Expanded(
             child: Text(
               label,
@@ -75,7 +122,7 @@ class CardRow extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
                 color: effectiveLabelColor,
-                fontSize: 15,
+                fontSize: m.labelSize,
                 fontWeight: destructive ? FontWeight.w600 : FontWeight.w500,
               ),
             ),
@@ -89,13 +136,20 @@ class CardRow extends StatelessWidget {
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.end,
-                style: TextStyle(color: context.textMuted, fontSize: 13),
+                style: TextStyle(
+                  color: context.textMuted,
+                  fontSize: m.trailingSize,
+                ),
               ),
             ),
           ],
           if (!destructive) ...[
             const SizedBox(width: 4),
-            Icon(Icons.chevron_right, size: 16, color: context.textMuted),
+            Icon(
+              Icons.chevron_right,
+              size: m.chevronSize,
+              color: context.textMuted,
+            ),
           ],
         ],
       ),
@@ -108,7 +162,7 @@ class CardRow extends StatelessWidget {
       child: Opacity(
         opacity: disabled ? 0.4 : 1,
         child: SizedBox(
-          height: _rowHeight,
+          height: m.rowHeight,
           child: Material(
             type: MaterialType.transparency,
             child: InkWell(
@@ -121,4 +175,28 @@ class CardRow extends StatelessWidget {
       ),
     );
   }
+}
+
+class _CardRowMetrics {
+  final double rowHeight;
+  final double hPadding;
+  final double badgeSize;
+  final double badgeRadius;
+  final double iconSize;
+  final double gap;
+  final double labelSize;
+  final double trailingSize;
+  final double chevronSize;
+
+  const _CardRowMetrics({
+    required this.rowHeight,
+    required this.hPadding,
+    required this.badgeSize,
+    required this.badgeRadius,
+    required this.iconSize,
+    required this.gap,
+    required this.labelSize,
+    required this.trailingSize,
+    required this.chevronSize,
+  });
 }

--- a/apps/client/lib/src/widgets/voice/participant_attention.dart
+++ b/apps/client/lib/src/widgets/voice/participant_attention.dart
@@ -1,0 +1,38 @@
+/// Phase 3c of `docs/ux-roadmap.md`: voice-lounge layer hierarchy.
+///
+/// The room guides attention automatically based on who is speaking.
+/// Tiles/pucks render one of three attention states; the parent
+/// computes the cross-participant context (`anyoneElseSpeaking`) and
+/// passes the resulting [ParticipantAttention] down to each leaf.
+library;
+
+/// Attention level of a single voice-lounge participant relative to
+/// the rest of the room.
+enum ParticipantAttention {
+  /// This participant is currently speaking.  Visually elevated.
+  speaking,
+
+  /// Someone else is speaking and this participant is not.
+  /// Visually receded so the speaker stands out.
+  faded,
+
+  /// Nobody is speaking.  Default rest state, full opacity, no
+  /// elevation.
+  idle,
+}
+
+/// Map a participant's speaking state plus the room's broader
+/// "is someone else speaking" signal into a [ParticipantAttention].
+///
+/// The two booleans are deliberately decoupled so the parent can
+/// compute the room-level state once per build and pass the same
+/// `anyoneElseSpeaking` value down to every tile, avoiding O(N²)
+/// recomputation per participant.
+ParticipantAttention attentionFor({
+  required bool isSpeaking,
+  required bool anyoneElseSpeaking,
+}) {
+  if (isSpeaking) return ParticipantAttention.speaking;
+  if (anyoneElseSpeaking) return ParticipantAttention.faded;
+  return ParticipantAttention.idle;
+}

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -13,8 +13,10 @@ import '../providers/auth_provider.dart';
 import '../providers/canvas_provider.dart';
 import '../providers/livekit_voice_provider.dart';
 import '../theme/echo_theme.dart';
+import '../theme/motion_tokens.dart';
 import '../utils/canvas_utils.dart';
 import 'puck_trail.dart';
+import 'voice/participant_attention.dart';
 import 'voice_speaking_ring.dart';
 
 const double _kAvatarSize = 48.0;
@@ -223,6 +225,12 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
       }
     }
 
+    // Phase 3c: room-level attention context computed once and passed
+    // to every puck so non-speakers fade back when someone else is on
+    // the air.  `_ParticipantInfo.isSpeaking` already does the
+    // threshold check at audioLevel > 0.05.
+    final anyoneSpeaking = participants.any((p) => p.isSpeaking);
+
     for (int i = 0; i < participants.length; i++) {
       final participant = participants[i];
       final pos = canvas.avatarPositions[participant.userId];
@@ -245,6 +253,11 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
         size.height > _kAvatarSize ? size.height - _kAvatarSize : 0.0,
       );
 
+      final attention = attentionFor(
+        isSpeaking: participant.isSpeaking,
+        anyoneElseSpeaking: anyoneSpeaking && !participant.isSpeaking,
+      );
+
       widgets.add(
         Positioned(
           left: left,
@@ -254,6 +267,7 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
             participant: participant,
             canvasSize: size,
             currentPos: CanvasPoint(x: normalized.x, y: normalized.y),
+            attention: attention,
             httpHeaders: authState.token != null
                 ? {'Authorization': 'Bearer ${authState.token}'}
                 : null,
@@ -542,6 +556,11 @@ class _DraggableAvatar extends StatefulWidget {
   final bool draggable;
   final VoidCallback? onDoubleTap;
 
+  /// Phase 3c: room-level attention (speaking / faded / idle).  Drives
+  /// the avatar's scale + opacity so non-speakers fade back when
+  /// someone else is on the air.
+  final ParticipantAttention attention;
+
   final Map<String, String>? httpHeaders;
 
   const _DraggableAvatar({
@@ -551,6 +570,7 @@ class _DraggableAvatar extends StatefulWidget {
     required this.currentPos,
     required this.onDrag,
     required this.onDragEnd,
+    this.attention = ParticipantAttention.idle,
     this.draggable = false,
     this.onDoubleTap,
     this.httpHeaders,
@@ -636,7 +656,29 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
     final avatarColor = HSLColor.fromAHSL(1.0, hue, 0.5, 0.35).toColor();
     final initial = info.name.isNotEmpty ? info.name[0].toUpperCase() : '?';
 
-    final scale = info.isSpeaking ? 1.12 : 1.0;
+    // Phase 3c: scale + opacity follow the room-level attention so
+    // non-speakers fade back when someone else has the floor.  Reduce-
+    // motion users get the flat 1.0/1.0 baseline; the speaking ring
+    // alone carries the elevation signal in that mode.
+    final attention = widget.attention;
+    final double targetScale;
+    final double targetOpacity;
+    if (_reduceMotion) {
+      targetScale = 1.0;
+      targetOpacity = 1.0;
+    } else {
+      switch (attention) {
+        case ParticipantAttention.speaking:
+          targetScale = 1.16;
+          targetOpacity = 1.0;
+        case ParticipantAttention.faded:
+          targetScale = 0.92;
+          targetOpacity = 0.62;
+        case ParticipantAttention.idle:
+          targetScale = 1.0;
+          targetOpacity = 1.0;
+      }
+    }
 
     final hasVideo = info.videoTrack != null;
 
@@ -679,25 +721,31 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
             ),
     );
 
-    final avatar = AnimatedScale(
-      scale: scale,
-      duration: const Duration(milliseconds: 150),
-      child: VoiceSpeakingRing(
-        audioLevel: info.audioLevel,
-        child: Container(
-          width: _kAvatarSize,
-          height: _kAvatarSize,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            boxShadow: [
-              BoxShadow(
-                color: context.mainBg.withValues(alpha: 0.35),
-                blurRadius: 8,
-                offset: const Offset(0, 3),
-              ),
-            ],
+    final avatar = AnimatedOpacity(
+      opacity: targetOpacity,
+      duration: MotionDurations.standard,
+      curve: MotionCurves.entrance,
+      child: AnimatedScale(
+        scale: targetScale,
+        duration: MotionDurations.quick,
+        curve: MotionCurves.emphasis,
+        child: VoiceSpeakingRing(
+          audioLevel: info.audioLevel,
+          child: Container(
+            width: _kAvatarSize,
+            height: _kAvatarSize,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: context.mainBg.withValues(alpha: 0.35),
+                  blurRadius: 8,
+                  offset: const Offset(0, 3),
+                ),
+              ],
+            ),
+            child: tile,
           ),
-          child: tile,
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/channels_provider.dart';
 import '../providers/livekit_voice_provider.dart';
 import '../providers/screen_share_provider.dart';
+import '../providers/theme_provider.dart' show UIDensity, uiDensityProvider;
 import '../providers/voice_settings_provider.dart';
 import '../theme/echo_theme.dart';
 
@@ -43,6 +44,8 @@ class VoiceDock extends ConsumerWidget {
     final voiceSettings = ref.watch(voiceSettingsProvider);
     final channelsState = ref.watch(channelsProvider);
     final screenShare = ref.watch(screenShareProvider);
+    final density = ref.watch(uiDensityProvider);
+    final m = _DockMetrics.forDensity(density);
     final conversationId = voiceLk.conversationId ?? '';
     final channelId = voiceLk.channelId!;
 
@@ -57,7 +60,7 @@ class VoiceDock extends ConsumerWidget {
       onTap: onNavigateToLounge,
       child: Container(
         width: width,
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        padding: EdgeInsets.symmetric(horizontal: m.hPad, vertical: m.vPad),
         decoration: BoxDecoration(
           color: context.surface,
           border: Border(
@@ -73,6 +76,7 @@ class VoiceDock extends ConsumerWidget {
               voiceLk.isJoining,
               peerCount,
               channelName,
+              m,
             ),
             ..._buildControlButtons(
               context,
@@ -82,6 +86,7 @@ class VoiceDock extends ConsumerWidget {
               screenShare,
               conversationId,
               channelId,
+              m,
             ),
           ],
         ),
@@ -106,12 +111,13 @@ class VoiceDock extends ConsumerWidget {
     bool isJoining,
     int peerCount,
     String channelName,
+    _DockMetrics m,
   ) {
     return Expanded(
       child: Row(
         children: [
-          Icon(Icons.graphic_eq, size: 14, color: statusColor),
-          const SizedBox(width: 6),
+          Icon(Icons.graphic_eq, size: m.statusIconSize, color: statusColor),
+          SizedBox(width: m.gap),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -121,13 +127,16 @@ class VoiceDock extends ConsumerWidget {
                   _voiceStatusLabel(isJoining, peerCount),
                   style: TextStyle(
                     color: statusColor,
-                    fontSize: 11,
+                    fontSize: m.statusBigFontSize,
                     fontWeight: FontWeight.w700,
                   ),
                 ),
                 Text(
                   '$channelName \u00b7 $peerCount ${peerCount == 1 ? 'peer' : 'peers'}',
-                  style: TextStyle(color: context.textMuted, fontSize: 10),
+                  style: TextStyle(
+                    color: context.textMuted,
+                    fontSize: m.statusSmallFontSize,
+                  ),
                   overflow: TextOverflow.ellipsis,
                 ),
               ],
@@ -148,15 +157,16 @@ class VoiceDock extends ConsumerWidget {
     ScreenShareState screenShare,
     String conversationId,
     String channelId,
+    _DockMetrics m,
   ) {
     return [
-      _buildVideoButton(context, ref, voiceLk),
-      _buildMuteButton(context, ref, voiceSettings),
+      _buildVideoButton(context, ref, voiceLk, m),
+      _buildMuteButton(context, ref, voiceSettings, m),
       _buildMicLevelIndicator(ref, voiceSettings),
-      _buildDeafenButton(context, ref, voiceSettings),
+      _buildDeafenButton(context, ref, voiceSettings, m),
       if (_supportsScreenShare)
-        _buildScreenShareButton(context, ref, screenShare),
-      _buildHangupButton(ref, screenShare, conversationId, channelId),
+        _buildScreenShareButton(context, ref, screenShare, m),
+      _buildHangupButton(ref, screenShare, conversationId, channelId, m),
     ];
   }
 
@@ -164,11 +174,13 @@ class VoiceDock extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     LiveKitVoiceState voiceLk,
+    _DockMetrics m,
   ) {
     return _DockIconButton(
       icon: voiceLk.isVideoEnabled ? Icons.videocam : Icons.videocam_off,
       color: voiceLk.isVideoEnabled ? context.accent : context.textSecondary,
       tooltip: voiceLk.isVideoEnabled ? 'Turn off camera' : 'Turn on camera',
+      iconSize: m.btnIconSize,
       onPressed: () async {
         await ref.read(livekitVoiceProvider.notifier).toggleVideo();
       },
@@ -179,6 +191,7 @@ class VoiceDock extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     VoiceSettingsState voiceSettings,
+    _DockMetrics m,
   ) {
     return _DockIconButton(
       icon: voiceSettings.selfMuted || voiceSettings.selfDeafened
@@ -186,6 +199,7 @@ class VoiceDock extends ConsumerWidget {
           : Icons.mic,
       color: _muteColor(context, voiceSettings),
       tooltip: _muteTooltip(voiceSettings),
+      iconSize: m.btnIconSize,
       onPressed: () async {
         final notifier = ref.read(voiceSettingsProvider.notifier);
         final nextMuted = !voiceSettings.selfMuted;
@@ -222,6 +236,7 @@ class VoiceDock extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     VoiceSettingsState voiceSettings,
+    _DockMetrics m,
   ) {
     return _DockIconButton(
       icon: voiceSettings.selfDeafened ? Icons.headset_off : Icons.headset,
@@ -229,6 +244,7 @@ class VoiceDock extends ConsumerWidget {
           ? EchoTheme.danger
           : context.textSecondary,
       tooltip: voiceSettings.selfDeafened ? 'Undeafen' : 'Deafen',
+      iconSize: m.btnIconSize,
       onPressed: () async {
         final notifier = ref.read(voiceSettingsProvider.notifier);
         final nextDeafened = !voiceSettings.selfDeafened;
@@ -242,6 +258,7 @@ class VoiceDock extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     ScreenShareState screenShare,
+    _DockMetrics m,
   ) {
     return _DockIconButton(
       icon: screenShare.isScreenSharing
@@ -251,6 +268,7 @@ class VoiceDock extends ConsumerWidget {
           ? EchoTheme.online
           : context.textSecondary,
       tooltip: screenShare.isScreenSharing ? 'Stop sharing' : 'Share screen',
+      iconSize: m.btnIconSize,
       onPressed: () async {
         final lkNotifier = ref.read(livekitVoiceProvider.notifier);
         final ssNotifier = ref.read(screenShareProvider.notifier);
@@ -272,11 +290,13 @@ class VoiceDock extends ConsumerWidget {
     ScreenShareState screenShare,
     String conversationId,
     String channelId,
+    _DockMetrics m,
   ) {
     return _DockIconButton(
       icon: Icons.call_end,
       color: EchoTheme.danger,
       tooltip: 'Leave',
+      iconSize: m.btnIconSize,
       onPressed: () async {
         if (screenShare.isScreenSharing) {
           await ref
@@ -312,12 +332,14 @@ class _DockIconButton extends StatelessWidget {
   final Color color;
   final String tooltip;
   final VoidCallback onPressed;
+  final double iconSize;
 
   const _DockIconButton({
     required this.icon,
     required this.color,
     required this.tooltip,
     required this.onPressed,
+    this.iconSize = 16,
   });
 
   @override
@@ -327,12 +349,75 @@ class _DockIconButton extends StatelessWidget {
       child: InkWell(
         onTap: onPressed,
         borderRadius: BorderRadius.circular(8),
+        // 44x44 hit target stays constant across density tiers (WCAG 2.5.5);
+        // only the visual icon scales.
         child: SizedBox(
           width: 44,
           height: 44,
-          child: Center(child: Icon(icon, size: 16, color: color)),
+          child: Center(
+            child: Icon(icon, size: iconSize, color: color),
+          ),
         ),
       ),
     );
+  }
+}
+
+class _DockMetrics {
+  final double hPad;
+  final double vPad;
+  final double statusIconSize;
+  final double gap;
+  final double statusBigFontSize;
+  final double statusSmallFontSize;
+  final double btnIconSize;
+
+  const _DockMetrics({
+    required this.hPad,
+    required this.vPad,
+    required this.statusIconSize,
+    required this.gap,
+    required this.statusBigFontSize,
+    required this.statusSmallFontSize,
+    required this.btnIconSize,
+  });
+
+  static const cozy = _DockMetrics(
+    hPad: 12,
+    vPad: 10,
+    statusIconSize: 16,
+    gap: 8,
+    statusBigFontSize: 12,
+    statusSmallFontSize: 11,
+    btnIconSize: 18,
+  );
+  static const normal = _DockMetrics(
+    hPad: 10,
+    vPad: 8,
+    statusIconSize: 15,
+    gap: 7,
+    statusBigFontSize: 11,
+    statusSmallFontSize: 10,
+    btnIconSize: 17,
+  );
+  static const compact = _DockMetrics(
+    hPad: 8,
+    vPad: 6,
+    statusIconSize: 14,
+    gap: 6,
+    statusBigFontSize: 11,
+    statusSmallFontSize: 10,
+    btnIconSize: 16,
+  );
+
+  static _DockMetrics forDensity(UIDensity d) {
+    switch (d) {
+      case UIDensity.cozy:
+        return cozy;
+      case UIDensity.normal:
+        return normal;
+      case UIDensity.compact:
+        return compact;
+    }
   }
 }

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:echo_app/src/models/channel.dart';
 import 'package:echo_app/src/providers/channels_provider.dart';
 import 'package:echo_app/src/providers/livekit_voice_provider.dart';
+import 'package:echo_app/src/providers/theme_provider.dart';
 import 'package:echo_app/src/providers/voice_settings_provider.dart';
 import 'package:echo_app/src/widgets/channel_bar.dart';
 
@@ -109,6 +110,18 @@ class _FakeVoiceSettingsConfirm extends VoiceSettings {
       const VoiceSettingsState(confirmBeforeJoinVoice: true);
 }
 
+/// Static UIDensity notifier used by Phase 2 density-tier tests
+/// to bypass the production notifier's SharedPreferences load.
+class _StaticUIDensity extends UIDensityNotifier {
+  final UIDensity _density;
+  _StaticUIDensity(this._density);
+
+  @override
+  UIDensity build() => _density;
+}
+
+void _noopChannelChanged(String? _) {}
+
 void main() {
   group('ChannelBar voice join confirmation', () {
     testWidgets('asks for confirmation before joining voice', (tester) async {
@@ -187,6 +200,49 @@ void main() {
       expect(fakeChannels.joinCalls, 1);
       expect(fakeVoiceRtc.joinCalls, 1);
       expect(activeVoice, 'voice-1');
+    });
+
+    // -------------------------------------------------------------
+    // Phase 2 follow-up: channel chip density.
+    // -------------------------------------------------------------
+
+    Future<void> pumpAtDensity(WidgetTester tester, UIDensity density) async {
+      await tester.pumpApp(
+        const ChannelBar(
+          conversationId: 'conv-1',
+          onTextChannelChanged: _noopChannelChanged,
+          onVoiceChannelChanged: _noopChannelChanged,
+        ),
+        overrides: [
+          authOverride(loggedInAuthState),
+          webSocketOverride(),
+          channelsProvider.overrideWith(_FakeChannelsNotifier.new),
+          voiceRtcProvider.overrideWith(_FakeVoiceRtcNotifier.new),
+          voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
+          uiDensityProvider.overrideWith(() => _StaticUIDensity(density)),
+        ],
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('cozy density renders 14pt voice chip label', (tester) async {
+      await pumpAtDensity(tester, UIDensity.cozy);
+      final label = tester.widget<Text>(find.text('lounge'));
+      expect(label.style?.fontSize, 14);
+    });
+
+    testWidgets('normal density renders 12pt voice chip label', (tester) async {
+      await pumpAtDensity(tester, UIDensity.normal);
+      final label = tester.widget<Text>(find.text('lounge'));
+      expect(label.style?.fontSize, 12);
+    });
+
+    testWidgets('compact density renders 11pt voice chip label', (
+      tester,
+    ) async {
+      await pumpAtDensity(tester, UIDensity.compact);
+      final label = tester.widget<Text>(find.text('lounge'));
+      expect(label.style?.fontSize, 11);
     });
 
     testWidgets('tapping active voice channel shows lounge', (tester) async {

--- a/apps/client/test/widgets/chat_panel/date_divider_test.dart
+++ b/apps/client/test/widgets/chat_panel/date_divider_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/providers/theme_provider.dart' show UIDensity;
+import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/widgets/chat_panel/date_divider.dart';
+
+Widget _wrap(Widget child) {
+  return ProviderScope(
+    child: MaterialApp(
+      theme: EchoTheme.darkTheme,
+      darkTheme: EchoTheme.darkTheme,
+      themeMode: ThemeMode.dark,
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+Future<void> _pumpAt(WidgetTester tester, UIDensity density) async {
+  await tester.pumpWidget(
+    _wrap(
+      DateDivider(
+        // Pick a date that always renders the long label ("May 8, 2025"),
+        // so the test isn't sensitive to "Today"/"Yesterday" timing.
+        timestamp: '2025-05-08T10:00:00Z',
+        density: density,
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('DateDivider density', () {
+    testWidgets('cozy renders 12pt label', (tester) async {
+      await _pumpAt(tester, UIDensity.cozy);
+      final label = tester.widget<Text>(find.byType(Text));
+      expect(label.style?.fontSize, 12);
+    });
+
+    testWidgets('normal renders 11pt label', (tester) async {
+      await _pumpAt(tester, UIDensity.normal);
+      final label = tester.widget<Text>(find.byType(Text));
+      expect(label.style?.fontSize, 11);
+    });
+
+    testWidgets('compact renders 11pt label (today\'s)', (tester) async {
+      await _pumpAt(tester, UIDensity.compact);
+      final label = tester.widget<Text>(find.byType(Text));
+      expect(label.style?.fontSize, 11);
+    });
+
+    testWidgets('renders SizedBox.shrink for malformed timestamp', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(const DateDivider(timestamp: 'not-a-date')),
+      );
+      await tester.pump();
+      expect(find.byType(Text), findsNothing);
+    });
+  });
+}

--- a/apps/client/test/widgets/message_item_density_test.dart
+++ b/apps/client/test/widgets/message_item_density_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+import 'package:echo_app/src/models/chat_message.dart';
+import 'package:echo_app/src/providers/theme_provider.dart' show UIDensity;
+import 'package:echo_app/src/widgets/message/rich_text_content.dart';
+import 'package:echo_app/src/widgets/message_item.dart';
+
+import '../helpers/pump_app.dart';
+
+ChatMessage _msg() => const ChatMessage(
+  id: 'msg-1',
+  fromUserId: 'peer',
+  fromUsername: 'alice',
+  conversationId: 'conv-1',
+  content: 'Hello world',
+  timestamp: '2026-05-08T10:30:00Z',
+  isMine: false,
+  status: MessageStatus.sent,
+);
+
+Future<RichTextContent> _pumpAndFindContent(
+  WidgetTester tester,
+  UIDensity density,
+) async {
+  await mockNetworkImagesFor(() async {
+    await tester.pumpApp(
+      MessageItem(
+        message: _msg(),
+        showHeader: true,
+        isLastInGroup: true,
+        myUserId: 'me',
+        density: density,
+      ),
+    );
+    await tester.pump();
+  });
+  // The bubble may host more than one RichTextContent (caption +
+  // body) but the test message has no caption, so just one is
+  // present.
+  return tester.widget<RichTextContent>(find.byType(RichTextContent));
+}
+
+void main() {
+  group('MessageItem density', () {
+    testWidgets('cozy passes UIDensity.cozy down to RichTextContent', (
+      tester,
+    ) async {
+      final content = await _pumpAndFindContent(tester, UIDensity.cozy);
+      expect(content.density, UIDensity.cozy);
+    });
+
+    testWidgets('normal passes UIDensity.normal down to RichTextContent', (
+      tester,
+    ) async {
+      final content = await _pumpAndFindContent(tester, UIDensity.normal);
+      expect(content.density, UIDensity.normal);
+    });
+
+    testWidgets('compact passes UIDensity.compact down to RichTextContent', (
+      tester,
+    ) async {
+      final content = await _pumpAndFindContent(tester, UIDensity.compact);
+      expect(content.density, UIDensity.compact);
+    });
+  });
+}

--- a/apps/client/test/widgets/reaction_bar_density_test.dart
+++ b/apps/client/test/widgets/reaction_bar_density_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/reaction.dart';
+import 'package:echo_app/src/providers/theme_provider.dart' show UIDensity;
+import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/widgets/message/reaction_bar.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: EchoTheme.darkTheme,
+    darkTheme: EchoTheme.darkTheme,
+    themeMode: ThemeMode.dark,
+    home: Scaffold(body: child),
+  );
+}
+
+const _reactions = [
+  Reaction(messageId: 'm1', userId: 'u1', username: 'alice', emoji: '🎉'),
+];
+
+Future<void> _pumpAt(WidgetTester tester, UIDensity density) async {
+  await tester.pumpWidget(
+    _wrap(
+      ReactionBar(
+        reactions: _reactions,
+        currentUserId: 'me',
+        isMine: false,
+        chatBgColor: Colors.black,
+        density: density,
+      ),
+    ),
+  );
+  // Settle the entry animation so the pill renders at full size.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}
+
+void main() {
+  group('ReactionBar density', () {
+    testWidgets('cozy renders 15pt emoji and 13pt count', (tester) async {
+      await _pumpAt(tester, UIDensity.cozy);
+      final emoji = tester.widget<Text>(find.text('🎉'));
+      final count = tester.widget<Text>(find.text('1'));
+      expect(emoji.style?.fontSize, 15);
+      expect(count.style?.fontSize, 13);
+    });
+
+    testWidgets('normal renders 14pt emoji and 12pt count', (tester) async {
+      await _pumpAt(tester, UIDensity.normal);
+      final emoji = tester.widget<Text>(find.text('🎉'));
+      final count = tester.widget<Text>(find.text('1'));
+      expect(emoji.style?.fontSize, 14);
+      expect(count.style?.fontSize, 12);
+    });
+
+    testWidgets('compact renders 13pt emoji and 11pt count (today\'s)', (
+      tester,
+    ) async {
+      await _pumpAt(tester, UIDensity.compact);
+      final emoji = tester.widget<Text>(find.text('🎉'));
+      final count = tester.widget<Text>(find.text('1'));
+      expect(emoji.style?.fontSize, 13);
+      expect(count.style?.fontSize, 11);
+    });
+
+    testWidgets('default density (no param) is compact for back-compat', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const ReactionBar(
+            reactions: _reactions,
+            currentUserId: 'me',
+            isMine: false,
+            chatBgColor: Colors.black,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      final emoji = tester.widget<Text>(find.text('🎉'));
+      expect(emoji.style?.fontSize, 13);
+    });
+  });
+}

--- a/apps/client/test/widgets/settings/card_row_test.dart
+++ b/apps/client/test/widgets/settings/card_row_test.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:echo_app/src/providers/theme_provider.dart' show UIDensity;
 import 'package:echo_app/src/theme/echo_theme.dart';
 import 'package:echo_app/src/widgets/settings/card_row.dart';
 
 Widget _wrap(Widget child) {
-  return MaterialApp(
-    theme: EchoTheme.darkTheme,
-    darkTheme: EchoTheme.darkTheme,
-    themeMode: ThemeMode.dark,
-    home: Scaffold(body: child),
+  return ProviderScope(
+    child: MaterialApp(
+      theme: EchoTheme.darkTheme,
+      darkTheme: EchoTheme.darkTheme,
+      themeMode: ThemeMode.dark,
+      home: Scaffold(body: child),
+    ),
   );
 }
 
@@ -96,6 +100,72 @@ void main() {
       // Still rendered, just dimmed.
       expect(find.text('About'), findsOneWidget);
       expect(find.byType(Opacity), findsWidgets);
+    });
+  });
+
+  // -------------------------------------------------------------
+  // Phase 2 follow-up: settings row density tiers.
+  // -------------------------------------------------------------
+
+  group('CardRow density', () {
+    Future<void> pumpAt(WidgetTester tester, UIDensity density) async {
+      await tester.pumpWidget(
+        _wrap(
+          CardRow(
+            icon: Icons.palette_outlined,
+            iconColor: const Color(0xFF8458E9),
+            label: 'Appearance',
+            trailingValue: 'Dark',
+            onTap: () {},
+            density: density,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('cozy renders 16pt label and 64px row', (tester) async {
+      await pumpAt(tester, UIDensity.cozy);
+      final label = tester.widget<Text>(find.text('Appearance'));
+      expect(label.style?.fontSize, 16);
+      final row = tester.widget<SizedBox>(
+        find
+            .ancestor(
+              of: find.byType(Material),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(row.height, 64);
+    });
+
+    testWidgets('normal renders 15pt label and 56px row', (tester) async {
+      await pumpAt(tester, UIDensity.normal);
+      final label = tester.widget<Text>(find.text('Appearance'));
+      expect(label.style?.fontSize, 15);
+      final row = tester.widget<SizedBox>(
+        find
+            .ancestor(
+              of: find.byType(Material),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(row.height, 56);
+    });
+
+    testWidgets('compact renders 13pt label and 44px row', (tester) async {
+      await pumpAt(tester, UIDensity.compact);
+      final label = tester.widget<Text>(find.text('Appearance'));
+      expect(label.style?.fontSize, 13);
+      final row = tester.widget<SizedBox>(
+        find
+            .ancestor(
+              of: find.byType(Material),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(row.height, 44);
     });
   });
 }

--- a/apps/client/test/widgets/voice/participant_attention_test.dart
+++ b/apps/client/test/widgets/voice/participant_attention_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/voice/participant_attention.dart';
+
+void main() {
+  group('attentionFor', () {
+    test('isSpeaking → speaking, regardless of room state', () {
+      expect(
+        attentionFor(isSpeaking: true, anyoneElseSpeaking: false),
+        ParticipantAttention.speaking,
+      );
+      expect(
+        attentionFor(isSpeaking: true, anyoneElseSpeaking: true),
+        ParticipantAttention.speaking,
+      );
+    });
+
+    test('not speaking but room has another speaker → faded', () {
+      expect(
+        attentionFor(isSpeaking: false, anyoneElseSpeaking: true),
+        ParticipantAttention.faded,
+      );
+    });
+
+    test('quiet room → idle', () {
+      expect(
+        attentionFor(isSpeaking: false, anyoneElseSpeaking: false),
+        ParticipantAttention.idle,
+      );
+    });
+  });
+}

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -180,9 +180,9 @@ low-risk, and unblocks every future onboarding / churn discussion.
 
 ## Phase 2 — Density tier (Cozy / Normal / Compact)
 
-**Status:** sidebar, message item, channel bar, and settings rows
-slices shipped. Voice dock / reactions / hover-actions density
-follow-ups still open.
+**Status:** sidebar, message item, channel bar, settings rows, and
+reactions / hover-timestamp slices shipped. Voice dock and remaining
+inline density follow-ups still open.
 
 **Goal:** Power users get Discord-compact density. New users get
 today's effective default (compact, matching the legacy
@@ -268,10 +268,22 @@ Phase 1 design against three target sizes from the start.
   record.  Cozy 64/14/40/16/14/18, Normal 56/12/36/15/13/16
   (today's), Compact 44/10/28/13/12/14.  Tests pin each tier.
 
+**Shipped (reactions slice):**
+
+- Reaction-pill density: `ReactionBar` takes a `density` param and
+  scales pill height / horizontal padding / corner radius / emoji
+  font / count font / inner gap via `_ReactionMetrics`.  Cozy
+  26/10/13/15/13/4, Normal 24/9/12/14/12/3, Compact 22/8/11/13/11/3
+  (today's).  `MessageItem` threads `widget.density` into the bar.
+- Hover-timestamp density: the on-hover edited-timestamp under each
+  message scales 12 / 11 / 10 with cozy / normal / compact, matching
+  the surrounding font ramp.
+- Hover-action chip dimensions intentionally unchanged: the 44×44
+  hit target is a WCAG 2.5.5 minimum and stays stable across tiers.
+
 **Deferred follow-ups (separate PRs):**
 
 - Bubble inner padding scaling.
-- Reaction-pill / hover-action / hover-timestamp density.
 - Date-divider density between message groups.
 - Inter-chip spacing scaling on the channel bar.
 - Voice control dock density.

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -249,12 +249,22 @@ Phase 1 design against three target sizes from the start.
   inline sender + timestamp font sizes now also key off density.
   Bubble inner padding intentionally unchanged for now.
 
+**Shipped (channel bar slice):**
+
+- Channel chip density: `ChannelBar` reads `uiDensityProvider` and
+  threads the density through `_buildTextChannelChip` /
+  `_buildVoiceChannelChip`, with one `_chipMetrics` helper packing
+  padding / icon size / label size / border radius into a single
+  record.  Cozy 14×9/16/14/22, Normal 10×6/14/12/20 (today's),
+  Compact 8×4/12/11/18.
+
 **Deferred follow-ups (separate PRs):**
 
 - Bubble inner padding scaling.
 - Reaction-pill / hover-action / hover-timestamp density.
 - Date-divider density between message groups.
-- Channel bar / group list density.
+- Inter-chip spacing scaling on the channel bar.
+- Voice control dock density.
 - Settings rows density.
 - Per-screen density overrides.
 - Mobile density (phones get a single density determined by viewport).

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -239,11 +239,21 @@ Phase 1 design against three target sizes from the start.
   `screens/settings/appearance_section.dart` directly below the
   existing "Message layout" picker.
 
+**Shipped (message-item slice):**
+
+- Message body density: `RichTextContent` gained an optional
+  `density: UIDensity?` param that drives a three-tier fontSize +
+  lineHeight table (16/1.55, 15/1.47, 13/1.35).  `MessageItem`
+  threads density through, replacing the `compact: widget.compactLayout`
+  proxy.  Inter-message `topPad` (header + follow-up) and
+  inline sender + timestamp font sizes now also key off density.
+  Bubble inner padding intentionally unchanged for now.
+
 **Deferred follow-ups (separate PRs):**
 
-- Message item density (line-height, bubble padding tied to
-  `UIDensity` instead of `MessageLayout.compact`). `MessageLayout`
-  still controls bubble compactness today.
+- Bubble inner padding scaling.
+- Reaction-pill / hover-action / hover-timestamp density.
+- Date-divider density between message groups.
 - Channel bar / group list density.
 - Settings rows density.
 - Per-screen density overrides.

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -180,8 +180,9 @@ low-risk, and unblocks every future onboarding / churn discussion.
 
 ## Phase 2 — Density tier (Cozy / Normal / Compact)
 
-**Status:** sidebar slice shipped. Message item / channel bar / settings
-row density follow-ups still open.
+**Status:** sidebar, message item, channel bar, and settings rows
+slices shipped. Voice dock / reactions / hover-actions density
+follow-ups still open.
 
 **Goal:** Power users get Discord-compact density. New users get
 today's effective default (compact, matching the legacy
@@ -258,6 +259,15 @@ Phase 1 design against three target sizes from the start.
   record.  Cozy 14×9/16/14/22, Normal 10×6/14/12/20 (today's),
   Compact 8×4/12/11/18.
 
+**Shipped (settings rows slice):**
+
+- Settings row density: `CardRow` (settings list, log-out button,
+  about row) became a `ConsumerWidget` that reads `uiDensityProvider`
+  and packs row-height / horizontal padding / icon-badge size /
+  label & trailing font size / chevron size into a `_CardRowMetrics`
+  record.  Cozy 64/14/40/16/14/18, Normal 56/12/36/15/13/16
+  (today's), Compact 44/10/28/13/12/14.  Tests pin each tier.
+
 **Deferred follow-ups (separate PRs):**
 
 - Bubble inner padding scaling.
@@ -265,7 +275,6 @@ Phase 1 design against three target sizes from the start.
 - Date-divider density between message groups.
 - Inter-chip spacing scaling on the channel bar.
 - Voice control dock density.
-- Settings rows density.
 - Per-screen density overrides.
 - Mobile density (phones get a single density determined by viewport).
 

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -180,9 +180,9 @@ low-risk, and unblocks every future onboarding / churn discussion.
 
 ## Phase 2 — Density tier (Cozy / Normal / Compact)
 
-**Status:** sidebar, message item, channel bar, settings rows, and
-reactions / hover-timestamp slices shipped. Voice dock and remaining
-inline density follow-ups still open.
+**Status:** sidebar, message item, channel bar, settings rows,
+reactions / hover-timestamp, and date-divider slices shipped.
+Voice dock and remaining inline density follow-ups still open.
 
 **Goal:** Power users get Discord-compact density. New users get
 today's effective default (compact, matching the legacy
@@ -281,10 +281,17 @@ Phase 1 design against three target sizes from the start.
 - Hover-action chip dimensions intentionally unchanged: the 44×44
   hit target is a WCAG 2.5.5 minimum and stays stable across tiers.
 
+**Shipped (date-divider slice):**
+
+- `DateDivider` became a `ConsumerWidget` that reads
+  `uiDensityProvider` and scales vertical padding / horizontal label
+  padding / font size via `_DateDividerMetrics`.  Cozy 8/12/12,
+  Normal 6/10/11, Compact 4/8/11 (today's).  The 1-pixel rule colors
+  stay constant across tiers so the divider weight reads identically.
+
 **Deferred follow-ups (separate PRs):**
 
 - Bubble inner padding scaling.
-- Date-divider density between message groups.
 - Inter-chip spacing scaling on the channel bar.
 - Voice control dock density.
 - Per-screen density overrides.

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -181,8 +181,9 @@ low-risk, and unblocks every future onboarding / churn discussion.
 ## Phase 2 — Density tier (Cozy / Normal / Compact)
 
 **Status:** sidebar, message item, channel bar, settings rows,
-reactions / hover-timestamp, and date-divider slices shipped.
-Voice dock and remaining inline density follow-ups still open.
+reactions / hover-timestamp, date-divider, and voice-dock slices
+shipped. Bubble inner padding and inter-chip spacing remain as
+deferred Phase 2 follow-ups.
 
 **Goal:** Power users get Discord-compact density. New users get
 today's effective default (compact, matching the legacy
@@ -289,11 +290,20 @@ Phase 1 design against three target sizes from the start.
   Normal 6/10/11, Compact 4/8/11 (today's).  The 1-pixel rule colors
   stay constant across tiers so the divider weight reads identically.
 
+**Shipped (voice-dock slice):**
+
+- `VoiceDock` reads `uiDensityProvider` and scales horizontal /
+  vertical chrome padding, the leading `graphic_eq` icon size,
+  the icon→text gap, the two status font sizes, and the control
+  button icon size via `_DockMetrics`.  Cozy 12/10/16/8/12/11/18,
+  Normal 10/8/15/7/11/10/17, Compact 8/6/14/6/11/10/16 (today's).
+  `_DockIconButton` keeps its 44×44 hit target across tiers per
+  WCAG 2.5.5 — only the visual icon scales.
+
 **Deferred follow-ups (separate PRs):**
 
 - Bubble inner padding scaling.
 - Inter-chip spacing scaling on the channel bar.
-- Voice control dock density.
 - Per-screen density overrides.
 - Mobile density (phones get a single density determined by viewport).
 

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -311,17 +311,28 @@ whom" without reading text labels.
 
 ### 3c — Layer hierarchy
 
+**Status:** speaker-driven attention shipped. Drawing-mode-driven
+attention and saturation desaturation remain open as follow-ups.
+
 **Goal:** The room guides attention automatically.
 
 **Scope:**
 
-- Active speaker visually elevated (size, contrast, ring intensity).
-- Shared content (screen share window, drawing canvas) elevated above
-  inactive participants.
-- Inactive users fade back — lower opacity, smaller size, less
-  saturated avatar color.
-- Current collaboration target (the thing being discussed / drawn on)
-  elevated above everything else.
+- ~~Active speaker visually elevated~~ — shipped: scale boost +
+  retained ring/audio-radius signal carries elevation.
+- ~~Inactive users fade back — lower opacity, smaller size~~ —
+  shipped: per-build `anyoneSpeaking` drives a `ParticipantAttention`
+  enum (`speaking` / `faded` / `idle`) consumed by both grid tiles
+  and canvas pucks via `AnimatedOpacity` + `AnimatedScale`.  Reduce-
+  motion fully gated.  ~~less saturated avatar color~~ deferred —
+  opacity reduction reads enough; promote later if user feedback
+  asks for it.
+- Shared content elevated — emergent: when participants fade, the
+  screen-share window / drawing canvas naturally stand out without
+  per-element work.  Direct elevation work deferred until needed.
+- Current collaboration target (drawing-mode-driven attention) —
+  **deferred** to a follow-up; speaker-driven covers most rooms
+  today.
 
 **Acceptance:** Screenshot of a busy room communicates the focal
 points to a stranger in <2 seconds.

--- a/scripts/seed_stress_data.sh
+++ b/scripts/seed_stress_data.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# seed_stress_data.sh — generate a "Big Data Test Group" with realistic
+# stress-test data so the UI can be audited under load.
+#
+# What gets created
+#   - Group: "Big Data Test Group" (public, plaintext)
+#   - Owner: admin_tester  (auto-created if missing)
+#   - Members: alice, bob, cara, dan, eve  (auto-created if missing)
+#   - Messages (defaults; tunable via env vars):
+#       1000  plain messages, rotating senders                  (MESSAGES)
+#        100  replies to one parent message (deep thread)       (REPLIES)
+#         10  ~8 KB long-text messages                          (BIG_TEXT)
+#         20  emoji-heavy messages (jumbo-emoji rendering)      (EMOJI)
+#         15  markdown stress (code blocks, lists, blockquotes) (MARKDOWN)
+#         10  reaction-heavy messages (5+ unique emoji each)    (REACTIONS)
+#         30  rapid-fire same-second timestamps                 (RAPIDFIRE)
+#
+# Usage
+#   ./scripts/seed_stress_data.sh                          # localhost
+#   SERVER_URL=https://staging.example ./scripts/seed_stress_data.sh
+#   MESSAGES=2000 REPLIES=200 ./scripts/seed_stress_data.sh
+#   RESET=1 ./scripts/seed_stress_data.sh                  # wipe & re-seed
+#
+# Performance
+#   1000+ messages over a single persistent WebSocket per sender; expect
+#   under 90 s on localhost.  The previous seed script's per-message WS
+#   open/close added ~1.2 s of TLS+upgrade per frame; this avoids that.
+#
+# Dependencies: curl, jq, websocat (cargo install websocat).
+
+set -euo pipefail
+
+SERVER_URL="${SERVER_URL:-http://localhost:8080}"
+WS_BASE="${SERVER_URL/http/ws}"
+PASSWORD="${PASSWORD:-stresspass123}"
+
+MESSAGES="${MESSAGES:-1000}"
+REPLIES="${REPLIES:-100}"
+BIG_TEXT="${BIG_TEXT:-10}"
+EMOJI="${EMOJI:-20}"
+MARKDOWN="${MARKDOWN:-15}"
+REACTIONS="${REACTIONS:-10}"
+RAPIDFIRE="${RAPIDFIRE:-30}"
+RESET="${RESET:-0}"
+
+GROUP_NAME="Big Data Test Group"
+OWNER="admin_tester"
+OWNER_PW="admin123"
+# Stress users use a `stress_` prefix so they don't collide with any
+# pre-existing demo accounts (which may already have been registered
+# with a different password by run.sh / seed_full_demo.sh).
+MEMBERS=(stress_alice stress_bob stress_cara stress_dan stress_eve)
+ALL_USERS=("$OWNER" "${MEMBERS[@]}")
+
+# ----- Dependency checks ----------------------------------------------------
+for cmd in curl jq websocat; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ERROR: '$cmd' is required but not on PATH" >&2
+    [ "$cmd" = "websocat" ] && \
+      echo "       install: cargo install websocat" >&2
+    exit 1
+  fi
+done
+
+# ----- Server reachability --------------------------------------------------
+log() { printf '%s\n' "$*"; }
+if ! curl -sf -m 5 "$SERVER_URL/api/health" >/dev/null 2>&1; then
+  echo "ERROR: server not reachable at $SERVER_URL/api/health" >&2
+  exit 1
+fi
+log "==> Big Data Test Group seeder"
+log "    server : $SERVER_URL"
+log "    volume : $MESSAGES plain + $REPLIES replies + $BIG_TEXT big + $EMOJI emoji + $MARKDOWN md + $REACTIONS rxn + $RAPIDFIRE rapid"
+
+api() {
+  local method="$1" path="$2" token="${3:-}" body="${4:-}"
+  local args=(-sS -X "$method" "$SERVER_URL$path" -H 'Content-Type: application/json')
+  [ -n "$token" ] && args+=(-H "Authorization: Bearer $token")
+  [ -n "$body" ]  && args+=(-d "$body")
+  curl "${args[@]}"
+}
+
+# Like api() but emits the literal "429" string when the server rate-limits.
+# Lets callers wait + retry without having to parse HTTP status codes.
+api_with_retry() {
+  local method="$1" path="$2" token="${3:-}" body="${4:-}"
+  local args=(-sS -w '\n__STATUS:%{http_code}' -X "$method" "$SERVER_URL$path" \
+    -H 'Content-Type: application/json')
+  [ -n "$token" ] && args+=(-H "Authorization: Bearer $token")
+  [ -n "$body" ]  && args+=(-d "$body")
+  local raw status resp
+  raw=$(curl "${args[@]}")
+  status="${raw##*__STATUS:}"
+  resp="${raw%__STATUS:*}"
+  if [ "$status" = "429" ]; then
+    echo "429"
+  else
+    printf '%s' "$resp"
+  fi
+}
+
+# ----- Phase 1: users -------------------------------------------------------
+log "==> Phase 1: users"
+declare -A USER_ID USER_TOKEN
+for u in "${ALL_USERS[@]}"; do
+  pw="$PASSWORD"
+  [ "$u" = "$OWNER" ] && pw="$OWNER_PW"
+  # Register first; the endpoint is rate-limited (3 / 60 s per IP) so wait
+  # and retry once on 429.  Then fall back to login on any other failure
+  # (typically "username taken" when the account already exists from a
+  # prior run).
+  resp=$(api_with_retry POST /api/auth/register "" "{\"username\":\"$u\",\"password\":\"$pw\"}")
+  if [ "$resp" = "429" ]; then
+    log "    [rate-limited] waiting 65 s before retrying $u…"
+    sleep 65
+    resp=$(api_with_retry POST /api/auth/register "" "{\"username\":\"$u\",\"password\":\"$pw\"}")
+  fi
+  if [ "$(jq -r '.access_token // empty' <<<"$resp" 2>/dev/null)" = "" ]; then
+    resp=$(api POST /api/auth/login "" "{\"username\":\"$u\",\"password\":\"$pw\"}")
+  fi
+  uid=$(jq -r '.user_id' <<<"$resp" 2>/dev/null || true)
+  tok=$(jq -r '.access_token' <<<"$resp" 2>/dev/null || true)
+  if [ "$uid" = "null" ] || [ -z "$uid" ]; then
+    echo "ERROR: register/login failed for $u: $resp" >&2; exit 1
+  fi
+  USER_ID[$u]="$uid"
+  USER_TOKEN[$u]="$tok"
+  printf "    user %-14s %s\n" "$u" "$uid"
+done
+
+# ----- Phase 2: group -------------------------------------------------------
+log "==> Phase 2: group"
+OWNER_TOKEN="${USER_TOKEN[$OWNER]}"
+
+# Find an existing group of this name owned by admin_tester.
+existing_id=""
+existing_resp=$(api GET /api/conversations "$OWNER_TOKEN" || true)
+existing_id=$(jq -r --arg n "$GROUP_NAME" \
+  '[.[] | select((.title // .name) == $n and ((.is_group // (.kind == "group")) == true))][0].id // (.. | .conversation_id? // empty) // empty' \
+  <<<"$existing_resp" 2>/dev/null || true)
+# Fallback: simpler match if the response shape differs.
+if [ -z "$existing_id" ] || [ "$existing_id" = "null" ]; then
+  existing_id=$(jq -r --arg n "$GROUP_NAME" \
+    '.[] | select((.title // .name) == $n) | (.conversation_id // .id)' \
+    <<<"$existing_resp" 2>/dev/null | head -n1)
+fi
+
+if [ "$RESET" = "1" ] && [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
+  log "    RESET=1, deleting existing group $existing_id"
+  api DELETE "/api/groups/$existing_id" "$OWNER_TOKEN" >/dev/null || true
+  existing_id=""
+fi
+
+if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
+  GROUP_ID="$existing_id"
+  log "    reusing existing group $GROUP_ID (append-only; pass RESET=1 to wipe)"
+else
+  body=$(jq -nc --arg n "$GROUP_NAME" \
+    '{name:$n, description:"Stress-test fixture for UX/perf audit", is_public:true}')
+  resp=$(api POST /api/groups "$OWNER_TOKEN" "$body")
+  GROUP_ID=$(jq -r '.id // .group_id // .conversation_id // empty' <<<"$resp" 2>/dev/null || true)
+  if [ -z "$GROUP_ID" ] || [ "$GROUP_ID" = "null" ]; then
+    echo "ERROR: group create failed: $resp" >&2; exit 1
+  fi
+  log "    created $GROUP_ID"
+fi
+
+# Add members (idempotent; server returns AlreadyMember error which we ignore).
+for m in "${MEMBERS[@]}"; do
+  body=$(jq -nc --arg uid "${USER_ID[$m]}" '{user_id:$uid}')
+  api POST "/api/groups/$GROUP_ID/members" "$OWNER_TOKEN" "$body" >/dev/null || true
+done
+log "    members: ${MEMBERS[*]}"
+
+# ----- Phase 3: open one persistent WS per sender ---------------------------
+log "==> Phase 3: open persistent WebSockets"
+TMP_DIR="$(mktemp -d)"
+declare -A WS_FIFO WS_PID
+trap 'cleanup_ws' EXIT
+
+cleanup_ws() {
+  for u in "${!WS_PID[@]}"; do
+    # Close the FIFO writer to send EOF, then kill the websocat process.
+    eval "exec ${WS_FD[$u]:-99}>&-" 2>/dev/null || true
+    kill "${WS_PID[$u]}" 2>/dev/null || true
+    wait "${WS_PID[$u]}" 2>/dev/null || true
+  done
+  rm -rf "$TMP_DIR"
+}
+
+declare -A WS_FD
+next_fd=10
+for u in "${ALL_USERS[@]}"; do
+  ticket=$(api POST /api/auth/ws-ticket "${USER_TOKEN[$u]}" '{}' | jq -r '.ticket // empty')
+  if [ -z "$ticket" ]; then
+    echo "ERROR: failed to mint WS ticket for $u" >&2; exit 1
+  fi
+  fifo="$TMP_DIR/ws-$u"
+  mkfifo "$fifo"
+  websocat --no-close -E "$WS_BASE/ws?ticket=$ticket" >/dev/null 2>&1 < "$fifo" &
+  WS_PID[$u]=$!
+  # Hold the FIFO open for writing on a unique fd so subsequent sends
+  # don't block waiting for the reader to come back.
+  fd=$next_fd
+  next_fd=$((next_fd + 1))
+  eval "exec $fd>$fifo"
+  WS_FD[$u]=$fd
+  WS_FIFO[$u]="$fifo"
+done
+log "    opened ${#WS_PID[@]} sockets"
+
+# Tiny delay so the WS upgrade completes before we start firing frames.
+sleep 0.5
+
+ws_send() {
+  # $1 = sender username, $2 = JSON payload (single line, NDJSON)
+  local u="$1" payload="$2"
+  local fd="${WS_FD[$u]}"
+  printf '%s\n' "$payload" >&"$fd"
+}
+
+# ----- Phase 4: stress messages ---------------------------------------------
+log "==> Phase 4: sending messages"
+
+mk_payload() {
+  jq -nc --arg cid "$GROUP_ID" --arg t "$1" \
+    '{type:"send_message", conversation_id:$cid, content:$t}'
+}
+mk_reply_payload() {
+  jq -nc --arg cid "$GROUP_ID" --arg t "$1" --arg p "$2" \
+    '{type:"send_message", conversation_id:$cid, content:$t, reply_to_id:$p}'
+}
+
+# Topical fragments to mix into plain messages so the body actually wraps,
+# scrolls, and reads as a real conversation.
+FRAGMENTS=(
+  "ship it"
+  "lgtm — running CI now"
+  "anyone else seeing the flaky test on main?"
+  "just rebased, please pull"
+  "morning all 👋"
+  "lunch run, back in 30"
+  "PSA: mfa rollout is tomorrow"
+  "what time is the design review?"
+  "I'll grab the on-call this week"
+  "merging once green"
+  "small nit: variable naming in the helper"
+  "took a quick look — overall direction feels right"
+  "tagging release candidate v3.1.0-rc.4"
+  "the staging build is up — kicking the tires now"
+  "meeting moved to 3pm tomorrow heads up"
+  "did anyone document the migration path yet?"
+  "pinned the runbook in #ops"
+  "new infra dashboard: \$DASHBOARD_URL"
+  "post-mortem draft is ready for review"
+  "running benchmarks against main now, will share numbers"
+)
+
+# Plain messages, rotating senders.
+log "    [a] $MESSAGES plain messages"
+sender_idx=0
+for i in $(seq 1 "$MESSAGES"); do
+  sender="${ALL_USERS[$((sender_idx % ${#ALL_USERS[@]}))]}"
+  text="${FRAGMENTS[$((RANDOM % ${#FRAGMENTS[@]}))]} (#$i)"
+  ws_send "$sender" "$(mk_payload "$text")"
+  sender_idx=$((sender_idx + 1))
+  # Yield every 50 frames so the server's WS reader can drain.
+  [ $((i % 50)) -eq 0 ] && sleep 0.05
+done
+
+# Big-text messages (~8 KB each).  Server caps at MAX_MESSAGE_LENGTH
+# (typically 10 KB) so 8 KB is safely under.
+log "    [b] $BIG_TEXT big-text messages"
+LOREM="The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. Sphinx of black quartz, judge my vow. How vexingly quick daft zebras jump. Bright vixens jump; dozy fowl quack. "
+for i in $(seq 1 "$BIG_TEXT"); do
+  body=""
+  for _ in $(seq 1 60); do body+="$LOREM"; done   # ~7.8 KB
+  body="big-text #$i: $body"
+  sender="${ALL_USERS[$((RANDOM % ${#ALL_USERS[@]}))]}"
+  ws_send "$sender" "$(mk_payload "$body")"
+done
+
+# Emoji-heavy / jumbo-emoji.
+log "    [c] $EMOJI emoji messages"
+EMOJIS=(🎉 🚀 😂 🔥 💯 ✨ 🥳 🎊 ❤️ 👀 🐛 💻 🖼️ 🎨 🎵 ⚡ 🌈 🍕 🦀 🐍)
+for i in $(seq 1 "$EMOJI"); do
+  count=$((1 + RANDOM % 12))
+  body=""
+  for _ in $(seq 1 "$count"); do body+="${EMOJIS[$((RANDOM % ${#EMOJIS[@]}))]}"; done
+  sender="${ALL_USERS[$((RANDOM % ${#ALL_USERS[@]}))]}"
+  ws_send "$sender" "$(mk_payload "$body")"
+done
+
+# Markdown stress: fenced code blocks, blockquotes, lists.
+log "    [d] $MARKDOWN markdown messages"
+for i in $(seq 1 "$MARKDOWN"); do
+  case $((i % 3)) in
+    0) body=$'```\nfn main() {\n    let xs = (0..1_000_000)\n        .filter(|n| n % 7 == 0)\n        .sum::<u64>();\n    println!("sum = {xs}");\n}\n```' ;;
+    1) body=$'> notable pull-quote from a doc somewhere on the internet\n>\n> nested too — this should still wrap at the bubble\'s max width without the blockquote indent eating the right side' ;;
+    *) body=$'- alpha\n- beta\n- gamma\n- delta\n- epsilon\n- zeta\n- eta' ;;
+  esac
+  sender="${ALL_USERS[$((RANDOM % ${#ALL_USERS[@]}))]}"
+  ws_send "$sender" "$(mk_payload "$body")"
+done
+
+# Rapid-fire same-second timestamps (no sleep between sends).
+log "    [e] $RAPIDFIRE rapid-fire messages"
+for i in $(seq 1 "$RAPIDFIRE"); do
+  sender="${ALL_USERS[$((sender_idx % ${#ALL_USERS[@]}))]}"
+  ws_send "$sender" "$(mk_payload "rapid #$i — same second, tests grouping")"
+  sender_idx=$((sender_idx + 1))
+done
+
+# Let the server settle before we pull message IDs for replies / reactions.
+log "    waiting for server to drain WS frames…"
+sleep 4
+
+# ----- Phase 5: reply thread + reactions ------------------------------------
+# Pull recent messages so we can target a parent for the reply thread and
+# pick targets for reactions.  The /api/messages/{cid} list returns newest
+# first; flip and slice as needed.
+log "==> Phase 5: replies + reactions"
+msgs_resp=$(api GET "/api/messages/$GROUP_ID?limit=200" "$OWNER_TOKEN")
+mapfile -t RECENT_IDS < <(jq -r '.[].id' <<<"$msgs_resp")
+
+if [ "${#RECENT_IDS[@]}" -lt 1 ]; then
+  echo "WARN: no recent message IDs returned; skipping replies + reactions" >&2
+else
+  # Reply thread: pick the message at index N/2 as the parent so the thread
+  # sits in the middle of the timeline and forces "scroll into thread".
+  parent="${RECENT_IDS[$(( ${#RECENT_IDS[@]} / 2 ))]}"
+  log "    [f] $REPLIES-reply thread on $parent"
+  for i in $(seq 1 "$REPLIES"); do
+    sender="${ALL_USERS[$((sender_idx % ${#ALL_USERS[@]}))]}"
+    text="reply #$i in the deep thread"
+    ws_send "$sender" "$(mk_reply_payload "$text" "$parent")"
+    sender_idx=$((sender_idx + 1))
+    [ $((i % 50)) -eq 0 ] && sleep 0.05
+  done
+
+  # Reaction-heavy messages: pick REACTIONS messages and add 5+ unique emoji
+  # to each from rotating senders.
+  log "    [g] $REACTIONS reaction-heavy messages"
+  RXN_EMOJIS=(👍 ❤️ 😂 🎉 🔥 🚀 ✨ 💯)
+  for r in $(seq 1 "$REACTIONS"); do
+    target="${RECENT_IDS[$((RANDOM % ${#RECENT_IDS[@]}))]}"
+    for j in $(seq 0 5); do
+      emoji="${RXN_EMOJIS[$((j % ${#RXN_EMOJIS[@]}))]}"
+      sender="${ALL_USERS[$((j % ${#ALL_USERS[@]}))]}"
+      body=$(jq -nc --arg e "$emoji" '{emoji:$e}')
+      api POST "/api/messages/$target/reactions" "${USER_TOKEN[$sender]}" "$body" >/dev/null || true
+    done
+  done
+fi
+
+# Drain remaining frames before the script exits and the trap closes sockets.
+sleep 2
+
+# ----- Summary --------------------------------------------------------------
+total=$((MESSAGES + BIG_TEXT + EMOJI + MARKDOWN + RAPIDFIRE + REPLIES))
+log ""
+log "✓ Big Data Test Group seeded"
+log "    $MESSAGES plain messages"
+log "    $REPLIES reply thread"
+log "    $BIG_TEXT big-text messages"
+log "    $EMOJI emoji messages"
+log "    $MARKDOWN markdown messages"
+log "    $REACTIONS reaction-heavy messages"
+log "    $RAPIDFIRE rapid-fire grouped messages"
+log "  Total: ~$total messages"
+log ""
+log "  Login: $OWNER / $OWNER_PW"
+log "  Group: \"$GROUP_NAME\" ($GROUP_ID)"


### PR DESCRIPTION
## Summary

Batch merge of 16 commits on dev for sanity testing on main. Three threads:

**Production hotfixes** (post-PR #816 from prod testing):
- `364b3a0` Hover action bar stretching full chat width in CanvasKit (#723) — defensive `IntrinsicWidth` wrap
- `87d0e00` Voice-lounge rebuild storm in browser — `==`/`hashCode` on `CanvasPoint` so 100ms audio polls don't cascade
- `16dcb9f` AppImage missing `libmpv.so.2` on Fedora — `release.yml` now bundles libmpv + transitive deps via `ldd` walk

**Phase 3c (voice lounge layer hierarchy):**
- `6929388` `ParticipantAttention` helper (speaking / faded / idle)
- `65c180e` Idle participants fade + scale when someone speaks; reduce-motion gated

**Phase 2 density follow-ups** (every density-aware surface now scales):
- Message item / `RichTextContent` — `dca6a67`, `47a9f14`
- Channel bar chips — `31ccead`
- Settings card rows — `931cfec`
- Reaction pills + hover timestamp — `1a73414` (44×44 hover-action hit target preserved per WCAG 2.5.5)
- Date divider — `e664f63`
- Voice control dock — `e2ec04e`

**Stress-test infrastructure:**
- `1186c68` \`scripts/seed_stress_data.sh\` — generates the "Big Data Test Group" (1000+ msgs, 100-reply thread, 8KB texts, jumbo emoji, markdown, reaction-heavy, rapid-fire) over persistent WebSockets per sender. Smoke-verified end-to-end.

## Test plan
- [ ] Linux desktop: open the app, switch density (cozy/normal/compact) in Settings → Appearance, walk the message stream, channel bar, reactions, date dividers, voice dock, settings list — confirm visual scaling per tier with no overlapping or clipping
- [ ] Web (CanvasKit): same density walk; verify hover-action overlay stays snug to its bubble (regression check for #723)
- [ ] Voice lounge: join with two participants, confirm idle participants fade when one speaks; confirm reduce-motion disables fades
- [ ] AppImage: download release artifact, confirm it launches on a fresh Fedora 43 box (libmpv path)
- [ ] Stress seeder: run \`RESET=1 ./scripts/seed_stress_data.sh\` against localhost; open the Big Data Test Group; confirm sidebar parses, message list lazy-loads, replies thread opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)