### PR TITLE
Remember scroll position when switching between groups

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -153,13 +153,25 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   void didUpdateWidget(covariant ChatPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.conversation?.id != oldWidget.conversation?.id) {
-      // Save scroll offset for the old conversation+channel
+      // Save scroll offset + current channel for the old conversation so a
+      // later return restores both. Order matters: capture channel BEFORE
+      // resetting selectedTextChannelId, and cache offset under the still-
+      // current cacheKeyFor (which uses that channel id).
       final oldId = oldWidget.conversation?.id;
       if (oldId != null) {
+        _controller.lastChannelByConversation[oldId] = _selectedTextChannelId;
         _controller.cacheCurrentOffset(oldId);
       }
 
-      _selectedTextChannelId = null;
+      // Restore the channel the user last viewed in this conversation BEFORE
+      // anything reads cacheKeyFor — otherwise the per-channel scroll cache
+      // misses on the very lookup that should be hitting.
+      final newId = widget.conversation?.id;
+      final restoredChannel = newId != null
+          ? _controller.lastChannelByConversation[newId]
+          : null;
+
+      _selectedTextChannelId = restoredChannel;
       _activeVoiceChannelId = null;
       _loadedHistoryKey = null;
       _controller.autoScrollConversationKey = null;
@@ -189,7 +201,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       // Restore cached scroll position for the new conversation, or scroll
       // to bottom if no cached position exists. If there's an unread boundary,
       // defer to the first-load callback which scrolls to the divider.
-      final newId = widget.conversation?.id;
       if (newId != null) {
         final cached =
             _controller.scrollPositions[_controller.cacheKeyFor(newId)];

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -34,6 +34,12 @@ class ChatPanelController extends ChangeNotifier {
   static const int kMaxScrollPositions = 50;
   final Map<String, double> scrollPositions = {};
 
+  // Last viewed channel per conversation. Lets a re-entered group restore the
+  // user to the channel they left off on (which in turn lets [scrollPositions]
+  // hit on its `"convId:channelId"` key — otherwise the channel id is null at
+  // restore time and the lookup misses, falling through to scroll-to-bottom).
+  final Map<String, String?> lastChannelByConversation = {};
+
   void evictScrollPositions() {
     while (scrollPositions.length > kMaxScrollPositions) {
       scrollPositions.remove(scrollPositions.keys.first);

--- a/apps/client/test/widgets/chat_panel_controller_test.dart
+++ b/apps/client/test/widgets/chat_panel_controller_test.dart
@@ -1,0 +1,125 @@
+/// Unit tests for [ChatPanelController]'s per-channel state caches.
+///
+/// Focused on the regression where switching between two groups would lose
+/// the saved scroll offset because the channel id was reset to `null`
+/// before the per-channel cache lookup.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/chat_panel_controller.dart';
+
+void main() {
+  group('ChatPanelController per-channel state cache', () {
+    test('cacheKeyFor reflects current selectedTextChannelId', () {
+      final c = ChatPanelController();
+      c.selectedTextChannelId = 'general';
+      expect(c.cacheKeyFor('groupA'), 'groupA:general');
+
+      c.selectedTextChannelId = null;
+      expect(c.cacheKeyFor('groupA'), 'groupA:');
+    });
+
+    test(
+      'lastChannelByConversation maps conv id to its last viewed channel',
+      () {
+        final c = ChatPanelController();
+        c.lastChannelByConversation['groupA'] = 'general';
+        c.lastChannelByConversation['groupB'] = 'random';
+
+        expect(c.lastChannelByConversation['groupA'], 'general');
+        expect(c.lastChannelByConversation['groupB'], 'random');
+        expect(c.lastChannelByConversation['neverVisited'], isNull);
+      },
+    );
+
+    test(
+      'group-switch round-trip preserves scroll offset under per-channel key',
+      () {
+        // Simulates: user in groupA/general scrolls to bottom, switches to
+        // groupB, then returns to groupA. The fix routes the channel through
+        // lastChannelByConversation so cacheKeyFor returns the SAME key on
+        // restore as on save.
+        final c = ChatPanelController();
+
+        // 1. User is in groupA on the 'general' channel.
+        c.selectedTextChannelId = 'general';
+        final keyAtSave = c.cacheKeyFor('groupA');
+        c.scrollPositions[keyAtSave] = 1240.0;
+        c.lastChannelByConversation['groupA'] = c.selectedTextChannelId;
+
+        // 2. Switch to groupB. The widget would normally reset
+        //    selectedTextChannelId; here we just set it to whatever B's
+        //    default would be (or null for "no channel picked yet").
+        c.selectedTextChannelId = null;
+
+        // 3. Coming back to groupA — restore the saved channel BEFORE the
+        //    lookup. This is the fix: lastChannelByConversation lets the
+        //    cacheKeyFor lookup match the saved key.
+        c.selectedTextChannelId = c.lastChannelByConversation['groupA'];
+        final keyAtRestore = c.cacheKeyFor('groupA');
+
+        expect(keyAtRestore, keyAtSave);
+        expect(c.scrollPositions[keyAtRestore], 1240.0);
+      },
+    );
+
+    test(
+      'pre-fix behavior: lookup with null channel misses the saved per-channel offset',
+      () {
+        // Documents what was wrong BEFORE the fix. If we reset the channel
+        // to null and never restore it, the cacheKeyFor lookup produces a
+        // different key than what was saved.
+        final c = ChatPanelController();
+
+        c.selectedTextChannelId = 'general';
+        c.scrollPositions[c.cacheKeyFor('groupA')] = 1240.0;
+
+        // Switch resets channel to null — the (buggy) lookup misses.
+        c.selectedTextChannelId = null;
+        final keyWithoutChannelRestore = c.cacheKeyFor('groupA');
+
+        expect(keyWithoutChannelRestore, 'groupA:');
+        expect(
+          c.scrollPositions[keyWithoutChannelRestore],
+          isNull,
+          reason: 'Saved under groupA:general; null-channel lookup must miss',
+        );
+      },
+    );
+
+    test('DM round-trip (no channel) hits the cache', () {
+      // Direct messages have no channel id. Both save and restore keys end
+      // up as "convId:" — they hit naturally without lastChannelByConversation.
+      final c = ChatPanelController();
+      c.selectedTextChannelId = null;
+
+      final keyAtSave = c.cacheKeyFor('dmAlice');
+      c.scrollPositions[keyAtSave] = 800.0;
+
+      c.selectedTextChannelId = null; // unchanged for DMs
+      final keyAtRestore = c.cacheKeyFor('dmAlice');
+
+      expect(keyAtRestore, keyAtSave);
+      expect(c.scrollPositions[keyAtRestore], 800.0);
+    });
+
+    test('evictScrollPositions drops oldest entries when over cap', () {
+      final c = ChatPanelController();
+      for (var i = 0; i < ChatPanelController.kMaxScrollPositions + 5; i++) {
+        c.scrollPositions['conv$i:'] = i.toDouble();
+      }
+      c.evictScrollPositions();
+      expect(c.scrollPositions.length, ChatPanelController.kMaxScrollPositions);
+      // Oldest 5 should be gone.
+      for (var i = 0; i < 5; i++) {
+        expect(c.scrollPositions['conv$i:'], isNull);
+      }
+      // Newest entries still present.
+      expect(
+        c.scrollPositions['conv${ChatPanelController.kMaxScrollPositions + 4}:'],
+        (ChatPanelController.kMaxScrollPositions + 4).toDouble(),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Fixed

- Switching from group A → group B → back to A no longer rescrolls A to the bottom. Your scroll position (and the channel you were on) is preserved across the round-trip.

## Root cause

The per-channel scroll cache is keyed by \`"conversationId:channelId"\` (\`ChatPanelController.cacheKeyFor\`). On save we capture the channel — e.g. \`"groupA:general"\`. But on conversation switch, \`didUpdateWidget\` resets \`selectedTextChannelId\` to \`null\` BEFORE the restore lookup, so the lookup key becomes \`"groupA:"\` — a miss against the \`"groupA:general"\` save. The widget falls through to \`_scrollToBottom\`.

## Fix

Track the last viewed channel per conversation (\`lastChannelByConversation: Map<String, String?>\`) and restore it BEFORE \`didUpdateWidget\` does its cache lookup. The lookup key now matches the save key.

Side benefit: when you return to a group you previously viewed, you also land on the same text channel you left off on (Discord-parity).

## Behind the scenes

- New field \`ChatPanelController.lastChannelByConversation\` (Map<String, String?>) — keyed by conv id, value is the channel id at the time of leaving.
- \`chat_panel.dart::didUpdateWidget\` now captures the channel BEFORE resetting \`_selectedTextChannelId\`, and restores it BEFORE the cache lookup.
- 6 new unit tests in \`apps/client/test/widgets/chat_panel_controller_test.dart\` covering the round-trip, the pre-fix miss (regression guard), DM round-trip, and eviction.

## Test plan

- [x] \`dart format\` clean
- [x] \`flutter analyze --fatal-infos\` clean
- [x] \`flutter test\` — 1476 passed (+6 new), 8 skipped, 0 failed
- [ ] Manual: open group A, scroll to bottom, switch to group B, scroll to bottom, switch back to A → lands at bottom without an animated scroll. Repeat with a non-bottom position to confirm scroll cache also works for mid-list positions.