### PR TITLE
ci: cache linux apt packages so the 500MB GTK stack downloads once

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -125,10 +125,14 @@ jobs:
         with:
           path: ~/.cache/echo-appimage-tools
           key: appimage-tools-v1
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build libgtk-3-dev libfuse2 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libsecret-1-dev libayatana-appindicator3-dev libasound2-dev libmpv-dev
+      - name: Install Linux dependencies (cached)
+        # Caches the .deb archives so the ~500 MB GTK + GStreamer + libmpv
+        # stack only downloads once. Cache key is hashed from the package
+        # list below; changes to that list invalidate the cache.
+        uses: awalsh128/cache-apt-pkgs-action@0e3c11464a8cfae52ee6ceb2b33777bcc9187892 # v1.6.0
+        with:
+          packages: clang cmake ninja-build libgtk-3-dev libfuse2 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libsecret-1-dev libayatana-appindicator3-dev libasound2-dev libmpv-dev
+          version: "1.0"
       - name: Build
         working-directory: apps/client
         run: flutter build linux --release --dart-define=APP_VERSION=dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,24 +326,18 @@ jobs:
         with:
           path: ~/.cache/echo-appimage-tools
           key: appimage-tools-v1
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          # libsndio7-dev + libjack-jackd2-dev are required so the
-          # bundling step can resolve libmpv's hard-linked audio
-          # backends via ldd.  Without them, ldd reports "not found"
-          # and walk_deps silently skips them, shipping a bundle that
-          # fails on every user host that doesn't have them either
-          # (sndio is OpenBSD's audio daemon, jack is pro-audio —
-          # neither is on typical Linux desktops).
-          sudo apt-get install -y \
-            clang cmake ninja-build \
-            libgtk-3-dev libfuse2 \
-            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-            gstreamer1.0-plugins-good \
-            libsecret-1-dev libayatana-appindicator3-dev \
-            libasound2-dev libmpv-dev \
-            libsndio-dev libjack-jackd2-dev
+      - name: Install Linux dependencies (cached)
+        # Caches the .deb archives so the ~500 MB GTK + GStreamer + libmpv
+        # stack only downloads once. libsndio-dev + libjack-jackd2-dev are
+        # required so the bundling step can resolve libmpv's hard-linked
+        # audio backends via ldd (sndio is OpenBSD's audio daemon, jack is
+        # pro-audio — neither is on typical Linux desktops, so without them
+        # ldd reports "not found" and walk_deps silently skips them,
+        # shipping a broken bundle).
+        uses: awalsh128/cache-apt-pkgs-action@0e3c11464a8cfae52ee6ceb2b33777bcc9187892 # v1.6.0
+        with:
+          packages: clang cmake ninja-build libgtk-3-dev libfuse2 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libsecret-1-dev libayatana-appindicator3-dev libasound2-dev libmpv-dev libsndio-dev libjack-jackd2-dev
+          version: "1.0"
       - name: Build
         working-directory: apps/client
         run: flutter build linux --release --dart-define=APP_VERSION=${{ needs.version.outputs.version }}


### PR DESCRIPTION
## Fixed

- Linux AppImage builds (both \`dev-build.yml\` and \`release.yml\`) were downloading the full ~500MB GTK + GStreamer + libmpv apt package set on every run. #863 cached the AppImage *tool* downloads but not the actual .deb archives. This PR fixes that.

## Behind the scenes

- Replaces \`sudo apt-get update && sudo apt-get install -y …\` with \`awalsh128/cache-apt-pkgs-action@v1.6.0\` (SHA-pinned). The action hashes the package list, caches .deb files in a user-writable location, and \`dpkg -i\`s them on cache hit — no network download.
- Cache key is hashed from the package list, so changing the list invalidates the cache automatically. The \`version: "1.0"\` field is an extra knob to bust the cache manually if needed (bump to \`"1.1"\`).
- Expected impact on the Linux AppImage build:
  - Cold (first run after merge): ~same as today; primes the cache.
  - Warm (every subsequent run): apt step drops from ~2-3 min to ~10-15 sec. The full Linux build should drop from ~10-24 min to ~5-7 min depending on whether other caches (pub, AppImage tools) are also warm.

## Test plan

- [x] Workflow YAML parses
- [ ] Push triggers the Linux build (this PR touches \`.github/workflows/release.yml\` which is on the workflow override filter for release.yml's path job, but the release workflow only fires on push to main — so it won't validate end-to-end until merge). The \`dev-build.yml\` change does fire on this branch push and will exercise the cache.
- [ ] After merge: confirm the next Linux release run shows "Cache hit" for the apt step and completes much faster.