### PR TITLE
fix(ci): skip self-mv of linuxdeploy-produced AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,10 +307,20 @@ jobs:
               --desktop-file Echo.AppDir/echo.desktop \
               --icon-file Echo.AppDir/echo.png \
               --output appimage
-          # linuxdeploy writes Echo-x86_64.AppImage to CWD with the
-          # version derived from Name= in the .desktop file.  Rename to
-          # the canonical artifact name expected by the release job.
-          mv Echo*.AppImage Echo-x86_64.AppImage
+          # linuxdeploy writes the AppImage to CWD with a name derived
+          # from the .desktop file's Name= field.  In our case that's
+          # already "Echo-x86_64.AppImage" — but be defensive for the
+          # case where linuxdeploy versions the filename.  Skip the
+          # rename when source == target so `mv` doesn't self-mv-error
+          # ("are the same file").
+          APPIMAGE=$(ls Echo*.AppImage 2>/dev/null | head -1)
+          if [ -z "$APPIMAGE" ]; then
+            echo "::error::linuxdeploy did not produce an AppImage"
+            exit 1
+          fi
+          if [ "$APPIMAGE" != "Echo-x86_64.AppImage" ]; then
+            mv "$APPIMAGE" Echo-x86_64.AppImage
+          fi
 
           # 6. Lightweight sanity: confirm libmpv made it in.  linuxdeploy
           #    silently skips libs in its excludelist, so missing libmpv


### PR DESCRIPTION
linuxdeploy actually **worked** in the previous release attempt — 132 MB AppImage, 624 files, all GTK/glib/libmpv transitives properly bundled. The release pipeline failed at the very last step on my own code:

```
mv: 'Echo-x86_64.AppImage' and 'Echo-x86_64.AppImage' are the same file
```

linuxdeploy outputs to a filename derived from the .desktop `Name=` field — in our case that's already `Echo-x86_64.AppImage`. The unconditional rename was wrong. Now: check source != target before rename.

If this lands cleanly, v0.0.306 should publish via linuxdeploy with proper bundling. **Test plan**: `./Echo-x86_64.AppImage` from v0.0.306 on the Fedora 44 host that broke v0.0.301..v0.0.303.
