### PR TITLE
fix(server): backend audit batch — multi-device delivery, invite toctou, mention fanout (#829)

### DIFF
--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -827,25 +827,71 @@ pub async fn list_invite_tokens(
     .await
 }
 
+/// Outcome of `accept_invite_token`.
+///
+/// `Expired` / `Exhausted` are surfaced by the in-tx revalidation gate
+/// (#829): the pre-tx checks in the route handler are an optimistic fast
+/// path, but concurrent accepts under a `max_uses=N` token could otherwise
+/// race past those checks and over-consume the token. The transaction now
+/// re-reads `expires_at` and `(max_uses, use_count)` under `FOR UPDATE`
+/// so the correctness gate runs after the row is locked.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AcceptInviteOutcome {
+    /// New member row was inserted (or a soft-removed row reactivated).
+    Added,
+    /// Caller was already an active member; no row changed.
+    AlreadyMember,
+    /// Token expired between pre-tx validation and the locked re-read.
+    Expired,
+    /// Token reached `max_uses` between pre-tx validation and the locked re-read.
+    Exhausted,
+}
+
 /// Atomically increment use_count and add the user to the group.
 ///
-/// Returns `Ok(true)` when the user was added, `Ok(false)` when already a member.
-/// The caller must validate expiry and max_uses before calling this function.
+/// Returns:
+/// - `Ok(AcceptInviteOutcome::Added)` when the user was added.
+/// - `Ok(AcceptInviteOutcome::AlreadyMember)` when no row changed.
+/// - `Ok(AcceptInviteOutcome::Expired)` when the token expired (raced past
+///   the pre-tx fast path).
+/// - `Ok(AcceptInviteOutcome::Exhausted)` when `max_uses` was already met
+///   under the locked re-read.
+///
+/// #829: the caller's pre-tx validation in the route handler is a
+/// best-effort fast reject; the in-tx revalidation below is the correctness
+/// gate against TOCTOU under concurrent accepts.
 pub async fn accept_invite_token(
     pool: &PgPool,
     token: &str,
     user_id: Uuid,
-) -> Result<bool, sqlx::Error> {
+) -> Result<AcceptInviteOutcome, sqlx::Error> {
     let mut tx = pool.begin().await?;
 
     // Lock the token row for update so concurrent accepts are serialised.
-    let row: (Uuid,) = sqlx::query_as(
-        "SELECT conversation_id FROM group_invite_tokens WHERE token = $1 FOR UPDATE",
+    // #829: fetch expires_at / max_uses / use_count under the same lock so
+    // the post-pre-tx-check window cannot be exploited.
+    let row: (Uuid, Option<DateTime<Utc>>, Option<i32>, i32) = sqlx::query_as(
+        "SELECT conversation_id, expires_at, max_uses, use_count \
+         FROM group_invite_tokens WHERE token = $1 FOR UPDATE",
     )
     .bind(token)
     .fetch_one(&mut *tx)
     .await?;
-    let conversation_id = row.0;
+    let (conversation_id, expires_at, max_uses, use_count) = row;
+
+    // Re-validate under the lock (#829).  Bail out before mutating membership
+    // or incrementing use_count so concurrent accepts cannot over-consume a
+    // max-uses=N token.  The caller maps these outcomes to the same error
+    // shape the pre-tx checks already use.
+    if expires_at.is_some_and(|exp| Utc::now() > exp) {
+        // Read-only tx; rollback is implicit on drop, but be explicit.
+        let _ = tx.rollback().await;
+        return Ok(AcceptInviteOutcome::Expired);
+    }
+    if max_uses.is_some_and(|max| use_count >= max) {
+        let _ = tx.rollback().await;
+        return Ok(AcceptInviteOutcome::Exhausted);
+    }
 
     // Add the member (reactivates soft-removed rows via ON CONFLICT).
     let result = sqlx::query(
@@ -875,5 +921,9 @@ pub async fn accept_invite_token(
         .await?;
 
     tx.commit().await?;
-    Ok(added)
+    Ok(if added {
+        AcceptInviteOutcome::Added
+    } else {
+        AcceptInviteOutcome::AlreadyMember
+    })
 }

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -927,3 +927,25 @@ pub async fn accept_invite_token(
         AcceptInviteOutcome::AlreadyMember
     })
 }
+
+/// Return the IDs of every group conversation whose only members are soft-removed.
+///
+/// #829: the historical query used `NOT IN (SELECT DISTINCT conversation_id
+/// FROM conversation_members)` without filtering `is_removed`, so a group
+/// whose only members were tombstones never qualified for reaping. The
+/// `NOT EXISTS` form below excludes soft-removed rows explicitly and is
+/// also a cleaner planner shape on large tables.
+pub async fn find_empty_group_ids(pool: &PgPool) -> Result<Vec<Uuid>, sqlx::Error> {
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT c.id FROM conversations c \
+         WHERE c.kind = 'group' \
+           AND NOT EXISTS ( \
+               SELECT 1 FROM conversation_members cm \
+               WHERE cm.conversation_id = c.id \
+                 AND cm.is_removed = false \
+           )",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}

--- a/apps/server/src/db/mentions.rs
+++ b/apps/server/src/db/mentions.rs
@@ -128,6 +128,28 @@ pub async fn extract_and_persist(
         return Ok(0);
     }
 
+    // #829: defence-in-depth -- verify the sender is a non-removed member of
+    // the conversation before persisting any mention rows. The upstream
+    // `send_message` path already enforces membership, but a future caller
+    // that forgets to gate could otherwise turn `@everyone` into an
+    // unauthenticated broadcast against an arbitrary group. Bail with an
+    // empty result so callers' logging stays quiet on legitimate misses.
+    let is_member: (bool,) = sqlx::query_as(
+        "SELECT EXISTS ( \
+             SELECT 1 FROM conversation_members \
+             WHERE conversation_id = $1 \
+               AND user_id = $2 \
+               AND is_removed = false \
+         )",
+    )
+    .bind(conversation_id)
+    .bind(sender_id)
+    .fetch_one(pool)
+    .await?;
+    if !is_member.0 {
+        return Ok(0);
+    }
+
     // Resolve to user_ids.  For broadcast keywords we pull every member;
     // for `@<username>` we pull only matching members.  In either case
     // the sender is filtered out client-side below.

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -236,7 +236,7 @@ pub async fn get_messages(
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
-         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
+         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
          LEFT JOIN ( \
              SELECT reply_to_id, COUNT(*) AS reply_count \
@@ -336,7 +336,7 @@ pub async fn get_undelivered(
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
-         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
+         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
          LEFT JOIN ( \
              SELECT reply_to_id, COUNT(*) AS reply_count \
@@ -590,7 +590,7 @@ pub async fn search_messages(
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
-         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
+         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
          LEFT JOIN LATERAL ( \
              SELECT COUNT(*) AS cnt FROM messages r \
@@ -952,7 +952,7 @@ pub async fn get_thread_replies(
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
-         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id \
+         LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
          LEFT JOIN LATERAL ( \
              SELECT COUNT(*) AS cnt FROM messages r \

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -307,6 +307,20 @@ pub async fn get_undelivered(
     // (O(N+M)) rather than a LATERAL correlated subquery that re-executes for
     // every returned row (O(N*M)).
     //
+    // #829: this query MUST NOT filter on `m.delivered = false`. The global
+    // `delivered` flag is flipped on first-device delivery (see
+    // `send_delivery_confirmation`), so a sibling device coming online later
+    // would never receive a replay. The per-device `message_deliveries`
+    // ledger is the correct gate -- the fanout path is responsible for
+    // populating it for online deliveries.
+    //
+    // System messages (sentinel-prefixed; e.g. `__system__:member_joined:...`)
+    // are best-effort UI pills broadcast at the moment of the event via
+    // `broadcast_json`; they intentionally do not flow through the ledger or
+    // mark_delivered path. We exclude them from replay so a member who was
+    // offline when a join/leave happened does NOT get a stale pill on
+    // reconnect, while real chat traffic still replays through the ledger.
+    //
     // The NOT EXISTS guard filters messages that were already pushed to THIS
     // device (either successfully decryptable or as an undecryptable marker).
     // Without it a device that can't decrypt a frame would receive the same
@@ -332,7 +346,8 @@ pub async fn get_undelivered(
          ) rc ON rc.reply_to_id = m.id \
          JOIN conversation_members cm ON cm.conversation_id = m.conversation_id AND cm.user_id = $1 \
                   AND cm.is_removed = false \
-         WHERE m.sender_id != $1 AND m.delivered = false AND m.deleted_at IS NULL \
+         WHERE m.sender_id != $1 AND m.deleted_at IS NULL \
+                  AND m.content NOT LIKE '\\_\\_system\\_\\_:%' ESCAPE '\\' \
                   AND NOT EXISTS ( \
                       SELECT 1 FROM message_deliveries md \
                       WHERE md.message_id = m.id \
@@ -372,6 +387,32 @@ pub async fn mark_device_delivered(
     .bind(message_id)
     .bind(recipient_user_id)
     .bind(device_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Record that a single message was accepted by the hub for a batch of
+/// `(recipient_user_id, device_id)` pairs. Idempotent via ON CONFLICT
+/// DO NOTHING.  Used by the fanout path (#829) so sibling devices that
+/// come online later are correctly excluded from `get_undelivered` replay.
+pub async fn mark_devices_delivered_pairs(
+    pool: &PgPool,
+    message_id: Uuid,
+    pairs: &[(Uuid, i32)],
+) -> Result<(), sqlx::Error> {
+    if pairs.is_empty() {
+        return Ok(());
+    }
+    let (user_ids, device_ids): (Vec<Uuid>, Vec<i32>) = pairs.iter().copied().unzip();
+    sqlx::query(
+        "INSERT INTO message_deliveries (message_id, recipient_user_id, device_id) \
+         SELECT $1, uid, did FROM UNNEST($2::uuid[], $3::int[]) AS t(uid, did) \
+         ON CONFLICT (message_id, recipient_user_id, device_id) DO NOTHING",
+    )
+    .bind(message_id)
+    .bind(&user_ids)
+    .bind(&device_ids)
     .execute(pool)
     .await?;
     Ok(())

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -207,17 +207,23 @@ async fn broadcast_voice_session_left(
     }
 }
 
-/// Delete empty groups (zero members) and all their dependent rows.
+/// Delete empty groups (zero ACTIVE members) and all their dependent rows.
+///
+/// #829: previously the inner SELECT did not filter `is_removed = false`,
+/// so a group whose only members were all soft-removed (tombstones) was
+/// never reaped. The query is now in `db::groups::find_empty_group_ids`
+/// (so the integration test can exercise it directly) and uses `NOT EXISTS`
+/// for cleaner planner behaviour on large `conversation_members` tables.
 async fn cleanup_empty_groups(pool: &PgPool) {
-    let empty_group_ids: Vec<(uuid::Uuid,)> = sqlx::query_as(
-        "SELECT id FROM conversations WHERE kind = 'group' \
-         AND id NOT IN (SELECT DISTINCT conversation_id FROM conversation_members)",
-    )
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    let empty_group_ids = match db::groups::find_empty_group_ids(pool).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::error!("cleanup_empty_groups: find_empty_group_ids failed: {e}");
+            return;
+        }
+    };
 
-    for (gid,) in &empty_group_ids {
+    for gid in &empty_group_ids {
         delete_group_dependents(pool, *gid).await;
     }
 }

--- a/apps/server/src/routes/groups.rs
+++ b/apps/server/src/routes/groups.rs
@@ -1260,9 +1260,25 @@ pub async fn accept_invite(
         })));
     }
 
-    db::groups::accept_invite_token(&state.pool, &token, auth.user_id)
+    // #829: the in-tx revalidation can surface `Expired` / `Exhausted` if a
+    // concurrent accept raced past the pre-tx fast path above. Map those
+    // outcomes to the same error shape the fast-path checks use so the API
+    // response is consistent.
+    let outcome = db::groups::accept_invite_token(&state.pool, &token, auth.user_id)
         .await
         .db_ctx("accept_invite/insert")?;
+    match outcome {
+        db::groups::AcceptInviteOutcome::Expired => {
+            return Err(AppError::not_found("Invite link has expired"));
+        }
+        db::groups::AcceptInviteOutcome::Exhausted => {
+            return Err(AppError::bad_request(
+                "Invite link has reached its use limit",
+            ));
+        }
+        db::groups::AcceptInviteOutcome::Added | db::groups::AcceptInviteOutcome::AlreadyMember => {
+        }
+    }
 
     invalidate_member_cache(invite.conversation_id);
 

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -215,9 +215,11 @@ pub async fn list_conversations(
             SELECT m2.conversation_id, COUNT(*) AS unread_count \
             FROM messages m2 \
             JOIN user_convs uc ON uc.conversation_id = m2.conversation_id \
+            LEFT JOIN channels ch ON ch.id = m2.channel_id \
             LEFT JOIN read_cte rc ON rc.conversation_id = m2.conversation_id \
             WHERE m2.sender_id != $1 \
               AND m2.deleted_at IS NULL \
+              AND (m2.channel_id IS NULL OR ch.deleted_at IS NULL) \
               AND m2.created_at > COALESCE(rc.last_read_at, '1970-01-01'::timestamptz) \
             GROUP BY m2.conversation_id \
         ), \
@@ -226,10 +228,12 @@ pub async fn list_conversations(
             FROM messages m3 \
             JOIN mentions mt ON mt.message_id = m3.id \
             JOIN user_convs uc2 ON uc2.conversation_id = m3.conversation_id \
+            LEFT JOIN channels ch2 ON ch2.id = m3.channel_id \
             LEFT JOIN read_cte rc2 ON rc2.conversation_id = m3.conversation_id \
             WHERE mt.mentioned_user_id = $1 \
               AND m3.sender_id != $1 \
               AND m3.deleted_at IS NULL \
+              AND (m3.channel_id IS NULL OR ch2.deleted_at IS NULL) \
               AND m3.created_at > COALESCE(rc2.last_read_at, '1970-01-01'::timestamptz) \
             GROUP BY m3.conversation_id \
         ) \

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -17,6 +17,14 @@ use crate::types::ConversationKind;
 use crate::ws::message_service;
 use crate::ws::typing_service;
 
+/// Application-level heartbeat payload (#829).
+///
+/// Browser WebSocket APIs swallow protocol-level Ping/Pong before they reach
+/// JavaScript, so the JSON heartbeat is the only signal a browser client can
+/// observe to confirm the socket is still alive. Hoisted to a `&'static str`
+/// so the 30-second tick doesn't allocate a fresh `String` per heartbeat.
+const HEARTBEAT_PAYLOAD: &str = r#"{"type":"heartbeat"}"#;
+
 #[derive(Deserialize)]
 #[serde(tag = "type")]
 enum ClientMessage {
@@ -240,8 +248,13 @@ pub async fn handle_socket(
                 WsMessage::Ping(vec![].into()),
             );
             // Application-level heartbeat (visible to all clients).
-            let hb = r#"{"type":"heartbeat"}"#.to_string();
-            if !ping_hub.send_to_device(&ping_user_id, ping_device_id, WsMessage::Text(hb.into())) {
+            // #829: payload is a module-level `&'static str` to avoid the
+            // per-tick `String` allocation.
+            if !ping_hub.send_to_device(
+                &ping_user_id,
+                ping_device_id,
+                WsMessage::Text(HEARTBEAT_PAYLOAD.into()),
+            ) {
                 break;
             }
         }
@@ -295,6 +308,11 @@ pub async fn handle_socket(
         }
     };
     drop(leftover_rx);
+    // #829: abort the heartbeat task on any disconnect path (clean close OR
+    // the err arm of the recv loop both flow through this select! cleanup).
+    // Without the explicit abort, the 30 s tick keeps firing until
+    // `send_to_device` returns false on the dropped queue -- one or two
+    // extra ticks past the disconnect under load.
     ping_task.abort();
 
     cleanup_user_voice_sessions(&state, user_id).await;

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -103,12 +103,22 @@ impl Hub {
     /// message. Full/closed queues are logged separately so beta-test
     /// telemetry distinguishes saturation from disconnect cleanup.
     pub fn send_to_user(&self, user_id: &Uuid, msg: WsMessage) -> bool {
+        !self.send_to_user_collecting(user_id, msg).is_empty()
+    }
+
+    /// Send a message to ALL connected devices of a user and return the
+    /// list of device IDs whose outbound queue accepted the message.
+    ///
+    /// Used by the fanout path (#829) so the per-device `message_deliveries`
+    /// ledger can be populated even on the legacy/plaintext code path that
+    /// doesn't carry a per-device frame map.
+    pub fn send_to_user_collecting(&self, user_id: &Uuid, msg: WsMessage) -> Vec<i32> {
         // Snapshot the device IDs while holding the read ref so we can
         // mutate `connections` (via `unregister`) without re-entrant locks
         // on the slow-consumer eviction path below.
         let device_ids: Vec<(i32, WsTx)> = {
             let Some(devices) = self.inner.connections.get(user_id) else {
-                return false;
+                return Vec::new();
             };
             devices
                 .iter()
@@ -116,13 +126,13 @@ impl Hub {
                 .collect()
         };
 
-        let mut any_sent = false;
+        let mut accepted = Vec::with_capacity(device_ids.len());
         for (device_id, tx) in device_ids {
             if self.try_send_tracked(*user_id, device_id, &tx, msg.clone()) {
-                any_sent = true;
+                accepted.push(device_id);
             }
         }
-        any_sent
+        accepted
     }
 
     /// Send a message to a specific device of a user. Returns true only when

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -448,11 +448,30 @@ pub(super) async fn store_and_confirm(
 
     // Store per-device ciphertexts if present. Per-user device IDs collide
     // across users, so each entry is keyed by (recipient_user_id, device_id).
+    //
+    // #829: drop ciphertext destined for recipients that have blocked the
+    // sender BEFORE writing to `message_device_contents`. The fanout path
+    // already filters blockers out of live delivery, but persisting their
+    // rows wastes storage and leaks ciphertext that should never be readable
+    // by anyone (blocked users never receive it, and a future audit-leak
+    // scenario would expose it for no benefit).
     if let Some(rdc) = recipient_device_contents {
+        let recipient_ids: Vec<Uuid> = rdc.keys().filter_map(|s| Uuid::parse_str(s).ok()).collect();
+        let blockers: Vec<Uuid> = if recipient_ids.is_empty() {
+            Vec::new()
+        } else {
+            db::contacts::get_blockers_of(&state.pool, &recipient_ids, sender_id)
+                .await
+                .unwrap_or_default()
+        };
+
         let entries: Vec<(Uuid, i32, &str)> = rdc
             .iter()
             .filter_map(|(uid_str, devices)| {
                 let recipient_id = Uuid::parse_str(uid_str).ok()?;
+                if blockers.contains(&recipient_id) {
+                    return None;
+                }
                 Some((recipient_id, devices))
             })
             .flat_map(|(recipient_id, devices)| {

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -796,34 +796,64 @@ pub(super) fn build_per_device_json(
 ///
 /// Both `per_recipient_json` entries and `legacy_msg` are `WsMessage::Text`
 /// (Bytes-backed); cloning inside the loop is O(1) — no string copying (#690).
+/// Outcome of a fan-out delivery attempt to a single conversation member.
+///
+/// `accepted_device_ids` lists the device IDs whose outbound queues actually
+/// accepted the frame on the per-device path -- the caller uses these to
+/// populate the per-device delivery ledger so sibling devices that come
+/// online later still replay the message (#829).
+pub(super) struct MemberDeliveryOutcome {
+    pub delivered: bool,
+    pub accepted_device_ids: Vec<i32>,
+}
+
 pub(super) fn deliver_to_member(
     hub: &crate::ws::hub::Hub,
     member_id: &Uuid,
     per_recipient_json: Option<&HashMap<Uuid, Vec<(i32, WsMessage)>>>,
     legacy_msg: Option<&WsMessage>,
-) -> bool {
+) -> MemberDeliveryOutcome {
     if let Some(by_recipient) = per_recipient_json
         && let Some(device_msgs) = by_recipient.get(member_id)
     {
         // Deliver to ALL recipient devices; OR-accumulate instead of short-circuiting
         // so a successful send to device #1 doesn't skip device #2.
-        let mut any_sent = false;
+        let mut accepted = Vec::with_capacity(device_msgs.len());
         for (did, msg) in device_msgs {
             // WsMessage::Text is Bytes-backed; clone is O(1).
             if hub.send_to_device(member_id, *did, msg.clone()) {
-                any_sent = true;
+                accepted.push(*did);
             }
         }
-        return any_sent;
+        return MemberDeliveryOutcome {
+            delivered: !accepted.is_empty(),
+            accepted_device_ids: accepted,
+        };
     }
     if let Some(msg) = legacy_msg {
-        hub.send_to_user(member_id, msg.clone())
-    } else {
-        false
+        // #829: the legacy/plaintext path also needs to populate the per-device
+        // ledger so sibling devices that come online later don't re-receive
+        // the message via `get_undelivered` replay. Use the collecting variant
+        // so we know which device queues actually accepted the frame.
+        let accepted = hub.send_to_user_collecting(member_id, msg.clone());
+        return MemberDeliveryOutcome {
+            delivered: !accepted.is_empty(),
+            accepted_device_ids: accepted,
+        };
+    }
+    MemberDeliveryOutcome {
+        delivered: false,
+        accepted_device_ids: Vec::new(),
     }
 }
 
 /// Mark messages as delivered in the DB and send a delivery confirmation back to the sender.
+///
+/// #829: the `messages.delivered` flag is no longer the gate for `get_undelivered`
+/// replay -- the per-device `message_deliveries` ledger is. This function exists
+/// purely for the sender's read-receipt UI: it tells the sending client "at least
+/// one recipient device accepted this frame". Sibling-device replay correctness
+/// is handled by `mark_devices_delivered_pairs` in `fanout_message`.
 pub(super) async fn send_delivery_confirmation(
     state: &AppState,
     sender_id: Uuid,
@@ -957,23 +987,51 @@ pub(super) async fn fanout_message(
 
     let mut any_delivered = false;
     let mut offline_user_ids = Vec::new();
+    // #829: collect (recipient_user_id, device_id) pairs that the hub actually
+    // accepted on the per-device path. After fanout we batch-insert them into
+    // `message_deliveries` so a sibling device that comes online later does
+    // NOT receive the same message again via `get_undelivered` replay.
+    let mut accepted_device_pairs: Vec<(Uuid, i32)> = Vec::new();
 
     let eligible = member_ids
         .iter()
         .filter(|id| **id != sender_id && !blockers.contains(id));
 
     for member_id in eligible {
-        let delivered = deliver_to_member(
+        let outcome = deliver_to_member(
             &state.hub,
             member_id,
             per_recipient_json.as_ref(),
             legacy_msg.as_ref(),
         );
-        if delivered {
+        if outcome.delivered {
             any_delivered = true;
         } else {
             offline_user_ids.push(*member_id);
         }
+        for did in outcome.accepted_device_ids {
+            accepted_device_pairs.push((*member_id, did));
+        }
+    }
+
+    // #829: populate the per-device ledger for every recipient device whose
+    // queue accepted the frame. Without this, sibling devices that were
+    // offline at fan-out time would never receive the message: the global
+    // `messages.delivered` flag was the historical gate but now only serves
+    // the read-receipt UI; the per-device ledger is the authoritative replay
+    // gate (see `db::messages::get_undelivered`).
+    if !accepted_device_pairs.is_empty()
+        && let Err(e) = db::messages::mark_devices_delivered_pairs(
+            &state.pool,
+            stored_id,
+            &accepted_device_pairs,
+        )
+        .await
+    {
+        tracing::error!(
+            message_id = %stored_id,
+            "failed to populate per-device delivery ledger on fanout: {e:?}"
+        );
     }
 
     if any_delivered {

--- a/apps/server/tests/api_invite_links.rs
+++ b/apps/server/tests/api_invite_links.rs
@@ -404,3 +404,99 @@ async fn banned_user_cannot_accept_invite() {
 
     assert_eq!(resp.status().as_u16(), 400);
 }
+
+// ---------------------------------------------------------------------------
+// TOCTOU concurrency (#829)
+// ---------------------------------------------------------------------------
+
+/// Concurrent accepts against a `max_uses=1` token must not be allowed to
+/// over-consume the token: only one accept may add a member. Pre-#829, the
+/// pre-tx validation in the route handler was checked OUTSIDE the
+/// FOR UPDATE lock on the token row, so a burst of N concurrent requests
+/// could each pass validation and then each insert a member.
+#[tokio::test]
+async fn concurrent_accept_respects_max_uses_under_lock() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (owner_token, _) = register_and_login(&client, &base, "invtoc_own").await;
+    let group_id = create_group(&client, &base, &owner_token, "InvToctouGroup").await;
+
+    // Create a single-use invite.
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/invites"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&serde_json::json!({ "max_uses": 1 }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    let inv_token = body["token"].as_str().unwrap().to_string();
+
+    // Register 2 prospective joiners and collect their tokens. 2 is enough
+    // contention to deterministically exercise the TOCTOU race without
+    // blowing the per-IP register rate limit (3/60s, shared with the
+    // owner registration above).
+    let mut joiner_tokens = Vec::with_capacity(2);
+    for i in 0..2 {
+        let (tok, _) = register_and_login(&client, &base, &format!("invtoc_j{i}")).await;
+        joiner_tokens.push(tok);
+    }
+
+    // Fire all accept requests concurrently.
+    let base_arc = std::sync::Arc::new(base);
+    let url_path = format!("/api/invites/{inv_token}/accept");
+    let mut handles = Vec::with_capacity(joiner_tokens.len());
+    for joiner_token in joiner_tokens {
+        let base_clone = base_arc.clone();
+        let url_path_clone = url_path.clone();
+        let c = client.clone();
+        handles.push(tokio::spawn(async move {
+            c.post(format!("{base_clone}{url_path_clone}"))
+                .header("Authorization", format!("Bearer {joiner_token}"))
+                .send()
+                .await
+                .map(|r| r.status().as_u16())
+        }));
+    }
+
+    let mut successes = 0;
+    let mut rejections = 0;
+    for h in handles {
+        match h.await.unwrap() {
+            Ok(200) => successes += 1,
+            Ok(400) | Ok(404) => rejections += 1,
+            Ok(other) => panic!("unexpected status {other}"),
+            Err(e) => panic!("request error: {e}"),
+        }
+    }
+
+    assert_eq!(
+        successes, 1,
+        "exactly one concurrent accept must succeed for a max_uses=1 token"
+    );
+    assert_eq!(
+        rejections, 1,
+        "the losing concurrent accept must be rejected"
+    );
+
+    // Verify use_count is exactly 1 in the listing.
+    let list_resp = client
+        .get(format!("{}/api/groups/{group_id}/invites", *base_arc))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .send()
+        .await
+        .unwrap();
+    let invites: Value = list_resp.json().await.unwrap();
+    let inv = invites
+        .as_array()
+        .expect("invites response is an array")
+        .iter()
+        .find(|i| i["token"].as_str() == Some(inv_token.as_str()))
+        .expect("invite still listed");
+    assert_eq!(
+        inv["use_count"].as_i64().unwrap(),
+        1,
+        "use_count must not exceed max_uses under concurrent load"
+    );
+}

--- a/apps/server/tests/db_cleanup_empty_groups.rs
+++ b/apps/server/tests/db_cleanup_empty_groups.rs
@@ -1,0 +1,75 @@
+//! #829: assert `find_empty_group_ids` reaps groups whose only members are
+//! soft-removed (tombstones).
+//!
+//! Pre-fix, `cleanup_empty_groups` checked `NOT IN (SELECT DISTINCT
+//! conversation_id FROM conversation_members)` without filtering
+//! `is_removed`, so tombstone-only groups looked "non-empty" forever.
+
+mod common;
+
+use sqlx::Executor;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn find_empty_group_ids_includes_tombstone_only_groups() {
+    let base = common::spawn_server().await;
+    let client = reqwest::Client::new();
+
+    // Owner + one member, in a fresh group.
+    let (owner_token, _owner_id, _owner_username) =
+        common::register_and_login(&client, &base, "ceg_own").await;
+    let (_member_token, member_id, _member_username) =
+        common::register_and_login(&client, &base, "ceg_mem").await;
+
+    let group_id = common::create_group(&client, &base, &owner_token, "TombstoneGroup").await;
+    let group_uuid = Uuid::parse_str(&group_id).expect("group id is a UUID");
+    common::add_member_to_group(&client, &base, &owner_token, &group_id, &member_id).await;
+
+    // Direct pool for assertion-phase manipulation. The server already ran
+    // migrations.
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("TEST_DATABASE_URL or DATABASE_URL must be set for integration tests");
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("connect to test db");
+
+    // Soft-remove every member of the group (owner and member). The group
+    // now has rows in `conversation_members` but none with
+    // `is_removed = false` -- the classic tombstone-only state.
+    pool.execute(
+        sqlx::query(
+            "UPDATE conversation_members \
+             SET is_removed = true, removed_at = now() \
+             WHERE conversation_id = $1",
+        )
+        .bind(group_uuid),
+    )
+    .await
+    .expect("soft-remove all members");
+
+    // `find_empty_group_ids` must surface this group.
+    let empty = echo_server::db::groups::find_empty_group_ids(&pool)
+        .await
+        .expect("find_empty_group_ids ok");
+    assert!(
+        empty.contains(&group_uuid),
+        "tombstone-only group must be reported as empty (got {empty:?})"
+    );
+
+    // Sanity: a group with at least one active member must NOT be returned.
+    // Use a second group from a fresh owner to avoid contaminating other
+    // tests that scan all groups.
+    let (other_token, _, _) = common::register_and_login(&client, &base, "ceg_oth").await;
+    let active_group_id = common::create_group(&client, &base, &other_token, "ActiveGroup").await;
+    let active_group_uuid = Uuid::parse_str(&active_group_id).expect("active id is a UUID");
+    let empty_after = echo_server::db::groups::find_empty_group_ids(&pool)
+        .await
+        .expect("find_empty_group_ids ok");
+    assert!(
+        !empty_after.contains(&active_group_uuid),
+        "group with an active member must NOT be reaped"
+    );
+}

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -1686,3 +1686,130 @@ async fn read_text_skipping_chatter(ws: &mut WsStream) -> String {
         return text;
     }
 }
+
+// Multi-device offline sibling replay regression (#829)
+// ---------------------------------------------------------------------------
+
+/// Bug #829 — when a recipient has multiple devices but only some are online
+/// at fan-out time, the historical global `messages.delivered = true` flag
+/// (flipped on first-device delivery) would cause `get_undelivered` to skip
+/// the message for the sibling devices that came online later. Those devices
+/// would silently never receive the message.
+///
+/// This test:
+///   1. Connects Alice, plus Bob device #1. Bob devices #2 and #3 are offline.
+///   2. Alice sends a message with per-device ciphertexts for all 3 of Bob's
+///      devices.
+///   3. Asserts device #1 receives `new_message` immediately.
+///   4. Connects Bob device #2, asserts it receives the replayed `new_message`
+///      with the device-#2 ciphertext (this is the load-bearing assertion --
+///      pre-#829, this would never arrive).
+///   5. Connects Bob device #3, asserts the same.
+#[tokio::test]
+async fn multi_device_offline_siblings_replay_on_reconnect() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "mdsib_alice").await;
+    let (bob_token, bob_id, bob_name) =
+        common::register_and_login(&client, &base, "mdsib_bob").await;
+
+    common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    // Alice connects (device id is irrelevant for this assertion).
+    let alice_ticket = common::get_ws_ticket_for_device(&client, &base, &alice_token, 1).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+
+    // Bob device #1 connects -- the only one online at fan-out time.
+    let bob_d1_ticket = common::get_ws_ticket_for_device(&client, &base, &bob_token, 31).await;
+    let mut bob_d1_ws = connect_ws(&base, &bob_d1_ticket).await;
+
+    drain_pending(&mut alice_ws).await;
+    drain_pending(&mut bob_d1_ws).await;
+
+    let bob_d1_ct = common::dummy_ciphertext("829_bob_d31");
+    let bob_d2_ct = common::dummy_ciphertext("829_bob_d32");
+    let bob_d3_ct = common::dummy_ciphertext("829_bob_d33");
+    let canonical = common::dummy_ciphertext("829_canonical");
+
+    // Alice sends to Bob with per-device ciphertexts for all 3 devices, even
+    // though only device #1 is online. Devices #2 and #3 must replay when
+    // they later reconnect.
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "to_user_id": bob_id,
+        "content": canonical,
+        "recipient_device_contents": {
+            bob_id.to_string(): {
+                "31": bob_d1_ct.clone(),
+                "32": bob_d2_ct.clone(),
+                "33": bob_d3_ct.clone(),
+            },
+        },
+    });
+    alice_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("Alice send failed");
+
+    // Alice gets her message_sent ack.
+    let ack_text = read_text_skipping_presence(&mut alice_ws).await;
+    let ack: Value = serde_json::from_str(&ack_text).unwrap();
+    assert_eq!(ack["type"], "message_sent");
+
+    // Bob device #1 (online) receives the live fan-out.
+    let d1_text = read_text_skipping_presence(&mut bob_d1_ws).await;
+    let d1: Value = serde_json::from_str(&d1_text).unwrap();
+    assert_eq!(d1["type"], "new_message", "device 1 should get new_message");
+    assert_eq!(
+        d1["content"], bob_d1_ct,
+        "device 1 must receive its own ciphertext on live fanout"
+    );
+
+    // Bob device #2 (offline at send time) connects now and must receive
+    // the replayed message via the per-device ledger. Pre-#829 this branch
+    // returned nothing because `messages.delivered` was flipped by device #1.
+    let bob_d2_ticket = common::get_ws_ticket_for_device(&client, &base, &bob_token, 32).await;
+    let mut bob_d2_ws = connect_ws(&base, &bob_d2_ticket).await;
+    let d2 = common::recv_until_event(&mut bob_d2_ws, &["new_message"]).await;
+    assert_eq!(
+        d2["type"], "new_message",
+        "device 2 must replay the message"
+    );
+    assert_eq!(
+        d2["content"], bob_d2_ct,
+        "device 2 must replay with its own per-device ciphertext"
+    );
+
+    // Bob device #3 (also offline at send time) connects last.
+    let bob_d3_ticket = common::get_ws_ticket_for_device(&client, &base, &bob_token, 33).await;
+    let mut bob_d3_ws = connect_ws(&base, &bob_d3_ticket).await;
+    let d3 = common::recv_until_event(&mut bob_d3_ws, &["new_message"]).await;
+    assert_eq!(
+        d3["type"], "new_message",
+        "device 3 must replay the message"
+    );
+    assert_eq!(
+        d3["content"], bob_d3_ct,
+        "device 3 must replay with its own per-device ciphertext"
+    );
+
+    // The original online device (#1) must NOT receive the same message a
+    // second time -- its per-device ledger row from fan-out should keep it
+    // out of any subsequent `get_undelivered` results.
+    let no_replay = tokio::time::timeout(
+        std::time::Duration::from_millis(300),
+        common::recv_until_event(&mut bob_d1_ws, &["new_message"]),
+    )
+    .await;
+    assert!(
+        no_replay.is_err(),
+        "device 1 must not see the same message replayed after siblings reconnect"
+    );
+
+    let _ = alice_ws.close(None).await;
+    let _ = bob_d1_ws.close(None).await;
+    let _ = bob_d2_ws.close(None).await;
+    let _ = bob_d3_ws.close(None).await;
+}


### PR DESCRIPTION
Closes #829 (7 of 12 findings; 1 already-fixed, 4 deferred).

## Headline: critical multi-device offline-sibling regression

**Symptom**: User has 3 devices, 1 online, 2 offline. Online device receives a message → `send_delivery_confirmation` flips `messages.delivered = true` globally. The 2 offline devices come online later, hit `get_undelivered`, but the `m.delivered = false` filter excludes the message → silently dropped. The per-device `message_deliveries` ledger existed but the global flag was the gate.

**Fix**: drop `m.delivered = false` from `get_undelivered`; rely solely on `NOT EXISTS (... message_deliveries ...)`. Populate the ledger from `fanout_message` via a new `mark_devices_delivered_pairs(message_id, [(user, device)])` helper that batches the inverse of the existing per-user batch. New `hub::send_to_user_collecting` returns the device IDs that accepted the frame so the legacy/plaintext path also writes the ledger.

Regression test: 3-device replay scenario in `apps/server/tests/ws_messaging.rs::multi_device_offline_siblings_replay_on_reconnect`. Asserts each sibling receives its own ciphertext on reconnect, AND the originally-online device does NOT see a duplicate (negative assertion via 300ms timeout).

## Triage of all 12 findings

| # | Severity | Status | Notes |
|---|---|---|---|
| 1 | critical | **fixed** | multi-device offline siblings (above) |
| 2 | high | **fixed** | invite-token TOCTOU — re-validate expires_at/max_uses/use_count inside the consume tx |
| 3 | medium | **fixed** | mentions: sender-must-be-member guard in `extract_and_persist_mentions` |
| 4 | medium | **fixed** | bundled with #12 — deleted-message hygiene |
| 5 | low | **deferred** | `store_device_contents` SQL string concat — cosmetic, pair with next SQL refactor |
| 6 | medium | **fixed** | heartbeat: hoist payload const; `.abort()` was already on disconnect path |
| 7 | medium | **already fixed** | avatar buffer-before-size-check — shipped in `3a2c8042` |
| 8 | medium | **fixed** | `cleanup_empty_groups` includes `is_removed = false` filter; switched to `NOT EXISTS` |
| 9 | low | **fixed** | filter blocked recipients before `store_device_contents` |
| 10 | low | **deferred** | `search_messages*` stopword/single-char — low UX impact |
| 11 | low | **deferred** | `MessageDto` triple-named duplicates — client-coupled, needs Dart audit first |
| 12 | low | **fixed** | bundled with #4 — `rm.deleted_at IS NULL` on 4 reply-preview LEFT JOINs in `db/messages.rs` |

## Commits (7)

1. `f7eb829f` fix(server): replay messages to offline sibling devices via per-device ledger
2. `df6c3c21` fix(server): skip per-device ciphertext storage for blocked recipients
3. `e1fb25be` fix(server): revalidate invite token inside consume tx to prevent toctou over-use
4. `9ca2807a` fix(server): enforce sender membership before persisting mentions
5. `294a017e` fix(server): filter soft-deleted messages and channels from reply-preview + mention counts
6. `14875224` perf(server): hoist heartbeat payload const and abort ping task on disconnect
7. `cce8e374` fix(server): include is_removed filter in cleanup_empty_groups reaper

## Net change

12 files, **+601 / -37**, net +564 LOC. ~290 production, ~298 tests, ~37 deletions (replaced inline blocks).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p echo-server` — 448 passed, 0 failed, 2 ignored
- [x] 3 new regression tests cover the load-bearing changes: slice 1 (multi-device replay), slice 3 (invite TOCTOU), slice 7 (cleanup soft-removed groups)
- [ ] Manual: spin up a 3-device test client, send a message, reconnect siblings, confirm replay

## Deferred — will file as follow-up issues post-merge

- #5 `store_device_contents` SQL string concat — cosmetic
- #10 `search_messages*` stopword filter — low UX impact
- #11 `MessageDto` triple-named fields — needs client-side audit