### PR TITLE
fix(server): MessageWithSender row contract + thread pagination order

### DIFF
--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -39,10 +39,12 @@ pub struct MessageWithSender {
     pub reply_count: i64,
     /// Reactions aggregated as a JSON array of
     /// `{message_id, user_id, username, emoji}` objects.  Public history
-    /// queries (`get_messages`, `get_thread_replies`) populate this so the
-    /// client can render reactions on history reload; the WS replay path
-    /// (`get_undelivered`) leaves it as `Null` because reactions are
-    /// rebroadcast independently over WebSocket.
+    /// queries (`get_messages`, `get_thread_replies`) populate this with
+    /// a real LATERAL aggregate so the client can render reactions on
+    /// history reload.  Other queries (`search_messages`,
+    /// `get_undelivered`) include `'[]'::json AS reactions` to satisfy
+    /// the FromRow contract -- sqlx requires every struct field to map
+    /// to a column in the row.
     #[serde(default)]
     pub reactions: Option<sqlx::types::Json<serde_json::Value>>,
 }
@@ -316,7 +318,8 @@ pub async fn get_undelivered(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.reply_count, 0) AS reply_count \
+                COALESCE(rc.reply_count, 0) AS reply_count, \
+                '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
@@ -542,7 +545,8 @@ pub async fn search_messages(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.cnt, 0) AS reply_count \
+                COALESCE(rc.cnt, 0) AS reply_count, \
+                '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
@@ -928,7 +932,7 @@ pub async fn get_thread_replies(
            AND m.conversation_id = $2 \
            AND m.deleted_at IS NULL \
            AND ($3::timestamptz IS NULL OR m.created_at < $3) \
-         ORDER BY m.created_at ASC \
+         ORDER BY m.created_at DESC \
          LIMIT $4",
     )
     .bind(parent_message_id)


### PR DESCRIPTION
## Summary

Follow-up to PR #824. The reactions field I added to \`MessageWithSender\` broke two queries that did not include the column, and thread-replies' ASC ordering made \`?before=\` useless for pagination.

### Bugs found while testing locally
1. \`search_messages\` returned **HTTP 500 "Database error"** — sqlx's \`FromRow\` requires every struct field to map to a column; adding \`reactions\` to \`MessageWithSender\` broke search.
2. \`get_undelivered\` (WS replay path) had the same vulnerability — not surfaced because it isn't user-callable directly, but the next reconnect would have crashed.
3. Thread-replies \`?before=\` was honored at the SQL level (PR #824 added it) but with \`ORDER BY ASC\` the cursor walks **toward older messages from a known cursor**, which doesn't compose with "load page 2" UX. First page gave the oldest 50, then \`before=oldest\` of-page-1 returned the same 49 again.

### Fixes
- \`search_messages\` and \`get_undelivered\` now include \`'[]'::json AS reactions\` in their SELECT to satisfy the \`MessageWithSender\` row contract. They don't aggregate real reactions because that work is wasted on those code paths (search hits don't need pill counts; WS replay rebroadcasts reaction events independently).
- Thread-replies query order flipped from ASC to DESC, matching the conversation-messages endpoint. Page 1 = newest 50; \`?before=oldest_of_page_1\` correctly returns the next-older 50. Verified end-to-end against the local stress group: page 1 returns replies #100→#51, page 2 returns #50→#1, 100 unique IDs across both pages.

## Test plan
- [ ] After deploy, \`GET /api/conversations/{id}/search?q=…\` returns 200 (was 500 before)
- [ ] \`GET /api/messages/{parent}/replies?limit=50\` followed by \`?limit=50&before=<oldest_ts>\` walks back across the full thread
- [ ] WS reconnect with undelivered backlog completes without "ColumnNotFound" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)