### PR TITLE
fix(ci): linuxdeploy-plugin-gtk source URL (404) + PATH wiring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,11 +233,18 @@ jobs:
           curl -fSL --retry 3 --retry-delay 2 \
             -o linuxdeploy-x86_64.AppImage \
             "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+          # linuxdeploy-plugin-gtk ships only as a shell script on the
+          # repo's main branch — no tagged release.  Pull it from raw.
           curl -fSL --retry 3 --retry-delay 2 \
             -o linuxdeploy-plugin-gtk.sh \
-            "https://github.com/linuxdeploy/linuxdeploy-plugin-gtk/releases/download/continuous/linuxdeploy-plugin-gtk.sh"
+            "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
           ls -la linuxdeploy-x86_64.AppImage linuxdeploy-plugin-gtk.sh
           chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-gtk.sh
+          # linuxdeploy looks for plugins by exact name `linuxdeploy-plugin-<name>`
+          # in $PATH, no .sh suffix accepted.  Symlink + export PATH so
+          # `--plugin gtk` resolves.
+          ln -sf linuxdeploy-plugin-gtk.sh linuxdeploy-plugin-gtk
+          export PATH="$(pwd):$PATH"
           # linuxdeploy itself is an AppImage and needs to be runnable;
           # GitHub Actions runners don't have FUSE 2 by default but our
           # apt-get step installs libfuse2.  Sanity-check by invoking


### PR DESCRIPTION
v0.0.305 second attempt got past the silent wget but hit a clear 404:

```
curl: (22) The requested URL returned error: 404
```

**Cause**: `linuxdeploy-plugin-gtk` doesn't have a tagged 'continuous' release. The plugin is a bash script shipped only on the repo's master branch. Pull from `raw.githubusercontent` instead.

**Bonus fix**: linuxdeploy's `--plugin <name>` flag resolves by exact filename `linuxdeploy-plugin-<name>` in `$PATH` — no `.sh` suffix accepted. Symlink + export PATH so the invocation can actually find the plugin.

Verified the URL is reachable locally:
```
$ curl -sSL -o /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
200
```

If this works, v0.0.306 publishes via linuxdeploy properly — and the lib-of-the-week pattern is structurally over.
