### PR TITLE
fix(client): three prod-stress findings — pagination cursor, reply jump, preview marker

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -553,7 +553,19 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         : chatState.messagesForConversation(conv.id);
     if (messages.isEmpty) return;
 
-    final oldestTimestamp = messages.first.timestamp;
+    // System events (member_joined, voice_session_started, ...) live at the
+    // conversation root with `channelId == null` and surface in every
+    // channel view, but their timestamps predate the actual channel messages
+    // -- they're created when the group is born.  If we use them as the
+    // pagination cursor, the server's `?channel_id=X&before=<system_ts>`
+    // query (correctly) returns zero rows, `hasMore` flips to false, and
+    // the message list dead-locks at the first page (#prod-2026-05-08).
+    // Use the oldest channel-scoped real message instead.
+    final paginationCursor = messages.firstWhere(
+      (m) => !m.isSystemEvent,
+      orElse: () => messages.first,
+    );
+    final oldestTimestamp = paginationCursor.timestamp;
     final auth = ref.read(authProvider);
     if (auth.token == null || auth.userId == null) return;
 
@@ -746,28 +758,95 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   // Jump to reply quote
   // ---------------------------------------------------------------------------
 
-  void _jumpToReplyQuote(String replyToId) {
+  Future<void> _jumpToReplyQuote(String replyToId) async {
     final conv = widget.conversation;
     if (conv == null) return;
-    final chatState = ref.read(chatProvider);
     final selectedChannelId = conv.isGroup ? _selectedTextChannelId : null;
     final includeUnchanneled = conv.isGroup && _selectedTextChannelId == null;
-    final messages = _resolveMessages(
-      conv,
-      chatState,
-      selectedChannelId,
-      includeUnchanneled,
-    );
-    final index = messages.indexWhere((m) => m.id == replyToId);
-    if (index < 0) {
-      ToastService.show(
-        context,
-        'Original message not loaded',
-        type: ToastType.info,
+
+    bool isLoaded() {
+      final state = ref.read(chatProvider);
+      final loaded = _resolveMessages(
+        conv,
+        state,
+        selectedChannelId,
+        includeUnchanneled,
       );
+      return loaded.indexWhere((m) => m.id == replyToId) >= 0;
+    }
+
+    // Fast path: already in memory.
+    if (isLoaded()) {
+      _highlightMessage(replyToId);
       return;
     }
-    _highlightMessage(replyToId);
+
+    // Slow path: paginate older history until the target appears or
+    // `hasMore` flips to false.  Cap to 30 rounds (~1500 msgs at 50/round)
+    // so a stale or removed parent can't spin forever.
+    final auth = ref.read(authProvider);
+    if (auth.token == null || auth.userId == null) return;
+
+    final groupCrypto = conv.isGroup
+        ? ref.read(groupCryptoServiceProvider)
+        : null;
+    groupCrypto?.setToken(auth.token!);
+
+    final cryptoState = ref.read(cryptoProvider);
+    final crypto = (!conv.isGroup && cryptoState.isInitialized)
+        ? ref.read(cryptoServiceProvider)
+        : null;
+    crypto?.setToken(auth.token!);
+
+    for (var round = 0; round < 30; round++) {
+      if (!mounted) return;
+      final state = ref.read(chatProvider);
+      if (!state.conversationHasMore(
+        conv.id,
+        channelId: _selectedTextChannelId,
+      )) {
+        break;
+      }
+      final loaded = _resolveMessages(
+        conv,
+        state,
+        selectedChannelId,
+        includeUnchanneled,
+      );
+      if (loaded.isEmpty) break;
+      // Use the oldest channel-scoped (non-system) message as the
+      // pagination cursor; system events live at the conversation root
+      // and would dead-end the channel-scoped ?before= query.
+      final cursor = loaded.firstWhere(
+        (m) => !m.isSystemEvent,
+        orElse: () => loaded.first,
+      );
+
+      await ref
+          .read(chatProvider.notifier)
+          .loadHistoryWithUserId(
+            conv.id,
+            auth.token!,
+            auth.userId!,
+            channelId: _selectedTextChannelId,
+            before: cursor.timestamp,
+            crypto: crypto,
+            isGroup: conv.isGroup,
+            groupCrypto: groupCrypto,
+          );
+      if (!mounted) return;
+      if (isLoaded()) {
+        _highlightMessage(replyToId);
+        return;
+      }
+    }
+
+    if (!mounted) return;
+    ToastService.show(
+      context,
+      'Original message not available',
+      type: ToastType.info,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -299,19 +299,31 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
 
   String? _applyMediaLabel(String? snippet) {
     if (snippet == null) return null;
-    if (RegExp(r'^\[img:.+\]$').hasMatch(snippet)) {
-      return '\u{1F4F7} Photo';
-    }
-    if (RegExp(r'^\[video:.+\]$').hasMatch(snippet)) {
-      return '\u{1F3AC} Video';
-    }
-    if (RegExp(r'^\[file:.+\]$').hasMatch(snippet)) {
-      return '\u{1F4CE} File';
-    }
-    if (RegExp(r'^\[voice:.+\]$').hasMatch(snippet)) {
-      return '\u{1F3A4} Voice message';
-    }
-    return snippet;
+    // Match a leading [kind:url] marker, optionally followed by a newline and
+    // a caption (the seed scripts emit `[img:URL]\ncaption` for captioned
+    // attachments).  The previous `^\[img:.+\]$` regex only matched bare
+    // markers, so captioned messages leaked the raw `[img:...]` text into
+    // the conversation preview (#prod-2026-05-08).
+    final match = RegExp(
+      r'^\[(img|video|file|voice):[^\]]+\]\s*\n?\s*',
+    ).firstMatch(snippet);
+    if (match == null) return snippet;
+    final kind = match.group(1)!;
+    final caption = snippet.substring(match.end).trim();
+    const icons = {
+      'img': '\u{1F4F7}',
+      'video': '\u{1F3AC}',
+      'file': '\u{1F4CE}',
+      'voice': '\u{1F3A4}',
+    };
+    const fallbacks = {
+      'img': 'Photo',
+      'video': 'Video',
+      'file': 'File',
+      'voice': 'Voice message',
+    };
+    final icon = icons[kind] ?? '';
+    return caption.isEmpty ? '$icon ${fallbacks[kind]!}' : '$icon $caption';
   }
 
   String? _prependSenderLabel(String? snippet, Conversation conv) {

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -405,6 +405,40 @@ void main() {
       expect(find.textContaining('[img:'), findsNothing);
     });
 
+    testWidgets('image marker WITH caption shows icon + caption, not marker', (
+      tester,
+    ) async {
+      // The seed scripts emit `[img:URL]\ncaption` for captioned attachments;
+      // the previous `^\[img:.+\]$` regex only matched bare markers, so the
+      // raw `[img:...]` text leaked into the conversation preview
+      // (#prod-2026-05-08).
+      final conv = _makeConversation(
+        isGroup: true,
+        lastMessage: '[img:/api/media/photo.png]\nthe reaction',
+        lastMessageSender: 'henry',
+        members: const [
+          ConversationMember(userId: 'henry-id', username: 'henry'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:30',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+
+      // Caption is shown after the icon; raw marker never leaks through.
+      expect(find.textContaining('the reaction'), findsOneWidget);
+      expect(find.textContaining('[img:'), findsNothing);
+    });
+
     testWidgets('sender label prepends "You" for own messages in groups', (
       tester,
     ) async {

--- a/scripts/seed_stress_data.sh
+++ b/scripts/seed_stress_data.sh
@@ -213,11 +213,27 @@ log "    opened ${#WS_PID[@]} sockets"
 sleep 0.5
 
 ws_send() {
-  # $1 = sender username, $2 = JSON payload (single line, NDJSON)
+  # $1 = sender username, $2 = JSON payload (single line, NDJSON).
+  # The trailing `|| true` is critical: if a websocat process at the other
+  # end of the FIFO has died (e.g. server closed the WS for a rate-limit
+  # violation), printf raises SIGPIPE and the bare `set -e` would abort
+  # the entire seed run.  We log a warning instead and let the loop
+  # continue with the remaining senders.
   local u="$1" payload="$2"
   local fd="${WS_FD[$u]}"
-  printf '%s\n' "$payload" >&"$fd"
+  if ! printf '%s\n' "$payload" >&"$fd" 2>/dev/null; then
+    echo "    [warn] ws_send to $u failed (socket closed?); continuing" >&2
+    return 0
+  fi
 }
+
+# Pace WebSocket sends to fit the server's per-connection rate limit:
+# the WS receive loop in apps/server/src/ws/handler.rs uses a token
+# bucket of 30 messages with 3-msg/sec refill, and closes the
+# connection after 3 consecutive violations.  With 6 rotating senders,
+# a sustained aggregate of ~12 msg/sec (=2 msg/sec/sender) keeps every
+# bucket well above empty.  Sleep 80 ms between sends -> 12.5 msg/sec.
+ws_pace_sleep="${WS_PACE_SLEEP:-0.08}"
 
 # ----- Phase 4: stress messages ---------------------------------------------
 log "==> Phase 4: sending messages"
@@ -264,8 +280,7 @@ for i in $(seq 1 "$MESSAGES"); do
   text="${FRAGMENTS[$((RANDOM % ${#FRAGMENTS[@]}))]} (#$i)"
   ws_send "$sender" "$(mk_payload "$text")"
   sender_idx=$((sender_idx + 1))
-  # Yield every 50 frames so the server's WS reader can drain.
-  [ $((i % 50)) -eq 0 ] && sleep 0.05
+  sleep "$ws_pace_sleep"
 done
 
 # Big-text messages (~8 KB each).  Server caps at MAX_MESSAGE_LENGTH
@@ -278,6 +293,7 @@ for i in $(seq 1 "$BIG_TEXT"); do
   body="big-text #$i: $body"
   sender="${ALL_USERS[$((RANDOM % ${#ALL_USERS[@]}))]}"
   ws_send "$sender" "$(mk_payload "$body")"
+  sleep "$ws_pace_sleep"
 done
 
 # Emoji-heavy / jumbo-emoji.
@@ -289,6 +305,7 @@ for i in $(seq 1 "$EMOJI"); do
   for _ in $(seq 1 "$count"); do body+="${EMOJIS[$((RANDOM % ${#EMOJIS[@]}))]}"; done
   sender="${ALL_USERS[$((RANDOM % ${#ALL_USERS[@]}))]}"
   ws_send "$sender" "$(mk_payload "$body")"
+  sleep "$ws_pace_sleep"
 done
 
 # Markdown stress: fenced code blocks, blockquotes, lists.
@@ -301,14 +318,19 @@ for i in $(seq 1 "$MARKDOWN"); do
   esac
   sender="${ALL_USERS[$((RANDOM % ${#ALL_USERS[@]}))]}"
   ws_send "$sender" "$(mk_payload "$body")"
+  sleep "$ws_pace_sleep"
 done
 
-# Rapid-fire same-second timestamps (no sleep between sends).
+# Rapid-fire same-second timestamps.  We still pace these (rotating across
+# 6 senders -> ~5 per sender per second after pacing) to avoid blowing up
+# the rate limit; the "same second" property is preserved by the timestamp
+# resolution server-side, not by sub-second wall clock here.
 log "    [e] $RAPIDFIRE rapid-fire messages"
 for i in $(seq 1 "$RAPIDFIRE"); do
   sender="${ALL_USERS[$((sender_idx % ${#ALL_USERS[@]}))]}"
   ws_send "$sender" "$(mk_payload "rapid #$i — same second, tests grouping")"
   sender_idx=$((sender_idx + 1))
+  sleep "$ws_pace_sleep"
 done
 
 # Let the server settle before we pull message IDs for replies / reactions.
@@ -335,7 +357,7 @@ else
     text="reply #$i in the deep thread"
     ws_send "$sender" "$(mk_reply_payload "$text" "$parent")"
     sender_idx=$((sender_idx + 1))
-    [ $((i % 50)) -eq 0 ] && sleep 0.05
+    sleep "$ws_pace_sleep"
   done
 
   # Reaction-heavy messages: pick REACTIONS messages and add 5+ unique emoji


### PR DESCRIPTION
## Summary

Three issues found while stress-testing the Big Data Test Group on prod (1170 messages across 100-reply thread, big-text, emoji, markdown, rapid-fire).

### \`534fa0a\` Conversation preview shows raw \`[img:URL]\` for captioned attachments

The seed scripts emit \`[img:URL]\\ncaption\` for captioned attachments, but \`_applyMediaLabel\` only matched bare \`^\\[img:.+\\]$\` markers — captioned messages skipped the formatter and the raw marker leaked into the conversation list (e.g. \`henry: [img:/api/media/89342a11-ce7b-4e7a-8ad...\`).

Fixed: regex now matches a leading \`[kind:URL]\` marker plus optional newline + caption. Preview becomes \`📷 caption\` (or \`📷 Photo\` if no caption). Tests cover both shapes.

### \`aa71206\` Message-list pagination cursor includes system events

Symptom: scrolling up in a heavily-populated channel dead-locks at exactly the first 50 messages. \`hasMore\` flips to false; further pagination requests stop firing.

Cause: \`_loadOlderMessages\` computed the pagination cursor as \`messages.first.timestamp\`, but \`messages\` includes \`__system__:member_joined\` events whose \`channelId\` is null. Those system events fire when the group is created, so their timestamps predate every channel-scoped real message. Result: the request becomes \`?channel_id=X&before=<group_creation_ts>\` — server (correctly) returns zero rows because no channel messages exist before group creation. Pagination dies.

Fixed: skip system events when picking the cursor; fall back to the oldest channel-scoped real message.

### \`aa71206\` Reply preview tap → "Original message not loaded"

Tapping the embedded original-message preview on a reply showed a dead-end toast when the original wasn't already in memory (very common for replies in long histories — original is buried 500+ messages deep).

Fixed: on cache miss, \`_jumpToReplyQuote\` now iterates page-by-page over older history (capped at 30 rounds ≈ 1500 msgs) using the same channel-scoped cursor logic, then jumps once the target appears. Falls back to a clearer "original message not available" message only if the parent is genuinely gone.

## Test plan
- [ ] Open the Big Data Test Group on prod, scroll to top — confirm pagination keeps loading older messages, eventually reaching the seed's first plain message
- [ ] Tap the original-message quote on any reply in the 100-reply thread — confirm the app jumps to the original (with a brief loading delay for deep replies)
- [ ] Conversation list — confirm Movie Club / Tech Talk / etc. previews show \`📷 caption\` rather than \`[img:/api/media/...]\`
- [ ] No regression: tests in \`test/widgets/conversation_item_test.dart\` (34 pass, including new captioned-marker case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)