### PR TITLE
Voice lounge fixes, density scaling, O(N+M) reply counts, universal search

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -34,6 +34,7 @@ import '../widgets/global_search_overlay.dart';
 import '../widgets/whats_new_modal.dart';
 import '../widgets/quick_switcher_overlay.dart';
 import '../widgets/voice_dock.dart';
+import '../widgets/voice_footer.dart';
 import '../widgets/window_chrome.dart';
 import 'contacts_screen.dart';
 import 'new_message_screen.dart';
@@ -332,9 +333,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       _pendingMessageId = messageId;
       _narrowPanelIndex = 1;
       _showSettings = false;
-      // Dismiss the voice lounge so the selected chat is visible.
+      // Collapse the lounge so the selected chat is visible.
+      // Only lock the auto-show when voice is already active (i.e., the user
+      // is deliberately navigating away from an in-progress call).  When
+      // voice is NOT yet active, leaving _userDismissedLounge false lets the
+      // lounge auto-show the moment the user joins voice from this chat.
       _showingLounge = false;
-      _userDismissedLounge = true;
+      if (ref.read(voiceRtcProvider).isActive) {
+        _userDismissedLounge = true;
+      }
     });
     // Clear notifications for this conversation now that the user is viewing it.
     NotificationService().cancelConversationNotifications(conv.id);
@@ -1374,7 +1381,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         body = SafeArea(child: _buildConversationPanel());
     }
 
-    return Scaffold(body: body, bottomNavigationBar: _buildMobileTabBar());
+    return Scaffold(
+      body: Column(
+        children: [
+          Expanded(child: body),
+          // Show the voice footer between the content and the tab bar when
+          // the user is in a call but has dismissed the lounge overlay.
+          if (voiceActive && !_showingLounge)
+            VoiceFooter(
+              onNavigateToLounge: () => setState(() {
+                _showingLounge = true;
+                _userDismissedLounge = false;
+              }),
+            ),
+        ],
+      ),
+      bottomNavigationBar: _buildMobileTabBar(),
+    );
   }
 
   /// Bottom tab bar shown on the mobile narrow viewport. Switching tabs

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -368,6 +368,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               .firstOrNull;
           if (conv != null) _selectConversation(conv);
         },
+        onContactTap: (userId, username) => _messageContact(userId, username),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -208,25 +208,34 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
 
   /// Phase 2 follow-up: per-density chip metrics.  Same shape as the
   /// switch tables in conversation_item.dart and message_item.dart.
-  ({EdgeInsets padding, double iconSize, double labelSize, double radius})
+  ({
+    EdgeInsets padding,
+    double iconSize,
+    double labelSize,
+    double radius,
+    double gap,
+  })
   _chipMetrics(UIDensity density) => switch (density) {
     UIDensity.cozy => (
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
       iconSize: 16,
       labelSize: 14,
       radius: 22,
+      gap: 8,
     ),
     UIDensity.normal => (
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       iconSize: 14,
       labelSize: 12,
       radius: 20,
+      gap: 6,
     ),
     UIDensity.compact => (
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       iconSize: 12,
       labelSize: 11,
       radius: 18,
+      gap: 4,
     ),
   };
 
@@ -466,7 +475,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                 children: [
                   for (final channel in textChannels) ...[
                     _buildTextChannelChip(channel, density),
-                    const SizedBox(width: 6),
+                    SizedBox(width: _chipMetrics(density).gap),
                   ],
                   if (textChannels.isNotEmpty && voiceChannels.isNotEmpty)
                     const SizedBox(
@@ -481,7 +490,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
                       activeVoiceChannelId,
                       density,
                     ),
-                    const SizedBox(width: 6),
+                    SizedBox(width: _chipMetrics(density).gap),
                   ],
                 ],
               ),

--- a/apps/client/lib/src/widgets/chat_panel/no_conversation_placeholder.dart
+++ b/apps/client/lib/src/widgets/chat_panel/no_conversation_placeholder.dart
@@ -1,5 +1,6 @@
 // Empty-state shown when no conversation is selected in the chat panel.
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../theme/echo_theme.dart';
 
@@ -35,6 +36,43 @@ class NoConversationPlaceholder extends StatelessWidget {
             Text(
               'Choose a conversation from the sidebar or start a new one',
               style: TextStyle(color: context.textMuted, fontSize: 14),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FilledButton.icon(
+                  onPressed: () => context.push('/contacts'),
+                  icon: const Icon(Icons.person_add_outlined, size: 18),
+                  label: const Text('Add Contact'),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: context.accent,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 12,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                OutlinedButton.icon(
+                  onPressed: () => context.push('/discover-groups'),
+                  icon: const Icon(Icons.explore_outlined, size: 18),
+                  label: const Text('Browse Groups'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 12,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -519,7 +519,10 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
                   wsOnlineUsers,
                 ),
               ),
-              VoiceFooter(onNavigateToLounge: widget.onNavigateToLounge),
+              // On narrow (mobile), VoiceFooter is rendered at the Scaffold
+              // level in home_screen.dart above the bottom tab bar.
+              if (MediaQuery.sizeOf(context).width >= 600)
+                VoiceFooter(onNavigateToLounge: widget.onNavigateToLounge),
               // Hide the status bar on mobile narrow — redundant with the
               // bottom tab bar that already exposes Settings + identity.
               if (MediaQuery.sizeOf(context).width >= 600)

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -13,14 +13,20 @@ import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
 import '../utils/fuzzy_score.dart';
 
-/// Global message search overlay (Ctrl+Shift+F or search icon).
+/// Universal search overlay (Ctrl+Shift+F or search icon).
 ///
-/// Searches messages across ALL conversations the user is a member of,
-/// using the server's full-text search endpoint (GIN index on messages).
+/// Searches messages (full-text, non-encrypted), contacts (by
+/// username/display name), and groups (by title) in a single request.
+/// Results are grouped by category with click-through navigation.
 class GlobalSearchOverlay extends ConsumerStatefulWidget {
   final void Function(String conversationId, String messageId) onResultTap;
+  final void Function(String userId, String username) onContactTap;
 
-  const GlobalSearchOverlay({super.key, required this.onResultTap});
+  const GlobalSearchOverlay({
+    super.key,
+    required this.onResultTap,
+    required this.onContactTap,
+  });
 
   @override
   ConsumerState<GlobalSearchOverlay> createState() =>
@@ -32,7 +38,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
   final _focusNode = FocusNode();
   final _keyboardFocusNode = FocusNode();
   Timer? _debounce;
-  List<_SearchResult> _results = [];
+  _UniversalResults? _results;
   bool _loading = false;
   String _lastQuery = '';
 
@@ -55,7 +61,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     _debounce?.cancel();
     if (query.trim().length < 2) {
       setState(() {
-        _results = [];
+        _results = null;
         _loading = false;
       });
       return;
@@ -73,7 +79,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     final serverUrl = ref.read(serverUrlProvider);
     final token = ref.read(authProvider).token ?? '';
     final uri = Uri.parse(
-      '$serverUrl/api/messages/search?q=${Uri.encodeQueryComponent(query)}&limit=20',
+      '$serverUrl/api/search?q=${Uri.encodeQueryComponent(query)}&limit=15',
     );
 
     try {
@@ -83,14 +89,16 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
       );
       if (!mounted) return;
       if (response.statusCode == 200) {
-        final list = jsonDecode(response.body) as List;
+        final body = jsonDecode(response.body) as Map<String, dynamic>;
         final conversations = ref.read(conversationsProvider).conversations;
         final myUserId = ref.read(authProvider).userId ?? '';
-        final parsed = list.map((item) {
+
+        final rawMessages = (body['messages'] as List? ?? []);
+        final messages = rawMessages.map((item) {
           final e = item as Map<String, dynamic>;
           final convId = (e['conversation_id'] ?? '').toString();
           final conv = conversations.where((c) => c.id == convId).firstOrNull;
-          return _SearchResult(
+          return _MessageResult(
             messageId: (e['message_id'] ?? '').toString(),
             conversationId: convId,
             conversationName: conv?.displayName(myUserId) ?? 'Unknown',
@@ -99,7 +107,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
             timestamp: (e['created_at'] ?? '').toString(),
           );
         }).toList();
-        parsed.sort((a, b) {
+        messages.sort((a, b) {
           final sa =
               fuzzyScore(query, a.content) +
               0.5 * fuzzyScore(query, a.conversationName) +
@@ -110,24 +118,63 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
               0.25 * fuzzyScore(query, b.senderUsername);
           return sb.compareTo(sa);
         });
+
+        final rawContacts = (body['contacts'] as List? ?? []);
+        final contacts = rawContacts.map((item) {
+          final e = item as Map<String, dynamic>;
+          return _ContactResult(
+            userId: (e['user_id'] ?? '').toString(),
+            username: (e['username'] ?? '').toString(),
+            displayName: e['display_name'] as String?,
+            avatarUrl: e['avatar_url'] as String?,
+          );
+        }).toList();
+
+        final rawGroups = (body['groups'] as List? ?? []);
+        final groups = rawGroups.map((item) {
+          final e = item as Map<String, dynamic>;
+          return _GroupResult(
+            conversationId: (e['conversation_id'] ?? '').toString(),
+            title: (e['title'] ?? 'Unnamed Group').toString(),
+            description: e['description'] as String?,
+            memberCount: (e['member_count'] as num?)?.toInt() ?? 0,
+          );
+        }).toList();
+
         setState(() {
-          _results = parsed;
+          _results = _UniversalResults(
+            messages: messages,
+            contacts: contacts,
+            groups: groups,
+          );
           _loading = false;
         });
       } else {
         setState(() {
-          _results = [];
+          _results = _UniversalResults.empty();
           _loading = false;
         });
       }
     } catch (_) {
       if (!mounted) return;
       setState(() {
-        _results = [];
+        _results = _UniversalResults.empty();
         _loading = false;
       });
     }
   }
+
+  bool get _hasResults =>
+      _results != null &&
+      (_results!.messages.isNotEmpty ||
+          _results!.contacts.isNotEmpty ||
+          _results!.groups.isNotEmpty);
+
+  bool get _showEmpty =>
+      _results != null &&
+      !_loading &&
+      !_hasResults &&
+      _controller.text.trim().length >= 2;
 
   @override
   Widget build(BuildContext context) {
@@ -148,11 +195,11 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
           color: Colors.black54,
           child: Center(
             child: GestureDetector(
-              onTap: () {}, // absorb taps on card
+              onTap: () {},
               child: Container(
                 width: width,
                 constraints: BoxConstraints(
-                  maxHeight: MediaQuery.of(context).size.height * 0.7,
+                  maxHeight: MediaQuery.of(context).size.height * 0.75,
                 ),
                 margin: const EdgeInsets.symmetric(vertical: 48),
                 decoration: BoxDecoration(
@@ -170,7 +217,6 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Search input
                     Padding(
                       padding: const EdgeInsets.all(12),
                       child: TextField(
@@ -182,7 +228,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
                           fontSize: 15,
                         ),
                         decoration: InputDecoration(
-                          hintText: 'Search all messages...',
+                          hintText: 'Search messages, contacts, groups...',
                           hintStyle: TextStyle(color: context.textMuted),
                           prefixIcon: Icon(
                             Icons.search,
@@ -214,25 +260,32 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
                         ),
                       ),
                     ),
-                    // Results
-                    if (_results.isNotEmpty)
+                    if (_hasResults)
                       Flexible(
-                        child: ListView.builder(
-                          itemCount: _results.length,
-                          padding: const EdgeInsets.only(bottom: 8),
-                          itemBuilder: (context, index) {
-                            final r = _results[index];
-                            return _buildResultTile(r);
-                          },
+                        child: ListView(
+                          shrinkWrap: true,
+                          padding: const EdgeInsets.only(bottom: 12),
+                          children: [
+                            if (_results!.messages.isNotEmpty) ...[
+                              _buildSectionHeader('Messages'),
+                              ..._results!.messages.map(_buildMessageTile),
+                            ],
+                            if (_results!.contacts.isNotEmpty) ...[
+                              _buildSectionHeader('Contacts'),
+                              ..._results!.contacts.map(_buildContactTile),
+                            ],
+                            if (_results!.groups.isNotEmpty) ...[
+                              _buildSectionHeader('Groups'),
+                              ..._results!.groups.map(_buildGroupTile),
+                            ],
+                          ],
                         ),
                       ),
-                    if (_results.isEmpty &&
-                        !_loading &&
-                        _controller.text.trim().length >= 2)
+                    if (_showEmpty)
                       Padding(
                         padding: const EdgeInsets.all(24),
                         child: Text(
-                          'No messages found',
+                          'No results found',
                           style: TextStyle(
                             color: context.textMuted,
                             fontSize: 14,
@@ -249,8 +302,22 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     );
   }
 
-  Widget _buildResultTile(_SearchResult r) {
-    // Truncate content for display
+  Widget _buildSectionHeader(String label) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 4),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: context.textMuted,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMessageTile(_MessageResult r) {
     final preview = r.content.length > 120
         ? '${r.content.substring(0, 120)}...'
         : r.content;
@@ -258,8 +325,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     String timeLabel = '';
     final dt = DateTime.tryParse(r.timestamp);
     if (dt != null) {
-      final now = DateTime.now();
-      final diff = now.difference(dt);
+      final diff = DateTime.now().difference(dt);
       if (diff.inDays > 0) {
         timeLabel = '${diff.inDays}d ago';
       } else if (diff.inHours > 0) {
@@ -272,7 +338,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     }
 
     return Semantics(
-      label: 'search result by ${r.senderUsername}',
+      label: 'message from ${r.senderUsername} in ${r.conversationName}',
       button: true,
       child: InkWell(
         onTap: () {
@@ -295,11 +361,13 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
                     ),
                   ),
                   const SizedBox(width: 6),
-                  Text(
-                    'in ${r.conversationName}',
-                    style: TextStyle(color: context.textMuted, fontSize: 12),
+                  Expanded(
+                    child: Text(
+                      'in ${r.conversationName}',
+                      style: TextStyle(color: context.textMuted, fontSize: 12),
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
-                  const Spacer(),
                   Text(
                     timeLabel,
                     style: TextStyle(color: context.textMuted, fontSize: 11),
@@ -319,9 +387,147 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
       ),
     );
   }
+
+  Widget _buildContactTile(_ContactResult r) {
+    final label = (r.displayName != null && r.displayName!.isNotEmpty)
+        ? r.displayName!
+        : r.username;
+
+    return Semantics(
+      label: 'contact $label',
+      button: true,
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).pop();
+          widget.onContactTap(r.userId, r.username);
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 16,
+                backgroundColor: context.accent.withValues(alpha: 0.15),
+                backgroundImage: r.avatarUrl != null
+                    ? NetworkImage(r.avatarUrl!)
+                    : null,
+                child: r.avatarUrl == null
+                    ? Text(
+                        label.isNotEmpty ? label[0].toUpperCase() : '?',
+                        style: TextStyle(
+                          color: context.accent,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      )
+                    : null,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      style: TextStyle(
+                        color: context.textPrimary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (r.displayName != null && r.displayName!.isNotEmpty)
+                      Text(
+                        '@${r.username}',
+                        style: TextStyle(
+                          color: context.textMuted,
+                          fontSize: 12,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chat_bubble_outline,
+                size: 16,
+                color: context.textMuted,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGroupTile(_GroupResult r) {
+    return Semantics(
+      label: 'group ${r.title}',
+      button: true,
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).pop();
+          widget.onResultTap(r.conversationId, '');
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 16,
+                backgroundColor: context.accent.withValues(alpha: 0.15),
+                child: Text(
+                  r.title.isNotEmpty ? r.title[0].toUpperCase() : '#',
+                  style: TextStyle(
+                    color: context.accent,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      r.title,
+                      style: TextStyle(
+                        color: context.textPrimary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Text(
+                      '${r.memberCount} member${r.memberCount == 1 ? '' : 's'}',
+                      style: TextStyle(color: context.textMuted, fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(Icons.group_outlined, size: 16, color: context.textMuted),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
-class _SearchResult {
+class _UniversalResults {
+  final List<_MessageResult> messages;
+  final List<_ContactResult> contacts;
+  final List<_GroupResult> groups;
+
+  const _UniversalResults({
+    required this.messages,
+    required this.contacts,
+    required this.groups,
+  });
+
+  factory _UniversalResults.empty() =>
+      const _UniversalResults(messages: [], contacts: [], groups: []);
+}
+
+class _MessageResult {
   final String messageId;
   final String conversationId;
   final String conversationName;
@@ -329,12 +535,40 @@ class _SearchResult {
   final String content;
   final String timestamp;
 
-  _SearchResult({
+  _MessageResult({
     required this.messageId,
     required this.conversationId,
     required this.conversationName,
     required this.senderUsername,
     required this.content,
     required this.timestamp,
+  });
+}
+
+class _ContactResult {
+  final String userId;
+  final String username;
+  final String? displayName;
+  final String? avatarUrl;
+
+  _ContactResult({
+    required this.userId,
+    required this.username,
+    required this.displayName,
+    required this.avatarUrl,
+  });
+}
+
+class _GroupResult {
+  final String conversationId;
+  final String title;
+  final String? description;
+  final int memberCount;
+
+  _GroupResult({
+    required this.conversationId,
+    required this.title,
+    required this.description,
+    required this.memberCount,
   });
 }

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1307,7 +1307,21 @@ class _MessageItemState extends State<MessageItem>
     } else if (widget.compactLayout) {
       padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 4);
     } else {
-      padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
+      // Bubbles layout: scale inner padding with density.
+      padding = switch (widget.density) {
+        UIDensity.cozy => const EdgeInsets.symmetric(
+          horizontal: 14,
+          vertical: 10,
+        ),
+        UIDensity.normal => const EdgeInsets.symmetric(
+          horizontal: 12,
+          vertical: 8,
+        ),
+        UIDensity.compact => const EdgeInsets.symmetric(
+          horizontal: 10,
+          vertical: 6,
+        ),
+      };
     }
 
     // Compact / Plain layouts (#794) flow to the full chat-pane width like

--- a/apps/server/src/db/contacts.rs
+++ b/apps/server/src/db/contacts.rs
@@ -13,6 +13,14 @@ pub const LIST_BLOCKED_LIMIT: i64 = 1_000;
 pub const LIST_PENDING_LIMIT: i64 = 1_000;
 
 #[derive(Debug, sqlx::FromRow, serde::Serialize)]
+pub struct ContactSearchResult {
+    pub user_id: Uuid,
+    pub username: String,
+    pub display_name: Option<String>,
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Debug, sqlx::FromRow, serde::Serialize)]
 pub struct ContactRow {
     pub id: Uuid,
     pub user_id: Uuid,
@@ -116,6 +124,36 @@ pub async fn list_contacts(pool: &PgPool, user_id: Uuid) -> Result<Vec<ContactRo
     )
     .bind(user_id)
     .bind(LIST_CONTACTS_LIMIT)
+    .fetch_all(pool)
+    .await
+}
+
+/// Search accepted contacts by username or display_name prefix (case-insensitive).
+pub async fn search_contacts(
+    pool: &PgPool,
+    user_id: Uuid,
+    query: &str,
+    limit: i64,
+) -> Result<Vec<ContactSearchResult>, sqlx::Error> {
+    let escaped = query
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    let pattern = format!("%{escaped}%");
+    sqlx::query_as::<_, ContactSearchResult>(
+        "SELECT \
+                CASE WHEN c.requester_id = $1 THEN c.target_id ELSE c.requester_id END AS user_id, \
+                u.username, u.display_name, u.avatar_url \
+         FROM contacts c \
+         JOIN users u ON u.id = CASE WHEN c.requester_id = $1 THEN c.target_id ELSE c.requester_id END \
+         WHERE (c.requester_id = $1 OR c.target_id = $1) AND c.status = 'accepted' \
+           AND (u.username ILIKE $2 ESCAPE '\\' OR u.display_name ILIKE $2 ESCAPE '\\') \
+         ORDER BY u.username \
+         LIMIT $3",
+    )
+    .bind(user_id)
+    .bind(&pattern)
+    .bind(limit)
     .fetch_all(pool)
     .await
 }

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -104,6 +104,15 @@ pub async fn create_group_with_visibility(
 }
 
 #[derive(Debug, sqlx::FromRow, Serialize)]
+pub struct GroupSearchResult {
+    pub conversation_id: Uuid,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub member_count: i64,
+    pub icon_url: Option<String>,
+}
+
+#[derive(Debug, sqlx::FromRow, Serialize)]
 pub struct PublicGroupRow {
     pub id: Uuid,
     pub title: Option<String>,
@@ -178,6 +187,36 @@ pub async fn list_public_groups(
 
 /// Join a public group. Returns an error if the group is not public.
 ///
+/// Search groups the requesting user is a member of, filtered by title (case-insensitive).
+pub async fn search_user_groups(
+    pool: &PgPool,
+    user_id: Uuid,
+    query: &str,
+    limit: i64,
+) -> Result<Vec<GroupSearchResult>, sqlx::Error> {
+    let escaped = query
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    let pattern = format!("%{escaped}%");
+    sqlx::query_as::<_, GroupSearchResult>(
+        "SELECT c.id AS conversation_id, c.title, c.description, \
+                c.member_count::BIGINT AS member_count, c.icon_url \
+         FROM conversations c \
+         JOIN conversation_members cm ON cm.conversation_id = c.id \
+              AND cm.user_id = $1 AND cm.is_removed = false \
+         WHERE c.kind = 'group' \
+           AND c.title ILIKE $2 ESCAPE '\\' \
+         ORDER BY c.title \
+         LIMIT $3",
+    )
+    .bind(user_id)
+    .bind(&pattern)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+
 /// Uses a single atomic INSERT ... SELECT to avoid a TOCTOU race between
 /// checking `is_public` and inserting the membership row. Increments
 /// `member_count` on the conversation when a new (or previously removed)

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -586,16 +586,18 @@ pub async fn search_messages(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.cnt, 0) AS reply_count, \
+                COALESCE(rc.reply_count, 0) AS reply_count, \
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
-         LEFT JOIN LATERAL ( \
-             SELECT COUNT(*) AS cnt FROM messages r \
-             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
-         ) rc ON true \
+         LEFT JOIN ( \
+             SELECT reply_to_id, COUNT(*) AS reply_count \
+             FROM messages \
+             WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL \
+             GROUP BY reply_to_id \
+         ) rc ON rc.reply_to_id = m.id \
          WHERE m.conversation_id = $1 \
            AND m.deleted_at IS NULL \
            AND to_tsvector('english', m.content) @@ plainto_tsquery('english', $2) \
@@ -948,16 +950,18 @@ pub async fn get_thread_replies(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.cnt, 0) AS reply_count, \
+                COALESCE(rc.reply_count, 0) AS reply_count, \
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
-         LEFT JOIN LATERAL ( \
-             SELECT COUNT(*) AS cnt FROM messages r \
-             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
-         ) rc ON true \
+         LEFT JOIN ( \
+             SELECT reply_to_id, COUNT(*) AS reply_count \
+             FROM messages \
+             WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL \
+             GROUP BY reply_to_id \
+         ) rc ON rc.reply_to_id = m.id \
          LEFT JOIN LATERAL ( \
              SELECT json_agg(json_build_object( \
                  'message_id', r.message_id, \

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub mod media;
 pub mod messages;
 pub mod push;
 pub mod reactions;
+pub mod search;
 pub mod server_info;
 pub mod users;
 pub mod voice;
@@ -366,6 +367,7 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
             "/api/link-preview",
             post(link_preview::fetch_preview).layer(middleware::from_fn(link_preview_limit)),
         )
+        .route("/api/search", get(search::universal_search))
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .route("/api/health", get(health))

--- a/apps/server/src/routes/search.rs
+++ b/apps/server/src/routes/search.rs
@@ -1,0 +1,69 @@
+//! Universal search endpoint.
+//!
+//! GET /api/search?q=<query>&limit=<n>
+//!
+//! Returns messages, contacts, and groups matching the query in one response.
+//! The three DB queries run concurrently via tokio::try_join!.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::middleware::AuthUser;
+use crate::db;
+use crate::error::{AppError, DbErrCtx};
+
+use super::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct UniversalSearchQuery {
+    pub q: String,
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+}
+
+fn default_limit() -> i64 {
+    15
+}
+
+#[derive(Debug, Serialize)]
+pub struct UniversalSearchResponse {
+    pub messages: Vec<db::messages::GlobalSearchResult>,
+    pub contacts: Vec<db::contacts::ContactSearchResult>,
+    pub groups: Vec<db::groups::GroupSearchResult>,
+}
+
+/// GET /api/search -- universal search across messages, contacts, and groups.
+///
+/// Messages are full-text searched across all conversations the user is a
+/// member of (non-encrypted only -- encrypted DM ciphertext is opaque to
+/// the server). Contacts are searched by username and display_name among
+/// the caller's accepted contacts. Groups are searched by title among
+/// groups the caller is an active member of.
+pub async fn universal_search(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<UniversalSearchQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let q = params.q.trim();
+    if q.is_empty() {
+        return Err(AppError::bad_request("Search query cannot be empty"));
+    }
+    let limit = params.limit.clamp(1, 25);
+
+    let (messages, contacts, groups) = tokio::try_join!(
+        db::messages::search_messages_global(&state.pool, auth.user_id, q, limit),
+        db::contacts::search_contacts(&state.pool, auth.user_id, q, limit),
+        db::groups::search_user_groups(&state.pool, auth.user_id, q, limit),
+    )
+    .db_ctx("universal_search")?;
+
+    Ok(Json(UniversalSearchResponse {
+        messages,
+        contacts,
+        groups,
+    }))
+}


### PR DESCRIPTION
## What's new

Bundles four shipped improvements into the main release.

### New
- Universal search — single `GET /api/search` endpoint returns messages, contacts, and groups concurrently; search overlay updated to show grouped results with click-through navigation (#726)

### Improved
- Density-scale bubble padding, chip gaps, and empty-state CTAs adapt to the active density setting

### Fixed
- Voice lounge auto-shows on join; footer no longer stacks above mobile tab bar
- Reply-count queries changed from O(N×M) LATERAL to O(N+M) aggregate subquery (#834 Finding 8)

### Behind the scenes
- `search_contacts`, `search_user_groups` DB helpers added
- New `routes/search.rs` module wired to router