### PR TITLE
Prod fixes (#835, #837) + audit quick wins (perf, theme, dedup, deps)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,10 @@ jobs:
           # on Fedora 43 / glib 2.84+ targets (reported 2026-05-08).  Keep
           # universal system libraries on the host; only bundle the media
           # stack we know minimal hosts may not ship.
-          BUNDLE_RE='^(libmpv|libav(codec|format|util|filter|device)|libsws(cale)?|libswresample|libpostproc|libplacebo|libmujs|libdovi|libshaderc|libspirv-cross|libass|libuchardet|libvpx|libx264|libx265|libtheora|libvorbis|libopus|libdav1d|libaom|liblcms|librubberband|libsoxr|libchromaprint|libbluray|libsrt|libnghttp[23])'
+          # libmpv on bookworm pulls liblua5.2 (embedded scripting).  Without
+          # it the AppImage fails on hosts that don't ship liblua5.2-0 with
+          # "liblua5.2.so.0: cannot open shared object file" (#835).
+          BUNDLE_RE='^(libmpv|libav(codec|format|util|filter|device)|libsws(cale)?|libswresample|libpostproc|libplacebo|libmujs|libdovi|libshaderc|libspirv-cross|libass|libuchardet|libvpx|libx264|libx265|libtheora|libvorbis|libopus|libdav1d|libaom|liblcms|librubberband|libsoxr|libchromaprint|libbluray|libsrt|libnghttp[23]|liblua5\.[0-9]+|libluajit)'
           ldd "$LIBMPV_PATH" | awk '/=>/ {print $3}' \
             | while read -r dep; do
                 [ -z "$dep" ] || [ ! -e "$dep" ] && continue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,18 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,17 +718,12 @@ dependencies = [
  "chrono",
  "criterion",
  "ed25519-dalek",
- "futures-util",
  "hkdf",
  "rand_core 0.6.4",
- "reqwest",
- "rusqlite",
  "serde",
  "serde_json",
  "sha2",
  "thiserror",
- "tokio",
- "tokio-tungstenite 0.28.0",
  "tracing",
  "uuid",
  "x25519-dalek",
@@ -864,24 +847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,21 +880,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1125,9 +1075,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1145,15 +1092,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "hashlink"
@@ -1662,16 +1600,9 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1776,23 +1707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,48 +1796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "page_size"
@@ -2427,20 +2303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink 0.9.1",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,19 +2315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2834,7 +2683,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashlink",
  "indexmap",
  "log",
  "memchr",
@@ -3075,19 +2924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,16 +3047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,9 +3075,7 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "tokio",
- "tokio-native-tls",
  "tungstenite 0.28.0",
 ]
 
@@ -3406,7 +3230,6 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.3",
  "sha1",
  "thiserror",

--- a/apps/client/lib/src/providers/ws_handlers/message_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/message_handlers.dart
@@ -22,10 +22,8 @@ extension MessageHandlersOn on WsMessageHandler {
           channelId: channelId,
           expiresAt: expiresAt,
         );
-    // Update status to sent
-    ref
-        .read(chatProvider.notifier)
-        .updateMessageStatus(conversationId, messageId, MessageStatus.sent);
+    // confirmSent already transitions status to sent atomically with the ID
+    // swap (chat_provider.dart:442); no follow-up updateMessageStatus needed.
 
     // Update conversation list preview so the sender sees their own message
     // reflected immediately (e.g. attachment markers, text). Without this the

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -1127,6 +1127,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     final voiceRtc = ref.watch(voiceRtcProvider);
     final voiceActive = voiceRtc.isActive && voiceRtc.channelId != null;
 
+    _autoShowLoungeOnJoin(voiceActive);
+
     Widget rightPanel;
     if (_showSettings) {
       rightPanel = SettingsContent(
@@ -1244,6 +1246,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   Widget _buildNarrowLayout() {
     final voiceRtc = ref.watch(voiceRtcProvider);
     final voiceActive = voiceRtc.isActive && voiceRtc.channelId != null;
+
+    _autoShowLoungeOnJoin(voiceActive);
+
+    // Voice lounge takes precedence over any tab on mobile narrow.  Without
+    // this gate, joining voice from Discover/Contacts/Settings left the user
+    // staring at that tab while the lounge state was already true.
+    if (voiceActive && _showingLounge) {
+      return Scaffold(
+        body: SafeArea(
+          child: VoiceLoungeScreen(
+            onBackToChat: () => setState(() {
+              _showingLounge = false;
+              _userDismissedLounge = true;
+            }),
+          ),
+        ),
+      );
+    }
 
     // When on the Chats tab AND a conversation is open, render the chat
     // full-screen with no bottom tab bar. Pressing back returns to the

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -1220,6 +1220,12 @@ extension EchoColors on BuildContext {
   Color get textMuted => echo.textMuted;
   Color get sentBubble => echo.sentBubble;
   Color get recvBubble => echo.recvBubble;
+
+  /// Foreground color for content rendered on top of [sentBubble].
+  /// Resolves to `ColorScheme.onPrimary` because most themes keep the sent
+  /// bubble at or near the accent color; promote to a dedicated
+  /// [EchoColorExtension] field if a theme ever needs a non-onPrimary value.
+  Color get onSentBubble => Theme.of(this).colorScheme.onPrimary;
   Color get cardRowBg => echo.resolvedCardRowBg;
   Gradient? get chatBgGradient => echo.chatBgGradient;
 

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -1826,7 +1826,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   @override
   Widget build(BuildContext context) {
     final conv = widget.conversation;
-    final myUserId = ref.watch(authProvider).userId ?? '';
+    final myUserId = ref.watch(authProvider.select((s) => s.userId)) ?? '';
     final voiceSettings = ref.watch(voiceSettingsProvider);
     final replyToMessage = ref.watch(
       chatProvider.select((s) => s.replyToMessage),

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -1693,6 +1693,32 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     return raw.where((m) => !_deletedForMeIds.contains(m.id)).toList();
   }
 
+  /// Apply channel + delete-for-me filters to a pre-fetched message list.
+  /// Used by the build path so a `.select` on the per-conversation list ref
+  /// keeps unrelated conversations from rebuilding.
+  List<ChatMessage> _filterChannelAndDeleted(
+    Conversation conv,
+    List<ChatMessage> raw,
+    String? selectedChannelId,
+    bool includeUnchanneled,
+  ) {
+    Iterable<ChatMessage> filtered = raw;
+    if (conv.isGroup &&
+        selectedChannelId != null &&
+        selectedChannelId.isNotEmpty) {
+      filtered = filtered.where((m) {
+        if (m.isSystemEvent) return true;
+        if (m.channelId == selectedChannelId) return true;
+        return includeUnchanneled &&
+            (m.channelId == null || m.channelId!.isEmpty);
+      });
+    }
+    if (_deletedForMeIds.isNotEmpty) {
+      filtered = filtered.where((m) => !_deletedForMeIds.contains(m.id));
+    }
+    return identical(filtered, raw) ? raw : filtered.toList();
+  }
+
   // ---------------------------------------------------------------------------
   // Build
   // ---------------------------------------------------------------------------
@@ -1743,17 +1769,29 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       ),
     );
 
-    final chatState = ref.watch(chatProvider);
-    final messages = _resolveMessages(
+    // Watch only this conversation's message list reference and the loading
+    // flag for this channel — `messagesByConversation` keeps inner list
+    // refs stable across copyWith for unaffected conversations, so adding
+    // a message to conv B no longer rebuilds conv A's panel (#834 F6).
+    final convMessages = ref.watch(
+      chatProvider.select((s) => s.messagesByConversation[conv.id]),
+    );
+    final messages = _filterChannelAndDeleted(
       conv,
-      chatState,
+      convMessages ?? const [],
       selectedChannelId,
       includeUnchanneled,
     );
 
-    final isLoadingHistory = chatState.isLoadingHistory(
-      conv.id,
-      channelId: selectedChannelId,
+    final isLoadingHistory = ref.watch(
+      chatProvider.select(
+        (s) => s.isLoadingHistory(conv.id, channelId: selectedChannelId),
+      ),
+    );
+    final hasMoreHistory = ref.watch(
+      chatProvider.select(
+        (s) => s.conversationHasMore(conv.id, channelId: selectedChannelId),
+      ),
     );
 
     final typingUsers = typingUserIds.where((u) => u != myUserId).map((uid) {
@@ -1862,7 +1900,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
                       ChatMessageList(
                         conv: conv,
                         messages: messages,
-                        chatState: chatState,
                         memberAvatars: memberAvatars,
                         myUserId: myUserId,
                         serverUrl: serverUrl,
@@ -1870,6 +1907,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
                         mediaTicket: mediaTicket,
                         channelId: selectedChannelId,
                         isLoadingHistory: isLoadingHistory,
+                        hasMoreHistory: hasMoreHistory,
                         displayName: displayName,
                         scrollController: _scrollController,
                         messageKeys: _messageKeys,

--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -14,7 +14,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../models/chat_message.dart';
 import '../../models/conversation.dart';
 import '../../providers/accessibility_provider.dart';
-import '../../providers/chat_provider.dart';
 import '../../providers/theme_provider.dart';
 import '../../theme/echo_theme.dart';
 import '../message_item.dart';
@@ -30,7 +29,6 @@ import 'unread_divider.dart';
 class ChatMessageList extends ConsumerWidget {
   final Conversation conv;
   final List<ChatMessage> messages;
-  final ChatState chatState;
   final Map<String, String?> memberAvatars;
   final String myUserId;
   final String serverUrl;
@@ -38,6 +36,7 @@ class ChatMessageList extends ConsumerWidget {
   final String? mediaTicket;
   final String? channelId;
   final bool isLoadingHistory;
+  final bool hasMoreHistory;
   final String displayName;
 
   /// Owned by parent [ChatPanel]; drives the floating-date pill and
@@ -95,7 +94,6 @@ class ChatMessageList extends ConsumerWidget {
     super.key,
     required this.conv,
     required this.messages,
-    required this.chatState,
     required this.memberAvatars,
     required this.myUserId,
     required this.serverUrl,
@@ -103,6 +101,7 @@ class ChatMessageList extends ConsumerWidget {
     required this.mediaTicket,
     required this.channelId,
     required this.isLoadingHistory,
+    required this.hasMoreHistory,
     required this.displayName,
     required this.scrollController,
     required this.messageKeys,
@@ -256,10 +255,10 @@ class ChatMessageList extends ConsumerWidget {
         itemCount: messages.length + 1,
         itemBuilder: (context, index) {
           if (index == 0) {
-            if (chatState.conversationHasMore(conv.id, channelId: channelId)) {
+            if (hasMoreHistory) {
               return SizedBox(
                 height: 48,
-                child: chatState.isLoadingHistory(conv.id, channelId: channelId)
+                child: isLoadingHistory
                     ? const Center(
                         child: SizedBox(
                           width: 16,

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -199,7 +199,9 @@ class _ReactionPillState extends State<_ReactionPill>
   @override
   Widget build(BuildContext context) {
     final bgColor = widget.isMine ? context.sentBubble : context.recvBubble;
-    final textColor = widget.isMine ? Colors.white : context.textPrimary;
+    final textColor = widget.isMine
+        ? context.onSentBubble
+        : context.textPrimary;
     final m = _ReactionMetrics.forDensity(widget.density);
 
     return GestureDetector(

--- a/apps/client/lib/src/widgets/message/reply_quote.dart
+++ b/apps/client/lib/src/widgets/message/reply_quote.dart
@@ -53,6 +53,8 @@ class ReplyQuote extends StatelessWidget {
             : 'In reply to ${replyToUsername ?? "Unknown"}: $truncated';
     }
 
+    final mineFg = context.onSentBubble;
+
     return Semantics(
       label: semanticsLabel,
       child: MouseRegion(
@@ -63,14 +65,12 @@ class ReplyQuote extends StatelessWidget {
             margin: const EdgeInsets.only(bottom: 6),
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
             decoration: BoxDecoration(
-              color: (isMine ? Colors.white : context.accent).withValues(
-                alpha: 0.12,
-              ),
+              color: (isMine ? mineFg : context.accent).withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(8),
               border: Border(
                 left: BorderSide(
                   color: isMine
-                      ? Colors.white.withValues(alpha: 0.5)
+                      ? mineFg.withValues(alpha: 0.5)
                       : context.accent,
                   width: 3,
                 ),
@@ -87,7 +87,7 @@ class ReplyQuote extends StatelessWidget {
                     fontSize: 11,
                     fontWeight: FontWeight.w600,
                     color: isMine
-                        ? Colors.white.withValues(alpha: 0.8)
+                        ? mineFg.withValues(alpha: 0.8)
                         : context.accent,
                   ),
                 ),
@@ -103,7 +103,7 @@ class ReplyQuote extends StatelessWidget {
 
   Widget _buildContentPreview(BuildContext context, ReplyAttachmentKind kind) {
     final textColor = isMine
-        ? Colors.white.withValues(alpha: 0.7)
+        ? context.onSentBubble.withValues(alpha: 0.7)
         : context.textSecondary;
 
     switch (kind) {

--- a/apps/server/src/db/mentions.rs
+++ b/apps/server/src/db/mentions.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 /// `containsMention`: the keyword is a standalone token if its left and
 /// right neighbours are start/end-of-string or non-word characters
 /// (anything other than `[A-Za-z0-9_]`).  Case-insensitive.
-fn is_standalone_keyword(content: &str, keyword: &str) -> bool {
+pub fn is_standalone_keyword(content: &str, keyword: &str) -> bool {
     if keyword.is_empty() {
         return false;
     }
@@ -230,5 +230,33 @@ mod tests {
         assert!(is_standalone_keyword("@everyone get in", "everyone"));
         assert!(is_standalone_keyword("ping @here", "here"));
         assert!(!is_standalone_keyword("@hereafter", "here"));
+    }
+
+    #[test]
+    fn standalone_keyword_with_punctuation() {
+        assert!(is_standalone_keyword("@here, please", "here"));
+        assert!(is_standalone_keyword("psst.@here!", "here"));
+    }
+
+    #[test]
+    fn standalone_keyword_rejects_email_prefix() {
+        assert!(!is_standalone_keyword("x@here", "here"));
+    }
+
+    #[test]
+    fn standalone_keyword_rejects_underscore_suffix() {
+        assert!(!is_standalone_keyword("@here_lounge", "here"));
+    }
+
+    #[test]
+    fn standalone_keyword_is_case_insensitive() {
+        assert!(is_standalone_keyword("Yo @Here folks", "here"));
+        assert!(is_standalone_keyword("YO @HERE FOLKS", "here"));
+    }
+
+    #[test]
+    fn standalone_keyword_no_at_is_false() {
+        assert!(!is_standalone_keyword("normal message", "here"));
+        assert!(!is_standalone_keyword("", "here"));
     }
 }

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -261,6 +261,14 @@ pub fn media_upload_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(30, 60, trusted_proxies)
 }
 
+/// Avatar upload rate limiter: 6 uploads per 60 seconds per IP.
+/// Tighter than media uploads — avatars rarely change, and the small
+/// per-request body (avatars cap at a few MB) makes cheap-to-issue
+/// floods more attractive without a tight cap (#831).
+pub fn avatar_upload_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+    RateLimiter::with_shared_proxies(6, 60, trusted_proxies)
+}
+
 /// Link preview rate limiter: 20 requests per 60 seconds per IP.
 pub fn link_preview_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(20, 60, trusted_proxies)

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -119,6 +119,57 @@ fn validate_password(password: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Return the first 8 hex chars of `sha256(token)` for safe-to-log
+/// correlation between the issuance log line and the row in
+/// `password_reset_tokens`.  Logs MUST NOT carry the raw token (#831 #2).
+fn token_fingerprint(token: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(token.as_bytes());
+    digest
+        .iter()
+        .take(4)
+        .fold(String::with_capacity(8), |mut s, b| {
+            use std::fmt::Write as _;
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
+#[cfg(test)]
+mod token_fingerprint_tests {
+    use super::token_fingerprint;
+
+    #[test]
+    fn deterministic_for_same_input() {
+        assert_eq!(token_fingerprint("abc"), token_fingerprint("abc"));
+    }
+
+    #[test]
+    fn different_for_different_inputs() {
+        assert_ne!(token_fingerprint("abc"), token_fingerprint("abd"));
+    }
+
+    #[test]
+    fn returns_eight_hex_chars() {
+        let fp = token_fingerprint("abc");
+        assert_eq!(fp.len(), 8);
+        assert!(
+            fp.chars().all(|c| c.is_ascii_hexdigit()),
+            "fingerprint must be hex: {fp}"
+        );
+    }
+
+    #[test]
+    fn does_not_leak_token_substring() {
+        let secret = "deadbeef-cafe-1234-token-do-not-log";
+        let fp = token_fingerprint(secret);
+        assert!(
+            !secret.contains(&fp[..]),
+            "fingerprint must not be a prefix of the raw token"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Refresh token helper (issue + persist)
 // ---------------------------------------------------------------------------
@@ -445,17 +496,22 @@ pub async fn forgot_password(
             .await
             .is_ok()
         {
-            // Admin-mediated: log token to stdout for the operator to relay.
-            // WARNING: this token grants full password reset access. Treat
-            // the server logs as sensitive material and rotate promptly.
+            // Admin-mediated: emit a fingerprint-only log line and require
+            // the operator to fetch the actual token from the DB via the
+            // password_reset table.  Logging the raw token at INFO turned
+            // log access into account takeover for any user who triggered
+            // forgot-password during the retention window (#831 #2).
+            let fingerprint = token_fingerprint(&token);
             tracing::info!(
-                username = %body.username,
-                user_id  = %user.id,
-                token    = %token,
-                expires  = %expires_at,
+                user_id = %user.id,
+                token_fingerprint = %fingerprint,
+                expires = %expires_at,
                 "[PASSWORD RESET] Single-use reset token issued. \
-                 Relay this token to the user via a trusted out-of-band channel. \
-                 It expires in 15 minutes. No email has been sent.",
+                 Operator: SELECT token FROM password_reset_tokens \
+                 WHERE user_id = '<user_id>' AND used_at IS NULL \
+                 ORDER BY created_at DESC LIMIT 1 \
+                 -- correlate via token_fingerprint above. \
+                 It expires in 15 minutes.",
             );
         }
     }

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -896,7 +896,7 @@ pub async fn unban_member(
 // ---------------------------------------------------------------------------
 
 /// Maximum group avatar size: 2 MB.
-const MAX_GROUP_AVATAR_SIZE: usize = 2 * 1024 * 1024;
+pub(super) const MAX_GROUP_AVATAR_SIZE: usize = 2 * 1024 * 1024;
 
 /// Allowed group avatar MIME types (validated via magic bytes, not client-supplied Content-Type).
 const ALLOWED_GROUP_AVATAR_TYPES: &[&str] = &["image/jpeg", "image/png", "image/webp", "image/gif"];
@@ -962,10 +962,7 @@ pub async fn upload_group_avatar(
             continue;
         }
 
-        let data = field
-            .bytes()
-            .await
-            .map_err(|e| AppError::bad_request(format!("Failed to read avatar data: {e}")))?;
+        let data = super::users::read_avatar_field_capped(field, MAX_GROUP_AVATAR_SIZE).await?;
 
         // Validate via magic bytes, not client-declared Content-Type
         let mime_type = match infer::get(&data) {
@@ -987,13 +984,6 @@ pub async fn upload_group_avatar(
                     ALLOWED_GROUP_AVATAR_TYPES.join(", ")
                 ),
             ));
-        }
-
-        if data.len() > MAX_GROUP_AVATAR_SIZE {
-            return Err(AppError::bad_request(format!(
-                "Avatar too large. Maximum size is {} bytes",
-                MAX_GROUP_AVATAR_SIZE
-            )));
         }
 
         let ext = avatar_extension_for_mime(&mime_type);

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -49,6 +49,7 @@ const ALLOWED_MIME_TYPES: &[&str] = &[
     "audio/ogg",
     "audio/wav",
     "audio/mp4",
+    "audio/m4a",
     "audio/aac",
     "audio/x-m4a",
     "audio/flac",
@@ -82,7 +83,7 @@ fn extension_for_mime(mime: &str) -> &str {
         "audio/mpeg" => "mp3",
         "audio/ogg" => "ogg",
         "audio/wav" => "wav",
-        "audio/mp4" | "audio/x-m4a" => "m4a",
+        "audio/mp4" | "audio/x-m4a" | "audio/m4a" => "m4a",
         "audio/aac" => "aac",
         "audio/flac" | "audio/x-flac" => "flac",
         "application/pdf" => "pdf",
@@ -118,12 +119,15 @@ fn validate_bytes(data: &[u8], declared_mime: &str) -> Result<String, AppError> 
     match infer::get(data) {
         Some(inferred) => {
             let m = inferred.mime_type();
-            // M4A audio files share the same MP4 container magic bytes as video/mp4.
-            // When infer reports video/mp4 but the client declared an audio/mp4 type,
-            // trust the declared audio MIME -- the container is valid regardless.
-            let effective = if m == "video/mp4"
-                && matches!(declared_mime, "audio/mp4" | "audio/x-m4a" | "audio/aac")
-            {
+            // M4A audio files share the same MP4 container magic bytes as
+            // video/mp4.  Different `infer` versions disambiguate differently:
+            // some report video/mp4 (and we trust the declared audio MIME),
+            // others report audio/m4a directly (which we accept on its own).
+            let effective = if (m == "video/mp4" || m == "audio/m4a")
+                && matches!(
+                    declared_mime,
+                    "audio/mp4" | "audio/x-m4a" | "audio/m4a" | "audio/aac"
+                ) {
                 declared_mime
             } else {
                 m
@@ -236,10 +240,14 @@ fn validate_head(head: &[u8], declared_mime: &str) -> Result<String, AppError> {
     match infer::get(head) {
         Some(inferred) => {
             let m = inferred.mime_type();
-            // M4A audio files share the same MP4 container magic bytes as video/mp4.
-            let effective = if m == "video/mp4"
-                && matches!(declared_mime, "audio/mp4" | "audio/x-m4a" | "audio/aac")
-            {
+            // M4A audio files share the same MP4 container magic bytes as
+            // video/mp4.  Different `infer` versions disambiguate differently
+            // (see validate_bytes for details).
+            let effective = if (m == "video/mp4" || m == "audio/m4a")
+                && matches!(
+                    declared_mime,
+                    "audio/mp4" | "audio/x-m4a" | "audio/m4a" | "audio/aac"
+                ) {
                 declared_mime
             } else {
                 m
@@ -786,6 +794,37 @@ mod tests {
         let head = make_m4v_head();
         let mime = validate_bytes(&head, "video/mp4").expect("M4V magic bytes should be accepted");
         assert_eq!(mime, "video/x-m4v");
+    }
+
+    // Minimal M4A header -- ftyp box with "M4A " brand, padded to 512 bytes.
+    // The `record` plugin on iOS/Android produces this brand for AAC-LC voice
+    // recordings.  Different `infer` crate versions return either "video/mp4"
+    // or "audio/m4a" for this magic; both must round-trip through validation.
+    fn make_m4a_head() -> Vec<u8> {
+        let mut v = vec![
+            0x00, 0x00, 0x00, 0x14, // box size = 20
+            b'f', b't', b'y', b'p', // box type = "ftyp"
+            b'M', b'4', b'A', b' ', // major brand = "M4A "
+            0x00, 0x00, 0x00, 0x00, // minor version
+            b'M', b'4', b'A', b' ', // compatible brand
+        ];
+        v.resize(512, 0);
+        v
+    }
+
+    #[test]
+    fn validate_bytes_accepts_m4a_voice_recording() {
+        // Regression for #837: voice messages from mobile (record plugin,
+        // AAC-LC in MP4 container) were rejected because the declared MIME
+        // path only accepted infer="video/mp4", and infer can also report
+        // "audio/m4a" for the same magic bytes.
+        let head = make_m4a_head();
+        let mime = validate_bytes(&head, "audio/mp4")
+            .expect("M4A voice recordings should be accepted when declared as audio/mp4");
+        assert!(
+            matches!(mime.as_str(), "audio/mp4" | "audio/m4a" | "audio/x-m4a"),
+            "unexpected normalized mime: {mime}"
+        );
     }
 
     #[test]

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -102,6 +102,10 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
         rate_limit::make_rate_limit_layer(rate_limit::ticket_limiter(Arc::clone(&proxies)));
     let media_upload_limit =
         rate_limit::make_rate_limit_layer(rate_limit::media_upload_limiter(Arc::clone(&proxies)));
+    let user_avatar_limit =
+        rate_limit::make_rate_limit_layer(rate_limit::avatar_upload_limiter(Arc::clone(&proxies)));
+    let group_avatar_limit =
+        rate_limit::make_rate_limit_layer(rate_limit::avatar_upload_limiter(Arc::clone(&proxies)));
     let link_preview_limit =
         rate_limit::make_rate_limit_layer(rate_limit::link_preview_limiter(Arc::clone(&proxies)));
     let key_reset_limit =
@@ -298,7 +302,12 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
         .route("/{id}/unban/{user_id}", post(groups::unban_member))
         .route(
             "/{id}/avatar",
-            put(groups::upload_group_avatar).get(groups::get_group_avatar),
+            put(groups::upload_group_avatar)
+                .get(groups::get_group_avatar)
+                .layer(DefaultBodyLimit::max(
+                    groups::MAX_GROUP_AVATAR_SIZE.saturating_mul(2),
+                ))
+                .layer(middleware::from_fn(group_avatar_limit)),
         )
         .route(
             "/{id}/invites",
@@ -320,7 +329,14 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
         )
         .route("/me/status", patch(users::update_presence_status))
         .route("/me/status-text", put(users::update_status_text))
-        .route("/me/avatar", put(users::upload_avatar))
+        .route(
+            "/me/avatar",
+            put(users::upload_avatar)
+                .layer(DefaultBodyLimit::max(
+                    users::MAX_AVATAR_SIZE.saturating_mul(2),
+                ))
+                .layer(middleware::from_fn(user_avatar_limit)),
+        )
         .route("/online", get(users::online_users))
         .route("/search", get(users::search_users))
         .route("/resolve/{username}", get(users::resolve_username_invite))

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -581,7 +581,7 @@ pub async fn resolve_username_invite(
 }
 
 /// Maximum avatar size: 2 MB.
-const MAX_AVATAR_SIZE: usize = 2 * 1024 * 1024;
+pub(super) const MAX_AVATAR_SIZE: usize = 2 * 1024 * 1024;
 
 /// Allowed avatar MIME types (validated via magic bytes, not client-supplied Content-Type).
 const ALLOWED_AVATAR_TYPES: &[&str] = &["image/jpeg", "image/png", "image/webp", "image/gif"];
@@ -606,6 +606,39 @@ fn mime_for_extension(ext: &str) -> &str {
         "gif" => "image/gif",
         _ => "application/octet-stream",
     }
+}
+
+/// Stream a multipart `field` into memory, rejecting the moment its byte
+/// total crosses `max_bytes`.  Avatars are capped at a few MB so the whole
+/// buffer is still small enough for `infer::get` validation, but the
+/// previous `field.bytes().await` path read the entire client-supplied
+/// payload into RAM before checking the cap (#831).  This helper closes
+/// that DoS window — concurrent attackers can no longer pin O(N * 100 MB)
+/// of process memory by spamming oversized POSTs.
+///
+/// Shared by both `/me/avatar` and `/groups/{id}/avatar` upload handlers.
+pub(super) async fn read_avatar_field_capped(
+    mut field: axum::extract::multipart::Field<'_>,
+    max_bytes: usize,
+) -> Result<Vec<u8>, AppError> {
+    let mut buf = Vec::with_capacity(max_bytes.min(64 * 1024));
+    loop {
+        let chunk = field
+            .chunk()
+            .await
+            .map_err(|e| AppError::bad_request(format!("Failed to read avatar data: {e}")))?;
+        let Some(bytes) = chunk else { break };
+        if bytes.is_empty() {
+            continue;
+        }
+        if buf.len().saturating_add(bytes.len()) > max_bytes {
+            return Err(AppError::bad_request(format!(
+                "Avatar too large. Maximum size is {max_bytes} bytes"
+            )));
+        }
+        buf.extend_from_slice(&bytes);
+    }
+    Ok(buf)
 }
 
 /// PUT /api/users/me/avatar
@@ -637,17 +670,7 @@ pub async fn upload_avatar(
             continue;
         }
 
-        let data = field
-            .bytes()
-            .await
-            .map_err(|e| AppError::bad_request(format!("Failed to read avatar data: {e}")))?;
-
-        if data.len() > MAX_AVATAR_SIZE {
-            return Err(AppError::bad_request(format!(
-                "Avatar too large. Maximum size is {} bytes",
-                MAX_AVATAR_SIZE
-            )));
-        }
+        let data = read_avatar_field_capped(field, MAX_AVATAR_SIZE).await?;
 
         // Validate via magic bytes, not client-declared Content-Type.
         let mime_type = match infer::get(&data) {

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -998,13 +998,13 @@ pub(super) async fn fanout_message(
     //
     // Guarded behind `!offline_user_ids.is_empty()` so the body scan
     // is skipped entirely when no offline recipients exist (the only
-    // path where suppression matters).  `mentions_broadcast` itself
+    // path where suppression matters).  `is_standalone_keyword` itself
     // already short-circuits on content with no '@', but this guard
     // skips even the call setup on the hot path.
     let suppress_offline_push = !offline_user_ids.is_empty()
         && is_group
         && !is_encrypted
-        && mentions_broadcast(&fields.content, "here");
+        && db::mentions::is_standalone_keyword(&fields.content, "here");
 
     if suppress_offline_push {
         // Audit trail for #451: suppressing pushes is observable abuse
@@ -1029,41 +1029,6 @@ pub(super) async fn fanout_message(
             stored_id,
         );
     }
-}
-
-/// Returns true when `content` contains `@<keyword>` as a standalone token.
-///
-/// Boundaries are start/end of string or any non-word character (anything
-/// other than alphanumeric or underscore).  Case-insensitive so users
-/// typing `@Here` or `@HERE` are still routed correctly.
-pub(super) fn mentions_broadcast(content: &str, keyword: &str) -> bool {
-    // Hot path: most messages don't contain '@' at all.  Bail before any
-    // allocation — `str::contains` for a single ASCII byte is SIMD-fast.
-    if !content.contains('@') {
-        return false;
-    }
-    let target = format!("@{}", keyword.to_lowercase());
-    let lower = content.to_lowercase();
-    let mut start = 0;
-    while let Some(rel) = lower[start..].find(&target) {
-        let abs = start + rel;
-        let after = abs + target.len();
-        let left_ok = abs == 0
-            || !lower[..abs]
-                .chars()
-                .next_back()
-                .is_some_and(|c| c.is_alphanumeric() || c == '_');
-        let right_ok = after == lower.len()
-            || !lower[after..]
-                .chars()
-                .next()
-                .is_some_and(|c| c.is_alphanumeric() || c == '_');
-        if left_ok && right_ok {
-            return true;
-        }
-        start = abs + target.len();
-    }
-    false
 }
 
 /// Deliver any messages that were stored while the user was offline, then mark
@@ -1237,63 +1202,5 @@ async fn deliver_one_batch(
                 .hub
                 .send_to(&msg.sender_id, WsMessage::Text(json.into()));
         }
-    }
-}
-
-#[cfg(test)]
-mod broadcast_tests {
-    use super::mentions_broadcast;
-
-    #[test]
-    fn matches_lone_at_here() {
-        assert!(mentions_broadcast("@here", "here"));
-    }
-
-    #[test]
-    fn matches_at_here_with_surrounding_text() {
-        assert!(mentions_broadcast("hi @here please look", "here"));
-    }
-
-    #[test]
-    fn matches_at_here_with_punctuation() {
-        assert!(mentions_broadcast("@here, please", "here"));
-        assert!(mentions_broadcast("psst.@here!", "here"));
-    }
-
-    #[test]
-    fn rejects_at_hereafter() {
-        assert!(!mentions_broadcast("@hereafter we go", "here"));
-    }
-
-    #[test]
-    fn rejects_email_like_x_at_here() {
-        assert!(!mentions_broadcast("x@here", "here"));
-    }
-
-    #[test]
-    fn rejects_underscore_suffix() {
-        assert!(!mentions_broadcast("@here_lounge", "here"));
-    }
-
-    #[test]
-    fn case_insensitive() {
-        assert!(mentions_broadcast("Yo @Here folks", "here"));
-        assert!(mentions_broadcast("YO @HERE FOLKS", "here"));
-    }
-
-    #[test]
-    fn matches_everyone_too() {
-        assert!(mentions_broadcast("@everyone get in here", "everyone"));
-        assert!(!mentions_broadcast("@everyones", "everyone"));
-    }
-
-    #[test]
-    fn empty_content_is_false() {
-        assert!(!mentions_broadcast("", "here"));
-    }
-
-    #[test]
-    fn no_match_is_false() {
-        assert!(!mentions_broadcast("normal message", "here"));
     }
 }

--- a/apps/server/tests/api_users.rs
+++ b/apps/server/tests/api_users.rs
@@ -728,6 +728,41 @@ async fn avatar_upload_valid_png_returns_200() {
 }
 
 #[tokio::test]
+async fn avatar_upload_oversize_payload_rejected_without_buffering() {
+    // Regression for #831 #1: pre-fix code path read the entire client
+    // payload into RAM before checking the size cap.  This test sends a
+    // multipart body well over the 2 MB avatar cap and asserts the server
+    // rejects with 4xx.  The body is also above axum's per-route
+    // DefaultBodyLimit (4 MB) so the request should fail at body-decode
+    // time rather than after fully buffering 8 MB of attacker bytes.
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _) = setup_user(&client, &base, "avbig").await;
+
+    // 8 MB blob (well over MAX_AVATAR_SIZE = 2 MB and the 4 MB body limit).
+    let oversize = vec![0u8; 8 * 1024 * 1024];
+    let part = Part::bytes(oversize)
+        .file_name("big.png")
+        .mime_str("image/png")
+        .unwrap();
+    let form = Form::new().part("avatar", part);
+
+    let resp = client
+        .put(format!("{base}/api/users/me/avatar"))
+        .header("Authorization", format!("Bearer {token}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status().as_u16();
+    assert!(
+        (400..500).contains(&status),
+        "oversize avatar must be rejected with 4xx, got {status}"
+    );
+}
+
+#[tokio::test]
 async fn avatar_upload_non_image_returns_4xx_with_code() {
     let base = common::spawn_server().await;
     let client = Client::new();

--- a/core/rust-core/Cargo.toml
+++ b/core/rust-core/Cargo.toml
@@ -8,7 +8,6 @@ license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
 crate-type = ["lib"]
 
 [dependencies]
-tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
@@ -16,13 +15,10 @@ thiserror.workspace = true
 tracing.workspace = true
 chrono.workspace = true
 
-# Networking
-tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
-futures-util = "0.3"
-reqwest = { version = "0.13", features = ["json"] }
-
-# Storage
-rusqlite = { version = "0.32", features = ["bundled-sqlcipher"] }
+# This crate ships Signal Protocol primitives only.  The FFI bridge to a
+# Dart-side runtime never landed (see CLAUDE.md "Known Limitations" #3),
+# so the abandoned FFI deps (tokio, tokio-tungstenite, futures-util,
+# reqwest, rusqlite + bundled-sqlcipher) are intentionally omitted.
 
 # Crypto utilities
 rand_core = { version = "0.6", features = ["getrandom"] }


### PR DESCRIPTION
## Summary

Bundle of 7 commits: 3 production fixes from user-reported issues + 4 audit-driven cleanup wins. All tests green (1444 Flutter + 135 server lib + 45 echo-core), workspace clippy clean with `-D warnings`, dart format clean.

### Production fixes

- **`fix(ci)` — Linux AppImage missing liblua5.2.so.0 (#835)**
  `libmpv` on bookworm pulls `liblua5.2-0` for embedded scripting; missing from `BUNDLE_RE` so AppImage launches failed on hosts without the lib system-installed. One-line regex addition + sanity check note.

- **`fix(server)` — m4a voice messages rejected (#837)**
  `infer` crate v0.19 returns `audio/m4a` for AAC-LC-in-MP4 (`.m4a`) recordings from the `record` plugin, but only `audio/mp4` and `audio/x-m4a` were in `ALLOWED_MIME_TYPES`. The override path also only handled `infer="video/mp4"`. Add `audio/m4a` to the allowlist + extension map + both override paths. Includes a regression test asserting an M4A `ftyp` head declared as `audio/mp4` round-trips successfully.

- **Mobile voice lounge UI (#836)** — deferred from this PR. The screen renders intentionally as `ParticipantGrid` so the issue is design-level, not a code typo. Filed with investigation pointers.

### Audit cleanup quick wins

- **`perf(client)` — `.select()` instead of full provider watch in chat hot path (#834 F6, F14)**
  `ChatPanel.build` watched the entire `chatProvider`, so adding a message in conv B rebuilt conv A's panel. Switch to `chatProvider.select((s) => s.messagesByConversation[conv.id])` (inner list refs are stable across `withMessage` copyWith for unaffected conversations) plus narrow `.select` calls for `isLoadingHistory` and `conversationHasMore`. `chat_input_bar` got the same treatment for `authProvider.select((s) => s.userId)`. `ChatMessageList` accepts `hasMoreHistory: bool` instead of the full `ChatState`.

- **`fix(client)` — theme-aware foreground in extracted `reply_quote` + `reaction_bar` (#830 F7, F8)**
  The message_item split (a36a01d, 9a06e21) inherited hardcoded `Colors.white` for the `isMine` path. Add `context.onSentBubble` (resolves to `ColorScheme.onPrimary`) and use it on both surfaces. Promote to a dedicated `EchoColorExtension` field if a theme ever needs a non-onPrimary value.

- **`refactor(client)` — drop redundant `updateMessageStatus` after `confirmSent` (#830 F5)**
  `confirmSent` already transitions status atomically with the ID swap; the follow-up call rebuilt the conversation list a second time per outgoing message.

- **`refactor(server)` — dedup standalone-at-keyword check (#834 F3)**
  `is_standalone_keyword` in `db/mentions.rs` and `mentions_broadcast` in `ws/message_service.rs` were byte-for-byte duplicates. Promote `db::mentions::is_standalone_keyword` to `pub`, delete the duplicate, consolidate `broadcast_tests` cases into `db::mentions::tests`.

- **`chore(core)` — drop abandoned FFI deps (#834 F1)**
  `tokio`, `tokio-tungstenite`, `futures-util`, `reqwest`, `rusqlite + bundled-sqlcipher` had zero `use` sites in `core/rust-core/src/`. CLAUDE.md known-limitation #3 already flagged this. Faster CI, smaller `Cargo.lock`.

## Audit context

Filed alongside this PR: 6 sectored audit issues #829–#834 covering the 71 findings from the multi-agent audit. This PR is the "quick wins" pass; remaining items are tracked in those issues plus the 3 prod-bug issues #835–#837.

## Test plan

- [x] `cargo test --workspace --lib` — 135 server + 45 echo-core, all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `flutter test` — 1444 tests pass
- [x] `flutter analyze --fatal-infos` — clean
- [x] M4A regression test added (`validate_bytes_accepts_m4a_voice_recording`)
- [ ] Manual: AppImage runs on a clean host without `liblua5.2-0` system-installed (verify CI artifact bundle list includes `liblua5.2.so.0`)
- [ ] Manual: record + send voice message on iOS TestFlight
- [ ] Manual: verify ChatPanel doesn't rebuild on cross-conversation activity (DevTools rebuild counter)
