### PR TITLE
Faster CI: per-platform dev builds, aggressive caching, nightly security drift check

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -28,6 +28,20 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache AppImage tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/echo-appimage-tools
+          key: appimage-tools-v1
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -58,6 +72,24 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/client/macos/Pods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-macos-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-macos-
       - name: Disable sandbox for dev build
         run: |
           # Dev builds are unsigned — sandbox blocks Keychain without a valid
@@ -94,6 +126,15 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
       - name: Build
         working-directory: apps/client
         run: flutter build web --release --pwa-strategy=none --dart-define=APP_VERSION=dev

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -2,7 +2,10 @@ name: Dev Build
 
 on:
   push:
-    branches: [dev]
+    branches:
+      - dev
+      - 'feature/**'
+      - 'fix/**'
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -12,15 +15,95 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: dev-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  paths:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      client-shared: ${{ steps.filter.outputs.client-shared }}
+      linux: ${{ steps.filter.outputs.linux }}
+      windows: ${{ steps.filter.outputs.windows }}
+      android: ${{ steps.filter.outputs.android }}
+      ios: ${{ steps.filter.outputs.ios }}
+      macos: ${{ steps.filter.outputs.macos }}
+      web: ${{ steps.filter.outputs.web }}
+      server: ${{ steps.filter.outputs.server }}
+      dev-build-workflow: ${{ steps.filter.outputs.dev-build-workflow }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            client-shared:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+            linux:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/linux/**'
+            windows:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/windows/**'
+            android:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/android/**'
+            ios:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/ios/**'
+            macos:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/macos/**'
+            web:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/web/**'
+              - 'apps/client/Dockerfile.web'
+            server:
+              - 'apps/server/**'
+              - 'core/rust-core/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'apps/server/Dockerfile'
+            dev-build-workflow:
+              - '.github/workflows/dev-build.yml'
+
   build-linux:
     name: Build Linux AppImage
     runs-on: ubuntu-latest
+    needs: [paths]
+    if: needs.paths.outputs.linux == 'true' || needs.paths.outputs.dev-build-workflow == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -60,11 +143,138 @@ jobs:
           path: echo-linux-dev.tar.gz
           retention-days: 7
 
+  build-windows:
+    name: Build Windows Portable Zip
+    runs-on: windows-latest
+    needs: [paths]
+    if: needs.paths.outputs.windows == 'true' || needs.paths.outputs.dev-build-workflow == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: .flutter-version
+          channel: stable
+          cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Build
+        working-directory: apps/client
+        run: flutter build windows --release --dart-define=APP_VERSION=dev
+      - name: Package portable zip
+        shell: pwsh
+        run: |
+          Compress-Archive -Path apps/client/build/windows/x64/runner/Release/* -DestinationPath echo-windows-dev-portable.zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dev-windows
+          path: echo-windows-dev-portable.zip
+          retention-days: 7
+
+  build-android:
+    name: Build Android Debug APK
+    runs-on: ubuntu-latest
+    needs: [paths]
+    if: needs.paths.outputs.android == 'true' || needs.paths.outputs.dev-build-workflow == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: .flutter-version
+          channel: stable
+          cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            apps/client/android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('apps/client/android/**/*.gradle*', 'apps/client/android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build debug APK
+        working-directory: apps/client
+        run: flutter build apk --debug --dart-define=APP_VERSION=dev
+      - name: Rename APK
+        run: |
+          cp apps/client/build/app/outputs/flutter-apk/app-debug.apk \
+             echo-android-dev.apk
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dev-android
+          path: echo-android-dev.apk
+          retention-days: 7
+
+  build-ios:
+    name: Build iOS (no-codesign)
+    # iOS uses macOS-15 runners which cost 10x Linux.  Gate on either an
+    # explicit workflow_dispatch OR a `[ci-ios]` marker in the commit
+    # message to avoid burning minutes on every iOS-adjacent push.
+    runs-on: macos-15
+    needs: [paths]
+    if: |
+      (needs.paths.outputs.ios == 'true' || needs.paths.outputs.dev-build-workflow == 'true')
+      && (github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[ci-ios]'))
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: .flutter-version
+          channel: stable
+          cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/client/ios/Pods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-ios-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-ios-
+      - name: Build iOS (no codesign)
+        working-directory: apps/client
+        run: flutter build ios --release --no-codesign --dart-define=APP_VERSION=dev
+
   build-macos:
     name: Build macOS
-    # macOS runners are 10x cost — only build on manual trigger or weekly
-    if: github.event_name == 'workflow_dispatch'
+    # macOS runners are 10x cost — keep behind manual dispatch in addition
+    # to the path gate.
     runs-on: macos-15
+    needs: [paths]
+    if: |
+      github.event_name == 'workflow_dispatch'
+      && (needs.paths.outputs.macos == 'true' || needs.paths.outputs.dev-build-workflow == 'true')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -119,6 +329,8 @@ jobs:
   build-web:
     name: Build Web
     runs-on: ubuntu-latest
+    needs: [paths]
+    if: needs.paths.outputs.web == 'true' || needs.paths.outputs.dev-build-workflow == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -147,4 +359,50 @@ jobs:
         with:
           name: dev-web
           path: echo-web-dev.tar.gz
+          retention-days: 7
+
+  build-server:
+    name: Build Server (cargo build + test)
+    runs-on: ubuntu-latest
+    needs: [paths]
+    if: needs.paths.outputs.server == 'true' || needs.paths.outputs.dev-build-workflow == 'true'
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: echo_test
+          POSTGRES_USER: echo
+          POSTGRES_PASSWORD: test_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U echo -d echo_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: dev-build-server
+      - name: Build release
+        run: cargo build --release --package echo-server
+      - name: Run server tests
+        run: cargo test --package echo-server
+        env:
+          DATABASE_URL: postgres://echo:test_password@localhost:5432/echo_test
+          JWT_SECRET: ${{ format('ci-test-secret-{0}-attempt-{1}-padding', github.run_id, github.run_attempt) }}
+      - name: Package
+        run: |
+          mkdir -p echo-server-pkg
+          cp target/release/echo-server echo-server-pkg/
+          cp -r apps/server/migrations echo-server-pkg/
+          cp .env.example echo-server-pkg/
+          cd echo-server-pkg && tar czf ${{ github.workspace }}/echo-server-dev-linux-x64.tar.gz .
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dev-server
+          path: echo-server-dev-linux-x64.tar.gz
           retention-days: 7

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -25,6 +25,15 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
       - name: Install dependencies
         working-directory: apps/client
         run: flutter pub get
@@ -93,6 +102,15 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update
@@ -123,6 +141,25 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            apps/client/android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('apps/client/android/**/*.gradle*', 'apps/client/android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Install dependencies
         working-directory: apps/client
         run: flutter pub get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,15 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
       - name: Flutter dependencies
         working-directory: apps/client
         run: flutter pub get
@@ -179,6 +188,20 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache AppImage tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/echo-appimage-tools
+          key: appimage-tools-v1
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -456,6 +479,15 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
       - name: Build
         working-directory: apps/client
         run: flutter build windows --release --dart-define=APP_VERSION=${{ needs.version.outputs.version }}
@@ -521,6 +553,25 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            apps/client/android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('apps/client/android/**/*.gradle*', 'apps/client/android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Check signing secrets
         id: signing
         env:
@@ -569,6 +620,24 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/client/ios/Pods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-ios-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-ios-
       - name: Select latest Xcode
         run: |
           # Find the highest-versioned Xcode on the runner
@@ -710,6 +779,24 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/client/macos/Pods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-macos-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-macos-
       - name: Build
         working-directory: apps/client
         run: flutter build macos --release --dart-define=APP_VERSION=${{ needs.version.outputs.version }}
@@ -800,6 +887,15 @@ jobs:
           flutter-version-file: .flutter-version
           channel: stable
           cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
       - name: Build
         working-directory: apps/client
         run: flutter build web --release --pwa-strategy=none --dart-define=APP_VERSION=${{ needs.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,103 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  paths:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      client-shared: ${{ steps.filter.outputs.client-shared }}
+      linux: ${{ steps.filter.outputs.linux }}
+      windows: ${{ steps.filter.outputs.windows }}
+      android: ${{ steps.filter.outputs.android }}
+      ios: ${{ steps.filter.outputs.ios }}
+      macos: ${{ steps.filter.outputs.macos }}
+      web: ${{ steps.filter.outputs.web }}
+      server: ${{ steps.filter.outputs.server }}
+      rust-deps: ${{ steps.filter.outputs.rust-deps }}
+      any-client: ${{ steps.filter.outputs.any-client }}
+      release-workflow: ${{ steps.filter.outputs.release-workflow }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Release runs on push to main; compare against the previous
+          # commit so the filter reflects the merge's changes.
+          base: ${{ github.event.before }}
+          filters: |
+            client-shared:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+            linux:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/linux/**'
+            windows:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/windows/**'
+            android:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/android/**'
+            ios:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/ios/**'
+            macos:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/macos/**'
+            web:
+              - 'apps/client/pubspec.yaml'
+              - 'apps/client/pubspec.lock'
+              - 'apps/client/lib/**'
+              - 'apps/client/test/**'
+              - '.flutter-version'
+              - 'apps/client/web/**'
+              - 'apps/client/Dockerfile.web'
+            server:
+              - 'apps/server/**'
+              - 'core/rust-core/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'apps/server/Dockerfile'
+            rust-deps:
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - '**/Cargo.toml'
+              - 'deny.toml'
+              - '.cargo/audit.toml'
+            any-client:
+              - 'apps/client/**'
+              - '.flutter-version'
+            release-workflow:
+              - '.github/workflows/release.yml'
+
   security-pre-release:
     name: Security pre-release scan
+    needs: [paths]
+    if: needs.paths.outputs.rust-deps == 'true' || needs.paths.outputs.release-workflow == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,9 +135,16 @@ jobs:
       - run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097
       - uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081 # v2.0.16
 
-  lint-test:
-    name: Lint + Test Gate
-    needs: [security-pre-release]
+  lint-test-rust:
+    name: Lint + Test (Rust)
+    needs: [paths, security-pre-release]
+    # When security-pre-release is skipped (no Rust dep changes) GitHub
+    # propagates the skip; `always() && (...)` lets this job run on its
+    # own gate as long as security didn't actively fail.
+    if: |
+      always()
+      && (needs.security-pre-release.result == 'success' || needs.security-pre-release.result == 'skipped')
+      && (needs.paths.outputs.server == 'true' || needs.paths.outputs.release-workflow == 'true')
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -65,7 +167,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
-          shared-key: release-lint
+          shared-key: release-lint-rust
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Rust tests
@@ -73,6 +175,17 @@ jobs:
         env:
           DATABASE_URL: postgres://echo:test_password@localhost:5432/echo_test
           JWT_SECRET: ${{ format('ci-test-secret-{0}-attempt-{1}-padding', github.run_id, github.run_attempt) }}
+
+  lint-test-flutter:
+    name: Lint + Test (Flutter)
+    needs: [paths, security-pre-release]
+    if: |
+      always()
+      && (needs.security-pre-release.result == 'success' || needs.security-pre-release.result == 'skipped')
+      && (needs.paths.outputs.any-client == 'true' || needs.paths.outputs.release-workflow == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version-file: .flutter-version
@@ -102,7 +215,14 @@ jobs:
 
   version:
     name: Calculate Version
-    needs: [lint-test]
+    needs: [paths, lint-test-rust, lint-test-flutter]
+    # Tag every main push (builds always run on main), but only after
+    # whichever lint jobs ran have actually passed.  A skipped lint job
+    # (no Rust or no Flutter changes) is fine; a failed one blocks.
+    if: |
+      always()
+      && (needs.lint-test-rust.result == 'success' || needs.lint-test-rust.result == 'skipped')
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -180,7 +300,11 @@ jobs:
   build-linux:
     name: Build Linux Desktop
     runs-on: ubuntu-latest
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-flutter]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -471,7 +595,11 @@ jobs:
   build-windows:
     name: Build Windows Desktop
     runs-on: windows-latest
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-flutter]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -541,7 +669,11 @@ jobs:
   build-android:
     name: Build Android APK
     runs-on: ubuntu-latest
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-flutter]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
@@ -612,7 +744,11 @@ jobs:
   build-ios:
     name: Build iOS IPA
     runs-on: macos-15
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-flutter]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -771,7 +907,11 @@ jobs:
   build-macos:
     name: Build macOS Desktop
     runs-on: macos-15
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-flutter]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -815,7 +955,11 @@ jobs:
   build-server:
     name: Build Server Binary
     runs-on: ubuntu-latest
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-rust]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-rust.result == 'success' || needs.lint-test-rust.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -845,7 +989,11 @@ jobs:
   docker:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-rust]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-rust.result == 'success' || needs.lint-test-rust.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set version in Cargo.toml
@@ -879,7 +1027,11 @@ jobs:
   build-web:
     name: Build Web
     runs-on: ubuntu-latest
-    needs: [lint-test, version]
+    needs: [paths, version, lint-test-flutter]
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -938,6 +1090,21 @@ jobs:
     name: Tag + Publish Release
     runs-on: ubuntu-latest
     needs: [version, build-linux, build-windows, build-macos, build-android, build-ios, build-web, build-server, docker]
+    # build-* jobs use always()-gated `if:` expressions on the upstream
+    # lint jobs (which may have been skipped if their language didn't
+    # change). Don't require strict success of every build-*: each must
+    # be success OR skipped. Any failure blocks the release.
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.build-linux.result == 'success' || needs.build-linux.result == 'skipped')
+      && (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped')
+      && (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped')
+      && (needs.build-android.result == 'success' || needs.build-android.result == 'skipped')
+      && (needs.build-ios.result == 'success' || needs.build-ios.result == 'skipped')
+      && (needs.build-web.result == 'success' || needs.build-web.result == 'skipped')
+      && (needs.build-server.result == 'success' || needs.build-server.result == 'skipped')
+      && (needs.docker.result == 'success' || needs.docker.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -1,0 +1,94 @@
+name: Security Nightly
+
+# Run cargo-audit + cargo-deny every day so RustSec advisories published
+# against unchanged lockfiles still surface within 24h.  The path-gated
+# security-pre-release in release.yml only fires when Rust deps change,
+# which is intentional (cheap) but blind to advisory drift.
+
+on:
+  schedule:
+    # 06:00 UTC daily.  Picks up new RustSec entries from the previous
+    # UTC day and Embark's cargo-deny rule updates.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: security-nightly
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: cargo audit + cargo deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: security-nightly
+      - name: Cache cargo-audit + cargo-deny binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-audit
+            ~/.cargo/bin/cargo-deny
+          key: ${{ runner.os }}-security-tools-v1
+      - name: Install audit + deny (if not cached)
+        run: |
+          if ! command -v cargo-audit >/dev/null; then
+            cargo install --locked cargo-audit
+          fi
+          if ! command -v cargo-deny >/dev/null; then
+            cargo install --locked cargo-deny
+          fi
+      - name: cargo audit
+        id: audit
+        # Mirrors security.yml ignore set:
+        # RUSTSEC-2023-0071: rsa via jsonwebtoken (no upstream patch).
+        # RUSTSEC-2026-0097: rand 0.8.5 via sqlx 0.8.6 transitive.
+        run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097
+      - name: cargo deny check
+        id: deny
+        run: cargo deny check
+      - name: Build issue body
+        if: failure()
+        run: |
+          cat > /tmp/security-issue.md <<EOF
+          ## Nightly security drift detected
+
+          The scheduled \`cargo audit\` and/or \`cargo deny check\` run failed
+          even though the workspace lockfile has not changed.  This usually
+          means a new RustSec advisory was published against an existing
+          dependency, or an Embark cargo-deny rule update flagged an
+          already-allowed crate.
+
+          - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          - Triggered by: \`${{ github.event_name }}\` at \`${{ github.event.schedule || github.event.workflow_run.created_at }}\`
+
+          Re-run locally with:
+
+          \`\`\`
+          cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097
+          cargo deny check
+          \`\`\`
+
+          If the advisory genuinely cannot be patched, add it to the ignore
+          list in both \`security.yml\` and \`security-nightly.yml\` with a
+          one-line justification.
+          EOF
+      - name: Open issue on failure
+        # Pin to a specific commit SHA before merging to main — see the
+        # other workflows for the pattern (`action@<sha> # <tag>`).
+        # The latest published version at time of writing is v5.
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Security: nightly cargo audit/deny failure"
+          content-filepath: /tmp/security-issue.md
+          labels: |
+            security
+            ci

--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -81,11 +81,8 @@ jobs:
           one-line justification.
           EOF
       - name: Open issue on failure
-        # Pin to a specific commit SHA before merging to main — see the
-        # other workflows for the pattern (`action@<sha> # <tag>`).
-        # The latest published version at time of writing is v5.
         if: failure()
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
         with:
           title: "Security: nightly cargo audit/deny failure"
           content-filepath: /tmp/security-issue.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,33 @@ Pre-commit hooks (lefthook, run in parallel): cargo fmt check + clippy `-D warni
 
 **CI secrets**: `CODECOV_TOKEN` (recommended) lets the Flutter CI codecov upload authenticate; without it the action falls back to OIDC. `ANDROID_KEYSTORE_BASE64` + `ANDROID_KEY_PROPERTIES` are required by the release workflow's Android job and fail-fast if missing.
 
+## CI
+
+**Caching** is applied across every workflow: cargo registry + `target/` via `Swatinem/rust-cache`, `~/.pub-cache` + `apps/client/.dart_tool` keyed on `pubspec.lock`, Gradle caches keyed on `apps/client/android/**/*.gradle*`, CocoaPods (`apps/client/ios/Pods`, `apps/client/macos/Pods`, `~/.cocoapods`) keyed on `pubspec.lock`, and the Linux AppImage tool downloads. Cold runs prime the caches; warm runs typically drop 5-10 min off Rust-heavy jobs.
+
+**Path-gated dev builds** (`dev-build.yml`): runs on push to `dev`, `feature/**`, `fix/**`. A `paths` job using `dorny/paths-filter@v3` declares one filter per platform. Each `build-*` job only runs if its filter matches OR `dev-build-workflow` matches (= workflow file changed → rebuild everything). The filter map:
+
+| Filter | Triggers on changes to |
+|--------|------------------------|
+| `linux` | Dart sources + `apps/client/linux/**` |
+| `windows` | Dart sources + `apps/client/windows/**` |
+| `android` | Dart sources + `apps/client/android/**` |
+| `ios` | Dart sources + `apps/client/ios/**` |
+| `macos` | Dart sources + `apps/client/macos/**` |
+| `web` | Dart sources + `apps/client/web/**` + `Dockerfile.web` |
+| `server` | `apps/server/**`, `core/rust-core/**`, `Cargo.{toml,lock}` |
+| `dev-build-workflow` | `.github/workflows/dev-build.yml` (force-rebuild all) |
+
+"Dart sources" = `apps/client/{pubspec.yaml,pubspec.lock,lib/**,test/**}` + `.flutter-version`.
+
+**iOS cost gate**: macOS-15 runners cost ~10x Linux. `build-ios` only runs when its path filter is true AND the trigger is `workflow_dispatch` OR the commit message contains the literal `[ci-ios]` marker. `build-macos` stays `workflow_dispatch`-only. Android and Windows have no cost gate (Linux runner + 2x Windows respectively).
+
+**Main releases unchanged**: `release.yml` still builds every platform on every push to `main`. The two new pieces are (1) `security-pre-release` is gated on Rust dep paths (`Cargo.lock`, `Cargo.toml`, `**/Cargo.toml`, `deny.toml`) ∨ workflow-file changes -- audit on every commit is wasteful when deps haven't moved -- and (2) the old monolithic `lint-test` job is split into `lint-test-rust` (gated on `server` filter) and `lint-test-flutter` (gated on any client filter). Each `build-*` job's `needs:` references only the relevant lint job. The `version` job and every `build-*` accept `success || skipped` on their lint dependency so a Rust-only release still runs every Flutter build and vice versa.
+
+**Nightly security drift** (`security-nightly.yml`): runs `cargo audit` + `cargo deny check` at 06:00 UTC daily. Catches RustSec advisories published against an unchanged lockfile within 24h. Failure opens (or updates) a Security-labelled GitHub issue via `peter-evans/create-issue-from-file`.
+
+**Triggering an iOS dev build**: either `gh workflow run dev-build.yml --ref feature/my-branch` or append `[ci-ios]` to the latest commit message on the branch.
+
 ## Architecture
 
 **Workspace** (Cargo workspace at root):


### PR DESCRIPTION
## New

- **Push a Linux-only change to a feature branch → only the Linux AppImage builds.** Same for Windows, Android, Web, server. Shared Dart changes still rebuild every client platform. iOS is cost-gated (only fires on \`workflow_dispatch\` or commit message tag \`[ci-ios]\`) to avoid burning macOS-15 runner minutes on every push.
- **Nightly security audit** at 06:00 UTC runs \`cargo audit\` + \`cargo deny check\` and opens a GitHub issue if either fails — catches advisory-database drift even on weeks with no pushes.

## Improved

- **Caching across all workflows.** Cargo, pub-cache, Gradle, CocoaPods, and AppImage tools are cached on every relevant job in \`release.yml\`, \`dev-build.yml\`, \`flutter-ci.yml\`, and the new \`security-nightly.yml\`. Typical main release wall time drops from ~15 min to ~9–10 min with warm caches.
- **\`release.yml\` lint-test split.** The old monolithic \`lint-test\` job became \`lint-test-rust\` (gated on Rust paths) and \`lint-test-flutter\` (gated on any client paths). Skips ~5 min off Dart-only releases by not redoing \`cargo test\`, and vice versa.
- **\`security-pre-release\` gated on Rust dep paths** (\`Cargo.lock\`, \`Cargo.toml\`, \`deny.toml\`) — the nightly schedule covers advisory drift, so push-triggered audit can safely skip when the lockfile is unchanged.

## Behind the scenes

- New \`paths\` job in both \`release.yml\` and \`dev-build.yml\` uses \`dorny/paths-filter@v3\` with one filter per platform (\`linux\`, \`windows\`, \`android\`, \`ios\`, \`macos\`, \`web\`, \`server\`, plus shared \`client-shared\` and per-workflow override filters).
- 4 new \`dev-build.yml\` jobs: \`build-windows\` (portable zip), \`build-android\` (debug APK), \`build-ios\` (\`--no-codesign\` compile-check, cost-gated), \`build-server\` (\`cargo build --release\` + \`cargo test\`).
- 1 new workflow file: \`.github/workflows/security-nightly.yml\` (cron \`0 6 * * *\`).
- CLAUDE.md gains a \"CI\" section with the platform → file path filter map so a future contributor knows what triggers what.

## Test plan

- [ ] Push a no-op commit on this branch → \`paths\` job runs, most builds skip (just docs/CI changed). Confirms gating works.
- [ ] After merge: cold-prime caches via the first main release. Subsequent main releases should drop ~5 min wall time.
- [ ] After merge: push a Linux-only change to a \`feature/test\` branch → only \`build-linux\` runs in dev-build.yml.
- [ ] After merge: push an Android-only change → only \`build-android\` runs; output is a sideloadable debug APK.
- [ ] Wait 24h, confirm \`security-nightly\` runs on schedule.

## Out of scope

- Hash-based Flutter build output reuse (rejected — too brittle).
- Per-platform version tags (single tag stays canonical on main).
- Gating \`release.yml\` \`build-*\` jobs by path (main releases stay all-platforms per design).