### PR TITLE
feat(server,client): server-side mention persistence

### DIFF
--- a/apps/client/lib/src/models/conversation.dart
+++ b/apps/client/lib/src/models/conversation.dart
@@ -92,6 +92,12 @@ class Conversation {
       lastMessageTimestamp: lastMsgTimestamp,
       lastMessageSender: lastMsgSender,
       unreadCount: json['unread_count'] as int? ?? 0,
+      // mention_count is populated by the server from the `mentions` table
+      // joined against this user's read_receipt; it survives a refresh.
+      // Old/legacy responses without the field default to 0 -- that's fine,
+      // the next WS message bump or the next /api/conversations fetch fills
+      // it in.
+      mentionCount: json['mention_count'] as int? ?? 0,
       isMuted: json['is_muted'] as bool? ?? false,
       isPinned: json['is_pinned'] as bool? ?? false,
       ttlSeconds:

--- a/apps/server/migrations/20260509000000_mentions.sql
+++ b/apps/server/migrations/20260509000000_mentions.sql
@@ -1,0 +1,26 @@
+-- Server-side mention persistence (#451 follow-up).
+--
+-- Each row records that `mentioned_user_id` was mentioned in `message_id`.
+-- The `list_conversations` query joins this against `read_receipts` to
+-- compute an unread mention count per (user, conversation) so the badge
+-- survives a refresh.  Client-side mention detection on incoming WS
+-- messages still drives the optimistic in-flight bump; this table is the
+-- source of truth on reload.
+--
+-- Encrypted groups skip server-side detection -- the server never sees
+-- plaintext, so mentions of `@<user>` / `@everyone` / `@here` cannot be
+-- extracted there.  For those conversations the client-side count remains
+-- best-effort and resets on refresh until per-recipient device crypto
+-- carries mention metadata in the envelope (separate slice).
+
+CREATE TABLE IF NOT EXISTS mentions (
+    message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    mentioned_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    PRIMARY KEY (message_id, mentioned_user_id)
+);
+
+-- Reverse-lookup index for the `list_conversations` query: counts
+-- mentions per recipient per message-set scoped by conversation, so the
+-- access pattern is (user_id, message_id) -> exists.
+CREATE INDEX IF NOT EXISTS idx_mentions_user
+    ON mentions (mentioned_user_id, message_id);

--- a/apps/server/src/db/mentions.rs
+++ b/apps/server/src/db/mentions.rs
@@ -1,0 +1,234 @@
+//! Server-side mention persistence.
+//!
+//! When a plaintext message is stored we scan the body for `@<username>`
+//! tokens that match a current member of the conversation, plus the
+//! broadcast keywords `@everyone` and `@here`.  Each match becomes one
+//! row in the `mentions` table keyed by `(message_id, mentioned_user_id)`.
+//! The `list_conversations` query joins these rows against the user's
+//! `read_receipts` row to compute an unread mention count that survives
+//! a page refresh -- the client previously bumped the badge in-memory
+//! only, so any reload reset it to zero.
+//!
+//! Encrypted-group messages skip this entirely: the server never sees
+//! plaintext, so the badge for those conversations remains a best-effort
+//! client-side signal until per-recipient envelopes carry mention
+//! metadata (separate slice).
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Word-boundary check identical in spirit to the client's
+/// `containsMention`: the keyword is a standalone token if its left and
+/// right neighbours are start/end-of-string or non-word characters
+/// (anything other than `[A-Za-z0-9_]`).  Case-insensitive.
+fn is_standalone_keyword(content: &str, keyword: &str) -> bool {
+    if keyword.is_empty() {
+        return false;
+    }
+    if !content.contains('@') {
+        return false;
+    }
+    let target = format!("@{}", keyword.to_lowercase());
+    let lower = content.to_lowercase();
+    let mut start = 0;
+    while let Some(rel) = lower[start..].find(&target) {
+        let abs = start + rel;
+        let after = abs + target.len();
+        let left_ok = abs == 0
+            || !lower[..abs]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        let right_ok = after == lower.len()
+            || !lower[after..]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if left_ok && right_ok {
+            return true;
+        }
+        start = abs + target.len();
+    }
+    false
+}
+
+/// Extract `@<username>` tokens from `content`, normalised lowercase.
+/// Returns the de-duplicated set of mentioned usernames.  Pure function;
+/// the DB lookup against the conversation's member roster happens in
+/// [`extract_and_persist`].
+fn extract_at_usernames(content: &str) -> Vec<String> {
+    if !content.contains('@') {
+        return Vec::new();
+    }
+    let mut out: Vec<String> = Vec::new();
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'@' {
+            i += 1;
+            continue;
+        }
+        // Boundary on the left: start-of-string or non-word.
+        let left_ok = i == 0
+            || !content[..i]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if !left_ok {
+            i += 1;
+            continue;
+        }
+        // Read [A-Za-z0-9_]+ token after `@`.
+        let token_start = i + 1;
+        let mut token_end = token_start;
+        while token_end < bytes.len() {
+            let c = bytes[token_end];
+            let word = c.is_ascii_alphanumeric() || c == b'_';
+            if !word {
+                break;
+            }
+            token_end += 1;
+        }
+        if token_end > token_start {
+            let token = content[token_start..token_end].to_lowercase();
+            // Skip the broadcast keywords -- those are scanned separately
+            // and resolved against the full membership roster, not by
+            // username match.
+            if token != "everyone" && token != "here" && !out.contains(&token) {
+                out.push(token);
+            }
+        }
+        i = token_end.max(i + 1);
+    }
+    out
+}
+
+/// Insert mention rows for `message_id` in conversation `conv_id`.
+///
+/// Resolves `@<username>` tokens against the conversation's member list
+/// (excluding the sender, who can't mention themselves) and includes
+/// every member when `@everyone` or `@here` appears.  Idempotent: rows
+/// conflict on the composite primary key and the second insert is a no-op.
+///
+/// Returns the number of rows inserted on this call.  Errors are
+/// propagated; callers typically log and continue so a mention-table
+/// failure never blocks the actual message send.
+pub async fn extract_and_persist(
+    pool: &PgPool,
+    message_id: Uuid,
+    conversation_id: Uuid,
+    sender_id: Uuid,
+    content: &str,
+) -> Result<usize, sqlx::Error> {
+    let usernames = extract_at_usernames(content);
+    let mentions_everyone = is_standalone_keyword(content, "everyone");
+    let mentions_here = is_standalone_keyword(content, "here");
+
+    if usernames.is_empty() && !mentions_everyone && !mentions_here {
+        return Ok(0);
+    }
+
+    // Resolve to user_ids.  For broadcast keywords we pull every member;
+    // for `@<username>` we pull only matching members.  In either case
+    // the sender is filtered out client-side below.
+    let mut targets: Vec<Uuid> = Vec::new();
+
+    if mentions_everyone || mentions_here {
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT cm.user_id FROM conversation_members cm \
+             WHERE cm.conversation_id = $1 AND cm.is_removed = false",
+        )
+        .bind(conversation_id)
+        .fetch_all(pool)
+        .await?;
+        targets.extend(rows.into_iter().map(|(uid,)| uid));
+    }
+
+    if !usernames.is_empty() {
+        // Lowercase comparison so capitalisation in the message doesn't
+        // gate detection.  `username` itself is canonically lowercase by
+        // registration validation, but we still LOWER() defensively.
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            "SELECT cm.user_id FROM conversation_members cm \
+             JOIN users u ON u.id = cm.user_id \
+             WHERE cm.conversation_id = $1 \
+               AND cm.is_removed = false \
+               AND LOWER(u.username) = ANY($2::text[])",
+        )
+        .bind(conversation_id)
+        .bind(&usernames)
+        .fetch_all(pool)
+        .await?;
+        targets.extend(rows.into_iter().map(|(uid,)| uid));
+    }
+
+    // Drop the sender (a self-mention should not bump their own badge)
+    // and de-dupe across the broadcast / explicit paths.
+    targets.retain(|uid| *uid != sender_id);
+    targets.sort_unstable();
+    targets.dedup();
+
+    if targets.is_empty() {
+        return Ok(0);
+    }
+
+    // Build `INSERT ... VALUES (..), (..)` with ON CONFLICT DO NOTHING.
+    // Using UNNEST here lets us bind a single array parameter.
+    let inserted = sqlx::query(
+        "INSERT INTO mentions (message_id, mentioned_user_id) \
+         SELECT $1, uid FROM UNNEST($2::uuid[]) AS t(uid) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(message_id)
+    .bind(&targets)
+    .execute(pool)
+    .await?;
+
+    Ok(inserted.rows_affected() as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_simple_username() {
+        assert_eq!(extract_at_usernames("hi @alice"), vec!["alice"]);
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(
+            extract_at_usernames("@Alice and @BOB"),
+            vec!["alice", "bob"]
+        );
+    }
+
+    #[test]
+    fn skips_broadcast_keywords() {
+        assert!(extract_at_usernames("@everyone @here").is_empty());
+    }
+
+    #[test]
+    fn requires_word_boundary_left() {
+        // Email-like patterns must not be parsed as mentions.
+        assert!(extract_at_usernames("ping me at me@host").is_empty());
+    }
+
+    #[test]
+    fn empty_for_no_at() {
+        assert!(extract_at_usernames("hello world").is_empty());
+    }
+
+    #[test]
+    fn dedupes_repeated_mentions() {
+        assert_eq!(extract_at_usernames("@alice @alice @alice"), vec!["alice"]);
+    }
+
+    #[test]
+    fn detects_broadcast_keyword() {
+        assert!(is_standalone_keyword("@everyone get in", "everyone"));
+        assert!(is_standalone_keyword("ping @here", "here"));
+        assert!(!is_standalone_keyword("@hereafter", "here"));
+    }
+}

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -4,6 +4,7 @@ pub mod contacts;
 pub mod groups;
 pub mod keys;
 pub mod media;
+pub mod mentions;
 pub mod messages;
 pub mod password_reset;
 pub mod push_tokens;

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -72,6 +72,14 @@ pub struct ConversationListItem {
     pub members: Vec<MemberInfo>,
     pub last_message: Option<LastMessageInfo>,
     pub unread_count: i64,
+    /// Unread mentions of this user (server-side, persistent across
+    /// refresh).  Computed from the `mentions` table joined against the
+    /// user's `read_receipts` row using the same `created_at >
+    /// last_read_at` predicate as `unread_count`, so marking the
+    /// conversation as read clears mentions in the same step.  Encrypted
+    /// groups always report 0 here -- the server can't see plaintext, so
+    /// no rows are inserted; their badge stays client-side-only.
+    pub mention_count: i64,
     pub is_pinned: bool,
 }
 
@@ -158,6 +166,7 @@ struct ConversationFullRow {
     members_json: Option<serde_json::Value>,
     last_message_json: Option<serde_json::Value>,
     unread_count: i64,
+    mention_count: i64,
     is_pinned: bool,
 }
 
@@ -211,6 +220,18 @@ pub async fn list_conversations(
               AND m2.deleted_at IS NULL \
               AND m2.created_at > COALESCE(rc.last_read_at, '1970-01-01'::timestamptz) \
             GROUP BY m2.conversation_id \
+        ), \
+        mention_cte AS ( \
+            SELECT m3.conversation_id, COUNT(*) AS mention_count \
+            FROM messages m3 \
+            JOIN mentions mt ON mt.message_id = m3.id \
+            JOIN user_convs uc2 ON uc2.conversation_id = m3.conversation_id \
+            LEFT JOIN read_cte rc2 ON rc2.conversation_id = m3.conversation_id \
+            WHERE mt.mentioned_user_id = $1 \
+              AND m3.sender_id != $1 \
+              AND m3.deleted_at IS NULL \
+              AND m3.created_at > COALESCE(rc2.last_read_at, '1970-01-01'::timestamptz) \
+            GROUP BY m3.conversation_id \
         ) \
         SELECT \
             c.id AS conversation_id, \
@@ -231,6 +252,7 @@ pub async fn list_conversations(
                  ELSE NULL \
             END AS last_message_json, \
             COALESCE(urc.unread_count, 0) AS unread_count, \
+            COALESCE(mnc.mention_count, 0) AS mention_count, \
             EXISTS( \
                 SELECT 1 FROM pinned_conversations pc \
                 WHERE pc.user_id = $1 AND pc.conversation_id = c.id \
@@ -240,6 +262,7 @@ pub async fn list_conversations(
         LEFT JOIN members_cte mc ON mc.conversation_id = c.id \
         LEFT JOIN last_msg_cte lm ON lm.conversation_id = c.id \
         LEFT JOIN unread_cte urc ON urc.conversation_id = c.id \
+        LEFT JOIN mention_cte mnc ON mnc.conversation_id = c.id \
         ORDER BY lm.created_at DESC NULLS LAST \
         LIMIT 50",
     )
@@ -274,6 +297,7 @@ pub async fn list_conversations(
             members,
             last_message,
             unread_count: row.unread_count,
+            mention_count: row.mention_count,
             is_pinned: row.is_pinned,
         });
     }

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -307,6 +307,7 @@ pub(super) async fn handle_send_message(
         reply_to_id,
         &recipient_device_contents,
         ttl_seconds,
+        conv_security.is_encrypted,
     )
     .await
     else {
@@ -358,6 +359,7 @@ pub(super) async fn store_and_confirm(
     reply_to_id: Option<Uuid>,
     recipient_device_contents: &Option<RecipientDeviceContents>,
     ttl_seconds: Option<i64>,
+    is_encrypted: bool,
 ) -> Option<db::messages::MessageRow> {
     // Resolve TTL: use per-message override first, then fall back to conversation setting.
     // Clamp to valid range: 5 seconds to 1 year. Reject non-positive values.
@@ -406,6 +408,30 @@ pub(super) async fn store_and_confirm(
             return None;
         }
     };
+
+    // Persist mentions for plaintext groups (#451 follow-up).  Encrypted
+    // groups skip this -- the canonical content here is ciphertext, so
+    // there's nothing to scan; their mention badges remain client-side.
+    // Errors are logged and swallowed so a mention-table hiccup never
+    // blocks the actual send.
+    if !is_encrypted {
+        match db::mentions::extract_and_persist(&state.pool, stored.id, conv_id, sender_id, content)
+            .await
+        {
+            Ok(0) => {}
+            Ok(n) => tracing::debug!(
+                message_id = %stored.id,
+                conversation_id = %conv_id,
+                count = n,
+                "persisted mentions"
+            ),
+            Err(e) => tracing::error!(
+                message_id = %stored.id,
+                conversation_id = %conv_id,
+                "failed to persist mentions: {e:?}"
+            ),
+        }
+    }
 
     // Store per-device ciphertexts if present. Per-user device IDs collide
     // across users, so each entry is keyed by (recipient_user_id, device_id).


### PR DESCRIPTION
## Summary

Mention badges previously lived in client memory only — refresh the page and they vanished. Roadmap Phase 1 explicitly calls this out as a follow-up:

> Mention badge ships as a *client-side-only* signal — refresh resets it. Server-side persistence and unread-count are a separate slice.

This is that slice.

### Schema
\`migrations/20260509000000_mentions.sql\` adds a \`mentions(message_id, mentioned_user_id)\` join table with an index on \`(mentioned_user_id, message_id)\`.

### Server flow
1. \`db::mentions::extract_and_persist\` scans message content for \`@<username>\` tokens (resolved against the conversation roster) and the broadcast keywords \`@everyone\` / \`@here\` (resolved to the full member list). Sender is filtered. Word-boundary matching mirrors the client's \`containsMention\` and the existing \`mentions_broadcast\` helper.
2. \`store_and_confirm\` (WS handler) calls \`extract_and_persist\` after the message is persisted, only for plaintext conversations. Encrypted groups skip — the canonical content there is ciphertext, so there's nothing to scan; their badge stays client-side until per-recipient envelopes carry mention metadata (separate slice).
3. \`list_conversations\` SQL gains a \`mention_cte\` that JOINs \`mentions\` on \`messages\`, filters by \`mentioned_user_id = $1\` and the same \`created_at > last_read_at\` predicate as \`unread_count\`. Result surfaces as \`mention_count\` on each \`ConversationListItem\`. Mark-as-read clears mentions in the same step (no separate write needed).

Errors during mention extraction are logged and swallowed so a hiccup in the mention table never blocks the actual message send.

### Client flow
\`Conversation.fromJson\` now reads \`mention_count\` from the server response. Optimistic in-flight bump on WS receive (\`containsMention\` + \`mentionCount + 1\`) is unchanged — the next \`/api/conversations\` fetch reconciles to the server count.

### Verified end-to-end on local stress group
- \`@stress_alice mention test\` → alice's \`mention_count\` flips 0 → 1
- \`@everyone heads up\` → bumped 1 → 2 (broadcast pulls every non-sender member)
- \`POST /api/conversations/{id}/read\` → mentions clear to 0 alongside unread

### Tests
\`db::mentions::tests\` covers the pure extractor: simple username, case-insensitive, broadcast-skip, word-boundary left rejection (rejects \`me@host\` patterns), dedupe, and broadcast keyword detection. 7 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)