### PR TITLE
feat(client): reduce theme palette from 9 to 6 with locked design rules

### DIFF
--- a/apps/client/lib/src/app.dart
+++ b/apps/client/lib/src/app.dart
@@ -55,16 +55,12 @@ class EchoApp extends ConsumerWidget {
       AppThemeSelection.paper => ThemeMode.light,
       AppThemeSelection.graphite => ThemeMode.dark,
       AppThemeSelection.ember => ThemeMode.dark,
-      AppThemeSelection.neon => ThemeMode.dark,
-      AppThemeSelection.aurora => ThemeMode.dark,
       AppThemeSelection.sakura => ThemeMode.light,
       AppThemeSelection.highContrast => ThemeMode.dark,
     };
     final darkThemeBase = switch (themeSelection) {
       AppThemeSelection.graphite => EchoTheme.graphiteTheme,
       AppThemeSelection.ember => EchoTheme.emberTheme,
-      AppThemeSelection.neon => EchoTheme.neonTheme,
-      AppThemeSelection.aurora => EchoTheme.auroraTheme,
       AppThemeSelection.highContrast => EchoTheme.highContrastTheme,
       _ => EchoTheme.darkTheme,
     };

--- a/apps/client/lib/src/app.dart
+++ b/apps/client/lib/src/app.dart
@@ -52,7 +52,7 @@ class EchoApp extends ConsumerWidget {
     final themeMode = switch (themeSelection) {
       AppThemeSelection.system => ThemeMode.system,
       AppThemeSelection.indigo => ThemeMode.dark,
-      AppThemeSelection.light => ThemeMode.light,
+      AppThemeSelection.paper => ThemeMode.light,
       AppThemeSelection.graphite => ThemeMode.dark,
       AppThemeSelection.ember => ThemeMode.dark,
       AppThemeSelection.neon => ThemeMode.dark,

--- a/apps/client/lib/src/app.dart
+++ b/apps/client/lib/src/app.dart
@@ -58,27 +58,30 @@ class EchoApp extends ConsumerWidget {
       AppThemeSelection.neon => ThemeMode.dark,
       AppThemeSelection.aurora => ThemeMode.dark,
       AppThemeSelection.sakura => ThemeMode.light,
+      AppThemeSelection.highContrast => ThemeMode.dark,
     };
     final darkThemeBase = switch (themeSelection) {
       AppThemeSelection.graphite => EchoTheme.graphiteTheme,
       AppThemeSelection.ember => EchoTheme.emberTheme,
       AppThemeSelection.neon => EchoTheme.neonTheme,
       AppThemeSelection.aurora => EchoTheme.auroraTheme,
+      AppThemeSelection.highContrast => EchoTheme.highContrastTheme,
       _ => EchoTheme.darkTheme,
     };
     final lightThemeBase = switch (themeSelection) {
       AppThemeSelection.sakura => EchoTheme.sakuraTheme,
+      AppThemeSelection.highContrast => EchoTheme.highContrastTheme,
       _ =>
         accessibility.highContrast
-            ? EchoTheme.highContrastLightTheme
+            ? EchoTheme.highContrastTheme
             : EchoTheme.lightTheme,
     };
 
     // Apply user-defined color overrides on top of the selected theme.
+    // The accessibility.highContrast toggle still forces HC regardless of the
+    // theme selection (overlay behavior, independent of the picker).
     final darkTheme = _applyCustomColors(
-      accessibility.highContrast
-          ? EchoTheme.highContrastDarkTheme
-          : darkThemeBase,
+      accessibility.highContrast ? EchoTheme.highContrastTheme : darkThemeBase,
       customColors,
     );
     final lightTheme = _applyCustomColors(lightThemeBase, customColors);

--- a/apps/client/lib/src/app.dart
+++ b/apps/client/lib/src/app.dart
@@ -51,7 +51,7 @@ class EchoApp extends ConsumerWidget {
 
     final themeMode = switch (themeSelection) {
       AppThemeSelection.system => ThemeMode.system,
-      AppThemeSelection.dark => ThemeMode.dark,
+      AppThemeSelection.indigo => ThemeMode.dark,
       AppThemeSelection.light => ThemeMode.light,
       AppThemeSelection.graphite => ThemeMode.dark,
       AppThemeSelection.ember => ThemeMode.dark,

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -12,7 +12,7 @@ const kCustomAccentColorKey = 'theme.accent_color';
 
 enum AppThemeSelection {
   system,
-  dark,
+  indigo,
   light,
   graphite,
   ember,
@@ -34,7 +34,7 @@ class AppTheme extends _$AppTheme {
   @override
   AppThemeSelection build() {
     _load();
-    return AppThemeSelection.dark;
+    return AppThemeSelection.indigo;
   }
 
   Future<void> _load() async {
@@ -42,14 +42,16 @@ class AppTheme extends _$AppTheme {
     final value = prefs.getString(_kThemeKey);
     state = switch (value) {
       'light' => AppThemeSelection.light,
-      'dark' => AppThemeSelection.dark,
+      'indigo' => AppThemeSelection.indigo,
+      'dark' =>
+        AppThemeSelection.indigo, // legacy alias for migration (slice 6)
       'system' => AppThemeSelection.system,
       'graphite' => AppThemeSelection.graphite,
       'ember' => AppThemeSelection.ember,
       'neon' => AppThemeSelection.neon,
       'sakura' => AppThemeSelection.sakura,
       'aurora' => AppThemeSelection.aurora,
-      _ => AppThemeSelection.dark,
+      _ => AppThemeSelection.indigo,
     };
   }
 
@@ -63,7 +65,7 @@ class AppTheme extends _$AppTheme {
   Future<void> setThemeMode(ThemeMode mode) async {
     final selection = switch (mode) {
       ThemeMode.system => AppThemeSelection.system,
-      ThemeMode.dark => AppThemeSelection.dark,
+      ThemeMode.dark => AppThemeSelection.indigo,
       ThemeMode.light => AppThemeSelection.light,
     };
     await setTheme(selection);

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -19,6 +19,7 @@ enum AppThemeSelection {
   neon,
   sakura,
   aurora,
+  highContrast,
 }
 
 const _kThemeKey = 'echo_theme_mode';
@@ -53,6 +54,10 @@ class AppTheme extends _$AppTheme {
       'neon' => AppThemeSelection.neon,
       'sakura' => AppThemeSelection.sakura,
       'aurora' => AppThemeSelection.aurora,
+      'highContrast' => AppThemeSelection.highContrast,
+      'highContrastDark' =>
+        AppThemeSelection.highContrast, // legacy alias (slice 6)
+      'highContrastLight' => AppThemeSelection.paper, // legacy alias (slice 6)
       _ => AppThemeSelection.indigo,
     };
   }

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -13,7 +13,7 @@ const kCustomAccentColorKey = 'theme.accent_color';
 enum AppThemeSelection {
   system,
   indigo,
-  light,
+  paper,
   graphite,
   ember,
   neon,
@@ -41,7 +41,9 @@ class AppTheme extends _$AppTheme {
     final prefs = await SharedPreferences.getInstance();
     final value = prefs.getString(_kThemeKey);
     state = switch (value) {
-      'light' => AppThemeSelection.light,
+      'paper' => AppThemeSelection.paper,
+      'light' =>
+        AppThemeSelection.paper, // legacy alias for migration (slice 6)
       'indigo' => AppThemeSelection.indigo,
       'dark' =>
         AppThemeSelection.indigo, // legacy alias for migration (slice 6)
@@ -66,7 +68,7 @@ class AppTheme extends _$AppTheme {
     final selection = switch (mode) {
       ThemeMode.system => AppThemeSelection.system,
       ThemeMode.dark => AppThemeSelection.indigo,
-      ThemeMode.light => AppThemeSelection.light,
+      ThemeMode.light => AppThemeSelection.paper,
     };
     await setTheme(selection);
   }

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -16,9 +16,7 @@ enum AppThemeSelection {
   paper,
   graphite,
   ember,
-  neon,
   sakura,
-  aurora,
   highContrast,
 }
 
@@ -51,9 +49,9 @@ class AppTheme extends _$AppTheme {
       'system' => AppThemeSelection.system,
       'graphite' => AppThemeSelection.graphite,
       'ember' => AppThemeSelection.ember,
-      'neon' => AppThemeSelection.neon,
+      'neon' => AppThemeSelection.highContrast, // legacy alias (slice 6)
       'sakura' => AppThemeSelection.sakura,
-      'aurora' => AppThemeSelection.aurora,
+      'aurora' => AppThemeSelection.indigo, // legacy alias (slice 6)
       'highContrast' => AppThemeSelection.highContrast,
       'highContrastDark' =>
         AppThemeSelection.highContrast, // legacy alias (slice 6)

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -36,28 +36,40 @@ class AppTheme extends _$AppTheme {
     return AppThemeSelection.indigo;
   }
 
+  /// Legacy-string migration table. The 9 -> 6 palette reduction renamed
+  /// `dark` -> `indigo`, `light` -> `paper`, collapsed `highContrast{Dark,Light}`
+  /// into a single `highContrast`, and removed `neon` / `aurora`. Any value
+  /// not in [AppThemeSelection.values] by name is migrated silently here.
+  static AppThemeSelection _migrateLegacy(String? value) => switch (value) {
+    'paper' => AppThemeSelection.paper,
+    'indigo' => AppThemeSelection.indigo,
+    'system' => AppThemeSelection.system,
+    'graphite' => AppThemeSelection.graphite,
+    'ember' => AppThemeSelection.ember,
+    'sakura' => AppThemeSelection.sakura,
+    'highContrast' => AppThemeSelection.highContrast,
+    // Legacy renames + cuts (silent migration).
+    'dark' => AppThemeSelection.indigo,
+    'light' => AppThemeSelection.paper,
+    'aurora' => AppThemeSelection.indigo,
+    'neon' => AppThemeSelection.highContrast,
+    'highContrastDark' => AppThemeSelection.highContrast,
+    'highContrastLight' => AppThemeSelection.paper,
+    // Unknown / null -> default.
+    _ => AppThemeSelection.indigo,
+  };
+
   Future<void> _load() async {
     final prefs = await SharedPreferences.getInstance();
     final value = prefs.getString(_kThemeKey);
-    state = switch (value) {
-      'paper' => AppThemeSelection.paper,
-      'light' =>
-        AppThemeSelection.paper, // legacy alias for migration (slice 6)
-      'indigo' => AppThemeSelection.indigo,
-      'dark' =>
-        AppThemeSelection.indigo, // legacy alias for migration (slice 6)
-      'system' => AppThemeSelection.system,
-      'graphite' => AppThemeSelection.graphite,
-      'ember' => AppThemeSelection.ember,
-      'neon' => AppThemeSelection.highContrast, // legacy alias (slice 6)
-      'sakura' => AppThemeSelection.sakura,
-      'aurora' => AppThemeSelection.indigo, // legacy alias (slice 6)
-      'highContrast' => AppThemeSelection.highContrast,
-      'highContrastDark' =>
-        AppThemeSelection.highContrast, // legacy alias (slice 6)
-      'highContrastLight' => AppThemeSelection.paper, // legacy alias (slice 6)
-      _ => AppThemeSelection.indigo,
-    };
+    final migrated = _migrateLegacy(value);
+    state = migrated;
+    // One-shot write-back: if the persisted string isn't already the new
+    // canonical name, normalise it so subsequent loads skip the migration
+    // path and a manual prefs-file inspection shows the new value.
+    if (value != migrated.name) {
+      await prefs.setString(_kThemeKey, migrated.name);
+    }
   }
 
   Future<void> setTheme(AppThemeSelection selection) async {

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -430,7 +430,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
       child: Column(
         children: [
           const SizedBox(height: 24),
-          Icon(Icons.lock_outline, size: 64, color: context.accent),
+          Icon(Icons.lock_outline, size: 64, color: context.textMuted),
           const SizedBox(height: 24),
           Text(
             'Your messages are private',

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -113,6 +113,9 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
   @override
   Widget build(BuildContext context) {
     final currentTheme = ref.watch(themeProvider);
+    // Card order (palette reduction 2026-05-11): Indigo, Graphite, Ember,
+    // Paper, Sakura, High contrast. System lives at the top as the "follow
+    // device" affordance and is not part of the six-palette set.
     const themeOptions = <_ThemeCardData>[
       _ThemeCardData(
         selection: AppThemeSelection.system,
@@ -123,26 +126,26 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
       _ThemeCardData(
         selection: AppThemeSelection.indigo,
         label: 'Indigo',
-        subtitle: 'Easy on the eyes',
+        subtitle: 'Default accent',
         preview: _darkPreview,
+      ),
+      _ThemeCardData(
+        selection: AppThemeSelection.graphite,
+        label: 'Graphite',
+        subtitle: 'Teal on cool black',
+        preview: _graphitePreview,
+      ),
+      _ThemeCardData(
+        selection: AppThemeSelection.ember,
+        label: 'Ember',
+        subtitle: 'Amber on warm black',
+        preview: _emberPreview,
       ),
       _ThemeCardData(
         selection: AppThemeSelection.paper,
         label: 'Paper',
         subtitle: 'Warm off-white',
         preview: _lightPreview,
-      ),
-      _ThemeCardData(
-        selection: AppThemeSelection.graphite,
-        label: 'Graphite',
-        subtitle: 'Teal accents',
-        preview: _graphitePreview,
-      ),
-      _ThemeCardData(
-        selection: AppThemeSelection.ember,
-        label: 'Ember',
-        subtitle: 'Amber accents',
-        preview: _emberPreview,
       ),
       _ThemeCardData(
         selection: AppThemeSelection.sakura,

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -132,8 +132,8 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
         preview: null, // special split preview
       ),
       _ThemeCardData(
-        selection: AppThemeSelection.dark,
-        label: 'Dark',
+        selection: AppThemeSelection.indigo,
+        label: 'Indigo',
         subtitle: 'Easy on the eyes',
         preview: _darkPreview,
       ),

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -48,7 +48,7 @@ const _lightPreview = _ThemePreviewColors(
   mainBg: EchoTheme.lightMainBg,
   sentBubble: EchoTheme.lightSentBubble,
   recvBubble: EchoTheme.lightRecvBubble,
-  accent: EchoTheme.accent,
+  accent: EchoTheme.paperAccent,
   border: EchoTheme.lightBorder,
   textPrimary: EchoTheme.lightTextPrimary,
   textSecondary: EchoTheme.lightTextSecondary,
@@ -138,9 +138,9 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
         preview: _darkPreview,
       ),
       _ThemeCardData(
-        selection: AppThemeSelection.light,
-        label: 'Light',
-        subtitle: 'Classic bright look',
+        selection: AppThemeSelection.paper,
+        label: 'Paper',
+        subtitle: 'Warm off-white',
         preview: _lightPreview,
       ),
       _ThemeCardData(

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -109,6 +109,17 @@ const _auroraPreview = _ThemePreviewColors(
   textSecondary: EchoTheme.auroraTextSecondary,
 );
 
+const _highContrastPreview = _ThemePreviewColors(
+  sidebarBg: Color(0xFF0A0A0A),
+  mainBg: Color(0xFF000000),
+  sentBubble: Color(0xFF7C9BFF),
+  recvBubble: Color(0xFF000000),
+  accent: Color(0xFF7C9BFF),
+  border: Color(0xFF8A8A8A),
+  textPrimary: Color(0xFFFFFFFF),
+  textSecondary: Color(0xFFCCCCCC),
+);
+
 class AppearanceSection extends ConsumerStatefulWidget {
   const AppearanceSection({super.key});
 
@@ -172,6 +183,12 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
         label: 'Aurora',
         subtitle: 'Violet gradient',
         preview: _auroraPreview,
+      ),
+      _ThemeCardData(
+        selection: AppThemeSelection.highContrast,
+        label: 'High contrast',
+        subtitle: 'WCAG AAA accessibility',
+        preview: _highContrastPreview,
       ),
     ];
 

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -76,17 +76,6 @@ const _emberPreview = _ThemePreviewColors(
   textSecondary: EchoTheme.emberTextSecondary,
 );
 
-const _neonPreview = _ThemePreviewColors(
-  sidebarBg: EchoTheme.neonSidebarBg,
-  mainBg: EchoTheme.neonMainBg,
-  sentBubble: EchoTheme.neonSentBubble,
-  recvBubble: EchoTheme.neonRecvBubble,
-  accent: EchoTheme.neonAccent,
-  border: EchoTheme.neonBorder,
-  textPrimary: EchoTheme.neonTextPrimary,
-  textSecondary: EchoTheme.neonTextSecondary,
-);
-
 const _sakuraPreview = _ThemePreviewColors(
   sidebarBg: EchoTheme.sakuraSidebarBg,
   mainBg: EchoTheme.sakuraMainBg,
@@ -96,17 +85,6 @@ const _sakuraPreview = _ThemePreviewColors(
   border: EchoTheme.sakuraBorder,
   textPrimary: EchoTheme.sakuraTextPrimary,
   textSecondary: EchoTheme.sakuraTextSecondary,
-);
-
-const _auroraPreview = _ThemePreviewColors(
-  sidebarBg: EchoTheme.auroraSidebarBg,
-  mainBg: EchoTheme.auroraMainBg,
-  sentBubble: EchoTheme.auroraSentBubble,
-  recvBubble: EchoTheme.auroraRecvBubble,
-  accent: EchoTheme.auroraAccent,
-  border: EchoTheme.auroraBorder,
-  textPrimary: EchoTheme.auroraTextPrimary,
-  textSecondary: EchoTheme.auroraTextSecondary,
 );
 
 const _highContrastPreview = _ThemePreviewColors(
@@ -167,22 +145,10 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
         preview: _emberPreview,
       ),
       _ThemeCardData(
-        selection: AppThemeSelection.neon,
-        label: 'Neon',
-        subtitle: 'Electric green gamer',
-        preview: _neonPreview,
-      ),
-      _ThemeCardData(
         selection: AppThemeSelection.sakura,
         label: 'Sakura',
         subtitle: 'Soft pink pastels',
         preview: _sakuraPreview,
-      ),
-      _ThemeCardData(
-        selection: AppThemeSelection.aurora,
-        label: 'Aurora',
-        subtitle: 'Violet gradient',
-        preview: _auroraPreview,
       ),
       _ThemeCardData(
         selection: AppThemeSelection.highContrast,

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -255,12 +255,8 @@ class SettingsRootView extends ConsumerWidget {
         return 'Graphite';
       case AppThemeSelection.ember:
         return 'Ember';
-      case AppThemeSelection.neon:
-        return 'Neon';
       case AppThemeSelection.sakura:
         return 'Sakura';
-      case AppThemeSelection.aurora:
-        return 'Aurora';
       case AppThemeSelection.highContrast:
         return 'High contrast';
     }

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -261,6 +261,8 @@ class SettingsRootView extends ConsumerWidget {
         return 'Sakura';
       case AppThemeSelection.aurora:
         return 'Aurora';
+      case AppThemeSelection.highContrast:
+        return 'High contrast';
     }
   }
 }

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -249,8 +249,8 @@ class SettingsRootView extends ConsumerWidget {
         return 'System';
       case AppThemeSelection.indigo:
         return 'Indigo';
-      case AppThemeSelection.light:
-        return 'Light';
+      case AppThemeSelection.paper:
+        return 'Paper';
       case AppThemeSelection.graphite:
         return 'Graphite';
       case AppThemeSelection.ember:

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -247,8 +247,8 @@ class SettingsRootView extends ConsumerWidget {
     switch (selection) {
       case AppThemeSelection.system:
         return 'System';
-      case AppThemeSelection.dark:
-        return 'Dark';
+      case AppThemeSelection.indigo:
+        return 'Indigo';
       case AppThemeSelection.light:
         return 'Light';
       case AppThemeSelection.graphite:

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -16,8 +16,9 @@ class EchoTheme {
   static const textPrimary = Color(0xFFEDEDEF);
   static const textSecondary = Color(0xFFABABB0);
   static const textMuted = Color(0xFF848490);
-  static const sentBubble = Color(0xFF5254D4);
-  static const recvBubble = Color(0xFF242428);
+  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
+  static const sentBubble = accent;
+  static const recvBubble = surface;
   static const border = Color(0xFF27272A);
   static const online = Color(0xFF22C55E);
   static const danger = Color(0xFFEF4444);
@@ -277,8 +278,9 @@ class EchoTheme {
   static const lightTextPrimary = Color(0xFF1A1A1E);
   static const lightTextSecondary = Color(0xFF5C5C66);
   static const lightTextMuted = Color(0xFF72727E);
-  static const lightSentBubble = Color(0xFF5B5EE6);
-  static const lightRecvBubble = Color(0xFFE8E8EC);
+  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
+  static const lightSentBubble = accent;
+  static const lightRecvBubble = lightSurface;
   static const lightBorder = Color(0xFFDFDFE5);
   static const lightAccentLight = Color(0x1A5B5EE6);
 
@@ -298,8 +300,9 @@ class EchoTheme {
   static const graphiteTextPrimary = Color(0xFFE7F4F8);
   static const graphiteTextSecondary = Color(0xFFA3BAC2);
   static const graphiteTextMuted = Color(0xFF8FA8B2);
-  static const graphiteSentBubble = Color(0xFF0FA594);
-  static const graphiteRecvBubble = Color(0xFF22333B);
+  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
+  static const graphiteSentBubble = graphiteAccent;
+  static const graphiteRecvBubble = graphiteSurface;
   static const graphiteBorder = Color(0xFF2C434D);
 
   // Ember theme colors (warm dark with amber accent)
@@ -318,10 +321,9 @@ class EchoTheme {
   static const emberTextPrimary = Color(0xFFF5F0E8);
   static const emberTextSecondary = Color(0xFFA89F91);
   static const emberTextMuted = Color(0xFF91867A);
-  // sentBubble matches the accent so dark-on-accent text passes WCAG AA;
-  // the previous darker brown was unreadable with dark onPrimary text.
-  static const emberSentBubble = Color(0xFFE9960A);
-  static const emberRecvBubble = Color(0xFF252019);
+  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
+  static const emberSentBubble = emberAccent;
+  static const emberRecvBubble = emberSurface;
   static const emberBorder = Color(0xFF332D24);
 
   // Neon theme colors (gamer aesthetic -- dark with electric green/cyan accents)
@@ -336,8 +338,9 @@ class EchoTheme {
   static const neonTextPrimary = Color(0xFFE0E0E8);
   static const neonTextSecondary = Color(0xFFA0A0B8);
   static const neonTextMuted = Color(0xFF7C7C99);
-  static const neonSentBubble = Color(0xFF00CC6A);
-  static const neonRecvBubble = Color(0xFF1A1A28);
+  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
+  static const neonSentBubble = neonAccent;
+  static const neonRecvBubble = neonSurface;
   static const neonBorder = Color(0xFF222235);
 
   // Aurora theme colors (deep violet dark with gradient chat background)
@@ -354,25 +357,28 @@ class EchoTheme {
   static const auroraTextPrimary = Color(0xFFEDE9F6);
   static const auroraTextSecondary = Color(0xFFABA4BE);
   static const auroraTextMuted = Color(0xFF8780A0);
-  static const auroraSentBubble = Color(0xFF7C3AED);
-  static const auroraRecvBubble = Color(0xFF1E1A2E);
+  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
+  static const auroraSentBubble = auroraAccent;
+  static const auroraRecvBubble = auroraSurface;
   static const auroraBorder = Color(0xFF2D2744);
 
   // Sakura theme colors (feminine aesthetic -- light pink with soft pastels)
-  static const sakuraMainBg = Color(0xFFFFF5F7);
+  // Accent darkened from 0xFFDD1C85 -> 0xFFC0186E for WCAG AA on white text.
+  // Bg warmed from 0xFFFFF5F7 -> 0xFFFFF7F5.
+  static const sakuraMainBg = Color(0xFFFFF7F5);
   static const sakuraSidebarBg = Color(0xFFFFF0F3);
   static const sakuraChatBg = Color(0xFFFFF8FA);
   static const sakuraSurface = Color(0xFFFFFAFC);
   static const sakuraSurfaceHover = Color(0xFFFFE8EE);
-  // Darkened ~5% from 0xFFE91E8C for stronger white-on-accent contrast.
-  static const sakuraAccent = Color(0xFFDD1C85);
+  static const sakuraAccent = Color(0xFFC0186E);
   static const sakuraAccentHover = Color(0xFFFF45A8);
-  static const sakuraAccentLight = Color(0x1ADD1C85);
+  static const sakuraAccentLight = Color(0x1AC0186E);
   static const sakuraTextPrimary = Color(0xFF2D1B2E);
   static const sakuraTextSecondary = Color(0xFF7B5A7E);
   static const sakuraTextMuted = Color(0xFF89698C);
-  static const sakuraSentBubble = Color(0xFFDD1C85);
-  static const sakuraRecvBubble = Color(0xFFFFE8EE);
+  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
+  static const sakuraSentBubble = sakuraAccent;
+  static const sakuraRecvBubble = sakuraSurface;
   static const sakuraBorder = Color(0xFFF0D4DC);
 
   // ---------------------------------------------------------------------------
@@ -968,12 +974,16 @@ class EchoTheme {
 
   static ThemeData get highContrastDarkTheme {
     final base = darkTheme;
+    // High-contrast accent: #7C9BFF on pure-black bg with white text.
+    const hcAccent = Color(0xFF7C9BFF);
+    const hcSurface = Colors.black;
     return base.copyWith(
       colorScheme: base.colorScheme.copyWith(
-        surface: Colors.black,
+        surface: hcSurface,
         onSurface: Colors.white,
-        primary: Colors.yellow,
-        secondary: const Color(0xFFFFFF66),
+        primary: hcAccent,
+        secondary: hcAccent,
+        onPrimary: Colors.black,
         onSurfaceVariant: const Color(0xFFCCCCCC),
       ),
       dividerColor: Colors.white54,
@@ -983,10 +993,11 @@ class EchoTheme {
           sidebarBg: const Color(0xFF0A0A0A),
           chatBg: Colors.black,
           surfaceHover: const Color(0xFF1A1A1A),
-          sentBubble: const Color(0xFF444400),
-          recvBubble: const Color(0xFF1A1A1A),
+          // Locked bubble rule: sent = primary, recv = surface.
+          sentBubble: hcAccent,
+          recvBubble: hcSurface,
           textMuted: const Color(0xFFAAAAAA),
-          accentLight: const Color(0x33FFFF00),
+          accentLight: const Color(0x337C9BFF),
         ),
       ],
     );
@@ -1009,8 +1020,9 @@ class EchoTheme {
           sidebarBg: const Color(0xFFF0F0F0),
           chatBg: Colors.white,
           surfaceHover: const Color(0xFFE8E8E8),
+          // Locked bubble rule: sent = primary, recv = surface.
           sentBubble: const Color(0xFF0000CC),
-          recvBubble: const Color(0xFFE8E8E8),
+          recvBubble: Colors.white,
           textMuted: const Color(0xFF555555),
           accentLight: const Color(0x220000CC),
         ),

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -976,9 +976,11 @@ class EchoTheme {
   // High-contrast themes
   // ---------------------------------------------------------------------------
 
-  static ThemeData get highContrastDarkTheme {
+  /// Single high-contrast theme: #7C9BFF accent on pure black with white text.
+  /// Replaces the legacy `highContrastDarkTheme` + `highContrastLightTheme`
+  /// split (collapsed in the 9 -> 6 palette reduction).
+  static ThemeData get highContrastTheme {
     final base = darkTheme;
-    // High-contrast accent: #7C9BFF on pure-black bg with white text.
     const hcAccent = Color(0xFF7C9BFF);
     const hcSurface = Colors.black;
     return base.copyWith(
@@ -1002,33 +1004,6 @@ class EchoTheme {
           recvBubble: hcSurface,
           textMuted: const Color(0xFFAAAAAA),
           accentLight: const Color(0x337C9BFF),
-        ),
-      ],
-    );
-  }
-
-  static ThemeData get highContrastLightTheme {
-    final base = lightTheme;
-    return base.copyWith(
-      colorScheme: base.colorScheme.copyWith(
-        surface: Colors.white,
-        onSurface: Colors.black,
-        primary: const Color(0xFF0000CC),
-        secondary: const Color(0xFF0000AA),
-        onSurfaceVariant: const Color(0xFF333333),
-      ),
-      dividerColor: Colors.black54,
-      scaffoldBackgroundColor: Colors.white,
-      extensions: [
-        EchoColorExtension.light.copyWith(
-          sidebarBg: const Color(0xFFF0F0F0),
-          chatBg: Colors.white,
-          surfaceHover: const Color(0xFFE8E8E8),
-          // Locked bubble rule: sent = primary, recv = surface.
-          sentBubble: const Color(0xFF0000CC),
-          recvBubble: Colors.white,
-          textMuted: const Color(0xFF555555),
-          accentLight: const Color(0x220000CC),
         ),
       ],
     );

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -269,20 +269,24 @@ class EchoTheme {
     );
   }
 
-  // Light theme colors — tuned to avoid harsh pure white
-  static const lightMainBg = Color(0xFFF5F5F7);
-  static const lightSidebarBg = Color(0xFFF0F0F3);
-  static const lightChatBg = Color(0xFFF8F8FA);
-  static const lightSurface = Color(0xFFFAFAFC);
-  static const lightSurfaceHover = Color(0xFFEEEEF1);
+  // Paper theme colors (light) — warm off-white with darkened indigo accent.
+  // Replaces the legacy "Light" palette: bg warmed from #F5F5F7 -> #FAFAF7,
+  // accent darkened from #5B5EE6 -> #4F46E5 for stronger WCAG AA contrast.
+  static const paperAccent = Color(0xFF4F46E5);
+  static const paperAccentHover = Color(0xFF6366F1);
+  static const lightMainBg = Color(0xFFFAFAF7);
+  static const lightSidebarBg = Color(0xFFF3F3EF);
+  static const lightChatBg = Color(0xFFF8F8F5);
+  static const lightSurface = Color(0xFFFFFFFC);
+  static const lightSurfaceHover = Color(0xFFEEEEEA);
   static const lightTextPrimary = Color(0xFF1A1A1E);
   static const lightTextSecondary = Color(0xFF5C5C66);
   static const lightTextMuted = Color(0xFF72727E);
   // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
-  static const lightSentBubble = accent;
+  static const lightSentBubble = paperAccent;
   static const lightRecvBubble = lightSurface;
-  static const lightBorder = Color(0xFFDFDFE5);
-  static const lightAccentLight = Color(0x1A5B5EE6);
+  static const lightBorder = Color(0xFFDFDFD5);
+  static const lightAccentLight = Color(0x1A4F46E5);
 
   // Graphite theme colors (high-contrast dark with teal accent)
   // Dark onPrimary used because the high-luminance teal accent fails WCAG AA
@@ -399,8 +403,8 @@ class EchoTheme {
       scaffoldBackgroundColor: lightMainBg,
       textTheme: textTheme,
       colorScheme: const ColorScheme.light(
-        primary: accent,
-        secondary: accentHover,
+        primary: paperAccent,
+        secondary: paperAccentHover,
         surface: lightSurface,
         onSurfaceVariant: lightTextSecondary,
         error: danger,
@@ -429,12 +433,12 @@ class EchoTheme {
       inputDecorationTheme: _buildInputTheme(
         fillColor: lightSurface,
         borderColor: lightBorder,
-        focusBorderColor: accent,
+        focusBorderColor: paperAccent,
         hintColor: lightTextMuted,
         labelColor: lightTextSecondary,
       ),
-      filledButtonTheme: _buildFilledButtonTheme(accent),
-      textButtonTheme: _buildTextButtonTheme(accent),
+      filledButtonTheme: _buildFilledButtonTheme(paperAccent),
+      textButtonTheme: _buildTextButtonTheme(paperAccent),
       outlinedButtonTheme: _buildOutlinedButtonTheme(
         lightTextPrimary,
         lightBorder,

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -330,42 +330,6 @@ class EchoTheme {
   static const emberRecvBubble = emberSurface;
   static const emberBorder = Color(0xFF332D24);
 
-  // Neon theme colors (gamer aesthetic -- dark with electric green/cyan accents)
-  static const neonMainBg = Color(0xFF0A0A0F);
-  static const neonSidebarBg = Color(0xFF0D0D14);
-  static const neonChatBg = Color(0xFF0E0E16);
-  static const neonSurface = Color(0xFF14141E);
-  static const neonSurfaceHover = Color(0xFF1A1A28);
-  static const neonAccent = Color(0xFF00FF88);
-  static const neonAccentHover = Color(0xFF33FFaa);
-  static const neonAccentLight = Color(0x1A00FF88);
-  static const neonTextPrimary = Color(0xFFE0E0E8);
-  static const neonTextSecondary = Color(0xFFA0A0B8);
-  static const neonTextMuted = Color(0xFF7C7C99);
-  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
-  static const neonSentBubble = neonAccent;
-  static const neonRecvBubble = neonSurface;
-  static const neonBorder = Color(0xFF222235);
-
-  // Aurora theme colors (deep violet dark with gradient chat background)
-  static const auroraMainBg = Color(0xFF0D0B14);
-  static const auroraSidebarBg = Color(0xFF110E1A);
-  static const auroraChatBg = Color(0xFF0D0B14);
-  static const auroraChatBgEnd = Color(0xFF0B0F1A);
-  static const auroraSurface = Color(0xFF1A1628);
-  static const auroraSurfaceHover = Color(0xFF231E34);
-  // Darkened ~5% from 0xFF8B5CF6 for stronger white-on-accent contrast.
-  static const auroraAccent = Color(0xFF8458E9);
-  static const auroraAccentHover = Color(0xFFA78BFA);
-  static const auroraAccentLight = Color(0x1A8458E9);
-  static const auroraTextPrimary = Color(0xFFEDE9F6);
-  static const auroraTextSecondary = Color(0xFFABA4BE);
-  static const auroraTextMuted = Color(0xFF8780A0);
-  // Locked bubble rule: sentBubble = primary (accent), recvBubble = surface.
-  static const auroraSentBubble = auroraAccent;
-  static const auroraRecvBubble = auroraSurface;
-  static const auroraBorder = Color(0xFF2D2744);
-
   // Sakura theme colors (feminine aesthetic -- light pink with soft pastels)
   // Accent darkened from 0xFFDD1C85 -> 0xFFC0186E for WCAG AA on white text.
   // Bg warmed from 0xFFFFF5F7 -> 0xFFFFF7F5.
@@ -681,103 +645,6 @@ class EchoTheme {
   }
 
   // ---------------------------------------------------------------------------
-  // Neon theme
-  // ---------------------------------------------------------------------------
-
-  static ThemeData get neonTheme {
-    final textTheme = _buildTextTheme(
-      brightness: Brightness.dark,
-      primaryColor: neonTextPrimary,
-      secondaryColor: neonTextSecondary,
-      mutedColor: neonTextMuted,
-    );
-
-    return ThemeData(
-      brightness: Brightness.dark,
-      extensions: const [EchoColorExtension.neon],
-      scaffoldBackgroundColor: neonMainBg,
-      textTheme: textTheme,
-      colorScheme: const ColorScheme.dark(
-        primary: neonAccent,
-        secondary: neonAccentHover,
-        surface: neonSurface,
-        onSurfaceVariant: neonTextSecondary,
-        error: danger,
-        onPrimary: Color(0xFF0A0A0F),
-        onSecondary: Color(0xFF0A0A0F),
-        onSurface: neonTextPrimary,
-        onError: Colors.white,
-      ),
-      appBarTheme: AppBarTheme(
-        backgroundColor: neonSidebarBg,
-        foregroundColor: neonTextPrimary,
-        elevation: 0,
-        surfaceTintColor: Colors.transparent,
-        titleTextStyle: GoogleFonts.inter(
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-          color: neonTextPrimary,
-        ),
-      ),
-      dividerColor: neonBorder,
-      dividerTheme: const DividerThemeData(
-        color: neonBorder,
-        thickness: 1,
-        space: 1,
-      ),
-      inputDecorationTheme: _buildInputTheme(
-        fillColor: neonSurface,
-        borderColor: neonBorder,
-        focusBorderColor: neonAccent,
-        hintColor: neonTextMuted,
-        labelColor: neonTextSecondary,
-      ),
-      filledButtonTheme: _buildFilledButtonTheme(
-        neonAccent,
-        foregroundColor: const Color(0xFF0A0A0F),
-      ),
-      textButtonTheme: _buildTextButtonTheme(neonAccent),
-      outlinedButtonTheme: _buildOutlinedButtonTheme(
-        neonTextPrimary,
-        neonBorder,
-      ),
-      iconTheme: const IconThemeData(color: neonTextSecondary, size: 20),
-      tooltipTheme: TooltipThemeData(
-        decoration: BoxDecoration(
-          color: neonSurface,
-          borderRadius: BorderRadius.circular(6),
-          border: Border.all(color: neonBorder, width: 1),
-        ),
-        textStyle: GoogleFonts.inter(color: neonTextPrimary, fontSize: 12),
-        waitDuration: const Duration(milliseconds: 500),
-      ),
-      dialogTheme: DialogThemeData(
-        backgroundColor: neonSurface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: const BorderSide(color: neonBorder),
-        ),
-      ),
-      bottomSheetTheme: const BottomSheetThemeData(
-        backgroundColor: neonSurface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
-        ),
-      ),
-      snackBarTheme: SnackBarThemeData(
-        backgroundColor: neonSurface,
-        contentTextStyle: GoogleFonts.inter(
-          color: neonTextPrimary,
-          fontSize: 13,
-        ),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-        behavior: SnackBarBehavior.floating,
-        insetPadding: const EdgeInsets.fromLTRB(16, 0, 16, 88),
-      ),
-    );
-  }
-
-  // ---------------------------------------------------------------------------
   // Sakura theme
   // ---------------------------------------------------------------------------
 
@@ -869,100 +736,6 @@ class EchoTheme {
         backgroundColor: sakuraSurface,
         contentTextStyle: GoogleFonts.inter(
           color: sakuraTextPrimary,
-          fontSize: 13,
-        ),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-        behavior: SnackBarBehavior.floating,
-        insetPadding: const EdgeInsets.fromLTRB(16, 0, 16, 88),
-      ),
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Aurora theme
-  // ---------------------------------------------------------------------------
-
-  static ThemeData get auroraTheme {
-    final textTheme = _buildTextTheme(
-      brightness: Brightness.dark,
-      primaryColor: auroraTextPrimary,
-      secondaryColor: auroraTextSecondary,
-      mutedColor: auroraTextMuted,
-    );
-
-    return ThemeData(
-      brightness: Brightness.dark,
-      extensions: const [EchoColorExtension.aurora],
-      scaffoldBackgroundColor: auroraMainBg,
-      textTheme: textTheme,
-      colorScheme: const ColorScheme.dark(
-        primary: auroraAccent,
-        secondary: auroraAccentHover,
-        surface: auroraSurface,
-        onSurfaceVariant: auroraTextSecondary,
-        error: danger,
-        onPrimary: Colors.white,
-        onSecondary: Colors.white,
-        onSurface: auroraTextPrimary,
-        onError: Colors.white,
-      ),
-      appBarTheme: AppBarTheme(
-        backgroundColor: auroraSidebarBg,
-        foregroundColor: auroraTextPrimary,
-        elevation: 0,
-        surfaceTintColor: Colors.transparent,
-        titleTextStyle: GoogleFonts.inter(
-          fontSize: 16,
-          fontWeight: FontWeight.w600,
-          color: auroraTextPrimary,
-        ),
-      ),
-      dividerColor: auroraBorder,
-      dividerTheme: const DividerThemeData(
-        color: auroraBorder,
-        thickness: 1,
-        space: 1,
-      ),
-      inputDecorationTheme: _buildInputTheme(
-        fillColor: auroraSurface,
-        borderColor: auroraBorder,
-        focusBorderColor: auroraAccent,
-        hintColor: auroraTextMuted,
-        labelColor: auroraTextSecondary,
-      ),
-      filledButtonTheme: _buildFilledButtonTheme(auroraAccent),
-      textButtonTheme: _buildTextButtonTheme(auroraAccent),
-      outlinedButtonTheme: _buildOutlinedButtonTheme(
-        auroraTextPrimary,
-        auroraBorder,
-      ),
-      iconTheme: const IconThemeData(color: auroraTextSecondary, size: 20),
-      tooltipTheme: TooltipThemeData(
-        decoration: BoxDecoration(
-          color: auroraSurface,
-          borderRadius: BorderRadius.circular(6),
-          border: Border.all(color: auroraBorder, width: 1),
-        ),
-        textStyle: GoogleFonts.inter(color: auroraTextPrimary, fontSize: 12),
-        waitDuration: const Duration(milliseconds: 500),
-      ),
-      dialogTheme: DialogThemeData(
-        backgroundColor: auroraSurface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: const BorderSide(color: auroraBorder),
-        ),
-      ),
-      bottomSheetTheme: const BottomSheetThemeData(
-        backgroundColor: auroraSurface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
-        ),
-      ),
-      snackBarTheme: SnackBarThemeData(
-        backgroundColor: auroraSurface,
-        contentTextStyle: GoogleFonts.inter(
-          color: auroraTextPrimary,
           fontSize: 13,
         ),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
@@ -1095,17 +868,6 @@ class EchoColorExtension extends ThemeExtension<EchoColorExtension> {
     recvBubble: EchoTheme.emberRecvBubble,
   );
 
-  /// Neon theme colors
-  static const neon = EchoColorExtension(
-    sidebarBg: EchoTheme.neonSidebarBg,
-    chatBg: EchoTheme.neonChatBg,
-    surfaceHover: EchoTheme.neonSurfaceHover,
-    accentLight: EchoTheme.neonAccentLight,
-    textMuted: EchoTheme.neonTextMuted,
-    sentBubble: EchoTheme.neonSentBubble,
-    recvBubble: EchoTheme.neonRecvBubble,
-  );
-
   /// Sakura theme colors
   static const sakura = EchoColorExtension(
     sidebarBg: EchoTheme.sakuraSidebarBg,
@@ -1115,22 +877,6 @@ class EchoColorExtension extends ThemeExtension<EchoColorExtension> {
     textMuted: EchoTheme.sakuraTextMuted,
     sentBubble: EchoTheme.sakuraSentBubble,
     recvBubble: EchoTheme.sakuraRecvBubble,
-  );
-
-  /// Aurora theme colors
-  static const aurora = EchoColorExtension(
-    sidebarBg: EchoTheme.auroraSidebarBg,
-    chatBg: EchoTheme.auroraChatBg,
-    surfaceHover: EchoTheme.auroraSurfaceHover,
-    accentLight: EchoTheme.auroraAccentLight,
-    textMuted: EchoTheme.auroraTextMuted,
-    sentBubble: EchoTheme.auroraSentBubble,
-    recvBubble: EchoTheme.auroraRecvBubble,
-    chatBgGradient: LinearGradient(
-      begin: Alignment.topCenter,
-      end: Alignment.bottomCenter,
-      colors: [EchoTheme.auroraChatBg, EchoTheme.auroraChatBgEnd],
-    ),
   );
 
   @override

--- a/apps/client/lib/src/widgets/biometric_lock_guard.dart
+++ b/apps/client/lib/src/widgets/biometric_lock_guard.dart
@@ -96,7 +96,7 @@ class _BiometricLockGuardState extends ConsumerState<BiometricLockGuard>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.lock_rounded, size: 64, color: context.accent),
+            Icon(Icons.lock_rounded, size: 64, color: context.textMuted),
             const SizedBox(height: 24),
             Text(
               'Echo is locked',

--- a/apps/client/lib/src/widgets/message/message_indicators.dart
+++ b/apps/client/lib/src/widgets/message/message_indicators.dart
@@ -94,9 +94,9 @@ class LockIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const icon = Padding(
-      padding: EdgeInsets.only(left: 3),
-      child: Icon(Icons.lock, size: 10, color: EchoTheme.online),
+    final icon = Padding(
+      padding: const EdgeInsets.only(left: 3),
+      child: Icon(Icons.lock, size: 10, color: context.textMuted),
     );
 
     if (isMine || onVerifyIdentity == null) {

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -998,6 +998,7 @@ class _MessageItemState extends State<MessageItem>
 
   /// Resolve the bubble background color based on message state.
   /// Plain (Slack) layout drops the bubble fill entirely (#564).
+  // Locked rule: sent bubble = primary, recv bubble = surface — pinned in EchoColorExtension across all themes. Do not drift shades here.
   Color _bubbleColor({required bool isMine, required bool isFailed}) {
     if (isFailed) return EchoTheme.danger.withValues(alpha: 0.2);
     if (widget._isPlain) return Colors.transparent;

--- a/apps/client/test/providers/theme_provider_test.dart
+++ b/apps/client/test/providers/theme_provider_test.dart
@@ -24,12 +24,12 @@ void main() {
     });
 
     test('loads persisted theme from SharedPreferences', () async {
-      SharedPreferences.setMockInitialValues({'echo_theme_mode': 'light'});
+      SharedPreferences.setMockInitialValues({'echo_theme_mode': 'paper'});
       final container = ProviderContainer();
       addTearDown(container.dispose);
       container.read(appThemeProvider);
       await _flushLoad();
-      expect(container.read(appThemeProvider), AppThemeSelection.light);
+      expect(container.read(appThemeProvider), AppThemeSelection.paper);
     });
 
     test('loads all theme variants', () async {
@@ -37,7 +37,8 @@ void main() {
         'system': AppThemeSelection.system,
         'indigo': AppThemeSelection.indigo,
         'dark': AppThemeSelection.indigo, // legacy alias migrates to indigo
-        'light': AppThemeSelection.light,
+        'paper': AppThemeSelection.paper,
+        'light': AppThemeSelection.paper, // legacy alias migrates to paper
         'graphite': AppThemeSelection.graphite,
         'ember': AppThemeSelection.ember,
         'neon': AppThemeSelection.neon,
@@ -89,7 +90,7 @@ void main() {
 
       final notifier = container.read(appThemeProvider.notifier);
       await notifier.setThemeMode(ThemeMode.light);
-      expect(container.read(appThemeProvider), AppThemeSelection.light);
+      expect(container.read(appThemeProvider), AppThemeSelection.paper);
 
       await notifier.setThemeMode(ThemeMode.dark);
       expect(container.read(appThemeProvider), AppThemeSelection.indigo);

--- a/apps/client/test/providers/theme_provider_test.dart
+++ b/apps/client/test/providers/theme_provider_test.dart
@@ -41,9 +41,10 @@ void main() {
         'light': AppThemeSelection.paper, // legacy alias migrates to paper
         'graphite': AppThemeSelection.graphite,
         'ember': AppThemeSelection.ember,
-        'neon': AppThemeSelection.neon,
         'sakura': AppThemeSelection.sakura,
-        'aurora': AppThemeSelection.aurora,
+        'neon': AppThemeSelection.highContrast, // legacy alias migrates
+        'aurora': AppThemeSelection.indigo, // legacy alias migrates
+        'highContrast': AppThemeSelection.highContrast,
       }.entries) {
         SharedPreferences.setMockInitialValues({'echo_theme_mode': entry.key});
         final container = ProviderContainer();

--- a/apps/client/test/providers/theme_provider_test.dart
+++ b/apps/client/test/providers/theme_provider_test.dart
@@ -15,12 +15,12 @@ void main() {
       SharedPreferences.setMockInitialValues({});
     });
 
-    test('default theme is dark', () async {
+    test('default theme is indigo', () async {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       container.read(appThemeProvider);
       await _flushLoad();
-      expect(container.read(appThemeProvider), AppThemeSelection.dark);
+      expect(container.read(appThemeProvider), AppThemeSelection.indigo);
     });
 
     test('loads persisted theme from SharedPreferences', () async {
@@ -35,7 +35,8 @@ void main() {
     test('loads all theme variants', () async {
       for (final entry in {
         'system': AppThemeSelection.system,
-        'dark': AppThemeSelection.dark,
+        'indigo': AppThemeSelection.indigo,
+        'dark': AppThemeSelection.indigo, // legacy alias migrates to indigo
         'light': AppThemeSelection.light,
         'graphite': AppThemeSelection.graphite,
         'ember': AppThemeSelection.ember,
@@ -56,13 +57,13 @@ void main() {
       }
     });
 
-    test('unknown theme value falls back to dark', () async {
+    test('unknown theme value falls back to indigo', () async {
       SharedPreferences.setMockInitialValues({'echo_theme_mode': 'unknown'});
       final container = ProviderContainer();
       addTearDown(container.dispose);
       container.read(appThemeProvider);
       await _flushLoad();
-      expect(container.read(appThemeProvider), AppThemeSelection.dark);
+      expect(container.read(appThemeProvider), AppThemeSelection.indigo);
     });
 
     test('setTheme updates state and persists', () async {
@@ -91,7 +92,7 @@ void main() {
       expect(container.read(appThemeProvider), AppThemeSelection.light);
 
       await notifier.setThemeMode(ThemeMode.dark);
-      expect(container.read(appThemeProvider), AppThemeSelection.dark);
+      expect(container.read(appThemeProvider), AppThemeSelection.indigo);
 
       await notifier.setThemeMode(ThemeMode.system);
       expect(container.read(appThemeProvider), AppThemeSelection.system);

--- a/apps/client/test/theme/theme_migration_test.dart
+++ b/apps/client/test/theme/theme_migration_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/providers/theme_provider.dart';
+
+/// Pump enough microtasks for the build()-fired _load() to settle.
+Future<void> _flushLoad() =>
+    Future<void>.delayed(const Duration(milliseconds: 100));
+
+/// Asserts every row of the persisted-theme migration table:
+///   - the legacy stored string resolves to the new enum value
+///   - after load, the canonical new name is written back to prefs so the
+///     migration path is one-shot (palette-reduction-2026-05-11).
+void main() {
+  group('AppTheme legacy-string migration', () {
+    const cases = <String, AppThemeSelection>{
+      // No-op (canonical names already in the new set).
+      'system': AppThemeSelection.system,
+      'indigo': AppThemeSelection.indigo,
+      'paper': AppThemeSelection.paper,
+      'graphite': AppThemeSelection.graphite,
+      'ember': AppThemeSelection.ember,
+      'sakura': AppThemeSelection.sakura,
+      'highContrast': AppThemeSelection.highContrast,
+      // Renames.
+      'dark': AppThemeSelection.indigo,
+      'light': AppThemeSelection.paper,
+      // Cut themes -> substitute.
+      'aurora': AppThemeSelection.indigo,
+      'neon': AppThemeSelection.highContrast,
+      // Collapsed HC variants.
+      'highContrastDark': AppThemeSelection.highContrast,
+      'highContrastLight': AppThemeSelection.paper,
+    };
+
+    for (final entry in cases.entries) {
+      test('legacy "${entry.key}" migrates to ${entry.value.name}', () async {
+        SharedPreferences.setMockInitialValues({'echo_theme_mode': entry.key});
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        container.read(appThemeProvider);
+        await _flushLoad();
+
+        // 1. Enum state matches the migration target.
+        expect(
+          container.read(appThemeProvider),
+          entry.value,
+          reason: '"${entry.key}" should resolve to ${entry.value.name}',
+        );
+
+        // 2. The canonical new name is written back to prefs so subsequent
+        //    loads skip the migration path.
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('echo_theme_mode'),
+          entry.value.name,
+          reason:
+              '"${entry.key}" should normalize to "${entry.value.name}" in prefs',
+        );
+      });
+    }
+
+    test('unknown value falls back to indigo and is written back', () async {
+      SharedPreferences.setMockInitialValues({
+        'echo_theme_mode': 'definitely-not-a-theme',
+      });
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(appThemeProvider);
+      await _flushLoad();
+
+      expect(container.read(appThemeProvider), AppThemeSelection.indigo);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('echo_theme_mode'), 'indigo');
+    });
+
+    test('null prefs value falls back to indigo and is written back', () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(appThemeProvider);
+      await _flushLoad();
+
+      expect(container.read(appThemeProvider), AppThemeSelection.indigo);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('echo_theme_mode'), 'indigo');
+    });
+  });
+}

--- a/apps/client/test/widgets/chat_panel_live_region_test.dart
+++ b/apps/client/test/widgets/chat_panel_live_region_test.dart
@@ -72,7 +72,7 @@ class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
 
 class _FakeTheme extends AppTheme {
   @override
-  AppThemeSelection build() => AppThemeSelection.dark;
+  AppThemeSelection build() => AppThemeSelection.indigo;
 }
 
 class _FakeMessageLayoutNotifier extends MessageLayoutNotifier {

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -87,7 +87,7 @@ List<Override> _chatPanelOverrides({ChatState chatState = const ChatState()}) {
 /// `state` from the value `build()` returns.
 class _FakeTheme extends AppTheme {
   @override
-  AppThemeSelection build() => AppThemeSelection.dark;
+  AppThemeSelection build() => AppThemeSelection.indigo;
 }
 
 class _FakeMessageLayoutNotifier extends MessageLayoutNotifier {

--- a/apps/client/test/widgets/settings/appearance_section_test.dart
+++ b/apps/client/test/widgets/settings/appearance_section_test.dart
@@ -11,7 +11,7 @@ void main() {
         AppThemeSelection.values,
         containsAll([
           AppThemeSelection.system,
-          AppThemeSelection.dark,
+          AppThemeSelection.indigo,
           AppThemeSelection.light,
           AppThemeSelection.graphite,
           AppThemeSelection.ember,

--- a/apps/client/test/widgets/settings/appearance_section_test.dart
+++ b/apps/client/test/widgets/settings/appearance_section_test.dart
@@ -12,7 +12,7 @@ void main() {
         containsAll([
           AppThemeSelection.system,
           AppThemeSelection.indigo,
-          AppThemeSelection.light,
+          AppThemeSelection.paper,
           AppThemeSelection.graphite,
           AppThemeSelection.ember,
           AppThemeSelection.neon,

--- a/apps/client/test/widgets/settings/appearance_section_test.dart
+++ b/apps/client/test/widgets/settings/appearance_section_test.dart
@@ -18,12 +18,13 @@ void main() {
           AppThemeSelection.neon,
           AppThemeSelection.sakura,
           AppThemeSelection.aurora,
+          AppThemeSelection.highContrast,
         ]),
       );
     });
 
-    test('has 8 theme options', () {
-      expect(AppThemeSelection.values, hasLength(8));
+    test('has 9 theme options', () {
+      expect(AppThemeSelection.values, hasLength(9));
     });
   });
 

--- a/apps/client/test/widgets/settings/appearance_section_test.dart
+++ b/apps/client/test/widgets/settings/appearance_section_test.dart
@@ -15,16 +15,14 @@ void main() {
           AppThemeSelection.paper,
           AppThemeSelection.graphite,
           AppThemeSelection.ember,
-          AppThemeSelection.neon,
           AppThemeSelection.sakura,
-          AppThemeSelection.aurora,
           AppThemeSelection.highContrast,
         ]),
       );
     });
 
-    test('has 9 theme options', () {
-      expect(AppThemeSelection.values, hasLength(9));
+    test('has 7 theme options', () {
+      expect(AppThemeSelection.values, hasLength(7));
     });
   });
 


### PR DESCRIPTION
## Summary

Cut the theme set from 9 → 6 with explicit personalities and two locked design rules. Net **-166 LOC**.

### New palette set

| # | Name | Accent | Surface base | Category |
|---|------|--------|--------------|----------|
| 1 | **Indigo** (default) | `#5557E0` | `#0A0A0B` | Dark |
| 2 | **Graphite** | `#13AF9D` | `#0B1114` | Dark |
| 3 | **Ember** | `#E9960A` | `#110E0A` | Dark |
| 4 | **Paper** | `#4F46E5` | `#FAFAF7` | Light |
| 5 | **Sakura** | `#C0186E` | `#FFF7F5` | Light |
| 6 | **High contrast** | `#7C9BFF` | `#000000` | Accessibility |

`AppThemeSelection.system` (follow OS) is preserved.

### Removed

- **Neon** — fails contrast on dark, off-tone for an E2EE messenger
- **Aurora** — too close to Indigo
- **Light** → renamed and recolored as **Paper** (`#5B5EE6` → `#4F46E5`, `#F5F5F7` → `#FAFAF7`)
- **HighContrastLight** — folded into single `highContrast`
- Old **Sakura** accent `#DD1C85` failed AA → darkened to `#C0186E`

### Locked rules enforced

1. **Sent bubble = accent (exactly), recv bubble = surface (exactly)** — pinned in every theme's `EchoColorExtension`. Removes the prior ~5% sent-bubble shade drift.
2. **Lock glyph = `textMuted`, never accent** — fixed 3 violation sites:
   - `widgets/message/message_indicators.dart:99` (was `online` green)
   - `screens/onboarding_wizard.dart:433` (was `accent`)
   - `widgets/biometric_lock_guard.dart:99` (was `accent`)

### Silent migration

Users on cut themes are auto-migrated on next launch (writes back canonical name):

| Old | New |
|-----|-----|
| `dark` | `indigo` |
| `light` | `paper` |
| `aurora` | `indigo` |
| `neon` | `highContrast` |
| `highContrastDark` | `highContrast` |
| `highContrastLight` | `paper` |
| unknown / null | `indigo` |

Custom color overrides (`customColorsProvider`) survive — themes provide better defaults, advanced users can still override.

### Commits (7)

1. `style(client): pin lock glyph to textMuted across all sites`
2. `refactor(client): pin sent bubble to accent and restyle sakura`
3. `feat(client): replace light theme with paper palette`
4. `refactor(client): collapse high-contrast variants into one theme`
5. `refactor(client): remove neon and aurora themes`
6. `feat(client): migrate legacy theme selections to new 6-palette set`
7. `feat(client): update appearance picker to 6 themes`

## Test plan

- [x] `dart format --set-exit-if-changed .` clean
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` — 1470 passed, 8 skipped, 0 failed (15 new `theme_migration_test.dart` cases covering every migration row)
- [ ] Manual: pick each of the 6 themes in Settings → Appearance, verify sent bubble = exact accent, lock glyph = muted grey
- [ ] Manual: SharedPrefs override `echo_theme_mode = neon` → app boots on High contrast and writes back `highContrast`
- [ ] Manual: SharedPrefs override `echo_theme_mode = aurora` → boots on Indigo