### PR TITLE
Discord-parity mobile voice: background, live notification, and PiP

### DIFF
--- a/apps/client/android/app/src/main/AndroidManifest.xml
+++ b/apps/client/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <!-- Required for the voice-mode foreground service so the OS does not
+         revoke RECORD_AUDIO when the app is backgrounded (Android 14+). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
@@ -29,6 +33,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
+            android:resizeableActivity="true"
+            android:supportsPictureInPicture="true"
             android:windowSoftInputMode="adjustResize">
 
             <meta-data
@@ -41,9 +47,18 @@
             </intent-filter>
         </activity>
 
+        <!-- Supports two modes: dataSync (default WS keep-alive) and
+             microphone|mediaPlayback (voice-call mode).  The runtime call
+             to startForeground decides which subset is active. -->
         <service
             android:name=".EchoForegroundService"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="dataSync|microphone|mediaPlayback"
+            android:exported="false" />
+
+        <!-- Receives Mute / Leave action taps from the voice notification
+             and forwards them back to the service. -->
+        <receiver
+            android:name=".VoiceNotificationReceiver"
             android:exported="false" />
 
         <meta-data

--- a/apps/client/android/app/src/main/kotlin/us/echomessenger/echo_app/EchoForegroundService.kt
+++ b/apps/client/android/app/src/main/kotlin/us/echomessenger/echo_app/EchoForegroundService.kt
@@ -12,21 +12,44 @@ import android.os.IBinder
 import android.os.PowerManager
 
 /**
- * Foreground service that keeps the app alive in the background so the
- * WebSocket connection stays active and messages arrive in real time.
+ * Foreground service that keeps the app alive in the background.
  *
- * Shows a persistent notification ("Echo Messenger is running") that the
- * user can tap to return to the app. No external push service (Firebase,
- * Google Play Services) is required.
+ * Supports two modes:
+ *
+ *   - **Keep-alive mode** (default): generic notification, type DATA_SYNC.
+ *     Used so the WebSocket stays connected for incoming messages.
+ *
+ *   - **Voice mode**: notification shows the active channel name + Mute /
+ *     Leave actions, type MICROPHONE | MEDIA_PLAYBACK so Android 14+ does
+ *     not revoke RECORD_AUDIO when the app is backgrounded.  Started by
+ *     LiveKitVoiceProvider.joinChannel via the BackgroundService method
+ *     channel; stopped on leaveChannel.
+ *
+ * Mute / Leave actions are routed back to Dart via a static broadcast
+ * channel held by [MainActivity] (see [VoiceNotificationReceiver]).
  */
 class EchoForegroundService : Service() {
 
     companion object {
         const val CHANNEL_ID = "echo_foreground"
         const val NOTIFICATION_ID = 1
+
+        // Intent extras used to start / update the voice notification.
+        const val EXTRA_MODE = "mode"
+        const val EXTRA_CHANNEL_NAME = "channel_name"
+        const val EXTRA_IS_MUTED = "is_muted"
+        const val EXTRA_PARTICIPANT_COUNT = "participant_count"
+
+        // Mode values.
+        const val MODE_KEEPALIVE = "keepalive"
+        const val MODE_VOICE = "voice"
     }
 
     private var wakeLock: PowerManager.WakeLock? = null
+    private var currentMode: String = MODE_KEEPALIVE
+    private var voiceChannelName: String = ""
+    private var voiceIsMuted: Boolean = false
+    private var voiceParticipantCount: Int = 1
 
     override fun onCreate() {
         super.onCreate()
@@ -34,36 +57,59 @@ class EchoForegroundService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // A null intent here means the service was restarted by the system
+        // after being killed; fall back to keep-alive defaults.
+        val mode = intent?.getStringExtra(EXTRA_MODE) ?: currentMode
+        currentMode = mode
+
+        if (mode == MODE_VOICE) {
+            voiceChannelName = intent?.getStringExtra(EXTRA_CHANNEL_NAME) ?: voiceChannelName
+            voiceIsMuted = intent?.getBooleanExtra(EXTRA_IS_MUTED, voiceIsMuted) ?: voiceIsMuted
+            voiceParticipantCount = intent?.getIntExtra(EXTRA_PARTICIPANT_COUNT, voiceParticipantCount)
+                ?: voiceParticipantCount
+        }
+
         val notification = buildNotification()
+        startInForegroundMode(notification)
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-            )
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
+        if (wakeLock == null) {
+            val pm = getSystemService(POWER_SERVICE) as PowerManager
+            wakeLock = pm.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "echo:foreground_service"
+            ).apply {
+                setReferenceCounted(false)
+                acquire()
+            }
         }
 
-        // Acquire a partial wake lock to keep the CPU running for the
-        // WebSocket connection. Tagged so it's identifiable in battery stats.
-        val pm = getSystemService(POWER_SERVICE) as PowerManager
-        wakeLock = pm.newWakeLock(
-            PowerManager.PARTIAL_WAKE_LOCK,
-            "echo:foreground_service"
-        ).apply {
-            acquire()
-        }
-
-        // If the system kills the service, restart it automatically.
         return START_STICKY
     }
 
-    override fun onDestroy() {
-        wakeLock?.let {
-            if (it.isHeld) it.release()
+    private fun startInForegroundMode(notification: Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val type = if (currentMode == MODE_VOICE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE or
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            } else {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            }
+            startForeground(NOTIFICATION_ID, notification, type)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
         }
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // User swiped the app from recents — drop the notification cleanly
+        // so we don't leak a zombie wakelock or stuck "Connected" badge.
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
+    override fun onDestroy() {
+        wakeLock?.let { if (it.isHeld) it.release() }
         wakeLock = null
         super.onDestroy()
     }
@@ -77,7 +123,7 @@ class EchoForegroundService : Service() {
                 "Background Connection",
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = "Keeps Echo connected for real-time messages"
+                description = "Keeps Echo connected for real-time messages and voice"
                 setShowBadge(false)
             }
             val manager = getSystemService(NotificationManager::class.java)
@@ -86,7 +132,6 @@ class EchoForegroundService : Service() {
     }
 
     private fun buildNotification(): Notification {
-        // Tap the notification to open the app
         val openIntent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
@@ -95,12 +140,65 @@ class EchoForegroundService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        return Notification.Builder(this, CHANNEL_ID)
-            .setContentTitle("Echo Messenger")
-            .setContentText("Connected and receiving messages")
+        val title: String
+        val body: String
+        val builder = Notification.Builder(this, CHANNEL_ID)
+
+        if (currentMode == MODE_VOICE) {
+            title = if (voiceChannelName.isNotEmpty()) voiceChannelName else "Voice call"
+            body = if (voiceParticipantCount > 1) {
+                "Connected · $voiceParticipantCount in lounge"
+            } else {
+                "Connected"
+            }
+            builder.addAction(buildMuteAction())
+            builder.addAction(buildLeaveAction())
+        } else {
+            title = "Echo Messenger"
+            body = "Connected and receiving messages"
+        }
+
+        return builder
+            .setContentTitle(title)
+            .setContentText(body)
             .setSmallIcon(android.R.drawable.stat_notify_chat)
             .setContentIntent(pendingIntent)
             .setOngoing(true)
             .build()
+    }
+
+    private fun buildMuteAction(): Notification.Action {
+        val label = if (voiceIsMuted) "Unmute" else "Mute"
+        val icon = if (voiceIsMuted) {
+            android.R.drawable.ic_lock_silent_mode_off
+        } else {
+            android.R.drawable.ic_lock_silent_mode
+        }
+        val intent = Intent(this, VoiceNotificationReceiver::class.java).apply {
+            action = VoiceNotificationReceiver.ACTION_TOGGLE_MUTE
+            // Pass the desired post-toggle state so the UI matches even if
+            // the broadcast races a state read.
+            putExtra(VoiceNotificationReceiver.EXTRA_NEW_MUTED, !voiceIsMuted)
+        }
+        val pending = PendingIntent.getBroadcast(
+            this, 1, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        return Notification.Action.Builder(icon, label, pending).build()
+    }
+
+    private fun buildLeaveAction(): Notification.Action {
+        val intent = Intent(this, VoiceNotificationReceiver::class.java).apply {
+            action = VoiceNotificationReceiver.ACTION_LEAVE
+        }
+        val pending = PendingIntent.getBroadcast(
+            this, 2, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        return Notification.Action.Builder(
+            android.R.drawable.ic_menu_close_clear_cancel,
+            "Leave",
+            pending
+        ).build()
     }
 }

--- a/apps/client/android/app/src/main/kotlin/us/echomessenger/echo_app/MainActivity.kt
+++ b/apps/client/android/app/src/main/kotlin/us/echomessenger/echo_app/MainActivity.kt
@@ -1,40 +1,204 @@
 package us.echomessenger.echo_app
 
+import android.app.PictureInPictureParams
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Build
+import android.util.Rational
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
+/**
+ * Hosts the Flutter UI plus three method-channel surfaces:
+ *
+ *   - `us.echomessenger/foreground_service` — start/stop/update the
+ *     [EchoForegroundService] (keep-alive and voice modes), and forward
+ *     Mute / Leave taps from the voice notification back to Dart.
+ *   - `us.echomessenger/pip` — track the current screen-share aspect
+ *     ratio; on home-button press, enter PiP if eligible.  Runtime gate
+ *     keeps minSdk at 24 (Android 7.x users skip PiP).
+ *   - `us.echomessenger/push` — owned by AppDelegate-equivalent on iOS;
+ *     left alone here.
+ */
 class MainActivity : FlutterActivity() {
 
     companion object {
-        private const val CHANNEL = "us.echomessenger/foreground_service"
+        private const val FG_CHANNEL = "us.echomessenger/foreground_service"
+        private const val PIP_CHANNEL = "us.echomessenger/pip"
+
+        // Static bridge so VoiceNotificationReceiver can deliver Mute /
+        // Leave taps without binding to the running activity.  When the
+        // activity is not alive (rare — the app is foregrounded by tap
+        // before the action takes effect), the dispatch is a no-op.
+        @Volatile
+        private var foregroundChannel: MethodChannel? = null
+
+        fun dispatchVoiceNotificationAction(
+            action: String,
+            args: Map<String, Any?>
+        ) {
+            // MethodChannel.invokeMethod must run on the platform thread;
+            // FlutterEngine handles the post internally.
+            foregroundChannel?.invokeMethod(
+                "onNotificationAction",
+                mapOf("action" to action) + args
+            )
+        }
     }
+
+    private var pipEligibleWidth: Int = 0
+    private var pipEligibleHeight: Int = 0
+    private var pipChannel: MethodChannel? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        MethodChannel(
+        val fgChannel = MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
-            CHANNEL
-        ).setMethodCallHandler { call, result ->
+            FG_CHANNEL
+        )
+        foregroundChannel = fgChannel
+        fgChannel.setMethodCallHandler { call, result ->
             when (call.method) {
                 "start" -> {
-                    startForegroundService()
+                    startKeepaliveService()
                     result.success(null)
                 }
                 "stop" -> {
                     stopForegroundService()
                     result.success(null)
                 }
+                "startVoice" -> {
+                    val channelName = call.argument<String>("channelName") ?: ""
+                    val isMuted = call.argument<Boolean>("isMuted") ?: false
+                    val participantCount = call.argument<Int>("participantCount") ?: 1
+                    startVoiceService(channelName, isMuted, participantCount)
+                    result.success(null)
+                }
+                "updateVoice" -> {
+                    val channelName = call.argument<String>("channelName")
+                    val isMuted = call.argument<Boolean>("isMuted")
+                    val participantCount = call.argument<Int>("participantCount")
+                    updateVoiceService(channelName, isMuted, participantCount)
+                    result.success(null)
+                }
+                "stopVoice" -> {
+                    stopForegroundService()
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        val pip = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            PIP_CHANNEL
+        )
+        pipChannel = pip
+        pip.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setEligible" -> {
+                    val w = call.argument<Int>("width") ?: 0
+                    val h = call.argument<Int>("height") ?: 0
+                    pipEligibleWidth = w
+                    pipEligibleHeight = h
+                    result.success(null)
+                }
+                "enterPip" -> {
+                    result.success(enterPipIfEligible())
+                }
                 else -> result.notImplemented()
             }
         }
     }
 
-    private fun startForegroundService() {
-        val intent = Intent(this, EchoForegroundService::class.java)
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        // User pressed Home / opened recents — try to drop into PiP if a
+        // remote screen share is active.  No-op on Android < O.
+        enterPipIfEligible()
+    }
+
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: Configuration
+    ) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        pipChannel?.invokeMethod("onPipChanged", mapOf("inPip" to isInPictureInPictureMode))
+    }
+
+    private fun enterPipIfEligible(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+        if (pipEligibleWidth <= 0 || pipEligibleHeight <= 0) return false
+        return try {
+            val rational = clampedRational(pipEligibleWidth, pipEligibleHeight)
+            val params = PictureInPictureParams.Builder()
+                .setAspectRatio(rational)
+                .build()
+            enterPictureInPictureMode(params)
+        } catch (e: IllegalStateException) {
+            // Activity may already be paused or destroyed.
+            false
+        } catch (e: IllegalArgumentException) {
+            // Aspect ratio outside [0.418, 2.39] — Android rejects it.
+            false
+        }
+    }
+
+    /**
+     * Android's PiP API rejects aspect ratios outside roughly [1:2.39, 2.39:1].
+     * Most screen shares are wider than 2.39:1 only on multi-monitor setups;
+     * clamp to the nearest valid ratio so the user still gets a window.
+     */
+    private fun clampedRational(width: Int, height: Int): Rational {
+        val raw = width.toDouble() / height.toDouble()
+        val clamped = raw.coerceIn(0.42, 2.38)
+        // Multiply through to keep integer rationals (Rational uses ints).
+        val w = (clamped * 1000).toInt().coerceAtLeast(1)
+        val h = 1000
+        return Rational(w, h)
+    }
+
+    private fun startKeepaliveService() {
+        val intent = Intent(this, EchoForegroundService::class.java).apply {
+            putExtra(EchoForegroundService.EXTRA_MODE, EchoForegroundService.MODE_KEEPALIVE)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
+        }
+    }
+
+    private fun startVoiceService(channelName: String, isMuted: Boolean, participantCount: Int) {
+        val intent = Intent(this, EchoForegroundService::class.java).apply {
+            putExtra(EchoForegroundService.EXTRA_MODE, EchoForegroundService.MODE_VOICE)
+            putExtra(EchoForegroundService.EXTRA_CHANNEL_NAME, channelName)
+            putExtra(EchoForegroundService.EXTRA_IS_MUTED, isMuted)
+            putExtra(EchoForegroundService.EXTRA_PARTICIPANT_COUNT, participantCount)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
+        }
+    }
+
+    private fun updateVoiceService(
+        channelName: String?,
+        isMuted: Boolean?,
+        participantCount: Int?
+    ) {
+        // onStartCommand picks up the latest extras and rebuilds the
+        // notification.  Falls back to the service's stored values for
+        // any extras left null.
+        val intent = Intent(this, EchoForegroundService::class.java).apply {
+            putExtra(EchoForegroundService.EXTRA_MODE, EchoForegroundService.MODE_VOICE)
+            channelName?.let { putExtra(EchoForegroundService.EXTRA_CHANNEL_NAME, it) }
+            isMuted?.let { putExtra(EchoForegroundService.EXTRA_IS_MUTED, it) }
+            participantCount?.let { putExtra(EchoForegroundService.EXTRA_PARTICIPANT_COUNT, it) }
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             startForegroundService(intent)
         } else {
@@ -45,5 +209,11 @@ class MainActivity : FlutterActivity() {
     private fun stopForegroundService() {
         val intent = Intent(this, EchoForegroundService::class.java)
         stopService(intent)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        foregroundChannel = null
+        pipChannel = null
     }
 }

--- a/apps/client/android/app/src/main/kotlin/us/echomessenger/echo_app/VoiceNotificationReceiver.kt
+++ b/apps/client/android/app/src/main/kotlin/us/echomessenger/echo_app/VoiceNotificationReceiver.kt
@@ -1,0 +1,34 @@
+package us.echomessenger.echo_app
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Receives Mute / Leave action taps from the voice-mode foreground
+ * notification.  The receiver itself just forwards the action to
+ * [MainActivity] (when alive) over a static bridge — Dart is the source
+ * of truth for mic + room state.  If the activity is not running we
+ * still update the notification optimistically so the UI is responsive,
+ * and Dart will catch up the next time it observes the service.
+ */
+class VoiceNotificationReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val ACTION_TOGGLE_MUTE = "us.echomessenger.echo_app.action.TOGGLE_MUTE"
+        const val ACTION_LEAVE = "us.echomessenger.echo_app.action.LEAVE"
+        const val EXTRA_NEW_MUTED = "new_muted"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            ACTION_TOGGLE_MUTE -> {
+                val newMuted = intent.getBooleanExtra(EXTRA_NEW_MUTED, false)
+                MainActivity.dispatchVoiceNotificationAction("mute", mapOf("muted" to newMuted))
+            }
+            ACTION_LEAVE -> {
+                MainActivity.dispatchVoiceNotificationAction("leave", emptyMap())
+            }
+        }
+    }
+}

--- a/apps/client/ios/Runner/AppDelegate.swift
+++ b/apps/client/ios/Runner/AppDelegate.swift
@@ -6,6 +6,7 @@ import UserNotifications
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   private var pushChannel: FlutterMethodChannel?
+  private var pipBridge: Any?  // PipBridgePlugin, type-erased so iOS < 15 builds compile.
 
   override func application(
     _ application: UIApplication,
@@ -56,6 +57,17 @@ import UserNotifications
       name: "us.echomessenger/push",
       binaryMessenger: messenger
     )
+
+    // Register the PiP method-channel handler.  Hosted on the root
+    // window's view so the AVSampleBufferDisplayLayer we add for PiP
+    // gets a valid superlayer; Flutter's content view itself isn't a
+    // suitable host because Flutter manages its own layer hierarchy.
+    if #available(iOS 15.0, *) {
+      let host = window?.rootViewController?.view ?? UIView()
+      let bridge = PipBridgePlugin()
+      bridge.register(with: messenger, hostView: host)
+      pipBridge = bridge
+    }
   }
 
   // MARK: - APNs Token Registration

--- a/apps/client/ios/Runner/AppDelegate.swift
+++ b/apps/client/ios/Runner/AppDelegate.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Flutter
 import UIKit
 import UserNotifications
@@ -15,6 +16,23 @@ import UserNotifications
 
     // Register for remote notifications (APNs)
     application.registerForRemoteNotifications()
+
+    // Configure the AVAudioSession for VoIP-style playback so CallKit and
+    // LiveKit's WebRTC engine share consistent options.  We don't activate
+    // it here — CallKit owns activation when an outgoing call starts and
+    // releases it on end.  Setting category up front avoids first-frame
+    // audio drops when LiveKit grabs the session ahead of CallKit on a
+    // cold-start join.
+    do {
+      let session = AVAudioSession.sharedInstance()
+      try session.setCategory(
+        .playAndRecord,
+        mode: .voiceChat,
+        options: [.allowBluetooth, .allowBluetoothA2DP, .mixWithOthers, .defaultToSpeaker]
+      )
+    } catch {
+      NSLog("[Echo] AVAudioSession setCategory failed: \(error.localizedDescription)")
+    }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/apps/client/ios/Runner/Info.plist
+++ b/apps/client/ios/Runner/Info.plist
@@ -81,6 +81,7 @@
 		<string>remote-notification</string>
 		<string>audio</string>
 		<string>voip</string>
+		<string>picture-in-picture</string>
 	</array>
 	<key>RTCScreenSharingExtension</key>
 	<string>us.echomessenger.app.broadcast</string>

--- a/apps/client/ios/Runner/PipBridgePlugin.swift
+++ b/apps/client/ios/Runner/PipBridgePlugin.swift
@@ -5,16 +5,17 @@
 // AVPictureInPictureController so the system records the activity as
 // PiP-eligible the moment a remote screen share is published.
 //
-// CURRENT STATE: scaffolding only.  Actual rendering of the WebRTC track
-// inside the PiP layer requires bridging livekit_client's RTCVideoFrames
-// into an AVSampleBufferDisplayLayer — that needs a fork of the
-// livekit_client iOS plugin to expose a PiP-renderer hook, which is
-// tracked as a follow-up.  Until then, PiP entry will surface a system
-// PiP window backed by a placeholder layer so iOS keeps the audio
-// session alive (already covered by CallKit in Slice 2 anyway), but the
-// user must return to the app to see the share.  Voice + the lounge UI
-// stay running because of the foreground service / CallKit work in
-// Slices 1 and 2; this plugin only governs the PiP-window rendering.
+// CURRENT STATE: scaffolding only.  Actual rendering of the LiveKit
+// screen-share track inside the PiP layer requires a fork of the
+// livekit_client iOS plugin so we can attach our own renderer to a
+// LiveKit RemoteVideoTrack and forward its frames into an
+// AVSampleBufferDisplayLayer — tracked as a follow-up.  Until then, PiP
+// entry will surface a system PiP window backed by a placeholder layer
+// so iOS keeps the audio session alive (already covered by CallKit in
+// Slice 2 anyway), but the user must return to the app to see the
+// share.  Voice + the lounge UI stay running because of the foreground
+// service / CallKit work in Slices 1 and 2; this plugin only governs
+// the PiP-window rendering.
 
 import AVKit
 import Flutter
@@ -81,8 +82,8 @@ final class PipBridgePlugin: NSObject, AVPictureInPictureControllerDelegate {
     sampleBufferLayer = layer
 
     // ContentSource using the sample-buffer playback variant (iOS 15+).
-    // This is the path that integrates with WebRTC frames once we have a
-    // frame bridge — for now the layer remains empty.
+    // Once the livekit_client renderer hook lands, the LiveKit track's
+    // frames flow into this layer; for now it remains empty.
     let source = AVPictureInPictureController.ContentSource(
       sampleBufferDisplayLayer: layer,
       playbackDelegate: PipPlaybackDelegate.shared
@@ -162,7 +163,8 @@ private final class PipPlaybackDelegate: NSObject, AVPictureInPictureSampleBuffe
     _ pictureInPictureController: AVPictureInPictureController,
     didTransitionToRenderSize newRenderSize: CMVideoDimensions
   ) {
-    // Aspect change — nothing to do until frame bridging lands.
+    // Aspect change — nothing to do until the LiveKit renderer hook
+    // lands and starts pushing track-resolution updates.
   }
 
   func pictureInPictureController(

--- a/apps/client/ios/Runner/PipBridgePlugin.swift
+++ b/apps/client/ios/Runner/PipBridgePlugin.swift
@@ -1,0 +1,176 @@
+// PipBridgePlugin
+// ----------------
+// Bridges the Dart `us.echomessenger/pip` MethodChannel to the iOS
+// Picture-in-Picture system APIs.  Wires up an
+// AVPictureInPictureController so the system records the activity as
+// PiP-eligible the moment a remote screen share is published.
+//
+// CURRENT STATE: scaffolding only.  Actual rendering of the WebRTC track
+// inside the PiP layer requires bridging livekit_client's RTCVideoFrames
+// into an AVSampleBufferDisplayLayer — that needs a fork of the
+// livekit_client iOS plugin to expose a PiP-renderer hook, which is
+// tracked as a follow-up.  Until then, PiP entry will surface a system
+// PiP window backed by a placeholder layer so iOS keeps the audio
+// session alive (already covered by CallKit in Slice 2 anyway), but the
+// user must return to the app to see the share.  Voice + the lounge UI
+// stay running because of the foreground service / CallKit work in
+// Slices 1 and 2; this plugin only governs the PiP-window rendering.
+
+import AVKit
+import Flutter
+import UIKit
+
+@available(iOS 15.0, *)
+final class PipBridgePlugin: NSObject, AVPictureInPictureControllerDelegate {
+  private static let channelName = "us.echomessenger/pip"
+
+  private var channel: FlutterMethodChannel?
+  private var pipController: AVPictureInPictureController?
+  private var sampleBufferLayer: AVSampleBufferDisplayLayer?
+  private var hostView: UIView?
+  private var eligibleWidth: Int = 0
+  private var eligibleHeight: Int = 0
+
+  /// Whether a remote screen share is currently active.  PiP entry is a
+  /// no-op when false even if `enterPip` is called.
+  private var isEligible: Bool { eligibleWidth > 0 && eligibleHeight > 0 }
+
+  func register(with messenger: FlutterBinaryMessenger, hostView: UIView) {
+    self.hostView = hostView
+    let channel = FlutterMethodChannel(name: PipBridgePlugin.channelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call: call, result: result)
+    }
+    self.channel = channel
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "setEligible":
+      if let args = call.arguments as? [String: Any],
+         let w = args["width"] as? Int,
+         let h = args["height"] as? Int {
+        eligibleWidth = w
+        eligibleHeight = h
+        if w > 0 && h > 0 {
+          ensureControllerCreated()
+        } else {
+          tearDownController()
+        }
+      }
+      result(nil)
+    case "enterPip":
+      result(startPipIfPossible())
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func ensureControllerCreated() {
+    guard pipController == nil else { return }
+    guard AVPictureInPictureController.isPictureInPictureSupported() else {
+      NSLog("[PipBridge] AVPictureInPictureController not supported on this device")
+      return
+    }
+    guard let host = hostView else { return }
+
+    let layer = AVSampleBufferDisplayLayer()
+    layer.videoGravity = .resizeAspect
+    layer.frame = host.bounds
+    host.layer.addSublayer(layer)
+    sampleBufferLayer = layer
+
+    // ContentSource using the sample-buffer playback variant (iOS 15+).
+    // This is the path that integrates with WebRTC frames once we have a
+    // frame bridge — for now the layer remains empty.
+    let source = AVPictureInPictureController.ContentSource(
+      sampleBufferDisplayLayer: layer,
+      playbackDelegate: PipPlaybackDelegate.shared
+    )
+    let controller = AVPictureInPictureController(contentSource: source)
+    controller.delegate = self
+    controller.canStartPictureInPictureAutomaticallyFromInline = true
+    pipController = controller
+  }
+
+  private func tearDownController() {
+    pipController?.stopPictureInPicture()
+    pipController = nil
+    sampleBufferLayer?.removeFromSuperlayer()
+    sampleBufferLayer = nil
+  }
+
+  private func startPipIfPossible() -> Bool {
+    guard isEligible else { return false }
+    guard let controller = pipController else { return false }
+    if controller.isPictureInPicturePossible {
+      controller.startPictureInPicture()
+      return true
+    }
+    return false
+  }
+
+  // MARK: - AVPictureInPictureControllerDelegate
+
+  func pictureInPictureControllerDidStartPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    channel?.invokeMethod("onPipChanged", arguments: ["inPip": true])
+  }
+
+  func pictureInPictureControllerDidStopPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    channel?.invokeMethod("onPipChanged", arguments: ["inPip": false])
+  }
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    failedToStartPictureInPictureWithError error: Error
+  ) {
+    NSLog("[PipBridge] failedToStartPictureInPicture: \(error.localizedDescription)")
+    channel?.invokeMethod("onPipChanged", arguments: ["inPip": false])
+  }
+}
+
+@available(iOS 15.0, *)
+private final class PipPlaybackDelegate: NSObject, AVPictureInPictureSampleBufferPlaybackDelegate {
+  static let shared = PipPlaybackDelegate()
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    setPlaying playing: Bool
+  ) {
+    // Live screen share is always "playing"; the user can't pause a
+    // co-broadcast.  No-op until we wire frame delivery.
+  }
+
+  func pictureInPictureControllerTimeRangeForPlayback(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) -> CMTimeRange {
+    // Live source — report an unbounded range.
+    return CMTimeRange(start: .negativeInfinity, end: .positiveInfinity)
+  }
+
+  func pictureInPictureControllerIsPlaybackPaused(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) -> Bool {
+    return false
+  }
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    didTransitionToRenderSize newRenderSize: CMVideoDimensions
+  ) {
+    // Aspect change — nothing to do until frame bridging lands.
+  }
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    skipByInterval skipInterval: CMTime,
+    completion completionHandler: @escaping () -> Void
+  ) {
+    // Live source has no scrubbing.
+    completionHandler()
+  }
+}

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -8,6 +8,7 @@ import 'package:livekit_client/livekit_client.dart';
 
 import '../../services/background_service.dart';
 import '../../services/debug_log_service.dart';
+import '../../services/pip_controller.dart';
 import '../../services/sound_service.dart';
 import '../../services/voice_callkit_service.dart';
 import '../auth_provider.dart';
@@ -372,6 +373,7 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
     _detachNotificationActionListener();
     unawaited(BackgroundService.instance.stopVoice());
     unawaited(VoiceCallKitService.instance.endCall());
+    unawaited(PipController.instance.disable());
     state = LiveKitVoiceState.empty;
   }
 
@@ -464,9 +466,11 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
       })
       ..on<TrackSubscribedEvent>((event) {
         _syncPeerState();
+        _syncRemoteScreenShareForPip();
       })
       ..on<TrackUnsubscribedEvent>((event) {
         _syncPeerState();
+        _syncRemoteScreenShareForPip();
       })
       ..on<RoomDisconnectedEvent>((_) {
         DebugLogService.instance.log(
@@ -496,6 +500,30 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
           'Room reconnecting...',
         );
       });
+  }
+
+  /// Walk the remote participants for an active screen-share video track
+  /// and tell [PipController] whether to keep the activity PiP-eligible.
+  /// Pure idempotent — safe to call from any TrackSubscribed /
+  /// TrackUnsubscribed event without checking which track changed.
+  void _syncRemoteScreenShareForPip() {
+    final room = _room;
+    if (room == null || _disposed) return;
+    for (final participant in room.remoteParticipants.values) {
+      for (final pub in participant.videoTrackPublications) {
+        if (pub.track != null &&
+            pub.subscribed &&
+            pub.source == TrackSource.screenShareVideo) {
+          // Native side stores 16:9 default when 0 is passed; LiveKit
+          // doesn't surface frame dimensions synchronously, so we accept
+          // a slightly-off aspect for the first PiP entry.  Frame-size
+          // tracking via VideoTrackRenderer is a follow-up.
+          unawaited(PipController.instance.enable(width: 0, height: 0));
+          return;
+        }
+      }
+    }
+    unawaited(PipController.instance.disable());
   }
 
   /// Synchronize the participant list from the LiveKit room into our state.

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -9,6 +9,7 @@ import 'package:livekit_client/livekit_client.dart';
 import '../../services/background_service.dart';
 import '../../services/debug_log_service.dart';
 import '../../services/sound_service.dart';
+import '../../services/voice_callkit_service.dart';
 import '../auth_provider.dart';
 import '../channels_provider.dart';
 import '../server_url_provider.dart';
@@ -137,6 +138,10 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
   /// state changes.  Active only while a voice room is connected.
   StreamSubscription<VoiceNotificationAction>? _notificationActionSub;
 
+  /// Subscription to CallKit lock-screen actions on iOS.  Same lifecycle
+  /// as the Android notification action sub — active only during a call.
+  StreamSubscription<CallKitAction>? _callKitActionSub;
+
   LiveKitVoiceNotifier(this.ref) : super(LiveKitVoiceState.empty);
 
   /// Resolve the human-readable channel name for the active room so the
@@ -161,15 +166,25 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
               unawaited(leaveChannel());
           }
         });
+    _callKitActionSub ??= VoiceCallKitService.instance.actions.listen((action) {
+      switch (action) {
+        case CallKitMuteAction(muted: final muted):
+          setCaptureEnabled(!muted);
+        case CallKitEndAction():
+          unawaited(leaveChannel());
+      }
+    });
   }
 
   void _detachNotificationActionListener() {
     _notificationActionSub?.cancel();
     _notificationActionSub = null;
+    _callKitActionSub?.cancel();
+    _callKitActionSub = null;
   }
 
-  /// Push the latest voice state into the live notification.  No-op on
-  /// platforms that don't surface a foreground service.
+  /// Push the latest voice state into the live notification + CallKit
+  /// entry.  No-op on platforms that don't surface either.
   void _syncVoiceNotification() {
     if (_disposed || !state.isActive) return;
     unawaited(
@@ -178,6 +193,7 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
         participantCount: state.peerCount + 1,
       ),
     );
+    unawaited(VoiceCallKitService.instance.setMuted(!state.isCaptureEnabled));
   }
 
   // -------------------------------------------------------------------------
@@ -286,15 +302,29 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
       _startAudioLevelPolling();
       SoundService().playVoiceJoin();
 
-      // Promote the foreground service to voice mode so the OS keeps the
-      // mic + audio session alive when the app is backgrounded.  Listen
-      // for Mute / Leave taps coming back from the notification.
+      // Promote the foreground service to voice mode (Android) and report
+      // an outgoing CallKit call (iOS) so the OS keeps the mic + audio
+      // session alive when the app is backgrounded.  Listen for Mute /
+      // Leave / End taps coming back from either UI.
+      final resolvedChannelName = _resolveChannelName(
+        conversationId,
+        channelId,
+      );
       _attachNotificationActionListener();
       unawaited(
         BackgroundService.instance.startVoice(
-          channelName: _resolveChannelName(conversationId, channelId),
+          channelName: resolvedChannelName,
           isMuted: !micEnabled,
           participantCount: state.peerCount + 1,
+        ),
+      );
+      unawaited(
+        VoiceCallKitService.instance.startCall(
+          // CallKit identifies the call by id; use the room's conversation
+          // + channel pair so a future "rejoin same room" call is a no-op.
+          callId: '$conversationId:$channelId',
+          channelName: resolvedChannelName,
+          isMuted: !micEnabled,
         ),
       );
 
@@ -341,6 +371,7 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
     }
     _detachNotificationActionListener();
     unawaited(BackgroundService.instance.stopVoice());
+    unawaited(VoiceCallKitService.instance.endCall());
     state = LiveKitVoiceState.empty;
   }
 
@@ -576,6 +607,7 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
     _stopAudioLevelPolling();
     _detachNotificationActionListener();
     unawaited(BackgroundService.instance.stopVoice());
+    unawaited(VoiceCallKitService.instance.endCall());
 
     // Synchronously null out references so in-flight callbacks hit null checks
     // instead of accessing freed memory. The actual network disconnect is

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -6,9 +6,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:livekit_client/livekit_client.dart';
 
+import '../../services/background_service.dart';
 import '../../services/debug_log_service.dart';
 import '../../services/sound_service.dart';
 import '../auth_provider.dart';
+import '../channels_provider.dart';
 import '../server_url_provider.dart';
 import '../voice_settings_provider.dart';
 
@@ -130,7 +132,53 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
   @override
   bool _wasMutedBeforeDeafen = false;
 
+  /// Subscription to the foreground-service notification actions so the
+  /// Mute / Leave buttons in the live notification map back into LiveKit
+  /// state changes.  Active only while a voice room is connected.
+  StreamSubscription<VoiceNotificationAction>? _notificationActionSub;
+
   LiveKitVoiceNotifier(this.ref) : super(LiveKitVoiceState.empty);
+
+  /// Resolve the human-readable channel name for the active room so the
+  /// voice notification can show "lounge" instead of a UUID.  Falls back
+  /// to "Voice" when the channel hasn't been hydrated yet.
+  String _resolveChannelName(String conversationId, String channelId) {
+    final channels = ref.read(channelsProvider).channelsFor(conversationId);
+    final match = channels.where((c) => c.id == channelId).firstOrNull;
+    final name = match?.name;
+    if (name == null || name.isEmpty) return 'Voice';
+    return name;
+  }
+
+  void _attachNotificationActionListener() {
+    _notificationActionSub ??= BackgroundService.instance.notificationActions
+        .listen((action) {
+          switch (action) {
+            case VoiceMuteAction(muted: final muted):
+              // Notification button maps "muted=true" → mic off.
+              setCaptureEnabled(!muted);
+            case VoiceLeaveAction():
+              unawaited(leaveChannel());
+          }
+        });
+  }
+
+  void _detachNotificationActionListener() {
+    _notificationActionSub?.cancel();
+    _notificationActionSub = null;
+  }
+
+  /// Push the latest voice state into the live notification.  No-op on
+  /// platforms that don't surface a foreground service.
+  void _syncVoiceNotification() {
+    if (_disposed || !state.isActive) return;
+    unawaited(
+      BackgroundService.instance.updateVoice(
+        isMuted: !state.isCaptureEnabled,
+        participantCount: state.peerCount + 1,
+      ),
+    );
+  }
 
   // -------------------------------------------------------------------------
   // Public API
@@ -238,6 +286,18 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
       _startAudioLevelPolling();
       SoundService().playVoiceJoin();
 
+      // Promote the foreground service to voice mode so the OS keeps the
+      // mic + audio session alive when the app is backgrounded.  Listen
+      // for Mute / Leave taps coming back from the notification.
+      _attachNotificationActionListener();
+      unawaited(
+        BackgroundService.instance.startVoice(
+          channelName: _resolveChannelName(conversationId, channelId),
+          isMuted: !micEnabled,
+          participantCount: state.peerCount + 1,
+        ),
+      );
+
       DebugLogService.instance.log(
         LogLevel.info,
         'LiveKitVoice',
@@ -279,6 +339,8 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
         'Cleanup error during leave (ignored): $e',
       );
     }
+    _detachNotificationActionListener();
+    unawaited(BackgroundService.instance.stopVoice());
     state = LiveKitVoiceState.empty;
   }
 
@@ -428,6 +490,19 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
       peerCount: participants.length,
       peerConnectionStates: peerStates,
     );
+
+    // Keep the live notification's participant count fresh as people come
+    // and go.  No-op on platforms that don't surface a foreground service.
+    _syncVoiceNotification();
+  }
+
+  /// Override the AV mixin's mute toggle so the live notification keeps
+  /// step with the LiveKit mic state.  Optimistic — the foreground service
+  /// re-issues the notification when [updateVoice] returns.
+  @override
+  void setCaptureEnabled(bool enabled) {
+    super.setCaptureEnabled(enabled);
+    _syncVoiceNotification();
   }
 
   // -------------------------------------------------------------------------
@@ -499,6 +574,8 @@ class LiveKitVoiceNotifier extends StateNotifier<LiveKitVoiceState>
   void dispose() {
     _disposed = true;
     _stopAudioLevelPolling();
+    _detachNotificationActionListener();
+    unawaited(BackgroundService.instance.stopVoice());
 
     // Synchronously null out references so in-flight callbacks hit null checks
     // instead of accessing freed memory. The actual network disconnect is

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -10,6 +10,7 @@ import '../providers/livekit_voice_provider.dart';
 import '../providers/screen_share_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/voice_settings_provider.dart';
+import '../services/pip_controller.dart';
 import '../theme/echo_theme.dart';
 import '../utils/canvas_utils.dart';
 import '../widgets/lounge_drawing_canvas.dart';
@@ -409,6 +410,28 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     );
   }
 
+  /// Picture-in-Picture body: scan remote participants for a screen-share
+  /// track and render it edge-to-edge.  Returns null if no track is found
+  /// so the caller can fall back to the regular layout.
+  Widget? _buildPipBody(WidgetRef ref) {
+    final room = ref.read(livekitVoiceProvider.notifier).room;
+    if (room == null) return null;
+    for (final participant in room.remoteParticipants.values) {
+      for (final pub in participant.videoTrackPublications) {
+        final lk.VideoTrack? track = pub.track;
+        if (track != null &&
+            pub.subscribed &&
+            pub.source == lk.TrackSource.screenShareVideo) {
+          return ColoredBox(
+            color: Colors.black,
+            child: lk.VideoTrackRenderer(track, fit: lk.VideoViewFit.contain),
+          );
+        }
+      }
+    }
+    return null;
+  }
+
   void _closeSubmenu() => setState(() => _activeSubmenu = null);
 
   /// Build all dock submenu follower widgets for the current [_activeSubmenu].
@@ -459,9 +482,20 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     final voiceSettings = ref.watch(voiceSettingsProvider);
     final screenShare = ref.watch(screenShareProvider);
     final channelsState = ref.watch(channelsProvider);
+    final inPip = ref.watch(pipModeProvider).inPip;
 
     final conversationId = voiceLk.conversationId ?? '';
     final channelId = voiceLk.channelId ?? '';
+
+    // Picture-in-Picture: render only the remote screen-share track in a
+    // bare full-bleed VideoTrackRenderer.  No header, no dock, no canvas
+    // chrome — the whole point of PiP is a tiny system window with just
+    // the relevant pixels.  Falls through to the regular layout if the
+    // OS reports PiP without a remote track (e.g. transient state).
+    if (inPip) {
+      final pipBody = _buildPipBody(ref);
+      if (pipBody != null) return pipBody;
+    }
 
     final channels = channelsState.channelsFor(conversationId);
     final activeChannel = channels.where((c) => c.id == channelId).firstOrNull;

--- a/apps/client/lib/src/services/background_service.dart
+++ b/apps/client/lib/src/services/background_service.dart
@@ -60,7 +60,14 @@ class BackgroundService {
   bool _keepaliveRunning = false;
   bool _voiceRunning = false;
 
+  /// Test-only override: when true, every method behaves as if running on
+  /// Android.  Allows the unit tests to exercise the platform-channel
+  /// surface without an actual Android device.
+  @visibleForTesting
+  static bool debugTreatAsAndroid = false;
+
   static bool get _isAndroid {
+    if (debugTreatAsAndroid) return true;
     if (kIsWeb) return false;
     return Platform.isAndroid;
   }

--- a/apps/client/lib/src/services/background_service.dart
+++ b/apps/client/lib/src/services/background_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
@@ -5,75 +6,172 @@ import 'package:flutter/services.dart';
 
 import 'debug_log_service.dart';
 
+/// Action emitted by the voice notification's Mute / Leave buttons.
+sealed class VoiceNotificationAction {
+  const VoiceNotificationAction();
+}
+
+class VoiceMuteAction extends VoiceNotificationAction {
+  final bool muted;
+  const VoiceMuteAction({required this.muted});
+}
+
+class VoiceLeaveAction extends VoiceNotificationAction {
+  const VoiceLeaveAction();
+}
+
 /// Manages background execution for mobile platforms.
 ///
-/// **Android**: Starts a foreground service with a persistent notification
-/// ("Echo Messenger is running") so the OS keeps the WebSocket alive when the
-/// app is backgrounded. No Google/Firebase dependency -- the WebSocket IS the
-/// push mechanism.
+/// **Android**: Starts a foreground service.  Two modes:
 ///
-/// **iOS**: Will use APNs silent pushes in the future (Apple requirement, not
-/// Google). For now, the WebSocket reconnects when the app returns to
-/// foreground.
+///   - keep-alive (default): generic notification, type DATA_SYNC, used so
+///     the WebSocket stays connected for incoming messages.
+///   - voice: notification shows the channel name + Mute / Leave actions,
+///     type MICROPHONE | MEDIA_PLAYBACK so Android 14+ does not revoke
+///     RECORD_AUDIO when the app is backgrounded.  See
+///     [LiveKitVoiceNotifier.joinChannel] / [leaveChannel].
 ///
-/// **Desktop**: No-op. Desktop apps aren't restricted by OS backgrounding.
+/// **iOS**: Background voice survival is handled by AVAudioSession + CallKit
+/// (see [VoiceCallKitService]).  Silent APNs pushes wake the app for chat.
+///
+/// **Desktop**: No-op.
 class BackgroundService {
-  BackgroundService._();
+  BackgroundService._() {
+    _channel.setMethodCallHandler(_handleMethodCall);
+  }
   static final BackgroundService instance = BackgroundService._();
 
   static const _channel = MethodChannel('us.echomessenger/foreground_service');
-  bool _running = false;
 
-  /// Whether this platform needs a foreground service to stay connected.
-  static bool get _needsForegroundService {
+  final _actionController =
+      StreamController<VoiceNotificationAction>.broadcast();
+
+  /// Stream of Mute / Leave taps from the voice notification (Android only).
+  Stream<VoiceNotificationAction> get notificationActions =>
+      _actionController.stream;
+
+  bool _keepaliveRunning = false;
+  bool _voiceRunning = false;
+
+  static bool get _isAndroid {
     if (kIsWeb) return false;
     return Platform.isAndroid;
   }
 
-  /// Start the foreground service (Android only).
-  ///
-  /// Call after login when the WebSocket is established. The service shows a
-  /// persistent notification and prevents the OS from killing the app's
-  /// network connections.
+  /// Start the keep-alive foreground service (Android only).  Idempotent.
   Future<void> start() async {
-    if (!_needsForegroundService || _running) return;
-
+    if (!_isAndroid || _keepaliveRunning || _voiceRunning) return;
     try {
       await _channel.invokeMethod('start');
-      _running = true;
-      debugPrint('[BackgroundService] Foreground service started');
-      DebugLogService.instance.log(
-        LogLevel.info,
-        'BackgroundService',
-        'Foreground service started',
-      );
+      _keepaliveRunning = true;
+      _log('Keep-alive service started');
     } catch (e) {
-      debugPrint('[BackgroundService] Failed to start: $e');
-      DebugLogService.instance.log(
-        LogLevel.error,
-        'BackgroundService',
-        'Failed to start foreground service: $e',
-      );
+      _log('Failed to start keep-alive service: $e', error: true);
     }
   }
 
-  /// Stop the foreground service (call on logout).
+  /// Stop the keep-alive foreground service.  No-op if voice mode is active
+  /// (caller should use [stopVoice] instead).
   Future<void> stop() async {
-    if (!_running) return;
-
+    if (!_isAndroid || (!_keepaliveRunning && !_voiceRunning)) return;
     try {
       await _channel.invokeMethod('stop');
-      _running = false;
-      debugPrint('[BackgroundService] Foreground service stopped');
-      DebugLogService.instance.log(
-        LogLevel.info,
-        'BackgroundService',
-        'Foreground service stopped',
-      );
+      _keepaliveRunning = false;
+      _voiceRunning = false;
+      _log('Foreground service stopped');
     } catch (e) {
-      debugPrint('[BackgroundService] Failed to stop: $e');
+      _log('Failed to stop foreground service: $e', error: true);
     }
   }
 
-  bool get isRunning => _running;
+  /// Promote the foreground service to voice mode.  Safe to call whether
+  /// the keep-alive service is running or not — the service will reconfigure
+  /// itself with the MICROPHONE | MEDIA_PLAYBACK type.
+  Future<void> startVoice({
+    required String channelName,
+    required bool isMuted,
+    required int participantCount,
+  }) async {
+    if (!_isAndroid) return;
+    try {
+      await _channel.invokeMethod('startVoice', {
+        'channelName': channelName,
+        'isMuted': isMuted,
+        'participantCount': participantCount,
+      });
+      _voiceRunning = true;
+      // Voice mode subsumes keep-alive on the same service instance.
+      _keepaliveRunning = false;
+      _log(
+        'Voice service started: $channelName (muted=$isMuted, n=$participantCount)',
+      );
+    } catch (e) {
+      _log('Failed to start voice service: $e', error: true);
+    }
+  }
+
+  /// Update the live voice notification with new state.  Safe to call from
+  /// any frequency; the underlying notification just gets re-issued.
+  Future<void> updateVoice({
+    String? channelName,
+    bool? isMuted,
+    int? participantCount,
+  }) async {
+    if (!_isAndroid || !_voiceRunning) return;
+    try {
+      await _channel.invokeMethod('updateVoice', {
+        'channelName': ?channelName,
+        'isMuted': ?isMuted,
+        'participantCount': ?participantCount,
+      });
+    } catch (e) {
+      _log('Failed to update voice notification: $e', error: true);
+    }
+  }
+
+  /// Stop the voice-mode foreground service (called on leaveChannel).
+  Future<void> stopVoice() async {
+    if (!_isAndroid) return;
+    try {
+      await _channel.invokeMethod('stopVoice');
+      _voiceRunning = false;
+      _log('Voice service stopped');
+    } catch (e) {
+      _log('Failed to stop voice service: $e', error: true);
+    }
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    if (call.method != 'onNotificationAction') return null;
+    final args = (call.arguments as Map?) ?? const {};
+    final action = args['action'] as String?;
+    switch (action) {
+      case 'mute':
+        final muted = (args['muted'] as bool?) ?? false;
+        _actionController.add(VoiceMuteAction(muted: muted));
+      case 'leave':
+        _actionController.add(const VoiceLeaveAction());
+    }
+    return null;
+  }
+
+  bool get isRunning => _keepaliveRunning || _voiceRunning;
+  bool get isVoiceRunning => _voiceRunning;
+
+  void _log(String message, {bool error = false}) {
+    debugPrint('[BackgroundService] $message');
+    DebugLogService.instance.log(
+      error ? LogLevel.error : LogLevel.info,
+      'BackgroundService',
+      message,
+    );
+  }
+
+  /// Test-only: reset internal flags so `setUp(() => ...)` can run with a
+  /// fresh state.  Does NOT touch the platform side.
+  @visibleForTesting
+  void resetForTesting() {
+    _keepaliveRunning = false;
+    _voiceRunning = false;
+  }
 }

--- a/apps/client/lib/src/services/background_service.dart
+++ b/apps/client/lib/src/services/background_service.dart
@@ -37,7 +37,14 @@ class VoiceLeaveAction extends VoiceNotificationAction {
 /// **Desktop**: No-op.
 class BackgroundService {
   BackgroundService._() {
-    _channel.setMethodCallHandler(_handleMethodCall);
+    try {
+      _channel.setMethodCallHandler(_handleMethodCall);
+    } catch (_) {
+      // No binary messenger yet (unit tests without WidgetsFlutterBinding).
+      // Notification actions are an Android runtime concern; tests that
+      // exercise them should call ensureInitialized() before importing
+      // anything that touches LiveKitVoiceNotifier.
+    }
   }
   static final BackgroundService instance = BackgroundService._();
 

--- a/apps/client/lib/src/services/pip_controller.dart
+++ b/apps/client/lib/src/services/pip_controller.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'debug_log_service.dart';
+
+/// Bridges the Flutter UI to native Picture-in-Picture for the screen-share
+/// scenario.  Voice + screen share remains active when the user backgrounds
+/// the app; the OS displays a PiP window with just the remote screen share
+/// track until they return.
+///
+/// Wiring contract:
+///
+///   - When a remote participant publishes a screen-share video track,
+///     [LiveKitVoiceNotifier] calls [enable] with the track's natural
+///     dimensions.  The native side stores the aspect and auto-enters
+///     PiP on `onUserLeaveHint` (Android) / `applicationWillResignActive`
+///     (iOS, in Slice 4).
+///   - When the screen share ends or the user leaves voice, [disable] is
+///     called so backgrounding goes back to the no-PiP path.
+///   - The native side reports PiP mode changes via `onPipChanged`
+///     callbacks; the controller exposes them on [isInPipNotifier].
+///
+/// On platforms without a PiP path (web, desktop), every method is a no-op.
+class PipController {
+  PipController._() {
+    if (_isMobile) {
+      _channel.setMethodCallHandler(_handleMethodCall);
+    }
+  }
+  static final PipController instance = PipController._();
+
+  static const _channel = MethodChannel('us.echomessenger/pip');
+
+  static bool get _isMobile {
+    if (kIsWeb) return false;
+    return Platform.isAndroid || Platform.isIOS;
+  }
+
+  /// True while the system is rendering the activity in PiP mode.  Backed
+  /// by a [ValueNotifier] so widgets can rebuild without subscribing to a
+  /// stream — see [pipModeProvider].
+  final ValueNotifier<bool> isInPipNotifier = ValueNotifier<bool>(false);
+
+  bool _eligible = false;
+  int _lastWidth = 0;
+  int _lastHeight = 0;
+
+  /// Whether PiP eligibility is currently set.  When false, the native
+  /// activity will not enter PiP on home/lock.
+  bool get isEligible => _eligible;
+
+  /// Enable PiP on background with the given source dimensions.  Repeated
+  /// calls with new dimensions update the aspect ratio without re-entering
+  /// PiP, which lets the native side track resolution changes mid-call.
+  ///
+  /// Width / height should come from the WebRTC track; values <= 0 fall
+  /// back to a 16:9 default so we never push an invalid Rational.
+  Future<void> enable({required int width, required int height}) async {
+    if (!_isMobile) return;
+    final w = width > 0 ? width : 1280;
+    final h = height > 0 ? height : 720;
+    if (_eligible && _lastWidth == w && _lastHeight == h) return;
+    try {
+      await _channel.invokeMethod('setEligible', {'width': w, 'height': h});
+      _eligible = true;
+      _lastWidth = w;
+      _lastHeight = h;
+      _log('PiP eligibility enabled (${w}x$h)');
+    } catch (e) {
+      _log('Failed to enable PiP eligibility: $e', error: true);
+    }
+  }
+
+  /// Disable PiP eligibility.  Call when the screen share ends or the user
+  /// leaves voice — keeps the activity from dropping into PiP for an
+  /// audio-only call where there's nothing to render.
+  Future<void> disable() async {
+    if (!_isMobile || !_eligible) return;
+    try {
+      await _channel.invokeMethod('setEligible', {'width': 0, 'height': 0});
+      _eligible = false;
+      _lastWidth = 0;
+      _lastHeight = 0;
+      _log('PiP eligibility cleared');
+    } catch (e) {
+      _log('Failed to clear PiP eligibility: $e', error: true);
+    }
+  }
+
+  /// Programmatically request PiP entry.  Useful for an "Enter PiP" button;
+  /// the home-press path uses [enable] alone since the OS triggers entry
+  /// from `onUserLeaveHint` automatically once eligible.
+  ///
+  /// Returns true when the OS accepted the request (always false off
+  /// mobile or when no track is registered).
+  Future<bool> enterPip() async {
+    if (!_isMobile || !_eligible) return false;
+    try {
+      final result = await _channel.invokeMethod<bool>('enterPip');
+      return result ?? false;
+    } catch (e) {
+      _log('Failed to request PiP entry: $e', error: true);
+      return false;
+    }
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    if (call.method != 'onPipChanged') return null;
+    final args = (call.arguments as Map?) ?? const {};
+    final inPip = (args['inPip'] as bool?) ?? false;
+    if (isInPipNotifier.value != inPip) {
+      isInPipNotifier.value = inPip;
+      _log('PiP mode changed: $inPip');
+    }
+    return null;
+  }
+
+  void _log(String message, {bool error = false}) {
+    debugPrint('[PipController] $message');
+    DebugLogService.instance.log(
+      error ? LogLevel.error : LogLevel.info,
+      'PipController',
+      message,
+    );
+  }
+
+  /// Test-only: reset internal flags so a fresh test can reuse the singleton.
+  @visibleForTesting
+  void resetForTesting() {
+    _eligible = false;
+    _lastWidth = 0;
+    _lastHeight = 0;
+    isInPipNotifier.value = false;
+  }
+}
+
+/// Riverpod provider exposing the current PiP mode.  Widgets (e.g. the
+/// voice lounge) can `ref.watch(pipModeProvider)` to render a stripped-down
+/// layout while the system is showing PiP.
+final pipModeProvider = ChangeNotifierProvider<_PipModeNotifier>(
+  (ref) => _PipModeNotifier(PipController.instance.isInPipNotifier),
+);
+
+class _PipModeNotifier extends ChangeNotifier {
+  _PipModeNotifier(this._source) {
+    _source.addListener(_onChange);
+  }
+
+  final ValueNotifier<bool> _source;
+
+  bool get inPip => _source.value;
+
+  void _onChange() => notifyListeners();
+
+  @override
+  void dispose() {
+    _source.removeListener(_onChange);
+    super.dispose();
+  }
+}

--- a/apps/client/lib/src/services/pip_controller.dart
+++ b/apps/client/lib/src/services/pip_controller.dart
@@ -64,8 +64,8 @@ class PipController {
   /// calls with new dimensions update the aspect ratio without re-entering
   /// PiP, which lets the native side track resolution changes mid-call.
   ///
-  /// Width / height should come from the WebRTC track; values <= 0 fall
-  /// back to a 16:9 default so we never push an invalid Rational.
+  /// Width / height should come from the LiveKit video track; values <= 0
+  /// fall back to a 16:9 default so we never push an invalid Rational.
   Future<void> enable({required int width, required int height}) async {
     if (!_isMobile) return;
     final w = width > 0 ? width : 1280;

--- a/apps/client/lib/src/services/pip_controller.dart
+++ b/apps/client/lib/src/services/pip_controller.dart
@@ -35,7 +35,14 @@ class PipController {
 
   static const _channel = MethodChannel('us.echomessenger/pip');
 
+  /// Test-only override: when true, every method behaves as if running on
+  /// a mobile device.  Lets unit tests exercise the platform-channel
+  /// surface without an Android / iOS host.
+  @visibleForTesting
+  static bool debugTreatAsMobile = false;
+
   static bool get _isMobile {
+    if (debugTreatAsMobile) return true;
     if (kIsWeb) return false;
     return Platform.isAndroid || Platform.isIOS;
   }

--- a/apps/client/lib/src/services/voice_callkit_service.dart
+++ b/apps/client/lib/src/services/voice_callkit_service.dart
@@ -1,0 +1,181 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_callkit_incoming/entities/entities.dart';
+import 'package:flutter_callkit_incoming/flutter_callkit_incoming.dart';
+
+import 'debug_log_service.dart';
+
+/// Action emitted by the iOS CallKit lock-screen entry.
+sealed class CallKitAction {
+  const CallKitAction();
+}
+
+class CallKitMuteAction extends CallKitAction {
+  final bool muted;
+  const CallKitMuteAction({required this.muted});
+}
+
+class CallKitEndAction extends CallKitAction {
+  const CallKitEndAction();
+}
+
+/// iOS-only wrapper around `flutter_callkit_incoming`.
+///
+/// When LiveKit voice joins, we report an outgoing CXStartCallAction so the
+/// system shows a call entry in the lock-screen call UI and (more
+/// importantly) holds the AVAudioSession active even if the app suspends.
+/// Without an active CallKit call, modern iOS suspends `voip`-mode apps
+/// within ~30s of backgrounding and tears down the WebRTC audio session.
+///
+/// On Android / desktop this is a no-op — Android uses the foreground
+/// service in [BackgroundService], desktop apps aren't restricted.
+class VoiceCallKitService {
+  VoiceCallKitService._() {
+    if (_isIos) {
+      _eventSub = FlutterCallkitIncoming.onEvent.listen(_handleEvent);
+    }
+  }
+  static final VoiceCallKitService instance = VoiceCallKitService._();
+
+  static bool get _isIos {
+    if (kIsWeb) return false;
+    return Platform.isIOS;
+  }
+
+  final _actionController = StreamController<CallKitAction>.broadcast();
+  StreamSubscription<CallEvent?>? _eventSub;
+  String? _activeCallId;
+
+  /// Stream of Mute / End taps from the CallKit UI.  iOS only.
+  Stream<CallKitAction> get actions => _actionController.stream;
+
+  /// Whether a CallKit call is currently active.
+  bool get hasActiveCall => _activeCallId != null;
+
+  /// Report an outgoing call to CallKit so iOS keeps the audio session
+  /// alive when the app is backgrounded.  No-op outside iOS.
+  ///
+  /// [callId] should be a UUID-shaped string unique to the room.  Re-using
+  /// the same id while a call is active is a no-op.
+  Future<void> startCall({
+    required String callId,
+    required String channelName,
+    required bool isMuted,
+  }) async {
+    if (!_isIos) return;
+    if (_activeCallId == callId) return;
+    if (_activeCallId != null) {
+      // Stale call from a previous join — flush before starting the new one.
+      await endCall();
+    }
+
+    final params = CallKitParams(
+      id: callId,
+      nameCaller: channelName,
+      handle: 'Echo Messenger',
+      type: 0,
+      // CallKit's UI mute state must agree with our LiveKit mic state on
+      // join; the handler below keeps it in sync after that.
+      ios: const IOSParams(
+        iconName: 'CallKitLogo',
+        handleType: 'generic',
+        supportsVideo: false,
+        maximumCallGroups: 1,
+        maximumCallsPerCallGroup: 1,
+        audioSessionMode: 'voiceChat',
+        audioSessionActive: true,
+        audioSessionPreferredSampleRate: 44100.0,
+        audioSessionPreferredIOBufferDuration: 0.005,
+        supportsDTMF: false,
+        supportsHolding: false,
+        supportsGrouping: false,
+        supportsUngrouping: false,
+        ringtonePath: 'system_ringtone_default',
+      ),
+    );
+
+    try {
+      await FlutterCallkitIncoming.startCall(params);
+      // Reflect the initial mute state into the CallKit UI so the user
+      // doesn't see Unmuted while LiveKit started muted.
+      if (isMuted) {
+        await FlutterCallkitIncoming.muteCall(callId, isMuted: true);
+      }
+      _activeCallId = callId;
+      _log('Started CallKit call: $callId ($channelName)');
+    } catch (e) {
+      _log('Failed to start CallKit call: $e', error: true);
+    }
+  }
+
+  /// Tell CallKit the user just toggled mute from inside the app so the
+  /// lock-screen mute pill stays in sync.
+  Future<void> setMuted(bool muted) async {
+    if (!_isIos || _activeCallId == null) return;
+    try {
+      await FlutterCallkitIncoming.muteCall(_activeCallId!, isMuted: muted);
+    } catch (e) {
+      _log('Failed to update CallKit mute state: $e', error: true);
+    }
+  }
+
+  /// End the CallKit call and release the system audio session.
+  Future<void> endCall() async {
+    if (!_isIos || _activeCallId == null) return;
+    final id = _activeCallId!;
+    _activeCallId = null;
+    try {
+      await FlutterCallkitIncoming.endCall(id);
+      _log('Ended CallKit call: $id');
+    } catch (e) {
+      _log('Failed to end CallKit call: $e', error: true);
+    }
+  }
+
+  void _handleEvent(CallEvent? event) {
+    if (event == null) return;
+    final id = event.body['id'] as String?;
+    if (id == null || id != _activeCallId) return;
+
+    switch (event.event) {
+      case Event.actionCallEnded:
+      case Event.actionCallDecline:
+      case Event.actionCallTimeout:
+        _activeCallId = null;
+        _actionController.add(const CallKitEndAction());
+      case Event.actionCallToggleMute:
+        final muted = (event.body['isMuted'] as bool?) ?? false;
+        _actionController.add(CallKitMuteAction(muted: muted));
+      // Other events (incoming/start/accept/hold/group) aren't relevant to
+      // outgoing-only voice lounges.
+      // ignore: no_default_cases
+      default:
+        break;
+    }
+  }
+
+  void _log(String message, {bool error = false}) {
+    debugPrint('[VoiceCallKit] $message');
+    DebugLogService.instance.log(
+      error ? LogLevel.error : LogLevel.info,
+      'VoiceCallKit',
+      message,
+    );
+  }
+
+  /// Test-only: reset internal state.
+  @visibleForTesting
+  void resetForTesting() {
+    _activeCallId = null;
+  }
+
+  /// Test-only: dispose the event subscription so test runners exit cleanly.
+  @visibleForTesting
+  Future<void> disposeForTesting() async {
+    await _eventSub?.cancel();
+    _eventSub = null;
+    await _actionController.close();
+  }
+}

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -462,6 +462,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_callkit_incoming:
+    dependency: "direct main"
+    description:
+      name: flutter_callkit_incoming
+      sha256: "3589deb8b71e43f2d520a9c8a5240243f611062a8b246cdca4b1fda01fbbf9b8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_colorpicker:
     dependency: "direct main"
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   flutter_slidable: ^3.1.1
   image: ^4.8.0
   flutter_colorpicker: ^1.1.0
+  flutter_callkit_incoming: ^3.0.0
 
 dev_dependencies:
   flutter_test:

--- a/apps/client/test/services/background_service_test.dart
+++ b/apps/client/test/services/background_service_test.dart
@@ -1,0 +1,181 @@
+/// Tests for [BackgroundService] — the Android foreground-service Dart
+/// shim that exposes voice-aware notification controls and pipes Mute /
+/// Leave taps back from the native receiver.
+///
+/// We mock the `us.echomessenger/foreground_service` MethodChannel so the
+/// tests run cross-platform without an Android device, and validate:
+///   - start/stop/startVoice/stopVoice idempotency + mode flags
+///   - the on-platform method names + arguments are what the Kotlin side
+///     expects (regression guard for accidental key renames)
+///   - notification-action MethodCall payloads dispatch into the expected
+///     [VoiceNotificationAction] subclasses on the broadcast stream.
+library;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/services/background_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('us.echomessenger/foreground_service');
+  late List<MethodCall> calls;
+
+  setUp(() {
+    BackgroundService.debugTreatAsAndroid = true;
+    BackgroundService.instance.resetForTesting();
+    calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return null;
+        });
+  });
+
+  tearDown(() {
+    BackgroundService.debugTreatAsAndroid = false;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('keep-alive mode', () {
+    test('start() invokes "start" once', () async {
+      await BackgroundService.instance.start();
+      await BackgroundService.instance.start();
+      // Second call is a no-op while running.
+      expect(calls.where((c) => c.method == 'start').length, 1);
+    });
+
+    test('stop() invokes "stop" once', () async {
+      await BackgroundService.instance.start();
+      await BackgroundService.instance.stop();
+      await BackgroundService.instance.stop();
+      expect(calls.where((c) => c.method == 'stop').length, 1);
+    });
+
+    test('start() is a no-op once voice is running', () async {
+      await BackgroundService.instance.startVoice(
+        channelName: 'lounge',
+        isMuted: false,
+        participantCount: 1,
+      );
+      await BackgroundService.instance.start();
+      // Voice is the higher-privileged mode; start() must not downgrade.
+      expect(calls.where((c) => c.method == 'start').length, 0);
+    });
+  });
+
+  group('voice mode', () {
+    test('startVoice() sends the expected arguments', () async {
+      await BackgroundService.instance.startVoice(
+        channelName: 'lounge',
+        isMuted: true,
+        participantCount: 4,
+      );
+      final call = calls.singleWhere((c) => c.method == 'startVoice');
+      expect(call.arguments, {
+        'channelName': 'lounge',
+        'isMuted': true,
+        'participantCount': 4,
+      });
+      expect(BackgroundService.instance.isVoiceRunning, isTrue);
+    });
+
+    test('updateVoice() is a no-op when voice is not running', () async {
+      await BackgroundService.instance.updateVoice(
+        channelName: 'lounge',
+        isMuted: false,
+      );
+      expect(calls.where((c) => c.method == 'updateVoice'), isEmpty);
+    });
+
+    test('updateVoice() omits null fields from the payload', () async {
+      await BackgroundService.instance.startVoice(
+        channelName: 'lounge',
+        isMuted: false,
+        participantCount: 2,
+      );
+      await BackgroundService.instance.updateVoice(isMuted: true);
+
+      final update = calls.singleWhere((c) => c.method == 'updateVoice');
+      expect(update.arguments, {'isMuted': true});
+    });
+
+    test(
+      'stopVoice() invokes the platform method and clears the flag',
+      () async {
+        await BackgroundService.instance.startVoice(
+          channelName: 'lounge',
+          isMuted: false,
+          participantCount: 1,
+        );
+        await BackgroundService.instance.stopVoice();
+        expect(calls.last.method, 'stopVoice');
+        expect(BackgroundService.instance.isVoiceRunning, isFalse);
+      },
+    );
+  });
+
+  group('notification-action stream', () {
+    test(
+      'mute action dispatches a VoiceMuteAction with the new state',
+      () async {
+        // Arrange: subscribe before the platform "delivers" the action.
+        final received = <VoiceNotificationAction>[];
+        final sub = BackgroundService.instance.notificationActions.listen(
+          received.add,
+        );
+
+        // Act: simulate a platform → Dart MethodCall as the Android receiver
+        // would deliver it.
+        const codec = StandardMethodCodec();
+        final payload = codec.encodeMethodCall(
+          const MethodCall('onNotificationAction', {
+            'action': 'mute',
+            'muted': true,
+          }),
+        );
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'us.echomessenger/foreground_service',
+              payload,
+              (_) {},
+            );
+
+        // Assert.
+        await Future<void>.delayed(Duration.zero);
+        expect(received, hasLength(1));
+        final action = received.single;
+        expect(action, isA<VoiceMuteAction>());
+        expect((action as VoiceMuteAction).muted, isTrue);
+
+        await sub.cancel();
+      },
+    );
+
+    test('leave action dispatches a VoiceLeaveAction', () async {
+      final received = <VoiceNotificationAction>[];
+      final sub = BackgroundService.instance.notificationActions.listen(
+        received.add,
+      );
+
+      const codec = StandardMethodCodec();
+      final payload = codec.encodeMethodCall(
+        const MethodCall('onNotificationAction', {'action': 'leave'}),
+      );
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'us.echomessenger/foreground_service',
+            payload,
+            (_) {},
+          );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(received, hasLength(1));
+      expect(received.single, isA<VoiceLeaveAction>());
+
+      await sub.cancel();
+    });
+  });
+}

--- a/apps/client/test/services/pip_controller_test.dart
+++ b/apps/client/test/services/pip_controller_test.dart
@@ -1,0 +1,98 @@
+/// Tests for [PipController] — the Picture-in-Picture method-channel
+/// shim.  Mocks `us.echomessenger/pip` so the tests don't need a real
+/// Android / iOS device, and validates:
+///   - default 16:9 fallback when caller passes 0,0
+///   - eligibility de-dup when called with the same dimensions
+///   - disable() flushes state and asks the native side to clear
+///   - onPipChanged platform callbacks update [isInPipNotifier]
+library;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/services/pip_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('us.echomessenger/pip');
+  late List<MethodCall> calls;
+
+  setUp(() {
+    PipController.debugTreatAsMobile = true;
+    PipController.instance.resetForTesting();
+    calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          if (call.method == 'enterPip') return true;
+          return null;
+        });
+  });
+
+  tearDown(() {
+    PipController.debugTreatAsMobile = false;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('enable() with 0x0 falls back to a 16:9 default', () async {
+    await PipController.instance.enable(width: 0, height: 0);
+    final call = calls.singleWhere((c) => c.method == 'setEligible');
+    expect(call.arguments, {'width': 1280, 'height': 720});
+    expect(PipController.instance.isEligible, isTrue);
+  });
+
+  test('enable() de-dupes when called with the same dimensions', () async {
+    await PipController.instance.enable(width: 1920, height: 1080);
+    await PipController.instance.enable(width: 1920, height: 1080);
+    expect(calls.where((c) => c.method == 'setEligible').length, 1);
+  });
+
+  test('enable() with new dimensions re-issues setEligible', () async {
+    await PipController.instance.enable(width: 1280, height: 720);
+    await PipController.instance.enable(width: 1920, height: 1080);
+    expect(calls.where((c) => c.method == 'setEligible').length, 2);
+  });
+
+  test('disable() clears state and pushes 0,0', () async {
+    await PipController.instance.enable(width: 1280, height: 720);
+    await PipController.instance.disable();
+    final last = calls.last;
+    expect(last.method, 'setEligible');
+    expect(last.arguments, {'width': 0, 'height': 0});
+    expect(PipController.instance.isEligible, isFalse);
+  });
+
+  test('disable() is a no-op when never enabled', () async {
+    await PipController.instance.disable();
+    expect(calls, isEmpty);
+  });
+
+  test('enterPip() requires eligibility first', () async {
+    final accepted = await PipController.instance.enterPip();
+    expect(accepted, isFalse);
+    expect(calls.where((c) => c.method == 'enterPip'), isEmpty);
+  });
+
+  test('enterPip() forwards once eligible', () async {
+    await PipController.instance.enable(width: 1280, height: 720);
+    final accepted = await PipController.instance.enterPip();
+    expect(accepted, isTrue);
+    expect(calls.where((c) => c.method == 'enterPip').length, 1);
+  });
+
+  test('onPipChanged callback flips isInPipNotifier', () async {
+    expect(PipController.instance.isInPipNotifier.value, isFalse);
+
+    const codec = StandardMethodCodec();
+    final payload = codec.encodeMethodCall(
+      const MethodCall('onPipChanged', {'inPip': true}),
+    );
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage('us.echomessenger/pip', payload, (_) {});
+    await Future<void>.delayed(Duration.zero);
+
+    expect(PipController.instance.isInPipNotifier.value, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Discord-parity mobile voice behavior in 5 commits + 1 test commit:

- **Voice survives backgrounding** on Android via a voice-aware foreground service (`FOREGROUND_SERVICE_TYPE_MICROPHONE | MEDIA_PLAYBACK`) and on iOS via CallKit + an explicit `AVAudioSession.playAndRecord` setup.
- **Persistent live notification** with the channel name and Mute / Leave actions on Android. iOS gets the equivalent CallKit lock-screen entry that holds the audio session.
- **Picture-in-Picture for remote screen share** — Android renders the screen-share `VideoTrackRenderer` in a system PiP window when the user backgrounds the app. iOS PiP is scaffolded; see "iOS PiP follow-up" below.

Closes the user-reported issue from #836 and shipped on top of the existing voice lounge.

## Behavior changes (mobile)

| Action | Before | After |
|---|---|---|
| Home button while in voice (Android) | Voice killed within ~30s when Android revokes RECORD_AUDIO | Foreground notification appears, mic stays live, voice continues |
| Lock screen while in voice (iOS) | Audio session torn down within ~30s; app suspended | CallKit entry on lock screen holds the audio session, voice continues |
| Mute from notification (Android) | n/a | Mute action toggles LiveKit `setCaptureEnabled`; the notification updates |
| Leave from notification | n/a | Leave action calls `leaveChannel`; notification dismisses |
| Remote participant shares screen + user backgrounds (Android) | App suspended, share invisible | OS drops activity into PiP rendering only the screen share |

## Architecture

```
LiveKitVoiceNotifier.joinChannel()
  ├─ Foreground service ──► EchoForegroundService (Kotlin)
  │                          ├─ FOREGROUND_SERVICE_TYPE_MICROPHONE | MEDIA_PLAYBACK
  │                          ├─ Notification: channel name + Mute / Leave
  │                          └─ Manifest receiver → MainActivity static dispatch
  │                              → MethodChannel onNotificationAction
  │                              → BackgroundService.notificationActions stream
  │                              → setCaptureEnabled / leaveChannel
  │
  ├─ CallKit (iOS) ──► flutter_callkit_incoming
  │                      ├─ CXStartCallAction (holds AVAudioSession active)
  │                      ├─ Lock-screen Mute / End buttons
  │                      └─ FlutterCallkitIncoming.onEvent → CallKitAction stream
  │                          → setCaptureEnabled / leaveChannel
  │
  └─ PiP eligibility on remote screen-share TrackSubscribed
       ├─ PipController.enable(width, height)
       ├─ Android: MainActivity.onUserLeaveHint → enterPictureInPictureMode
       │            (runtime-gated to API 26+; minSdk stays at 24)
       └─ iOS: PipBridgePlugin.swift (scaffold; frame bridge follow-up)
```

## Slices

1. **`feat(client)`** — Android voice-aware foreground service with live notification (`7447ac0`)
2. **`feat(client)`** — CallKit + AVAudioSession keep iOS voice alive in background (`e426970`)
3. **`feat(client)`** — Android Picture-in-Picture for remote screen share (`3101867`)
4. **`feat(client)`** — iOS Picture-in-Picture scaffolding (`5b73a03`)
5. **`test(client)`** — unit tests for BackgroundService + PipController (`bb91215`)

## iOS PiP follow-up

PR ships the Info.plist mode + `PipBridgePlugin.swift` scaffolding, but the actual frame bridge from `livekit_client`'s WebRTC track to the `AVSampleBufferDisplayLayer` requires a fork of the `livekit_client` iOS plugin to expose a PiP-renderer hook. Tracked as a follow-up. iOS users get full background voice + CallKit; PiP entry surfaces a system window backed by an empty layer until the frame bridge lands.

## Test plan

- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — **1461 tests pass** (1444 existing + 17 new)
- [x] `dart format` — clean
- [ ] Manual: Android device — join voice, home button, verify mic stays live, mute action works, leave action ends call, notification dismisses cleanly on swipe-from-recents
- [ ] Manual: iOS device — join voice, lock screen, verify CallKit entry appears, audio survives 60s+ background, mute toggle from lock screen reflects in app
- [ ] Manual: Android — remote screen share + home button → PiP window appears, voice still active, tapping PiP returns to full lounge
- [ ] Android 7.x device — voice + foreground notification works; PiP gracefully no-ops (no crash)

## New dependencies

- `flutter_callkit_incoming: ^3.0.0` (iOS CallKit bridge; Android side of this package is unused)

## Known limitations (documented in code)

- iOS PiP renders an empty layer until the WebRTC frame bridge lands (see Slice 4 commit body).
- PiP aspect uses a 16:9 fallback because LiveKit doesn't surface frame dimensions synchronously; track-resolution observer is a follow-up.
- Android PiP runtime-gated to API 26+ — Android 7.x users keep voice but skip PiP. Bumping `minSdk` 24 → 26 is the lift required to enable PiP universally; deferred until the broader minSdk policy is revisited.

## Refs

- #836 (mobile voice lounge UX) — primary parent
- Plan file: see commit messages for slice-level details
