### PR TITLE
Two-column signup and login on desktop, mobile flow unchanged (#729)

### DIFF
--- a/apps/client/lib/src/screens/forgot_password_screen.dart
+++ b/apps/client/lib/src/screens/forgot_password_screen.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
+import '../widgets/auth/auth_layout.dart';
 import '../widgets/auth/auth_scaffold_chrome.dart';
 import '../widgets/echo_logo_icon.dart';
 
@@ -78,16 +79,11 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
       body: Stack(
         children: [
           const AuthBackground(),
-          SafeArea(
-            child: Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 400),
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(24, 24, 24, 56),
-                  child: _submitted ? _buildSuccess(context) : _buildForm(),
-                ),
-              ),
-            ),
+          AuthLayout(
+            tagline: 'Reset your password.',
+            formTitle: 'Reset your password.',
+            compactHeader: _buildHeader(),
+            formColumn: _submitted ? _buildSuccess(context) : _buildForm(),
           ),
         ],
       ),
@@ -100,8 +96,6 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _buildHeader(),
-          const SizedBox(height: 32),
           TextFormField(
             controller: _usernameController,
             autofillHints: const [AutofillHints.username],
@@ -164,8 +158,6 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _buildHeader(),
-        const SizedBox(height: 32),
         Icon(
           Icons.mark_email_read_outlined,
           size: 48,

--- a/apps/client/lib/src/screens/login_screen.dart
+++ b/apps/client/lib/src/screens/login_screen.dart
@@ -8,6 +8,7 @@ import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
 import '../utils/version_utils.dart';
+import '../widgets/auth/auth_layout.dart';
 import '../widgets/auth/auth_scaffold_chrome.dart';
 import '../widgets/echo_logo_icon.dart';
 
@@ -111,61 +112,55 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
       body: Stack(
         children: [
           const AuthBackground(),
-          SafeArea(
-            child: Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 400),
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(24, 24, 24, _bottomPad),
-                  child: Form(
-                    key: _formKey,
-                    child: AutofillGroup(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          _buildHeader(),
-                          const SizedBox(height: 32),
-                          _buildUsernameField(),
-                          const SizedBox(height: 16),
-                          _buildPasswordField(),
-                          _buildErrorMessage(authState),
-                          const SizedBox(height: 24),
-                          _buildLoginButton(authState),
-                          const SizedBox(height: 4),
-                          SizedBox(
-                            height: 44,
-                            child: Semantics(
-                              button: true,
-                              label: 'forgot-password',
-                              child: TextButton(
-                                onPressed: () => context.go('/forgot-password'),
-                                style: TextButton.styleFrom(
-                                  foregroundColor: context.textSecondary,
-                                ),
-                                child: const Text('Forgot password?'),
-                              ),
-                            ),
+          AuthLayout(
+            tagline: 'Welcome back.',
+            formTitle: 'Welcome back.',
+            compactHeader: _buildHeader(),
+            narrowPadding: const EdgeInsets.fromLTRB(24, 24, 24, _bottomPad),
+            formColumn: Form(
+              key: _formKey,
+              child: AutofillGroup(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _buildUsernameField(),
+                    const SizedBox(height: 16),
+                    _buildPasswordField(),
+                    _buildErrorMessage(authState),
+                    const SizedBox(height: 24),
+                    _buildLoginButton(authState),
+                    const SizedBox(height: 4),
+                    SizedBox(
+                      height: 44,
+                      child: Semantics(
+                        button: true,
+                        label: 'forgot-password',
+                        child: TextButton(
+                          onPressed: () => context.go('/forgot-password'),
+                          style: TextButton.styleFrom(
+                            foregroundColor: context.textSecondary,
                           ),
-                          SizedBox(
-                            height: 44,
-                            // TextButton + Text already produce a
-                            // button-role accessibility node named "Create an
-                            // account" — wrapping in another Semantics
-                            // duplicates the node and trips strict-mode
-                            // selectors (`getByRole('button', { name: /create
-                            // an account/i })` resolves to 2).
-                            child: TextButton(
-                              onPressed: () => context.go('/register'),
-                              style: TextButton.styleFrom(
-                                foregroundColor: context.textSecondary,
-                              ),
-                              child: const Text('Create an account'),
-                            ),
-                          ),
-                        ],
+                          child: const Text('Forgot password?'),
+                        ),
                       ),
                     ),
-                  ),
+                    SizedBox(
+                      height: 44,
+                      // TextButton + Text already produce a
+                      // button-role accessibility node named "Create an
+                      // account" — wrapping in another Semantics
+                      // duplicates the node and trips strict-mode
+                      // selectors (`getByRole('button', { name: /create
+                      // an account/i })` resolves to 2).
+                      child: TextButton(
+                        onPressed: () => context.go('/register'),
+                        style: TextButton.styleFrom(
+                          foregroundColor: context.textSecondary,
+                        ),
+                        child: const Text('Create an account'),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/apps/client/lib/src/screens/register_screen.dart
+++ b/apps/client/lib/src/screens/register_screen.dart
@@ -8,6 +8,7 @@ import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
 import '../utils/version_utils.dart';
+import '../widgets/auth/auth_layout.dart';
 import '../widgets/auth/auth_scaffold_chrome.dart';
 import '../widgets/echo_logo_icon.dart';
 
@@ -162,46 +163,40 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
       body: Stack(
         children: [
           const AuthBackground(),
-          SafeArea(
-            child: Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 400),
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(24, 24, 24, _bottomPad),
-                  child: Form(
-                    key: _formKey,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        _buildHeader(context),
-                        const SizedBox(height: 32),
-                        _buildUsernameField(),
-                        const SizedBox(height: 16),
-                        _buildPasswordField(),
-                        if (_passwordText.isNotEmpty ||
-                            _passwordFocused ||
-                            _hasAttemptedSubmit)
-                          _buildPasswordHint(context)
-                        else
-                          const SizedBox.shrink(),
-                        _buildStrengthIndicator(context, strength),
-                        const SizedBox(height: 12),
-                        _buildConfirmPasswordField(),
-                        _buildErrorMessage(context, authState),
-                        const SizedBox(height: 24),
-                        _buildSubmitButton(authState),
-                        const SizedBox(height: 12),
-                        TextButton(
-                          onPressed: () => context.go('/login'),
-                          style: TextButton.styleFrom(
-                            foregroundColor: context.textSecondary,
-                          ),
-                          child: const Text('Already have an account? Log in'),
-                        ),
-                      ],
+          AuthLayout(
+            tagline: 'Sign up. Talk privately.',
+            formTitle: 'Create your account',
+            compactHeader: _buildHeader(context),
+            narrowPadding: const EdgeInsets.fromLTRB(24, 24, 24, _bottomPad),
+            formColumn: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildUsernameField(),
+                  const SizedBox(height: 16),
+                  _buildPasswordField(),
+                  if (_passwordText.isNotEmpty ||
+                      _passwordFocused ||
+                      _hasAttemptedSubmit)
+                    _buildPasswordHint(context)
+                  else
+                    const SizedBox.shrink(),
+                  _buildStrengthIndicator(context, strength),
+                  const SizedBox(height: 12),
+                  _buildConfirmPasswordField(),
+                  _buildErrorMessage(context, authState),
+                  const SizedBox(height: 24),
+                  _buildSubmitButton(authState),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: () => context.go('/login'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: context.textSecondary,
                     ),
+                    child: const Text('Already have an account? Log in'),
                   ),
-                ),
+                ],
               ),
             ),
           ),

--- a/apps/client/lib/src/screens/reset_password_screen.dart
+++ b/apps/client/lib/src/screens/reset_password_screen.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 
 import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
+import '../widgets/auth/auth_layout.dart';
 import '../widgets/auth/auth_scaffold_chrome.dart';
 import '../widgets/echo_logo_icon.dart';
 
@@ -97,151 +98,142 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
       body: Stack(
         children: [
           const AuthBackground(),
-          SafeArea(
-            child: Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 400),
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(24, 24, 24, 56),
-                  child: Form(
-                    key: _formKey,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        _buildHeader(),
-                        const SizedBox(height: 32),
-                        TextFormField(
-                          controller: _tokenController,
-                          decoration: const InputDecoration(
-                            labelText: 'Reset token',
-                            border: OutlineInputBorder(),
-                            helperText:
-                                'Paste the token your admin shared with you',
-                          ),
-                          textInputAction: TextInputAction.next,
-                          autocorrect: false,
-                          enableSuggestions: false,
-                          validator: (value) {
-                            if (value == null || value.trim().isEmpty) {
-                              return 'Reset token is required';
-                            }
-                            return null;
-                          },
+          AuthLayout(
+            tagline: 'Choose a new password.',
+            formTitle: 'Choose a new password.',
+            compactHeader: _buildHeader(),
+            formColumn: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: _tokenController,
+                    decoration: const InputDecoration(
+                      labelText: 'Reset token',
+                      border: OutlineInputBorder(),
+                      helperText: 'Paste the token your admin shared with you',
+                    ),
+                    textInputAction: TextInputAction.next,
+                    autocorrect: false,
+                    enableSuggestions: false,
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Reset token is required';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _passwordController,
+                    obscureText: _obscurePassword,
+                    autofillHints: const [AutofillHints.newPassword],
+                    decoration: InputDecoration(
+                      labelText: 'New password',
+                      border: const OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscurePassword
+                              ? Icons.visibility_off
+                              : Icons.visibility,
                         ),
-                        const SizedBox(height: 16),
-                        TextFormField(
-                          controller: _passwordController,
-                          obscureText: _obscurePassword,
-                          autofillHints: const [AutofillHints.newPassword],
-                          decoration: InputDecoration(
-                            labelText: 'New password',
-                            border: const OutlineInputBorder(),
-                            suffixIcon: IconButton(
-                              icon: Icon(
-                                _obscurePassword
-                                    ? Icons.visibility_off
-                                    : Icons.visibility,
-                              ),
-                              onPressed: () => setState(
-                                () => _obscurePassword = !_obscurePassword,
-                              ),
-                              constraints: const BoxConstraints(
-                                minWidth: 44,
-                                minHeight: 44,
-                              ),
-                              padding: EdgeInsets.zero,
-                              visualDensity: VisualDensity.compact,
-                            ),
-                          ),
-                          textInputAction: TextInputAction.next,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return 'Password is required';
-                            }
-                            if (value.length < 8) {
-                              return 'Password must be at least 8 characters';
-                            }
-                            return null;
-                          },
+                        onPressed: () => setState(
+                          () => _obscurePassword = !_obscurePassword,
                         ),
-                        const SizedBox(height: 16),
-                        TextFormField(
-                          controller: _confirmController,
-                          obscureText: _obscureConfirm,
-                          autofillHints: const [AutofillHints.newPassword],
-                          decoration: InputDecoration(
-                            labelText: 'Confirm new password',
-                            border: const OutlineInputBorder(),
-                            suffixIcon: IconButton(
-                              icon: Icon(
-                                _obscureConfirm
-                                    ? Icons.visibility_off
-                                    : Icons.visibility,
-                              ),
-                              onPressed: () => setState(
-                                () => _obscureConfirm = !_obscureConfirm,
-                              ),
-                              constraints: const BoxConstraints(
-                                minWidth: 44,
-                                minHeight: 44,
-                              ),
-                              padding: EdgeInsets.zero,
-                              visualDensity: VisualDensity.compact,
-                            ),
-                          ),
-                          onFieldSubmitted: (_) => _submit(),
-                          validator: (value) {
-                            if (value != _passwordController.text) {
-                              return 'Passwords do not match';
-                            }
-                            return null;
-                          },
+                        constraints: const BoxConstraints(
+                          minWidth: 44,
+                          minHeight: 44,
                         ),
-                        if (_error != null) ...[
-                          const SizedBox(height: 12),
-                          Text(
-                            _error!,
-                            style: TextStyle(
-                              color: Theme.of(context).colorScheme.error,
-                            ),
-                          ),
-                        ],
-                        const SizedBox(height: 24),
-                        SizedBox(
-                          width: double.infinity,
-                          child: Semantics(
-                            button: true,
-                            label: 'reset-password',
-                            child: FilledButton(
-                              onPressed: _isLoading ? null : _submit,
-                              child: _isLoading
-                                  ? const SizedBox(
-                                      height: 20,
-                                      width: 20,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 2,
-                                      ),
-                                    )
-                                  : const Text('Set new password'),
-                            ),
-                          ),
+                        padding: EdgeInsets.zero,
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    ),
+                    textInputAction: TextInputAction.next,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Password is required';
+                      }
+                      if (value.length < 8) {
+                        return 'Password must be at least 8 characters';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _confirmController,
+                    obscureText: _obscureConfirm,
+                    autofillHints: const [AutofillHints.newPassword],
+                    decoration: InputDecoration(
+                      labelText: 'Confirm new password',
+                      border: const OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscureConfirm
+                              ? Icons.visibility_off
+                              : Icons.visibility,
                         ),
-                        const SizedBox(height: 12),
-                        Semantics(
-                          button: true,
-                          label: 'back-to-login',
-                          child: TextButton(
-                            onPressed: () => context.go('/login'),
-                            style: TextButton.styleFrom(
-                              foregroundColor: context.textSecondary,
-                            ),
-                            child: const Text('Back to login'),
-                          ),
+                        onPressed: () =>
+                            setState(() => _obscureConfirm = !_obscureConfirm),
+                        constraints: const BoxConstraints(
+                          minWidth: 44,
+                          minHeight: 44,
                         ),
-                      ],
+                        padding: EdgeInsets.zero,
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    ),
+                    onFieldSubmitted: (_) => _submit(),
+                    validator: (value) {
+                      if (value != _passwordController.text) {
+                        return 'Passwords do not match';
+                      }
+                      return null;
+                    },
+                  ),
+                  if (_error != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _error!,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: Semantics(
+                      button: true,
+                      label: 'reset-password',
+                      child: FilledButton(
+                        onPressed: _isLoading ? null : _submit,
+                        child: _isLoading
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Set new password'),
+                      ),
                     ),
                   ),
-                ),
+                  const SizedBox(height: 12),
+                  Semantics(
+                    button: true,
+                    label: 'back-to-login',
+                    child: TextButton(
+                      onPressed: () => context.go('/login'),
+                      style: TextButton.styleFrom(
+                        foregroundColor: context.textSecondary,
+                      ),
+                      child: const Text('Back to login'),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/apps/client/lib/src/widgets/auth/auth_layout.dart
+++ b/apps/client/lib/src/widgets/auth/auth_layout.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../theme/echo_theme.dart';
+import '../echo_logo_icon.dart';
+
+/// Two-column auth layout for desktop and a single-column flow for phones.
+///
+/// At widths >= 900 the form sits in a 440-wide card on the right with a
+/// brand panel on the left showing the wordmark, tagline, and a short list
+/// of product highlights. Below 900 we fall back to the historical centered
+/// form (the [compactHeader] is rendered above [formColumn]).
+///
+/// Callers pass [compactHeader] separately so the existing narrow header
+/// (logo + "Echo" + tagline) keeps its semantics on phones. The wide layout
+/// reuses the same logo/wordmark inside its brand panel and a smaller inline
+/// title above the form card so text-based e2e selectors still match.
+class AuthLayout extends StatelessWidget {
+  /// Short marketing line shown under the wordmark in the brand panel.
+  /// Example: "Sign up. Talk privately." / "Welcome back."
+  final String tagline;
+
+  /// Inline title displayed above [formColumn] inside the wide-mode form
+  /// card. Phones get the [compactHeader] instead, which usually already
+  /// carries this string in a larger size.
+  final String formTitle;
+
+  /// Logo+wordmark+tagline block used in narrow mode (typically the screen's
+  /// existing `_buildHeader()`).
+  final Widget compactHeader;
+
+  /// The actual `Form` subtree -- fields, buttons, error text, etc.
+  final Widget formColumn;
+
+  /// Vertical padding above the form in narrow mode (lets each screen keep
+  /// its existing scroll padding without leaking the constant here).
+  final EdgeInsets narrowPadding;
+
+  const AuthLayout({
+    super.key,
+    required this.tagline,
+    required this.formTitle,
+    required this.compactHeader,
+    required this.formColumn,
+    this.narrowPadding = const EdgeInsets.fromLTRB(24, 24, 24, 56),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth >= 900;
+        if (isWide) {
+          return _buildWide(context);
+        }
+        return _buildNarrow(context);
+      },
+    );
+  }
+
+  Widget _buildNarrow(BuildContext context) {
+    return SafeArea(
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: SingleChildScrollView(
+            padding: narrowPadding,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [compactHeader, const SizedBox(height: 32), formColumn],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWide(BuildContext context) {
+    return SafeArea(
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1100),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 32),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(child: _BrandPanel(tagline: tagline)),
+                const SizedBox(width: 48),
+                _FormCard(
+                  title: formTitle,
+                  child: SingleChildScrollView(child: formColumn),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BrandPanel extends StatelessWidget {
+  final String tagline;
+
+  const _BrandPanel({required this.tagline});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const EchoLogoIcon(size: 96),
+        const SizedBox(height: 16),
+        Text(
+          'Echo',
+          style: GoogleFonts.inter(
+            fontSize: 56,
+            fontWeight: FontWeight.w700,
+            letterSpacing: -1.0,
+            color: context.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          tagline,
+          style: GoogleFonts.inter(
+            fontSize: 18,
+            fontWeight: FontWeight.w500,
+            color: context.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 32),
+        const _FeatureRow(
+          icon: Icons.lock_outline,
+          title: 'End-to-end encrypted',
+          body: 'Signal Protocol with X3DH + Double Ratchet',
+        ),
+        const SizedBox(height: 16),
+        const _FeatureRow(
+          icon: Icons.devices_outlined,
+          title: 'Every platform',
+          body: 'Web, Linux, Windows, Android, iOS',
+        ),
+        const SizedBox(height: 16),
+        const _FeatureRow(
+          icon: Icons.dns_outlined,
+          title: 'Self-hostable',
+          body: 'Your server, your data',
+        ),
+      ],
+    );
+  }
+}
+
+class _FeatureRow extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String body;
+
+  const _FeatureRow({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: context.accent.withValues(alpha: 0.12),
+            shape: BoxShape.circle,
+          ),
+          alignment: Alignment.center,
+          child: Icon(icon, size: 20, color: context.accent),
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: GoogleFonts.inter(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: context.textPrimary,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                body,
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w400,
+                  color: context.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FormCard extends StatelessWidget {
+  final String title;
+  final Widget child;
+
+  const _FormCard({required this.title, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 440,
+      child: Container(
+        padding: const EdgeInsets.all(32),
+        decoration: BoxDecoration(
+          color: context.surface.withValues(alpha: 0.85),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Theme.of(context).dividerColor, width: 1),
+          boxShadow: [
+            BoxShadow(
+              color: context.shadowColor,
+              blurRadius: 24,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              title,
+              style: GoogleFonts.inter(
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 20),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Closes #729.

## New

- Signup, login, forgot-password, and reset-password screens get a real two-column layout on desktop (≥900px wide). The right column is the existing form card; the left column is a brand panel with the Echo logo, tagline, and three quick feature highlights (end-to-end encryption, every platform, self-hostable).
- Below 900px, the layouts are byte-identical to today — phone + narrow-window users see no change.

## Behind the scenes

- New shared widget `apps/client/lib/src/widgets/auth/auth_layout.dart` (256 LOC). One `LayoutBuilder` threshold at 900px branches between single-column (current) and two-column (new). All four auth screens use it via `AuthLayout(tagline, compactHeader, formColumn, formTitle)`.
- Keeps `AutofillGroup`, `Semantics(label: ...)`, `TextInputAction` chain, and all `FilledButton` styling intact — no logic change, no behavior change, no copy-string drift.
- Inline form-card title ("Create your account" / "Welcome back.") on wide layouts so text-based selectors still match the existing on-narrow header subtitle.

## CI validation goal (secondary)

This PR's other purpose is to validate the caching work that landed in #857/#863/#865:

- Path filter: changes are all in `apps/client/lib/**` → trips `client-shared`, every client platform builds in `dev-build.yml`. iOS/macOS skip (cost gate).
- Expected Linux AppImage timing on the next runs: "Install Linux dependencies (cached)" should hit the apt cache and finish in ~15s instead of ~2-3min. Pub-cache, AppImage tools, and Gradle should all be warm.

If those numbers don't materialize in the CI run, that's a real signal to investigate.

## Test plan

- [x] `dart format --set-exit-if-changed .` clean
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` — 1476 passed, 8 skipped, 0 failed
- [ ] Manual: resize desktop window from 600 → 1500 → see layout flip at 900px boundary, no jank
- [ ] Manual: switch to Paper (light) theme → brand panel + form card both read correctly
- [ ] Manual: submit form via keyboard `Enter` → still works
- [ ] Manual: password manager autofill → still works (`AutofillGroup` preserved)
- [ ] CI: confirm warm-cache wall times match expectations on Linux AppImage build