### PR TITLE
fix(server,client): more stress-test findings — reactions, thread pagination, compact hover

### DIFF
--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1721,7 +1721,14 @@ class _MessageItemState extends State<MessageItem>
       opacity: _isHovered ? 1.0 : 0.0,
       duration: const Duration(milliseconds: 140),
       child: Padding(
-        padding: EdgeInsets.only(top: 2, left: isMine ? 0 : 36),
+        // Compact / plain layouts left-align every message regardless of
+        // sender, so even "my" messages need the 36px avatar-gutter inset
+        // to line up with the bubble.  Only bubbles-layout sent messages
+        // sit flush right and warrant `left: 0`.
+        padding: EdgeInsets.only(
+          top: 2,
+          left: (isMine && !widget.compactLayout) ? 0 : 36,
+        ),
         child: Text(
           msg.editedAt != null
               ? '${formatMessageTimestamp(msg.timestamp)} (edited)'
@@ -1746,6 +1753,12 @@ class _MessageItemState extends State<MessageItem>
     required bool isMine,
     required String? mediaUrl,
   }) {
+    // In bubbles layout, "my" messages are right-aligned so the overlay
+    // anchors to the right edge.  In compact / plain layouts every message
+    // is left-aligned regardless of sender, so right-anchoring the
+    // overlay parks it on the far right of the chat -- nowhere near the
+    // bubble (#prod-2026-05-08).  Use the bubble's actual visual side.
+    final bubbleOnRight = isMine && !widget.compactLayout;
     return Positioned(
       top: -28,
       // Anchor only the side closest to the bubble so the overlay sizes to
@@ -1754,8 +1767,8 @@ class _MessageItemState extends State<MessageItem>
       // `right: 0`, but received bubbles previously also set `right: 8`,
       // which is what produced the asymmetric full-width hover bar on
       // left-side messages.
-      left: isMine ? null : 36,
-      right: isMine ? 0 : null,
+      left: bubbleOnRight ? null : 36,
+      right: bubbleOnRight ? 0 : null,
       // Defensive `IntrinsicWidth` wrap: in CanvasKit (web) the action
       // row's `Container > Row(MainAxisSize.min)` was still expanding to
       // the full Stack width despite the Positioned only setting one

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -37,6 +37,14 @@ pub struct MessageWithSender {
     pub reply_to_content: Option<String>,
     pub reply_to_username: Option<String>,
     pub reply_count: i64,
+    /// Reactions aggregated as a JSON array of
+    /// `{message_id, user_id, username, emoji}` objects.  Public history
+    /// queries (`get_messages`, `get_thread_replies`) populate this so the
+    /// client can render reactions on history reload; the WS replay path
+    /// (`get_undelivered`) leaves it as `Null` because reactions are
+    /// rebroadcast independently over WebSocket.
+    #[serde(default)]
+    pub reactions: Option<sqlx::types::Json<serde_json::Value>>,
 }
 
 #[derive(Debug, sqlx::FromRow)]
@@ -222,7 +230,8 @@ pub async fn get_messages(
                 m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.reply_count, 0) AS reply_count \
+                COALESCE(rc.reply_count, 0) AS reply_count, \
+                COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
@@ -233,6 +242,17 @@ pub async fn get_messages(
              WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL \
              GROUP BY reply_to_id \
          ) rc ON rc.reply_to_id = m.id \
+         LEFT JOIN LATERAL ( \
+             SELECT json_agg(json_build_object( \
+                 'message_id', r.message_id, \
+                 'user_id', r.user_id, \
+                 'username', rxu.username, \
+                 'emoji', r.emoji \
+             )) AS reactions \
+             FROM reactions r \
+             JOIN users rxu ON rxu.id = r.user_id \
+             WHERE r.message_id = m.id \
+         ) rx ON true \
          LEFT JOIN message_device_contents mdc \
                 ON $5::int IS NOT NULL \
                AND mdc.message_id = m.id \
@@ -883,7 +903,8 @@ pub async fn get_thread_replies(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.cnt, 0) AS reply_count \
+                COALESCE(rc.cnt, 0) AS reply_count, \
+                COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
@@ -892,6 +913,17 @@ pub async fn get_thread_replies(
              SELECT COUNT(*) AS cnt FROM messages r \
              WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
          ) rc ON true \
+         LEFT JOIN LATERAL ( \
+             SELECT json_agg(json_build_object( \
+                 'message_id', r.message_id, \
+                 'user_id', r.user_id, \
+                 'username', rxu.username, \
+                 'emoji', r.emoji \
+             )) AS reactions \
+             FROM reactions r \
+             JOIN users rxu ON rxu.id = r.user_id \
+             WHERE r.message_id = m.id \
+         ) rx ON true \
          WHERE m.reply_to_id = $1 \
            AND m.conversation_id = $2 \
            AND m.deleted_at IS NULL \

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -873,6 +873,7 @@ pub async fn get_thread_replies(
     pool: &PgPool,
     parent_message_id: Uuid,
     conversation_id: Uuid,
+    before: Option<chrono::DateTime<chrono::Utc>>,
     limit: i64,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
     sqlx::query_as::<_, MessageWithSender>(
@@ -894,11 +895,13 @@ pub async fn get_thread_replies(
          WHERE m.reply_to_id = $1 \
            AND m.conversation_id = $2 \
            AND m.deleted_at IS NULL \
+           AND ($3::timestamptz IS NULL OR m.created_at < $3) \
          ORDER BY m.created_at ASC \
-         LIMIT $3",
+         LIMIT $4",
     )
     .bind(parent_message_id)
     .bind(conversation_id)
+    .bind(before)
     .bind(limit)
     .fetch_all(pool)
     .await

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -110,6 +110,11 @@ pub struct MessageDto {
     pub reply_to_content: Option<String>,
     pub reply_to_username: Option<String>,
     pub reply_count: i64,
+    /// Reactions on this message: array of
+    /// `{message_id, user_id, username, emoji}`.  Aggregated by the DB
+    /// query so history reloads render reactions immediately instead of
+    /// silently dropping them until the next WS reaction-update event.
+    pub reactions: serde_json::Value,
 }
 
 impl From<db::messages::MessageWithSender> for MessageDto {
@@ -131,6 +136,10 @@ impl From<db::messages::MessageWithSender> for MessageDto {
             reply_to_content: m.reply_to_content,
             reply_to_username: m.reply_to_username,
             reply_count: m.reply_count,
+            reactions: m
+                .reactions
+                .map(|j| j.0)
+                .unwrap_or_else(|| serde_json::json!([])),
         }
     }
 }

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -474,6 +474,10 @@ pub async fn edit_message(
 #[derive(Debug, Deserialize)]
 pub struct ThreadRepliesQuery {
     pub limit: Option<i64>,
+    /// Optional cursor for pagination: return only replies whose
+    /// `created_at < before`.  Without this, threads with more than
+    /// `limit` replies (default 50, max 100) silently truncate.
+    pub before: Option<DateTime<Utc>>,
 }
 
 pub async fn get_thread_replies(
@@ -508,9 +512,15 @@ pub async fn get_thread_replies(
     let limit = params.limit.unwrap_or(50).min(100);
     // Scope to the parent's conversation so cross-conversation replies cannot
     // leak content across DMs.
-    let replies = db::messages::get_thread_replies(&state.pool, message_id, conversation_id, limit)
-        .await
-        .db_ctx("get_thread_replies/fetch")?;
+    let replies = db::messages::get_thread_replies(
+        &state.pool,
+        message_id,
+        conversation_id,
+        params.before,
+        limit,
+    )
+    .await
+    .db_ctx("get_thread_replies/fetch")?;
 
     Ok(Json(replies))
 }


### PR DESCRIPTION
## Summary

Three more bugs found while continuing the Big Data Test Group stress audit on prod.

### \`fb10596\` Reactions invisible after page reload
**This is a P1 product bug, not just stress-state.**  \`MessageDto\` and the underlying \`MessageWithSender\` query had no \`reactions\` field — historical message-list and thread-replies responses simply omitted them. So reactions only ever showed up if the user happened to be connected via WebSocket when somebody clicked the picker; reload the conversation and every reaction silently vanished.

Fixed: both \`get_messages\` and \`get_thread_replies\` now \`LEFT JOIN LATERAL\` over the \`reactions\` table and aggregate as a JSON array of \`{message_id, user_id, username, emoji}\` objects.  \`MessageDto\` exposes them; client's existing \`Reaction.fromJson\` already accepts that shape.  WS replay path (\`get_undelivered\`) is intentionally left alone — reactions on offline-replay messages get rebroadcast independently.

### \`c76ce00\` Thread-replies endpoint silently ignores \`?before=\`
Pagination on \`/api/messages/{id}/replies\` returned the same first page no matter what \`before\` value was passed.  Server's \`ThreadRepliesQuery\` only had \`limit\`; the SQL had no cursor predicate.  For threads ≤100 replies the bug was invisible, but anything bigger silently truncated.

Fixed: query gains \`before: Option<DateTime<Utc>>\` and \`db::messages::get_thread_replies\` adds \`AND ($3::timestamptz IS NULL OR m.created_at < $3)\`.  Mirrors the conversation-messages cursor shape so existing client wiring will work after a follow-up to thread_view_panel.

### \`87a292d\` Compact-mode hover overlay parks on far right of the chat
In compact / plain layouts every message is left-aligned regardless of sender, but the hover-overlay anchor used \`isMine ? right:0 : left:36\` — for the user's own messages in compact, that anchored the overlay to the far right of the entire chat width, well away from the actual bubble.  Hover-timestamp had the same problem.

Fixed: anchor by **bubble side**, not \`isMine\`.  \`bubbleOnRight = isMine && !widget.compactLayout\` — only true when the bubble is actually flush right.

## Test plan
- [ ] Open the Big Data Test Group, reload the page, scroll to a reaction-heavy message — reactions should now appear without needing live WS push
- [ ] Scroll to the 100-reply thread parent, open it — confirm replies render normally (server fix is defensive; client thread view doesn't yet paginate)
- [ ] Switch Settings → Appearance → Layout → Compact, hover a message you sent — overlay should appear directly above your message, not on the far right
- [ ] Toggle back to Bubbles layout, hover a sent message — overlay still anchors to the right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)