### PR TITLE
feat+fix: What's New modal + deny host-coupled libs in Linux bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,40 @@ jobs:
             # System services / IPC.
             'libdbus|libsystemd|libudev|libelogind|libavahi'
 
+            # util-linux suite — libmount + libblkid are tightly coupled
+            # to the host's libgio version via MOUNT_2.* symbol versions.
+            # Bundling an Ubuntu-built libmount shadows the host's and
+            # breaks libgio symbol lookups on Fedora 44+ (#v0.0.303
+            # incident).
+            'libmount|libblkid|libsmartcols|libuuid|libfdisk'
+
+            # ICU (text + Unicode) — Ubuntu and Fedora ship different
+            # major versions (74 vs 76+); symbol mismatches surface as
+            # silent crashes in GTK/Pango when bundled.
+            'libicudata|libicuuc|libicui18n|libicutu|libicuio'
+
+            # GPU / video acceleration — talks to host kernel + driver.
+            'libvulkan|libvdpau|libva\.|libva-drm|libva-wayland|libva-x11'
+            'libGLdispatch|libGLU|libnvidia'
+
+            # Compiler runtimes + ELF tooling.
+            'libgfortran|libgomp\.|libunwind|libdw\.|libquadmath'
+
+            # Wayland decorations / theming — must match compositor.
+            'libdecor-0|libdecor'
+
+            # ncurses / terminal info — host's terminfo data is
+            # /etc/terminfo, not bundlable.
+            'libtinfo|libncurses|libslang'
+
+            # GLib / gobject introspection extras (some pulled by
+            # libgio in addition to the libglib- pattern above).
+            'libgirepository|libgthread'
+
+            # Misc gettext + libunistring + libidn2 — distros patch
+            # these for locale data; bundling causes UTF-8 weirdness.
+            'libgettext|libintl|libunistring|libidn2'
+
             # System crypto / TLS — distros patch these heavily.
             'libcrypto\.|libssl\.|libgcrypt|libgpg-error|libgnutls|libtasn1'
             'libnettle|libhogweed|libidn|libldap|libsasl|libkrb5|libcom_err'

--- a/apps/client/lib/src/providers/release_notes_provider.dart
+++ b/apps/client/lib/src/providers/release_notes_provider.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../version.dart';
+import 'update_provider.dart';
+
+/// Persisted key: the app version whose release notes the user has
+/// already been shown.  Set to `appVersion` on fresh install so first
+/// launches don't surface a "What's New" modal that assumes prior
+/// knowledge.
+const String _lastShownVersionKey = 'release_notes_last_shown';
+
+/// Snapshot of what the What's-New modal should render.  `null` when
+/// either the release-notes fetch hasn't completed or the user has
+/// already seen the current version's notes.
+class ReleaseNotesView {
+  /// Version string the body belongs to (e.g. "0.0.302").
+  final String version;
+
+  /// Cleaned markdown body (auto-generated footer + Dependabot URLs
+  /// stripped by [sanitizeReleaseBody]).
+  final String body;
+
+  const ReleaseNotesView({required this.version, required this.body});
+}
+
+/// Riverpod provider exposing whether the What's-New modal should be
+/// shown on the current launch.  Computed from [updateProvider]'s
+/// cached release body + a persisted "last shown" version key.
+///
+/// Returns null until both the update check has run AND the persisted
+/// "last shown" key has been read — guards against flashing the modal
+/// before the first-install bootstrap completes.
+final releaseNotesProvider =
+    AsyncNotifierProvider<ReleaseNotesNotifier, ReleaseNotesView?>(
+      ReleaseNotesNotifier.new,
+    );
+
+class ReleaseNotesNotifier extends AsyncNotifier<ReleaseNotesView?> {
+  @override
+  Future<ReleaseNotesView?> build() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    // Fresh install bootstrap: if we have no record of a previously-
+    // shown version, mark the CURRENT app version as seen and bail
+    // out.  The user gets release notes only on FUTURE updates, never
+    // on first launch (matches Discord / VS Code / GitHub Desktop UX).
+    final stored = prefs.getString(_lastShownVersionKey);
+    if (stored == null) {
+      if (appVersion != 'dev') {
+        await prefs.setString(_lastShownVersionKey, appVersion);
+      }
+      return null;
+    }
+
+    // Already shown the notes for this version — done.
+    if (stored == appVersion) return null;
+
+    // We have an outdated "last shown" record; the user updated since
+    // we last showed them notes.  Watch updateProvider for the body to
+    // arrive.  If updateProvider's check completed before this notifier
+    // built, ref.read returns the populated state immediately.
+    final update = ref.watch(updateProvider);
+    final body = update.releaseBody;
+    final remote = update.latestVersion;
+
+    // Two cases for the version comparison:
+    //   1. updateProvider already saw the new release ⇒ remote == appVersion
+    //   2. server lags ⇒ remote is older than appVersion (still show
+    //      whatever notes were cached for the version we know about,
+    //      since the user has clearly updated past `stored`).
+    // Either way, we render the cached body if non-empty.
+    if (body == null || body.isEmpty) return null;
+
+    // Show notes for the running app version.  The body in cache may
+    // correspond to a slightly different release on the server, but
+    // for the user the headline is "you updated; here's what changed".
+    return ReleaseNotesView(version: remote ?? appVersion, body: body);
+  }
+
+  /// Persist that the user has seen the notes for the current app
+  /// version, and clear the in-memory `state` so the modal doesn't
+  /// re-fire on hot reload.
+  Future<void> markShown() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lastShownVersionKey, appVersion);
+    state = const AsyncData(null);
+  }
+
+  /// Test-only override: reset the persisted "last shown" key so unit
+  /// tests can re-exercise the bootstrap path without restarting the
+  /// process.
+  Future<void> resetForTesting() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_lastShownVersionKey);
+    state = const AsyncData(null);
+  }
+}

--- a/apps/client/lib/src/providers/update_provider.dart
+++ b/apps/client/lib/src/providers/update_provider.dart
@@ -29,6 +29,12 @@ class UpdateState {
   final String? errorMessage;
   final bool dismissed;
 
+  /// Markdown body of the latest release's notes, as returned by the
+  /// GitHub releases API.  Cached locally; null until the first check
+  /// completes.  Consumed by [WhatsNewModal] (via [releaseNotesProvider])
+  /// to render the "What's New" sheet on first launch after an update.
+  final String? releaseBody;
+
   const UpdateState({
     this.status = UpdateStatus.idle,
     this.latestVersion,
@@ -38,6 +44,7 @@ class UpdateState {
     this.downloadProgress = 0,
     this.errorMessage,
     this.dismissed = false,
+    this.releaseBody,
   });
 
   bool get updateAvailable =>
@@ -57,6 +64,7 @@ class UpdateState {
     double? downloadProgress,
     String? errorMessage,
     bool? dismissed,
+    String? releaseBody,
   }) {
     return UpdateState(
       status: status ?? this.status,
@@ -67,8 +75,56 @@ class UpdateState {
       downloadProgress: downloadProgress ?? this.downloadProgress,
       errorMessage: errorMessage ?? this.errorMessage,
       dismissed: dismissed ?? this.dismissed,
+      releaseBody: releaseBody ?? this.releaseBody,
     );
   }
+}
+
+/// Strip auto-generated noise from a GitHub release notes body so the
+/// What's-New modal shows a clean changelog.  Trims:
+///
+///   - The `**Full Changelog**: https://...compare/vA...vB` trailer that
+///     `softprops/action-gh-release` always appends.
+///   - Dependabot's `bumps `dep` from X to Y` diff URLs (one per line) —
+///     the human commit subject above them is what readers actually
+///     want.
+///   - `Co-Authored-By:` trailers from squash commits.
+///   - Leading/trailing whitespace.
+///
+/// Pure function — exposed for unit tests.
+String? sanitizeReleaseBody(String? raw) {
+  if (raw == null || raw.trim().isEmpty) return null;
+  var body = raw;
+
+  // GitHub's auto-changelog footer: "**Full Changelog**: <url>"
+  body = body.replaceAll(
+    RegExp(
+      r'\*\*Full Changelog\*\*:\s*https://github\.com/\S+',
+      multiLine: true,
+    ),
+    '',
+  );
+
+  // Dependabot dependency diff URLs.
+  body = body.replaceAll(
+    RegExp(
+      r'^- \[.*\]\(https://github\.com/\S+/compare/\S+\)$',
+      multiLine: true,
+    ),
+    '',
+  );
+
+  // Co-author trailers from squashed PRs.
+  body = body.replaceAll(
+    RegExp(r'^Co-Authored-By:.*$', multiLine: true, caseSensitive: false),
+    '',
+  );
+
+  // Collapse 3+ blank lines into a single blank line.
+  body = body.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+
+  body = body.trim();
+  return body.isEmpty ? null : body;
 }
 
 bool _isNewer(String remote, String local) {
@@ -164,6 +220,7 @@ class Update extends _$Update {
       latestVersion: version,
       downloadUrl: data['url'] as String?,
       assetDownloadUrl: data['assetUrl'] as String?,
+      releaseBody: data['body'] as String?,
       dismissed: dismissed,
       status: readyPath != null
           ? UpdateStatus.readyToInstall
@@ -192,10 +249,16 @@ class Update extends _$Update {
     final version = tagName.startsWith('v') ? tagName.substring(1) : tagName;
     final url = (data['html_url'] as String?) ?? _releasesPageUrl;
     final assetUrl = _findPlatformAssetUrl(data);
+    final body = sanitizeReleaseBody(data['body'] as String?);
 
     await prefs.setString(
       _cacheKey,
-      jsonEncode({'version': version, 'url': url, 'assetUrl': assetUrl}),
+      jsonEncode({
+        'version': version,
+        'url': url,
+        'assetUrl': assetUrl,
+        'body': body,
+      }),
     );
     await prefs.setInt(_cacheTimeKey, DateTime.now().millisecondsSinceEpoch);
 
@@ -206,6 +269,7 @@ class Update extends _$Update {
       latestVersion: version,
       downloadUrl: url,
       assetDownloadUrl: assetUrl,
+      releaseBody: body,
       dismissed: dismissed,
       status: readyPath != null
           ? UpdateStatus.readyToInstall

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -19,6 +19,7 @@ import '../providers/privacy_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/livekit_voice_provider.dart';
+import '../providers/release_notes_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../services/notification_service.dart';
 import '../services/tray_service.dart';
@@ -31,6 +32,7 @@ import '../widgets/members_panel.dart';
 import '../utils/web_lifecycle.dart';
 import '../widgets/keyboard_shortcuts_overlay.dart';
 import '../widgets/global_search_overlay.dart';
+import '../widgets/whats_new_modal.dart';
 import '../widgets/quick_switcher_overlay.dart';
 import '../widgets/voice_dock.dart';
 import 'contacts_screen.dart';
@@ -186,14 +188,34 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     // 5. Load privacy preferences used for read-receipt/plaintext behavior.
     await ref.read(privacyProvider.notifier).load();
 
-    // 6. Check for app updates (non-blocking)
-    ref.read(updateProvider.notifier).check();
+    // 6. Check for app updates.  Awaited so step 6b can read the
+    // resulting release-notes body and decide whether to show the
+    // What's New modal — without await the body isn't populated yet
+    // and the modal silently skips.  Cached path is sync (≤ 1ms);
+    // network path is a single 10s-timeout GET so worst-case impact
+    // on home-screen first paint is bounded.
+    await ref.read(updateProvider.notifier).check();
+
+    // 6b. Show the What's New modal once per upgrade.  No-op on fresh
+    // install (releaseNotesProvider bootstraps last_shown = appVersion
+    // so first launch never surfaces a changelog).
+    await _showWhatsNewIfNeeded();
 
     // 7b. Init system tray (desktop only; no-op on web/mobile).
     unawaited(TrayService.instance.init());
 
     // 7. Show first-login server notice
     await _showServerNoticeIfNeeded();
+  }
+
+  Future<void> _showWhatsNewIfNeeded() async {
+    if (!mounted) return;
+    // Force AsyncNotifier.build() to run before reading .value — the
+    // first read of an AsyncNotifierProvider returns AsyncLoading; we
+    // need the resolved snapshot.
+    await ref.read(releaseNotesProvider.future);
+    if (!mounted) return;
+    await maybeShowWhatsNew(context, ref);
   }
 
   void _startPendingRefreshLoop() {

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../providers/release_notes_provider.dart';
+import '../theme/echo_theme.dart';
+
+/// Bottom-sheet style "What's New" modal showing the GitHub release
+/// notes for the version the user just updated to.  Markdown body is
+/// pre-sanitized by [sanitizeReleaseBody] so the user sees a clean
+/// changelog without the auto-generated diff URLs.
+///
+/// Triggered once per upgrade from [home_screen]'s post-login flow via
+/// [maybeShowWhatsNew].
+class WhatsNewModal extends ConsumerWidget {
+  final ReleaseNotesView notes;
+
+  const WhatsNewModal({super.key, required this.notes});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final mediaQuery = MediaQuery.of(context);
+    // Cap the sheet height at 80% of screen so long release notes
+    // don't push the dismiss button off-screen on shorter devices.
+    final maxHeight = mediaQuery.size.height * 0.8;
+
+    return Container(
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      padding: EdgeInsets.only(
+        // Safe-area + visual-density-aware paddings.
+        bottom: mediaQuery.padding.bottom + 16,
+      ),
+      decoration: BoxDecoration(
+        color: context.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Drag-handle indicator (matches other bottom sheets in app).
+          const SizedBox(height: 8),
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: context.textMuted.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Title row.
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.celebration_outlined,
+                  color: context.accent,
+                  size: 28,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        "What's New",
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        'Echo v${notes.version}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: context.textMuted,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Scrollable markdown body.
+          Flexible(
+            child: Markdown(
+              data: notes.body,
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              shrinkWrap: true,
+              selectable: true,
+              styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
+                p: theme.textTheme.bodyMedium?.copyWith(height: 1.45),
+                h1: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+                h2: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+                h3: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+                listBullet: theme.textTheme.bodyMedium,
+                code: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  backgroundColor: context.surfaceHover,
+                ),
+                codeblockDecoration: BoxDecoration(
+                  color: context.surfaceHover,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                a: theme.textTheme.bodyMedium?.copyWith(
+                  color: context.accent,
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+              onTapLink: (text, href, title) {
+                if (href != null) {
+                  launchUrl(
+                    Uri.parse(href),
+                    mode: LaunchMode.externalApplication,
+                  );
+                }
+              },
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Dismiss button.
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: FilledButton(
+              onPressed: () async {
+                await ref.read(releaseNotesProvider.notifier).markShown();
+                if (context.mounted) Navigator.of(context).pop();
+              },
+              style: FilledButton.styleFrom(
+                backgroundColor: context.accent,
+                minimumSize: const Size.fromHeight(48),
+              ),
+              child: const Text('Got it'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Convenience wrapper called by `home_screen` once after login.  Shows
+/// the modal if-and-only-if [releaseNotesProvider] has populated
+/// [ReleaseNotesView] data (i.e. the user updated since they last saw
+/// notes AND we have a non-empty body to render).
+Future<void> maybeShowWhatsNew(BuildContext context, WidgetRef ref) async {
+  final view = ref.read(releaseNotesProvider).value;
+  if (view == null) return;
+  if (!context.mounted) return;
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => WhatsNewModal(notes: view),
+  );
+}

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -523,6 +523,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7+1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -853,6 +861,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   image: ^4.8.0
   flutter_colorpicker: ^1.1.0
   flutter_callkit_incoming: ^3.0.0
+  flutter_markdown: ^0.7.7+1
 
 dev_dependencies:
   flutter_test:

--- a/apps/client/test/providers/release_notes_sanitizer_test.dart
+++ b/apps/client/test/providers/release_notes_sanitizer_test.dart
@@ -1,0 +1,126 @@
+/// Pure-function tests for [sanitizeReleaseBody], the regex pass that
+/// strips GitHub-auto-generated noise from release-notes markdown
+/// before the What's-New modal renders it.  No Flutter binding needed.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/providers/update_provider.dart';
+
+void main() {
+  group('sanitizeReleaseBody', () {
+    test('returns null on null input', () {
+      expect(sanitizeReleaseBody(null), isNull);
+    });
+
+    test('returns null on empty / whitespace-only input', () {
+      expect(sanitizeReleaseBody(''), isNull);
+      expect(sanitizeReleaseBody('   \n\n\t'), isNull);
+    });
+
+    test('strips the Full Changelog trailer', () {
+      const raw = '''
+## What's Changed
+* fix: thing by @npc in #42
+
+**Full Changelog**: https://github.com/NC1107/echo-messenger/compare/v0.0.301...v0.0.302
+''';
+      final out = sanitizeReleaseBody(raw)!;
+      expect(out, contains('## What\'s Changed'));
+      expect(out, isNot(contains('Full Changelog')));
+      expect(out, isNot(contains('compare/v0.0.301')));
+    });
+
+    test('strips Dependabot bump diff lines', () {
+      const raw = '''
+## Bumps
+- [tokio](https://github.com/tokio-rs/tokio/compare/tokio-1.50.0...tokio-1.52.2)
+- [serde](https://github.com/serde-rs/serde/compare/v1.0.0...v1.0.1)
+
+Real human commit message here.
+''';
+      final out = sanitizeReleaseBody(raw)!;
+      expect(out, contains('## Bumps'));
+      expect(out, contains('Real human commit message here.'));
+      // Bumps shouldn't appear in body — only diff URL lines are
+      // stripped; the headline survives, which is fine.
+      expect(out, isNot(contains('tokio-rs/tokio/compare')));
+      expect(out, isNot(contains('serde-rs/serde/compare')));
+    });
+
+    test('strips Co-Authored-By trailers', () {
+      const raw = '''
+fix: something
+
+Co-Authored-By: dev <dev@example.com>
+Co-Authored-By: Other Dev <other@example.com>
+
+More content.
+''';
+      final out = sanitizeReleaseBody(raw)!;
+      expect(out, isNot(contains('Co-Authored-By')));
+      expect(out, contains('More content.'));
+    });
+
+    test('preserves regular markdown headers, lists, and code', () {
+      const raw = '''
+## What's Changed
+- Feature: PiP mode for voice calls
+- Fix: `MessageList` rebuild storm
+
+```dart
+final foo = 'bar';
+```
+
+Inline `code` example.
+''';
+      final out = sanitizeReleaseBody(raw)!;
+      expect(out, contains("## What's Changed"));
+      expect(out, contains('- Feature: PiP mode for voice calls'));
+      expect(out, contains('```dart'));
+      expect(out, contains('Inline `code` example.'));
+    });
+
+    test('collapses runs of blank lines', () {
+      const raw = 'Line 1\n\n\n\n\nLine 2';
+      final out = sanitizeReleaseBody(raw)!;
+      expect(out, 'Line 1\n\nLine 2');
+    });
+
+    test('returns null when sanitization leaves nothing meaningful', () {
+      const raw = '''
+
+
+**Full Changelog**: https://github.com/x/y/compare/v1...v2
+
+
+''';
+      expect(sanitizeReleaseBody(raw), isNull);
+    });
+
+    test('handles a realistic compound release body', () {
+      const raw = '''
+## What's Changed
+* fix(ios): drop invalid `picture-in-picture` UIBackgroundMode by @npc in #841
+* feat(client): density tiers on voice control dock by @npc in #823
+
+### Dependency bumps
+- [tokio](https://github.com/tokio-rs/tokio/compare/tokio-1.50.0...tokio-1.52.2)
+
+Co-Authored-By: dev <dev@example.com>
+
+**Full Changelog**: https://github.com/NC1107/echo-messenger/compare/v0.0.301...v0.0.302
+''';
+      final out = sanitizeReleaseBody(raw)!;
+      expect(out, contains('* fix(ios): drop invalid `picture-in-picture`'));
+      expect(
+        out,
+        contains('* feat(client): density tiers on voice control dock'),
+      );
+      expect(out, contains('### Dependency bumps'));
+      expect(out, isNot(contains('Full Changelog')));
+      expect(out, isNot(contains('Co-Authored-By')));
+      expect(out, isNot(contains('tokio-rs/tokio/compare')));
+    });
+  });
+}


### PR DESCRIPTION
Two-pack PR covering two unrelated improvements that landed on `dev` back-to-back.

## 1. What's New modal (feature)

After a user updates and re-opens Echo, a bottom sheet renders the latest release's markdown body (fetched from the GitHub releases API call that `update_provider` already polls). Persisted `last_shown` key in SharedPreferences ensures each version's notes show exactly once.

- **Free-ride** on the existing API call; `UpdateState.releaseBody` is added alongside the existing cached version + URL.
- **Sanitizer** (`sanitizeReleaseBody`, unit-tested) strips GitHub's `**Full Changelog**: <url>` trailer, Dependabot diff URLs, `Co-Authored-By:` lines, and 3+ blank-line runs.
- **Fresh install bootstrap** sets `last_shown = appVersion` so first launches never surface a changelog.
- **Markdown rendering** via `flutter_markdown` (deprecated but stable; follow-up to swap to `markdown_widget` tracked).
- Wired into `home_screen._initData`: awaits update check, then `maybeShowWhatsNew`.
- **9 sanitizer unit tests** added; full test suite still passes (1470 total).

## 2. Linux AppImage: deny host-coupled libs (hotfix)

v0.0.303 launched on most hosts but crashed on Fedora 44 with:

```
/lib64/libgio-2.0.so.0: version 'MOUNT_2_40' not found
(required by /tmp/.mount.../usr/bin/lib/libmount.so.1)
```

Different bug class from the missing-lib cycle that #845 fixed: soname-level validation confirmed `libmount.so.1` was present, but the bundled (Ubuntu 22.04 util-linux 2.39) version didn't expose `MOUNT_2_40` symbols that the host's newer libgio required. `LD_LIBRARY_PATH` put our older libmount first, host's libgio loaded it, symbol resolution failed.

util-linux + ICU + GPU/video accel libs are tightly coupled to the host's GLib/kernel-driver versions at the symbol level. Adding to `DENY_RE`:

| Group | Libs |
|---|---|
| util-linux | `libmount`, `libblkid`, `libsmartcols`, `libuuid`, `libfdisk` |
| ICU | `libicudata`, `libicuuc`, `libicui18n`, `libicutu`, `libicuio` |
| GPU / video | `libvulkan`, `libvdpau`, `libva*`, `libGLU`, `libnvidia*` |
| Compiler RT | `libgfortran`, `libunwind`, `libdw`, `libquadmath` |
| Wayland deco | `libdecor-0` |
| Terminal | `libtinfo`, `libncurses`, `libslang` |
| GLib extras | `libgirepository` |
| Locale data | `libgettext`, `libintl`, `libunistring`, `libidn2` |

**18 libs in v0.0.303's bundle are now correctly excluded.** Each is universally present on Linux desktops.

### Known structural limit (follow-up)

DT_NEEDED-only validation can't catch symbol-version skew — the validation step would still have passed on v0.0.303 even though the bundle was wrong. The proper long-term fix is one of:

1. Build on Ubuntu 22.04 LTS (older glibc symbols are forward-compatible across user hosts).
2. Switch to `linuxdeploy` / `appimage-builder` with curated exclude lists.
3. Strip more deps via static linking.

Tracked as follow-up — not in this PR. The expanded deny list buys us correctness for the known host-coupled libs while we plan that work.

## Test plan

- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 1470 pass (9 new sanitizer cases)
- [x] Local simulation: 18 libs from v0.0.303's bundle correctly excluded by new deny rules
- [ ] CI Linux build + DT_NEEDED validation passes
- [ ] Manual: `Echo-x86_64.AppImage` from v0.0.304 launches on the Fedora 44 host that broke v0.0.303
- [ ] Manual: simulate upgrade (edit `release_notes_last_shown` key in shared prefs → relaunch) → What's New modal appears with v0.0.304 notes