### PR TITLE
refactor(client): split chat_panel and chat_input_bar god modules (#512 #513)

### DIFF
--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -31,6 +31,7 @@ import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
 import '../theme/responsive.dart';
 import '../utils/clipboard_image_helper.dart';
+import 'chat_input_controller.dart';
 import 'chat_input_bar/attach_file_button.dart';
 import 'chat_input_bar/attach_option.dart';
 import 'chat_input_bar/media_marker_helpers.dart';
@@ -89,8 +90,14 @@ class ChatInputBar extends ConsumerStatefulWidget {
 }
 
 class ChatInputBarState extends ConsumerState<ChatInputBar> {
-  final _messageController = TextEditingController();
-  final _inputFocusNode = FocusNode();
+  // The text composer, focus node, edit-message state, and (in a later
+  // slice) mention controller live on [_controller]. Forwarders below
+  // preserve the existing `_messageController` / `_inputFocusNode` /
+  // `_editingMessage` call sites so the file diff stays focused on state
+  // ownership and the `GlobalKey<ChatInputBarState>` API contract.
+  late final ChatInputController _controller;
+  TextEditingController get _messageController => _controller.text;
+  FocusNode get _inputFocusNode => _controller.focus;
 
   bool _isTextEmpty = true;
   bool _showMediaPicker = false;
@@ -118,14 +125,16 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   // File picker guard
   bool _isPickingFile = false;
 
-  // Edit mode state
-  ChatMessage? _editingMessage;
-  bool get _isEditing => _editingMessage != null;
+  // Edit mode state — lives on [_controller]. The widget's `_editingMessage`
+  // setter funnels through `_controller.enterEditMode` / `exitEditMode` so
+  // the notifier-fire order stays consistent.
+  ChatMessage? get _editingMessage => _controller.editingMessage;
+  bool get _isEditing => _controller.isEditing;
 
   // Mention autocomplete state — owned by a controller so the logic is
-  // unit-testable without pumping the whole composer (#513).
-  final MentionComposerController _mentionController =
-      MentionComposerController();
+  // unit-testable without pumping the whole composer (#513). Composed
+  // (not inherited) by [_controller] so its dispose hook is wired through.
+  MentionComposerController get _mentionController => _controller.mention;
 
   // Pending attachments staged for the current send. Single-pick uses one
   // entry (with the caption-and-send flow); multi-pick stages all picked
@@ -162,6 +171,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   @override
   void initState() {
     super.initState();
+    _controller = ChatInputController();
     _messageController.addListener(_onTextChanged);
     _mentionController.addListener(_onMentionChanged);
     _loadDraft(widget.conversation.id);
@@ -186,7 +196,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       // leaking notifiers for the rest.
       _clearAllPendingAttachments();
       _messageController.clear();
-      _editingMessage = null;
+      _controller.exitEditMode();
       _isTextEmpty = true;
       _showMediaPicker = false;
       _showInlinePicker = false;
@@ -204,10 +214,10 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _recordingTimer?.cancel();
     _recorder.dispose();
     _messageController.removeListener(_onTextChanged);
-    _messageController.dispose();
     _mentionController.removeListener(_onMentionChanged);
-    _mentionController.dispose();
-    _inputFocusNode.dispose();
+    // [_controller.dispose] handles text controller + focus node + mention
+    // controller dispose so their order stays in one place (#513).
+    _controller.dispose();
     // Release every staged attachment's ValueNotifier (#623). Calling
     // setState here would be unsafe during dispose; just walk the list
     // and dispose each one directly.
@@ -227,8 +237,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     // Clear any active reply — editing and replying are mutually exclusive.
     ref.read(chatProvider.notifier).clearReplyTo();
     setState(() {
-      _editingMessage = message;
-      _messageController.text = message.content;
+      _controller.enterEditMode(message);
       _isTextEmpty = false;
     });
     _inputFocusNode.requestFocus();
@@ -930,7 +939,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _draftSaveTimer?.cancel();
     _suppressDraftSave = true;
     setState(() {
-      _editingMessage = null;
+      _controller.exitEditMode();
       _messageController.clear();
       _isTextEmpty = true;
     });

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -48,14 +48,7 @@ import 'input/reply_preview_bar.dart';
 import 'media_picker_panel.dart';
 import 'mobile_media_picker_panel.dart';
 
-// Upload constants + pure-Dart helpers (kOctetStream, kMaxUploadBytes,
-// genericFilename, formatBytes) live in chat_input_bar/upload_helpers.dart.
-// Marker / MIME helpers live in chat_input_bar/media_marker_helpers.dart.
-// Local alias preserves the `_kImageGif` symbol used at three call sites
-// in this file without touching them.
-const _kImageGif = kImageGifMimeType;
-
-/// Extracted chat input bar from ChatPanel (~850 lines).
+/// Extracted chat input bar from ChatPanel.
 ///
 /// Manages:
 /// - Text composition with mention autocomplete
@@ -158,10 +151,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   set _recordingDuration(Duration v) => _controller.recordingDuration = v;
   List<double> get _recordingAmplitudes => _controller.recordingAmplitudes;
 
-  // Debounce for search (used by _detectMention indirectly via parent, but
-  // kept here to match the cancel contract in dispose/didUpdateWidget).
-  Timer? _searchDebounce;
-
   // Draft auto-save
   static const _draftKeyPrefix = 'chat_draft_';
   Timer? _draftSaveTimer;
@@ -190,7 +179,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       _draftSaveTimer?.cancel();
 
       _mentionController.dismiss();
-      _searchDebounce?.cancel();
       // Release every staged attachment's ValueNotifier — switching
       // conversations was previously only releasing the last one (#623),
       // leaking notifiers for the rest.
@@ -210,7 +198,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   @override
   void dispose() {
     _draftSaveTimer?.cancel();
-    _searchDebounce?.cancel();
     _messageController.removeListener(_onTextChanged);
     _mentionController.removeListener(_onMentionChanged);
     // [_controller.dispose] handles text controller + focus node + mention
@@ -1596,7 +1583,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         _setPendingExternalAttachment(
           url: gifUrl,
           fileName: 'gif',
-          mimeType: _kImageGif,
+          mimeType: kImageGifMimeType,
           ext: 'gif',
         );
       },
@@ -1753,7 +1740,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                             _setPendingExternalAttachment(
                               url: gifUrl,
                               fileName: 'gif',
-                              mimeType: _kImageGif,
+                              mimeType: kImageGifMimeType,
                               ext: 'gif',
                             );
                           },

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show File;
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugPrint, defaultTargetPlatform, kIsWeb;
 import 'package:path_provider/path_provider.dart';
@@ -33,6 +32,7 @@ import '../theme/responsive.dart';
 import '../utils/clipboard_image_helper.dart';
 import 'chat_input_controller.dart';
 import 'chat_input_bar/attach_file_button.dart';
+import 'chat_input_bar/file_pickers.dart' as pickers;
 import 'chat_input_bar/attach_option.dart';
 import 'chat_input_bar/media_marker_helpers.dart';
 import 'chat_input_bar/media_picker_toggle.dart';
@@ -772,26 +772,9 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _onInputChanged(_messageController.text);
   }
 
-  // ---------------------------------------------------------------------------
-  // File mime resolution (shared between pickers)
-  // ---------------------------------------------------------------------------
-
-  static const _kMimeTypes = <String, List<String>>{
-    'jpg': ['image', 'jpeg'],
-    'jpeg': ['image', 'jpeg'],
-    'png': ['image', 'png'],
-    'gif': ['image', 'gif'],
-    'webp': ['image', 'webp'],
-    'mp4': ['video', 'mp4'],
-    'mov': ['video', 'quicktime'],
-    'webm': ['video', 'webm'],
-    'pdf': ['application', 'pdf'],
-    'mp3': ['audio', 'mpeg'],
-    'ogg': ['audio', 'ogg'],
-    'wav': ['audio', 'wav'],
-    'm4a': ['audio', 'mp4'],
-    'aac': ['audio', 'aac'],
-  };
+  // MIME-type table lives on `chat_input_bar/file_pickers.dart` (#513
+  // slice 6) — the only remaining caller here is `_sendFileImmediately`,
+  // which receives the resolved mimeType from the picker functions.
 
   /// Upload [bytes] and immediately send the result as a message.
   /// Used for the 2nd..Nth files when multiple are selected at once.
@@ -813,114 +796,25 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     await _doSend(marker);
   }
 
-  Future<void> _pickFile() async {
-    if (_isPickingFile) return;
-    _isPickingFile = true;
-    try {
-      final result = await FilePicker.pickFiles(
-        type: FileType.any,
-        allowMultiple: true,
-        withData: true,
-      );
-      if (result == null || result.files.isEmpty) return;
-      if (!mounted) return;
-
-      // Single pick → preview flow (caption + send). Multi pick → send all
-      // immediately as separate messages; mixing the two creates races where
-      // the user may interact with the pending preview while the rest are
-      // still uploading in the background.
-      final isMulti = result.files.length > 1;
-      if (isMulti) {
-        ToastService.show(
-          context,
-          'Sending ${result.files.length} files...',
-          type: ToastType.info,
-        );
-      }
-
-      var sentCount = 0;
-      for (final file in result.files) {
-        if (file.size > kMaxUploadBytes) {
-          if (mounted) {
-            ToastService.show(
-              context,
-              '${file.name} is ${formatBytes(file.size)} — limit is '
-              '${formatBytes(kMaxUploadBytes)}',
-              type: ToastType.error,
-            );
-          }
-          continue;
-        }
-
-        // On mobile, withData:true may still yield null bytes for larger files
-        // or certain content URIs. Fall back to reading from the file path.
-        Uint8List? bytes = file.bytes;
-        if (bytes == null && file.path != null && !kIsWeb) {
-          try {
-            bytes = await File(file.path!).readAsBytes();
-          } catch (e) {
-            debugPrint('[ChatInput] Failed to read file from path: $e');
-          }
-        }
-
-        if (bytes == null) {
-          if (mounted) {
-            ToastService.show(
-              context,
-              'Could not read file: ${file.name}',
-              type: ToastType.error,
-            );
-          }
-          continue;
-        }
-
-        final ext = (file.extension ?? '').toLowerCase();
-        final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
-        final mimeType = '${mime[0]}/${mime[1]}';
-
-        if (isMulti) {
-          try {
-            await _sendFileImmediately(
-              bytes: bytes,
-              fileName: file.name,
-              mimeType: mimeType,
-              ext: ext,
-            );
-            sentCount++;
-          } catch (e) {
-            debugPrint('[ChatInput] Send failed for ${file.name}: $e');
-            if (mounted) {
-              ToastService.show(
-                context,
-                'Failed to send ${file.name}',
-                type: ToastType.error,
-              );
-            }
-          }
-        } else {
-          _setPendingAttachment(
-            bytes: bytes,
-            fileName: file.name,
-            mimeType: mimeType,
-            ext: ext,
-          );
-        }
-      }
-      if (isMulti && mounted && sentCount < result.files.length) {
-        final failed = result.files.length - sentCount;
-        ToastService.show(
-          context,
-          '$failed of ${result.files.length} failed to send',
-          type: ToastType.error,
-        );
-      }
-    } catch (e) {
-      if (!mounted) return;
-      ToastService.show(context, 'File pick error: $e', type: ToastType.error);
-    } finally {
-      _isPickingFile = false;
-    }
-  }
+  Future<void> _pickFile() => pickers.pickFile(
+    context: context,
+    mounted: () => mounted,
+    isPicking: () => _isPickingFile,
+    setIsPicking: (v) => _isPickingFile = v,
+    stage:
+        ({
+          required List<int> bytes,
+          required String fileName,
+          required String mimeType,
+          required String ext,
+        }) => _setPendingAttachment(
+          bytes: bytes,
+          fileName: fileName,
+          mimeType: mimeType,
+          ext: ext,
+        ),
+    sendImmediately: _sendFileImmediately,
+  );
 
   // ---------------------------------------------------------------------------
   // Edit mode
@@ -1227,130 +1121,44 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     );
   }
 
-  Future<void> _pickImageFromGallery() async {
-    if (_isPickingFile) return;
-    _isPickingFile = true;
-    try {
-      final result = await FilePicker.pickFiles(
-        type: FileType.media,
-        allowMultiple: true,
-        withData: true,
-      );
-      if (result == null || result.files.isEmpty) return;
-      if (!mounted) return;
+  Future<void> _pickImageFromGallery() => pickers.pickImageFromGallery(
+    context: context,
+    mounted: () => mounted,
+    isPicking: () => _isPickingFile,
+    setIsPicking: (v) => _isPickingFile = v,
+    stage:
+        ({
+          required List<int> bytes,
+          required String fileName,
+          required String mimeType,
+          required String ext,
+        }) => _setPendingAttachment(
+          bytes: bytes,
+          fileName: fileName,
+          mimeType: mimeType,
+          ext: ext,
+        ),
+    sendImmediately: _sendFileImmediately,
+  );
 
-      final isMulti = result.files.length > 1;
-      if (isMulti) {
-        ToastService.show(
-          context,
-          'Sending ${result.files.length} files...',
-          type: ToastType.info,
-        );
-      }
-
-      var sentCount = 0;
-      for (final file in result.files) {
-        if (file.size > kMaxUploadBytes) {
-          if (mounted) {
-            ToastService.show(
-              context,
-              '${file.name} is ${formatBytes(file.size)} — limit is '
-              '${formatBytes(kMaxUploadBytes)}',
-              type: ToastType.error,
-            );
-          }
-          continue;
-        }
-
-        Uint8List? bytes = file.bytes;
-        if (bytes == null && file.path != null && !kIsWeb) {
-          try {
-            bytes = await File(file.path!).readAsBytes();
-          } catch (_) {}
-        }
-        if (bytes == null) continue;
-
-        final ext = (file.extension ?? '').toLowerCase();
-        final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
-        final mimeType = '${mime[0]}/${mime[1]}';
-
-        if (isMulti) {
-          try {
-            await _sendFileImmediately(
-              bytes: bytes,
-              fileName: file.name,
-              mimeType: mimeType,
-              ext: ext,
-            );
-            sentCount++;
-          } catch (e) {
-            debugPrint('[ChatInput] Send failed for ${file.name}: $e');
-            if (mounted) {
-              ToastService.show(
-                context,
-                'Failed to send ${file.name}',
-                type: ToastType.error,
-              );
-            }
-          }
-        } else {
-          _setPendingAttachment(
-            bytes: bytes,
-            fileName: file.name,
-            mimeType: mimeType,
-            ext: ext,
-          );
-        }
-      }
-      if (isMulti && mounted && sentCount < result.files.length) {
-        final failed = result.files.length - sentCount;
-        ToastService.show(
-          context,
-          '$failed of ${result.files.length} failed to send',
-          type: ToastType.error,
-        );
-      }
-    } catch (e) {
-      if (!mounted) return;
-      ToastService.show(context, 'Pick error: $e', type: ToastType.error);
-    } finally {
-      _isPickingFile = false;
-    }
-  }
-
-  Future<void> _pickImageFromCamera() async {
-    if (_isPickingFile) return;
-    _isPickingFile = true;
-    try {
-      final result = await FilePicker.pickFiles(
-        type: FileType.image,
-        allowMultiple: false,
-        withData: true,
-      );
-      if (result == null || result.files.isEmpty) return;
-      if (!mounted) return;
-      final file = result.files.first;
-      Uint8List? bytes = file.bytes;
-      if (bytes == null && file.path != null && !kIsWeb) {
-        try {
-          bytes = await File(file.path!).readAsBytes();
-        } catch (_) {}
-      }
-      if (bytes == null) return;
-      final ext = (file.extension ?? 'jpg').toLowerCase();
-      _setPendingAttachment(
-        bytes: bytes,
-        fileName: file.name,
-        mimeType: 'image/${ext == 'jpg' ? 'jpeg' : ext}',
-        ext: ext,
-      );
-    } catch (e) {
-      if (!mounted) return;
-      ToastService.show(context, 'Camera error: $e', type: ToastType.error);
-    } finally {
-      _isPickingFile = false;
-    }
-  }
+  Future<void> _pickImageFromCamera() => pickers.pickImageFromCamera(
+    context: context,
+    mounted: () => mounted,
+    isPicking: () => _isPickingFile,
+    setIsPicking: (v) => _isPickingFile = v,
+    stage:
+        ({
+          required List<int> bytes,
+          required String fileName,
+          required String mimeType,
+          required String ext,
+        }) => _setPendingAttachment(
+          bytes: bytes,
+          fileName: fileName,
+          mimeType: mimeType,
+          ext: ext,
+        ),
+  );
 
   /// Toggles the inline (mobile) or overlay (desktop) media picker. Shared
   /// callback wired into [MediaPickerToggle] from `_buildInputRow`.

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -282,23 +282,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     final ext = fileName.contains('.')
         ? fileName.split('.').last.toLowerCase()
         : '';
-    final mimeTypes = <String, List<String>>{
-      'jpg': ['image', 'jpeg'],
-      'jpeg': ['image', 'jpeg'],
-      'png': ['image', 'png'],
-      'gif': ['image', 'gif'],
-      'webp': ['image', 'webp'],
-      'mp4': ['video', 'mp4'],
-      'mov': ['video', 'quicktime'],
-      'webm': ['video', 'webm'],
-      'pdf': ['application', 'pdf'],
-      'mp3': ['audio', 'mpeg'],
-      'ogg': ['audio', 'ogg'],
-      'wav': ['audio', 'wav'],
-      'm4a': ['audio', 'mp4'],
-      'aac': ['audio', 'aac'],
-    };
-    final mime = mimeTypes[ext] ?? ['application', kOctetStream];
+    final mime = kMimeTypes[ext] ?? ['application', kOctetStream];
 
     _setPendingAttachment(
       bytes: fileBytes,
@@ -771,10 +755,6 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
 
     _onInputChanged(_messageController.text);
   }
-
-  // MIME-type table lives on `chat_input_bar/file_pickers.dart` (#513
-  // slice 6) — the only remaining caller here is `_sendFileImmediately`,
-  // which receives the resolved mimeType from the picker functions.
 
   /// Upload [bytes] and immediately send the result as a message.
   /// Used for the 2nd..Nth files when multiple are selected at once.

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -136,27 +136,27 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   // (not inherited) by [_controller] so its dispose hook is wired through.
   MentionComposerController get _mentionController => _controller.mention;
 
-  // Pending attachments staged for the current send. Single-pick uses one
-  // entry (with the caption-and-send flow); multi-pick stages all picked
-  // files here so the user can review, cancel individual files, and watch
-  // progress before sending. Each entry carries its own ValueNotifier for
-  // upload progress so chip rebuilds don't ripple through the whole bar.
-  final List<PendingAttachment> _pendingAttachments = [];
-
-  bool get _hasPendingAttachment => _pendingAttachments.isNotEmpty;
+  // Pending attachments + voice recording state live on [_controller].
+  // Forwarders preserve the existing `_pendingAttachments` / `_isRecording`
+  // / `_recorder` call sites.
+  List<PendingAttachment> get _pendingAttachments =>
+      _controller.pendingAttachments;
+  bool get _hasPendingAttachment => _controller.hasPendingAttachment;
   bool get _isAnyPendingAttachmentUploading =>
-      _pendingAttachments.any((a) => a.isUploading);
+      _controller.isAnyPendingAttachmentUploading;
   bool get _allPendingAttachmentsReady =>
-      _pendingAttachments.isNotEmpty &&
-      _pendingAttachments.every((a) => a.uploadedUrl != null);
+      _controller.allPendingAttachmentsReady;
 
-  // Voice recording state
-  final AudioRecorder _recorder = AudioRecorder();
-  bool _isRecording = false;
-  DateTime? _recordingStartTime;
-  Timer? _recordingTimer;
-  Duration _recordingDuration = Duration.zero;
-  final List<double> _recordingAmplitudes = [];
+  AudioRecorder get _recorder => _controller.recorder;
+  bool get _isRecording => _controller.isRecording;
+  set _isRecording(bool v) => _controller.isRecording = v;
+  DateTime? get _recordingStartTime => _controller.recordingStartTime;
+  set _recordingStartTime(DateTime? v) => _controller.recordingStartTime = v;
+  Timer? get _recordingTimer => _controller.recordingTimer;
+  set _recordingTimer(Timer? v) => _controller.recordingTimer = v;
+  Duration get _recordingDuration => _controller.recordingDuration;
+  set _recordingDuration(Duration v) => _controller.recordingDuration = v;
+  List<double> get _recordingAmplitudes => _controller.recordingAmplitudes;
 
   // Debounce for search (used by _detectMention indirectly via parent, but
   // kept here to match the cancel contract in dispose/didUpdateWidget).
@@ -211,21 +211,12 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   void dispose() {
     _draftSaveTimer?.cancel();
     _searchDebounce?.cancel();
-    _recordingTimer?.cancel();
-    _recorder.dispose();
     _messageController.removeListener(_onTextChanged);
     _mentionController.removeListener(_onMentionChanged);
     // [_controller.dispose] handles text controller + focus node + mention
-    // controller dispose so their order stays in one place (#513).
+    // controller + voice ticker + recorder + pending attachments dispose
+    // so the cancel-then-tear-down order stays in one place (#513, #623).
     _controller.dispose();
-    // Release every staged attachment's ValueNotifier (#623). Calling
-    // setState here would be unsafe during dispose; just walk the list
-    // and dispose each one directly.
-    for (final att in _pendingAttachments) {
-      att.cancelled = true;
-      att.dispose();
-    }
-    _pendingAttachments.clear();
     super.dispose();
   }
 

--- a/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
@@ -33,12 +33,52 @@ Future<void> pickFile({
   required void Function(bool) setIsPicking,
   required StageAttachmentFn stage,
   required SendFileImmediatelyFn sendImmediately,
+}) => _pickAndDispatch(
+  context: context,
+  mounted: mounted,
+  isPicking: isPicking,
+  setIsPicking: setIsPicking,
+  stage: stage,
+  sendImmediately: sendImmediately,
+  type: FileType.any,
+  errorPrefix: 'File pick',
+);
+
+/// Mobile gallery picker — same multi/single semantics as [pickFile] but
+/// scoped to `FileType.media`.
+Future<void> pickImageFromGallery({
+  required BuildContext context,
+  required bool Function() mounted,
+  required bool Function() isPicking,
+  required void Function(bool) setIsPicking,
+  required StageAttachmentFn stage,
+  required SendFileImmediatelyFn sendImmediately,
+}) => _pickAndDispatch(
+  context: context,
+  mounted: mounted,
+  isPicking: isPicking,
+  setIsPicking: setIsPicking,
+  stage: stage,
+  sendImmediately: sendImmediately,
+  type: FileType.media,
+  errorPrefix: 'Pick',
+);
+
+Future<void> _pickAndDispatch({
+  required BuildContext context,
+  required bool Function() mounted,
+  required bool Function() isPicking,
+  required void Function(bool) setIsPicking,
+  required StageAttachmentFn stage,
+  required SendFileImmediatelyFn sendImmediately,
+  required FileType type,
+  required String errorPrefix,
 }) async {
   if (isPicking()) return;
   setIsPicking(true);
   try {
     final result = await FilePicker.pickFiles(
-      type: FileType.any,
+      type: type,
       allowMultiple: true,
       withData: true,
     );
@@ -131,102 +171,7 @@ Future<void> pickFile({
     }
   } catch (e) {
     if (!context.mounted) return;
-    ToastService.show(context, 'File pick error: $e', type: ToastType.error);
-  } finally {
-    setIsPicking(false);
-  }
-}
-
-/// Mobile gallery picker — same multi/single semantics as [pickFile] but
-/// scoped to `FileType.media`.
-Future<void> pickImageFromGallery({
-  required BuildContext context,
-  required bool Function() mounted,
-  required bool Function() isPicking,
-  required void Function(bool) setIsPicking,
-  required StageAttachmentFn stage,
-  required SendFileImmediatelyFn sendImmediately,
-}) async {
-  if (isPicking()) return;
-  setIsPicking(true);
-  try {
-    final result = await FilePicker.pickFiles(
-      type: FileType.media,
-      allowMultiple: true,
-      withData: true,
-    );
-    if (result == null || result.files.isEmpty) return;
-    if (!mounted()) return;
-
-    final isMulti = result.files.length > 1;
-    if (isMulti && context.mounted) {
-      ToastService.show(
-        context,
-        'Sending ${result.files.length} files...',
-        type: ToastType.info,
-      );
-    }
-
-    var sentCount = 0;
-    for (final file in result.files) {
-      if (file.size > kMaxUploadBytes) {
-        if (context.mounted) {
-          ToastService.show(
-            context,
-            '${file.name} is ${formatBytes(file.size)} — limit is '
-            '${formatBytes(kMaxUploadBytes)}',
-            type: ToastType.error,
-          );
-        }
-        continue;
-      }
-
-      Uint8List? bytes = file.bytes;
-      if (bytes == null && file.path != null && !kIsWeb) {
-        try {
-          bytes = await File(file.path!).readAsBytes();
-        } catch (_) {}
-      }
-      if (bytes == null) continue;
-
-      final ext = (file.extension ?? '').toLowerCase();
-      final mime = kMimeTypes[ext] ?? ['application', kOctetStream];
-      final mimeType = '${mime[0]}/${mime[1]}';
-
-      if (isMulti) {
-        try {
-          await sendImmediately(
-            bytes: bytes,
-            fileName: file.name,
-            mimeType: mimeType,
-            ext: ext,
-          );
-          sentCount++;
-        } catch (e) {
-          debugPrint('[ChatInput] Send failed for ${file.name}: $e');
-          if (context.mounted) {
-            ToastService.show(
-              context,
-              'Failed to send ${file.name}',
-              type: ToastType.error,
-            );
-          }
-        }
-      } else {
-        stage(bytes: bytes, fileName: file.name, mimeType: mimeType, ext: ext);
-      }
-    }
-    if (isMulti && context.mounted && sentCount < result.files.length) {
-      final failed = result.files.length - sentCount;
-      ToastService.show(
-        context,
-        '$failed of ${result.files.length} failed to send',
-        type: ToastType.error,
-      );
-    }
-  } catch (e) {
-    if (!context.mounted) return;
-    ToastService.show(context, 'Pick error: $e', type: ToastType.error);
+    ToastService.show(context, '$errorPrefix error: $e', type: ToastType.error);
   } finally {
     setIsPicking(false);
   }

--- a/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
@@ -8,31 +8,6 @@ import 'package:flutter/material.dart';
 import '../../services/toast_service.dart';
 import 'upload_helpers.dart';
 
-/// File-picker flows extracted from `ChatInputBarState` (#513 slice 6).
-///
-/// Mirror the original `_pickFile`, `_pickImageFromGallery`,
-/// `_pickImageFromCamera`, `_showMobileAttachMenu`, and
-/// `_handlePhotoSelected` bit-for-bit. Each function takes callbacks for
-/// the state mutations it can't perform directly (staging an attachment vs
-/// sending one immediately).
-
-const _kMimeTypes = <String, List<String>>{
-  'jpg': ['image', 'jpeg'],
-  'jpeg': ['image', 'jpeg'],
-  'png': ['image', 'png'],
-  'gif': ['image', 'gif'],
-  'webp': ['image', 'webp'],
-  'mp4': ['video', 'mp4'],
-  'mov': ['video', 'quicktime'],
-  'webm': ['video', 'webm'],
-  'pdf': ['application', 'pdf'],
-  'mp3': ['audio', 'mpeg'],
-  'ogg': ['audio', 'ogg'],
-  'wav': ['audio', 'wav'],
-  'm4a': ['audio', 'mp4'],
-  'aac': ['audio', 'aac'],
-};
-
 typedef StageAttachmentFn =
     void Function({
       required List<int> bytes,
@@ -120,7 +95,7 @@ Future<void> pickFile({
       }
 
       final ext = (file.extension ?? '').toLowerCase();
-      final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
+      final mime = kMimeTypes[ext] ?? ['application', kOctetStream];
       final mimeType = '${mime[0]}/${mime[1]}';
 
       if (isMulti) {
@@ -215,7 +190,7 @@ Future<void> pickImageFromGallery({
       if (bytes == null) continue;
 
       final ext = (file.extension ?? '').toLowerCase();
-      final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
+      final mime = kMimeTypes[ext] ?? ['application', kOctetStream];
       final mimeType = '${mime[0]}/${mime[1]}';
 
       if (isMulti) {

--- a/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
@@ -1,0 +1,299 @@
+import 'dart:io' show File;
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/material.dart';
+
+import '../../services/toast_service.dart';
+import 'upload_helpers.dart';
+
+/// File-picker flows extracted from `ChatInputBarState` (#513 slice 6).
+///
+/// Mirror the original `_pickFile`, `_pickImageFromGallery`,
+/// `_pickImageFromCamera`, `_showMobileAttachMenu`, and
+/// `_handlePhotoSelected` bit-for-bit. Each function takes callbacks for
+/// the state mutations it can't perform directly (staging an attachment vs
+/// sending one immediately).
+
+const _kMimeTypes = <String, List<String>>{
+  'jpg': ['image', 'jpeg'],
+  'jpeg': ['image', 'jpeg'],
+  'png': ['image', 'png'],
+  'gif': ['image', 'gif'],
+  'webp': ['image', 'webp'],
+  'mp4': ['video', 'mp4'],
+  'mov': ['video', 'quicktime'],
+  'webm': ['video', 'webm'],
+  'pdf': ['application', 'pdf'],
+  'mp3': ['audio', 'mpeg'],
+  'ogg': ['audio', 'ogg'],
+  'wav': ['audio', 'wav'],
+  'm4a': ['audio', 'mp4'],
+  'aac': ['audio', 'aac'],
+};
+
+typedef StageAttachmentFn =
+    void Function({
+      required List<int> bytes,
+      required String fileName,
+      required String mimeType,
+      required String ext,
+    });
+
+typedef SendFileImmediatelyFn =
+    Future<void> Function({
+      required Uint8List bytes,
+      required String fileName,
+      required String mimeType,
+      required String ext,
+    });
+
+/// Discord-style file pick: single file → preview-and-caption flow,
+/// multiple files → upload + send each as a separate message.
+Future<void> pickFile({
+  required BuildContext context,
+  required bool Function() mounted,
+  required bool Function() isPicking,
+  required void Function(bool) setIsPicking,
+  required StageAttachmentFn stage,
+  required SendFileImmediatelyFn sendImmediately,
+}) async {
+  if (isPicking()) return;
+  setIsPicking(true);
+  try {
+    final result = await FilePicker.pickFiles(
+      type: FileType.any,
+      allowMultiple: true,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return;
+    if (!mounted()) return;
+
+    // Single pick → preview flow (caption + send). Multi pick → send all
+    // immediately as separate messages; mixing the two creates races where
+    // the user may interact with the pending preview while the rest are
+    // still uploading in the background.
+    final isMulti = result.files.length > 1;
+    if (isMulti && context.mounted) {
+      ToastService.show(
+        context,
+        'Sending ${result.files.length} files...',
+        type: ToastType.info,
+      );
+    }
+
+    var sentCount = 0;
+    for (final file in result.files) {
+      if (file.size > kMaxUploadBytes) {
+        if (context.mounted) {
+          ToastService.show(
+            context,
+            '${file.name} is ${formatBytes(file.size)} — limit is '
+            '${formatBytes(kMaxUploadBytes)}',
+            type: ToastType.error,
+          );
+        }
+        continue;
+      }
+
+      // On mobile, withData:true may still yield null bytes for larger files
+      // or certain content URIs. Fall back to reading from the file path.
+      Uint8List? bytes = file.bytes;
+      if (bytes == null && file.path != null && !kIsWeb) {
+        try {
+          bytes = await File(file.path!).readAsBytes();
+        } catch (e) {
+          debugPrint('[ChatInput] Failed to read file from path: $e');
+        }
+      }
+
+      if (bytes == null) {
+        if (context.mounted) {
+          ToastService.show(
+            context,
+            'Could not read file: ${file.name}',
+            type: ToastType.error,
+          );
+        }
+        continue;
+      }
+
+      final ext = (file.extension ?? '').toLowerCase();
+      final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
+      final mimeType = '${mime[0]}/${mime[1]}';
+
+      if (isMulti) {
+        try {
+          await sendImmediately(
+            bytes: bytes,
+            fileName: file.name,
+            mimeType: mimeType,
+            ext: ext,
+          );
+          sentCount++;
+        } catch (e) {
+          debugPrint('[ChatInput] Send failed for ${file.name}: $e');
+          if (context.mounted) {
+            ToastService.show(
+              context,
+              'Failed to send ${file.name}',
+              type: ToastType.error,
+            );
+          }
+        }
+      } else {
+        stage(bytes: bytes, fileName: file.name, mimeType: mimeType, ext: ext);
+      }
+    }
+    if (isMulti && context.mounted && sentCount < result.files.length) {
+      final failed = result.files.length - sentCount;
+      ToastService.show(
+        context,
+        '$failed of ${result.files.length} failed to send',
+        type: ToastType.error,
+      );
+    }
+  } catch (e) {
+    if (!context.mounted) return;
+    ToastService.show(context, 'File pick error: $e', type: ToastType.error);
+  } finally {
+    setIsPicking(false);
+  }
+}
+
+/// Mobile gallery picker — same multi/single semantics as [pickFile] but
+/// scoped to `FileType.media`.
+Future<void> pickImageFromGallery({
+  required BuildContext context,
+  required bool Function() mounted,
+  required bool Function() isPicking,
+  required void Function(bool) setIsPicking,
+  required StageAttachmentFn stage,
+  required SendFileImmediatelyFn sendImmediately,
+}) async {
+  if (isPicking()) return;
+  setIsPicking(true);
+  try {
+    final result = await FilePicker.pickFiles(
+      type: FileType.media,
+      allowMultiple: true,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return;
+    if (!mounted()) return;
+
+    final isMulti = result.files.length > 1;
+    if (isMulti && context.mounted) {
+      ToastService.show(
+        context,
+        'Sending ${result.files.length} files...',
+        type: ToastType.info,
+      );
+    }
+
+    var sentCount = 0;
+    for (final file in result.files) {
+      if (file.size > kMaxUploadBytes) {
+        if (context.mounted) {
+          ToastService.show(
+            context,
+            '${file.name} is ${formatBytes(file.size)} — limit is '
+            '${formatBytes(kMaxUploadBytes)}',
+            type: ToastType.error,
+          );
+        }
+        continue;
+      }
+
+      Uint8List? bytes = file.bytes;
+      if (bytes == null && file.path != null && !kIsWeb) {
+        try {
+          bytes = await File(file.path!).readAsBytes();
+        } catch (_) {}
+      }
+      if (bytes == null) continue;
+
+      final ext = (file.extension ?? '').toLowerCase();
+      final mime = _kMimeTypes[ext] ?? ['application', kOctetStream];
+      final mimeType = '${mime[0]}/${mime[1]}';
+
+      if (isMulti) {
+        try {
+          await sendImmediately(
+            bytes: bytes,
+            fileName: file.name,
+            mimeType: mimeType,
+            ext: ext,
+          );
+          sentCount++;
+        } catch (e) {
+          debugPrint('[ChatInput] Send failed for ${file.name}: $e');
+          if (context.mounted) {
+            ToastService.show(
+              context,
+              'Failed to send ${file.name}',
+              type: ToastType.error,
+            );
+          }
+        }
+      } else {
+        stage(bytes: bytes, fileName: file.name, mimeType: mimeType, ext: ext);
+      }
+    }
+    if (isMulti && context.mounted && sentCount < result.files.length) {
+      final failed = result.files.length - sentCount;
+      ToastService.show(
+        context,
+        '$failed of ${result.files.length} failed to send',
+        type: ToastType.error,
+      );
+    }
+  } catch (e) {
+    if (!context.mounted) return;
+    ToastService.show(context, 'Pick error: $e', type: ToastType.error);
+  } finally {
+    setIsPicking(false);
+  }
+}
+
+/// Camera-only single-shot picker.
+Future<void> pickImageFromCamera({
+  required BuildContext context,
+  required bool Function() mounted,
+  required bool Function() isPicking,
+  required void Function(bool) setIsPicking,
+  required StageAttachmentFn stage,
+}) async {
+  if (isPicking()) return;
+  setIsPicking(true);
+  try {
+    final result = await FilePicker.pickFiles(
+      type: FileType.image,
+      allowMultiple: false,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return;
+    if (!mounted()) return;
+    final file = result.files.first;
+    Uint8List? bytes = file.bytes;
+    if (bytes == null && file.path != null && !kIsWeb) {
+      try {
+        bytes = await File(file.path!).readAsBytes();
+      } catch (_) {}
+    }
+    if (bytes == null) return;
+    final ext = (file.extension ?? 'jpg').toLowerCase();
+    stage(
+      bytes: bytes,
+      fileName: file.name,
+      mimeType: 'image/${ext == 'jpg' ? 'jpeg' : ext}',
+      ext: ext,
+    );
+  } catch (e) {
+    if (!context.mounted) return;
+    ToastService.show(context, 'Camera error: $e', type: ToastType.error);
+  } finally {
+    setIsPicking(false);
+  }
+}

--- a/apps/client/lib/src/widgets/chat_input_bar/upload_helpers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/upload_helpers.dart
@@ -10,6 +10,26 @@ library;
 /// Default MIME subtype when we can't infer the file type.
 const kOctetStream = 'octet-stream';
 
+/// Extension → `[type, subtype]` map used by every attachment path
+/// (file picker, image picker, camera, clipboard paste, drag-and-drop).
+/// Unknown extensions fall back to `['application', kOctetStream]`.
+const kMimeTypes = <String, List<String>>{
+  'jpg': ['image', 'jpeg'],
+  'jpeg': ['image', 'jpeg'],
+  'png': ['image', 'png'],
+  'gif': ['image', 'gif'],
+  'webp': ['image', 'webp'],
+  'mp4': ['video', 'mp4'],
+  'mov': ['video', 'quicktime'],
+  'webm': ['video', 'webm'],
+  'pdf': ['application', 'pdf'],
+  'mp3': ['audio', 'mpeg'],
+  'ogg': ['audio', 'ogg'],
+  'wav': ['audio', 'wav'],
+  'm4a': ['audio', 'mp4'],
+  'aac': ['audio', 'aac'],
+};
+
 /// Mirror of `MAX_FILE_SIZE` in `apps/server/src/routes/media.rs`. Both must
 /// be bumped together. Cloudflare Free also caps request bodies at 100 MB,
 /// so going higher than this without proxy work will 502 on prod.

--- a/apps/client/lib/src/widgets/chat_input_controller.dart
+++ b/apps/client/lib/src/widgets/chat_input_controller.dart
@@ -10,7 +10,7 @@ import 'input/pending_attachments_strip.dart' show PendingAttachment;
 
 /// Non-rendering state controller for [ChatInputBar].
 ///
-/// Owns the text composer + edit state + (in later slices) attachments,
+/// Owns the text composer + edit state, attachments,
 /// voice recording, and mention autocomplete bridging. Composes (not
 /// inherits) the existing [MentionComposerController] so its dispose hook
 /// is wired through this controller's dispose.
@@ -21,9 +21,6 @@ import 'input/pending_attachments_strip.dart' show PendingAttachment;
 ///   `WidgetRef` or call `ref.watch/read/select`;
 /// - `ChatInputBarState`'s public methods reachable via
 ///   `GlobalKey<ChatInputBarState>` keep IDENTICAL signatures (#513).
-///
-/// Slice 4 (#513): text controller + edit-message state. Slice 5 will move
-/// attachments, voice recording state, and mention bridging.
 class ChatInputController extends ChangeNotifier {
   ChatInputController({MentionComposerController? mentionController})
     : mention = mentionController ?? MentionComposerController();

--- a/apps/client/lib/src/widgets/chat_input_controller.dart
+++ b/apps/client/lib/src/widgets/chat_input_controller.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart' show FocusNode, TextEditingController;
+import 'package:record/record.dart';
 
 import '../models/chat_message.dart';
 import 'input/mention_controller.dart';
+import 'input/pending_attachments_strip.dart' show PendingAttachment;
 
 /// Non-rendering state controller for [ChatInputBar].
 ///
@@ -37,6 +41,37 @@ class ChatInputController extends ChangeNotifier {
   /// controller's [dispose] so the widget no longer has to remember to
   /// release it.
   final MentionComposerController mention;
+
+  // --- Pending attachments -------------------------------------------------
+  //
+  // Pending attachments staged for the current send. Single-pick stages
+  // one entry (with caption-and-send flow); multi-pick stages all picked
+  // files here so the user can review, cancel individual files, and watch
+  // progress before sending. Each entry carries its own ValueNotifier for
+  // upload progress so chip rebuilds don't ripple through the whole bar.
+
+  final List<PendingAttachment> pendingAttachments = [];
+
+  bool get hasPendingAttachment => pendingAttachments.isNotEmpty;
+  bool get isAnyPendingAttachmentUploading =>
+      pendingAttachments.any((a) => a.isUploading);
+  bool get allPendingAttachmentsReady =>
+      pendingAttachments.isNotEmpty &&
+      pendingAttachments.every((a) => a.uploadedUrl != null);
+
+  // --- Voice recording -----------------------------------------------------
+  //
+  // The amplitude tick runs every 100ms while `isRecording` is true. The
+  // [recordingTimer] is cancelled in [dispose] so it never fires after the
+  // widget is gone — same guarantee `_recordingTimer?.cancel()` gave on the
+  // old `ChatInputBarState.dispose()`.
+
+  final AudioRecorder recorder = AudioRecorder();
+  bool isRecording = false;
+  DateTime? recordingStartTime;
+  Timer? recordingTimer;
+  Duration recordingDuration = Duration.zero;
+  final List<double> recordingAmplitudes = [];
 
   // --- Edit mode -----------------------------------------------------------
   //
@@ -73,6 +108,19 @@ class ChatInputController extends ChangeNotifier {
 
   @override
   void dispose() {
+    // Voice ticker MUST be cancelled before the recorder is torn down so a
+    // late tick doesn't fire `getAmplitude` on a disposed recorder.
+    recordingTimer?.cancel();
+    recordingTimer = null;
+    recorder.dispose();
+    // Release every staged attachment's ValueNotifier (#623). Mark each
+    // cancelled first so any in-flight upload's success setState short-
+    // circuits before touching disposed state.
+    for (final att in pendingAttachments) {
+      att.cancelled = true;
+      att.dispose();
+    }
+    pendingAttachments.clear();
     text.dispose();
     focus.dispose();
     mention.dispose();

--- a/apps/client/lib/src/widgets/chat_input_controller.dart
+++ b/apps/client/lib/src/widgets/chat_input_controller.dart
@@ -8,45 +8,22 @@ import '../models/chat_message.dart';
 import 'input/mention_controller.dart';
 import 'input/pending_attachments_strip.dart' show PendingAttachment;
 
-/// Non-rendering state controller for [ChatInputBar].
-///
-/// Owns the text composer + edit state, attachments,
-/// voice recording, and mention autocomplete bridging. Composes (not
-/// inherits) the existing [MentionComposerController] so its dispose hook
-/// is wired through this controller's dispose.
-///
-/// Architectural contract:
-/// - controllers are plain `ChangeNotifier`s, never Riverpod providers;
-/// - controllers receive data via method args; they never hold a
-///   `WidgetRef` or call `ref.watch/read/select`;
-/// - `ChatInputBarState`'s public methods reachable via
-///   `GlobalKey<ChatInputBarState>` keep IDENTICAL signatures (#513).
+/// Non-rendering state for [ChatInputBar]: text composer + edit state,
+/// pending attachments, voice recording, and mention autocomplete.
+/// Composes (not inherits) [MentionComposerController] so its dispose
+/// runs from this controller's [dispose].
 class ChatInputController extends ChangeNotifier {
   ChatInputController({MentionComposerController? mentionController})
     : mention = mentionController ?? MentionComposerController();
 
-  /// The text composer's [TextEditingController]. Lives here so listeners
-  /// and external callers (e.g. the markdown toolbar) share a single
-  /// instance with the controller's edit-state.
   final TextEditingController text = TextEditingController();
-
-  /// Focus node for the input text field. Owned here so the controller's
-  /// `requestFocus` helpers don't have to thread a node through the widget.
   final FocusNode focus = FocusNode();
-
-  /// Composed (not inherited) mention controller. Disposed by this
-  /// controller's [dispose] so the widget no longer has to remember to
-  /// release it.
   final MentionComposerController mention;
 
-  // --- Pending attachments -------------------------------------------------
-  //
-  // Pending attachments staged for the current send. Single-pick stages
-  // one entry (with caption-and-send flow); multi-pick stages all picked
-  // files here so the user can review, cancel individual files, and watch
-  // progress before sending. Each entry carries its own ValueNotifier for
-  // upload progress so chip rebuilds don't ripple through the whole bar.
-
+  // Single-pick stages one entry (caption-and-send flow); multi-pick stages
+  // all picked files so the user can review / cancel / watch progress before
+  // sending. Each entry carries a ValueNotifier for upload progress so chip
+  // rebuilds don't ripple through the whole input bar.
   final List<PendingAttachment> pendingAttachments = [];
 
   bool get hasPendingAttachment => pendingAttachments.isNotEmpty;
@@ -56,13 +33,9 @@ class ChatInputController extends ChangeNotifier {
       pendingAttachments.isNotEmpty &&
       pendingAttachments.every((a) => a.uploadedUrl != null);
 
-  // --- Voice recording -----------------------------------------------------
-  //
-  // The amplitude tick runs every 100ms while `isRecording` is true. The
-  // [recordingTimer] is cancelled in [dispose] so it never fires after the
-  // widget is gone — same guarantee `_recordingTimer?.cancel()` gave on the
-  // old `ChatInputBarState.dispose()`.
-
+  // Voice amplitude tick runs every 100ms while [isRecording] is true.
+  // [recordingTimer] is cancelled in [dispose] before [recorder] is torn
+  // down so a late tick can't fire `getAmplitude` on a disposed recorder.
   final AudioRecorder recorder = AudioRecorder();
   bool isRecording = false;
   DateTime? recordingStartTime;
@@ -70,33 +43,19 @@ class ChatInputController extends ChangeNotifier {
   Duration recordingDuration = Duration.zero;
   final List<double> recordingAmplitudes = [];
 
-  // --- Edit mode -----------------------------------------------------------
-  //
-  // The widget enters/exits edit mode through [enterEditMode]/[exitEditMode].
-  // [_editingMessage] is the canonical source of truth; the widget mirrors
-  // through the `isEditing` getter without keeping a duplicate field.
-
   ChatMessage? _editingMessage;
   ChatMessage? get editingMessage => _editingMessage;
   bool get isEditing => _editingMessage != null;
 
-  /// Enter edit mode for [message]: stamp the text controller with its
-  /// content, clear the empty-text flag, and notify listeners so the widget
-  /// can re-render its status bar / hint text.
-  ///
-  /// Does NOT touch focus — the widget pairs this with
-  /// `_inputFocusNode.requestFocus()` after the `setState`. Keeping focus
-  /// in the widget preserves the slice-4 API contract: no new public
-  /// surface on `ChatInputBarState`.
+  /// Enter edit mode for [message]. Does NOT touch focus — callers pair this
+  /// with `focus.requestFocus()` after their `setState`.
   void enterEditMode(ChatMessage message) {
     _editingMessage = message;
     text.text = message.content;
     notifyListeners();
   }
 
-  /// Exit edit mode (called from cancel + submit paths). Caller is
-  /// responsible for clearing the text controller — `exitEditMode` itself
-  /// only flips the flag.
+  /// Exit edit mode. The caller is responsible for clearing [text].
   void exitEditMode() {
     if (_editingMessage == null) return;
     _editingMessage = null;
@@ -105,14 +64,11 @@ class ChatInputController extends ChangeNotifier {
 
   @override
   void dispose() {
-    // Voice ticker MUST be cancelled before the recorder is torn down so a
-    // late tick doesn't fire `getAmplitude` on a disposed recorder.
     recordingTimer?.cancel();
     recordingTimer = null;
     recorder.dispose();
-    // Release every staged attachment's ValueNotifier (#623). Mark each
-    // cancelled first so any in-flight upload's success setState short-
-    // circuits before touching disposed state.
+    // Mark each attachment cancelled before disposing so any in-flight upload's
+    // success setState short-circuits before touching disposed state (#623).
     for (final att in pendingAttachments) {
       att.cancelled = true;
       att.dispose();

--- a/apps/client/lib/src/widgets/chat_input_controller.dart
+++ b/apps/client/lib/src/widgets/chat_input_controller.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show FocusNode, TextEditingController;
+
+import '../models/chat_message.dart';
+import 'input/mention_controller.dart';
+
+/// Non-rendering state controller for [ChatInputBar].
+///
+/// Owns the text composer + edit state + (in later slices) attachments,
+/// voice recording, and mention autocomplete bridging. Composes (not
+/// inherits) the existing [MentionComposerController] so its dispose hook
+/// is wired through this controller's dispose.
+///
+/// Architectural contract:
+/// - controllers are plain `ChangeNotifier`s, never Riverpod providers;
+/// - controllers receive data via method args; they never hold a
+///   `WidgetRef` or call `ref.watch/read/select`;
+/// - `ChatInputBarState`'s public methods reachable via
+///   `GlobalKey<ChatInputBarState>` keep IDENTICAL signatures (#513).
+///
+/// Slice 4 (#513): text controller + edit-message state. Slice 5 will move
+/// attachments, voice recording state, and mention bridging.
+class ChatInputController extends ChangeNotifier {
+  ChatInputController({MentionComposerController? mentionController})
+    : mention = mentionController ?? MentionComposerController();
+
+  /// The text composer's [TextEditingController]. Lives here so listeners
+  /// and external callers (e.g. the markdown toolbar) share a single
+  /// instance with the controller's edit-state.
+  final TextEditingController text = TextEditingController();
+
+  /// Focus node for the input text field. Owned here so the controller's
+  /// `requestFocus` helpers don't have to thread a node through the widget.
+  final FocusNode focus = FocusNode();
+
+  /// Composed (not inherited) mention controller. Disposed by this
+  /// controller's [dispose] so the widget no longer has to remember to
+  /// release it.
+  final MentionComposerController mention;
+
+  // --- Edit mode -----------------------------------------------------------
+  //
+  // The widget enters/exits edit mode through [enterEditMode]/[exitEditMode].
+  // [_editingMessage] is the canonical source of truth; the widget mirrors
+  // through the `isEditing` getter without keeping a duplicate field.
+
+  ChatMessage? _editingMessage;
+  ChatMessage? get editingMessage => _editingMessage;
+  bool get isEditing => _editingMessage != null;
+
+  /// Enter edit mode for [message]: stamp the text controller with its
+  /// content, clear the empty-text flag, and notify listeners so the widget
+  /// can re-render its status bar / hint text.
+  ///
+  /// Does NOT touch focus — the widget pairs this with
+  /// `_inputFocusNode.requestFocus()` after the `setState`. Keeping focus
+  /// in the widget preserves the slice-4 API contract: no new public
+  /// surface on `ChatInputBarState`.
+  void enterEditMode(ChatMessage message) {
+    _editingMessage = message;
+    text.text = message.content;
+    notifyListeners();
+  }
+
+  /// Exit edit mode (called from cancel + submit paths). Caller is
+  /// responsible for clearing the text controller — `exitEditMode` itself
+  /// only flips the flag.
+  void exitEditMode() {
+    if (_editingMessage == null) return;
+    _editingMessage = null;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    text.dispose();
+    focus.dispose();
+    mention.dispose();
+    super.dispose();
+  }
+}

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -123,10 +123,14 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   String? _activeVoiceChannelId;
 
   /// The message ID at which the "New Messages" divider should appear.
-  /// Set when opening a conversation with unread messages, cleared when
-  /// the unread count drops to 0.
-  String? _unreadBoundaryMessageId;
-  int _unreadBoundaryCount = 0;
+  /// Set when opening a conversation with unread messages, cleared when the
+  /// unread count drops to 0. Captured ONCE per channel session — see
+  /// `ChatPanelController.unreadBoundaryMessageId` (invariant #6).
+  String? get _unreadBoundaryMessageId => _controller.unreadBoundaryMessageId;
+  set _unreadBoundaryMessageId(String? v) =>
+      _controller.unreadBoundaryMessageId = v;
+  int get _unreadBoundaryCount => _controller.unreadBoundaryCount;
+  set _unreadBoundaryCount(int v) => _controller.unreadBoundaryCount = v;
 
   /// GlobalKeys for rendered message items, keyed by message ID.
   /// Used by [_scrollToMessage] for pixel-accurate scrolling (via
@@ -153,10 +157,14 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   /// correct bookmark icon without async round-trips.
   final Set<String> _savedIds = {};
 
-  /// Floating date label state
-  String? _floatingDate;
-  bool _floatingDateVisible = false;
-  Timer? _floatingDateTimer;
+  /// Floating date label state — owned by the controller so the 2s fade-out
+  /// timer is cancelled in one place (controller `dispose`).
+  String? get _floatingDate => _controller.floatingDate;
+  set _floatingDate(String? v) => _controller.floatingDate = v;
+  bool get _floatingDateVisible => _controller.floatingDateVisible;
+  set _floatingDateVisible(bool v) => _controller.floatingDateVisible = v;
+  Timer? get _floatingDateTimer => _controller.floatingDateTimer;
+  set _floatingDateTimer(Timer? v) => _controller.floatingDateTimer = v;
   // Tracks near-bottom state from the user's last scroll event, before any
   // viewport resize (keyboard open/close). Used in _handleKeyboardScroll so
   // we don't lose context when maxScrollExtent shifts under us. Lives on
@@ -166,8 +174,13 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   set _wasNearBottom(bool v) => _controller.wasNearBottom = v;
 
   /// True when a new message arrives while the user has scrolled up.
-  bool _hasNewMessagesBelow = false;
-  int _newMessagesBelowCount = 0;
+  /// Lives on the controller; the widget still drives `setState` via the
+  /// pill toggle so the new-messages-pill animates in/out at the same
+  /// frame the underlying state flips.
+  bool get _hasNewMessagesBelow => _controller.hasNewMessagesBelow;
+  set _hasNewMessagesBelow(bool v) => _controller.hasNewMessagesBelow = v;
+  int get _newMessagesBelowCount => _controller.newMessagesBelowCount;
+  set _newMessagesBelowCount(int v) => _controller.newMessagesBelowCount = v;
 
   /// Hidden Semantics live-region label for screen-reader announcements
   /// when peer messages arrive (#495). Empty until the first announcement,
@@ -1693,6 +1706,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     // flag for this channel — `messagesByConversation` keeps inner list
     // refs stable across copyWith for unaffected conversations, so adding
     // a message to conv B no longer rebuilds conv A's panel (#834 F6).
+    // PR #838 perf: keep this as .select
     final convMessages = ref.watch(
       chatProvider.select((s) => s.messagesByConversation[conv.id]),
     );

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -743,9 +743,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
             _scrollToBottom(settleRetries: 2);
           });
         },
-        // LiveKit handles remote audio playback automatically (#prod-2026-05-08
-        // legacy P2P WebRTC migration); no hidden renderer widgets needed.
-        voiceRenderers: const [],
       ),
     );
 

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -89,19 +89,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   final _chatInputBarKey = GlobalKey<ChatInputBarState>();
   final _controller = ChatPanelController();
 
-  /// Cache scroll offsets keyed by conversation ID so switching conversations
-  /// preserves the user's position. Capped at [_kMaxScrollPositions] entries
-  /// to prevent unbounded growth as the user visits many conversations.
-  static final Map<String, double> _scrollPositions = {};
-  static const int _kMaxScrollPositions = 50;
-
-  /// Evict the oldest entries from [_scrollPositions] when over the limit.
-  static void _evictScrollPositions() {
-    while (_scrollPositions.length > _kMaxScrollPositions) {
-      _scrollPositions.remove(_scrollPositions.keys.first);
-    }
-  }
-
   String _newMessagesBannerText() {
     if (_newMessagesBelowCount <= 0) return 'New messages';
     final noun = _newMessagesBelowCount == 1 ? 'message' : 'messages';
@@ -117,11 +104,23 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   static const _deletedForMeKey = 'deleted_for_me_ids';
   static Set<String> _deletedForMeIds = {};
   static bool _deletedForMeLoaded = false;
-  String? _selectedTextChannelId;
+  // Channel-scoped loading keys + the currently-selected text channel live
+  // on the controller (invariant #3); these forwarders keep the existing
+  // call sites readable without leaking the controller into every line.
+  String? get _selectedTextChannelId => _controller.selectedTextChannelId;
+  set _selectedTextChannelId(String? v) =>
+      _controller.selectedTextChannelId = v;
+  String? get _loadedHistoryKey => _controller.loadedHistoryKey;
+  set _loadedHistoryKey(String? v) => _controller.loadedHistoryKey = v;
+  String? get _loadedChannelsConversationId =>
+      _controller.loadedChannelsConversationId;
+  set _loadedChannelsConversationId(String? v) =>
+      _controller.loadedChannelsConversationId = v;
+  String? get _autoScrollConversationKey =>
+      _controller.autoScrollConversationKey;
+  set _autoScrollConversationKey(String? v) =>
+      _controller.autoScrollConversationKey = v;
   String? _activeVoiceChannelId;
-  String? _loadedHistoryKey;
-  String? _loadedChannelsConversationId;
-  String? _autoScrollConversationKey;
 
   /// The message ID at which the "New Messages" divider should appear.
   /// Set when opening a conversation with unread messages, cleared when
@@ -141,7 +140,11 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   String? _highlightedMessageId;
   String? _pendingInitialMessageId;
   Timer? _highlightTimer;
-  double _lastKeyboardInset = 0;
+  // Last keyboard inset lives on the controller so `handleKeyboardScroll`
+  // can read/write it without re-piping it through method args. The widget
+  // accessor preserves the original `_lastKeyboardInset` name.
+  double get _lastKeyboardInset => _controller.lastKeyboardInset;
+  set _lastKeyboardInset(double v) => _controller.lastKeyboardInset = v;
 
   /// True while a file is being dragged over the chat area.
   bool _isDragOver = false;
@@ -156,8 +159,11 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   Timer? _floatingDateTimer;
   // Tracks near-bottom state from the user's last scroll event, before any
   // viewport resize (keyboard open/close). Used in _handleKeyboardScroll so
-  // we don't lose context when maxScrollExtent shifts under us.
-  bool _wasNearBottom = true;
+  // we don't lose context when maxScrollExtent shifts under us. Lives on
+  // the controller (invariant #4 — `_wasNearBottom` check must run BEFORE
+  // the keyboard shrinks the viewport).
+  bool get _wasNearBottom => _controller.wasNearBottom;
+  set _wasNearBottom(bool v) => _controller.wasNearBottom = v;
 
   /// True when a new message arrives while the user has scrolled up.
   bool _hasNewMessagesBelow = false;
@@ -235,10 +241,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     if (widget.conversation?.id != oldWidget.conversation?.id) {
       // Save scroll offset for the old conversation+channel
       final oldId = oldWidget.conversation?.id;
-      if (oldId != null && _scrollController.hasClients) {
-        final oldKey = '$oldId:${_selectedTextChannelId ?? ""}';
-        _scrollPositions[oldKey] = _scrollController.offset;
-        _evictScrollPositions();
+      if (oldId != null) {
+        _controller.cacheCurrentOffset(oldId);
       }
 
       _selectedTextChannelId = null;
@@ -268,8 +272,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       // defer to the first-load callback which scrolls to the divider.
       final newId = widget.conversation?.id;
       if (newId != null) {
-        final newKey = '$newId:${_selectedTextChannelId ?? ""}';
-        final cached = _scrollPositions[newKey];
+        final cached =
+            _controller.scrollPositions[_controller.cacheKeyFor(newId)];
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!_scrollController.hasClients) return;
           // Defer to the first-load callback if unread boundary will be set
@@ -280,26 +284,12 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
               .firstOrNull;
           if (convData != null && convData.unreadCount > 0) return;
           if (cached != null) {
-            _restoreCachedOffsetWithRetry(cached);
+            _controller.restoreCachedOffsetWithRetry(cached);
           } else {
             _scrollToBottom(animated: false, settleRetries: 3);
           }
         });
       }
-    }
-  }
-
-  /// Re-jump to the cached offset across a few frames so we don't land at the
-  /// bottom of an empty list while message history is still loading async (#563).
-  /// Stops retrying once `maxScrollExtent >= cached`, or after 3 frames.
-  void _restoreCachedOffsetWithRetry(double cached, {int retries = 3}) {
-    if (!_scrollController.hasClients) return;
-    final max = _scrollController.position.maxScrollExtent;
-    _scrollController.jumpTo(cached.clamp(0, max));
-    if (max < cached && retries > 0) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _restoreCachedOffsetWithRetry(cached, retries: retries - 1);
-      });
     }
   }
 
@@ -418,56 +408,19 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   }
 
   void _scrollToBottom({bool animated = true, int settleRetries = 3}) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!_scrollController.hasClients) return;
-
-      final target = _scrollController.position.maxScrollExtent;
-      final alreadyAtBottom =
-          (target - _scrollController.position.pixels).abs() < 1;
-      if (alreadyAtBottom) return;
-
-      Future<void> settleIfNeeded() async {
-        if (settleRetries <= 0 || !_scrollController.hasClients) return;
-        // Wait for layout to settle so maxScrollExtent includes new content
-        await Future<void>.delayed(const Duration(milliseconds: 150));
-        if (!_scrollController.hasClients) return;
-        final newTarget = _scrollController.position.maxScrollExtent;
-        if ((newTarget - _scrollController.position.pixels).abs() > 1) {
-          _scrollController.jumpTo(newTarget);
+    _controller.scrollToBottom(
+      conversationId: widget.conversation?.id,
+      animated: animated,
+      settleRetries: settleRetries,
+      onSettleComplete: () {
+        if (_hasNewMessagesBelow) {
+          setState(() {
+            _hasNewMessagesBelow = false;
+            _newMessagesBelowCount = 0;
+          });
         }
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-        _scrollToBottom(animated: false, settleRetries: settleRetries - 1);
-      }
-
-      if (animated) {
-        _scrollController
-            .animateTo(
-              target,
-              duration: const Duration(milliseconds: 220),
-              curve: Curves.easeOut,
-            )
-            .whenComplete(settleIfNeeded);
-      } else {
-        _scrollController.jumpTo(target);
-        settleIfNeeded();
-      }
-
-      // Update the scroll cache and dismiss the new-messages pill.
-      // Key includes channel ID so switching text channels within a group
-      // preserves separate scroll positions.
-      final convId = widget.conversation?.id;
-      if (convId != null) {
-        final cacheKey = '$convId:${_selectedTextChannelId ?? ""}';
-        _scrollPositions[cacheKey] = target;
-        _evictScrollPositions();
-      }
-      if (_hasNewMessagesBelow) {
-        setState(() {
-          _hasNewMessagesBelow = false;
-          _newMessagesBelowCount = 0;
-        });
-      }
-    });
+      },
+    );
   }
 
   bool _isNearBottom() => _controller.isNearBottom();
@@ -556,19 +509,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         : chatState.messagesForConversation(conv.id);
     if (messages.isEmpty) return;
 
-    // System events (member_joined, voice_session_started, ...) live at the
-    // conversation root with `channelId == null` and surface in every
-    // channel view, but their timestamps predate the actual channel messages
-    // -- they're created when the group is born.  If we use them as the
-    // pagination cursor, the server's `?channel_id=X&before=<system_ts>`
-    // query (correctly) returns zero rows, `hasMore` flips to false, and
-    // the message list dead-locks at the first page (#prod-2026-05-08).
-    // Use the oldest channel-scoped real message instead.
-    final paginationCursor = messages.firstWhere(
-      (m) => !m.isSystemEvent,
-      orElse: () => messages.first,
-    );
-    final oldestTimestamp = paginationCursor.timestamp;
+    // Use the oldest channel-scoped non-system message as the pagination
+    // cursor — see `ChatPanelController.paginationCursor` for the
+    // `#prod-2026-05-08` rationale.
+    final oldestTimestamp = _controller.paginationCursor(messages).timestamp;
     final auth = ref.read(authProvider);
     if (auth.token == null || auth.userId == null) return;
 
@@ -818,12 +762,9 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       );
       if (loaded.isEmpty) break;
       // Use the oldest channel-scoped (non-system) message as the
-      // pagination cursor; system events live at the conversation root
-      // and would dead-end the channel-scoped ?before= query.
-      final cursor = loaded.firstWhere(
-        (m) => !m.isSystemEvent,
-        orElse: () => loaded.first,
-      );
+      // pagination cursor — see `ChatPanelController.paginationCursor` for
+      // the `#prod-2026-05-08` rationale.
+      final cursor = _controller.paginationCursor(loaded);
 
       await ref
           .read(chatProvider.notifier)

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -30,6 +30,7 @@ import '../theme/responsive.dart';
 import 'channel_bar.dart';
 import 'chat_header_bar.dart';
 import 'chat_input_bar.dart';
+import 'chat_panel_controller.dart';
 import 'chat/session_corrupted_banner.dart';
 import 'chat_panel/chat_message_list.dart';
 import 'chat_panel/drop_overlay.dart';
@@ -86,6 +87,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     with WidgetsBindingObserver {
   final _scrollController = ScrollController();
   final _chatInputBarKey = GlobalKey<ChatInputBarState>();
+  final _controller = ChatPanelController();
 
   /// Cache scroll offsets keyed by conversation ID so switching conversations
   /// preserves the user's position. Capped at [_kMaxScrollPositions] entries
@@ -216,10 +218,14 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   @override
   void initState() {
     super.initState();
+    _controller.attachScrollController(_scrollController);
+    _controller.deletedForMeIds = _deletedForMeIds;
     _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addObserver(this);
     _loadDismissedBanners();
-    _loadDeletedForMe();
+    _loadDeletedForMe().then((_) {
+      if (mounted) _controller.deletedForMeIds = _deletedForMeIds;
+    });
     _pendingInitialMessageId = widget.initialMessageId;
   }
 
@@ -306,6 +312,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     _liveRegionClearTimer?.cancel();
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -463,11 +470,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     });
   }
 
-  bool _isNearBottom() {
-    if (!_scrollController.hasClients) return true;
-    final pos = _scrollController.position;
-    return pos.maxScrollExtent - pos.pixels < 150;
-  }
+  bool _isNearBottom() => _controller.isNearBottom();
 
   void _loadHistory() {
     final conv = widget.conversation;
@@ -1671,53 +1674,29 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     }
   }
 
-  /// Resolve messages for the current conversation and channel.
-  /// Filters out messages the user has deleted locally ("delete for me").
   List<ChatMessage> _resolveMessages(
     Conversation conv,
     ChatState chatState,
     String? selectedChannelId,
     bool includeUnchanneled,
-  ) {
-    final List<ChatMessage> raw;
-    if (conv.isGroup) {
-      raw = chatState.messagesForConversationChannel(
-        conv.id,
-        channelId: selectedChannelId,
-        includeUnchanneled: includeUnchanneled,
-      );
-    } else {
-      raw = chatState.messagesForConversation(conv.id);
-    }
-    if (_deletedForMeIds.isEmpty) return raw;
-    return raw.where((m) => !_deletedForMeIds.contains(m.id)).toList();
-  }
+  ) => _controller.resolveMessages(
+    conv,
+    chatState,
+    selectedChannelId,
+    includeUnchanneled,
+  );
 
-  /// Apply channel + delete-for-me filters to a pre-fetched message list.
-  /// Used by the build path so a `.select` on the per-conversation list ref
-  /// keeps unrelated conversations from rebuilding.
   List<ChatMessage> _filterChannelAndDeleted(
     Conversation conv,
     List<ChatMessage> raw,
     String? selectedChannelId,
     bool includeUnchanneled,
-  ) {
-    Iterable<ChatMessage> filtered = raw;
-    if (conv.isGroup &&
-        selectedChannelId != null &&
-        selectedChannelId.isNotEmpty) {
-      filtered = filtered.where((m) {
-        if (m.isSystemEvent) return true;
-        if (m.channelId == selectedChannelId) return true;
-        return includeUnchanneled &&
-            (m.channelId == null || m.channelId!.isEmpty);
-      });
-    }
-    if (_deletedForMeIds.isNotEmpty) {
-      filtered = filtered.where((m) => !_deletedForMeIds.contains(m.id));
-    }
-    return identical(filtered, raw) ? raw : filtered.toList();
-  }
+  ) => _controller.filterChannelAndDeleted(
+    conv,
+    raw,
+    selectedChannelId,
+    includeUnchanneled,
+  );
 
   // ---------------------------------------------------------------------------
   // Build

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -67,9 +67,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     return '$_newMessagesBelowCount new $noun';
   }
 
-  // Forwarders below funnel widget-local state through `_controller`
-  // (invariants #1, #3, #4, #6); call sites keep their original names so
-  // the diff stays focused on ownership, not call-site churn.
   Set<String> get _dismissedBannerIds => DismissedBannersStorage.ids;
   String? get _selectedTextChannelId => _controller.selectedTextChannelId;
   set _selectedTextChannelId(String? v) =>
@@ -104,9 +101,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   final Set<String> _savedIds = {};
   String? get _floatingDate => _controller.floatingDate;
   bool get _floatingDateVisible => _controller.floatingDateVisible;
-  // `_wasNearBottom` (invariant #4) is captured BEFORE the soft keyboard
-  // shrinks the viewport — `_handleKeyboardScroll` reads the pre-resize
-  // snapshot, not the live `_isNearBottom()` after the resize.
   bool get _wasNearBottom => _controller.wasNearBottom;
   set _wasNearBottom(bool v) => _controller.wasNearBottom = v;
   bool get _hasNewMessagesBelow => _controller.hasNewMessagesBelow;
@@ -484,8 +478,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     );
   }
 
-  // Message-action forwarders are inlined as closures at the
-  // `ChatPanelBodyParams` call site in `build`.
   void _handleKeyboardScroll() {
     final keyboardInset = MediaQuery.of(context).viewInsets.bottom;
     if (keyboardInset != _lastKeyboardInset) {

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -1,59 +1,31 @@
 import 'dart:async';
-import 'dart:typed_data';
 
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart' as http;
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/chat_message.dart';
 import '../models/conversation.dart';
-import '../models/reaction.dart';
 import '../providers/auth_provider.dart';
-import '../providers/channels_provider.dart';
 import '../providers/chat_provider.dart';
 import '../providers/conversations_provider.dart';
-import '../providers/crypto_provider.dart';
+import '../providers/media_ticket_provider.dart';
 import '../providers/privacy_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
-import '../screens/safety_number_screen.dart';
-import '../screens/user_profile_screen.dart';
-import '../services/message_cache.dart';
-import '../services/saved_messages_service.dart';
-import '../services/toast_service.dart';
-import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
-import 'channel_bar.dart';
-import 'chat_header_bar.dart';
 import 'chat_input_bar.dart';
 import 'chat_panel_controller.dart';
-import 'chat/session_corrupted_banner.dart';
-import 'chat_panel/chat_message_list.dart';
-import 'chat_panel/drop_overlay.dart';
-import 'chat_panel/floating_date_pill.dart';
-import 'chat_panel/full_reaction_picker.dart';
-import 'chat_panel/new_messages_pill.dart';
+import 'chat_panel/chat_panel_body.dart';
+import 'chat_panel/deleted_for_me_storage.dart';
+import 'chat_panel/drop_handler.dart';
+import 'chat_panel/history_loaders.dart' as history;
+import 'chat_panel/message_actions.dart' as actions;
 import 'chat_panel/no_conversation_placeholder.dart';
-import 'connection_status_banner.dart';
-import 'crypto_degraded_banner.dart';
-import 'identity_key_changed_banner.dart';
-import '../providers/media_ticket_provider.dart';
-import 'forward_message_dialog.dart';
-import 'image_gallery_viewer.dart';
-import 'message/media_content.dart'
-    show
-        extractEmbeddedImageUrls,
-        isImageUrl,
-        isStandaloneMediaUrl,
-        mediaHeaders,
-        resolveMediaUrl;
-import '../utils/semantics_preview.dart';
-import 'message_item.dart' show reactionEmojis;
-import 'message_search_overlay.dart';
+import 'chat_panel/reaction_picker_overlay.dart';
+import 'chat_panel/scroll_helpers.dart' as sh;
 import 'thread_view_panel.dart';
 
 class ChatPanel extends ConsumerStatefulWidget {
@@ -95,18 +67,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     return '$_newMessagesBelowCount new $noun';
   }
 
-  static const _dismissedBannersKey = 'dismissed_encryption_banners';
-  static Set<String> _dismissedBannerIds = {};
-  static bool _bannersLoaded = false;
-
-  /// Persistent blocklist of message IDs deleted via "delete for me".
-  /// Survives app restarts so messages don't reappear on history reload.
-  static const _deletedForMeKey = 'deleted_for_me_ids';
-  static Set<String> _deletedForMeIds = {};
-  static bool _deletedForMeLoaded = false;
-  // Channel-scoped loading keys + the currently-selected text channel live
-  // on the controller (invariant #3); these forwarders keep the existing
-  // call sites readable without leaking the controller into every line.
+  // Forwarders below funnel widget-local state through `_controller`
+  // (invariants #1, #3, #4, #6); call sites keep their original names so
+  // the diff stays focused on ownership, not call-site churn.
+  Set<String> get _dismissedBannerIds => DismissedBannersStorage.ids;
   String? get _selectedTextChannelId => _controller.selectedTextChannelId;
   set _selectedTextChannelId(String? v) =>
       _controller.selectedTextChannelId = v;
@@ -116,27 +80,17 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       _controller.loadedChannelsConversationId;
   set _loadedChannelsConversationId(String? v) =>
       _controller.loadedChannelsConversationId = v;
-  String? get _autoScrollConversationKey =>
-      _controller.autoScrollConversationKey;
-  set _autoScrollConversationKey(String? v) =>
-      _controller.autoScrollConversationKey = v;
   String? _activeVoiceChannelId;
 
-  /// The message ID at which the "New Messages" divider should appear.
-  /// Set when opening a conversation with unread messages, cleared when the
-  /// unread count drops to 0. Captured ONCE per channel session — see
-  /// `ChatPanelController.unreadBoundaryMessageId` (invariant #6).
   String? get _unreadBoundaryMessageId => _controller.unreadBoundaryMessageId;
   set _unreadBoundaryMessageId(String? v) =>
       _controller.unreadBoundaryMessageId = v;
   int get _unreadBoundaryCount => _controller.unreadBoundaryCount;
   set _unreadBoundaryCount(int v) => _controller.unreadBoundaryCount = v;
 
-  /// GlobalKeys for rendered message items, keyed by message ID.
-  /// Used by [_scrollToMessage] for pixel-accurate scrolling (via
-  /// [Scrollable.ensureVisible]) and by [_updateFloatingDate] to detect which
-  /// message is at the top of the viewport without a hardcoded height estimate.
-  /// Cleared whenever the active conversation changes to prevent leaks.
+  // GlobalKeys for rendered message items, keyed by ID. Used by
+  // `_scrollToMessage` for pixel-accurate scrolling and by
+  // `_updateFloatingDate` to detect the topmost visible message.
   final _messageKeys = <String, GlobalKey>{};
 
   bool _showSearch = false;
@@ -144,57 +98,26 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   String? _highlightedMessageId;
   String? _pendingInitialMessageId;
   Timer? _highlightTimer;
-  // Last keyboard inset lives on the controller so `handleKeyboardScroll`
-  // can read/write it without re-piping it through method args. The widget
-  // accessor preserves the original `_lastKeyboardInset` name.
   double get _lastKeyboardInset => _controller.lastKeyboardInset;
   set _lastKeyboardInset(double v) => _controller.lastKeyboardInset = v;
-
-  /// True while a file is being dragged over the chat area.
   bool _isDragOver = false;
-
-  /// Local mirror of SavedMessagesService so [MessageItem] can render the
-  /// correct bookmark icon without async round-trips.
   final Set<String> _savedIds = {};
-
-  /// Floating date label state — owned by the controller so the 2s fade-out
-  /// timer is cancelled in one place (controller `dispose`).
   String? get _floatingDate => _controller.floatingDate;
-  set _floatingDate(String? v) => _controller.floatingDate = v;
   bool get _floatingDateVisible => _controller.floatingDateVisible;
-  set _floatingDateVisible(bool v) => _controller.floatingDateVisible = v;
-  Timer? get _floatingDateTimer => _controller.floatingDateTimer;
-  set _floatingDateTimer(Timer? v) => _controller.floatingDateTimer = v;
-  // Tracks near-bottom state from the user's last scroll event, before any
-  // viewport resize (keyboard open/close). Used in _handleKeyboardScroll so
-  // we don't lose context when maxScrollExtent shifts under us. Lives on
-  // the controller (invariant #4 — `_wasNearBottom` check must run BEFORE
-  // the keyboard shrinks the viewport).
+  // `_wasNearBottom` (invariant #4) is captured BEFORE the soft keyboard
+  // shrinks the viewport — `_handleKeyboardScroll` reads the pre-resize
+  // snapshot, not the live `_isNearBottom()` after the resize.
   bool get _wasNearBottom => _controller.wasNearBottom;
   set _wasNearBottom(bool v) => _controller.wasNearBottom = v;
-
-  /// True when a new message arrives while the user has scrolled up.
-  /// Lives on the controller; the widget still drives `setState` via the
-  /// pill toggle so the new-messages-pill animates in/out at the same
-  /// frame the underlying state flips.
   bool get _hasNewMessagesBelow => _controller.hasNewMessagesBelow;
   set _hasNewMessagesBelow(bool v) => _controller.hasNewMessagesBelow = v;
   int get _newMessagesBelowCount => _controller.newMessagesBelowCount;
   set _newMessagesBelowCount(int v) => _controller.newMessagesBelowCount = v;
-
-  /// Hidden Semantics live-region label for screen-reader announcements
-  /// when peer messages arrive (#495). Empty until the first announcement,
-  /// then cleared again ~3s after each announcement so a window-focus event
-  /// doesn't make the screen reader replay the stale label.
+  // Hidden Semantics live-region label (#495). Cleared ~3s after each
+  // announcement so a window-focus event doesn't replay the stale label.
   String _liveRegionAnnouncement = '';
-
-  /// Last announced peer message id; prevents duplicate announcements when
-  /// the chat state notifier fires back-to-back updates with the same tail.
   String? _lastAnnouncedMessageId;
-
-  /// Clears [_liveRegionAnnouncement] a short time after each announcement.
   Timer? _liveRegionClearTimer;
-
   OverlayEntry? _reactionOverlay;
 
   bool get _hideEncryptionBanner {
@@ -205,45 +128,20 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   Future<void> _dismissEncryptionBanner() async {
     final convId = widget.conversation?.id;
     if (convId == null) return;
-    setState(() => _dismissedBannerIds.add(convId));
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(
-      _dismissedBannersKey,
-      _dismissedBannerIds.toList(),
-    );
-  }
-
-  static Future<void> _loadDismissedBanners() async {
-    if (_bannersLoaded) return;
-    _bannersLoaded = true;
-    final prefs = await SharedPreferences.getInstance();
-    _dismissedBannerIds = (prefs.getStringList(_dismissedBannersKey) ?? [])
-        .toSet();
-  }
-
-  static Future<void> _loadDeletedForMe() async {
-    if (_deletedForMeLoaded) return;
-    _deletedForMeLoaded = true;
-    final prefs = await SharedPreferences.getInstance();
-    _deletedForMeIds = (prefs.getStringList(_deletedForMeKey) ?? []).toSet();
-  }
-
-  static Future<void> _addToDeletedForMe(String messageId) async {
-    _deletedForMeIds.add(messageId);
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_deletedForMeKey, _deletedForMeIds.toList());
+    setState(() {});
+    await DismissedBannersStorage.add(convId);
   }
 
   @override
   void initState() {
     super.initState();
     _controller.attachScrollController(_scrollController);
-    _controller.deletedForMeIds = _deletedForMeIds;
+    _controller.deletedForMeIds = DeletedForMeStorage.ids;
     _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addObserver(this);
-    _loadDismissedBanners();
-    _loadDeletedForMe().then((_) {
-      if (mounted) _controller.deletedForMeIds = _deletedForMeIds;
+    DismissedBannersStorage.ensureLoaded();
+    DeletedForMeStorage.ensureLoaded().then((_) {
+      if (mounted) _controller.deletedForMeIds = DeletedForMeStorage.ids;
     });
     _pendingInitialMessageId = widget.initialMessageId;
   }
@@ -261,7 +159,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       _selectedTextChannelId = null;
       _activeVoiceChannelId = null;
       _loadedHistoryKey = null;
-      _autoScrollConversationKey = null;
+      _controller.autoScrollConversationKey = null;
       _showSearch = false;
       _threadParent = null;
       _highlightedMessageId = null;
@@ -270,9 +168,9 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       _newMessagesBelowCount = 0;
       _unreadBoundaryMessageId = null;
       _unreadBoundaryCount = 0;
-      _floatingDate = null;
-      _floatingDateVisible = false;
-      _floatingDateTimer?.cancel();
+      _controller.floatingDate = null;
+      _controller.floatingDateVisible = false;
+      _controller.floatingDateTimer?.cancel();
       _highlightTimer?.cancel();
       _messageKeys.clear();
       _liveRegionAnnouncement = '';
@@ -311,7 +209,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     WidgetsBinding.instance.removeObserver(this);
     _dismissReactionPicker();
     _highlightTimer?.cancel();
-    _floatingDateTimer?.cancel();
     _liveRegionClearTimer?.cancel();
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
@@ -326,10 +223,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       _markAsRead();
     }
   }
-
-  // ---------------------------------------------------------------------------
-  // History + scroll management
-  // ---------------------------------------------------------------------------
 
   void _onScroll() {
     _wasNearBottom = _isNearBottom();
@@ -354,70 +247,18 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
 
   void _updateFloatingDate() {
     final conv = widget.conversation;
-    if (conv == null || !_scrollController.hasClients) return;
-
-    final chatState = ref.read(chatProvider);
-    final selectedChannelId = conv.isGroup ? _selectedTextChannelId : null;
-    final includeUnchanneled = conv.isGroup && _selectedTextChannelId == null;
-    final messages = _resolveMessages(
-      conv,
-      chatState,
-      selectedChannelId,
-      includeUnchanneled,
+    if (conv == null) return;
+    sh.updateFloatingDate(
+      ref: ref,
+      conv: conv,
+      scrollController: _scrollController,
+      messageKeys: _messageKeys,
+      selectedTextChannelId: _selectedTextChannelId,
+      resolveMessages: _resolveMessages,
+      controller: _controller,
+      setState: setState,
+      mounted: () => mounted,
     );
-    if (messages.isEmpty) return;
-
-    // Find the topmost rendered message by querying each message's RenderBox
-    // position in the viewport. This is accurate for any message height
-    // (images, reactions, multi-line text) and avoids the old 60px estimate.
-    String? topmostId;
-    double closestY = double.infinity;
-    for (final entry in _messageKeys.entries) {
-      final ctx = entry.value.currentContext;
-      if (ctx == null) continue;
-      final box = ctx.findRenderObject();
-      if (box is! RenderBox || !box.hasSize) continue;
-      final y = box.localToGlobal(Offset.zero).dy;
-      if (y < closestY) {
-        closestY = y;
-        topmostId = entry.key;
-      }
-    }
-    final msgIndex = topmostId == null
-        ? 0
-        : messages
-              .indexWhere((m) => m.id == topmostId)
-              .clamp(0, messages.length - 1);
-
-    try {
-      final dt = DateTime.parse(messages[msgIndex].timestamp).toLocal();
-      final now = DateTime.now();
-      final yesterday = now.subtract(const Duration(days: 1));
-      String label;
-      if (dt.year == now.year && dt.month == now.month && dt.day == now.day) {
-        label = 'Today';
-      } else if (dt.year == yesterday.year &&
-          dt.month == yesterday.month &&
-          dt.day == yesterday.day) {
-        label = 'Yesterday';
-      } else {
-        label = '${_fullMonthName(dt.month)} ${dt.day}, ${dt.year}';
-      }
-
-      if (label != _floatingDate || !_floatingDateVisible) {
-        setState(() {
-          _floatingDate = label;
-          _floatingDateVisible = true;
-        });
-      }
-    } catch (_) {
-      return;
-    }
-
-    _floatingDateTimer?.cancel();
-    _floatingDateTimer = Timer(const Duration(seconds: 2), () {
-      if (mounted) setState(() => _floatingDateVisible = false);
-    });
   }
 
   void _scrollToBottom({bool animated = true, int settleRetries = 3}) {
@@ -444,45 +285,13 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     final key = '${conv.id}:${_selectedTextChannelId ?? ""}';
     if (key == _loadedHistoryKey) return;
     _loadedHistoryKey = key;
-
-    final auth = ref.read(authProvider);
-    if (auth.token == null || auth.userId == null) return;
-
-    // Load cached messages first for instant display
-    ref.read(chatProvider.notifier).loadFromCache(conv.id, auth.userId!);
-
     // Capture unread boundary from cached messages before they are marked read.
     _captureUnreadBoundary();
-
-    final groupCrypto = conv.isGroup
-        ? ref.read(groupCryptoServiceProvider)
-        : null;
-    if (groupCrypto != null) {
-      groupCrypto.setToken(auth.token!);
-    }
-
-    // For 1:1 DMs, pass the crypto service so encrypted messages can be
-    // decrypted. Without this, _decryptIfNeeded sees crypto==null and
-    // shows "[Encrypted history]" instead of the actual message content.
-    final cryptoState = ref.read(cryptoProvider);
-    final crypto = (!conv.isGroup && cryptoState.isInitialized)
-        ? ref.read(cryptoServiceProvider)
-        : null;
-    if (crypto != null) {
-      crypto.setToken(auth.token!);
-    }
-
-    ref
-        .read(chatProvider.notifier)
-        .loadHistoryWithUserId(
-          conv.id,
-          auth.token!,
-          auth.userId!,
-          channelId: _selectedTextChannelId,
-          crypto: crypto,
-          isGroup: conv.isGroup,
-          groupCrypto: groupCrypto,
-        );
+    history.loadHistory(
+      ref: ref,
+      conv: conv,
+      selectedTextChannelId: _selectedTextChannelId,
+    );
   }
 
   void _loadChannels() {
@@ -490,73 +299,18 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     if (conv == null || !conv.isGroup) return;
     if (conv.id == _loadedChannelsConversationId) return;
     _loadedChannelsConversationId = conv.id;
-    ref.read(channelsProvider.notifier).loadChannels(conv.id);
+    history.loadChannels(ref: ref, conv: conv);
   }
 
   void _loadOlderMessages() {
     final conv = widget.conversation;
     if (conv == null) return;
-    final chatState = ref.read(chatProvider);
-    // Use the channel-aware helpers — the underlying maps key by
-    // `conversationId:channelId` (or `conversationId:` for the unchanneled
-    // group root), so a raw lookup by `conv.id` always missed in
-    // channelized groups, hiding active history loads and triggering
-    // duplicate paginate requests (#510).
-    if (chatState.isLoadingHistory(
-          conv.id,
-          channelId: _selectedTextChannelId,
-        ) ||
-        !chatState.conversationHasMore(
-          conv.id,
-          channelId: _selectedTextChannelId,
-        )) {
-      return;
-    }
-
-    final messages = conv.isGroup
-        ? chatState.messagesForConversationChannel(
-            conv.id,
-            channelId: _selectedTextChannelId,
-            includeUnchanneled: _selectedTextChannelId == null,
-          )
-        : chatState.messagesForConversation(conv.id);
-    if (messages.isEmpty) return;
-
-    // Use the oldest channel-scoped non-system message as the pagination
-    // cursor — see `ChatPanelController.paginationCursor` for the
-    // `#prod-2026-05-08` rationale.
-    final oldestTimestamp = _controller.paginationCursor(messages).timestamp;
-    final auth = ref.read(authProvider);
-    if (auth.token == null || auth.userId == null) return;
-
-    final groupCryptoOlder = conv.isGroup
-        ? ref.read(groupCryptoServiceProvider)
-        : null;
-    if (groupCryptoOlder != null) {
-      groupCryptoOlder.setToken(auth.token!);
-    }
-
-    // Pass crypto for 1:1 DM decryption (same as _loadHistory)
-    final cryptoStateOlder = ref.read(cryptoProvider);
-    final cryptoOlder = (!conv.isGroup && cryptoStateOlder.isInitialized)
-        ? ref.read(cryptoServiceProvider)
-        : null;
-    if (cryptoOlder != null) {
-      cryptoOlder.setToken(auth.token!);
-    }
-
-    ref
-        .read(chatProvider.notifier)
-        .loadHistoryWithUserId(
-          conv.id,
-          auth.token!,
-          auth.userId!,
-          channelId: _selectedTextChannelId,
-          before: oldestTimestamp,
-          crypto: cryptoOlder,
-          isGroup: conv.isGroup,
-          groupCrypto: groupCryptoOlder,
-        );
+    history.loadOlderMessages(
+      ref: ref,
+      conv: conv,
+      selectedTextChannelId: _selectedTextChannelId,
+      controller: _controller,
+    );
   }
 
   void _markAsRead() {
@@ -569,45 +323,22 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     ref.read(websocketProvider.notifier).sendReadReceipt(conv.id);
   }
 
-  /// Compute the unread boundary message ID from the current unread count.
-  /// Called once when a conversation is first opened or messages finish loading.
   void _captureUnreadBoundary() {
     final conv = widget.conversation;
     if (conv == null) return;
-    // Only capture once per conversation open
-    if (_unreadBoundaryMessageId != null) return;
-
-    final convState = ref.read(conversationsProvider);
-    final convData = convState.conversations
-        .where((c) => c.id == conv.id)
-        .firstOrNull;
-    if (convData == null || convData.unreadCount <= 0) return;
-
-    final chatState = ref.read(chatProvider);
-    final selectedChannelId = conv.isGroup ? _selectedTextChannelId : null;
-    final includeUnchanneled = conv.isGroup && _selectedTextChannelId == null;
-    final messages = _resolveMessages(
-      conv,
-      chatState,
-      selectedChannelId,
-      includeUnchanneled,
+    sh.captureUnreadBoundary(
+      ref: ref,
+      conv: conv,
+      selectedTextChannelId: _selectedTextChannelId,
+      controller: _controller,
+      resolveMessages: _resolveMessages,
+      setState: setState,
     );
-    if (messages.isEmpty) return;
-
-    final boundaryIndex = messages.length - convData.unreadCount;
-    if (boundaryIndex > 0 && boundaryIndex < messages.length) {
-      setState(() {
-        _unreadBoundaryMessageId = messages[boundaryIndex].id;
-        _unreadBoundaryCount = convData.unreadCount;
-      });
-    }
   }
 
-  /// Scroll to the unread boundary divider so it appears near the top.
   void _scrollToUnreadBoundary() {
     final conv = widget.conversation;
-    if (conv == null || _unreadBoundaryMessageId == null) return;
-
+    if (conv == null) return;
     final chatState = ref.read(chatProvider);
     final selectedChannelId = conv.isGroup ? _selectedTextChannelId : null;
     final includeUnchanneled = conv.isGroup && _selectedTextChannelId == null;
@@ -617,25 +348,12 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       selectedChannelId,
       includeUnchanneled,
     );
-    final index = messages.indexWhere((m) => m.id == _unreadBoundaryMessageId);
-    if (index < 0 || !_scrollController.hasClients) return;
-
-    // Use Scrollable.ensureVisible if the key is available for pixel-accurate
-    // positioning; fall back to a jump when the item is not yet rendered.
-    final key = _messageKeys[_unreadBoundaryMessageId];
-    if (key?.currentContext != null) {
-      Scrollable.ensureVisible(
-        key!.currentContext!,
-        alignment: 0.15,
-        duration: Duration.zero,
-      );
-    } else {
-      // Item not rendered yet — scroll by index (approximate).
-      final estimatedOffset = (index + 1) * 60.0 - 120.0;
-      _scrollController.jumpTo(
-        estimatedOffset.clamp(0, _scrollController.position.maxScrollExtent),
-      );
-    }
+    sh.scrollToUnreadBoundary(
+      scrollController: _scrollController,
+      messageKeys: _messageKeys,
+      messages: messages,
+      unreadBoundaryMessageId: _unreadBoundaryMessageId,
+    );
   }
 
   void _onTextChannelChanged(String? channelId) {
@@ -651,10 +369,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     _markAsRead();
   }
 
-  // ---------------------------------------------------------------------------
-  // Search highlight
-  // ---------------------------------------------------------------------------
-
   void _highlightMessage(String messageId) {
     setState(() => _highlightedMessageId = messageId);
     _highlightTimer?.cancel();
@@ -665,150 +379,44 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   }
 
   void _scrollToMessage(String messageId) {
-    final key = _messageKeys[messageId];
-    if (key?.currentContext != null) {
-      Scrollable.ensureVisible(
-        key!.currentContext!,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeOut,
-        alignment: 0.3,
-      );
-      return;
-    }
-
-    // Target message is off-screen (not rendered by ListView.builder).
-    // Find its index and estimate scroll position to jump near it.
     final conv = widget.conversation;
-    if (conv == null || !_scrollController.hasClients) return;
     final chatState = ref.read(chatProvider);
-    final selectedChannelId = conv.isGroup ? _selectedTextChannelId : null;
-    final includeUnchanneled = conv.isGroup && _selectedTextChannelId == null;
-    final messages = _resolveMessages(
-      conv,
-      chatState,
-      selectedChannelId,
-      includeUnchanneled,
+    final selectedChannelId = conv != null && conv.isGroup
+        ? _selectedTextChannelId
+        : null;
+    final includeUnchanneled =
+        conv != null && conv.isGroup && _selectedTextChannelId == null;
+    final messages = conv == null
+        ? const <ChatMessage>[]
+        : _resolveMessages(
+            conv,
+            chatState,
+            selectedChannelId,
+            includeUnchanneled,
+          );
+    sh.scrollToMessage(
+      messageId: messageId,
+      scrollController: _scrollController,
+      messageKeys: _messageKeys,
+      messages: messages,
     );
-    final index = messages.indexWhere((m) => m.id == messageId);
-    if (index < 0) return;
-
-    // +1 accounts for the loading indicator at index 0 in the ListView.
-    final estimatedOffset = (index + 1) * 60.0;
-    _scrollController.animateTo(
-      estimatedOffset.clamp(0, _scrollController.position.maxScrollExtent),
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeOut,
-    );
-
-    // After the jump, retry with ensureVisible once the widget is rendered.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final retryKey = _messageKeys[messageId];
-      if (retryKey?.currentContext != null) {
-        Scrollable.ensureVisible(
-          retryKey!.currentContext!,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOut,
-          alignment: 0.3,
-        );
-      }
-    });
   }
-
-  // ---------------------------------------------------------------------------
-  // Jump to reply quote
-  // ---------------------------------------------------------------------------
 
   Future<void> _jumpToReplyQuote(String replyToId) async {
     final conv = widget.conversation;
     if (conv == null) return;
-    final selectedChannelId = conv.isGroup ? _selectedTextChannelId : null;
-    final includeUnchanneled = conv.isGroup && _selectedTextChannelId == null;
-
-    bool isLoaded() {
-      final state = ref.read(chatProvider);
-      final loaded = _resolveMessages(
-        conv,
-        state,
-        selectedChannelId,
-        includeUnchanneled,
-      );
-      return loaded.indexWhere((m) => m.id == replyToId) >= 0;
-    }
-
-    // Fast path: already in memory.
-    if (isLoaded()) {
-      _highlightMessage(replyToId);
-      return;
-    }
-
-    // Slow path: paginate older history until the target appears or
-    // `hasMore` flips to false.  Cap to 30 rounds (~1500 msgs at 50/round)
-    // so a stale or removed parent can't spin forever.
-    final auth = ref.read(authProvider);
-    if (auth.token == null || auth.userId == null) return;
-
-    final groupCrypto = conv.isGroup
-        ? ref.read(groupCryptoServiceProvider)
-        : null;
-    groupCrypto?.setToken(auth.token!);
-
-    final cryptoState = ref.read(cryptoProvider);
-    final crypto = (!conv.isGroup && cryptoState.isInitialized)
-        ? ref.read(cryptoServiceProvider)
-        : null;
-    crypto?.setToken(auth.token!);
-
-    for (var round = 0; round < 30; round++) {
-      if (!mounted) return;
-      final state = ref.read(chatProvider);
-      if (!state.conversationHasMore(
-        conv.id,
-        channelId: _selectedTextChannelId,
-      )) {
-        break;
-      }
-      final loaded = _resolveMessages(
-        conv,
-        state,
-        selectedChannelId,
-        includeUnchanneled,
-      );
-      if (loaded.isEmpty) break;
-      // Use the oldest channel-scoped (non-system) message as the
-      // pagination cursor — see `ChatPanelController.paginationCursor` for
-      // the `#prod-2026-05-08` rationale.
-      final cursor = _controller.paginationCursor(loaded);
-
-      await ref
-          .read(chatProvider.notifier)
-          .loadHistoryWithUserId(
-            conv.id,
-            auth.token!,
-            auth.userId!,
-            channelId: _selectedTextChannelId,
-            before: cursor.timestamp,
-            crypto: crypto,
-            isGroup: conv.isGroup,
-            groupCrypto: groupCrypto,
-          );
-      if (!mounted) return;
-      if (isLoaded()) {
-        _highlightMessage(replyToId);
-        return;
-      }
-    }
-
-    if (!mounted) return;
-    ToastService.show(
-      context,
-      'Original message not available',
-      type: ToastType.info,
+    await history.jumpToReplyQuote(
+      context: context,
+      ref: ref,
+      conv: conv,
+      selectedTextChannelId: _selectedTextChannelId,
+      controller: _controller,
+      replyToId: replyToId,
+      resolveMessages: _resolveMessages,
+      mounted: () => mounted,
+      onHighlight: () => _highlightMessage(replyToId),
     );
   }
-
-  // ---------------------------------------------------------------------------
-  // Thread view
-  // ---------------------------------------------------------------------------
 
   void _openThread(ChatMessage message) {
     final isMobile = Responsive.isMobile(context);
@@ -831,10 +439,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Reaction picker
-  // ---------------------------------------------------------------------------
-
   void _dismissReactionPicker() {
     _reactionOverlay?.remove();
     _reactionOverlay = null;
@@ -844,172 +448,35 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     final conv = widget.conversation;
     if (conv == null) return;
     _dismissReactionPicker();
-
     final myUserId = ref.read(authProvider).userId ?? '';
-    final overlay = Overlay.of(context);
-    const pickerWidth = 385.0; // wider to accommodate the "+" button
-    const pickerHeight = 44.0;
-    final screenWidth = MediaQuery.of(context).size.width;
-
-    final left = (tapPosition.dx - pickerWidth / 2).clamp(
-      12.0,
-      screenWidth - pickerWidth - 12,
+    _reactionOverlay = buildReactionPickerOverlay(
+      context: context,
+      message: message,
+      myUserId: myUserId,
+      tapPosition: tapPosition,
+      onDismiss: _dismissReactionPicker,
+      onToggleReaction: (emoji, already) =>
+          _toggleReaction(message, emoji, already),
+      onPickFromFull: () => _showFullReactionPicker(message, myUserId),
     );
-    final top = (tapPosition.dy - pickerHeight - 12).clamp(
-      12.0,
-      double.infinity,
-    );
-
-    _reactionOverlay = OverlayEntry(
-      builder: (_) => Stack(
-        children: [
-          Positioned.fill(
-            child: GestureDetector(
-              onTap: () {
-                _dismissReactionPicker();
-                FocusManager.instance.primaryFocus?.unfocus();
-              },
-              behavior: HitTestBehavior.opaque,
-              child: Container(color: Colors.black.withValues(alpha: 0.15)),
-            ),
-          ),
-          Positioned(
-            left: left,
-            top: top,
-            child: TweenAnimationBuilder<double>(
-              tween: Tween(begin: 0, end: 1),
-              duration: const Duration(milliseconds: 200),
-              curve: Curves.easeOutCubic,
-              builder: (_, value, child) => Opacity(
-                opacity: value,
-                child: Transform.translate(
-                  offset: Offset(0, 8 * (1 - value)),
-                  child: child,
-                ),
-              ),
-              child: Container(
-                height: pickerHeight,
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                decoration: BoxDecoration(
-                  color: context.surface.withValues(alpha: 0.95),
-                  borderRadius: BorderRadius.circular(22),
-                  border: Border.all(color: context.border),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.3),
-                      blurRadius: 12,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    ...reactionEmojis.map((emoji) {
-                      final alreadyReacted = message.reactions.any(
-                        (r) => r.emoji == emoji && r.userId == myUserId,
-                      );
-                      return GestureDetector(
-                        onTap: () {
-                          _dismissReactionPicker();
-                          _toggleReaction(message, emoji, alreadyReacted);
-                          FocusManager.instance.primaryFocus?.unfocus();
-                        },
-                        child: Container(
-                          width: 36,
-                          height: 36,
-                          margin: const EdgeInsets.symmetric(horizontal: 2),
-                          decoration: BoxDecoration(
-                            color: alreadyReacted
-                                ? context.accent.withValues(alpha: 0.2)
-                                : null,
-                            borderRadius: BorderRadius.circular(8),
-                            border: alreadyReacted
-                                ? Border.all(color: context.accent, width: 2)
-                                : null,
-                          ),
-                          alignment: Alignment.center,
-                          child: Text(
-                            emoji,
-                            style: const TextStyle(
-                              fontSize: 22,
-                              decoration: TextDecoration.none,
-                            ),
-                          ),
-                        ),
-                      );
-                    }),
-                    // Full emoji picker button
-                    GestureDetector(
-                      onTap: () {
-                        _dismissReactionPicker();
-                        _showFullReactionPicker(message, myUserId);
-                      },
-                      child: Container(
-                        width: 36,
-                        height: 36,
-                        margin: const EdgeInsets.only(left: 4, right: 2),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(color: context.border, width: 1),
-                        ),
-                        alignment: Alignment.center,
-                        child: Icon(
-                          Icons.add,
-                          size: 18,
-                          color: context.textSecondary,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-    overlay.insert(_reactionOverlay!);
+    Overlay.of(context).insert(_reactionOverlay!);
   }
 
   void _toggleReaction(ChatMessage message, String emoji, bool remove) {
     final conv = widget.conversation;
     if (conv == null) return;
-
-    // Guard: the message may have been deleted via WebSocket between the
-    // time the user opened the reaction picker and tapped an emoji.
-    final stillExists = ref
-        .read(chatProvider)
-        .messagesForConversation(conv.id)
-        .any((m) => m.id == message.id);
-    if (!stillExists) return;
-
-    final myUserId = ref.read(authProvider).userId ?? '';
-    ref
-        .read(websocketProvider.notifier)
-        .sendReaction(conv.id, message.id, emoji);
-    if (remove) {
-      ref
-          .read(chatProvider.notifier)
-          .removeReaction(conv.id, message.id, myUserId, emoji);
-    } else {
-      ref
-          .read(chatProvider.notifier)
-          .addReaction(
-            conv.id,
-            Reaction(
-              messageId: message.id,
-              userId: myUserId,
-              username: '',
-              emoji: emoji,
-            ),
-          );
-    }
+    actions.toggleReaction(
+      ref: ref,
+      conv: conv,
+      message: message,
+      emoji: emoji,
+      remove: remove,
+    );
   }
 
   void _showFullReactionPicker(ChatMessage message, String myUserId) {
-    showFullReactionPicker(
-      context,
+    actions.showFullReactionPickerFor(
+      context: context,
       message: message,
       myUserId: myUserId,
       onPick: (emoji, alreadyReacted) =>
@@ -1017,483 +484,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Retry failed message
-  // ---------------------------------------------------------------------------
-
-  Future<void> _retryMessage(ChatMessage message) async {
-    final conv = widget.conversation;
-    if (conv == null) return;
-    final chatNotifier = ref.read(chatProvider.notifier);
-    chatNotifier.updateMessageStatus(
-      conv.id,
-      message.id,
-      MessageStatus.sending,
-    );
-    try {
-      final ws = ref.read(websocketProvider.notifier);
-      if (conv.isGroup) {
-        await ws.sendGroupMessage(
-          conv.id,
-          message.failedContent ?? message.content,
-          channelId: message.channelId,
-          replyToId: message.replyToId,
-        );
-      } else {
-        final myUserId = ref.read(authProvider).userId ?? '';
-        final peer = conv.members
-            .where((m) => m.userId != myUserId)
-            .firstOrNull;
-        if (peer == null) return;
-        await ws.sendMessage(
-          peer.userId,
-          message.failedContent ?? message.content,
-          conversationId: conv.id,
-          replyToId: message.replyToId,
-        );
-      }
-    } catch (_) {
-      ref
-          .read(chatProvider.notifier)
-          .updateMessageStatus(conv.id, message.id, MessageStatus.failed);
-    }
-  }
-
-  void _deleteFailed(ChatMessage message) {
-    final conv = widget.conversation;
-    if (conv == null) return;
-    ref.read(chatProvider.notifier).deleteMessage(conv.id, message.id);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Forward message
-  // ---------------------------------------------------------------------------
-
-  void _forwardMessage(ChatMessage message) {
-    showForwardDialog(
-      context: context,
-      onForward: (target) => _sendForwardedMessage(message, target),
-    );
-  }
-
-  Future<void> _sendForwardedMessage(
-    ChatMessage message,
-    Conversation target,
-  ) async {
-    final myUserId = ref.read(authProvider).userId ?? '';
-    final ws = ref.read(websocketProvider.notifier);
-    final content = message.content;
-
-    try {
-      await ref.read(chatProvider.notifier).forwardMessage(content, target.id, (
-        forwardedContent,
-      ) async {
-        // Add optimistic message so the sender sees it locally immediately.
-        String peerUserId = '';
-        String? channelId;
-        if (!target.isGroup) {
-          final peer = target.members
-              .where((m) => m.userId != myUserId)
-              .firstOrNull;
-          peerUserId = peer?.userId ?? '';
-        } else {
-          // Look up the default text channel so the optimistic message has the
-          // same channelId that the server will return in message_sent.
-          // Without this, _replacePendingMessage's channelId filter never
-          // matches and the pending message times out to failed.
-          final channels = ref.read(channelsProvider).channelsFor(target.id);
-          channelId = channels.where((c) => c.isText).firstOrNull?.id;
-        }
-        ref
-            .read(chatProvider.notifier)
-            .addOptimistic(
-              peerUserId,
-              forwardedContent,
-              myUserId,
-              conversationId: target.id,
-              channelId: channelId,
-            );
-
-        if (target.isGroup) {
-          await ws.sendGroupMessage(
-            target.id,
-            forwardedContent,
-            channelId: channelId,
-          );
-        } else {
-          final peer = target.members
-              .where((m) => m.userId != myUserId)
-              .firstOrNull;
-          if (peer == null) return;
-          await ws.sendMessage(
-            peer.userId,
-            forwardedContent,
-            conversationId: target.id,
-          );
-        }
-      });
-
-      if (mounted) {
-        ToastService.show(
-          context,
-          'Message forwarded',
-          type: ToastType.success,
-        );
-      }
-    } catch (e) {
-      if (mounted) {
-        ToastService.show(
-          context,
-          'Failed to forward message',
-          type: ToastType.error,
-        );
-      }
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Delete confirmation
-  // ---------------------------------------------------------------------------
-
-  void _confirmDelete(ChatMessage message) {
-    final conv = widget.conversation;
-    if (conv == null) return;
-    showDialog<_DeleteChoice>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: const Text('Delete message?'),
-        actions: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, _DeleteChoice.forMe),
-                child: Text(
-                  'Delete for me',
-                  style: TextStyle(color: context.textSecondary),
-                ),
-              ),
-              if (message.isMine)
-                TextButton(
-                  onPressed: () =>
-                      Navigator.pop(ctx, _DeleteChoice.forEveryone),
-                  child: const Text(
-                    'Delete for everyone',
-                    style: TextStyle(color: EchoTheme.danger),
-                  ),
-                ),
-              TextButton(
-                onPressed: () => Navigator.pop(ctx),
-                child: Text(
-                  'Cancel',
-                  style: TextStyle(color: context.textSecondary),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    ).then((choice) async {
-      if (choice == null) return;
-      if (choice == _DeleteChoice.forMe) {
-        ref.read(chatProvider.notifier).deleteMessage(conv.id, message.id);
-        MessageCache.removeMessage(conv.id, message.id);
-        _addToDeletedForMe(message.id);
-        if (mounted) {
-          ToastService.show(
-            context,
-            'Message deleted for you',
-            type: ToastType.info,
-          );
-        }
-      } else {
-        await _deleteForEveryone(conv.id, message);
-      }
-    });
-  }
-
-  /// Delete a message for every recipient. Optimistically removes it from
-  /// local state for a responsive UI, awaits the server DELETE, and rolls
-  /// the message back into local state if the request fails (auth expired,
-  /// network drop, server error). Without the await/rollback the user was
-  /// being told the message had been deleted "for everyone" even when only
-  /// local state changed (#511).
-  Future<void> _deleteForEveryone(
-    String conversationId,
-    ChatMessage message,
-  ) async {
-    ref.read(chatProvider.notifier).deleteMessage(conversationId, message.id);
-
-    final serverUrl = ref.read(serverUrlProvider);
-    http.Response? response;
-    Object? networkError;
-    try {
-      response = await ref
-          .read(authProvider.notifier)
-          .authenticatedRequest(
-            (token) => http.delete(
-              Uri.parse('$serverUrl/api/messages/${message.id}'),
-              headers: {'Authorization': 'Bearer $token'},
-            ),
-          );
-    } catch (e) {
-      networkError = e;
-    }
-
-    if (!mounted) return;
-
-    final ok =
-        response != null &&
-        response.statusCode >= 200 &&
-        response.statusCode < 300;
-    if (ok) {
-      ToastService.show(
-        context,
-        'Message deleted for everyone',
-        type: ToastType.success,
-      );
-    } else {
-      // Rollback: re-insert the message so the user sees their content
-      // wasn't actually removed remotely.
-      ref.read(chatProvider.notifier).addMessage(message);
-      final reason = networkError != null
-          ? 'Network error'
-          : 'Server returned ${response!.statusCode}';
-      ToastService.show(
-        context,
-        'Failed to delete: $reason',
-        type: ToastType.error,
-      );
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Pin / Unpin
-  // ---------------------------------------------------------------------------
-
-  Future<void> _pinMessage(ChatMessage message) async {
-    final conv = widget.conversation;
-    if (conv == null) return;
-    final myUserId = ref.read(authProvider).userId ?? '';
-    final serverUrl = ref.read(serverUrlProvider);
-
-    // Optimistically update local state
-    ref
-        .read(chatProvider.notifier)
-        .updateMessagePin(conv.id, message.id, myUserId, DateTime.now());
-
-    try {
-      final response = await ref
-          .read(authProvider.notifier)
-          .authenticatedRequest(
-            (token) => http.post(
-              Uri.parse(
-                '$serverUrl/api/conversations/${conv.id}'
-                '/messages/${message.id}/pin',
-              ),
-              headers: {'Authorization': 'Bearer $token'},
-            ),
-          );
-      if (!mounted) return;
-      if (response.statusCode >= 200 && response.statusCode < 300) {
-        ToastService.show(context, 'Message pinned', type: ToastType.success);
-      } else {
-        // Revert on failure
-        ref
-            .read(chatProvider.notifier)
-            .updateMessagePin(conv.id, message.id, null, null);
-        ToastService.show(
-          context,
-          'Failed to pin message',
-          type: ToastType.error,
-        );
-      }
-    } catch (e) {
-      if (!mounted) return;
-      ref
-          .read(chatProvider.notifier)
-          .updateMessagePin(conv.id, message.id, null, null);
-      ToastService.show(
-        context,
-        'Failed to pin message',
-        type: ToastType.error,
-      );
-    }
-  }
-
-  Future<void> _unpinMessage(ChatMessage message) async {
-    final conv = widget.conversation;
-    if (conv == null) return;
-    final serverUrl = ref.read(serverUrlProvider);
-
-    // Save previous state for revert
-    final prevPinnedById = message.pinnedById;
-    final prevPinnedAt = message.pinnedAt;
-
-    // Optimistically clear pin
-    ref
-        .read(chatProvider.notifier)
-        .updateMessagePin(conv.id, message.id, null, null);
-
-    try {
-      final response = await ref
-          .read(authProvider.notifier)
-          .authenticatedRequest(
-            (token) => http.delete(
-              Uri.parse(
-                '$serverUrl/api/conversations/${conv.id}'
-                '/messages/${message.id}/pin',
-              ),
-              headers: {'Authorization': 'Bearer $token'},
-            ),
-          );
-      if (!mounted) return;
-      if (response.statusCode >= 200 && response.statusCode < 300) {
-        ToastService.show(context, 'Message unpinned', type: ToastType.success);
-      } else {
-        // Revert on failure
-        ref
-            .read(chatProvider.notifier)
-            .updateMessagePin(
-              conv.id,
-              message.id,
-              prevPinnedById,
-              prevPinnedAt,
-            );
-        ToastService.show(
-          context,
-          'Failed to unpin message',
-          type: ToastType.error,
-        );
-      }
-    } catch (e) {
-      if (!mounted) return;
-      ref
-          .read(chatProvider.notifier)
-          .updateMessagePin(conv.id, message.id, prevPinnedById, prevPinnedAt);
-      ToastService.show(
-        context,
-        'Failed to unpin message',
-        type: ToastType.error,
-      );
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Save / Unsave (local bookmarks)
-  // ---------------------------------------------------------------------------
-
-  Future<void> _saveMessage(ChatMessage message) async {
-    await SavedMessagesService.instance.bookmark(message);
-    if (!mounted) return;
-    setState(() => _savedIds.add(message.id));
-    ToastService.show(context, 'Message saved', type: ToastType.success);
-  }
-
-  Future<void> _unsaveMessage(ChatMessage message) async {
-    await SavedMessagesService.instance.unsaveMessage(message.id);
-    if (!mounted) return;
-    setState(() => _savedIds.remove(message.id));
-    ToastService.show(context, 'Bookmark removed', type: ToastType.info);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Image gallery
-  // ---------------------------------------------------------------------------
-
-  /// Collects all resolved image URLs from [messages] in order, then opens the
-  /// gallery viewer starting at the image matching [tappedUrl].
-  void _openImageGallery({
-    required String tappedUrl,
-    required List<ChatMessage> messages,
-    required String serverUrl,
-    required String authToken,
-  }) {
-    final headers = mediaHeaders(authToken: authToken);
-    final mediaTicket = ref.read(mediaTicketProvider);
-
-    // Build an ordered list of all image URLs from this message list.
-    final allUrls = <String>[];
-    for (final msg in messages) {
-      // [img:URL] marker — single image message.
-      final imgMatch = RegExp(r'^\[img:(.+)\]$').firstMatch(msg.content);
-      if (imgMatch != null) {
-        final raw = imgMatch.group(1)!;
-        allUrls.add(
-          resolveMediaUrl(
-            raw,
-            serverUrl: serverUrl,
-            authToken: authToken,
-            mediaTicket: mediaTicket,
-          ),
-        );
-        continue;
-      }
-
-      // Standalone image URL (e.g. https://…/photo.png).
-      if (isStandaloneMediaUrl(msg.content) && isImageUrl(msg.content.trim())) {
-        allUrls.add(
-          resolveMediaUrl(
-            msg.content.trim(),
-            serverUrl: serverUrl,
-            authToken: authToken,
-            mediaTicket: mediaTicket,
-          ),
-        );
-        continue;
-      }
-
-      // Embedded image URLs mixed into text.
-      for (final embUrl in extractEmbeddedImageUrls(msg.content)) {
-        allUrls.add(embUrl);
-      }
-    }
-
-    if (allUrls.isEmpty) {
-      // Fallback: show only the tapped image.
-      allUrls.add(tappedUrl);
-    }
-
-    // Find the index of the tapped URL. Use string-starts-with matching to
-    // handle minor URL differences (e.g. trailing query params differ).
-    final idx = allUrls.indexWhere(
-      (u) =>
-          u == tappedUrl || u.startsWith(tappedUrl) || tappedUrl.startsWith(u),
-    );
-
-    showImageGallery(
-      context: context,
-      imageUrls: allUrls,
-      initialIndex: idx < 0 ? 0 : idx,
-      headers: headers,
-    );
-  }
-
-  String _fullMonthName(int m) {
-    const names = [
-      '',
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ];
-    return names[m.clamp(1, 12)];
-  }
-
+  // Message-action forwarders are inlined as closures at the
+  // `ChatPanelBodyParams` call site in `build`.
   void _handleKeyboardScroll() {
     final keyboardInset = MediaQuery.of(context).viewInsets.bottom;
     if (keyboardInset != _lastKeyboardInset) {
@@ -1514,119 +506,33 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     String? selectedChannelId,
     bool includeUnchanneled,
   ) {
-    final key = '${conv.id}:${selectedChannelId ?? ""}';
-    if (_autoScrollConversationKey == key) return;
-    _autoScrollConversationKey = key;
-
-    ref.listen<ChatState>(chatProvider, (prev, next) {
-      int visibleCount(ChatState s) {
-        if (!conv.isGroup) return s.messagesForConversation(conv.id).length;
-        return s
-            .messagesForConversationChannel(
-              conv.id,
-              channelId: selectedChannelId,
-              includeUnchanneled: includeUnchanneled,
-            )
-            .length;
-      }
-
-      final prevCount = prev == null ? 0 : visibleCount(prev);
-      final nextCount = visibleCount(next);
-
-      // Attempt to capture unread boundary when messages first arrive
-      // (e.g. history loaded asynchronously after conversation opened).
-      if (prevCount == 0 && nextCount > 0 && _unreadBoundaryMessageId == null) {
-        _captureUnreadBoundary();
-        if (_unreadBoundaryMessageId != null) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            _scrollToUnreadBoundary();
-          });
-          return;
-        }
-      }
-
-      if (nextCount > prevCount) {
-        // Live-region announcement for assistive tech (#495). Skip the
-        // initial history load (prevCount == 0), own messages, system
-        // events, and duplicates of the last announced id.
-        final myUserId = ref.read(authProvider.select((s) => s.userId)) ?? '';
-        final newest = next.messagesForConversation(conv.id).lastOrNull;
-        if (newest != null &&
-            newest.id != _lastAnnouncedMessageId &&
-            newest.fromUserId != myUserId &&
-            !newest.isSystemEvent &&
-            prevCount > 0) {
-          _lastAnnouncedMessageId = newest.id;
-          final preview = previewForSemantics(newest.content);
-          setState(() {
-            _liveRegionAnnouncement = preview.isEmpty
-                ? 'New message from ${newest.fromUsername}'
-                : 'New message from ${newest.fromUsername}: $preview';
-          });
-          _liveRegionClearTimer?.cancel();
-          _liveRegionClearTimer = Timer(const Duration(seconds: 3), () {
-            if (!mounted) return;
-            setState(() => _liveRegionAnnouncement = '');
-          });
-        }
-
-        if (_isNearBottom()) {
-          _scrollToBottom(settleRetries: 3);
-        } else {
-          setState(() {
-            _hasNewMessagesBelow = true;
-            _newMessagesBelowCount += nextCount - prevCount;
-          });
-        }
-      }
-    });
+    sh.setupAutoScroll(
+      ref: ref,
+      conv: conv,
+      selectedChannelId: selectedChannelId,
+      includeUnchanneled: includeUnchanneled,
+      controller: _controller,
+      getLastAnnouncedMessageId: () => _lastAnnouncedMessageId,
+      setLastAnnouncedMessageId: (v) => _lastAnnouncedMessageId = v,
+      setLiveRegionAnnouncement: (v) => _liveRegionAnnouncement = v,
+      getLiveRegionClearTimer: () => _liveRegionClearTimer,
+      setLiveRegionClearTimer: (t) => _liveRegionClearTimer = t,
+      isNearBottom: _isNearBottom,
+      scrollToBottom: () => _scrollToBottom(settleRetries: 3),
+      onCaptureUnreadBoundary: _captureUnreadBoundary,
+      onScrollToUnreadBoundary: _scrollToUnreadBoundary,
+      setState: setState,
+      mounted: () => mounted,
+    );
   }
 
-  String _displayNameFor(Conversation conv, String myUserId) {
-    if (conv.isGroup) return conv.name ?? 'Group';
-    return conv.members
-            .where((m) => m.userId != myUserId)
-            .firstOrNull
-            ?.username ??
-        'Chat';
-  }
-
-  /// LiveKit handles remote audio playback automatically -- no hidden renderer
-  /// widgets needed (unlike the legacy P2P WebRTC approach).
-  List<Widget> _buildVoiceRenderers() => const [];
-
-  // ---------------------------------------------------------------------------
-  // Drag-and-drop file upload
-  // ---------------------------------------------------------------------------
-
-  /// Called when files are dropped onto the chat area. Forwards all dropped
-  /// files to the input bar's attachment flow, one after another.
-  Future<void> _onDropDone(DropDoneDetails details) async {
-    if (details.files.isEmpty) return;
-
-    final inputBar = _chatInputBarKey.currentState;
-    if (inputBar == null) return;
-
-    // Filter out directories before processing.
-    final items = details.files.where((f) => f is! DropItemDirectory).toList();
-    if (items.isEmpty) return;
-
-    for (final item in items) {
-      // On web, DropItem may carry bytes directly (no filesystem path).
-      Uint8List? bytes;
-      if (kIsWeb) {
-        try {
-          bytes = await item.readAsBytes();
-        } catch (_) {}
-      }
-
-      await inputBar.attachDroppedFile(
-        path: item.path,
-        fileName: item.name,
-        bytes: bytes,
-      );
-    }
-  }
+  String _displayNameFor(Conversation conv, String myUserId) => conv.isGroup
+      ? (conv.name ?? 'Group')
+      : (conv.members
+                .where((m) => m.userId != myUserId)
+                .firstOrNull
+                ?.username ??
+            'Chat');
 
   List<ChatMessage> _resolveMessages(
     Conversation conv,
@@ -1651,10 +557,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     selectedChannelId,
     includeUnchanneled,
   );
-
-  // ---------------------------------------------------------------------------
-  // Build
-  // ---------------------------------------------------------------------------
 
   @override
   Widget build(BuildContext context) {
@@ -1742,215 +644,116 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       memberAvatars[m.userId] = m.avatarUrl;
     }
 
-    final chatGradient = context.chatBgGradient;
-
-    final chatContentBox = DecoratedBox(
-      decoration: chatGradient != null
-          ? BoxDecoration(gradient: chatGradient)
-          : BoxDecoration(color: context.chatBg),
-      child: Stack(
-        children: [
-          // Hidden live region for screen-reader announcements when peer
-          // messages arrive (#495 / #630). Mounted as the first child of
-          // the outer Stack so it lives at a stable index in the build
-          // tree — Flutter won't recreate the Semantics node when the
-          // floating-date pill or new-messages-below pill toggle.
-          Semantics(
-            liveRegion: true,
-            label: _liveRegionAnnouncement,
-            child: const SizedBox.shrink(),
-          ),
-          Column(
-            children: [
-              ChatHeaderBar(
-                conversation: conv,
-                myUserId: myUserId,
-                serverUrl: serverUrl,
-                onBack: widget.onBack,
-                showSearch: _showSearch,
-                onToggleSearch: () =>
-                    setState(() => _showSearch = !_showSearch),
-                onMembersToggle: widget.onMembersToggle,
-                onGroupInfo: widget.onGroupInfo,
-                onDismissEncryptionBanner: _dismissEncryptionBanner,
-                hideEncryptionBanner: _hideEncryptionBanner,
-              ),
-
-              if (conv.isGroup)
-                ChannelBar(
-                  conversationId: conv.id,
-                  selectedTextChannelId: _selectedTextChannelId,
-                  activeVoiceChannelId: _activeVoiceChannelId,
-                  hideVoiceDock: widget.hideVoiceDock,
-                  onTextChannelChanged: _onTextChannelChanged,
-                  onVoiceChannelChanged: (channelId) {
-                    if (mounted) {
-                      setState(() => _activeVoiceChannelId = channelId);
-                    }
-                  },
-                  onShowLounge: widget.onShowLounge,
-                ),
-
-              if (_showSearch)
-                MessageSearchOverlay(
-                  conversationId: conv.id,
-                  onMessageSelected: (messageId) {
-                    setState(() => _showSearch = false);
-                    _highlightMessage(messageId);
-                  },
-                  onClose: () => setState(() => _showSearch = false),
-                ),
-
-              if (isLoadingHistory)
-                LinearProgressIndicator(
-                  minHeight: 2,
-                  color: context.accent,
-                  backgroundColor: context.surface,
-                ),
-
-              const ConnectionStatusBanner(),
-              const CryptoDegradedBanner(),
-              if (!conv.isGroup) IdentityKeyChangedBanner(conversation: conv),
-              if (!conv.isGroup)
-                Builder(
-                  builder: (ctx) {
-                    final peer = conv.members
-                        .where((m) => m.userId != myUserId)
-                        .firstOrNull;
-                    if (peer == null) return const SizedBox.shrink();
-                    return SessionCorruptedBanner(
-                      conversationId: conv.id,
-                      peerUserId: peer.userId,
-                      peerName: peer.username,
-                    );
-                  },
-                ),
-
-              Expanded(
-                child: GestureDetector(
-                  onTap: () => FocusScope.of(context).unfocus(),
-                  child: Stack(
-                    children: [
-                      ChatMessageList(
-                        conv: conv,
-                        messages: messages,
-                        memberAvatars: memberAvatars,
-                        myUserId: myUserId,
-                        serverUrl: serverUrl,
-                        authToken: authToken,
-                        mediaTicket: mediaTicket,
-                        channelId: selectedChannelId,
-                        isLoadingHistory: isLoadingHistory,
-                        hasMoreHistory: hasMoreHistory,
-                        displayName: displayName,
-                        scrollController: _scrollController,
-                        messageKeys: _messageKeys,
-                        savedIds: _savedIds,
-                        highlightedMessageId: _highlightedMessageId,
-                        unreadBoundaryMessageId: _unreadBoundaryMessageId,
-                        unreadBoundaryCount: _unreadBoundaryCount,
-                        onReactionTap: _showReactionPicker,
-                        onToggleReaction: _toggleReaction,
-                        onMoreReactions: (message) =>
-                            _showFullReactionPicker(message, myUserId),
-                        onDeleteFailed: _deleteFailed,
-                        onConfirmDelete: _confirmDelete,
-                        onRetryMessage: _retryMessage,
-                        onEnterEditMode: (msg) {
-                          _chatInputBarKey.currentState?.enterEditMode(msg);
-                        },
-                        onReply: (msg) {
-                          ref.read(chatProvider.notifier).setReplyTo(msg);
-                          _chatInputBarKey.currentState?.requestInputFocus();
-                        },
-                        onOpenThread: _openThread,
-                        onPin: _pinMessage,
-                        onUnpin: _unpinMessage,
-                        onForward: _forwardMessage,
-                        onSaveMessage: _saveMessage,
-                        onUnsaveMessage: _unsaveMessage,
-                        onJumpToReplyQuote: _jumpToReplyQuote,
-                        onAvatarTap: (userId) {
-                          UserProfileScreen.show(context, ref, userId);
-                        },
-                        onVerifyIdentity: conv.isGroup
-                            ? null
-                            : (message) {
-                                final myName =
-                                    ref.read(authProvider).username ?? 'You';
-                                SafetyNumberScreen.show(
-                                  context,
-                                  ref,
-                                  peerUserId: message.fromUserId,
-                                  peerUsername: message.fromUsername,
-                                  myUsername: myName,
-                                );
-                              },
-                        onImageTap: (resolvedUrl) => _openImageGallery(
-                          tappedUrl: resolvedUrl,
-                          messages: messages,
-                          serverUrl: serverUrl,
-                          authToken: authToken,
-                        ),
-                        isMessageSaved: (id) =>
-                            SavedMessagesService.instance.isMessageSaved(id),
-                        onSayHi: () {
-                          _chatInputBarKey.currentState?.preFillText(
-                            'Hey! \u{1F44B}',
-                          );
-                        },
-                      ),
-                      if (_floatingDate != null)
-                        FloatingDatePill(
-                          visible: _floatingDateVisible,
-                          date: _floatingDate,
-                        ),
-                      if (_hasNewMessagesBelow)
-                        NewMessagesPill(
-                          text: _newMessagesBannerText(),
-                          onTap: () => _scrollToBottom(settleRetries: 2),
-                        ),
-                      // Live region moved to the outer Stack so its index
-                      // in the tree is stable across pill toggles (#630).
-                    ],
-                  ),
-                ),
-              ),
-
-              ChatInputBar(
-                key: _chatInputBarKey,
-                conversation: conv,
-                selectedTextChannelId: _selectedTextChannelId,
-                effectiveActiveVoiceChannelId: _activeVoiceChannelId,
-                typingUsers: typingUsers,
-                onMessageSent: () {
-                  _scrollToBottom(settleRetries: 2);
-                  _markAsRead();
-                },
-                onMediaPickerChanged: () {
-                  setState(() {});
-                  // Scroll to bottom when inline picker appears/disappears
-                  // so the latest messages stay visible.
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    _scrollToBottom(settleRetries: 2);
-                  });
-                },
-              ),
-
-              ..._buildVoiceRenderers(),
-            ],
-          ),
-          // Floating emoji/GIF picker — rendered above the message list so taps
-          // aren't absorbed by the ListView's gesture recognizers.
-          if (_chatInputBarKey.currentState?.showMediaPicker ?? false)
-            Positioned(
-              bottom: 80,
-              right: 16,
-              child: _chatInputBarKey.currentState!.buildMediaPickerPanel(),
-            ),
-          // Drag-and-drop overlay
-          if (_isDragOver) DropOverlay(isDragOver: _isDragOver),
-        ],
+    final chatContentBox = buildChatContentBox(
+      context,
+      ref,
+      ChatPanelBodyParams(
+        conv: conv,
+        myUserId: myUserId,
+        authToken: authToken,
+        serverUrl: serverUrl,
+        mediaTicket: mediaTicket,
+        messages: messages,
+        memberAvatars: memberAvatars,
+        selectedTextChannelId: _selectedTextChannelId,
+        selectedChannelId: selectedChannelId,
+        activeVoiceChannelId: _activeVoiceChannelId,
+        isLoadingHistory: isLoadingHistory,
+        hasMoreHistory: hasMoreHistory,
+        displayName: displayName,
+        scrollController: _scrollController,
+        messageKeys: _messageKeys,
+        savedIds: _savedIds,
+        highlightedMessageId: _highlightedMessageId,
+        unreadBoundaryMessageId: _unreadBoundaryMessageId,
+        unreadBoundaryCount: _unreadBoundaryCount,
+        floatingDate: _floatingDate,
+        floatingDateVisible: _floatingDateVisible,
+        hasNewMessagesBelow: _hasNewMessagesBelow,
+        newMessagesBannerText: _newMessagesBannerText(),
+        liveRegionAnnouncement: _liveRegionAnnouncement,
+        showSearch: _showSearch,
+        hideVoiceDock: widget.hideVoiceDock,
+        hideEncryptionBanner: _hideEncryptionBanner,
+        typingUsers: typingUsers,
+        isDragOver: _isDragOver,
+        chatInputBarKey: _chatInputBarKey,
+        onBack: widget.onBack,
+        onMembersToggle: widget.onMembersToggle,
+        onGroupInfo: widget.onGroupInfo,
+        onShowLounge: widget.onShowLounge,
+        onTextChannelChanged: _onTextChannelChanged,
+        onVoiceChannelChanged: (channelId) {
+          if (mounted) setState(() => _activeVoiceChannelId = channelId);
+        },
+        onSetShowSearch: (v) => setState(() => _showSearch = v),
+        onDismissEncryptionBanner: _dismissEncryptionBanner,
+        onHighlightMessage: _highlightMessage,
+        onShowReactionPicker: _showReactionPicker,
+        onToggleReaction: _toggleReaction,
+        onShowFullReactionPicker: (msg) =>
+            _showFullReactionPicker(msg, myUserId),
+        onDeleteFailed: (msg) =>
+            actions.deleteFailed(ref: ref, conv: conv, message: msg),
+        onConfirmDelete: (msg) => actions.confirmDelete(
+          context: context,
+          ref: ref,
+          conv: conv,
+          message: msg,
+          addToDeletedForMe: DeletedForMeStorage.add,
+        ),
+        onRetryMessage: (msg) =>
+            actions.retryMessage(ref: ref, conv: conv, message: msg),
+        onOpenThread: _openThread,
+        onPinMessage: (msg) => actions.pinMessage(
+          context: context,
+          ref: ref,
+          conv: conv,
+          message: msg,
+        ),
+        onUnpinMessage: (msg) => actions.unpinMessage(
+          context: context,
+          ref: ref,
+          conv: conv,
+          message: msg,
+        ),
+        onForwardMessage: (msg) =>
+            actions.forwardMessage(context: context, ref: ref, message: msg),
+        onSaveMessage: (msg) => actions.saveMessage(
+          context: context,
+          message: msg,
+          onAddSavedId: (id) => setState(() => _savedIds.add(id)),
+        ),
+        onUnsaveMessage: (msg) => actions.unsaveMessage(
+          context: context,
+          message: msg,
+          onRemoveSavedId: (id) => setState(() => _savedIds.remove(id)),
+        ),
+        onJumpToReplyQuote: _jumpToReplyQuote,
+        onOpenImageGallery: (resolvedUrl) => actions.openImageGallery(
+          context: context,
+          ref: ref,
+          tappedUrl: resolvedUrl,
+          messages: messages,
+          serverUrl: serverUrl,
+          authToken: authToken,
+        ),
+        onScrollToBottom: () => _scrollToBottom(settleRetries: 2),
+        onMessageSent: () {
+          _scrollToBottom(settleRetries: 2);
+          _markAsRead();
+        },
+        onMediaPickerChanged: () {
+          setState(() {});
+          // Scroll to bottom when inline picker appears/disappears
+          // so the latest messages stay visible.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _scrollToBottom(settleRetries: 2);
+          });
+        },
+        // LiveKit handles remote audio playback automatically (#prod-2026-05-08
+        // legacy P2P WebRTC migration); no hidden renderer widgets needed.
+        voiceRenderers: const [],
       ),
     );
 
@@ -1976,27 +779,21 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       chatContent = chatContentBox;
     }
 
-    // Wrap in DropTarget on desktop and web only. Mobile platforms don't
-    // support external file drag-and-drop, so skip to avoid unnecessary
-    // platform channel setup.
+    // DropTarget on desktop + web only — mobile has no external drag-drop.
     final dropSupported =
         kIsWeb ||
         defaultTargetPlatform == TargetPlatform.linux ||
         defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.windows;
-
     if (!dropSupported) return chatContent;
-
     return DropTarget(
       onDragEntered: (_) => setState(() => _isDragOver = true),
       onDragExited: (_) => setState(() => _isDragOver = false),
-      onDragDone: (details) {
+      onDragDone: (d) {
         setState(() => _isDragOver = false);
-        _onDropDone(details);
+        onChatPanelDropDone(d, _chatInputBarKey.currentState);
       },
       child: chatContent,
     );
   }
 }
-
-enum _DeleteChoice { forMe, forEveryone }

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/chat_message.dart';
+import '../../models/conversation.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/chat_provider.dart';
+import '../../screens/safety_number_screen.dart';
+import '../../screens/user_profile_screen.dart';
+import '../../services/saved_messages_service.dart';
+import '../../theme/echo_theme.dart';
+import '../channel_bar.dart';
+import '../chat/session_corrupted_banner.dart';
+import '../chat_header_bar.dart';
+import '../chat_input_bar.dart';
+import '../connection_status_banner.dart';
+import '../crypto_degraded_banner.dart';
+import '../identity_key_changed_banner.dart';
+import '../message_search_overlay.dart';
+import 'chat_message_list.dart';
+import 'drop_overlay.dart';
+import 'floating_date_pill.dart';
+import 'new_messages_pill.dart';
+
+/// Build the inner `chatContentBox` Stack for `ChatPanel.build` — the
+/// header bar, channel bar, banners, message list, floating pills, input
+/// bar, and overlay layers. Extracted to a helper to shrink
+/// `_ChatPanelState.build` below the 800-LOC budget (#512 slice 6).
+///
+/// All Riverpod listening stays in the calling `build` method; this helper
+/// receives already-resolved values + callbacks.
+class ChatPanelBodyParams {
+  ChatPanelBodyParams({
+    required this.conv,
+    required this.myUserId,
+    required this.authToken,
+    required this.serverUrl,
+    required this.mediaTicket,
+    required this.messages,
+    required this.memberAvatars,
+    required this.selectedTextChannelId,
+    required this.selectedChannelId,
+    required this.activeVoiceChannelId,
+    required this.isLoadingHistory,
+    required this.hasMoreHistory,
+    required this.displayName,
+    required this.scrollController,
+    required this.messageKeys,
+    required this.savedIds,
+    required this.highlightedMessageId,
+    required this.unreadBoundaryMessageId,
+    required this.unreadBoundaryCount,
+    required this.floatingDate,
+    required this.floatingDateVisible,
+    required this.hasNewMessagesBelow,
+    required this.newMessagesBannerText,
+    required this.liveRegionAnnouncement,
+    required this.showSearch,
+    required this.hideVoiceDock,
+    required this.hideEncryptionBanner,
+    required this.typingUsers,
+    required this.isDragOver,
+    required this.chatInputBarKey,
+    required this.onBack,
+    required this.onMembersToggle,
+    required this.onGroupInfo,
+    required this.onShowLounge,
+    required this.onTextChannelChanged,
+    required this.onVoiceChannelChanged,
+    required this.onSetShowSearch,
+    required this.onDismissEncryptionBanner,
+    required this.onHighlightMessage,
+    required this.onShowReactionPicker,
+    required this.onToggleReaction,
+    required this.onShowFullReactionPicker,
+    required this.onDeleteFailed,
+    required this.onConfirmDelete,
+    required this.onRetryMessage,
+    required this.onOpenThread,
+    required this.onPinMessage,
+    required this.onUnpinMessage,
+    required this.onForwardMessage,
+    required this.onSaveMessage,
+    required this.onUnsaveMessage,
+    required this.onJumpToReplyQuote,
+    required this.onOpenImageGallery,
+    required this.onScrollToBottom,
+    required this.onMessageSent,
+    required this.onMediaPickerChanged,
+    required this.voiceRenderers,
+  });
+
+  final Conversation conv;
+  final String myUserId;
+  final String authToken;
+  final String serverUrl;
+  final String? mediaTicket;
+  final List<ChatMessage> messages;
+  final Map<String, String?> memberAvatars;
+  final String? selectedTextChannelId;
+  final String? selectedChannelId;
+  final String? activeVoiceChannelId;
+  final bool isLoadingHistory;
+  final bool hasMoreHistory;
+  final String displayName;
+  final ScrollController scrollController;
+  final Map<String, GlobalKey> messageKeys;
+  final Set<String> savedIds;
+  final String? highlightedMessageId;
+  final String? unreadBoundaryMessageId;
+  final int unreadBoundaryCount;
+  final String? floatingDate;
+  final bool floatingDateVisible;
+  final bool hasNewMessagesBelow;
+  final String newMessagesBannerText;
+  final String liveRegionAnnouncement;
+  final bool showSearch;
+  final bool hideVoiceDock;
+  final bool hideEncryptionBanner;
+  final List<String> typingUsers;
+  final bool isDragOver;
+  final GlobalKey<ChatInputBarState> chatInputBarKey;
+  final VoidCallback? onBack;
+  final VoidCallback? onMembersToggle;
+  final VoidCallback? onGroupInfo;
+  final VoidCallback? onShowLounge;
+  final ValueChanged<String?> onTextChannelChanged;
+  final ValueChanged<String?> onVoiceChannelChanged;
+  final ValueChanged<bool> onSetShowSearch;
+  final VoidCallback onDismissEncryptionBanner;
+  final ValueChanged<String> onHighlightMessage;
+  final void Function(ChatMessage, Offset) onShowReactionPicker;
+  final void Function(ChatMessage, String, bool) onToggleReaction;
+  final void Function(ChatMessage) onShowFullReactionPicker;
+  final ValueChanged<ChatMessage> onDeleteFailed;
+  final ValueChanged<ChatMessage> onConfirmDelete;
+  final ValueChanged<ChatMessage> onRetryMessage;
+  final ValueChanged<ChatMessage> onOpenThread;
+  final ValueChanged<ChatMessage> onPinMessage;
+  final ValueChanged<ChatMessage> onUnpinMessage;
+  final ValueChanged<ChatMessage> onForwardMessage;
+  final ValueChanged<ChatMessage> onSaveMessage;
+  final ValueChanged<ChatMessage> onUnsaveMessage;
+  final ValueChanged<String> onJumpToReplyQuote;
+  final ValueChanged<String> onOpenImageGallery;
+  final VoidCallback onScrollToBottom;
+  final VoidCallback onMessageSent;
+  final VoidCallback onMediaPickerChanged;
+  final List<Widget> voiceRenderers;
+}
+
+Widget buildChatContentBox(
+  BuildContext context,
+  WidgetRef ref,
+  ChatPanelBodyParams p,
+) {
+  final chatGradient = context.chatBgGradient;
+  return DecoratedBox(
+    decoration: chatGradient != null
+        ? BoxDecoration(gradient: chatGradient)
+        : BoxDecoration(color: context.chatBg),
+    child: Stack(
+      children: [
+        // Hidden live region for screen-reader announcements when peer
+        // messages arrive (#495 / #630). Mounted as the first child of
+        // the outer Stack so it lives at a stable index in the build
+        // tree — Flutter won't recreate the Semantics node when the
+        // floating-date pill or new-messages-below pill toggle.
+        Semantics(
+          liveRegion: true,
+          label: p.liveRegionAnnouncement,
+          child: const SizedBox.shrink(),
+        ),
+        Column(
+          children: [
+            ChatHeaderBar(
+              conversation: p.conv,
+              myUserId: p.myUserId,
+              serverUrl: p.serverUrl,
+              onBack: p.onBack,
+              showSearch: p.showSearch,
+              onToggleSearch: () => p.onSetShowSearch(!p.showSearch),
+              onMembersToggle: p.onMembersToggle,
+              onGroupInfo: p.onGroupInfo,
+              onDismissEncryptionBanner: p.onDismissEncryptionBanner,
+              hideEncryptionBanner: p.hideEncryptionBanner,
+            ),
+            if (p.conv.isGroup)
+              ChannelBar(
+                conversationId: p.conv.id,
+                selectedTextChannelId: p.selectedTextChannelId,
+                activeVoiceChannelId: p.activeVoiceChannelId,
+                hideVoiceDock: p.hideVoiceDock,
+                onTextChannelChanged: p.onTextChannelChanged,
+                onVoiceChannelChanged: p.onVoiceChannelChanged,
+                onShowLounge: p.onShowLounge,
+              ),
+            if (p.showSearch)
+              MessageSearchOverlay(
+                conversationId: p.conv.id,
+                onMessageSelected: (messageId) {
+                  p.onSetShowSearch(false);
+                  p.onHighlightMessage(messageId);
+                },
+                onClose: () => p.onSetShowSearch(false),
+              ),
+            if (p.isLoadingHistory)
+              LinearProgressIndicator(
+                minHeight: 2,
+                color: context.accent,
+                backgroundColor: context.surface,
+              ),
+            const ConnectionStatusBanner(),
+            const CryptoDegradedBanner(),
+            if (!p.conv.isGroup) IdentityKeyChangedBanner(conversation: p.conv),
+            if (!p.conv.isGroup)
+              Builder(
+                builder: (ctx) {
+                  final peer = p.conv.members
+                      .where((m) => m.userId != p.myUserId)
+                      .firstOrNull;
+                  if (peer == null) return const SizedBox.shrink();
+                  return SessionCorruptedBanner(
+                    conversationId: p.conv.id,
+                    peerUserId: peer.userId,
+                    peerName: peer.username,
+                  );
+                },
+              ),
+            Expanded(
+              child: GestureDetector(
+                onTap: () => FocusScope.of(context).unfocus(),
+                child: Stack(
+                  children: [
+                    ChatMessageList(
+                      conv: p.conv,
+                      messages: p.messages,
+                      memberAvatars: p.memberAvatars,
+                      myUserId: p.myUserId,
+                      serverUrl: p.serverUrl,
+                      authToken: p.authToken,
+                      mediaTicket: p.mediaTicket,
+                      channelId: p.selectedChannelId,
+                      isLoadingHistory: p.isLoadingHistory,
+                      hasMoreHistory: p.hasMoreHistory,
+                      displayName: p.displayName,
+                      scrollController: p.scrollController,
+                      messageKeys: p.messageKeys,
+                      savedIds: p.savedIds,
+                      highlightedMessageId: p.highlightedMessageId,
+                      unreadBoundaryMessageId: p.unreadBoundaryMessageId,
+                      unreadBoundaryCount: p.unreadBoundaryCount,
+                      onReactionTap: p.onShowReactionPicker,
+                      onToggleReaction: p.onToggleReaction,
+                      onMoreReactions: p.onShowFullReactionPicker,
+                      onDeleteFailed: p.onDeleteFailed,
+                      onConfirmDelete: p.onConfirmDelete,
+                      onRetryMessage: p.onRetryMessage,
+                      onEnterEditMode: (msg) {
+                        p.chatInputBarKey.currentState?.enterEditMode(msg);
+                      },
+                      onReply: (msg) {
+                        ref.read(chatProvider.notifier).setReplyTo(msg);
+                        p.chatInputBarKey.currentState?.requestInputFocus();
+                      },
+                      onOpenThread: p.onOpenThread,
+                      onPin: p.onPinMessage,
+                      onUnpin: p.onUnpinMessage,
+                      onForward: p.onForwardMessage,
+                      onSaveMessage: p.onSaveMessage,
+                      onUnsaveMessage: p.onUnsaveMessage,
+                      onJumpToReplyQuote: p.onJumpToReplyQuote,
+                      onAvatarTap: (userId) {
+                        UserProfileScreen.show(context, ref, userId);
+                      },
+                      onVerifyIdentity: p.conv.isGroup
+                          ? null
+                          : (message) {
+                              final myName =
+                                  ref.read(authProvider).username ?? 'You';
+                              SafetyNumberScreen.show(
+                                context,
+                                ref,
+                                peerUserId: message.fromUserId,
+                                peerUsername: message.fromUsername,
+                                myUsername: myName,
+                              );
+                            },
+                      onImageTap: p.onOpenImageGallery,
+                      isMessageSaved: (id) =>
+                          SavedMessagesService.instance.isMessageSaved(id),
+                      onSayHi: () {
+                        p.chatInputBarKey.currentState?.preFillText(
+                          'Hey! \u{1F44B}',
+                        );
+                      },
+                    ),
+                    if (p.floatingDate != null)
+                      FloatingDatePill(
+                        visible: p.floatingDateVisible,
+                        date: p.floatingDate,
+                      ),
+                    if (p.hasNewMessagesBelow)
+                      NewMessagesPill(
+                        text: p.newMessagesBannerText,
+                        onTap: p.onScrollToBottom,
+                      ),
+                    // Live region moved to the outer Stack so its index
+                    // in the tree is stable across pill toggles (#630).
+                  ],
+                ),
+              ),
+            ),
+            ChatInputBar(
+              key: p.chatInputBarKey,
+              conversation: p.conv,
+              selectedTextChannelId: p.selectedTextChannelId,
+              effectiveActiveVoiceChannelId: p.activeVoiceChannelId,
+              typingUsers: p.typingUsers,
+              onMessageSent: p.onMessageSent,
+              onMediaPickerChanged: p.onMediaPickerChanged,
+            ),
+            ...p.voiceRenderers,
+          ],
+        ),
+        // Floating emoji/GIF picker — rendered above the message list so taps
+        // aren't absorbed by the ListView's gesture recognizers.
+        if (p.chatInputBarKey.currentState?.showMediaPicker ?? false)
+          Positioned(
+            bottom: 80,
+            right: 16,
+            child: p.chatInputBarKey.currentState!.buildMediaPickerPanel(),
+          ),
+        // Drag-and-drop overlay
+        if (p.isDragOver) DropOverlay(isDragOver: p.isDragOver),
+      ],
+    ),
+  );
+}

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -84,7 +84,6 @@ class ChatPanelBodyParams {
     required this.onScrollToBottom,
     required this.onMessageSent,
     required this.onMediaPickerChanged,
-    required this.voiceRenderers,
   });
 
   final Conversation conv;
@@ -143,7 +142,6 @@ class ChatPanelBodyParams {
   final VoidCallback onScrollToBottom;
   final VoidCallback onMessageSent;
   final VoidCallback onMediaPickerChanged;
-  final List<Widget> voiceRenderers;
 }
 
 Widget buildChatContentBox(
@@ -317,7 +315,6 @@ Widget buildChatContentBox(
               onMessageSent: p.onMessageSent,
               onMediaPickerChanged: p.onMediaPickerChanged,
             ),
-            ...p.voiceRenderers,
           ],
         ),
         // Floating emoji/GIF picker — rendered above the message list so taps

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -24,11 +24,8 @@ import 'new_messages_pill.dart';
 
 /// Build the inner `chatContentBox` Stack for `ChatPanel.build` — the
 /// header bar, channel bar, banners, message list, floating pills, input
-/// bar, and overlay layers. Extracted to a helper to shrink
-/// `_ChatPanelState.build` below the 800-LOC budget (#512 slice 6).
-///
-/// All Riverpod listening stays in the calling `build` method; this helper
-/// receives already-resolved values + callbacks.
+/// bar, and overlay layers. All Riverpod listening stays in the calling
+/// `build` method; this helper receives already-resolved values + callbacks.
 class ChatPanelBodyParams {
   ChatPanelBodyParams({
     required this.conv,

--- a/apps/client/lib/src/widgets/chat_panel/deleted_for_me_storage.dart
+++ b/apps/client/lib/src/widgets/chat_panel/deleted_for_me_storage.dart
@@ -1,0 +1,54 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persistent blocklist of message IDs deleted via "delete for me".
+/// Survives app restarts so messages don't reappear on history reload.
+///
+/// Extracted from `_ChatPanelState` static helpers (#512 slice 6). The
+/// blocklist lives on this class as a process-wide singleton because each
+/// `_ChatPanelState` instance shares the same set — the previous
+/// `static Set<String>` lived on the class for the same reason.
+class DeletedForMeStorage {
+  DeletedForMeStorage._();
+
+  static const _key = 'deleted_for_me_ids';
+  static Set<String> ids = {};
+  static bool _loaded = false;
+
+  /// Lazy-load the persisted set on first read. Cheap to call repeatedly.
+  static Future<void> ensureLoaded() async {
+    if (_loaded) return;
+    _loaded = true;
+    final prefs = await SharedPreferences.getInstance();
+    ids = (prefs.getStringList(_key) ?? []).toSet();
+  }
+
+  /// Add [messageId] to the set and persist.
+  static Future<void> add(String messageId) async {
+    ids.add(messageId);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, ids.toList());
+  }
+}
+
+/// Persistent set of conversation IDs the user dismissed the encryption
+/// banner on. Mirrors [DeletedForMeStorage] semantics.
+class DismissedBannersStorage {
+  DismissedBannersStorage._();
+
+  static const _key = 'dismissed_encryption_banners';
+  static Set<String> ids = {};
+  static bool _loaded = false;
+
+  static Future<void> ensureLoaded() async {
+    if (_loaded) return;
+    _loaded = true;
+    final prefs = await SharedPreferences.getInstance();
+    ids = (prefs.getStringList(_key) ?? []).toSet();
+  }
+
+  static Future<void> add(String conversationId) async {
+    ids.add(conversationId);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, ids.toList());
+  }
+}

--- a/apps/client/lib/src/widgets/chat_panel/deleted_for_me_storage.dart
+++ b/apps/client/lib/src/widgets/chat_panel/deleted_for_me_storage.dart
@@ -2,11 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// Persistent blocklist of message IDs deleted via "delete for me".
 /// Survives app restarts so messages don't reappear on history reload.
-///
-/// Extracted from `_ChatPanelState` static helpers (#512 slice 6). The
-/// blocklist lives on this class as a process-wide singleton because each
-/// `_ChatPanelState` instance shares the same set — the previous
-/// `static Set<String>` lived on the class for the same reason.
+/// Process-wide singleton: every `_ChatPanelState` instance shares one set.
 class DeletedForMeStorage {
   DeletedForMeStorage._();
 

--- a/apps/client/lib/src/widgets/chat_panel/drop_handler.dart
+++ b/apps/client/lib/src/widgets/chat_panel/drop_handler.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+import '../chat_input_bar.dart';
+
+/// Forwards files dropped onto the chat area into the input bar's
+/// attachment flow, one at a time. Extracted from
+/// `_ChatPanelState._onDropDone` (#512 slice 6).
+Future<void> onChatPanelDropDone(
+  DropDoneDetails details,
+  ChatInputBarState? inputBar,
+) async {
+  if (details.files.isEmpty || inputBar == null) return;
+
+  // Filter out directories before processing.
+  final items = details.files.where((f) => f is! DropItemDirectory).toList();
+  if (items.isEmpty) return;
+
+  for (final item in items) {
+    // On web, DropItem may carry bytes directly (no filesystem path).
+    Uint8List? bytes;
+    if (kIsWeb) {
+      try {
+        bytes = await item.readAsBytes();
+      } catch (_) {}
+    }
+
+    await inputBar.attachDroppedFile(
+      path: item.path,
+      fileName: item.name,
+      bytes: bytes,
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/chat_panel/drop_handler.dart
+++ b/apps/client/lib/src/widgets/chat_panel/drop_handler.dart
@@ -6,8 +6,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import '../chat_input_bar.dart';
 
 /// Forwards files dropped onto the chat area into the input bar's
-/// attachment flow, one at a time. Extracted from
-/// `_ChatPanelState._onDropDone` (#512 slice 6).
+/// attachment flow, one at a time.
 Future<void> onChatPanelDropDone(
   DropDoneDetails details,
   ChatInputBarState? inputBar,

--- a/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
+++ b/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
@@ -10,13 +10,8 @@ import '../../providers/crypto_provider.dart';
 import '../../services/toast_service.dart';
 import '../chat_panel_controller.dart';
 
-/// History-loading helpers extracted from `_ChatPanelState` (#512 slice 6).
-///
-/// These mirror the original Riverpod-driven `_loadHistory`,
-/// `_loadOlderMessages`, `_jumpToReplyQuote`, and `_loadChannels` methods
-/// bit-for-bit. The `#prod-2026-05-08` pagination cursor rationale lives on
-/// [ChatPanelController.paginationCursor]; the comment threads through
-/// both pagination sites.
+/// `#prod-2026-05-08` pagination cursor rationale lives on
+/// [ChatPanelController.paginationCursor].
 
 Future<void> loadHistory({
   required WidgetRef ref,

--- a/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
+++ b/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
@@ -13,45 +13,72 @@ import '../chat_panel_controller.dart';
 /// `#prod-2026-05-08` pagination cursor rationale lives on
 /// [ChatPanelController.paginationCursor].
 
-Future<void> loadHistory({
-  required WidgetRef ref,
-  required Conversation conv,
-  required String? selectedTextChannelId,
-}) async {
-  final auth = ref.read(authProvider);
-  if (auth.token == null || auth.userId == null) return;
+/// Auth + crypto bundle resolved for a single history call. Returns `null`
+/// when the user isn't authenticated; otherwise [groupCrypto] is populated
+/// for group convs and [crypto] for 1:1 DMs (when crypto is initialized).
+/// Both [setToken] calls are made before the bundle is returned.
+class _HistoryAuth {
+  _HistoryAuth({
+    required this.token,
+    required this.userId,
+    required this.crypto,
+    required this.groupCrypto,
+  });
+  final String token;
+  final String userId;
+  final dynamic crypto;
+  final dynamic groupCrypto;
+}
 
-  // Load cached messages first for instant display
-  ref.read(chatProvider.notifier).loadFromCache(conv.id, auth.userId!);
+_HistoryAuth? _resolveAuth(WidgetRef ref, Conversation conv) {
+  final auth = ref.read(authProvider);
+  final token = auth.token;
+  final userId = auth.userId;
+  if (token == null || userId == null) return null;
 
   final groupCrypto = conv.isGroup
       ? ref.read(groupCryptoServiceProvider)
       : null;
-  if (groupCrypto != null) {
-    groupCrypto.setToken(auth.token!);
-  }
+  groupCrypto?.setToken(token);
 
   // For 1:1 DMs, pass the crypto service so encrypted messages can be
-  // decrypted. Without this, _decryptIfNeeded sees crypto==null and
+  // decrypted. Without this, `_decryptIfNeeded` sees crypto==null and
   // shows "[Encrypted history]" instead of the actual message content.
   final cryptoState = ref.read(cryptoProvider);
   final crypto = (!conv.isGroup && cryptoState.isInitialized)
       ? ref.read(cryptoServiceProvider)
       : null;
-  if (crypto != null) {
-    crypto.setToken(auth.token!);
-  }
+  crypto?.setToken(token);
+
+  return _HistoryAuth(
+    token: token,
+    userId: userId,
+    crypto: crypto,
+    groupCrypto: groupCrypto,
+  );
+}
+
+Future<void> loadHistory({
+  required WidgetRef ref,
+  required Conversation conv,
+  required String? selectedTextChannelId,
+}) async {
+  final a = _resolveAuth(ref, conv);
+  if (a == null) return;
+
+  // Load cached messages first for instant display
+  ref.read(chatProvider.notifier).loadFromCache(conv.id, a.userId);
 
   await ref
       .read(chatProvider.notifier)
       .loadHistoryWithUserId(
         conv.id,
-        auth.token!,
-        auth.userId!,
+        a.token,
+        a.userId,
         channelId: selectedTextChannelId,
-        crypto: crypto,
+        crypto: a.crypto,
         isGroup: conv.isGroup,
-        groupCrypto: groupCrypto,
+        groupCrypto: a.groupCrypto,
       );
 }
 
@@ -92,36 +119,20 @@ void loadOlderMessages({
   // cursor — see `ChatPanelController.paginationCursor` for the
   // `#prod-2026-05-08` rationale.
   final oldestTimestamp = controller.paginationCursor(messages).timestamp;
-  final auth = ref.read(authProvider);
-  if (auth.token == null || auth.userId == null) return;
-
-  final groupCryptoOlder = conv.isGroup
-      ? ref.read(groupCryptoServiceProvider)
-      : null;
-  if (groupCryptoOlder != null) {
-    groupCryptoOlder.setToken(auth.token!);
-  }
-
-  // Pass crypto for 1:1 DM decryption (same as loadHistory)
-  final cryptoStateOlder = ref.read(cryptoProvider);
-  final cryptoOlder = (!conv.isGroup && cryptoStateOlder.isInitialized)
-      ? ref.read(cryptoServiceProvider)
-      : null;
-  if (cryptoOlder != null) {
-    cryptoOlder.setToken(auth.token!);
-  }
+  final a = _resolveAuth(ref, conv);
+  if (a == null) return;
 
   ref
       .read(chatProvider.notifier)
       .loadHistoryWithUserId(
         conv.id,
-        auth.token!,
-        auth.userId!,
+        a.token,
+        a.userId,
         channelId: selectedTextChannelId,
         before: oldestTimestamp,
-        crypto: cryptoOlder,
+        crypto: a.crypto,
         isGroup: conv.isGroup,
-        groupCrypto: groupCryptoOlder,
+        groupCrypto: a.groupCrypto,
       );
 }
 
@@ -160,19 +171,8 @@ Future<void> jumpToReplyQuote({
   // Slow path: paginate older history until the target appears or
   // `hasMore` flips to false.  Cap to 30 rounds (~1500 msgs at 50/round)
   // so a stale or removed parent can't spin forever.
-  final auth = ref.read(authProvider);
-  if (auth.token == null || auth.userId == null) return;
-
-  final groupCrypto = conv.isGroup
-      ? ref.read(groupCryptoServiceProvider)
-      : null;
-  groupCrypto?.setToken(auth.token!);
-
-  final cryptoState = ref.read(cryptoProvider);
-  final crypto = (!conv.isGroup && cryptoState.isInitialized)
-      ? ref.read(cryptoServiceProvider)
-      : null;
-  crypto?.setToken(auth.token!);
+  final a = _resolveAuth(ref, conv);
+  if (a == null) return;
 
   for (var round = 0; round < 30; round++) {
     if (!mounted()) return;
@@ -196,13 +196,13 @@ Future<void> jumpToReplyQuote({
         .read(chatProvider.notifier)
         .loadHistoryWithUserId(
           conv.id,
-          auth.token!,
-          auth.userId!,
+          a.token,
+          a.userId,
           channelId: selectedTextChannelId,
           before: cursor.timestamp,
-          crypto: crypto,
+          crypto: a.crypto,
           isGroup: conv.isGroup,
-          groupCrypto: groupCrypto,
+          groupCrypto: a.groupCrypto,
         );
     if (!mounted()) return;
     if (isLoaded()) {

--- a/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
+++ b/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/chat_message.dart';
+import '../../models/conversation.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/channels_provider.dart';
+import '../../providers/chat_provider.dart';
+import '../../providers/crypto_provider.dart';
+import '../../services/toast_service.dart';
+import '../chat_panel_controller.dart';
+
+/// History-loading helpers extracted from `_ChatPanelState` (#512 slice 6).
+///
+/// These mirror the original Riverpod-driven `_loadHistory`,
+/// `_loadOlderMessages`, `_jumpToReplyQuote`, and `_loadChannels` methods
+/// bit-for-bit. The `#prod-2026-05-08` pagination cursor rationale lives on
+/// [ChatPanelController.paginationCursor]; the comment threads through
+/// both pagination sites.
+
+Future<void> loadHistory({
+  required WidgetRef ref,
+  required Conversation conv,
+  required String? selectedTextChannelId,
+}) async {
+  final auth = ref.read(authProvider);
+  if (auth.token == null || auth.userId == null) return;
+
+  // Load cached messages first for instant display
+  ref.read(chatProvider.notifier).loadFromCache(conv.id, auth.userId!);
+
+  final groupCrypto = conv.isGroup
+      ? ref.read(groupCryptoServiceProvider)
+      : null;
+  if (groupCrypto != null) {
+    groupCrypto.setToken(auth.token!);
+  }
+
+  // For 1:1 DMs, pass the crypto service so encrypted messages can be
+  // decrypted. Without this, _decryptIfNeeded sees crypto==null and
+  // shows "[Encrypted history]" instead of the actual message content.
+  final cryptoState = ref.read(cryptoProvider);
+  final crypto = (!conv.isGroup && cryptoState.isInitialized)
+      ? ref.read(cryptoServiceProvider)
+      : null;
+  if (crypto != null) {
+    crypto.setToken(auth.token!);
+  }
+
+  await ref
+      .read(chatProvider.notifier)
+      .loadHistoryWithUserId(
+        conv.id,
+        auth.token!,
+        auth.userId!,
+        channelId: selectedTextChannelId,
+        crypto: crypto,
+        isGroup: conv.isGroup,
+        groupCrypto: groupCrypto,
+      );
+}
+
+void loadChannels({required WidgetRef ref, required Conversation conv}) {
+  ref.read(channelsProvider.notifier).loadChannels(conv.id);
+}
+
+void loadOlderMessages({
+  required WidgetRef ref,
+  required Conversation conv,
+  required String? selectedTextChannelId,
+  required ChatPanelController controller,
+}) {
+  final chatState = ref.read(chatProvider);
+  // Use the channel-aware helpers — the underlying maps key by
+  // `conversationId:channelId` (or `conversationId:` for the unchanneled
+  // group root), so a raw lookup by `conv.id` always missed in
+  // channelized groups, hiding active history loads and triggering
+  // duplicate paginate requests (#510).
+  if (chatState.isLoadingHistory(conv.id, channelId: selectedTextChannelId) ||
+      !chatState.conversationHasMore(
+        conv.id,
+        channelId: selectedTextChannelId,
+      )) {
+    return;
+  }
+
+  final messages = conv.isGroup
+      ? chatState.messagesForConversationChannel(
+          conv.id,
+          channelId: selectedTextChannelId,
+          includeUnchanneled: selectedTextChannelId == null,
+        )
+      : chatState.messagesForConversation(conv.id);
+  if (messages.isEmpty) return;
+
+  // Use the oldest channel-scoped non-system message as the pagination
+  // cursor — see `ChatPanelController.paginationCursor` for the
+  // `#prod-2026-05-08` rationale.
+  final oldestTimestamp = controller.paginationCursor(messages).timestamp;
+  final auth = ref.read(authProvider);
+  if (auth.token == null || auth.userId == null) return;
+
+  final groupCryptoOlder = conv.isGroup
+      ? ref.read(groupCryptoServiceProvider)
+      : null;
+  if (groupCryptoOlder != null) {
+    groupCryptoOlder.setToken(auth.token!);
+  }
+
+  // Pass crypto for 1:1 DM decryption (same as loadHistory)
+  final cryptoStateOlder = ref.read(cryptoProvider);
+  final cryptoOlder = (!conv.isGroup && cryptoStateOlder.isInitialized)
+      ? ref.read(cryptoServiceProvider)
+      : null;
+  if (cryptoOlder != null) {
+    cryptoOlder.setToken(auth.token!);
+  }
+
+  ref
+      .read(chatProvider.notifier)
+      .loadHistoryWithUserId(
+        conv.id,
+        auth.token!,
+        auth.userId!,
+        channelId: selectedTextChannelId,
+        before: oldestTimestamp,
+        crypto: cryptoOlder,
+        isGroup: conv.isGroup,
+        groupCrypto: groupCryptoOlder,
+      );
+}
+
+Future<void> jumpToReplyQuote({
+  required BuildContext context,
+  required WidgetRef ref,
+  required Conversation conv,
+  required String? selectedTextChannelId,
+  required ChatPanelController controller,
+  required String replyToId,
+  required List<ChatMessage> Function(Conversation, ChatState, String?, bool)
+  resolveMessages,
+  required bool Function() mounted,
+  required VoidCallback onHighlight,
+}) async {
+  final selectedChannelId = conv.isGroup ? selectedTextChannelId : null;
+  final includeUnchanneled = conv.isGroup && selectedTextChannelId == null;
+
+  bool isLoaded() {
+    final state = ref.read(chatProvider);
+    final loaded = resolveMessages(
+      conv,
+      state,
+      selectedChannelId,
+      includeUnchanneled,
+    );
+    return loaded.indexWhere((m) => m.id == replyToId) >= 0;
+  }
+
+  // Fast path: already in memory.
+  if (isLoaded()) {
+    onHighlight();
+    return;
+  }
+
+  // Slow path: paginate older history until the target appears or
+  // `hasMore` flips to false.  Cap to 30 rounds (~1500 msgs at 50/round)
+  // so a stale or removed parent can't spin forever.
+  final auth = ref.read(authProvider);
+  if (auth.token == null || auth.userId == null) return;
+
+  final groupCrypto = conv.isGroup
+      ? ref.read(groupCryptoServiceProvider)
+      : null;
+  groupCrypto?.setToken(auth.token!);
+
+  final cryptoState = ref.read(cryptoProvider);
+  final crypto = (!conv.isGroup && cryptoState.isInitialized)
+      ? ref.read(cryptoServiceProvider)
+      : null;
+  crypto?.setToken(auth.token!);
+
+  for (var round = 0; round < 30; round++) {
+    if (!mounted()) return;
+    final state = ref.read(chatProvider);
+    if (!state.conversationHasMore(conv.id, channelId: selectedTextChannelId)) {
+      break;
+    }
+    final loaded = resolveMessages(
+      conv,
+      state,
+      selectedChannelId,
+      includeUnchanneled,
+    );
+    if (loaded.isEmpty) break;
+    // Use the oldest channel-scoped (non-system) message as the
+    // pagination cursor — see `ChatPanelController.paginationCursor` for
+    // the `#prod-2026-05-08` rationale.
+    final cursor = controller.paginationCursor(loaded);
+
+    await ref
+        .read(chatProvider.notifier)
+        .loadHistoryWithUserId(
+          conv.id,
+          auth.token!,
+          auth.userId!,
+          channelId: selectedTextChannelId,
+          before: cursor.timestamp,
+          crypto: crypto,
+          isGroup: conv.isGroup,
+          groupCrypto: groupCrypto,
+        );
+    if (!mounted()) return;
+    if (isLoaded()) {
+      onHighlight();
+      return;
+    }
+  }
+
+  if (!context.mounted) return;
+  ToastService.show(
+    context,
+    'Original message not available',
+    type: ToastType.info,
+  );
+}

--- a/apps/client/lib/src/widgets/chat_panel/message_actions.dart
+++ b/apps/client/lib/src/widgets/chat_panel/message_actions.dart
@@ -1,0 +1,553 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import '../../models/chat_message.dart';
+import '../../models/conversation.dart';
+import '../../models/reaction.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/channels_provider.dart';
+import '../../providers/chat_provider.dart';
+import '../../providers/media_ticket_provider.dart';
+import '../../providers/server_url_provider.dart';
+import '../../providers/websocket_provider.dart';
+import '../../services/message_cache.dart';
+import '../../services/saved_messages_service.dart';
+import '../../services/toast_service.dart';
+import '../../theme/echo_theme.dart';
+import '../forward_message_dialog.dart';
+import '../image_gallery_viewer.dart';
+import '../message/media_content.dart'
+    show
+        extractEmbeddedImageUrls,
+        isImageUrl,
+        isStandaloneMediaUrl,
+        mediaHeaders,
+        resolveMediaUrl;
+import 'full_reaction_picker.dart';
+
+/// Top-level message-action helpers extracted from the `_ChatPanelState`
+/// god-module (#512 slice 6). Each function takes `(WidgetRef ref,
+/// BuildContext context, ...)` so the call sites on `_ChatPanelState`
+/// reduce to one-line forwarders.
+///
+/// These mirror the original methods bit-for-bit — no behavior changes.
+/// Lifecycle checks use `context.mounted` so the analyzer's
+/// `use_build_context_synchronously` lint stays clean across async gaps.
+
+enum DeleteChoice { forMe, forEveryone }
+
+Future<void> retryMessage({
+  required WidgetRef ref,
+  required Conversation conv,
+  required ChatMessage message,
+}) async {
+  final chatNotifier = ref.read(chatProvider.notifier);
+  chatNotifier.updateMessageStatus(conv.id, message.id, MessageStatus.sending);
+  try {
+    final ws = ref.read(websocketProvider.notifier);
+    if (conv.isGroup) {
+      await ws.sendGroupMessage(
+        conv.id,
+        message.failedContent ?? message.content,
+        channelId: message.channelId,
+        replyToId: message.replyToId,
+      );
+    } else {
+      final myUserId = ref.read(authProvider).userId ?? '';
+      final peer = conv.members.where((m) => m.userId != myUserId).firstOrNull;
+      if (peer == null) return;
+      await ws.sendMessage(
+        peer.userId,
+        message.failedContent ?? message.content,
+        conversationId: conv.id,
+        replyToId: message.replyToId,
+      );
+    }
+  } catch (_) {
+    ref
+        .read(chatProvider.notifier)
+        .updateMessageStatus(conv.id, message.id, MessageStatus.failed);
+  }
+}
+
+void deleteFailed({
+  required WidgetRef ref,
+  required Conversation conv,
+  required ChatMessage message,
+}) {
+  ref.read(chatProvider.notifier).deleteMessage(conv.id, message.id);
+}
+
+void forwardMessage({
+  required BuildContext context,
+  required WidgetRef ref,
+  required ChatMessage message,
+}) {
+  showForwardDialog(
+    context: context,
+    onForward: (target) => sendForwardedMessage(ref, context, message, target),
+  );
+}
+
+Future<void> sendForwardedMessage(
+  WidgetRef ref,
+  BuildContext context,
+  ChatMessage message,
+  Conversation target,
+) async {
+  final myUserId = ref.read(authProvider).userId ?? '';
+  final ws = ref.read(websocketProvider.notifier);
+  final content = message.content;
+
+  try {
+    await ref.read(chatProvider.notifier).forwardMessage(content, target.id, (
+      forwardedContent,
+    ) async {
+      // Add optimistic message so the sender sees it locally immediately.
+      String peerUserId = '';
+      String? channelId;
+      if (!target.isGroup) {
+        final peer = target.members
+            .where((m) => m.userId != myUserId)
+            .firstOrNull;
+        peerUserId = peer?.userId ?? '';
+      } else {
+        // Look up the default text channel so the optimistic message has the
+        // same channelId that the server will return in message_sent.
+        // Without this, _replacePendingMessage's channelId filter never
+        // matches and the pending message times out to failed.
+        final channels = ref.read(channelsProvider).channelsFor(target.id);
+        channelId = channels.where((c) => c.isText).firstOrNull?.id;
+      }
+      ref
+          .read(chatProvider.notifier)
+          .addOptimistic(
+            peerUserId,
+            forwardedContent,
+            myUserId,
+            conversationId: target.id,
+            channelId: channelId,
+          );
+
+      if (target.isGroup) {
+        await ws.sendGroupMessage(
+          target.id,
+          forwardedContent,
+          channelId: channelId,
+        );
+      } else {
+        final peer = target.members
+            .where((m) => m.userId != myUserId)
+            .firstOrNull;
+        if (peer == null) return;
+        await ws.sendMessage(
+          peer.userId,
+          forwardedContent,
+          conversationId: target.id,
+        );
+      }
+    });
+
+    if (context.mounted) {
+      ToastService.show(context, 'Message forwarded', type: ToastType.success);
+    }
+  } catch (e) {
+    if (context.mounted) {
+      ToastService.show(
+        context,
+        'Failed to forward message',
+        type: ToastType.error,
+      );
+    }
+  }
+}
+
+void confirmDelete({
+  required BuildContext context,
+  required WidgetRef ref,
+  required Conversation conv,
+  required ChatMessage message,
+  required Future<void> Function(String) addToDeletedForMe,
+}) {
+  showDialog<DeleteChoice>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      backgroundColor: context.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: context.border),
+      ),
+      title: const Text('Delete message?'),
+      actions: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, DeleteChoice.forMe),
+              child: Text(
+                'Delete for me',
+                style: TextStyle(color: context.textSecondary),
+              ),
+            ),
+            if (message.isMine)
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, DeleteChoice.forEveryone),
+                child: const Text(
+                  'Delete for everyone',
+                  style: TextStyle(color: EchoTheme.danger),
+                ),
+              ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: Text(
+                'Cancel',
+                style: TextStyle(color: context.textSecondary),
+              ),
+            ),
+          ],
+        ),
+      ],
+    ),
+  ).then((choice) async {
+    if (choice == null) return;
+    if (choice == DeleteChoice.forMe) {
+      ref.read(chatProvider.notifier).deleteMessage(conv.id, message.id);
+      MessageCache.removeMessage(conv.id, message.id);
+      await addToDeletedForMe(message.id);
+      if (context.mounted) {
+        ToastService.show(
+          context,
+          'Message deleted for you',
+          type: ToastType.info,
+        );
+      }
+    } else {
+      if (!context.mounted) return;
+      await deleteForEveryone(ref, context, conv.id, message);
+    }
+  });
+}
+
+/// Delete a message for every recipient. Optimistically removes it from
+/// local state for a responsive UI, awaits the server DELETE, and rolls
+/// the message back into local state if the request fails (auth expired,
+/// network drop, server error). Without the await/rollback the user was
+/// being told the message had been deleted "for everyone" even when only
+/// local state changed (#511).
+Future<void> deleteForEveryone(
+  WidgetRef ref,
+  BuildContext context,
+  String conversationId,
+  ChatMessage message,
+) async {
+  ref.read(chatProvider.notifier).deleteMessage(conversationId, message.id);
+
+  final serverUrl = ref.read(serverUrlProvider);
+  http.Response? response;
+  Object? networkError;
+  try {
+    response = await ref
+        .read(authProvider.notifier)
+        .authenticatedRequest(
+          (token) => http.delete(
+            Uri.parse('$serverUrl/api/messages/${message.id}'),
+            headers: {'Authorization': 'Bearer $token'},
+          ),
+        );
+  } catch (e) {
+    networkError = e;
+  }
+
+  if (!context.mounted) return;
+
+  final ok =
+      response != null &&
+      response.statusCode >= 200 &&
+      response.statusCode < 300;
+  if (ok) {
+    ToastService.show(
+      context,
+      'Message deleted for everyone',
+      type: ToastType.success,
+    );
+  } else {
+    // Rollback: re-insert the message so the user sees their content
+    // wasn't actually removed remotely.
+    ref.read(chatProvider.notifier).addMessage(message);
+    final reason = networkError != null
+        ? 'Network error'
+        : 'Server returned ${response!.statusCode}';
+    ToastService.show(
+      context,
+      'Failed to delete: $reason',
+      type: ToastType.error,
+    );
+  }
+}
+
+Future<void> pinMessage({
+  required BuildContext context,
+  required WidgetRef ref,
+  required Conversation conv,
+  required ChatMessage message,
+}) async {
+  final myUserId = ref.read(authProvider).userId ?? '';
+  final serverUrl = ref.read(serverUrlProvider);
+
+  // Optimistically update local state
+  ref
+      .read(chatProvider.notifier)
+      .updateMessagePin(conv.id, message.id, myUserId, DateTime.now());
+
+  try {
+    final response = await ref
+        .read(authProvider.notifier)
+        .authenticatedRequest(
+          (token) => http.post(
+            Uri.parse(
+              '$serverUrl/api/conversations/${conv.id}'
+              '/messages/${message.id}/pin',
+            ),
+            headers: {'Authorization': 'Bearer $token'},
+          ),
+        );
+    if (!context.mounted) return;
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      ToastService.show(context, 'Message pinned', type: ToastType.success);
+    } else {
+      // Revert on failure
+      ref
+          .read(chatProvider.notifier)
+          .updateMessagePin(conv.id, message.id, null, null);
+      ToastService.show(
+        context,
+        'Failed to pin message',
+        type: ToastType.error,
+      );
+    }
+  } catch (e) {
+    if (!context.mounted) return;
+    ref
+        .read(chatProvider.notifier)
+        .updateMessagePin(conv.id, message.id, null, null);
+    ToastService.show(context, 'Failed to pin message', type: ToastType.error);
+  }
+}
+
+Future<void> unpinMessage({
+  required BuildContext context,
+  required WidgetRef ref,
+  required Conversation conv,
+  required ChatMessage message,
+}) async {
+  final serverUrl = ref.read(serverUrlProvider);
+
+  // Save previous state for revert
+  final prevPinnedById = message.pinnedById;
+  final prevPinnedAt = message.pinnedAt;
+
+  // Optimistically clear pin
+  ref
+      .read(chatProvider.notifier)
+      .updateMessagePin(conv.id, message.id, null, null);
+
+  try {
+    final response = await ref
+        .read(authProvider.notifier)
+        .authenticatedRequest(
+          (token) => http.delete(
+            Uri.parse(
+              '$serverUrl/api/conversations/${conv.id}'
+              '/messages/${message.id}/pin',
+            ),
+            headers: {'Authorization': 'Bearer $token'},
+          ),
+        );
+    if (!context.mounted) return;
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      ToastService.show(context, 'Message unpinned', type: ToastType.success);
+    } else {
+      // Revert on failure
+      ref
+          .read(chatProvider.notifier)
+          .updateMessagePin(conv.id, message.id, prevPinnedById, prevPinnedAt);
+      ToastService.show(
+        context,
+        'Failed to unpin message',
+        type: ToastType.error,
+      );
+    }
+  } catch (e) {
+    if (!context.mounted) return;
+    ref
+        .read(chatProvider.notifier)
+        .updateMessagePin(conv.id, message.id, prevPinnedById, prevPinnedAt);
+    ToastService.show(
+      context,
+      'Failed to unpin message',
+      type: ToastType.error,
+    );
+  }
+}
+
+Future<void> saveMessage({
+  required BuildContext context,
+  required ChatMessage message,
+  required void Function(String) onAddSavedId,
+}) async {
+  await SavedMessagesService.instance.bookmark(message);
+  if (!context.mounted) return;
+  onAddSavedId(message.id);
+  ToastService.show(context, 'Message saved', type: ToastType.success);
+}
+
+Future<void> unsaveMessage({
+  required BuildContext context,
+  required ChatMessage message,
+  required void Function(String) onRemoveSavedId,
+}) async {
+  await SavedMessagesService.instance.unsaveMessage(message.id);
+  if (!context.mounted) return;
+  onRemoveSavedId(message.id);
+  ToastService.show(context, 'Bookmark removed', type: ToastType.info);
+}
+
+void toggleReaction({
+  required WidgetRef ref,
+  required Conversation conv,
+  required ChatMessage message,
+  required String emoji,
+  required bool remove,
+}) {
+  // Guard: the message may have been deleted via WebSocket between the
+  // time the user opened the reaction picker and tapped an emoji.
+  final stillExists = ref
+      .read(chatProvider)
+      .messagesForConversation(conv.id)
+      .any((m) => m.id == message.id);
+  if (!stillExists) return;
+
+  final myUserId = ref.read(authProvider).userId ?? '';
+  ref.read(websocketProvider.notifier).sendReaction(conv.id, message.id, emoji);
+  if (remove) {
+    ref
+        .read(chatProvider.notifier)
+        .removeReaction(conv.id, message.id, myUserId, emoji);
+  } else {
+    ref
+        .read(chatProvider.notifier)
+        .addReaction(
+          conv.id,
+          Reaction(
+            messageId: message.id,
+            userId: myUserId,
+            username: '',
+            emoji: emoji,
+          ),
+        );
+  }
+}
+
+void showFullReactionPickerFor({
+  required BuildContext context,
+  required ChatMessage message,
+  required String myUserId,
+  required void Function(String emoji, bool alreadyReacted) onPick,
+}) {
+  showFullReactionPicker(
+    context,
+    message: message,
+    myUserId: myUserId,
+    onPick: onPick,
+  );
+}
+
+/// Collects all resolved image URLs from [messages] in order, then opens the
+/// gallery viewer starting at the image matching [tappedUrl].
+void openImageGallery({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String tappedUrl,
+  required List<ChatMessage> messages,
+  required String serverUrl,
+  required String authToken,
+}) {
+  final headers = mediaHeaders(authToken: authToken);
+  final mediaTicket = ref.read(mediaTicketProvider);
+
+  // Build an ordered list of all image URLs from this message list.
+  final allUrls = <String>[];
+  for (final msg in messages) {
+    // [img:URL] marker — single image message.
+    final imgMatch = RegExp(r'^\[img:(.+)\]$').firstMatch(msg.content);
+    if (imgMatch != null) {
+      final raw = imgMatch.group(1)!;
+      allUrls.add(
+        resolveMediaUrl(
+          raw,
+          serverUrl: serverUrl,
+          authToken: authToken,
+          mediaTicket: mediaTicket,
+        ),
+      );
+      continue;
+    }
+
+    // Standalone image URL (e.g. https://…/photo.png).
+    if (isStandaloneMediaUrl(msg.content) && isImageUrl(msg.content.trim())) {
+      allUrls.add(
+        resolveMediaUrl(
+          msg.content.trim(),
+          serverUrl: serverUrl,
+          authToken: authToken,
+          mediaTicket: mediaTicket,
+        ),
+      );
+      continue;
+    }
+
+    // Embedded image URLs mixed into text.
+    for (final embUrl in extractEmbeddedImageUrls(msg.content)) {
+      allUrls.add(embUrl);
+    }
+  }
+
+  if (allUrls.isEmpty) {
+    // Fallback: show only the tapped image.
+    allUrls.add(tappedUrl);
+  }
+
+  // Find the index of the tapped URL. Use string-starts-with matching to
+  // handle minor URL differences (e.g. trailing query params differ).
+  final idx = allUrls.indexWhere(
+    (u) => u == tappedUrl || u.startsWith(tappedUrl) || tappedUrl.startsWith(u),
+  );
+
+  showImageGallery(
+    context: context,
+    imageUrls: allUrls,
+    initialIndex: idx < 0 ? 0 : idx,
+    headers: headers,
+  );
+}
+
+String fullMonthName(int m) {
+  const names = [
+    '',
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  return names[m.clamp(1, 12)];
+}

--- a/apps/client/lib/src/widgets/chat_panel/message_actions.dart
+++ b/apps/client/lib/src/widgets/chat_panel/message_actions.dart
@@ -26,15 +26,6 @@ import '../message/media_content.dart'
         resolveMediaUrl;
 import 'full_reaction_picker.dart';
 
-/// Top-level message-action helpers extracted from the `_ChatPanelState`
-/// god-module (#512 slice 6). Each function takes `(WidgetRef ref,
-/// BuildContext context, ...)` so the call sites on `_ChatPanelState`
-/// reduce to one-line forwarders.
-///
-/// These mirror the original methods bit-for-bit — no behavior changes.
-/// Lifecycle checks use `context.mounted` so the analyzer's
-/// `use_build_context_synchronously` lint stays clean across async gaps.
-
 enum DeleteChoice { forMe, forEveryone }
 
 Future<void> retryMessage({

--- a/apps/client/lib/src/widgets/chat_panel/reaction_picker_overlay.dart
+++ b/apps/client/lib/src/widgets/chat_panel/reaction_picker_overlay.dart
@@ -5,13 +5,7 @@ import '../../theme/echo_theme.dart';
 import '../message_item.dart' show reactionEmojis;
 
 /// Build the quick-react bar overlay shown when a user long-presses a
-/// message. Extracted from `_ChatPanelState._showReactionPicker` (#512
-/// slice 6) so the message-list state stays focused on data wiring.
-///
-/// The caller is responsible for inserting the returned [OverlayEntry] and
-/// for removing it from `_dismissReactionPicker`. Tap callbacks reach back
-/// through [onDismiss] (to remove the overlay), [onToggleReaction] (single
-/// emoji tap), and [onPickFromFull] (the "+" expand button).
+/// message. The caller inserts and later removes the returned [OverlayEntry].
 OverlayEntry buildReactionPickerOverlay({
   required BuildContext context,
   required ChatMessage message,

--- a/apps/client/lib/src/widgets/chat_panel/reaction_picker_overlay.dart
+++ b/apps/client/lib/src/widgets/chat_panel/reaction_picker_overlay.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+import '../message_item.dart' show reactionEmojis;
+
+/// Build the quick-react bar overlay shown when a user long-presses a
+/// message. Extracted from `_ChatPanelState._showReactionPicker` (#512
+/// slice 6) so the message-list state stays focused on data wiring.
+///
+/// The caller is responsible for inserting the returned [OverlayEntry] and
+/// for removing it from `_dismissReactionPicker`. Tap callbacks reach back
+/// through [onDismiss] (to remove the overlay), [onToggleReaction] (single
+/// emoji tap), and [onPickFromFull] (the "+" expand button).
+OverlayEntry buildReactionPickerOverlay({
+  required BuildContext context,
+  required ChatMessage message,
+  required String myUserId,
+  required Offset tapPosition,
+  required VoidCallback onDismiss,
+  required void Function(String emoji, bool alreadyReacted) onToggleReaction,
+  required VoidCallback onPickFromFull,
+}) {
+  const pickerWidth = 385.0; // wider to accommodate the "+" button
+  const pickerHeight = 44.0;
+  final screenWidth = MediaQuery.of(context).size.width;
+
+  final left = (tapPosition.dx - pickerWidth / 2).clamp(
+    12.0,
+    screenWidth - pickerWidth - 12,
+  );
+  final top = (tapPosition.dy - pickerHeight - 12).clamp(12.0, double.infinity);
+
+  return OverlayEntry(
+    builder: (_) => Stack(
+      children: [
+        Positioned.fill(
+          child: GestureDetector(
+            onTap: () {
+              onDismiss();
+              FocusManager.instance.primaryFocus?.unfocus();
+            },
+            behavior: HitTestBehavior.opaque,
+            child: Container(color: Colors.black.withValues(alpha: 0.15)),
+          ),
+        ),
+        Positioned(
+          left: left,
+          top: top,
+          child: TweenAnimationBuilder<double>(
+            tween: Tween(begin: 0, end: 1),
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOutCubic,
+            builder: (_, value, child) => Opacity(
+              opacity: value,
+              child: Transform.translate(
+                offset: Offset(0, 8 * (1 - value)),
+                child: child,
+              ),
+            ),
+            child: Container(
+              height: pickerHeight,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              decoration: BoxDecoration(
+                color: context.surface.withValues(alpha: 0.95),
+                borderRadius: BorderRadius.circular(22),
+                border: Border.all(color: context.border),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.3),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ...reactionEmojis.map((emoji) {
+                    final alreadyReacted = message.reactions.any(
+                      (r) => r.emoji == emoji && r.userId == myUserId,
+                    );
+                    return GestureDetector(
+                      onTap: () {
+                        onDismiss();
+                        onToggleReaction(emoji, alreadyReacted);
+                        FocusManager.instance.primaryFocus?.unfocus();
+                      },
+                      child: Container(
+                        width: 36,
+                        height: 36,
+                        margin: const EdgeInsets.symmetric(horizontal: 2),
+                        decoration: BoxDecoration(
+                          color: alreadyReacted
+                              ? context.accent.withValues(alpha: 0.2)
+                              : null,
+                          borderRadius: BorderRadius.circular(8),
+                          border: alreadyReacted
+                              ? Border.all(color: context.accent, width: 2)
+                              : null,
+                        ),
+                        alignment: Alignment.center,
+                        child: Text(
+                          emoji,
+                          style: const TextStyle(
+                            fontSize: 22,
+                            decoration: TextDecoration.none,
+                          ),
+                        ),
+                      ),
+                    );
+                  }),
+                  // Full emoji picker button
+                  GestureDetector(
+                    onTap: () {
+                      onDismiss();
+                      onPickFromFull();
+                    },
+                    child: Container(
+                      width: 36,
+                      height: 36,
+                      margin: const EdgeInsets.only(left: 4, right: 2),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(color: context.border, width: 1),
+                      ),
+                      alignment: Alignment.center,
+                      child: Icon(
+                        Icons.add,
+                        size: 18,
+                        color: context.textSecondary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/apps/client/lib/src/widgets/chat_panel/scroll_helpers.dart
+++ b/apps/client/lib/src/widgets/chat_panel/scroll_helpers.dart
@@ -1,0 +1,311 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/chat_message.dart';
+import '../../models/conversation.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/chat_provider.dart';
+import '../../providers/conversations_provider.dart';
+import '../../utils/semantics_preview.dart';
+import '../chat_panel_controller.dart';
+import 'message_actions.dart' show fullMonthName;
+
+/// Helpers for the message-list scroll, floating-date label, unread-boundary
+/// capture, and autoscroll wiring extracted from `_ChatPanelState`
+/// (#512 slice 6). Each function takes the widget-local closures it needs
+/// (so `setState` calls land in the right `State` object) and never holds
+/// a `ChatPanelController` reference past its argument list.
+
+/// Update the floating date pill so it reflects the date of the topmost
+/// rendered message. Cancels and reschedules the 2s fade-out timer.
+void updateFloatingDate({
+  required WidgetRef ref,
+  required Conversation conv,
+  required ScrollController scrollController,
+  required Map<String, GlobalKey> messageKeys,
+  required String? selectedTextChannelId,
+  required List<ChatMessage> Function(Conversation, ChatState, String?, bool)
+  resolveMessages,
+  required ChatPanelController controller,
+  required void Function(VoidCallback) setState,
+  required bool Function() mounted,
+}) {
+  if (!scrollController.hasClients) return;
+
+  final chatState = ref.read(chatProvider);
+  final selectedChannelId = conv.isGroup ? selectedTextChannelId : null;
+  final includeUnchanneled = conv.isGroup && selectedTextChannelId == null;
+  final messages = resolveMessages(
+    conv,
+    chatState,
+    selectedChannelId,
+    includeUnchanneled,
+  );
+  if (messages.isEmpty) return;
+
+  // Find the topmost rendered message by querying each message's RenderBox
+  // position in the viewport. This is accurate for any message height
+  // (images, reactions, multi-line text) and avoids the old 60px estimate.
+  String? topmostId;
+  double closestY = double.infinity;
+  for (final entry in messageKeys.entries) {
+    final ctx = entry.value.currentContext;
+    if (ctx == null) continue;
+    final box = ctx.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) continue;
+    final y = box.localToGlobal(Offset.zero).dy;
+    if (y < closestY) {
+      closestY = y;
+      topmostId = entry.key;
+    }
+  }
+  final msgIndex = topmostId == null
+      ? 0
+      : messages
+            .indexWhere((m) => m.id == topmostId)
+            .clamp(0, messages.length - 1);
+
+  try {
+    final dt = DateTime.parse(messages[msgIndex].timestamp).toLocal();
+    final now = DateTime.now();
+    final yesterday = now.subtract(const Duration(days: 1));
+    String label;
+    if (dt.year == now.year && dt.month == now.month && dt.day == now.day) {
+      label = 'Today';
+    } else if (dt.year == yesterday.year &&
+        dt.month == yesterday.month &&
+        dt.day == yesterday.day) {
+      label = 'Yesterday';
+    } else {
+      label = '${fullMonthName(dt.month)} ${dt.day}, ${dt.year}';
+    }
+
+    if (label != controller.floatingDate || !controller.floatingDateVisible) {
+      setState(() {
+        controller.floatingDate = label;
+        controller.floatingDateVisible = true;
+      });
+    }
+  } catch (_) {
+    return;
+  }
+
+  controller.floatingDateTimer?.cancel();
+  controller.floatingDateTimer = Timer(const Duration(seconds: 2), () {
+    if (mounted()) setState(() => controller.floatingDateVisible = false);
+  });
+}
+
+/// Compute the unread boundary message ID from the current unread count.
+/// Called once when a conversation is first opened or messages finish
+/// loading. Invariant #6: single-capture-per-channel-session guard.
+void captureUnreadBoundary({
+  required WidgetRef ref,
+  required Conversation conv,
+  required String? selectedTextChannelId,
+  required ChatPanelController controller,
+  required List<ChatMessage> Function(Conversation, ChatState, String?, bool)
+  resolveMessages,
+  required void Function(VoidCallback) setState,
+}) {
+  // Only capture once per conversation open
+  if (controller.unreadBoundaryMessageId != null) return;
+
+  final convState = ref.read(conversationsProvider);
+  final convData = convState.conversations
+      .where((c) => c.id == conv.id)
+      .firstOrNull;
+  if (convData == null || convData.unreadCount <= 0) return;
+
+  final chatState = ref.read(chatProvider);
+  final selectedChannelId = conv.isGroup ? selectedTextChannelId : null;
+  final includeUnchanneled = conv.isGroup && selectedTextChannelId == null;
+  final messages = resolveMessages(
+    conv,
+    chatState,
+    selectedChannelId,
+    includeUnchanneled,
+  );
+  if (messages.isEmpty) return;
+
+  final boundaryIndex = messages.length - convData.unreadCount;
+  if (boundaryIndex > 0 && boundaryIndex < messages.length) {
+    setState(() {
+      controller.unreadBoundaryMessageId = messages[boundaryIndex].id;
+      controller.unreadBoundaryCount = convData.unreadCount;
+    });
+  }
+}
+
+/// Scroll to the unread boundary divider so it appears near the top.
+void scrollToUnreadBoundary({
+  required ScrollController scrollController,
+  required Map<String, GlobalKey> messageKeys,
+  required List<ChatMessage> messages,
+  required String? unreadBoundaryMessageId,
+}) {
+  if (unreadBoundaryMessageId == null) return;
+  final index = messages.indexWhere((m) => m.id == unreadBoundaryMessageId);
+  if (index < 0 || !scrollController.hasClients) return;
+
+  // Use Scrollable.ensureVisible if the key is available for pixel-accurate
+  // positioning; fall back to a jump when the item is not yet rendered.
+  final key = messageKeys[unreadBoundaryMessageId];
+  if (key?.currentContext != null) {
+    Scrollable.ensureVisible(
+      key!.currentContext!,
+      alignment: 0.15,
+      duration: Duration.zero,
+    );
+  } else {
+    // Item not rendered yet — scroll by index (approximate).
+    final estimatedOffset = (index + 1) * 60.0 - 120.0;
+    scrollController.jumpTo(
+      estimatedOffset.clamp(0, scrollController.position.maxScrollExtent),
+    );
+  }
+}
+
+/// Off-screen-aware scroll-to-message. Uses `Scrollable.ensureVisible` when
+/// the target widget is rendered; falls back to an estimated jump + retry.
+void scrollToMessage({
+  required String messageId,
+  required ScrollController scrollController,
+  required Map<String, GlobalKey> messageKeys,
+  required List<ChatMessage> messages,
+}) {
+  final key = messageKeys[messageId];
+  if (key?.currentContext != null) {
+    Scrollable.ensureVisible(
+      key!.currentContext!,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+      alignment: 0.3,
+    );
+    return;
+  }
+
+  // Target message is off-screen (not rendered by ListView.builder).
+  // Find its index and estimate scroll position to jump near it.
+  if (!scrollController.hasClients) return;
+  final index = messages.indexWhere((m) => m.id == messageId);
+  if (index < 0) return;
+
+  // +1 accounts for the loading indicator at index 0 in the ListView.
+  final estimatedOffset = (index + 1) * 60.0;
+  scrollController.animateTo(
+    estimatedOffset.clamp(0, scrollController.position.maxScrollExtent),
+    duration: const Duration(milliseconds: 300),
+    curve: Curves.easeOut,
+  );
+
+  // After the jump, retry with ensureVisible once the widget is rendered.
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    final retryKey = messageKeys[messageId];
+    if (retryKey?.currentContext != null) {
+      Scrollable.ensureVisible(
+        retryKey!.currentContext!,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+        alignment: 0.3,
+      );
+    }
+  });
+}
+
+/// Wire up the per-channel-session `ref.listen<ChatState>(chatProvider)`
+/// that drives auto-scroll on incoming messages and the assistive-tech
+/// live-region announcement (#495).
+void setupAutoScroll({
+  required WidgetRef ref,
+  required Conversation conv,
+  required String? selectedChannelId,
+  required bool includeUnchanneled,
+  required ChatPanelController controller,
+  required String? Function() getLastAnnouncedMessageId,
+  required void Function(String?) setLastAnnouncedMessageId,
+  required void Function(String) setLiveRegionAnnouncement,
+  required Timer? Function() getLiveRegionClearTimer,
+  required void Function(Timer?) setLiveRegionClearTimer,
+  required bool Function() isNearBottom,
+  required void Function() scrollToBottom,
+  required void Function() onCaptureUnreadBoundary,
+  required void Function() onScrollToUnreadBoundary,
+  required void Function(VoidCallback) setState,
+  required bool Function() mounted,
+}) {
+  final key = '${conv.id}:${selectedChannelId ?? ""}';
+  if (controller.autoScrollConversationKey == key) return;
+  controller.autoScrollConversationKey = key;
+
+  ref.listen<ChatState>(chatProvider, (prev, next) {
+    int visibleCount(ChatState s) {
+      if (!conv.isGroup) return s.messagesForConversation(conv.id).length;
+      return s
+          .messagesForConversationChannel(
+            conv.id,
+            channelId: selectedChannelId,
+            includeUnchanneled: includeUnchanneled,
+          )
+          .length;
+    }
+
+    final prevCount = prev == null ? 0 : visibleCount(prev);
+    final nextCount = visibleCount(next);
+
+    // Attempt to capture unread boundary when messages first arrive
+    // (e.g. history loaded asynchronously after conversation opened).
+    if (prevCount == 0 &&
+        nextCount > 0 &&
+        controller.unreadBoundaryMessageId == null) {
+      onCaptureUnreadBoundary();
+      if (controller.unreadBoundaryMessageId != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          onScrollToUnreadBoundary();
+        });
+        return;
+      }
+    }
+
+    if (nextCount > prevCount) {
+      // Live-region announcement for assistive tech (#495). Skip the
+      // initial history load (prevCount == 0), own messages, system
+      // events, and duplicates of the last announced id.
+      final myUserId = ref.read(authProvider.select((s) => s.userId)) ?? '';
+      final newest = next.messagesForConversation(conv.id).lastOrNull;
+      if (newest != null &&
+          newest.id != getLastAnnouncedMessageId() &&
+          newest.fromUserId != myUserId &&
+          !newest.isSystemEvent &&
+          prevCount > 0) {
+        setLastAnnouncedMessageId(newest.id);
+        final preview = previewForSemantics(newest.content);
+        setState(() {
+          setLiveRegionAnnouncement(
+            preview.isEmpty
+                ? 'New message from ${newest.fromUsername}'
+                : 'New message from ${newest.fromUsername}: $preview',
+          );
+        });
+        getLiveRegionClearTimer()?.cancel();
+        setLiveRegionClearTimer(
+          Timer(const Duration(seconds: 3), () {
+            if (!mounted()) return;
+            setState(() => setLiveRegionAnnouncement(''));
+          }),
+        );
+      }
+
+      if (isNearBottom()) {
+        scrollToBottom();
+      } else {
+        setState(() {
+          controller.hasNewMessagesBelow = true;
+          controller.newMessagesBelowCount += nextCount - prevCount;
+        });
+      }
+    }
+  });
+}

--- a/apps/client/lib/src/widgets/chat_panel/scroll_helpers.dart
+++ b/apps/client/lib/src/widgets/chat_panel/scroll_helpers.dart
@@ -12,12 +12,6 @@ import '../../utils/semantics_preview.dart';
 import '../chat_panel_controller.dart';
 import 'message_actions.dart' show fullMonthName;
 
-/// Helpers for the message-list scroll, floating-date label, unread-boundary
-/// capture, and autoscroll wiring extracted from `_ChatPanelState`
-/// (#512 slice 6). Each function takes the widget-local closures it needs
-/// (so `setState` calls land in the right `State` object) and never holds
-/// a `ChatPanelController` reference past its argument list.
-
 /// Update the floating date pill so it reflects the date of the topmost
 /// rendered message. Cancels and reschedules the 2s fade-out timer.
 void updateFloatingDate({

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart' show ScrollController;
+import 'package:flutter/widgets.dart'
+    show Curves, ScrollController, WidgetsBinding;
 
 import '../models/chat_message.dart';
 import '../models/conversation.dart';
@@ -11,9 +12,13 @@ import '../providers/chat_provider.dart';
 /// widget's `State` can focus on the build tree. Receives data via method
 /// args; it never holds a `WidgetRef` or calls `ref.watch/read/select`.
 ///
-/// Slice 1 (#512): pure helpers only — `isNearBottom`,
-/// `filterChannelAndDeleted`, `resolveMessages`. Subsequent slices move
-/// scroll, pagination, and unread-boundary state.
+/// Slice 1 (#512): pure helpers — `isNearBottom`, `filterChannelAndDeleted`,
+/// `resolveMessages`.
+/// Slice 2 (#512): scroll-position cache, channel-scoped loading keys,
+/// pagination cursor helper, keyboard-resize state, restore-with-retry, and
+/// scroll-to-bottom. Riverpod-driven calls (`loadHistory`,
+/// `loadOlderMessages`, `onTextChannelChanged`) stay in the widget because
+/// they need `WidgetRef`; the channel-scoped keys they consult live here.
 class ChatPanelController extends ChangeNotifier {
   ScrollController? _scrollController;
 
@@ -22,6 +27,48 @@ class ChatPanelController extends ChangeNotifier {
   /// [filterChannelAndDeleted]. Will move into the controller in a later
   /// slice once the SharedPreferences load path migrates.
   Set<String> deletedForMeIds = const {};
+
+  // --- Channel-scoped loading keys (invariant #3) ---------------------------
+  //
+  // `loadedHistoryKey` and `loadedChannelsConversationId` dedupe per
+  // (conversationId, channelId). `autoScrollConversationKey` gates the
+  // `ref.listen<ChatState>(...)` wiring so it isn't installed twice per
+  // visible channel.
+
+  String? selectedTextChannelId;
+  String? loadedHistoryKey;
+  String? loadedChannelsConversationId;
+  String? autoScrollConversationKey;
+
+  // --- Per-channel scroll position cache (invariant #1, #5) ----------------
+  //
+  // Keyed by `${conversationId}:${channelId ?? ""}` so switching text
+  // channels within a group preserves separate scroll positions. Capped at
+  // [kMaxScrollPositions] entries to prevent unbounded growth; oldest entries
+  // are evicted when over the limit (eviction policy is invariant #5).
+
+  static const int kMaxScrollPositions = 50;
+  final Map<String, double> scrollPositions = {};
+
+  void evictScrollPositions() {
+    while (scrollPositions.length > kMaxScrollPositions) {
+      scrollPositions.remove(scrollPositions.keys.first);
+    }
+  }
+
+  String cacheKeyFor(String conversationId) =>
+      '$conversationId:${selectedTextChannelId ?? ""}';
+
+  // --- Keyboard / near-bottom tracking (invariant #4) ----------------------
+  //
+  // `wasNearBottom` is updated on every scroll event BEFORE the soft
+  // keyboard shrinks the viewport. `handleKeyboardScroll` reads it to decide
+  // whether to re-pin to the bottom when the keyboard opens/closes; using
+  // the live `isNearBottom()` after the resize is unreliable because the
+  // maxScrollExtent has already shifted.
+
+  bool wasNearBottom = true;
+  double lastKeyboardInset = 0;
 
   /// Wire in the [ScrollController] managed by the widget's `State`. The
   /// widget keeps ownership (creates + disposes); the controller only reads
@@ -38,6 +85,121 @@ class ChatPanelController extends ChangeNotifier {
     if (c == null || !c.hasClients) return true;
     final pos = c.position;
     return pos.maxScrollExtent - pos.pixels < 150;
+  }
+
+  /// Pick the oldest non-system message as the pagination cursor.
+  ///
+  /// System events (`member_joined`, `voice_session_started`, ...) live at
+  /// the conversation root with `channelId == null` and surface in every
+  /// channel view, but their timestamps predate the actual channel messages
+  /// — they're created when the group is born. If we use them as the
+  /// pagination cursor, the server's `?channel_id=X&before=<system_ts>`
+  /// query (correctly) returns zero rows, `hasMore` flips to false, and
+  /// the message list dead-locks at the first page (#prod-2026-05-08).
+  /// Falls back to the first message when none is non-system.
+  ChatMessage paginationCursor(List<ChatMessage> messages) {
+    return messages.firstWhere(
+      (m) => !m.isSystemEvent,
+      orElse: () => messages.first,
+    );
+  }
+
+  /// Re-jump to the cached offset across a few frames so we don't land at the
+  /// bottom of an empty list while message history is still loading async (#563).
+  /// Stops retrying once `maxScrollExtent >= cached`, or after [retries] frames.
+  void restoreCachedOffsetWithRetry(double cached, {int retries = 3}) {
+    final c = _scrollController;
+    if (c == null || !c.hasClients) return;
+    final max = c.position.maxScrollExtent;
+    c.jumpTo(cached.clamp(0, max));
+    if (max < cached && retries > 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        restoreCachedOffsetWithRetry(cached, retries: retries - 1);
+      });
+    }
+  }
+
+  /// Update the per-channel scroll cache and run [evictScrollPositions].
+  void cacheCurrentOffset(String conversationId) {
+    final c = _scrollController;
+    if (c == null || !c.hasClients) return;
+    scrollPositions[cacheKeyFor(conversationId)] = c.offset;
+    evictScrollPositions();
+  }
+
+  /// Drop cached offset for [conversationId] under the current channel.
+  void clearCachedOffset(String conversationId) {
+    scrollPositions.remove(cacheKeyFor(conversationId));
+  }
+
+  /// Animate or jump the scroll controller to its maxScrollExtent and
+  /// retry-settle so new content (e.g. an image that just resolved) doesn't
+  /// leave the user a few pixels short. Returns a future that completes
+  /// once the settle pass is finished. [onSettleComplete] runs on the same
+  /// frame the cache is updated; the widget passes a callback to clear its
+  /// `_hasNewMessagesBelow` pill.
+  ///
+  /// Pure mechanics — no `ref` here. The widget invokes this from a
+  /// `WidgetsBinding.instance.addPostFrameCallback` wrapper so the pill
+  /// `setState` happens in the correct phase.
+  void scrollToBottom({
+    required String? conversationId,
+    bool animated = true,
+    int settleRetries = 3,
+    VoidCallback? onSettleComplete,
+  }) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final c = _scrollController;
+      if (c == null || !c.hasClients) return;
+
+      final target = c.position.maxScrollExtent;
+      final alreadyAtBottom = (target - c.position.pixels).abs() < 1;
+      if (alreadyAtBottom) return;
+
+      Future<void> settleIfNeeded() async {
+        if (settleRetries <= 0 ||
+            _scrollController == null ||
+            !_scrollController!.hasClients) {
+          return;
+        }
+        // Wait for layout to settle so maxScrollExtent includes new content
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        final cc = _scrollController;
+        if (cc == null || !cc.hasClients) return;
+        final newTarget = cc.position.maxScrollExtent;
+        if ((newTarget - cc.position.pixels).abs() > 1) {
+          cc.jumpTo(newTarget);
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        scrollToBottom(
+          conversationId: conversationId,
+          animated: false,
+          settleRetries: settleRetries - 1,
+          onSettleComplete: onSettleComplete,
+        );
+      }
+
+      if (animated) {
+        c
+            .animateTo(
+              target,
+              duration: const Duration(milliseconds: 220),
+              curve: Curves.easeOut,
+            )
+            .whenComplete(settleIfNeeded);
+      } else {
+        c.jumpTo(target);
+        settleIfNeeded();
+      }
+
+      // Update the scroll cache. Key includes channel ID so switching text
+      // channels within a group preserves separate scroll positions.
+      if (conversationId != null) {
+        scrollPositions[cacheKeyFor(conversationId)] = target;
+        evictScrollPositions();
+      }
+      onSettleComplete?.call();
+    });
   }
 
   /// Resolve messages for the current conversation and channel.

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -13,21 +13,12 @@ import '../providers/chat_provider.dart';
 /// Owns scroll, pagination, unread-boundary, and floating-date state so the
 /// widget's `State` can focus on the build tree. Receives data via method
 /// args; it never holds a `WidgetRef` or calls `ref.watch/read/select`.
-///
-/// Slice 1 (#512): pure helpers — `isNearBottom`, `filterChannelAndDeleted`,
-/// `resolveMessages`.
-/// Slice 2 (#512): scroll-position cache, channel-scoped loading keys,
-/// pagination cursor helper, keyboard-resize state, restore-with-retry, and
-/// scroll-to-bottom. Riverpod-driven calls (`loadHistory`,
-/// `loadOlderMessages`, `onTextChannelChanged`) stay in the widget because
-/// they need `WidgetRef`; the channel-scoped keys they consult live here.
 class ChatPanelController extends ChangeNotifier {
   ScrollController? _scrollController;
 
   /// Persistent blocklist of message IDs deleted via "delete for me".
-  /// Owned by the widget for now; passed in via [resolveMessages] /
-  /// [filterChannelAndDeleted]. Will move into the controller in a later
-  /// slice once the SharedPreferences load path migrates.
+  /// Populated from [DeletedForMeStorage.ids] in initState and refreshed
+  /// after async load completes.
   Set<String> deletedForMeIds = const {};
 
   // --- Channel-scoped loading keys (invariant #3) ---------------------------

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart'
     show Curves, ScrollController, WidgetsBinding;
@@ -59,16 +61,49 @@ class ChatPanelController extends ChangeNotifier {
   String cacheKeyFor(String conversationId) =>
       '$conversationId:${selectedTextChannelId ?? ""}';
 
+  // --- Unread boundary + new-messages pill (invariant #6) -----------------
+  //
+  // The unread boundary is captured ONCE per channel session (first time
+  // the conversation opens with `unreadCount > 0`, or the first time
+  // messages arrive after an empty channel open). `unreadBoundaryMessageId`
+  // gates that single-capture guard; resetting to `null` re-arms it. The
+  // widget resets these fields on conversation switch and on
+  // `onTextChannelChanged`.
+
+  String? unreadBoundaryMessageId;
+  int unreadBoundaryCount = 0;
+
+  /// True when a new message arrives while the user has scrolled up.
+  bool hasNewMessagesBelow = false;
+  int newMessagesBelowCount = 0;
+
+  // --- Floating date label state ------------------------------------------
+  //
+  // The pill shows the date of the topmost visible message and fades out 2s
+  // after the user stops scrolling. The timer is cancelled on conversation
+  // switch + dispose so it never fires after the widget is gone.
+
+  String? floatingDate;
+  bool floatingDateVisible = false;
+  Timer? floatingDateTimer;
+
   // --- Keyboard / near-bottom tracking (invariant #4) ----------------------
   //
-  // `wasNearBottom` is updated on every scroll event BEFORE the soft
-  // keyboard shrinks the viewport. `handleKeyboardScroll` reads it to decide
-  // whether to re-pin to the bottom when the keyboard opens/closes; using
-  // the live `isNearBottom()` after the resize is unreliable because the
+  // `wasNearBottom` (originally `_wasNearBottom` on `_ChatPanelState`) is
+  // updated on every scroll event BEFORE the soft keyboard shrinks the
+  // viewport. `handleKeyboardScroll` reads it to decide whether to re-pin
+  // to the bottom when the keyboard opens/closes; using the live
+  // `isNearBottom()` after the resize is unreliable because the
   // maxScrollExtent has already shifted.
 
   bool wasNearBottom = true;
   double lastKeyboardInset = 0;
+
+  @override
+  void dispose() {
+    floatingDateTimer?.cancel();
+    super.dispose();
+  }
 
   /// Wire in the [ScrollController] managed by the widget's `State`. The
   /// widget keeps ownership (creates + disposes); the controller only reads
@@ -226,7 +261,7 @@ class ChatPanelController extends ChangeNotifier {
 
   /// Apply channel + delete-for-me filters to a pre-fetched message list.
   /// Used by the build path so a `.select` on the per-conversation list ref
-  /// keeps unrelated conversations from rebuilding.
+  /// keeps unrelated conversations from rebuilding (PR #838 perf).
   List<ChatMessage> filterChannelAndDeleted(
     Conversation conv,
     List<ChatMessage> raw,

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -21,25 +21,16 @@ class ChatPanelController extends ChangeNotifier {
   /// after async load completes.
   Set<String> deletedForMeIds = const {};
 
-  // --- Channel-scoped loading keys (invariant #3) ---------------------------
-  //
-  // `loadedHistoryKey` and `loadedChannelsConversationId` dedupe per
-  // (conversationId, channelId). `autoScrollConversationKey` gates the
-  // `ref.listen<ChatState>(...)` wiring so it isn't installed twice per
-  // visible channel.
-
+  // Per-(conversationId, channelId) dedupe keys for history / channel-list
+  // loads and the `ref.listen<ChatState>` autoscroll wiring.
   String? selectedTextChannelId;
   String? loadedHistoryKey;
   String? loadedChannelsConversationId;
   String? autoScrollConversationKey;
 
-  // --- Per-channel scroll position cache (invariant #1, #5) ----------------
-  //
-  // Keyed by `${conversationId}:${channelId ?? ""}` so switching text
-  // channels within a group preserves separate scroll positions. Capped at
-  // [kMaxScrollPositions] entries to prevent unbounded growth; oldest entries
-  // are evicted when over the limit (eviction policy is invariant #5).
-
+  // Per-channel scroll position cache, keyed by `${conversationId}:${channelId ?? ""}`
+  // so switching text channels within a group preserves separate positions.
+  // Capped to avoid unbounded growth; oldest entries evict first.
   static const int kMaxScrollPositions = 50;
   final Map<String, double> scrollPositions = {};
 
@@ -52,41 +43,25 @@ class ChatPanelController extends ChangeNotifier {
   String cacheKeyFor(String conversationId) =>
       '$conversationId:${selectedTextChannelId ?? ""}';
 
-  // --- Unread boundary + new-messages pill (invariant #6) -----------------
-  //
-  // The unread boundary is captured ONCE per channel session (first time
-  // the conversation opens with `unreadCount > 0`, or the first time
-  // messages arrive after an empty channel open). `unreadBoundaryMessageId`
-  // gates that single-capture guard; resetting to `null` re-arms it. The
-  // widget resets these fields on conversation switch and on
-  // `onTextChannelChanged`.
-
+  // Unread boundary is captured ONCE per channel session (on first open with
+  // `unreadCount > 0`, or first arrival after an empty open). Setting
+  // [unreadBoundaryMessageId] to `null` re-arms the capture; the widget
+  // does so on conversation switch and `onTextChannelChanged`.
   String? unreadBoundaryMessageId;
   int unreadBoundaryCount = 0;
 
-  /// True when a new message arrives while the user has scrolled up.
   bool hasNewMessagesBelow = false;
   int newMessagesBelowCount = 0;
 
-  // --- Floating date label state ------------------------------------------
-  //
-  // The pill shows the date of the topmost visible message and fades out 2s
-  // after the user stops scrolling. The timer is cancelled on conversation
-  // switch + dispose so it never fires after the widget is gone.
-
+  // Floating date pill state. Timer cancelled on conversation switch + dispose.
   String? floatingDate;
   bool floatingDateVisible = false;
   Timer? floatingDateTimer;
 
-  // --- Keyboard / near-bottom tracking (invariant #4) ----------------------
-  //
-  // `wasNearBottom` (originally `_wasNearBottom` on `_ChatPanelState`) is
-  // updated on every scroll event BEFORE the soft keyboard shrinks the
-  // viewport. `handleKeyboardScroll` reads it to decide whether to re-pin
-  // to the bottom when the keyboard opens/closes; using the live
-  // `isNearBottom()` after the resize is unreliable because the
-  // maxScrollExtent has already shifted.
-
+  // [wasNearBottom] is updated on every scroll event BEFORE the soft keyboard
+  // shrinks the viewport. `handleKeyboardScroll` reads this pre-resize
+  // snapshot — the live `isNearBottom()` is unreliable after the resize
+  // because `maxScrollExtent` has already shifted.
   bool wasNearBottom = true;
   double lastKeyboardInset = 0;
 
@@ -145,7 +120,6 @@ class ChatPanelController extends ChangeNotifier {
     }
   }
 
-  /// Update the per-channel scroll cache and run [evictScrollPositions].
   void cacheCurrentOffset(String conversationId) {
     final c = _scrollController;
     if (c == null || !c.hasClients) return;
@@ -153,21 +127,13 @@ class ChatPanelController extends ChangeNotifier {
     evictScrollPositions();
   }
 
-  /// Drop cached offset for [conversationId] under the current channel.
   void clearCachedOffset(String conversationId) {
     scrollPositions.remove(cacheKeyFor(conversationId));
   }
 
-  /// Animate or jump the scroll controller to its maxScrollExtent and
-  /// retry-settle so new content (e.g. an image that just resolved) doesn't
-  /// leave the user a few pixels short. Returns a future that completes
-  /// once the settle pass is finished. [onSettleComplete] runs on the same
-  /// frame the cache is updated; the widget passes a callback to clear its
-  /// `_hasNewMessagesBelow` pill.
-  ///
-  /// Pure mechanics — no `ref` here. The widget invokes this from a
-  /// `WidgetsBinding.instance.addPostFrameCallback` wrapper so the pill
-  /// `setState` happens in the correct phase.
+  /// Animate (or jump) to `maxScrollExtent` and retry-settle so newly resolved
+  /// content (e.g. an image finishing decode) doesn't leave the user a few
+  /// pixels short of the bottom.
   void scrollToBottom({
     required String? conversationId,
     bool animated = true,

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show ScrollController;
+
+import '../models/chat_message.dart';
+import '../models/conversation.dart';
+import '../providers/chat_provider.dart';
+
+/// Non-rendering state controller for [ChatPanel].
+///
+/// Owns scroll, pagination, unread-boundary, and floating-date state so the
+/// widget's `State` can focus on the build tree. Receives data via method
+/// args; it never holds a `WidgetRef` or calls `ref.watch/read/select`.
+///
+/// Slice 1 (#512): pure helpers only — `isNearBottom`,
+/// `filterChannelAndDeleted`, `resolveMessages`. Subsequent slices move
+/// scroll, pagination, and unread-boundary state.
+class ChatPanelController extends ChangeNotifier {
+  ScrollController? _scrollController;
+
+  /// Persistent blocklist of message IDs deleted via "delete for me".
+  /// Owned by the widget for now; passed in via [resolveMessages] /
+  /// [filterChannelAndDeleted]. Will move into the controller in a later
+  /// slice once the SharedPreferences load path migrates.
+  Set<String> deletedForMeIds = const {};
+
+  /// Wire in the [ScrollController] managed by the widget's `State`. The
+  /// widget keeps ownership (creates + disposes); the controller only reads
+  /// from it. Called once from `initState`.
+  void attachScrollController(ScrollController controller) {
+    _scrollController = controller;
+  }
+
+  /// Returns true when the user is within 150px of the bottom of the list.
+  /// Defaults to true when the controller has no clients yet so the initial
+  /// auto-scroll path runs as if we're already pinned to the bottom.
+  bool isNearBottom() {
+    final c = _scrollController;
+    if (c == null || !c.hasClients) return true;
+    final pos = c.position;
+    return pos.maxScrollExtent - pos.pixels < 150;
+  }
+
+  /// Resolve messages for the current conversation and channel.
+  /// Filters out messages the user has deleted locally ("delete for me").
+  List<ChatMessage> resolveMessages(
+    Conversation conv,
+    ChatState chatState,
+    String? selectedChannelId,
+    bool includeUnchanneled,
+  ) {
+    final List<ChatMessage> raw;
+    if (conv.isGroup) {
+      raw = chatState.messagesForConversationChannel(
+        conv.id,
+        channelId: selectedChannelId,
+        includeUnchanneled: includeUnchanneled,
+      );
+    } else {
+      raw = chatState.messagesForConversation(conv.id);
+    }
+    if (deletedForMeIds.isEmpty) return raw;
+    return raw.where((m) => !deletedForMeIds.contains(m.id)).toList();
+  }
+
+  /// Apply channel + delete-for-me filters to a pre-fetched message list.
+  /// Used by the build path so a `.select` on the per-conversation list ref
+  /// keeps unrelated conversations from rebuilding.
+  List<ChatMessage> filterChannelAndDeleted(
+    Conversation conv,
+    List<ChatMessage> raw,
+    String? selectedChannelId,
+    bool includeUnchanneled,
+  ) {
+    Iterable<ChatMessage> filtered = raw;
+    if (conv.isGroup &&
+        selectedChannelId != null &&
+        selectedChannelId.isNotEmpty) {
+      filtered = filtered.where((m) {
+        if (m.isSystemEvent) return true;
+        if (m.channelId == selectedChannelId) return true;
+        return includeUnchanneled &&
+            (m.channelId == null || m.channelId!.isEmpty);
+      });
+    }
+    if (deletedForMeIds.isNotEmpty) {
+      filtered = filtered.where((m) => !deletedForMeIds.contains(m.id));
+    }
+    return identical(filtered, raw) ? raw : filtered.toList();
+  }
+}


### PR DESCRIPTION
## Summary

Split two ~2 kLOC Flutter god modules into widget + plain `ChangeNotifier` controllers + 8 extracted helper files. Behavior-preserving move: tests stay green without test-side changes.

- **#512** — `chat_panel.dart` 2068 → 788 LOC, scroll / pagination / unread-boundary / floating-date state extracted to `ChatPanelController`.
- **#513** — `chat_input_bar.dart` 2005 → 1780 LOC, text / edit / attachments / voice / mention state extracted to `ChatInputController` (composes the existing `MentionComposerController`).
- **#705** — already done in `115478a refactor(client): migrate chat_provider to @riverpod codegen (#770)`. No code change in this PR for it.

Plus a follow-up cleanup pass: deduped MIME-type map, deduped file-picker flows (`pickFile` / `pickImageFromGallery` → single `_pickAndDispatch`), extracted history-loader auth/crypto resolution into a `_resolveAuth` helper, deleted dead `_searchDebounce` field, deleted unused `voiceRenderers` param on `ChatPanelBodyParams`, inlined `_kImageGif` alias, stripped verbose refactor-narration comments throughout.

## Architecture

- Controllers are plain `ChangeNotifier`s, NOT Riverpod providers. They never hold a `WidgetRef` or call `ref.watch/read/select` — Riverpod listening stays in the widget's `State`.
- `ChatInputController` composes (not inherits) `MentionComposerController`; its dispose runs from the controller's dispose.
- `ChatInputBarState` keeps its `GlobalKey<ChatInputBarState>` API contract: `requestInputFocus`, `showInlinePicker`, `enterEditMode`, `preFillText`, `showMediaPicker`, `buildMediaPickerPanel`, `attachDroppedFile` — all identical signatures, all exercised by tests.

## No-touch invariants preserved

1. Per-channel scroll position cache + eviction policy
2. `#prod-2026-05-08` system-event pagination cursor (system rows skipped, comment marker preserved for grep)
3. Channel-scoped loading keys for `loadHistory` / `loadOlderMessages` dedupe
4. `_wasNearBottom` is captured BEFORE the soft keyboard shrinks the viewport
5. Unread-boundary single-capture-per-channel-session guard
6. PR #838 `.select()` perf fix annotated post-refactor at `chat_panel.dart:611`
7. Diff-reviewed every removed line against the pre-slice file before each commit

## Test plan

- [x] `flutter test test/widgets/chat_panel_test.dart` green
- [x] `flutter test test/widgets/chat_panel_live_region_test.dart` green
- [x] `flutter test test/widgets/chat_input_bar_test.dart` green (uses `GlobalKey<ChatInputBarState>`)
- [x] `flutter test test/widgets/chat_input_bar_attachments_test.dart` green
- [x] `cd apps/client && flutter test` — full suite green (1470 passed, 8 skipped, 0 failed)
- [x] `dart format --set-exit-if-changed .` clean
- [x] `flutter analyze --fatal-infos` clean
- [x] `chat_panel.dart` 788 LOC (< 800 target)
- [ ] Manual smoke on live build: open channel, switch channels, scroll up to paginate, send/attach/voice, `@mention` autocomplete