### PR TITLE
ci(e2e): Prod Smoke workflow — run Playwright against live URL from gh-hosted runners

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,84 @@
+name: Prod Smoke
+
+# Runs the manual Playwright smokes against the live prod deployment from a
+# GitHub-hosted runner.  No SSH, no host access -- just HTTP/WS to
+# echo-messenger.us like any normal browser.  Useful as a post-deploy
+# sanity check.
+#
+# Spec lanes (selectable via `spec` input; default = density_walkthrough):
+#   density_walkthrough  -- screenshots Cozy / Normal / Compact across the
+#                           surfaces shipped in PR #817
+#   open_prod            -- the existing two-user flow against prod
+#
+# All output (screenshots, traces, video) is uploaded as a workflow artifact.
+
+on:
+  workflow_dispatch:
+    inputs:
+      spec:
+        description: 'Which manual spec to run'
+        required: true
+        type: choice
+        default: density_walkthrough
+        options:
+          - density_walkthrough
+          - open_prod
+      target_url:
+        description: 'Override target (default https://echo-messenger.us)'
+        required: false
+        type: string
+        default: 'https://echo-messenger.us'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Playwright -> ${{ inputs.target_url }} (${{ inputs.spec }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Install Playwright + browsers
+        working-directory: tests/e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Probe target
+        env:
+          TARGET: ${{ inputs.target_url }}
+        run: |
+          echo "Probing $TARGET ..."
+          curl -sf -m 10 "$TARGET/api/health" | tee /tmp/health.json
+          version=$(jq -r '.version' < /tmp/health.json)
+          echo "Prod is on version: $version"
+          echo "PROD_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Run ${{ inputs.spec }}
+        working-directory: tests/e2e
+        env:
+          ECHO_SERVER: ${{ inputs.target_url }}
+          ECHO_URL: ${{ inputs.target_url }}
+        run: |
+          npx playwright test "${{ inputs.spec }}.spec.ts" \
+            --project=manual \
+            --timeout=300000
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: prod-smoke-${{ inputs.spec }}-${{ env.PROD_VERSION || 'unknown' }}
+          path: |
+            tests/e2e/test-results/
+            tests/e2e/tests/e2e/test-results/
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
## Summary

Splits "test prod" from "deploy prod". Adds \`.github/workflows/prod-smoke.yml\` which runs the manual Playwright specs against \`https://echo-messenger.us\` from a stock GitHub-hosted runner — no SSH, no VPS access, just HTTP/WS like a normal browser.

\`workflow_dispatch\` inputs:
- \`spec\` — \`density_walkthrough\` (default) or \`open_prod\`
- \`target_url\` — defaults to prod, override for staging

Probes \`/api/health\` first so the run logs the version under test. All Playwright output (screenshots, traces, video) is uploaded as a workflow artifact, retention 14d, named with the prod version so cross-release diffs are easy.

This unblocks "verify prod after a deploy" without depending on PR #818's SSH path. Cleanly separable.

## Test plan
- [ ] \`gh workflow run "Prod Smoke" -f spec=density_walkthrough\` after main merges
- [ ] Artifact uploaded with screenshots showing prod's current density UI state
- [ ] Re-run after prod is rolled to v0.0.286 — confirm Cozy / Normal / Compact sections appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)