### PR TITLE
fix(ios): drop invalid UIBackgroundMode + harden TestFlight upload check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,11 +492,25 @@ jobs:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
-          xcrun altool --upload-app \
-            -f echo-ios-${{ needs.version.outputs.version }}.ipa \
-            -t ios \
-            --apiKey "$ASC_KEY_ID" \
-            --apiIssuer "$ASC_ISSUER_ID"
+          set -e
+          # altool can exit 0 even when the upload fails Apple-side
+          # validation (e.g. invalid Info.plist values in v0.0.298),
+          # so capture the output and grep for the failure marker.
+          UPLOAD_LOG=$(mktemp)
+          if xcrun altool --upload-app \
+              -f echo-ios-${{ needs.version.outputs.version }}.ipa \
+              -t ios \
+              --apiKey "$ASC_KEY_ID" \
+              --apiIssuer "$ASC_ISSUER_ID" 2>&1 | tee "$UPLOAD_LOG"
+          then
+            if grep -qE 'UPLOAD FAILED|Validation failed|ERROR ITMS' "$UPLOAD_LOG"; then
+              echo "::error::altool reported a validation failure even though it exited 0"
+              exit 1
+            fi
+          else
+            echo "::error::altool returned a non-zero exit code"
+            exit 1
+          fi
       - name: Upload iOS artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/apps/client/ios/Runner/Info.plist
+++ b/apps/client/ios/Runner/Info.plist
@@ -81,7 +81,6 @@
 		<string>remote-notification</string>
 		<string>audio</string>
 		<string>voip</string>
-		<string>picture-in-picture</string>
 	</array>
 	<key>RTCScreenSharingExtension</key>
 	<string>us.echomessenger.app.broadcast</string>


### PR DESCRIPTION
Hotfix for the v0.0.298 TestFlight rejection.

## What happened

```
Validation failed (409) Invalid Info.plist value.
The Info.plist key UIBackgroundModes contains an invalid value: 'picture-in-picture'.
```

I added `picture-in-picture` to `UIBackgroundModes` in #839 thinking it was a valid value (some docs imply it). It isn't — Apple's allowed UIBackgroundModes list doesn't include it. Picture-in-Picture is enabled at runtime via `AVPictureInPictureController` + the existing `audio` mode; no separate Info.plist entry needed.

Net effect: TestFlight users are still on **v0.0.296** because v0.0.297's IPA build failed and v0.0.298's IPA was rejected by App Store Connect. The pipeline reported "success" because `xcrun altool` exited 0 despite the validation error.

## Changes

1. **Drop `picture-in-picture`** from `apps/client/ios/Runner/Info.plist`.
2. **Harden the TestFlight upload step** in `release.yml` — tee altool output to a log and grep for `UPLOAD FAILED` / `Validation failed` / `ERROR ITMS` so a future Apple-side rejection fails the job instead of silently shipping a stale build.

## Test plan

- [x] `flutter analyze --fatal-infos` — clean (no Dart code touched)
- [ ] CI iOS IPA builds + TestFlight upload now reaches v0.0.299
- [ ] TestFlight propagation: v0.0.299 visible in TestFlight after Apple processing (~10-30 min after the release pipeline finishes)
