### PR TITLE
revert: apt cache action hangs on large package set (reverts #865)

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -125,14 +125,10 @@ jobs:
         with:
           path: ~/.cache/echo-appimage-tools
           key: appimage-tools-v1
-      - name: Install Linux dependencies (cached)
-        # Caches the .deb archives so the ~500 MB GTK + GStreamer + libmpv
-        # stack only downloads once. Cache key is hashed from the package
-        # list below; changes to that list invalidate the cache.
-        uses: awalsh128/cache-apt-pkgs-action@0e3c11464a8cfae52ee6ceb2b33777bcc9187892 # v1.6.0
-        with:
-          packages: clang cmake ninja-build libgtk-3-dev libfuse2 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libsecret-1-dev libayatana-appindicator3-dev libasound2-dev libmpv-dev
-          version: "1.0"
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build libgtk-3-dev libfuse2 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libsecret-1-dev libayatana-appindicator3-dev libasound2-dev libmpv-dev
       - name: Build
         working-directory: apps/client
         run: flutter build linux --release --dart-define=APP_VERSION=dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,18 +326,24 @@ jobs:
         with:
           path: ~/.cache/echo-appimage-tools
           key: appimage-tools-v1
-      - name: Install Linux dependencies (cached)
-        # Caches the .deb archives so the ~500 MB GTK + GStreamer + libmpv
-        # stack only downloads once. libsndio-dev + libjack-jackd2-dev are
-        # required so the bundling step can resolve libmpv's hard-linked
-        # audio backends via ldd (sndio is OpenBSD's audio daemon, jack is
-        # pro-audio — neither is on typical Linux desktops, so without them
-        # ldd reports "not found" and walk_deps silently skips them,
-        # shipping a broken bundle).
-        uses: awalsh128/cache-apt-pkgs-action@0e3c11464a8cfae52ee6ceb2b33777bcc9187892 # v1.6.0
-        with:
-          packages: clang cmake ninja-build libgtk-3-dev libfuse2 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good libsecret-1-dev libayatana-appindicator3-dev libasound2-dev libmpv-dev libsndio-dev libjack-jackd2-dev
-          version: "1.0"
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          # libsndio7-dev + libjack-jackd2-dev are required so the
+          # bundling step can resolve libmpv's hard-linked audio
+          # backends via ldd.  Without them, ldd reports "not found"
+          # and walk_deps silently skips them, shipping a bundle that
+          # fails on every user host that doesn't have them either
+          # (sndio is OpenBSD's audio daemon, jack is pro-audio —
+          # neither is on typical Linux desktops).
+          sudo apt-get install -y \
+            clang cmake ninja-build \
+            libgtk-3-dev libfuse2 \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-good \
+            libsecret-1-dev libayatana-appindicator3-dev \
+            libasound2-dev libmpv-dev \
+            libsndio-dev libjack-jackd2-dev
       - name: Build
         working-directory: apps/client
         run: flutter build linux --release --dart-define=APP_VERSION=${{ needs.version.outputs.version }}


### PR DESCRIPTION
## Fixed

- Reverts #865. The \`awalsh128/cache-apt-pkgs-action@v1.6.0\` step hung for 19+ minutes on a cache-miss run with our ~500MB Linux desktop package set (libgtk-3-dev, libmpv-dev, gstreamer plugins, etc.). The plain \`apt-get install\` flow that preceded #865 reliably completes in 2-3 min — that's the failure mode we accept.

## Why the original idea failed

Two compounding issues:

1. **Performance**: the cache action's tar + upload step on cache miss takes longer than the apt install itself. For our package set it appears to hang indefinitely (last run at 19+ min still in progress, had to manually cancel).
2. **Scope**: dev-build.yml only fires on \`dev\`/\`feature/**\`/\`fix/**\`. Caches it creates are scoped to those branches and orphaned on merge-and-delete. main never runs dev-build.yml to seed the default-branch cache, so subsequent feature branches always miss.

## What stays from PR #863

The pub-cache, AppImage-tools cache, Gradle cache, CocoaPods cache, and Swatinem rust-cache are all unaffected by this revert. The Linux build still benefits from those — only the apt step goes back to plain install.

## Follow-up

Filing an issue (separate PR) to revisit apt caching with a working approach. Options:
- Run dev-build.yml on \`main\` (paths-gated) so main can seed the cache for feature branches
- Use a different action that doesn't tar+upload (e.g. \`actions/cache@v4\` on \`/var/cache/apt/archives\` with manual move)
- Pre-build a custom runner image with the deps baked in

## Test plan

- [x] Workflow YAML parses
- [ ] After merge, next Linux build completes in ~10-12 min cold (the time we had before #865) instead of hanging