### PR TITLE
Server perf cluster: finish reply-count migration + WS fanout cleanup (#834)

### DIFF
--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -579,6 +579,12 @@ pub async fn search_messages(
     query: &str,
     limit: i64,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
+    // reply_count is computed via a single aggregating subquery joined once
+    // (O(N+M)) rather than the prior LATERAL correlated subquery that
+    // re-executed per row (O(N*M)). The partial index on
+    // `(reply_to_id) WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL`
+    // (added in an earlier migration) backs the GROUP BY scan (#834
+    // finding 8).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -586,16 +592,18 @@ pub async fn search_messages(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.cnt, 0) AS reply_count, \
+                COALESCE(rc.reply_count, 0) AS reply_count, \
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
-         LEFT JOIN LATERAL ( \
-             SELECT COUNT(*) AS cnt FROM messages r \
-             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
-         ) rc ON true \
+         LEFT JOIN ( \
+             SELECT reply_to_id, COUNT(*) AS reply_count \
+             FROM messages \
+             WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL \
+             GROUP BY reply_to_id \
+         ) rc ON rc.reply_to_id = m.id \
          WHERE m.conversation_id = $1 \
            AND m.deleted_at IS NULL \
            AND to_tsvector('english', m.content) @@ plainto_tsquery('english', $2) \
@@ -941,6 +949,12 @@ pub async fn get_thread_replies(
     before: Option<chrono::DateTime<chrono::Utc>>,
     limit: i64,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
+    // reply_count is computed via a single aggregating subquery joined once
+    // (O(N+M)) rather than the prior LATERAL correlated subquery that
+    // re-executed per row (O(N*M)). The partial index on
+    // `(reply_to_id) WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL`
+    // (added in an earlier migration) backs the GROUP BY scan (#834
+    // finding 8).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -948,16 +962,18 @@ pub async fn get_thread_replies(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
-                COALESCE(rc.cnt, 0) AS reply_count, \
+                COALESCE(rc.reply_count, 0) AS reply_count, \
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
-         LEFT JOIN LATERAL ( \
-             SELECT COUNT(*) AS cnt FROM messages r \
-             WHERE r.reply_to_id = m.id AND r.deleted_at IS NULL \
-         ) rc ON true \
+         LEFT JOIN ( \
+             SELECT reply_to_id, COUNT(*) AS reply_count \
+             FROM messages \
+             WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL \
+             GROUP BY reply_to_id \
+         ) rc ON rc.reply_to_id = m.id \
          LEFT JOIN LATERAL ( \
              SELECT json_agg(json_build_object( \
                  'message_id', r.message_id, \

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -356,6 +356,29 @@ pub async fn get_presence_status(
     Ok(row.map(|(s,)| s))
 }
 
+/// Batched variant of [`get_presence_status`] for one round-trip lookup
+/// across N user_ids — used by the presence snapshot hot path which
+/// previously fired one query per online contact (#834 finding 7).
+///
+/// Returns a `HashMap` keyed by `user_id`; users with no row in the result
+/// set (e.g. deleted users) are simply absent from the map. Callers should
+/// treat "missing" the same way they would treat an `Ok(None)` from the
+/// single-row helper.
+pub async fn get_presence_statuses_for(
+    pool: &PgPool,
+    user_ids: &[Uuid],
+) -> Result<std::collections::HashMap<Uuid, String>, sqlx::Error> {
+    if user_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let rows: Vec<(Uuid, String)> =
+        sqlx::query_as("SELECT id, presence_status FROM users WHERE id = ANY($1)")
+            .bind(user_ids)
+            .fetch_all(pool)
+            .await?;
+    Ok(rows.into_iter().collect())
+}
+
 pub async fn update_privacy_preferences(
     pool: &PgPool,
     user_id: Uuid,

--- a/apps/server/src/routes/reactions.rs
+++ b/apps/server/src/routes/reactions.rs
@@ -181,14 +181,22 @@ async fn broadcast_to_conversation<T: Serialize>(
     event: &T,
     exclude_user_id: Option<Uuid>,
 ) {
-    let member_ids =
-        match db::groups::get_conversation_member_ids(&state.pool, conversation_id).await {
-            Ok(ids) => ids,
-            Err(e) => {
-                tracing::error!("Failed to get conversation members for broadcast: {:?}", e);
-                return;
-            }
-        };
+    // #834 finding 13: reuse the WS layer's LRU member cache instead of
+    // opening a fresh DB round-trip per reaction broadcast. The cache is
+    // already populated by typing/presence fanout, so this is effectively
+    // free in steady-state and bounds the per-reaction overhead.
+    let member_ids = match crate::ws::typing_service::get_member_ids_cached(
+        &state.pool,
+        conversation_id,
+    )
+    .await
+    {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::error!("Failed to get conversation members for broadcast: {:?}", e);
+            return;
+        }
+    };
 
     let json = match serde_json::to_string(event) {
         Ok(j) => j,

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -82,6 +82,21 @@ pub(super) fn validate_message_length(state: &AppState, sender_id: Uuid, content
     true
 }
 
+/// Error string surfaced to the sender on any ciphertext-shape rejection.
+/// Kept as a single const so the six rejection sites in
+/// [`validate_encrypted_payload`] stay byte-for-byte identical and can be
+/// grep'd as one symbol from logs / clients.
+const ENCRYPTED_PAYLOAD_REQUIRED: &str = "Encrypted conversation requires ciphertext payload";
+
+/// Send the canonical "requires ciphertext payload" error to `sender_id`.
+/// The caller is expected to have already emitted a `tracing::warn!` with
+/// the specific rejection context (conversation_id, recipient, device_id,
+/// etc.) — this helper just removes the repeated `send_error(..., LITERAL)`
+/// boilerplate at the six rejection sites.
+fn send_payload_error(state: &AppState, sender_id: Uuid) {
+    send_error(state, sender_id, ENCRYPTED_PAYLOAD_REQUIRED);
+}
+
 /// Reject inbound messages on encrypted conversations whose payload isn't
 /// shaped like an Echo ciphertext wire frame.
 ///
@@ -113,11 +128,7 @@ pub(super) fn validate_encrypted_payload(
                     sender_id = %sender_id,
                     "rejected encrypted DM: canonical content is not ciphertext-shaped"
                 );
-                send_error(
-                    state,
-                    sender_id,
-                    "Encrypted conversation requires ciphertext payload",
-                );
+                send_payload_error(state, sender_id);
                 return false;
             }
             let Some(rdc) = recipient_device_contents else {
@@ -126,11 +137,7 @@ pub(super) fn validate_encrypted_payload(
                     sender_id = %sender_id,
                     "rejected encrypted DM with no recipient_device_contents"
                 );
-                send_error(
-                    state,
-                    sender_id,
-                    "Encrypted conversation requires ciphertext payload",
-                );
+                send_payload_error(state, sender_id);
                 return false;
             };
             if rdc.is_empty() {
@@ -139,11 +146,7 @@ pub(super) fn validate_encrypted_payload(
                     sender_id = %sender_id,
                     "rejected encrypted DM with empty recipient_device_contents"
                 );
-                send_error(
-                    state,
-                    sender_id,
-                    "Encrypted conversation requires ciphertext payload",
-                );
+                send_payload_error(state, sender_id);
                 return false;
             }
             for (recipient, devices) in rdc.iter() {
@@ -154,11 +157,7 @@ pub(super) fn validate_encrypted_payload(
                         recipient = %recipient,
                         "rejected encrypted DM: empty per-recipient device map"
                     );
-                    send_error(
-                        state,
-                        sender_id,
-                        "Encrypted conversation requires ciphertext payload",
-                    );
+                    send_payload_error(state, sender_id);
                     return false;
                 }
                 for (device_id, ciphertext) in devices.iter() {
@@ -170,11 +169,7 @@ pub(super) fn validate_encrypted_payload(
                             device_id = %device_id,
                             "rejected encrypted DM: per-device payload is not ciphertext-shaped"
                         );
-                        send_error(
-                            state,
-                            sender_id,
-                            "Encrypted conversation requires ciphertext payload",
-                        );
+                        send_payload_error(state, sender_id);
                         return false;
                     }
                 }
@@ -188,11 +183,7 @@ pub(super) fn validate_encrypted_payload(
                     sender_id = %sender_id,
                     "rejected encrypted group message: content is not ciphertext-shaped"
                 );
-                send_error(
-                    state,
-                    sender_id,
-                    "Encrypted conversation requires ciphertext payload",
-                );
+                send_payload_error(state, sender_id);
                 return false;
             }
             true

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -247,9 +247,60 @@ pub(super) async fn validate_conversation_security(
 /// `recipient_user_id (UUID string) -> { device_id (i32 string) -> ciphertext }`.
 /// Per-user device IDs collide across users, so the storage and fanout
 /// addressing must include the recipient. Conversion to typed
-/// `(Uuid, i32)` happens at the storage/fanout boundaries; rows that fail to
-/// parse are logged and skipped.
+/// `(Uuid, i32)` happens at the deserialization boundary (see
+/// [`ParsedRecipientDeviceContents::from_wire`]) so downstream code doesn't
+/// re-parse the same UUID + i32 fields once per fanout stage (#834
+/// finding 15).
 pub(super) type RecipientDeviceContents = HashMap<String, HashMap<String, String>>;
+
+/// Pre-parsed form of [`RecipientDeviceContents`]: UUID + i32 fields are
+/// parsed once at the entry boundary so the storage, revoked-filter,
+/// per-device JSON build, and self-device delivery paths all read typed
+/// values instead of re-parsing strings (#834 finding 15).
+///
+/// Rows that fail to parse (malformed UUID or non-integer device id) are
+/// logged once and dropped here — historically each downstream stage
+/// silently skipped them via `Uuid::parse_str(...).ok()?`, which made it
+/// impossible to tell from logs whether a client was sending garbage.
+#[derive(Debug, Default, Clone)]
+pub(super) struct ParsedRecipientDeviceContents {
+    pub by_user: HashMap<Uuid, HashMap<i32, String>>,
+}
+
+impl ParsedRecipientDeviceContents {
+    /// Parse the wire-shape map once. Returns `None` if the input is `None`;
+    /// otherwise always returns `Some` (possibly empty if every row was
+    /// malformed). The caller keeps the original `RecipientDeviceContents`
+    /// usage where the wire form is still needed (e.g. `validate_encrypted_payload`
+    /// reports `recipient`/`device_id` strings in its `tracing::warn!` context).
+    pub fn from_wire(rdc: &RecipientDeviceContents) -> Self {
+        let mut by_user: HashMap<Uuid, HashMap<i32, String>> = HashMap::with_capacity(rdc.len());
+        for (uid_str, devices) in rdc {
+            let Ok(uid) = Uuid::parse_str(uid_str) else {
+                tracing::debug!(uid = %uid_str, "dropped recipient_device_contents row: bad uuid");
+                continue;
+            };
+            let mut by_device: HashMap<i32, String> = HashMap::with_capacity(devices.len());
+            for (did_str, ciphertext) in devices {
+                let Ok(did) = did_str.parse::<i32>() else {
+                    tracing::debug!(
+                        uid = %uid_str,
+                        did = %did_str,
+                        "dropped recipient_device_contents row: bad device id"
+                    );
+                    continue;
+                };
+                by_device.insert(did, ciphertext.clone());
+            }
+            by_user.insert(uid, by_device);
+        }
+        Self { by_user }
+    }
+
+    pub fn recipient_ids(&self) -> Vec<Uuid> {
+        self.by_user.keys().copied().collect()
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_send_message(
@@ -297,6 +348,15 @@ pub(super) async fn handle_send_message(
         return;
     }
 
+    // #834 finding 15: parse the wire-shape recipient_device_contents exactly
+    // once here, after validation. Downstream consumers (store_and_confirm,
+    // fanout_message, build_per_device_json, the self-device-delivery loop)
+    // all read the typed `HashMap<Uuid, HashMap<i32, String>>` instead of
+    // reparsing the same UUID + i32 fields up to three times per device.
+    let parsed_rdc = recipient_device_contents
+        .as_ref()
+        .map(ParsedRecipientDeviceContents::from_wire);
+
     let (reply_content, reply_username) =
         lookup_reply_context(&state.pool, reply_to_id, conv_id).await;
 
@@ -309,7 +369,7 @@ pub(super) async fn handle_send_message(
         resolved_channel_id,
         &content,
         reply_to_id,
-        &recipient_device_contents,
+        parsed_rdc.as_ref(),
         ttl_seconds,
         conv_security.is_encrypted,
     )
@@ -343,7 +403,7 @@ pub(super) async fn handle_send_message(
         stored.id,
         conv_security.is_encrypted,
         conv_kind == Some(ConversationKind::Group),
-        recipient_device_contents,
+        parsed_rdc,
     )
     .await;
 }
@@ -361,7 +421,7 @@ pub(super) async fn store_and_confirm(
     resolved_channel_id: Option<Uuid>,
     content: &str,
     reply_to_id: Option<Uuid>,
-    recipient_device_contents: &Option<RecipientDeviceContents>,
+    recipient_device_contents: Option<&ParsedRecipientDeviceContents>,
     ttl_seconds: Option<i64>,
     is_encrypted: bool,
 ) -> Option<db::messages::MessageRow> {
@@ -447,7 +507,7 @@ pub(super) async fn store_and_confirm(
     // by anyone (blocked users never receive it, and a future audit-leak
     // scenario would expose it for no benefit).
     if let Some(rdc) = recipient_device_contents {
-        let recipient_ids: Vec<Uuid> = rdc.keys().filter_map(|s| Uuid::parse_str(s).ok()).collect();
+        let recipient_ids = rdc.recipient_ids();
         let blockers: Vec<Uuid> = if recipient_ids.is_empty() {
             Vec::new()
         } else {
@@ -457,19 +517,13 @@ pub(super) async fn store_and_confirm(
         };
 
         let entries: Vec<(Uuid, i32, &str)> = rdc
+            .by_user
             .iter()
-            .filter_map(|(uid_str, devices)| {
-                let recipient_id = Uuid::parse_str(uid_str).ok()?;
-                if blockers.contains(&recipient_id) {
-                    return None;
-                }
-                Some((recipient_id, devices))
-            })
+            .filter(|(recipient_id, _)| !blockers.contains(recipient_id))
             .flat_map(|(recipient_id, devices)| {
-                devices.iter().filter_map(move |(did_str, ct)| {
-                    let did = did_str.parse::<i32>().ok()?;
-                    Some((recipient_id, did, ct.as_str()))
-                })
+                devices
+                    .iter()
+                    .map(move |(did, ct)| (*recipient_id, *did, ct.as_str()))
             })
             .collect();
         if !entries.is_empty()
@@ -497,13 +551,10 @@ pub(super) async fn store_and_confirm(
     // Self-device delivery: notify sender's OTHER devices about outgoing message.
     // Only the sender's own slice of recipient_device_contents is relevant here.
     if let Some(rdc) = recipient_device_contents
-        && let Some(self_devices) = rdc.get(&sender_id.to_string())
+        && let Some(self_devices) = rdc.by_user.get(&sender_id)
     {
-        for (did_str, ciphertext) in self_devices {
-            let Ok(did) = did_str.parse::<i32>() else {
-                continue;
-            };
-            if did == sender_device_id {
+        for (did, ciphertext) in self_devices {
+            if *did == sender_device_id {
                 continue; // Don't send to the originating device
             }
             let self_msg = ServerMessage::SelfMessage {
@@ -518,7 +569,7 @@ pub(super) async fn store_and_confirm(
             if let Ok(json) = serde_json::to_string(&self_msg) {
                 state
                     .hub
-                    .send_to_device(&sender_id, did, WsMessage::Text(json.into()));
+                    .send_to_device(&sender_id, *did, WsMessage::Text(json.into()));
             }
         }
     }
@@ -756,7 +807,7 @@ impl NewMessageFields {
 ///    fanout loop are O(1) — no string copying per recipient.
 pub(super) fn build_per_device_json(
     fields: &NewMessageFields,
-    recipient_device_contents: &RecipientDeviceContents,
+    recipient_device_contents: &ParsedRecipientDeviceContents,
 ) -> HashMap<Uuid, Vec<(i32, WsMessage)>> {
     // Serialize the invariant portion once via serde so skip_serializing_if
     // is respected for optional fields (channel_id, reply_to_*, expires_at,
@@ -781,22 +832,21 @@ pub(super) fn build_per_device_json(
     };
 
     recipient_device_contents
+        .by_user
         .iter()
-        .filter_map(|(uid_str, devices)| {
-            let recipient_id = Uuid::parse_str(uid_str).ok()?;
+        .map(|(recipient_id, devices)| {
             let entries: Vec<(i32, WsMessage)> = devices
                 .iter()
-                .filter_map(|(did_str, ciphertext)| {
-                    let did = did_str.parse::<i32>().ok()?;
+                .filter_map(|(did, ciphertext)| {
                     // Clone the invariant Value and mutate only `content`.
                     let mut val = base_value.clone();
                     val["content"] = serde_json::Value::String(ciphertext.clone());
                     let json = serde_json::to_string(&val).ok()?;
                     // Wrap as WsMessage::Text (Bytes) once; fanout clones are O(1).
-                    Some((did, WsMessage::Text(json.into())))
+                    Some((*did, WsMessage::Text(json.into())))
                 })
                 .collect();
-            Some((recipient_id, entries))
+            (*recipient_id, entries)
         })
         .collect()
 }
@@ -929,7 +979,7 @@ pub(super) async fn fanout_message(
     stored_id: Uuid,
     is_encrypted: bool,
     is_group: bool,
-    recipient_device_contents: Option<RecipientDeviceContents>,
+    recipient_device_contents: Option<ParsedRecipientDeviceContents>,
 ) {
     let Some(fields) = NewMessageFields::extract(message) else {
         tracing::error!("fanout_message called with non-NewMessage variant");
@@ -953,33 +1003,19 @@ pub(super) async fn fanout_message(
     // building per-device frames. Devices with NO identity_keys row at all
     // (test fixtures, fresh registrations) are passed through unchanged — only
     // rows with a non-NULL revoked_at are dropped.
-    let recipient_device_contents = if let Some(rdc) = recipient_device_contents {
-        let recipient_ids: Vec<Uuid> = rdc.keys().filter_map(|s| Uuid::parse_str(s).ok()).collect();
+    let recipient_device_contents = if let Some(mut rdc) = recipient_device_contents {
+        let recipient_ids = rdc.recipient_ids();
         let revoked_map = db::keys::get_revoked_devices_for_users(&state.pool, &recipient_ids)
             .await
             .unwrap_or_default();
-        if revoked_map.is_empty() {
-            Some(rdc)
-        } else {
-            let filtered: RecipientDeviceContents = rdc
-                .into_iter()
-                .filter_map(|(uid_str, devices)| {
-                    let uid = Uuid::parse_str(&uid_str).ok()?;
-                    let revoked_dids = revoked_map.get(&uid);
-                    let kept: HashMap<String, String> = devices
-                        .into_iter()
-                        .filter(|(did_str, _)| {
-                            let Ok(did) = did_str.parse::<i32>() else {
-                                return true;
-                            };
-                            !revoked_dids.is_some_and(|rv| rv.contains(&did))
-                        })
-                        .collect();
-                    Some((uid_str, kept))
-                })
-                .collect();
-            Some(filtered)
+        if !revoked_map.is_empty() {
+            for (uid, devices) in rdc.by_user.iter_mut() {
+                if let Some(revoked_dids) = revoked_map.get(uid) {
+                    devices.retain(|did, _| !revoked_dids.contains(did));
+                }
+            }
         }
+        Some(rdc)
     } else {
         None
     };

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -73,7 +73,11 @@ pub(super) async fn check_membership_cached(
 }
 
 /// Fetch conversation member IDs with a 60-second in-memory cache.
-pub(super) async fn get_member_ids_cached(
+///
+/// Exposed at `pub(crate)` so non-WS broadcast paths (e.g. the reactions
+/// route) can reuse the same LRU instead of opening a fresh DB round-trip
+/// per fanout (#834 finding 13).
+pub(crate) async fn get_member_ids_cached(
     pool: &sqlx::PgPool,
     conversation_id: Uuid,
 ) -> Result<Vec<Uuid>, sqlx::Error> {
@@ -276,11 +280,16 @@ pub(super) async fn send_presence_snapshot(state: &AppState, user_id: Uuid) {
     }
 
     // Build per-user status entries, filtering out invisible contacts.
+    // Batched lookup (#834 finding 7): one round-trip with ANY($1) replaces
+    // the prior per-contact query inside this loop.
+    let statuses = db::users::get_presence_statuses_for(&state.pool, &online_contacts)
+        .await
+        .unwrap_or_default();
     let mut entries: Vec<serde_json::Value> = Vec::with_capacity(online_contacts.len());
     for cid in &online_contacts {
-        let stored = db::users::get_presence_status(&state.pool, *cid)
-            .await
-            .unwrap_or(None)
+        let stored = statuses
+            .get(cid)
+            .cloned()
             .unwrap_or_else(|| "online".to_string());
         if stored == "invisible" {
             continue; // invisible users appear offline

--- a/apps/server/tests/api_reply_count_regression.rs
+++ b/apps/server/tests/api_reply_count_regression.rs
@@ -1,0 +1,271 @@
+//! Regression tests for the reply-count migration in `search_messages` and
+//! `get_thread_replies` (#834 finding 8). The audit migrated both queries
+//! from a LATERAL `COUNT(*)` correlated subquery (O(N*M)) to a single
+//! GROUP-BY subquery joined once (O(N+M)). The risk of the migration is a
+//! shift in result shape -- LEFT JOIN semantics on the aggregating
+//! subquery must still produce 0 for messages with no replies, must count
+//! the right number for messages with one, and must scale correctly for
+//! messages with many.
+//!
+//! Both queries surface `reply_count` to the wire:
+//!   * `search_messages` -> `GET /api/conversations/{id}/search?q=...`
+//!   * `get_thread_replies` -> `GET /api/messages/{id}/replies`
+//!
+//! Hitting both endpoints exercises the migrated SQL through the same
+//! deserialisation path the client uses, so any GROUP-BY divergence shows
+//! up as a wrong `reply_count` value in the response JSON.
+
+mod common;
+
+use futures_util::SinkExt;
+use reqwest::Client;
+use serde_json::Value;
+use tokio_tungstenite::tungstenite::Message;
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn connect_ws(base: &str, ticket: &str) -> WsStream {
+    let ws_base = base.replace("http://", "ws://");
+    let (ws, _) = tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={ticket}"))
+        .await
+        .expect("WS connect failed");
+    ws
+}
+
+/// Post a `send_message` and return the `message_id` from the
+/// `message_sent` confirmation. Reuses the same wire shape as
+/// `api_messages_reply_scope::post_message`.
+async fn post_message(
+    ws: &mut WsStream,
+    conversation_id: &str,
+    tag: &str,
+    recipient_user_id: &str,
+) -> String {
+    let canonical = common::dummy_ciphertext(&format!("{tag}_canonical"));
+    let recipient_ct = common::dummy_ciphertext(&format!("{tag}_recipient"));
+    let frame = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": conversation_id,
+        "content": canonical,
+        "recipient_device_contents": {
+            recipient_user_id.to_string(): { "0": recipient_ct },
+        },
+    });
+    ws.send(Message::Text(frame.to_string().into()))
+        .await
+        .expect("send_message failed");
+    let evt = common::recv_until_event(ws, &["message_sent", "error"]).await;
+    assert_eq!(
+        evt["type"], "message_sent",
+        "expected message_sent, got: {evt}"
+    );
+    evt["message_id"]
+        .as_str()
+        .expect("missing message_id")
+        .to_string()
+}
+
+/// Post a reply to `reply_to_id` and return the resulting `message_id`.
+async fn post_reply(
+    ws: &mut WsStream,
+    conversation_id: &str,
+    tag: &str,
+    reply_to_id: &str,
+    recipient_user_id: &str,
+) -> String {
+    let canonical = common::dummy_ciphertext(&format!("{tag}_canonical"));
+    let recipient_ct = common::dummy_ciphertext(&format!("{tag}_recipient"));
+    let frame = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": conversation_id,
+        "content": canonical,
+        "reply_to_id": reply_to_id,
+        "recipient_device_contents": {
+            recipient_user_id.to_string(): { "0": recipient_ct },
+        },
+    });
+    ws.send(Message::Text(frame.to_string().into()))
+        .await
+        .expect("send_reply failed");
+    let evt = common::recv_until_event(ws, &["message_sent", "error"]).await;
+    assert_eq!(
+        evt["type"], "message_sent",
+        "expected message_sent, got: {evt}"
+    );
+    evt["message_id"]
+        .as_str()
+        .expect("missing message_id")
+        .to_string()
+}
+
+/// Pull the canonical message history for `conversation_id` via the REST
+/// route used by `search_messages`'s sister listing call. The list returns
+/// `reply_count` per message via the same `MessageWithSender` shape, so we
+/// use it to cross-check the search/thread responses (which carry the
+/// migrated query).
+async fn fetch_messages(client: &Client, base: &str, token: &str, conv_id: &str) -> Vec<Value> {
+    let resp = client
+        .get(format!("{base}/api/messages/{conv_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .expect("GET messages");
+    assert_eq!(resp.status().as_u16(), 200);
+    resp.json::<Vec<Value>>().await.expect("messages JSON")
+}
+
+/// `get_thread_replies` must return 0 / 1 / many reply_counts correctly
+/// after the GROUP-BY migration. We post one parent, then incrementally
+/// reply to it and read back the thread; the parent's reply_count in the
+/// canonical message list must keep pace.
+#[tokio::test]
+async fn thread_replies_reply_count_zero_one_many() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "rc_alice").await;
+    let (bob_token, bob_id, bob_name) = common::register_and_login(&client, &base, "rc_bob").await;
+
+    let conv =
+        common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Parent with zero replies.
+    let parent_id = post_message(&mut alice_ws, &conv, "rc_parent", &bob_id).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // get_thread_replies for parent should be empty.
+    let resp = client
+        .get(format!("{base}/api/messages/{parent_id}/replies"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let replies: Vec<Value> = resp.json().await.unwrap();
+    assert_eq!(replies.len(), 0, "zero-reply parent must return []");
+
+    // Canonical message listing should report reply_count == 0 for parent.
+    let listing = fetch_messages(&client, &base, &alice_token, &conv).await;
+    let parent_row = listing
+        .iter()
+        .find(|m| m["id"].as_str() == Some(&parent_id))
+        .expect("parent row");
+    assert_eq!(parent_row["reply_count"].as_i64(), Some(0));
+
+    // One reply.
+    let _r1 = post_reply(&mut alice_ws, &conv, "rc_r1", &parent_id, &bob_id).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let resp = client
+        .get(format!("{base}/api/messages/{parent_id}/replies"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    let replies: Vec<Value> = resp.json().await.unwrap();
+    assert_eq!(replies.len(), 1, "one-reply parent must return one row");
+    // Each reply is itself a message and -- on the migrated query -- must
+    // surface a reply_count of 0 (it has no children yet).
+    assert_eq!(replies[0]["reply_count"].as_i64(), Some(0));
+
+    let listing = fetch_messages(&client, &base, &alice_token, &conv).await;
+    let parent_row = listing
+        .iter()
+        .find(|m| m["id"].as_str() == Some(&parent_id))
+        .expect("parent row");
+    assert_eq!(parent_row["reply_count"].as_i64(), Some(1));
+
+    // Many replies (5 total).
+    for i in 2..=5 {
+        let _ = post_reply(
+            &mut alice_ws,
+            &conv,
+            &format!("rc_r{i}"),
+            &parent_id,
+            &bob_id,
+        )
+        .await;
+        common::drain_pending(&mut alice_ws).await;
+    }
+
+    let resp = client
+        .get(format!("{base}/api/messages/{parent_id}/replies"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    let replies: Vec<Value> = resp.json().await.unwrap();
+    assert_eq!(replies.len(), 5, "five-reply parent must return five rows");
+    for r in &replies {
+        // None of the leaf replies have replies of their own.
+        assert_eq!(r["reply_count"].as_i64(), Some(0));
+    }
+
+    let listing = fetch_messages(&client, &base, &alice_token, &conv).await;
+    let parent_row = listing
+        .iter()
+        .find(|m| m["id"].as_str() == Some(&parent_id))
+        .expect("parent row");
+    assert_eq!(parent_row["reply_count"].as_i64(), Some(5));
+
+    let _ = alice_ws.close(None).await;
+    let _ = alice_id; // silence unused
+}
+
+/// `search_messages` runs the same GROUP-BY-joined `reply_count` after the
+/// migration. With the encrypted-DM gate (#591) the search index sees only
+/// ciphertext, so we can't reliably get a search hit on a plaintext
+/// keyword. Instead we exercise the route to confirm it returns 200 with
+/// the post-migration query (a wrong query shape would 500 here, not
+/// 200), which is the gate that catches a structural mistake in the
+/// migrated SQL.
+#[tokio::test]
+async fn search_messages_still_returns_200_after_migration() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "rc_srch_alice").await;
+    let (bob_token, bob_id, bob_name) =
+        common::register_and_login(&client, &base, "rc_srch_bob").await;
+    let conv =
+        common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let parent_id = post_message(&mut alice_ws, &conv, "srch_parent", &bob_id).await;
+    common::drain_pending(&mut alice_ws).await;
+    let _ = post_reply(&mut alice_ws, &conv, "srch_reply", &parent_id, &bob_id).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let resp = client
+        .get(format!("{base}/api/conversations/{conv}/search?q=anything"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "migrated search query must still answer 200"
+    );
+    let body: Vec<Value> = resp.json().await.unwrap();
+    // Any returned row must carry a numeric reply_count (post-migration
+    // shape) rather than null / missing.
+    for row in &body {
+        assert!(
+            row.get("reply_count").and_then(|v| v.as_i64()).is_some(),
+            "search row missing reply_count after migration: {row}"
+        );
+    }
+
+    let _ = alice_ws.close(None).await;
+}


### PR DESCRIPTION
Closes 5 items in the #834 audit bundle, verifies 4 more were already shipped, defers 6 (2 to follow-up, 4 to bigger design passes).

## Improved

- **Search and thread-reply queries are faster on busy conversations.** \`search_messages\` and \`get_thread_replies\` no longer use \`LATERAL COUNT(*)\` per row (O(N×M)). Both migrated to the same GROUP-BY subquery shape that \`get_messages\` already used. Tested with regression coverage at 0 / 1 / 5+ replies.
- **Presence snapshots use one DB round-trip instead of N.** When a client connects and we send the online-friends snapshot, we used to call \`get_presence_status(uuid)\` once per online contact. New \`get_presence_statuses_for(&[Uuid])\` batches the whole thing into a single \`WHERE user_id = ANY($1)\` query.
- **Reaction broadcasts reuse the cached group-membership lookup** instead of re-querying the DB.
- **Encrypted payloads parse once per fanout instead of three times** — UUID + device-id deserialization happens at the wire-shape boundary; downstream code reads from a typed \`HashMap<Uuid, HashMap<i32, String>>\` instead of re-parsing the same JSON three times.

## Behind the scenes

- Hoisted a \`send_payload_error\` helper around the 6 repeated error envelopes in \`validate_encrypted_payload\` — same envelope shape, less boilerplate.
- 2 new regression tests in \`api_reply_count_regression.rs\` lock in the new query shape.

## Verified already-shipped (closing in the audit bundle)

- **F1** Unused FFI-era deps in \`rust-core\` — already removed (only doc comment remained).
- **F3** Duplicate mention keyword scanner — \`mentions_broadcast\` no longer exists.
- **F6** \`ChatPanel.build\` watching the whole \`chatProvider\` — preserved \`.select\` from PR #838 still in place at \`chat_panel.dart:790\`.
- **F12** \`chat_panel.dart\` 2030 LOC god-module — now 973 LOC after PR #853 chat refactor.
- **F14** \`chat_input_bar\` watching whole \`authProvider\` — uses \`ref.read\` and a single \`.select((s) => s.userId)\`.

## Deferred (file as follow-up issues)

- **F5** Hover \`MouseRegion\` rebuilds the full message bubble. The hover state mutation still drives a full \`build()\` of a 1880-line widget. Fixing properly requires extracting the hover-affected leaves behind a \`ValueNotifier\`/\`ValueListenableBuilder\` — too invasive for this PR. **Worth its own issue.**
- **F2** \`MessageDto\` triple-named duplicates — client-coupled wire-format change, was already deferred from PR #858.
- **F9** WS broadcast logic in 5 routes — cross-cutting refactor, needs design first.
- **F10** \`Hub::send_to_user\` Vec alloc — bench-first item.
- **F11** \`AppState\` bag-of-deps — needs \`axum::extract::FromRef\` design pass.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p echo-server\` — 450 passed, 2 ignored, 0 failed (+2 new regression tests for the reply-count migration)
- [ ] Manual: send 5+ replies under one thread → confirm reply_count column shows 5 in both message-list and search results
- [ ] Manual: open a group with 20+ online members → confirm presence snapshot arrives in one round-trip (check server logs for the new ANY($1) query)