### PR TITLE
refactor(client): chat + websocket provider migrations + message_item leaf splits

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart' as http;
-
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../models/chat_message.dart';
 import '../models/reaction.dart';
@@ -16,6 +15,8 @@ import '../utils/crypto_utils.dart';
 import 'auth_provider.dart';
 import 'conversations_provider.dart';
 import 'server_url_provider.dart';
+
+part 'chat_provider.g.dart';
 
 /// Placeholder content strings emitted by ws_message_handler.dart while a
 /// message is awaiting decryption.  When [ChatState.withMessage] sees an
@@ -169,14 +170,24 @@ class ChatState {
 /// Maximum messages retained per conversation to bound memory usage.
 const _maxMessagesPerConv = 500;
 
-class ChatNotifier extends StateNotifier<ChatState> {
-  final Ref ref;
-
+@Riverpod(keepAlive: true)
+class Chat extends _$Chat {
   /// Timers that transition pending messages to failed after 15 seconds
   /// without server confirmation.
   final Map<String, Timer> _sendTimeouts = {};
 
-  ChatNotifier(this.ref) : super(const ChatState());
+  @override
+  ChatState build() {
+    // Cancel any pending send-timeout timers when this notifier is
+    // disposed (mirrors the legacy `dispose()` override).
+    ref.onDispose(() {
+      for (final timer in _sendTimeouts.values) {
+        timer.cancel();
+      }
+      _sendTimeouts.clear();
+    });
+    return const ChatState();
+  }
 
   String get _serverUrl => ref.read(serverUrlProvider);
 
@@ -933,26 +944,15 @@ class ChatNotifier extends StateNotifier<ChatState> {
     await sender(forwarded);
   }
 
+  /// Reset all in-memory state.  Used on logout / account switch.
+  /// (`build()`'s `ref.onDispose` already covers timer teardown when
+  /// the provider itself is disposed; this method handles "stay
+  /// alive but clear" semantics.)
   void clear() {
-    // Cancel all pending send-timeout timers to prevent orphaned callbacks.
     for (final timer in _sendTimeouts.values) {
       timer.cancel();
     }
     _sendTimeouts.clear();
     state = const ChatState();
   }
-
-  @override
-  void dispose() {
-    // Cancel any remaining timers so they don't fire after disposal.
-    for (final timer in _sendTimeouts.values) {
-      timer.cancel();
-    }
-    _sendTimeouts.clear();
-    super.dispose();
-  }
 }
-
-final chatProvider = StateNotifierProvider<ChatNotifier, ChatState>((ref) {
-  return ChatNotifier(ref);
-});

--- a/apps/client/lib/src/providers/chat_provider.g.dart
+++ b/apps/client/lib/src/providers/chat_provider.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$chatHash() => r'29f82287a3528cfdc19a7fb979c64d2e5882b00c';
+
+/// See also [Chat].
+@ProviderFor(Chat)
+final chatProvider = NotifierProvider<Chat, ChatState>.internal(
+  Chat.new,
+  name: r'chatProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$chatHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$Chat = Notifier<ChatState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../models/chat_message.dart';
@@ -21,10 +21,10 @@ import 'ws_message_handler.dart';
 
 export 'ws_message_handler.dart' show WsMessageHandler, WebSocketState;
 
-class WebSocketNotifier extends StateNotifier<WebSocketState>
-    with WsMessageHandler {
-  @override
-  final Ref ref;
+part 'websocket_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
   WebSocketChannel? _channel;
   StreamSubscription? _subscription;
   Timer? _typingCleanupTimer;
@@ -54,29 +54,42 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
   /// Throttle: track last typing event sent per conversation.
   final Map<String, DateTime> _lastTypingSent = {};
 
-  WebSocketNotifier(this.ref) : super(const WebSocketState()) {
-    // Periodically clean up stale typing indicators
+  @override
+  WebSocketState build() {
+    // Periodically clean up stale typing indicators.
     _typingCleanupTimer = Timer.periodic(
       const Duration(seconds: 2),
       (_) => _cleanupTyping(),
     );
 
     // Re-bind the websocket whenever the active server URL changes (#PR-2).
-    // The previous code path read the URL via `ref.read` at connect time,
-    // which left the live socket pointed at the OLD origin after a switch.
-    // We listen here, in the constructor, so the subscription lasts as long
-    // as the notifier itself.
+    // We listen inside `build()`, so the subscription lasts as long as the
+    // notifier itself (matches the legacy constructor's lifetime).
     ref.listen<String>(serverUrlProvider, (previous, next) {
       if (previous == next) return;
       // Always tear down the existing socket; the old origin must not see
       // any further frames from this client.
       disconnect();
-      // Reconnect only if we still have an authenticated session. The login
+      // Reconnect only if we still have an authenticated session.  The login
       // flow will call `connect()` itself once auth completes.
       if (ref.read(authProvider).isLoggedIn) {
         connect();
       }
     });
+
+    // Mirror the legacy `dispose()` teardown.
+    ref.onDispose(() {
+      _heartbeatTimer?.cancel();
+      _heartbeatTimer = null;
+      _reconnectTimer?.cancel();
+      _reconnectTimer = null;
+      _typingCleanupTimer?.cancel();
+      _voiceSignalController.close();
+      _deviceRevokedController.close();
+      disconnect();
+    });
+
+    return const WebSocketState();
   }
 
   Stream<Map<String, dynamic>> get voiceSignals =>
@@ -710,22 +723,11 @@ class WebSocketNotifier extends StateNotifier<WebSocketState>
       state = state.copyWith(typingUsers: updatedTyping);
     }
   }
-
-  @override
-  void dispose() {
-    _heartbeatTimer?.cancel();
-    _heartbeatTimer = null;
-    _reconnectTimer?.cancel();
-    _reconnectTimer = null;
-    _typingCleanupTimer?.cancel();
-    _voiceSignalController.close();
-    _deviceRevokedController.close();
-    disconnect();
-    super.dispose();
-  }
 }
 
-final websocketProvider =
-    StateNotifierProvider<WebSocketNotifier, WebSocketState>((ref) {
-      return WebSocketNotifier(ref);
-    });
+/// Short alias matching the historical provider symbol.  Codegen names
+/// the generated provider after the class (`webSocketNotifierProvider`),
+/// but the rest of the codebase has always referenced this as
+/// `websocketProvider`; the alias avoids a cross-cutting rename that's
+/// orthogonal to the migration.
+final websocketProvider = webSocketNotifierProvider;

--- a/apps/client/lib/src/providers/websocket_provider.g.dart
+++ b/apps/client/lib/src/providers/websocket_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'websocket_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$webSocketNotifierHash() => r'c670de5d312c9a44c89622cc2416adc8f2103256';
+
+/// See also [WebSocketNotifier].
+@ProviderFor(WebSocketNotifier)
+final webSocketNotifierProvider =
+    NotifierProvider<WebSocketNotifier, WebSocketState>.internal(
+      WebSocketNotifier.new,
+      name: r'webSocketNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$webSocketNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$WebSocketNotifier = Notifier<WebSocketState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -126,8 +126,10 @@ class WebSocketState {
 ///
 /// The handler implementations are split across feature-grouped part files
 /// in `ws_handlers/` (message, typing/reaction, presence, voice, crypto).
-mixin WsMessageHandler on StateNotifier<WebSocketState> {
-  Ref get ref;
+mixin WsMessageHandler on Notifier<WebSocketState> {
+  // `ref` is provided by the parent Notifier class (codegen migration #770);
+  // the redundant getter declaration the legacy StateNotifier mixin needed
+  // is no longer required.
   StreamController<Map<String, dynamic>> get voiceSignalController;
 
   /// Broadcast of `device_revoked` events for the current user. UI surfaces

--- a/apps/client/lib/src/widgets/message/message_indicators.dart
+++ b/apps/client/lib/src/widgets/message/message_indicators.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+
+/// Small in-bubble indicators (pinned, forwarded, lock, decrypt-failure)
+/// extracted from `message_item.dart` (#refactor-2026-05-09).  Each one is
+/// a pure stateless renderer with no closure over the parent state, so
+/// callers just instantiate the widget directly inside `_bubbleChildren`.
+
+/// Pin badge shown at the top of a pinned message's bubble.
+class PinnedIndicator extends StatelessWidget {
+  final bool isMine;
+
+  const PinnedIndicator({super.key, required this.isMine});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isMine
+        ? Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.7)
+        : context.accent;
+    return Semantics(
+      label: 'Pinned message',
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.push_pin, size: 11, color: color),
+            const SizedBox(width: 3),
+            Text(
+              'Pinned',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                fontWeight: FontWeight.w500,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// "Forwarded" italic label shown when a message starts with the
+/// forward-prefix sentinel.
+class ForwardedBadge extends StatelessWidget {
+  final bool isMine;
+
+  const ForwardedBadge({super.key, required this.isMine});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isMine
+        ? Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.7)
+        : context.textMuted;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.forward, size: 12, color: color),
+          const SizedBox(width: 4),
+          Text(
+            'Forwarded',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontStyle: FontStyle.italic,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Tiny encryption-status lock shown next to a message timestamp.  Tapping
+/// it on the recipient side surfaces the identity-verification screen via
+/// [onVerifyIdentity]; sender's own lock is non-interactive.
+class LockIcon extends StatelessWidget {
+  final ChatMessage message;
+  final bool isMine;
+  final ValueChanged<ChatMessage>? onVerifyIdentity;
+
+  const LockIcon({
+    super.key,
+    required this.message,
+    required this.isMine,
+    this.onVerifyIdentity,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const icon = Padding(
+      padding: EdgeInsets.only(left: 3),
+      child: Icon(Icons.lock, size: 10, color: EchoTheme.online),
+    );
+
+    if (isMine || onVerifyIdentity == null) {
+      return icon;
+    }
+
+    return Tooltip(
+      message: 'End-to-end encrypted. Tap to verify.',
+      child: InkWell(
+        onTap: () => onVerifyIdentity!(message),
+        borderRadius: BorderRadius.circular(6),
+        child: icon,
+      ),
+    );
+  }
+}
+
+/// Soft pill shown in place of a message body when decryption fails and
+/// the user has opted to keep the row visible (#668).
+class DecryptFailurePill extends StatelessWidget {
+  const DecryptFailurePill({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Message could not be decrypted',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: context.textMuted.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.lock_outline, size: 16, color: context.textSecondary),
+            const SizedBox(width: 6),
+            Text(
+              'Message could not be decrypted',
+              style: GoogleFonts.inter(
+                fontStyle: FontStyle.italic,
+                color: context.textSecondary,
+                fontSize: 13,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/reply_count_badge.dart
+++ b/apps/client/lib/src/widgets/message/reply_count_badge.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+
+/// Tappable "X replies" pill shown beneath a message that has at least
+/// one threaded reply.  Aligns to the bubble's own side (right for
+/// "my" messages in bubbles layout, left otherwise).  Tapping fires
+/// [onTap] -- typically opens the thread view.
+class ReplyCountBadge extends StatelessWidget {
+  final ChatMessage message;
+  final bool isMine;
+  final ValueChanged<ChatMessage>? onTap;
+
+  const ReplyCountBadge({
+    super.key,
+    required this.message,
+    required this.isMine,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final count = message.replyCount;
+    final label = count == 1 ? '1 reply' : '$count replies';
+    return Padding(
+      padding: EdgeInsets.only(top: 4, left: isMine ? 0 : 36),
+      child: Align(
+        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+        child: Semantics(
+          label: 'View $label',
+          button: true,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: onTap == null ? null : () => onTap!(message),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: context.accent.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.forum_outlined, size: 12, color: context.accent),
+                    const SizedBox(width: 4),
+                    Text(
+                      label,
+                      style: GoogleFonts.inter(
+                        fontSize: 12,
+                        color: context.accent,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/retry_row.dart
+++ b/apps/client/lib/src/widgets/message/retry_row.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+
+/// Retry / delete affordance shown below a failed outbound message.
+/// Extracted from `message_item.dart` (#refactor-2026-05-09).  Either
+/// callback may be null; if both are null only the failure label
+/// renders.
+class RetryRow extends StatelessWidget {
+  final ChatMessage message;
+  final ValueChanged<ChatMessage>? onRetry;
+  final ValueChanged<ChatMessage>? onDelete;
+
+  const RetryRow({
+    super.key,
+    required this.message,
+    this.onRetry,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(top: 4, right: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: EchoTheme.danger.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: EchoTheme.danger.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          const Icon(Icons.error_rounded, size: 16, color: EchoTheme.danger),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              message.content.contains('not have been delivered')
+                  ? 'Message may not have been delivered'
+                  : 'Failed to send',
+              style: const TextStyle(
+                fontSize: 12,
+                color: EchoTheme.danger,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          if (onRetry != null) ...[
+            const SizedBox(width: 10),
+            GestureDetector(
+              onTap: () => onRetry!(message),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  color: context.accent,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  'Retry',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+          if (onDelete != null) ...[
+            const SizedBox(width: 6),
+            GestureDetector(
+              onTap: () => onDelete!(message),
+              child: Text(
+                'Delete',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  color: EchoTheme.danger.withValues(alpha: 0.8),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/sender_name_label.dart
+++ b/apps/client/lib/src/widgets/message/sender_name_label.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../models/chat_message.dart';
+import '../../providers/theme_provider.dart' show UIDensity;
+import '../../theme/echo_theme.dart';
+import '../../utils/time_utils.dart';
+import '../avatar_utils.dart' show senderLabelColor;
+
+/// Sender name shown above a group message bubble.  In compact / plain
+/// layouts the name and timestamp share a single inline row to save
+/// vertical space; in bubbles layout the name stands alone above the
+/// bubble.  Density drives the font sizes on both halves.
+class SenderNameLabel extends StatelessWidget {
+  final ChatMessage message;
+  final bool hasMedia;
+  final bool compactLayout;
+  final UIDensity density;
+
+  const SenderNameLabel({
+    super.key,
+    required this.message,
+    required this.hasMedia,
+    required this.compactLayout,
+    required this.density,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final double nameFontSize = switch (density) {
+      UIDensity.cozy => 14,
+      UIDensity.normal => 13,
+      UIDensity.compact => 12,
+    };
+    final double timestampFontSize = switch (density) {
+      UIDensity.cozy => 12,
+      UIDensity.normal => 11,
+      UIDensity.compact => 10,
+    };
+
+    final nameText = Text(
+      message.fromUsername,
+      style: GoogleFonts.inter(
+        fontSize: nameFontSize,
+        fontWeight: FontWeight.w600,
+        color: senderLabelColor(message.fromUsername),
+      ),
+    );
+
+    final padding = EdgeInsets.only(bottom: 4, left: hasMedia ? 8 : 0);
+
+    if (!compactLayout) {
+      return Padding(padding: padding, child: nameText);
+    }
+
+    return Padding(
+      padding: padding,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          nameText,
+          const SizedBox(width: 6),
+          Text(
+            formatMessageTimestamp(message.timestamp),
+            style: GoogleFonts.inter(
+              fontSize: timestampFontSize,
+              color: context.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/system_event_pill.dart
+++ b/apps/client/lib/src/widgets/message/system_event_pill.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+
+/// Centered pill shown for in-timeline system events: member joined/left,
+/// encryption key changes, voice call started, etc.  Extracted from
+/// `message_item.dart` (#refactor-2026-05-09) so the rendering logic is
+/// reusable from the thread view + saved-messages view without dragging
+/// the full MessageItem state machine.
+class SystemEventPill extends StatelessWidget {
+  final ChatMessage message;
+
+  const SystemEventPill({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 24),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: context.surface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: context.border),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                systemEventIcon(message.content),
+                size: 13,
+                color: context.textMuted,
+              ),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  message.content,
+                  style: GoogleFonts.inter(
+                    color: context.textMuted,
+                    fontSize: 11,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Pick an icon for a system-event message based on a few keyword
+/// heuristics in the rendered text.  Public so other timeline surfaces
+/// (thread view, saved messages) can mirror the same affordance.
+IconData systemEventIcon(String content) {
+  final lower = content.toLowerCase();
+  if (lower.contains('call')) {
+    return Icons.call;
+  }
+  if (lower.contains('encryption') || lower.contains('key')) {
+    return Icons.vpn_key;
+  }
+  if (lower.contains('joined') ||
+      lower.contains('left') ||
+      lower.contains('removed') ||
+      lower.contains('banned')) {
+    return Icons.group;
+  }
+  return Icons.info_outline;
+}

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -19,7 +19,7 @@ import '../utils/download_helper.dart';
 import '../utils/clipboard_image_helper.dart' show writeImageToClipboard;
 import '../utils/semantics_preview.dart';
 import '../utils/time_utils.dart';
-import 'avatar_utils.dart' show buildAvatar, avatarColor, senderLabelColor;
+import 'avatar_utils.dart' show buildAvatar, avatarColor;
 import '../services/media_cache_service.dart';
 import 'message/hover_action_button.dart';
 import 'message/link_preview_card.dart';
@@ -27,9 +27,11 @@ import 'message/media_content.dart';
 import 'message/message_status_icon.dart';
 import 'message/message_indicators.dart';
 import 'message/reaction_bar.dart';
+import 'message/reply_count_badge.dart';
 import 'message/reply_quote.dart';
 import 'message/retry_row.dart';
 import 'message/rich_text_content.dart';
+import 'message/sender_name_label.dart';
 import 'message/system_event_pill.dart';
 import 'message/youtube_embed.dart';
 
@@ -230,14 +232,6 @@ class _MessageItemState extends State<MessageItem>
     if (left.inMinutes < 60) return '${left.inMinutes}m';
     if (left.inHours < 24) return '${left.inHours}h';
     return '${left.inDays}d';
-  }
-
-  /// Sender-name label color for group messages. Uses a contrast-safe palette
-  /// against the dark recv bubble (#500); the sidebar avatar background still
-  /// uses `avatarColor`, where contrast rules differ.
-  Color _getSenderLabelColor(String userId) {
-    final name = widget.message.fromUsername;
-    return senderLabelColor(name);
   }
 
   /// Avatar background color (contrast for the avatar's white initial glyph).
@@ -1026,66 +1020,6 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  /// Build the sender name label shown above the message bubble.
-  ///
-  /// In compact layout the sender name and timestamp share a single inline
-  /// row ("Username 12:34 PM") to save vertical space. Everywhere else the
-  /// name stands alone on its own line above the bubble.
-  Widget _buildSenderNameLabel({
-    required ChatMessage msg,
-    required bool hasMedia,
-  }) {
-    // Phase 2 follow-up: density-aware sender + inline-timestamp
-    // sizing.  Layout (bubble style) still controls *whether* the
-    // timestamp is inline vs separate; density controls the font
-    // sizes on whichever side it lands.
-    final double nameFontSize = switch (widget.density) {
-      UIDensity.cozy => 14,
-      UIDensity.normal => 13,
-      UIDensity.compact => 12,
-    };
-    final double timestampFontSize = switch (widget.density) {
-      UIDensity.cozy => 12,
-      UIDensity.normal => 11,
-      UIDensity.compact => 10,
-    };
-
-    final nameText = Text(
-      msg.fromUsername,
-      style: GoogleFonts.inter(
-        fontSize: nameFontSize,
-        fontWeight: FontWeight.w600,
-        color: _getSenderLabelColor(msg.fromUserId),
-      ),
-    );
-
-    final padding = EdgeInsets.only(bottom: 4, left: hasMedia ? 8 : 0);
-
-    if (!widget.compactLayout) {
-      return Padding(padding: padding, child: nameText);
-    }
-
-    return Padding(
-      padding: padding,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.baseline,
-        textBaseline: TextBaseline.alphabetic,
-        children: [
-          nameText,
-          const SizedBox(width: 6),
-          Text(
-            formatMessageTimestamp(msg.timestamp),
-            style: GoogleFonts.inter(
-              fontSize: timestampFontSize,
-              color: context.textMuted,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   /// Returns true when [content] is a known decrypt-failure sentinel.
   ///
   /// Mirrors [MessageCache.failureSentinels] so system sentinels (prefixed
@@ -1272,7 +1206,12 @@ class _MessageItemState extends State<MessageItem>
     return [
       if (msg.pinnedAt != null) PinnedIndicator(isMine: isMine),
       if (widget.showHeader && (!isMine || widget.compactLayout))
-        _buildSenderNameLabel(msg: msg, hasMedia: hasMedia),
+        SenderNameLabel(
+          message: msg,
+          hasMedia: hasMedia,
+          compactLayout: widget.compactLayout,
+          density: widget.density,
+        ),
       if (msg.replyToContent != null)
         ReplyQuote(
           replyToUsername: msg.replyToUsername,
@@ -1472,53 +1411,6 @@ class _MessageItemState extends State<MessageItem>
             ),
           if (isMine) MessageStatusIcon(status: msg.status),
         ],
-      ),
-    );
-  }
-
-  Widget _buildReplyCountBadge({
-    required ChatMessage msg,
-    required bool isMine,
-  }) {
-    final count = msg.replyCount;
-    final label = count == 1 ? '1 reply' : '$count replies';
-    return Padding(
-      padding: EdgeInsets.only(top: 4, left: isMine ? 0 : 36),
-      child: Align(
-        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
-        child: Semantics(
-          label: 'View $label',
-          button: true,
-          child: Material(
-            color: Colors.transparent,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(12),
-              onTap: () => widget.onViewThread?.call(msg),
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: context.accent.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.forum_outlined, size: 12, color: context.accent),
-                    const SizedBox(width: 4),
-                    Text(
-                      label,
-                      style: GoogleFonts.inter(
-                        fontSize: 12,
-                        color: context.accent,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }
@@ -1818,7 +1710,11 @@ class _MessageItemState extends State<MessageItem>
                 ),
               ),
               if (msg.replyCount > 0)
-                _buildReplyCountBadge(msg: msg, isMine: isMine),
+                ReplyCountBadge(
+                  message: msg,
+                  isMine: isMine,
+                  onTap: widget.onViewThread,
+                ),
               if (widget.isLastInGroup)
                 _buildTimestampRow(msg: msg, isMine: isMine)
               else

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -25,9 +25,12 @@ import 'message/hover_action_button.dart';
 import 'message/link_preview_card.dart';
 import 'message/media_content.dart';
 import 'message/message_status_icon.dart';
+import 'message/message_indicators.dart';
 import 'message/reaction_bar.dart';
 import 'message/reply_quote.dart';
+import 'message/retry_row.dart';
 import 'message/rich_text_content.dart';
+import 'message/system_event_pill.dart';
 import 'message/youtube_embed.dart';
 
 /// Common emojis for the reaction picker.
@@ -1094,106 +1097,6 @@ class _MessageItemState extends State<MessageItem>
   /// Build a clean lock-icon pill for messages that could not be decrypted.
   ///
   /// Replaces the old verbose text with a rounded pill containing a lock icon
-  /// and short italic label so users see a polished affordance (#668).
-  Widget _buildDecryptFailurePill() {
-    return Semantics(
-      label: 'Message could not be decrypted',
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        decoration: BoxDecoration(
-          color: context.textMuted.withValues(alpha: 0.10),
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.lock_outline, size: 16, color: context.textSecondary),
-            const SizedBox(width: 6),
-            Text(
-              'Message could not be decrypted',
-              style: GoogleFonts.inter(
-                fontStyle: FontStyle.italic,
-                color: context.textSecondary,
-                fontSize: 13,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// Build the retry/delete row shown below a failed outbound message.
-  Widget _buildRetryRow({required ChatMessage msg}) {
-    return Container(
-      margin: const EdgeInsets.only(top: 4, right: 4),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: EchoTheme.danger.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: EchoTheme.danger.withValues(alpha: 0.3)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: [
-          const Icon(Icons.error_rounded, size: 16, color: EchoTheme.danger),
-          const SizedBox(width: 6),
-          Flexible(
-            child: Text(
-              msg.content.contains('not have been delivered')
-                  ? 'Message may not have been delivered'
-                  : 'Failed to send',
-              style: const TextStyle(
-                fontSize: 12,
-                color: EchoTheme.danger,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-          if (widget.onRetry != null) ...[
-            const SizedBox(width: 10),
-            GestureDetector(
-              onTap: () => widget.onRetry?.call(msg),
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 10,
-                  vertical: 4,
-                ),
-                decoration: BoxDecoration(
-                  color: context.accent,
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: Text(
-                  'Retry',
-                  style: GoogleFonts.inter(
-                    fontSize: 12,
-                    color: Colors.white,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-            ),
-          ],
-          if (widget.onDelete != null) ...[
-            const SizedBox(width: 6),
-            GestureDetector(
-              onTap: () => widget.onDelete?.call(msg),
-              child: Text(
-                'Delete',
-                style: GoogleFonts.inter(
-                  fontSize: 12,
-                  color: EchoTheme.danger.withValues(alpha: 0.8),
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
   /// Resolve text color for message content.
   Color _contentTextColor({required bool isMine, required bool isFailed}) {
     if (isFailed) return EchoTheme.danger;
@@ -1243,7 +1146,7 @@ class _MessageItemState extends State<MessageItem>
       );
     }
     if (_isDecryptFailure(msg.content)) {
-      return _buildDecryptFailurePill();
+      return const DecryptFailurePill();
     }
 
     final displayContent = msg.content.startsWith(_forwardedPrefix)
@@ -1359,74 +1262,6 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  /// Build a small pinned indicator shown inside the bubble.
-  Widget _buildPinnedIndicator({required bool isMine}) {
-    return Semantics(
-      label: 'Pinned message',
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 4),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.push_pin,
-              size: 11,
-              color: isMine
-                  ? Theme.of(
-                      context,
-                    ).colorScheme.onPrimary.withValues(alpha: 0.7)
-                  : context.accent,
-            ),
-            const SizedBox(width: 3),
-            Text(
-              'Pinned',
-              style: GoogleFonts.inter(
-                fontSize: 10,
-                fontWeight: FontWeight.w500,
-                color: isMine
-                    ? Theme.of(
-                        context,
-                      ).colorScheme.onPrimary.withValues(alpha: 0.7)
-                    : context.accent,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildForwardedBadge({required bool isMine}) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 4),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.forward,
-            size: 12,
-            color: isMine
-                ? Theme.of(context).colorScheme.onPrimary.withValues(alpha: 0.7)
-                : context.textMuted,
-          ),
-          const SizedBox(width: 4),
-          Text(
-            'Forwarded',
-            style: GoogleFonts.inter(
-              fontSize: 11,
-              fontStyle: FontStyle.italic,
-              color: isMine
-                  ? Theme.of(
-                      context,
-                    ).colorScheme.onPrimary.withValues(alpha: 0.7)
-                  : context.textMuted,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   /// Assemble the children of the bubble Column.
   List<Widget> _bubbleChildren({
     required ChatMessage msg,
@@ -1435,7 +1270,7 @@ class _MessageItemState extends State<MessageItem>
     required bool hasMedia,
   }) {
     return [
-      if (msg.pinnedAt != null) _buildPinnedIndicator(isMine: isMine),
+      if (msg.pinnedAt != null) PinnedIndicator(isMine: isMine),
       if (widget.showHeader && (!isMine || widget.compactLayout))
         _buildSenderNameLabel(msg: msg, hasMedia: hasMedia),
       if (msg.replyToContent != null)
@@ -1448,7 +1283,7 @@ class _MessageItemState extends State<MessageItem>
               : null,
         ),
       if (msg.content.startsWith(_forwardedPrefix))
-        _buildForwardedBadge(isMine: isMine),
+        ForwardedBadge(isMine: isMine),
       _buildBubbleContent(
         msg: msg,
         isMine: isMine,
@@ -1576,27 +1411,6 @@ class _MessageItemState extends State<MessageItem>
 
   /// Build the tiny green lock icon shown next to the timestamp on encrypted
   /// messages. Received-message lock is tappable to open the safety-number
-  /// verification screen; my own lock icon is non-interactive.
-  Widget _buildLockIcon({required ChatMessage msg, required bool isMine}) {
-    const icon = Padding(
-      padding: EdgeInsets.only(left: 3),
-      child: Icon(Icons.lock, size: 10, color: EchoTheme.online),
-    );
-
-    if (isMine || widget.onVerifyIdentity == null) {
-      return icon;
-    }
-
-    return Tooltip(
-      message: 'End-to-end encrypted. Tap to verify.',
-      child: InkWell(
-        onTap: () => widget.onVerifyIdentity!(msg),
-        borderRadius: BorderRadius.circular(6),
-        child: icon,
-      ),
-    );
-  }
-
   /// Build the timestamp row shown below the last message in a group.
   Widget _buildTimestampRow({required ChatMessage msg, required bool isMine}) {
     return Padding(
@@ -1611,7 +1425,12 @@ class _MessageItemState extends State<MessageItem>
             formatMessageTimestamp(msg.timestamp),
             style: GoogleFonts.inter(fontSize: 11, color: context.textMuted),
           ),
-          if (msg.isEncrypted) _buildLockIcon(msg: msg, isMine: isMine),
+          if (msg.isEncrypted)
+            LockIcon(
+              message: msg,
+              isMine: isMine,
+              onVerifyIdentity: widget.onVerifyIdentity,
+            ),
           if (msg.pinnedAt != null)
             Padding(
               padding: const EdgeInsets.only(left: 4),
@@ -1828,43 +1647,6 @@ class _MessageItemState extends State<MessageItem>
   }
 
   /// Build the system event pill (centered, borderless).
-  Widget _buildSystemEventPill(ChatMessage msg) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 24),
-      child: Center(
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          decoration: BoxDecoration(
-            color: context.surface,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: context.border),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                _systemEventIcon(msg.content),
-                size: 13,
-                color: context.textMuted,
-              ),
-              const SizedBox(width: 6),
-              Flexible(
-                child: Text(
-                  msg.content,
-                  style: GoogleFonts.inter(
-                    color: context.textMuted,
-                    fontSize: 11,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   /// Whether the current platform supports touch-based swipe gestures.
   static bool get _isMobileTouch =>
       !kIsWeb &&
@@ -1952,7 +1734,7 @@ class _MessageItemState extends State<MessageItem>
     final isFailed = msg.status == MessageStatus.failed;
     final isSending = msg.status == MessageStatus.sending;
 
-    if (msg.isSystemEvent) return _buildSystemEventPill(msg);
+    if (msg.isSystemEvent) return SystemEventPill(message: msg);
 
     // Hide undecryptable messages entirely when the user has opted in (#668).
     if (widget.hideUndecryptable && _isDecryptFailure(msg.content)) {
@@ -2041,7 +1823,12 @@ class _MessageItemState extends State<MessageItem>
                 _buildTimestampRow(msg: msg, isMine: isMine)
               else
                 _buildHoverTimestamp(msg: msg, isMine: isMine),
-              if (isFailed && isMine) _buildRetryRow(msg: msg),
+              if (isFailed && isMine)
+                RetryRow(
+                  message: msg,
+                  onRetry: widget.onRetry,
+                  onDelete: widget.onDelete,
+                ),
             ],
           ),
           if (!hasReactions)
@@ -2100,21 +1887,4 @@ class _MessageItemState extends State<MessageItem>
       ),
     );
   }
-}
-
-IconData _systemEventIcon(String content) {
-  final lower = content.toLowerCase();
-  if (lower.contains('call')) {
-    return Icons.call;
-  }
-  if (lower.contains('encryption') || lower.contains('key')) {
-    return Icons.vpn_key;
-  }
-  if (lower.contains('joined') ||
-      lower.contains('left') ||
-      lower.contains('removed') ||
-      lower.contains('banned')) {
-    return Icons.group;
-  }
-  return Icons.info_outline;
 }

--- a/apps/client/test/helpers/mock_providers.dart
+++ b/apps/client/test/helpers/mock_providers.dart
@@ -173,13 +173,14 @@ class _FakeContacts extends Contacts {
 
 /// Override [websocketProvider] with a disconnected state.
 Override webSocketOverride() {
-  return websocketProvider.overrideWith((ref) => _FakeWebSocketNotifier(ref));
+  return websocketProvider.overrideWith(() => _FakeWebSocketNotifier());
 }
 
 class _FakeWebSocketNotifier extends WebSocketNotifier {
-  _FakeWebSocketNotifier(super.ref) {
-    state = const WebSocketState();
-  }
+  _FakeWebSocketNotifier();
+
+  @override
+  WebSocketState build() => const WebSocketState();
 
   @override
   void connect() {}

--- a/apps/client/test/providers/chat_cold_start_hydration_test.dart
+++ b/apps/client/test/providers/chat_cold_start_hydration_test.dart
@@ -12,7 +12,7 @@ import 'package:echo_app/src/services/message_cache.dart';
 
 /// Creates a fresh [ChatNotifier] (empty state, no WS events) to simulate a
 /// cold-start scenario where the user has not yet opened any chat panel.
-ChatNotifier _createNotifier() {
+Chat _createNotifier() {
   final container = ProviderContainer(
     overrides: [
       authProvider.overrideWith((ref) {

--- a/apps/client/test/providers/chat_notifier_test.dart
+++ b/apps/client/test/providers/chat_notifier_test.dart
@@ -8,7 +8,7 @@ import 'package:echo_app/src/providers/chat_provider.dart';
 import 'package:echo_app/src/providers/server_url_provider.dart';
 
 /// Create a real ChatNotifier backed by a ProviderContainer.
-ChatNotifier _createNotifier() {
+Chat _createNotifier() {
   final container = ProviderContainer(
     overrides: [
       authProvider.overrideWith((ref) {

--- a/apps/client/test/providers/websocket_url_change_test.dart
+++ b/apps/client/test/providers/websocket_url_change_test.dart
@@ -18,7 +18,7 @@ class _RecordingWsNotifier extends WebSocketNotifier {
   int connectCalls = 0;
   int disconnectCalls = 0;
 
-  _RecordingWsNotifier(super.ref);
+  _RecordingWsNotifier();
 
   @override
   void connect() {
@@ -54,8 +54,8 @@ void main() {
             ),
           ),
         ),
-        websocketProvider.overrideWith((ref) {
-          ws = _RecordingWsNotifier(ref);
+        websocketProvider.overrideWith(() {
+          ws = _RecordingWsNotifier();
           return ws;
         }),
       ],

--- a/apps/client/test/providers/ws_message_handler_test.dart
+++ b/apps/client/test/providers/ws_message_handler_test.dart
@@ -110,11 +110,7 @@ class _FakeConversationsNotifier extends ConversationsNotifier {
 // Concrete handler for testing
 // ---------------------------------------------------------------------------
 
-class _TestWsHandler extends StateNotifier<WebSocketState>
-    with WsMessageHandler {
-  @override
-  final Ref ref;
-
+class _TestWsHandler extends Notifier<WebSocketState> with WsMessageHandler {
   @override
   final StreamController<Map<String, dynamic>> voiceSignalController =
       StreamController<Map<String, dynamic>>.broadcast();
@@ -123,13 +119,13 @@ class _TestWsHandler extends StateNotifier<WebSocketState>
   final StreamController<Map<String, dynamic>> deviceRevokedController =
       StreamController<Map<String, dynamic>>.broadcast();
 
-  _TestWsHandler(this.ref) : super(const WebSocketState());
+  @override
+  WebSocketState build() => const WebSocketState();
 }
 
-final _testHandlerProvider =
-    StateNotifierProvider<_TestWsHandler, WebSocketState>(
-      (ref) => _TestWsHandler(ref),
-    );
+final _testHandlerProvider = NotifierProvider<_TestWsHandler, WebSocketState>(
+  _TestWsHandler.new,
+);
 
 // ---------------------------------------------------------------------------
 // Test setup

--- a/apps/client/test/widgets/chat_input_bar_test.dart
+++ b/apps/client/test/widgets/chat_input_bar_test.dart
@@ -17,13 +17,16 @@ import '../helpers/pump_app.dart';
 
 /// Override [chatProvider] with a specific [ChatState].
 Override chatOverride([ChatState state = const ChatState()]) {
-  return chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, state));
+  return chatProvider.overrideWith(() => _FakeChatNotifier(state));
 }
 
-class _FakeChatNotifier extends ChatNotifier {
-  _FakeChatNotifier(super.ref, ChatState initial) {
-    state = initial;
-  }
+class _FakeChatNotifier extends Chat {
+  _FakeChatNotifier(this._initial);
+
+  final ChatState _initial;
+
+  @override
+  ChatState build() => _initial;
 
   @override
   Future<void> loadHistoryWithUserId(

--- a/apps/client/test/widgets/chat_panel_live_region_test.dart
+++ b/apps/client/test/widgets/chat_panel_live_region_test.dart
@@ -18,10 +18,13 @@ import '../helpers/mock_providers.dart';
 import '../helpers/pump_app.dart';
 
 /// Notifier we can mutate from the test body.
-class _FakeChatNotifier extends ChatNotifier {
-  _FakeChatNotifier(super.ref, ChatState initial) {
-    state = initial;
-  }
+class _FakeChatNotifier extends Chat {
+  _FakeChatNotifier(this._initial);
+
+  final ChatState _initial;
+
+  @override
+  ChatState build() => _initial;
 
   @override
   Future<void> loadHistoryWithUserId(
@@ -123,8 +126,8 @@ List<Override> _overrides({
 }) {
   return [
     ...standardOverrides(),
-    chatProvider.overrideWith((ref) {
-      final n = _FakeChatNotifier(ref, initial);
+    chatProvider.overrideWith(() {
+      final n = _FakeChatNotifier(initial);
       holder.notifier = n;
       return n;
     }),

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -20,10 +20,13 @@ import '../helpers/pump_app.dart';
 // Fake notifiers for additional providers ChatPanel depends on
 // ---------------------------------------------------------------------------
 
-class _FakeChatNotifier extends ChatNotifier {
-  _FakeChatNotifier(super.ref, ChatState initial) {
-    state = initial;
-  }
+class _FakeChatNotifier extends Chat {
+  _FakeChatNotifier(this._initial);
+
+  final ChatState _initial;
+
+  @override
+  ChatState build() => _initial;
 
   @override
   Future<void> loadHistoryWithUserId(
@@ -69,7 +72,7 @@ class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
 List<Override> _chatPanelOverrides({ChatState chatState = const ChatState()}) {
   return [
     ...standardOverrides(),
-    chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, chatState)),
+    chatProvider.overrideWith(() => _FakeChatNotifier(chatState)),
     channelsProvider.overrideWith(_FakeChannelsNotifier.new),
     privacyProvider.overrideWith(_FakePrivacy.new),
     voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),

--- a/apps/client/test/widgets/connection_status_banner_test.dart
+++ b/apps/client/test/widgets/connection_status_banner_test.dart
@@ -11,7 +11,18 @@ import 'package:echo_app/src/widgets/connection_status_banner.dart';
 /// the inherited init (typing-cleanup Timer) is harmless under the
 /// fake_async pump cadence the widget tests use.
 class _TestWsNotifier extends WebSocketNotifier {
-  _TestWsNotifier(super.ref);
+  _TestWsNotifier(this._initial);
+
+  final WebSocketState _initial;
+
+  /// `build()` is the only sanctioned slot in @riverpod codegen for setting
+  /// the initial state -- assigning to `state` from the constructor body is
+  /// a no-op because the framework overwrites it with `build()`'s return.
+  /// Test code calls `setStateForTest` AFTER the framework has materialised
+  /// the notifier (post-pump), so the constructor receives the very first
+  /// state the widget should see.
+  @override
+  WebSocketState build() => _initial;
 
   void setStateForTest(WebSocketState next) => state = next;
 
@@ -21,9 +32,9 @@ class _TestWsNotifier extends WebSocketNotifier {
   }
 }
 
-ProviderScope _wrap(_TestWsNotifier Function(Ref) build) {
+ProviderScope _wrap(_TestWsNotifier Function() build) {
   return ProviderScope(
-    overrides: [websocketProvider.overrideWith((ref) => build(ref))],
+    overrides: [websocketProvider.overrideWith(() => build())],
     child: const MaterialApp(home: Scaffold(body: ConnectionStatusBanner())),
   );
 }
@@ -32,9 +43,8 @@ void main() {
   group('ConnectionStatusBanner (#499)', () {
     testWidgets('hidden when connected', (tester) async {
       await tester.pumpWidget(
-        _wrap((ref) {
-          final n = _TestWsNotifier(ref);
-          n.setStateForTest(const WebSocketState(isConnected: true));
+        _wrap(() {
+          final n = _TestWsNotifier(const WebSocketState(isConnected: true));
           return n;
         }),
       );
@@ -50,9 +60,8 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        _wrap((ref) {
-          final n = _TestWsNotifier(ref);
-          n.setStateForTest(
+        _wrap(() {
+          final n = _TestWsNotifier(
             const WebSocketState(isConnected: false, reconnectAttempts: 0),
           );
           return n;
@@ -70,9 +79,8 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        _wrap((ref) {
-          final n = _TestWsNotifier(ref);
-          n.setStateForTest(
+        _wrap(() {
+          final n = _TestWsNotifier(
             const WebSocketState(isConnected: false, reconnectAttempts: 2),
           );
           return n;
@@ -88,9 +96,8 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        _wrap((ref) {
-          final n = _TestWsNotifier(ref);
-          n.setStateForTest(
+        _wrap(() {
+          final n = _TestWsNotifier(
             const WebSocketState(isConnected: false, reconnectAttempts: 10),
           );
           return n;
@@ -108,9 +115,8 @@ void main() {
 
     testWidgets('shows session-replaced label + retry', (tester) async {
       await tester.pumpWidget(
-        _wrap((ref) {
-          final n = _TestWsNotifier(ref);
-          n.setStateForTest(
+        _wrap(() {
+          final n = _TestWsNotifier(
             const WebSocketState(isConnected: false, wasReplaced: true),
           );
           return n;
@@ -126,9 +132,8 @@ void main() {
     ) async {
       late _TestWsNotifier notifier;
       await tester.pumpWidget(
-        _wrap((ref) {
-          notifier = _TestWsNotifier(ref);
-          notifier.setStateForTest(
+        _wrap(() {
+          notifier = _TestWsNotifier(
             const WebSocketState(isConnected: false, reconnectAttempts: 1),
           );
           return notifier;

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -678,8 +678,8 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            chatProvider.overrideWith((ref) {
-              final n = _MutableChatNotifier(ref, initialState);
+            chatProvider.overrideWith(() {
+              final n = _MutableChatNotifier(initialState);
               capturedNotifier = n;
               return n;
             }),
@@ -1013,10 +1013,13 @@ class _StaticUIDensity extends UIDensityNotifier {
 // ChatNotifier subclass that exposes direct state mutation for tests.
 // Skips all network/cache operations so tests stay hermetic.
 // ---------------------------------------------------------------------------
-class _MutableChatNotifier extends ChatNotifier {
-  _MutableChatNotifier(super.ref, ChatState initial) {
-    state = initial;
-  }
+class _MutableChatNotifier extends Chat {
+  _MutableChatNotifier(this._initial);
+
+  final ChatState _initial;
+
+  @override
+  ChatState build() => _initial;
 
   @override
   void addMessage(ChatMessage msg) => state = state.withMessage(msg);

--- a/apps/client/test/widgets/graceful_shutdown_test.dart
+++ b/apps/client/test/widgets/graceful_shutdown_test.dart
@@ -23,9 +23,10 @@ import '../helpers/mock_providers.dart';
 // ---------------------------------------------------------------------------
 
 class _TrackingWsNotifier extends WebSocketNotifier {
-  _TrackingWsNotifier(super.ref) {
-    state = const WebSocketState(isConnected: true);
-  }
+  _TrackingWsNotifier();
+
+  @override
+  WebSocketState build() => const WebSocketState(isConnected: true);
 
   int disconnectCalls = 0;
 
@@ -53,8 +54,8 @@ void main() {
         ProviderScope(
           overrides: [
             ...standardOverrides(),
-            websocketProvider.overrideWith((ref) {
-              ws = _TrackingWsNotifier(ref);
+            websocketProvider.overrideWith(() {
+              ws = _TrackingWsNotifier();
               return ws;
             }),
           ],
@@ -85,8 +86,8 @@ void main() {
         ProviderScope(
           overrides: [
             ...standardOverrides(),
-            websocketProvider.overrideWith((ref) {
-              ws = _TrackingWsNotifier(ref);
+            websocketProvider.overrideWith(() {
+              ws = _TrackingWsNotifier();
               return ws;
             }),
           ],

--- a/apps/client/test/widgets/settings/about_section_test.dart
+++ b/apps/client/test/widgets/settings/about_section_test.dart
@@ -11,13 +11,16 @@ import 'package:echo_app/src/theme/echo_theme.dart';
 import '../../helpers/mock_providers.dart';
 
 Override chatOverride([ChatState state = const ChatState()]) {
-  return chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, state));
+  return chatProvider.overrideWith(() => _FakeChatNotifier(state));
 }
 
-class _FakeChatNotifier extends ChatNotifier {
-  _FakeChatNotifier(super.ref, ChatState initial) {
-    state = initial;
-  }
+class _FakeChatNotifier extends Chat {
+  _FakeChatNotifier(this._initial);
+
+  final ChatState _initial;
+
+  @override
+  ChatState build() => _initial;
 }
 
 Override updateOverride([UpdateState initial = const UpdateState()]) {

--- a/apps/client/test/widgets/slash_commands_widget_test.dart
+++ b/apps/client/test/widgets/slash_commands_widget_test.dart
@@ -18,13 +18,16 @@ import '../helpers/pump_app.dart';
 // ---------------------------------------------------------------------------
 
 Override _chatOverride([ChatState state = const ChatState()]) {
-  return chatProvider.overrideWith((ref) => _FakeChatNotifier(ref, state));
+  return chatProvider.overrideWith(() => _FakeChatNotifier(state));
 }
 
-class _FakeChatNotifier extends ChatNotifier {
-  _FakeChatNotifier(super.ref, ChatState initial) {
-    state = initial;
-  }
+class _FakeChatNotifier extends Chat {
+  _FakeChatNotifier(this._initial);
+
+  final ChatState _initial;
+
+  @override
+  ChatState build() => _initial;
 
   @override
   Future<void> loadHistoryWithUserId(


### PR DESCRIPTION
## Summary

Four refactor commits batched for the next merge to main. All are dev-only churn — no behavior change, no public-API change, no migration steps.

### \`115478a\` chat_provider → @riverpod codegen
958 LOC \`StateNotifier<ChatState>\` → \`@Riverpod(keepAlive: true) class Chat extends _\$Chat\`. \`build()\` returns \`const ChatState()\` and registers \`ref.onDispose\` to cancel the per-conversation send-timeout timers. \`final Ref ref;\` field gone (provided by base). Test fakes updated to new pattern (no constructor ref, override callback signature \`() => ...\` instead of \`(ref) => ...\`) across 8 test files. Symbol unchanged: \`chatProvider\` because \`Chat\` → \`chatProvider\` from codegen.

### \`9a06e21\` + \`a36a01d\` message_item.dart leaf-renderer extractions
2120 → 1786 LOC (-334) across 5 new files in \`widgets/message/\`:
- \`system_event_pill.dart\` — centered pill for member_joined / call / encryption-key events + \`systemEventIcon()\` helper
- \`message_indicators.dart\` — pinned, forwarded, lock-icon, decrypt-failure-pill (4 small stateless renderers grouped)
- \`retry_row.dart\` — failed-message retry/delete affordance
- \`sender_name_label.dart\` — group sender label + inline timestamp (compact mode)
- \`reply_count_badge.dart\` — tappable "X replies" pill

Orchestration core (\`_buildBubble\`, hover overlay, action sheet, swipe-to-reply) kept intact — those need deeper restructuring than mechanical extraction; tracked for a follow-up.

### \`be8bcee\` websocket_provider → @riverpod codegen
731 LOC \`StateNotifier<WebSocketState>\` → \`@Riverpod(keepAlive: true) class WebSocketNotifier extends _\$WebSocketNotifier with WsMessageHandler\`. The lifecycle that lived in the constructor body (typing-cleanup timer, URL-change listener) moved into \`build()\`; the \`dispose()\` override moved into \`ref.onDispose\`. Mixin constraint flipped from \`on StateNotifier<...>\` to \`on Notifier<...>\` — the only call site (\`ws_message_handler_test.dart\`'s \`_TestWsHandler\`) updated to extend \`Notifier\` and use a \`NotifierProvider\`. Symbol kept stable via \`final websocketProvider = webSocketNotifierProvider\` alias so every \`ref.read(websocketProvider...)\` in the tree continues to work.

## Test plan
- 1444 client tests pass after this branch (was 1444 before — same coverage, no skips added).
- \`flutter analyze\` clean.
- No public API or wire-format change; the refactor is contained to the provider layer + 5 widget extractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)