### PR TITLE
ci(deploy): auto-roll prod on release + density walkthrough smoke

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,116 @@
+name: Prod Deploy
+
+# Roll the production VPS onto a published release.  Triggered automatically
+# when the Release workflow publishes a GitHub release, and also exposed as
+# `workflow_dispatch` so a specific tag can be re-applied (or rolled back) on
+# demand.  The deploy is a thin wrapper around the manual command documented
+# in `infra/docker/docker-compose.prod.yml`:
+#
+#   SERVER_VERSION=vX.Y.Z WEB_VERSION=vX.Y.Z docker compose pull && \
+#     docker compose up -d
+#
+# Required repo secrets:
+#   PROD_SSH_HOST     hostname or IP of the prod VPS
+#   PROD_SSH_USER     SSH user with `docker compose` privileges
+#   PROD_SSH_KEY      private key (PEM, no passphrase) authorized on the host
+#   PROD_COMPOSE_DIR  absolute path to the directory holding
+#                     docker-compose.prod.yml + .env on the VPS
+#
+# Optional repo secrets:
+#   PROD_SSH_PORT     non-default SSH port
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy (e.g. v0.0.286). Defaults to latest published.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Roll prod to ${{ github.event.inputs.tag || github.event.release.tag_name }}
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Resolve target tag
+        id: target
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            tag='${{ github.event.inputs.tag }}'
+          else
+            tag='${{ github.event.release.tag_name }}'
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::No tag resolved (release event missing tag_name and no manual input)."
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Deploying tag: $tag"
+
+      - name: Verify required secrets
+        run: |
+          missing=()
+          [ -z "${{ secrets.PROD_SSH_HOST }}" ]    && missing+=(PROD_SSH_HOST)
+          [ -z "${{ secrets.PROD_SSH_USER }}" ]    && missing+=(PROD_SSH_USER)
+          [ -z "${{ secrets.PROD_SSH_KEY }}" ]     && missing+=(PROD_SSH_KEY)
+          [ -z "${{ secrets.PROD_COMPOSE_DIR }}" ] && missing+=(PROD_COMPOSE_DIR)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Roll prod via SSH
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          port: ${{ secrets.PROD_SSH_PORT || 22 }}
+          # `command_timeout` covers `docker compose pull` over the network plus
+          # `up -d` time for ~5 services.  10 minutes is generous; bump if pulls
+          # ever start exceeding that window.
+          command_timeout: 10m
+          envs: TAG
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.PROD_COMPOSE_DIR }}"
+            export SERVER_VERSION="$TAG"
+            export WEB_VERSION="$TAG"
+            echo "Pulling images for $TAG..."
+            docker compose -f docker-compose.prod.yml pull server web
+            echo "Rolling services..."
+            docker compose -f docker-compose.prod.yml up -d server web
+            echo "Pruning untagged images..."
+            docker image prune -f
+            echo "Done. Current health:"
+            curl -sfm 5 https://echo-messenger.us/api/health || true
+        env:
+          TAG: ${{ steps.target.outputs.tag }}
+
+      - name: Verify prod is on the new tag
+        run: |
+          # Health endpoint reports `0.X.Y` (no leading `v`); strip it to compare.
+          want='${{ steps.target.outputs.tag }}'
+          want_strip="${want#v}"
+          for i in 1 2 3 4 5 6; do
+            got=$(curl -sf -m 5 https://echo-messenger.us/api/health \
+                  | jq -r '.version' 2>/dev/null || echo '')
+            echo "attempt $i: prod reports version=$got (want $want_strip)"
+            if [ "$got" = "$want_strip" ]; then
+              echo "::notice::Prod is now serving $want"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Prod is still not on $want after 60s of polling."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ tests/e2e/*.spec.ts
 !tests/e2e/hover_then_type.spec.ts
 !tests/e2e/group_create_ui.spec.ts
 !tests/e2e/group_messaging_ui.spec.ts
+!tests/e2e/density_walkthrough.spec.ts
 test-results/
 
 # Uploaded media files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,8 @@ Three compose files in `infra/docker/`:
 - `docker-compose.test.yml` -- CI (PostgreSQL on port 5433, avoids conflicts)
 - `docker-compose.prod.yml` -- production: Traefik with Cloudflare TLS, PostgreSQL backups (7-day/4-week/6-month retention), LiveKit for voice
 
+**Prod deploy** is automated via `.github/workflows/prod-deploy.yml`. It fires automatically when the Release workflow publishes a GitHub release and is also `workflow_dispatch`-able for manual rolls or rollbacks (`gh workflow run "Prod Deploy" -f tag=v0.0.123`). Required repo secrets: `PROD_SSH_HOST`, `PROD_SSH_USER`, `PROD_SSH_KEY`, `PROD_COMPOSE_DIR` (optional `PROD_SSH_PORT`). The workflow SSHes in, sets `SERVER_VERSION`/`WEB_VERSION` to the tag, runs `docker compose pull && up -d` against the `server` and `web` services, and polls `/api/health` until the version matches. The `production` GitHub environment can gate it behind required reviewers in repo settings.
+
 ## Known Limitations
 
 1. Session keys cached in memory with 24h idle TTL + 200-entry LRU cap; evicted entries have key material zeroed and reload from secure storage on demand.

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -105,8 +105,10 @@ services:
 
   # Watchtower removed: auto-pulling `latest` every 5 minutes risks deploying
   # broken builds with zero human review.  Pin image versions via SERVER_VERSION
-  # and WEB_VERSION env vars and deploy manually or via CI/CD.
-  # To update:
+  # and WEB_VERSION env vars and deploy via the Prod Deploy workflow
+  # (.github/workflows/prod-deploy.yml), which fires automatically when a
+  # GitHub release publishes and is also workflow_dispatch-able for manual
+  # rolls / rollbacks.  Manual fallback if the workflow is unavailable:
   #   SERVER_VERSION=v1.2.3 WEB_VERSION=v1.2.3 docker compose pull && docker compose up -d
 
   backup:

--- a/tests/e2e/density_walkthrough.spec.ts
+++ b/tests/e2e/density_walkthrough.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Manual smoke test for the Phase 2 density tiers shipped in PR #817.
+ *
+ * Walks Settings → Appearance → Density and screenshots the three tiers
+ * (Cozy / Normal / Compact) on the surfaces that picked up density in
+ * this PR: sidebar, message stream, channel bar, settings rows, voice
+ * dock, reactions, date divider.
+ *
+ * Run against production once the main-branch release deploy lands:
+ *
+ *   ECHO_SERVER=https://echo-messenger.us \
+ *   ECHO_URL=https://echo-messenger.us \
+ *   npx playwright test density_walkthrough.spec.ts \
+ *     --project=manual --headed --timeout=300000
+ *
+ * Or against a local dev stack (default):
+ *
+ *   npx playwright test density_walkthrough.spec.ts --project=manual --headed
+ */
+import { test, Page, expect } from '@playwright/test';
+
+const SERVER = process.env.ECHO_SERVER || 'http://localhost:8080';
+const WEB = process.env.ECHO_URL || 'http://localhost:8081';
+const APP = `${WEB}/?server=${encodeURIComponent(SERVER)}`;
+const SS = 'tests/e2e/test-results/density';
+
+async function ss(page: Page, name: string) {
+  await page.screenshot({ path: `${SS}/${name}.png`, fullPage: true });
+}
+
+async function waitForFlutter(page: Page) {
+  await page.waitForFunction(
+    () =>
+      document.querySelector('flt-semantics') !== null ||
+      document.querySelector('input[aria-label]') !== null,
+    { timeout: 30000 },
+  );
+  await page.waitForTimeout(2000);
+}
+
+async function loginAsNew(page: Page, username: string, password: string) {
+  // Register via REST first; falls back to login if the username already
+  // exists (e.g. the spec is rerun without rotating the suffix).
+  const reg = await fetch(`${SERVER}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  })
+    .then((r) => r.json())
+    .catch(() => ({}));
+  // Some servers rate-limit registration; if so, sign in via the existing
+  // account flow.  The test only needs a logged-in session.
+  if (!reg.access_token) {
+    await fetch(`${SERVER}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+  }
+
+  await page.goto(APP);
+  await waitForFlutter(page);
+  await page.getByLabel('Username').click();
+  await page.waitForTimeout(200);
+  await page.keyboard.type(username, { delay: 10 });
+  // Tab to the password field — getByLabel('Password') is ambiguous in
+  // CanvasKit because the show/hide eye-icon also carries an aria-label
+  // hit by the same heuristic.
+  await page.keyboard.press('Tab');
+  await page.waitForTimeout(200);
+  await page.keyboard.type(password, { delay: 10 });
+  await page.getByRole('button', { name: /^log in$/i }).click();
+  await page.waitForTimeout(8000);
+}
+
+async function openSettings(page: Page) {
+  // Settings is reachable from the user-status footer in the left sidebar.
+  // Try by aria label first; fall back to a common gear icon click.
+  const settingsBtn = page.getByRole('button', { name: /settings/i }).first();
+  if (await settingsBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await settingsBtn.click();
+  } else {
+    // Hash route fallback — the GoRouter route map exposes /settings.
+    await page.goto(`${APP}#/settings`);
+  }
+  await page.waitForTimeout(1500);
+}
+
+async function selectDensity(page: Page, label: 'Cozy' | 'Normal' | 'Compact') {
+  // Density radio is in the Appearance section, directly below the
+  // Message Layout picker.  Each tile renders with semantics label
+  // "<Label> layout" — Cozy/Normal are unique, Compact appears twice
+  // (once for message layout, once for density), so for Compact we
+  // pick the second match (density tile lives after the layout tiles).
+  const appearance = page
+    .getByRole('button', { name: /appearance settings/i })
+    .first();
+  if (await appearance.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await appearance.click();
+    await page.waitForTimeout(800);
+  }
+  const tiles = page.getByRole('button', {
+    name: new RegExp(`^${label} layout$`, 'i'),
+  });
+  const idx = label === 'Compact' ? 1 : 0;
+  await tiles.nth(idx).click({ timeout: 5000 });
+  await page.waitForTimeout(800);
+}
+
+test('density tier visual walkthrough', async ({ browser }) => {
+    test.setTimeout(0);
+    const ts = Date.now().toString().slice(-5);
+    const u = `density_${ts}`;
+    const pw = 'densitypass123';
+
+    const ctx = await browser.newContext({
+      viewport: { width: 1920, height: 993 },
+    });
+    const page = await ctx.newPage();
+
+    await loginAsNew(page, u, pw);
+    await ss(page, '00-loaded');
+
+    // 1. Default density (today's compact) — sidebar reference.
+    await ss(page, '01-default-sidebar');
+
+    // 2. Open settings, snap each density tier.
+    await openSettings(page);
+    await ss(page, '02-settings-default');
+
+    for (const tier of ['Cozy', 'Normal', 'Compact'] as const) {
+      await selectDensity(page, tier);
+      await ss(page, `03-settings-${tier.toLowerCase()}`);
+
+      // Pop back to home so we capture the sidebar at this density.
+      const backBtn = page.getByRole('button', { name: /^back$/i }).first();
+      if (await backBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+        await backBtn.click();
+        await page.waitForTimeout(800);
+      } else {
+        await page.goto(APP);
+        await page.waitForTimeout(2000);
+      }
+      await ss(page, `04-home-${tier.toLowerCase()}`);
+
+      // Re-enter settings for the next iteration.
+      await openSettings(page);
+    }
+
+  // No assertions — this is a screenshot-collection smoke for visual review.
+  expect(true).toBe(true);
+  await ctx.close();
+});

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
         'live_test.spec.ts',
         'open_prod.spec.ts',
         'prod_test.spec.ts',
+        'density_walkthrough.spec.ts',
       ],
       use: { browserName: 'chromium' },
     },


### PR DESCRIPTION
## Summary

Two follow-ups from PR #817 sanity testing.

### 1. Prod deploy gap
PR #817 published \`v0.0.286\` to GHCR, but production stayed on \`v0.0.262\` because there's no auto-deploy wired up. \`infra/docker/docker-compose.prod.yml\` documents a manual \`docker compose pull && up -d\` flow only.

\`6a713be\` adds \`.github/workflows/prod-deploy.yml\`:
- Triggers on \`release: { types: [published] }\` so future releases roll automatically
- Also \`workflow_dispatch\`-able with a \`tag\` input for manual rolls / rollbacks
- Gated behind the existing \`production\` GitHub environment (so you can require reviewers in repo settings)
- SSHes via SHA-pinned \`appleboy/ssh-action@v1.2.5\`, runs \`docker compose pull && up -d\` on \`server\` + \`web\`, prunes untagged images, then polls \`/api/health\` for up to 60s until the version flips
- Verify-secrets preflight fails fast if any of the four required secrets are missing
- Concurrency group \`prod-deploy\` with \`cancel-in-progress: false\` so two deploys can't race

### 2. Density walkthrough smoke
\`0432da7\` adds \`tests/e2e/density_walkthrough.spec.ts\` — a manual Playwright smoke that walks Settings → Appearance → Density and screenshots Cozy / Normal / Compact across the surfaces shipped in #817 (sidebar, settings rows, message stream). Already shaken out against prod login + settings nav; the only reason it didn't reach the density picker was that prod was still on \`v0.0.262\`.

## Required action after merge
The deploy workflow needs four repo secrets (it fails fast if any are missing):
- \`PROD_SSH_HOST\` — VPS hostname or IP
- \`PROD_SSH_USER\` — SSH user with \`docker compose\` permission
- \`PROD_SSH_KEY\` — private key (PEM, no passphrase) authorized on the host
- \`PROD_COMPOSE_DIR\` — absolute path to the directory holding \`docker-compose.prod.yml\` on the VPS
- (optional) \`PROD_SSH_PORT\`

Once those are added, roll the current release to prod manually:

\`\`\`bash
gh workflow run "Prod Deploy" -f tag=v0.0.286
\`\`\`

After that lands, re-run the density walkthrough against prod:

\`\`\`bash
cd tests/e2e
ECHO_SERVER=https://echo-messenger.us ECHO_URL=https://echo-messenger.us \
  npx playwright test density_walkthrough.spec.ts --project=manual --timeout=300000
\`\`\`

## Test plan
- [ ] Add the four \`PROD_*\` secrets to the repo (or to the \`production\` environment)
- [ ] Trigger \`gh workflow run "Prod Deploy" -f tag=v0.0.286\`; watch \`/api/health\` flip from \`0.0.262\` to \`0.0.286\`
- [ ] Confirm the density walkthrough screenshots show Cozy / Normal / Compact tiers in Settings → Appearance
- [ ] Cut a follow-up release; verify the workflow auto-fires on release publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)