### PR TITLE
fix(server): four bugs from continued correctness audit

### DIFF
--- a/apps/server/src/db/reactions.rs
+++ b/apps/server/src/db/reactions.rs
@@ -51,14 +51,23 @@ pub async fn remove_reaction(
 }
 
 /// Get the conversation_id for a given message.
+///
+/// Rejects soft-deleted messages so callers (add_reaction, remove_reaction)
+/// can't keep building reaction state on a message the user has explicitly
+/// removed.  Without this filter, a stale client cursor would happily add
+/// 💯 to a tombstone, and the row would surface again the moment the
+/// `deleted_at IS NULL` filter on history queries is bypassed.
 pub async fn get_message_conversation_id(
     pool: &PgPool,
     message_id: Uuid,
 ) -> Result<Option<Uuid>, sqlx::Error> {
-    let row: Option<(Uuid,)> = sqlx::query_as("SELECT conversation_id FROM messages WHERE id = $1")
-        .bind(message_id)
-        .fetch_optional(pool)
-        .await?;
+    let row: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT conversation_id FROM messages \
+         WHERE id = $1 AND deleted_at IS NULL",
+    )
+    .bind(message_id)
+    .fetch_optional(pool)
+    .await?;
     Ok(row.map(|(id,)| id))
 }
 

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -954,8 +954,11 @@ pub async fn upload_group_avatar(
         .await
         .map_err(|e| AppError::bad_request(format!("Invalid multipart data: {e}")))?
     {
+        // Accept either "avatar" (historical) or "file" (matches the
+        // /api/media/upload convention used by the seed scripts and most
+        // generic upload pickers).
         let field_name = field.name().unwrap_or_default().to_string();
-        if field_name != "avatar" {
+        if field_name != "avatar" && field_name != "file" {
             continue;
         }
 
@@ -1016,7 +1019,7 @@ pub async fn upload_group_avatar(
     }
 
     Err(AppError::bad_request(
-        "Missing 'avatar' field in multipart form data",
+        "Missing avatar in multipart form data (expected field name 'avatar' or 'file')",
     ))
 }
 

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -442,7 +442,10 @@ pub async fn edit_message(
     Path(message_id): Path<Uuid>,
     Json(body): Json<EditMessageRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    if body.content.is_empty() {
+    // Reject empty *and* whitespace-only edits.  Without the trim, a
+    // user could replace a real message with `"   "` and surface a
+    // blank bubble in the timeline.
+    if body.content.trim().is_empty() {
         return Err(AppError::bad_request("Content cannot be empty"));
     }
     if body.content.len() > 10_000 {

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -627,8 +627,13 @@ pub async fn upload_avatar(
         .await
         .map_err(|e| AppError::bad_request(format!("Invalid multipart data: {e}")))?
     {
+        // Accept either "avatar" (historical) or "file" (matches the
+        // /api/media/upload convention used by the seed scripts and most
+        // generic upload pickers).  Mismatch was returning a confusing
+        // "Missing 'avatar' field in multipart form data" even when a
+        // perfectly valid PNG was attached under the wrong field name.
         let field_name = field.name().unwrap_or_default().to_string();
-        if field_name != "avatar" {
+        if field_name != "avatar" && field_name != "file" {
             continue;
         }
 
@@ -690,7 +695,7 @@ pub async fn upload_avatar(
     }
 
     Err(AppError::bad_request(
-        "Missing 'avatar' field in multipart form data",
+        "Missing avatar in multipart form data (expected field name 'avatar' or 'file')",
     ))
 }
 

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -52,8 +52,21 @@ pub(super) fn is_valid_ciphertext_shape(b64: &str) -> bool {
     false
 }
 
-/// Validate that the message content does not exceed the maximum length.
+/// Validate that the message content is non-empty (after trimming) and
+/// does not exceed the maximum length.  REST edit already rejects empty
+/// strings; the WS path didn't, which let clients persist a whitespace-
+/// only message that surfaced as a blank bubble in the timeline.
+///
+/// Trim-emptiness only applies to the *plaintext* path -- encrypted
+/// conversations carry base64-encoded ciphertext that starts with magic
+/// bytes (`0xEC 0x01/0x02` or a 4-byte LE header_len of 40), so the
+/// canonical content is never empty there.  We still gate it through a
+/// trim because base64 of a real ciphertext doesn't whitespace-out.
 pub(super) fn validate_message_length(state: &AppState, sender_id: Uuid, content: &str) -> bool {
+    if content.trim().is_empty() {
+        send_error(state, sender_id, "Content cannot be empty");
+        return false;
+    }
     if content.len() > MAX_MESSAGE_LENGTH {
         send_error(
             state,

--- a/docs/ux-roadmap.md
+++ b/docs/ux-roadmap.md
@@ -119,9 +119,11 @@ their owning files are touched.
 
 ## Phase 1 — Sidebar state hierarchy
 
-**Status:** shipped. Mention badge ships as a *client-side-only* signal
-(see "Out of scope / follow-ups" below); the rest of the deltas land in
-the same PR as Phase 0b.
+**Status:** shipped. Server-side mention persistence landed as a
+follow-up — the badge now survives a refresh for plaintext groups
+(encrypted-group mentions remain client-side only because the server
+can't see ciphertext content).  The rest of the Phase 1 deltas
+shipped alongside Phase 0b.
 
 **Goal:** Unread / muted / mentioned / active conversations are
 distinguishable in <100ms of glance, not after parsing color and font
@@ -165,13 +167,14 @@ low-risk, and unblocks every future onboarding / churn discussion.
 
 **Out of scope / follow-ups:**
 
-- **Server-side mention persistence.** The shipped mention badge is
-  derived client-side: when a `new_message` arrives, the WS handler
-  scans the decrypted plaintext for `@<myUsername>`, `@everyone`, or
-  `@here` and increments `Conversation.mentionCount` (a
-  client-state-only field). `markAsRead` clears it. Multi-device sync
-  of "you have mentions waiting" requires a server column + API
-  change — deferred until needed.
+- ~~**Server-side mention persistence.**~~ Shipped 2026-05-09: a
+  `mentions(message_id, mentioned_user_id)` table is populated when a
+  plaintext message is stored, and `list_conversations` joins it
+  against the user's read receipt to produce a `mention_count` that
+  survives a refresh. Encrypted groups still rely on client-side
+  detection because the server never sees plaintext there — that
+  follow-up will need per-recipient envelopes to carry mention
+  metadata.
 - Full sidebar redesign (server list, channel tree).
 - Nav rework (top bar, search, profile menu).
 - Mobile-specific tweaks.


### PR DESCRIPTION
## Summary

Four more server bugs found while auditing the message / reaction / avatar / edit endpoints against the stress dataset.

### \`a1b23d9\` Reactions could be added to soft-deleted messages
\`db::reactions::get_message_conversation_id\` looked up the message without filtering on \`deleted_at IS NULL\`. A user could fire \`POST /api/messages/{deleted_id}/reactions\` and the server happily inserted a row keyed off a tombstone. The reaction never surfaced (since history queries filter \`deleted_at\`), but it bloated the table and would leak if anyone bypassed the filter. Fix adds the same \`deleted_at IS NULL\` predicate the rest of the message lookups use; reaction add/remove now returns 400 "Message not found" on a soft-deleted parent, matching reply / pin behavior.

### \`a1b23d9\` Avatar upload field-name mismatch
\`PUT /api/users/me/avatar\` only accepted multipart field name \`avatar\`. Seed scripts and most generic upload pickers send \`file\` -- mismatch returned a confusing "Missing 'avatar' field in multipart form data" even when the PNG was perfectly valid. Now accepts either \`avatar\` or \`file\`; error message updated to spell out both.

### \`cfb3c38\` Group avatar had the same field-name bug
\`PUT /api/groups/{id}/avatar\` shares the same multipart shape and same field-name gate as user avatar. Mirrored the fix.

### \`0ca58a2\` Empty + whitespace-only messages bypassed validation
- WS \`send_message\` accepted \`""\` and \`"   "\` and persisted them as blank bubbles in the timeline (REST edit already rejected empty, but not whitespace-only).
- \`PUT /api/messages/{id}\` rejected empty but accepted \`"   "\`.

\`validate_message_length\` (WS path) gains a \`content.trim().is_empty()\` guard. \`edit_message\` (REST path) switched its empty check from \`is_empty()\` to \`trim().is_empty()\`. Both paths now return "Content cannot be empty" for either input.

## Test plan
- [ ] After deploy, verify on prod: reaction add to a deleted message returns 400; avatar upload with \`-F file=@x.png\` succeeds; sending empty / "   " content returns "Content cannot be empty"
- [ ] Run the existing integration tests (reaction-scope, message-edit) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)