### PR TITLE
Beta prep: dev docker tag, screenshot tour, gap fixes, feedback + admin stats, update polling

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -406,3 +406,78 @@ jobs:
           name: dev-server
           path: echo-server-dev-linux-x64.tar.gz
           retention-days: 7
+
+  docker-build-dev-server:
+    name: Build Server :dev image
+    runs-on: ubuntu-latest
+    needs: [paths]
+    if: needs.paths.outputs.server == 'true' || needs.paths.outputs.dev-build-workflow == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ghcr.io/${{ github.repository }}/server
+          tags: |
+            type=raw,value=dev
+            type=sha,prefix=dev-,format=short
+      # Only push from the `dev` branch.  feature/* and fix/* branches
+      # still build for verification but don't pollute ghcr with tags
+      # we'd never pull from.  `:dev` itself is rolling; `dev-<sha>` is
+      # the rollback handle if `:dev` breaks.
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: apps/server/Dockerfile
+          push: ${{ github.ref == 'refs/heads/dev' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-build-dev-web:
+    name: Build Web :dev image
+    runs-on: ubuntu-latest
+    needs: [paths]
+    if: needs.paths.outputs.web == 'true' || needs.paths.outputs.dev-build-workflow == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ghcr.io/${{ github.repository }}/web
+          tags: |
+            type=raw,value=dev
+            type=sha,prefix=dev-,format=short
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: apps/client
+          file: apps/client/Dockerfile.web
+          push: ${{ github.ref == 'refs/heads/dev' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_ID=${{ github.run_id }}
+            APP_VERSION=dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ tests/e2e/*.spec.ts
 !tests/e2e/group_create_ui.spec.ts
 !tests/e2e/group_messaging_ui.spec.ts
 !tests/e2e/density_walkthrough.spec.ts
+!tests/e2e/screenshot_tour.spec.ts
 test-results/
 
 # Uploaded media files

--- a/apps/client/lib/src/providers/update_provider.dart
+++ b/apps/client/lib/src/providers/update_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -165,9 +166,24 @@ class Update extends _$Update {
   /// `mounted` flag has no equivalent on Notifier, so we track it manually).
   bool _disposed = false;
 
+  /// Background timer that re-checks GitHub for new releases while the app
+  /// is open. Without this, long-lived sessions (e.g. desktop users who
+  /// leave the app running) never learn about updates until they restart.
+  /// The 30-minute interval pairs with the 1h cache TTL so worst-case
+  /// GitHub-hit rate is once per hour. See [_cacheTtl].
+  Timer? _periodicTimer;
+
   @override
   UpdateState build() {
-    ref.onDispose(() => _disposed = true);
+    _periodicTimer = Timer.periodic(const Duration(minutes: 30), (_) {
+      // best-effort silent re-check; honors the same 1h cache TTL so two
+      // ticks within an hour won't both hit GitHub
+      check(force: false);
+    });
+    ref.onDispose(() {
+      _periodicTimer?.cancel();
+      _disposed = true;
+    });
     return const UpdateState();
   }
 

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -852,6 +852,26 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
               'End-to-end encrypted · $memberLabel',
               style: TextStyle(color: context.textMuted, fontSize: 12),
             ),
+            const SizedBox(width: 8),
+            // Group E2EE is wired but session-key distribution can stall
+            // ("Securing message…", #434).  Label it so testers don't file
+            // duplicates -- remove once #591 lands server-side enforcement.
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: context.accentLight,
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(color: context.accent, width: 0.5),
+              ),
+              child: Text(
+                'Experimental',
+                style: TextStyle(
+                  color: context.accent,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
           ] else
             Text(
               memberLabel,

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -349,6 +349,36 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
     return SingleChildScrollView(
       child: Column(
         children: [
+          // Beta banner.  We don't want testers surprised when something
+          // breaks or when their account gets wiped before launch.  Subtle
+          // accent treatment -- not a scary red -- so it reads as info.
+          Container(
+            margin: const EdgeInsets.only(bottom: 20),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: context.accentLight,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: context.accent, width: 1),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.science_outlined, size: 16, color: context.accent),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Echo is in beta. Bugs and breakage are expected, and '
+                    'your data may be reset before the public release.',
+                    style: TextStyle(
+                      color: context.textMuted,
+                      fontSize: 12.5,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
           Text(
             'Welcome to Echo!',
             style: TextStyle(

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -21,6 +21,7 @@ import '../../services/secure_key_store.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../version.dart';
+import '../../widgets/feedback_dialog.dart';
 
 class AboutSection extends ConsumerStatefulWidget {
   const AboutSection({super.key});
@@ -712,6 +713,31 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
               },
             ),
             const SizedBox(height: 8),
+            // Beta-prep #4c: surface the feedback dialog from About so testers
+            // have a one-tap path to report issues without leaving the app.
+            ListTile(
+              key: const Key('about-send-feedback'),
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(
+                Icons.feedback_outlined,
+                color: context.textSecondary,
+                size: 22,
+              ),
+              title: Text(
+                'Send feedback',
+                style: TextStyle(color: context.textPrimary, fontSize: 15),
+              ),
+              subtitle: Text(
+                'Report a bug or share a suggestion.',
+                style: TextStyle(color: context.textMuted, fontSize: 12),
+              ),
+              trailing: Icon(
+                Icons.chevron_right,
+                color: context.textMuted,
+                size: 20,
+              ),
+              onTap: () => showFeedbackDialog(context),
+            ),
             // Privacy link — opens the GitHub-rendered docs/PRIVACY.md so the
             // canonical text isn't bundled in every app build.
             ListTile(

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../providers/auth_provider.dart';
 import '../../providers/chat_provider.dart';
@@ -708,6 +709,47 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
                     builder: (_) => const _DebugLogsSubpage(),
                   ),
                 );
+              },
+            ),
+            const SizedBox(height: 8),
+            // Privacy link — opens the GitHub-rendered docs/PRIVACY.md so the
+            // canonical text isn't bundled in every app build.
+            ListTile(
+              key: const Key('about-privacy-link'),
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(
+                Icons.privacy_tip_outlined,
+                color: context.textSecondary,
+                size: 22,
+              ),
+              title: Text(
+                'Privacy',
+                style: TextStyle(color: context.textPrimary, fontSize: 15),
+              ),
+              subtitle: Text(
+                'What Echo stores, what it does not, and where the data lives.',
+                style: TextStyle(color: context.textMuted, fontSize: 12),
+              ),
+              trailing: Icon(
+                Icons.open_in_new,
+                color: context.textMuted,
+                size: 18,
+              ),
+              onTap: () async {
+                final uri = Uri.parse(
+                  'https://github.com/NC1107/echo-messenger/blob/main/docs/PRIVACY.md',
+                );
+                final ok = await launchUrl(
+                  uri,
+                  mode: LaunchMode.externalApplication,
+                );
+                if (!ok && context.mounted) {
+                  ToastService.show(
+                    context,
+                    'Could not open privacy link.',
+                    type: ToastType.error,
+                  );
+                }
               },
             ),
             const SizedBox(height: 16),

--- a/apps/client/lib/src/screens/settings/language_section.dart
+++ b/apps/client/lib/src/screens/settings/language_section.dart
@@ -39,11 +39,17 @@ class LanguageSection extends ConsumerWidget {
                 height: 1.5,
               ),
             ),
+            const SizedBox(height: 16),
+            // Beta banner — translations beyond English are scaffolded but
+            // most labels still fall through to English.  Surfacing this
+            // here (#791) saves testers the "is my install broken?" loop.
+            _ComingSoonBanner(),
             const Divider(height: 24),
             ...kSupportedLocales.map(
               (entry) => _LocaleOption(
                 entry: entry,
                 isSelected: currentLocale.languageCode == entry.tag,
+                isFullyTranslated: entry.tag == 'en',
                 onTap: () => ref
                     .read(localeProvider.notifier)
                     .setLocale(Locale(entry.tag)),
@@ -70,21 +76,58 @@ class LanguageSection extends ConsumerWidget {
 // Single locale list tile
 // ---------------------------------------------------------------------------
 
+class _ComingSoonBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: context.accentLight,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: context.accent, width: 1),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.info_outline, size: 18, color: context.accent),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'Language support is in development. Only English is fully '
+              'translated right now — picking another language will fall '
+              'back to English for most labels.',
+              style: TextStyle(
+                color: context.textPrimary,
+                fontSize: 12.5,
+                height: 1.45,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _LocaleOption extends StatelessWidget {
   final LocaleEntry entry;
   final bool isSelected;
+  final bool isFullyTranslated;
   final VoidCallback onTap;
 
   const _LocaleOption({
     required this.entry,
     required this.isSelected,
+    required this.isFullyTranslated,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      label: '${entry.displayName} language option',
+      label: isFullyTranslated
+          ? '${entry.displayName} language option'
+          : '${entry.displayName} language option (coming soon)',
       button: true,
       selected: isSelected,
       child: Padding(
@@ -108,15 +151,33 @@ class _LocaleOption extends StatelessWidget {
               child: Row(
                 children: [
                   Expanded(
-                    child: Text(
-                      entry.displayName,
-                      style: TextStyle(
-                        color: isSelected
-                            ? context.accent
-                            : context.textPrimary,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
-                      ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          entry.displayName,
+                          style: TextStyle(
+                            color: isSelected
+                                ? context.accent
+                                : isFullyTranslated
+                                ? context.textPrimary
+                                : context.textMuted,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        if (!isFullyTranslated) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            'Coming soon',
+                            style: TextStyle(
+                              color: context.textMuted,
+                              fontSize: 11.5,
+                              fontStyle: FontStyle.italic,
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
                   ),
                   if (isSelected)

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -27,6 +27,7 @@ import 'connection_status_badge.dart';
 import 'conversation_item.dart';
 import 'echo_logo_icon.dart';
 import 'empty_state.dart';
+import 'feedback_dialog.dart';
 import 'skeleton_loader.dart';
 import 'voice_footer.dart';
 
@@ -1100,8 +1101,11 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         update.updateAvailable ||
         isActive ||
         update.status == UpdateStatus.error;
-    if (!isVisible) return const SizedBox.shrink();
-    if (update.dismissed && !isActive) return const SizedBox.shrink();
+    // When no update banner is showing, fall back to a small "Report a bug"
+    // affordance so the user can reach the feedback dialog without leaving
+    // the sidebar / opening Settings.
+    if (!isVisible) return _buildBugReportRow(context);
+    if (update.dismissed && !isActive) return _buildBugReportRow(context);
 
     final String label;
     final Widget? action;
@@ -1254,6 +1258,34 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           ),
           ?progress,
         ],
+      ),
+    );
+  }
+
+  /// Small "Report a bug" affordance shown in the slot the update banner
+  /// otherwise occupies. Visible only when no update is in flight — keeps
+  /// the sidebar tight when an update is pending / installing.
+  Widget _buildBugReportRow(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: context.mainBg,
+        border: Border(top: BorderSide(color: context.border, width: 1)),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: TextButton.icon(
+          icon: const Icon(Icons.bug_report_outlined, size: 14),
+          label: const Text('Report a bug'),
+          onPressed: () => showFeedbackDialog(context),
+          style: TextButton.styleFrom(
+            foregroundColor: context.textMuted,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            textStyle: const TextStyle(fontSize: 11),
+          ),
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/feedback_dialog.dart
+++ b/apps/client/lib/src/widgets/feedback_dialog.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import '../providers/auth_provider.dart';
+import '../providers/server_url_provider.dart';
+import '../services/toast_service.dart';
+import '../theme/echo_theme.dart';
+
+/// Top-level entry: open the "Send feedback" dialog. Resolves to `true` when
+/// the report was POSTed successfully, `false` on cancel / failure.
+///
+/// The dialog is intentionally lightweight -- title + body + public-ok
+/// checkbox -- matching the matching server contract in
+/// `apps/server/src/routes/feedback.rs`.  Server-side rate limit kicks in
+/// at 5 reports per 24h; the dialog surfaces a toast on 429 rather than
+/// blocking submission client-side.
+Future<bool?> showFeedbackDialog(BuildContext context) {
+  return showDialog<bool>(
+    context: context,
+    builder: (_) => const _FeedbackDialog(),
+  );
+}
+
+class _FeedbackDialog extends ConsumerStatefulWidget {
+  const _FeedbackDialog();
+
+  @override
+  ConsumerState<_FeedbackDialog> createState() => _FeedbackDialogState();
+}
+
+class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
+  final _titleController = TextEditingController();
+  final _bodyController = TextEditingController();
+  // Mirrors the server caps in `routes::feedback`.  We enforce client-side
+  // so the user gets immediate feedback instead of a 400 round-trip.
+  static const int _maxTitle = 100;
+  static const int _maxBody = 4000;
+
+  bool _publicOk = false;
+  bool _sending = false;
+  String? _errorText;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _bodyController.dispose();
+    super.dispose();
+  }
+
+  bool get _canSend =>
+      !_sending &&
+      _titleController.text.trim().isNotEmpty &&
+      _bodyController.text.trim().isNotEmpty;
+
+  Future<void> _send() async {
+    final title = _titleController.text.trim();
+    final body = _bodyController.text.trim();
+    if (title.isEmpty || body.isEmpty) return;
+
+    setState(() {
+      _sending = true;
+      _errorText = null;
+    });
+
+    final serverUrl = ref.read(serverUrlProvider);
+    try {
+      final resp = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.post(
+              Uri.parse('$serverUrl/api/feedback'),
+              headers: {
+                'Authorization': 'Bearer $token',
+                'Content-Type': 'application/json',
+              },
+              body: jsonEncode({
+                'title': title,
+                'body': body,
+                'public_ok': _publicOk,
+              }),
+            ),
+          );
+
+      if (!mounted) return;
+
+      if (resp.statusCode == 201) {
+        Navigator.of(context).pop(true);
+        ToastService.show(
+          context,
+          'Thanks — your report was sent.',
+          type: ToastType.success,
+        );
+        return;
+      }
+
+      if (resp.statusCode == 429) {
+        setState(() {
+          _errorText =
+              "You've sent several reports recently. Please try again later.";
+        });
+        return;
+      }
+
+      // Best-effort decode of the server error envelope.
+      String message = 'Could not send. Please try again.';
+      try {
+        final decoded = jsonDecode(resp.body) as Map<String, dynamic>;
+        final msg = decoded['error'] ?? decoded['message'];
+        if (msg is String && msg.isNotEmpty) {
+          message = msg;
+        }
+      } catch (_) {}
+      setState(() => _errorText = message);
+    } catch (_) {
+      if (mounted) {
+        setState(() => _errorText = 'Network error. Please try again.');
+      }
+    } finally {
+      if (mounted) setState(() => _sending = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: context.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: context.border),
+      ),
+      title: Row(
+        children: [
+          Icon(Icons.feedback_outlined, size: 20, color: context.textSecondary),
+          const SizedBox(width: 8),
+          Text(
+            'Send feedback',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+      content: SizedBox(
+        width: 480,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Found a bug or have a suggestion? Tell us about it. Your '
+              'report goes straight to the maintainer.',
+              style: TextStyle(
+                color: context.textSecondary,
+                fontSize: 13,
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _titleController,
+              maxLength: _maxTitle,
+              style: TextStyle(color: context.textPrimary, fontSize: 14),
+              decoration: const InputDecoration(
+                labelText: 'Title',
+                hintText: 'Short summary',
+                counterText: '',
+              ),
+              autofocus: true,
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _bodyController,
+              maxLength: _maxBody,
+              maxLines: 6,
+              minLines: 4,
+              style: TextStyle(color: context.textPrimary, fontSize: 14),
+              decoration: const InputDecoration(
+                labelText: 'Details',
+                hintText: 'Steps to reproduce, what you expected, etc.',
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 12),
+            CheckboxListTile(
+              key: const Key('feedback-public-ok-checkbox'),
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+              value: _publicOk,
+              onChanged: (v) => setState(() => _publicOk = v ?? false),
+              title: Text(
+                'OK to share this report publicly on GitHub',
+                style: TextStyle(color: context.textPrimary, fontSize: 13),
+              ),
+              subtitle: Text(
+                'If unchecked, only the maintainer sees this.',
+                style: TextStyle(color: context.textMuted, fontSize: 11.5),
+              ),
+            ),
+            if (_errorText != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                _errorText!,
+                style: const TextStyle(color: EchoTheme.danger, fontSize: 12),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _sending ? null : () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton.icon(
+          key: const Key('feedback-send-button'),
+          onPressed: _canSend ? _send : null,
+          icon: _sending
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Icon(Icons.send, size: 16),
+          label: Text(_sending ? 'Sending...' : 'Send'),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/client/test/widgets/feedback_dialog_test.dart
+++ b/apps/client/test/widgets/feedback_dialog_test.dart
@@ -71,8 +71,9 @@ void main() {
       // We locate it via its key so the test stays robust to layout
       // changes elsewhere in the dialog.
       bool isEnabled() {
-        final btn = tester.widget(find.byKey(const Key('feedback-send-button')))
-            as ButtonStyleButton;
+        final btn =
+            tester.widget(find.byKey(const Key('feedback-send-button')))
+                as ButtonStyleButton;
         return btn.onPressed != null;
       }
 

--- a/apps/client/test/widgets/feedback_dialog_test.dart
+++ b/apps/client/test/widgets/feedback_dialog_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+
+import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/widgets/feedback_dialog.dart';
+
+import '../helpers/mock_http_client.dart';
+import '../helpers/mock_providers.dart';
+
+/// Pumps a button that opens the feedback dialog inside a ProviderScope
+/// with a logged-in auth state and a fixed server URL.
+Future<void> _pumpHost(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authOverride(loggedInAuthState),
+        serverUrlOverride('http://localhost:8080'),
+      ],
+      child: MaterialApp(
+        theme: EchoTheme.darkTheme,
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => showFeedbackDialog(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(registerHttpFallbackValues);
+
+  group('feedback_dialog', () {
+    testWidgets('renders title, body, public-ok checkbox and send button', (
+      tester,
+    ) async {
+      await _pumpHost(tester);
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Send feedback'), findsOneWidget);
+      expect(find.text('Title'), findsOneWidget);
+      expect(find.text('Details'), findsOneWidget);
+      expect(
+        find.byKey(const Key('feedback-public-ok-checkbox')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('feedback-send-button')), findsOneWidget);
+    });
+
+    testWidgets('send button is disabled until both fields have content', (
+      tester,
+    ) async {
+      await _pumpHost(tester);
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // `FilledButton.icon` constructs a `FilledButton` widget internally;
+      // we read the public `onPressed` field which is null while disabled.
+      // We locate it via its key so the test stays robust to layout
+      // changes elsewhere in the dialog.
+      bool isEnabled() {
+        final btn = tester.widget(find.byKey(const Key('feedback-send-button')))
+            as ButtonStyleButton;
+        return btn.onPressed != null;
+      }
+
+      expect(isEnabled(), isFalse);
+
+      await tester.enterText(find.widgetWithText(TextField, 'Title'), 'Bug');
+      await tester.pump();
+      expect(isEnabled(), isFalse);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Details'),
+        'Steps to reproduce here.',
+      );
+      await tester.pump();
+      expect(isEnabled(), isTrue);
+    });
+
+    testWidgets('posts to /api/feedback when send is tapped', (tester) async {
+      final mockClient = MockHttpClient();
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/feedback')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(jsonEncode({'feedback_id': 'fb-1234'}), 201),
+      );
+
+      // Wrap the pump in runWithClient so the dialog's authenticatedRequest
+      // picks up the mocked HTTP client.
+      await http.runWithClient(() async {
+        await _pumpHost(tester);
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Title'),
+          'Login button mis-aligned',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Details'),
+          'Tapping it does nothing on iOS 18.',
+        );
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('feedback-send-button')));
+        // Pump a couple of frames to let the async POST resolve and the
+        // dialog close; avoid pumpAndSettle because the success toast
+        // schedules a dismiss timer that would otherwise leak.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+      }, () => mockClient);
+
+      verify(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/feedback')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).called(1);
+
+      // Let any pending toast dismiss-timers drain before the test ends.
+      await tester.pump(const Duration(seconds: 4));
+    });
+  });
+}

--- a/apps/client/test/widgets/settings/language_section_test.dart
+++ b/apps/client/test/widgets/settings/language_section_test.dart
@@ -66,5 +66,25 @@ void main() {
       // Confirm the selected text is styled differently (accent color).
       expect(find.text('Français'), findsOneWidget);
     });
+
+    testWidgets('renders coming-soon banner so testers expect English only', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(const LanguageSection()));
+      await tester.pump(_kLoadDelay);
+      expect(find.textContaining('Only English is fully'), findsOneWidget);
+    });
+
+    testWidgets('non-English options carry a Coming soon subtitle', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(const LanguageSection()));
+      await tester.pump(_kLoadDelay);
+      // One "Coming soon" subtitle per non-English locale.
+      final nonEnglishCount = kSupportedLocales
+          .where((e) => e.tag != 'en')
+          .length;
+      expect(find.text('Coming soon'), findsNWidgets(nonEnglishCount));
+    });
   });
 }

--- a/apps/client/test/widgets/settings/language_section_test.dart
+++ b/apps/client/test/widgets/settings/language_section_test.dart
@@ -26,6 +26,18 @@ Widget _wrap(Widget child, {List<Override> overrides = const []}) {
 
 const _kLoadDelay = Duration(milliseconds: 100);
 
+// Bump the test viewport so the ListView renders every locale option in
+// one frame.  The "Coming soon" banner + 7 locale tiles overflow the
+// default 600 px test height and the section uses a ListView, so without
+// this guard the last 2-3 tiles get lazily-built and the find queries
+// miss them.
+void _setLargeViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 1600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
@@ -39,6 +51,7 @@ void main() {
     });
 
     testWidgets('renders all supported locale display names', (tester) async {
+      _setLargeViewport(tester);
       await tester.pumpWidget(_wrap(const LanguageSection()));
       await tester.pump(_kLoadDelay);
       for (final entry in kSupportedLocales) {
@@ -78,6 +91,7 @@ void main() {
     testWidgets('non-English options carry a Coming soon subtitle', (
       tester,
     ) async {
+      _setLargeViewport(tester);
       await tester.pumpWidget(_wrap(const LanguageSection()));
       await tester.pump(_kLoadDelay);
       // One "Coming soon" subtitle per non-English locale.

--- a/apps/server/migrations/20260515000000_add_feedback_and_is_admin.sql
+++ b/apps/server/migrations/20260515000000_add_feedback_and_is_admin.sql
@@ -1,0 +1,26 @@
+-- Beta-prep #4: in-app feedback inbox + an admin flag for the operator.
+--
+-- `users.is_admin` defaults to FALSE so this migration is safe on running
+-- prod data; promotion is a one-off UPDATE the operator runs manually.
+-- See `docs/dev-environment.md` for the bootstrap command.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE IF NOT EXISTS feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  public_ok BOOLEAN NOT NULL DEFAULT FALSE,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'triaged', 'closed')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The admin inbox lists `open` reports newest-first; this composite index
+-- backs the `WHERE status = $1 ORDER BY created_at DESC LIMIT $2` query
+-- without touching the unfiltered hot path on `feedback(user_id, ...)` that
+-- the per-user 24h rate-limit count needs.
+CREATE INDEX IF NOT EXISTS feedback_status_created_at_idx
+  ON feedback (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS feedback_user_id_created_at_idx
+  ON feedback (user_id, created_at DESC);

--- a/apps/server/src/routes/admin.rs
+++ b/apps/server/src/routes/admin.rs
@@ -182,7 +182,9 @@ pub async fn list_feedback(
     }
     let limit = q.limit.clamp(1, 200);
 
-    let rows: Vec<(
+    // Wrap the wide row tuple in a typedef so clippy::type_complexity is
+    // satisfied without an `#[allow]`.
+    type Row = (
         uuid::Uuid,
         uuid::Uuid,
         Option<String>,
@@ -191,7 +193,8 @@ pub async fn list_feedback(
         bool,
         String,
         chrono::DateTime<chrono::Utc>,
-    )> = sqlx::query_as(
+    );
+    let rows: Vec<Row> = sqlx::query_as(
         "SELECT f.id, f.user_id, u.username, f.title, f.body, f.public_ok, f.status, f.created_at \
          FROM feedback f LEFT JOIN users u ON u.id = f.user_id \
          WHERE f.status = $1 \

--- a/apps/server/src/routes/admin.rs
+++ b/apps/server/src/routes/admin.rs
@@ -1,0 +1,224 @@
+//! Operator-only admin endpoints.
+//!
+//! Gated by an `AdminUser` extractor that wraps `AuthUser` and additionally
+//! requires `users.is_admin = TRUE`.  Promotion is a manual `UPDATE` the
+//! operator runs against the DB (see `docs/dev-environment.md`); we
+//! deliberately don't expose a "make me admin" API.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{FromRequestParts, Query, State};
+use axum::http::request::Parts;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::middleware::AuthUser;
+use crate::error::{AppError, DbErrCtx};
+use crate::routes::AppState;
+
+/// Extractor that resolves a JWT to a user and then short-circuits with 403
+/// unless `users.is_admin` is TRUE.  Implemented on top of [`AuthUser`] so
+/// the underlying token validation stays in one place.
+pub struct AdminUser {
+    #[allow(dead_code)]
+    pub user_id: uuid::Uuid,
+}
+
+impl FromRequestParts<Arc<AppState>> for AdminUser {
+    type Rejection = AppError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let auth = AuthUser::from_request_parts(parts, state).await?;
+        let (is_admin,): (bool,) = sqlx::query_as("SELECT is_admin FROM users WHERE id = $1")
+            .bind(auth.user_id)
+            .fetch_one(&state.pool)
+            .await
+            .db_ctx("admin/is_admin_lookup")?;
+        if !is_admin {
+            return Err(AppError::forbidden("Admin access required"));
+        }
+        Ok(AdminUser {
+            user_id: auth.user_id,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminStats {
+    pub users_total: i64,
+    pub users_active_24h: i64,
+    pub messages_24h: i64,
+    pub groups_total: i64,
+    pub online_devices: i64,
+    pub feedback_open: i64,
+    pub feedback_last_24h: i64,
+}
+
+pub async fn get_stats(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminUser,
+) -> Result<impl IntoResponse, AppError> {
+    // One round trip per metric keeps the SQL readable.  All seven scans
+    // hit indexed columns (`identity_keys.last_seen`, `messages.created_at`,
+    // `feedback.status` / `created_at`) so even on a busy server the
+    // dashboard load stays cheap; we can fold this into one CTE later if
+    // it shows up in slow-query logs.
+    let (users_total,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
+        .fetch_one(&state.pool)
+        .await
+        .db_ctx("admin/users_total")?;
+
+    // "Active in last 24h" approximates presence via the MAX(last_seen)
+    // across each user's device fingerprints in `identity_keys`. That's
+    // the column the WS hub bumps on every connect (`update_last_seen`
+    // in `db::keys`). Users with no devices fall back to `created_at`
+    // so brand-new sign-ups still count for the first 24h.
+    let (users_active_24h,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM users u \
+         WHERE COALESCE( \
+                 (SELECT MAX(ik.last_seen) FROM identity_keys ik \
+                  WHERE ik.user_id = u.id), \
+                 u.created_at \
+               ) > NOW() - INTERVAL '24 hours'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .db_ctx("admin/users_active_24h")?;
+
+    let (messages_24h,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM messages WHERE created_at > NOW() - INTERVAL '24 hours'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .db_ctx("admin/messages_24h")?;
+
+    let (groups_total,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM conversations WHERE kind = 'group'")
+            .fetch_one(&state.pool)
+            .await
+            .db_ctx("admin/groups_total")?;
+
+    // Hub-level counter: the WS hub keeps one DashMap entry per connected
+    // device, but we can't reach that map from a thread-state extractor
+    // without lifetime gymnastics.  Use the DB's view instead -- it
+    // approximates "currently online" via identity_keys.last_seen within
+    // the last 90 seconds.
+    let (online_devices,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM identity_keys \
+         WHERE last_seen > NOW() - INTERVAL '90 seconds'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .db_ctx("admin/online_devices")?;
+
+    let (feedback_open,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM feedback WHERE status = 'open'")
+            .fetch_one(&state.pool)
+            .await
+            .db_ctx("admin/feedback_open")?;
+
+    let (feedback_last_24h,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM feedback WHERE created_at > NOW() - INTERVAL '24 hours'",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .db_ctx("admin/feedback_last_24h")?;
+
+    Ok(Json(AdminStats {
+        users_total,
+        users_active_24h,
+        messages_24h,
+        groups_total,
+        online_devices,
+        feedback_open,
+        feedback_last_24h,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListFeedbackQuery {
+    #[serde(default = "default_status")]
+    pub status: String,
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+}
+
+fn default_status() -> String {
+    "open".to_string()
+}
+
+fn default_limit() -> i64 {
+    50
+}
+
+#[derive(Debug, Serialize)]
+pub struct FeedbackRow {
+    pub id: String,
+    pub user_id: String,
+    pub username: Option<String>,
+    pub title: String,
+    pub body: String,
+    pub public_ok: bool,
+    pub status: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+pub async fn list_feedback(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminUser,
+    Query(q): Query<ListFeedbackQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    // Whitelist status values to keep the predicate sargable against the
+    // `feedback_status_created_at_idx` index.  Anything else 400s rather
+    // than silently returning an empty page.
+    if !matches!(q.status.as_str(), "open" | "triaged" | "closed") {
+        return Err(AppError::bad_request(
+            "status must be one of: open, triaged, closed",
+        ));
+    }
+    let limit = q.limit.clamp(1, 200);
+
+    let rows: Vec<(
+        uuid::Uuid,
+        uuid::Uuid,
+        Option<String>,
+        String,
+        String,
+        bool,
+        String,
+        chrono::DateTime<chrono::Utc>,
+    )> = sqlx::query_as(
+        "SELECT f.id, f.user_id, u.username, f.title, f.body, f.public_ok, f.status, f.created_at \
+         FROM feedback f LEFT JOIN users u ON u.id = f.user_id \
+         WHERE f.status = $1 \
+         ORDER BY f.created_at DESC \
+         LIMIT $2",
+    )
+    .bind(&q.status)
+    .bind(limit)
+    .fetch_all(&state.pool)
+    .await
+    .db_ctx("admin/list_feedback")?;
+
+    let payload: Vec<FeedbackRow> = rows
+        .into_iter()
+        .map(
+            |(id, user_id, username, title, body, public_ok, status, created_at)| FeedbackRow {
+                id: id.to_string(),
+                user_id: user_id.to_string(),
+                username,
+                title,
+                body,
+                public_ok,
+                status,
+                created_at,
+            },
+        )
+        .collect();
+
+    Ok(Json(serde_json::json!({ "feedback": payload })))
+}

--- a/apps/server/src/routes/feedback.rs
+++ b/apps/server/src/routes/feedback.rs
@@ -1,0 +1,115 @@
+//! Beta feedback endpoint.
+//!
+//! `POST /api/feedback` lets a logged-in user file a single bug-report /
+//! feature-request row.  Reports land in the `feedback` table where the
+//! operator reads them via `/api/admin/feedback` (see `routes::admin`).
+//!
+//! The 5-per-24h rate limit is enforced by counting recent rows for the
+//! caller before insert; in-memory limiter (used elsewhere) would reset on
+//! restart and burn anonymous quota across users that share an IP, neither
+//! of which we want for an authenticated abuse-prevention gate.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::middleware::AuthUser;
+use crate::error::{AppError, DbErrCtx};
+use crate::routes::AppState;
+
+/// Hard caps on user-supplied free text so a malicious or buggy client can't
+/// fill the table with megabyte-sized rows.
+const MAX_TITLE_CHARS: usize = 100;
+const MAX_BODY_CHARS: usize = 4_000;
+
+/// How many open/closed/triaged reports a single user may file per rolling
+/// 24-hour window.  Generous enough that a tester pasting 4 follow-ups in a
+/// row still goes through; tight enough that a runaway script can't flood
+/// the inbox.
+const RATE_LIMIT_PER_24H: i64 = 5;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateFeedbackRequest {
+    pub title: String,
+    pub body: String,
+    #[serde(default)]
+    pub public_ok: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateFeedbackResponse {
+    pub feedback_id: String,
+}
+
+pub async fn create_feedback(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Json(req): Json<CreateFeedbackRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let title = req.title.trim();
+    let body = req.body.trim();
+
+    if title.is_empty() {
+        return Err(AppError::bad_request("Title is required"));
+    }
+    if body.is_empty() {
+        return Err(AppError::bad_request("Body is required"));
+    }
+    if title.chars().count() > MAX_TITLE_CHARS {
+        return Err(AppError::bad_request(format!(
+            "Title must be {MAX_TITLE_CHARS} characters or fewer"
+        )));
+    }
+    if body.chars().count() > MAX_BODY_CHARS {
+        return Err(AppError::bad_request(format!(
+            "Body must be {MAX_BODY_CHARS} characters or fewer"
+        )));
+    }
+
+    // Rolling-window rate limit.  We count the caller's reports in the last
+    // 24h, including triaged + closed ones, so closing a report can't be
+    // used to refill the quota.  `feedback_user_id_created_at_idx` keeps
+    // this cheap even as the table grows.
+    let (recent,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM feedback \
+         WHERE user_id = $1 AND created_at > NOW() - INTERVAL '24 hours'",
+    )
+    .bind(auth.user_id)
+    .fetch_one(&state.pool)
+    .await
+    .db_ctx("feedback/rate_limit_count")?;
+
+    if recent >= RATE_LIMIT_PER_24H {
+        return Err(AppError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            message: format!(
+                "You've sent {RATE_LIMIT_PER_24H} reports in the last 24h. Please wait before sending more."
+            ),
+            code: crate::error::ErrorCode::RateLimited,
+            body: None,
+        });
+    }
+
+    let (id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO feedback (user_id, title, body, public_ok) \
+         VALUES ($1, $2, $3, $4) RETURNING id",
+    )
+    .bind(auth.user_id)
+    .bind(title)
+    .bind(body)
+    .bind(req.public_ok)
+    .fetch_one(&state.pool)
+    .await
+    .db_ctx("feedback/insert")?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateFeedbackResponse {
+            feedback_id: id.to_string(),
+        }),
+    ))
+}

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod canvas;
 pub mod channels;
 pub mod contacts;
+pub mod feedback;
 pub mod group_keys;
 pub mod groups;
 pub mod keys;
@@ -399,6 +400,7 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
             post(link_preview::fetch_preview).layer(middleware::from_fn(link_preview_limit)),
         )
         .route("/api/search", get(search::universal_search))
+        .route("/api/feedback", post(feedback::create_feedback))
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .route("/api/health", get(health))

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod auth;
 pub mod canvas;
 pub mod channels;
@@ -401,6 +402,8 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
         )
         .route("/api/search", get(search::universal_search))
         .route("/api/feedback", post(feedback::create_feedback))
+        .route("/api/admin/stats", get(admin::get_stats))
+        .route("/api/admin/feedback", get(admin::list_feedback))
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .route("/api/health", get(health))

--- a/apps/server/tests/api_admin_stats.rs
+++ b/apps/server/tests/api_admin_stats.rs
@@ -1,0 +1,127 @@
+//! Beta-prep #4 — admin stats + feedback listing endpoints.
+//!
+//! Covers:
+//!  - 403 for callers without `is_admin = TRUE`
+//!  - 200 for an explicitly-promoted admin with the expected JSON shape
+//!  - 200 for `GET /api/admin/feedback?status=open`
+
+mod common;
+
+use common::{register_and_login, spawn_server, test_pool};
+use reqwest::Client;
+use uuid::Uuid;
+
+/// Promote a user to admin by UPDATE-ing the DB directly (the only way --
+/// there is intentionally no public API for this).
+async fn promote_to_admin(user_id: &str) {
+    let pool = test_pool().await;
+    let id = Uuid::parse_str(user_id).expect("valid user_id");
+    sqlx::query("UPDATE users SET is_admin = TRUE WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect("promote to admin");
+}
+
+#[tokio::test]
+async fn admin_stats_rejects_non_admin() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = register_and_login(&client, &base, "stats_plain").await;
+
+    let resp = client
+        .get(format!("{base}/api/admin/stats"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 403);
+}
+
+#[tokio::test]
+async fn admin_stats_returns_payload_for_admin() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, user_id, _) = register_and_login(&client, &base, "stats_admin").await;
+    promote_to_admin(&user_id).await;
+
+    let resp = client
+        .get(format!("{base}/api/admin/stats"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    for key in [
+        "users_total",
+        "users_active_24h",
+        "messages_24h",
+        "groups_total",
+        "online_devices",
+        "feedback_open",
+        "feedback_last_24h",
+    ] {
+        assert!(
+            body[key].is_i64() || body[key].is_u64(),
+            "expected integer for {key} in {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn admin_feedback_list_returns_open_reports() {
+    let base = spawn_server().await;
+    let client = Client::new();
+
+    // A regular user files a report.
+    let (reporter_token, _, _) = register_and_login(&client, &base, "fb_reporter").await;
+    let resp = client
+        .post(format!("{base}/api/feedback"))
+        .header("Authorization", format!("Bearer {reporter_token}"))
+        .json(&serde_json::json!({
+            "title": "Visible to admin",
+            "body": "This row should appear in the admin inbox.",
+            "public_ok": true,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+
+    // A separate user, promoted to admin, reads the inbox.
+    let (admin_token, admin_id, _) = register_and_login(&client, &base, "fb_admin").await;
+    promote_to_admin(&admin_id).await;
+
+    let resp = client
+        .get(format!("{base}/api/admin/feedback?status=open"))
+        .header("Authorization", format!("Bearer {admin_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let rows = body["feedback"].as_array().expect("feedback array");
+    assert!(
+        rows.iter().any(|r| r["title"] == "Visible to admin"),
+        "expected our report to appear in the inbox, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn admin_feedback_list_rejects_invalid_status() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, user_id, _) = register_and_login(&client, &base, "fb_admin_bad").await;
+    promote_to_admin(&user_id).await;
+
+    let resp = client
+        .get(format!("{base}/api/admin/feedback?status=banana"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}

--- a/apps/server/tests/api_feedback.rs
+++ b/apps/server/tests/api_feedback.rs
@@ -1,0 +1,111 @@
+//! Beta-prep #4 — feedback endpoint integration tests.
+//!
+//! Covers:
+//!  - happy path (201 + feedback_id)
+//!  - rejects unauthenticated callers (401)
+//!  - enforces 5/24h rate limit (429 on the 6th report)
+
+mod common;
+
+use common::{register_and_login, spawn_server};
+use reqwest::Client;
+
+#[tokio::test]
+async fn create_feedback_happy_path() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = register_and_login(&client, &base, "fb_happy").await;
+
+    let resp = client
+        .post(format!("{base}/api/feedback"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({
+            "title": "Login screen looks weird on iOS",
+            "body": "The input cursor jumps when I rotate to landscape.",
+            "public_ok": true,
+        }))
+        .send()
+        .await
+        .expect("feedback request failed");
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body["feedback_id"].as_str().is_some(),
+        "expected feedback_id in response, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn create_feedback_requires_auth() {
+    let base = spawn_server().await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/feedback"))
+        .json(&serde_json::json!({
+            "title": "Anon bug",
+            "body": "This should not be accepted.",
+        }))
+        .send()
+        .await
+        .expect("feedback request failed");
+
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[tokio::test]
+async fn create_feedback_rejects_empty_title() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = register_and_login(&client, &base, "fb_empty").await;
+
+    let resp = client
+        .post(format!("{base}/api/feedback"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "title": "  ", "body": "Has a body but no title." }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn create_feedback_rate_limit_kicks_in_after_five() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = register_and_login(&client, &base, "fb_rate").await;
+
+    // First 5 should succeed.
+    for i in 0..5 {
+        let resp = client
+            .post(format!("{base}/api/feedback"))
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&serde_json::json!({
+                "title": format!("Report {i}"),
+                "body": "Filler body to pass validation",
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status().as_u16(),
+            201,
+            "report {i} should succeed, got {}",
+            resp.status()
+        );
+    }
+
+    // 6th should be rate-limited.
+    let resp = client
+        .post(format!("{base}/api/feedback"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({
+            "title": "Report 6",
+            "body": "Should be rate limited",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 429);
+}

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,49 @@
+# Echo Privacy
+
+Last updated: 2026-05-15. Echo is in beta; this doc evolves with the product.
+
+## What Echo stores
+
+| Data | Where | Why |
+|---|---|---|
+| Account (username, hashed password via Argon2id) | Echo Postgres | Lets you log back in |
+| 1:1 message ciphertext + envelope metadata | Echo Postgres | Delivery when the recipient is offline |
+| Plaintext-group messages (sender, room, content) | Echo Postgres | Group rooms aren't E2E-encrypted yet |
+| Avatar images | Echo server filesystem (`./uploads/avatars`) | Profile rendering |
+| Contact graph (who is in your contacts) | Echo Postgres | Friend list display |
+| Push notification tokens (APNs / FCM) | Echo Postgres | Phone wake-ups for new messages |
+| In-memory rate-limit state derived from IP | Echo server RAM (no disk) | Spam / abuse prevention; cleared on restart |
+| Device fingerprints + per-device public keys | Echo Postgres | Multi-device key routing for E2E |
+
+## What Echo does NOT store
+
+- **Plaintext of E2E-encrypted messages.** 1:1 messages use the Signal Protocol (X3DH + Double Ratchet) — the server only sees ciphertext + sender/recipient routing info.
+- **Payment information.** Echo has no payments.
+- **Third-party analytics or trackers.** No Mixpanel, no Segment, no Google Analytics, no Sentry.
+- **Your private keys.** They're generated on-device and stored in your platform keystore (Keychain on iOS/macOS, Credential Manager on Android, libsecret on Linux, etc.).
+
+## Where the data lives
+
+PostgreSQL on the self-hosted server (`echo-messenger.us`). Access is restricted to the operator (GitHub user `NC1107`).
+
+## Retention
+
+- Messages live until you delete them or your account is deleted.
+- Soft-deleted messages remain in the database until the disappearing-messages TTL or group cleanup hard-deletes them.
+- Account deletion (Settings → About → Delete Account) purges every row referencing your user id via cascading foreign keys.
+
+## Third parties
+
+- **Apple Push Notification service (APNs)** for iOS push. Pushes carry encrypted content only — Apple cannot read messages.
+- **Firebase Cloud Messaging (FCM)** for Android push. Same property — encrypted content only.
+- **Cloudflare** terminates TLS and proxies HTTPS to the Echo server. Cloudflare can see request metadata (IP, headers, paths) but not message contents (E2E ciphertext is opaque to them).
+- **LiveKit** is used for voice/video calls. Audio/video relays through the operator-controlled LiveKit instance.
+
+## Contact
+
+Privacy questions, removal requests, or beta-data-wipe coordination: please open an issue on the GitHub repo at <https://github.com/NC1107/echo-messenger>.
+
+## Beta caveats
+
+- Group messages are **not** end-to-end encrypted yet. The "Securing message" UI and the experimental encryption flag are scaffolds for the work tracked in #434 and #591.
+- Account data may be reset before the public release. This is noted in the onboarding wizard's welcome banner.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -1,0 +1,149 @@
+# Dev environment (`dev.echo-messenger.us`)
+
+Echo runs two production-like stacks:
+
+| Stack | Domain | Image tag | Branch |
+|-------|--------|-----------|--------|
+| Production | `echo-messenger.us` | `:latest` (+ `:vX.Y.Z`) | `main` |
+| Dev / staging | `dev.echo-messenger.us` | `:dev` (+ `dev-<sha>`) | `dev` |
+
+Every push to `dev` rebuilds and pushes `ghcr.io/NC1107/echo-messenger/server:dev` and
+`ghcr.io/NC1107/echo-messenger/web:dev` via `.github/workflows/dev-build.yml`. The
+rolling `:dev` tag is what your dev-stack `watchtower` pulls. The accompanying
+`dev-<short-sha>` tag is the rollback handle if `:dev` lands broken — pin to the
+last-known-good SHA in the compose file, restart, then unpin once `:dev` is healed.
+
+## Host setup
+
+The same host can run both stacks: they share Traefik, are isolated by their
+container names, networks, and Postgres database. Pick a separate data
+volume for the dev Postgres so dev migrations can't corrupt production.
+
+### Cloudflare DNS
+
+Point `dev.echo-messenger.us` at the same host IP as `echo-messenger.us`
+(A or AAAA, proxied). Traefik routes by hostname.
+
+### Compose snippet
+
+Drop this alongside the existing `~/docker-server/echo-messenger/docker-compose.yml`
+(e.g. `~/docker-server/echo-messenger-dev/docker-compose.yml`):
+
+```yaml
+services:
+  postgres-dev:
+    image: postgres:17
+    container_name: echo-postgres-dev
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: echo_db_dev
+      POSTGRES_USER: echo
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD_DEV}
+    volumes:
+      - postgres-dev-data:/var/lib/postgresql/data
+    networks:
+      - echo-dev-net
+
+  server-dev:
+    image: ghcr.io/nc1107/echo-messenger/server:dev
+    container_name: echo-server-dev
+    restart: unless-stopped
+    depends_on:
+      - postgres-dev
+    environment:
+      DATABASE_URL: postgres://echo:${POSTGRES_PASSWORD_DEV}@postgres-dev:5432/echo_db_dev
+      JWT_SECRET: ${JWT_SECRET_DEV}
+      RUST_LOG: echo_server=info
+      CORS_ORIGINS: https://dev.echo-messenger.us
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY_DEV}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET_DEV}
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=traefik-public
+      - traefik.http.routers.echo-api-dev.rule=Host(`dev.echo-messenger.us`) && (PathPrefix(`/api`) || PathPrefix(`/ws`))
+      - traefik.http.routers.echo-api-dev.entrypoints=websecure
+      - traefik.http.routers.echo-api-dev.tls.certresolver=cloudflare
+      - traefik.http.routers.echo-api-dev.priority=100
+      - traefik.http.services.echo-api-dev.loadbalancer.server.port=8080
+    networks:
+      - echo-dev-net
+      - traefik-public
+
+  web-dev:
+    image: ghcr.io/nc1107/echo-messenger/web:dev
+    container_name: echo-web-dev
+    restart: unless-stopped
+    # See CLAUDE.md "Prod topology" gotcha: the baked-in healthcheck
+    # resolves localhost to IPv6 first, but nginx only listens on v4.
+    # Override here so Traefik's docker provider doesn't filter the
+    # container out for being "unhealthy".
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1/ >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=traefik-public
+      - traefik.http.routers.echo-web-dev.rule=Host(`dev.echo-messenger.us`)
+      - traefik.http.routers.echo-web-dev.entrypoints=websecure
+      - traefik.http.routers.echo-web-dev.tls.certresolver=cloudflare
+      - traefik.http.routers.echo-web-dev.priority=1
+      - traefik.http.services.echo-web-dev.loadbalancer.server.port=80
+    networks:
+      - traefik-public
+
+volumes:
+  postgres-dev-data:
+
+networks:
+  echo-dev-net:
+  traefik-public:
+    external: true
+```
+
+### Watchtower
+
+The existing production watchtower (single instance, label-scoped) already
+watches every container with the standard label. Either:
+
+- Add `com.centurylinklabs.watchtower.enable=true` to each dev label set
+  above (recommended), so the existing watchtower picks them up too, OR
+- Run a second watchtower scoped to the `echo-dev-net` if you want
+  different polling intervals for dev.
+
+### Rolling back a bad `:dev`
+
+```bash
+# Find the last-good SHA from the dev-build run logs:
+gh run list --workflow=dev-build.yml --branch=dev --limit=20
+
+# Edit ~/docker-server/echo-messenger-dev/docker-compose.yml:
+#   image: ghcr.io/nc1107/echo-messenger/server:dev-abc1234
+# Restart:
+docker compose -f ~/docker-server/echo-messenger-dev/docker-compose.yml \
+  up -d server-dev web-dev
+
+# Fix `:dev` in code, push to dev, then revert the pin once `:dev` rolls.
+```
+
+### Bootstrapping the dev database
+
+First run only:
+
+```bash
+docker compose -f ~/docker-server/echo-messenger-dev/docker-compose.yml \
+  up -d postgres-dev
+# Wait ~5s for it to come up, then bring up the server — it auto-runs
+# every migration in apps/server/migrations/ on startup.
+docker compose -f ~/docker-server/echo-messenger-dev/docker-compose.yml \
+  up -d server-dev web-dev
+```
+
+Promote yourself to admin (for `/api/admin/stats`):
+
+```bash
+docker compose -f ~/docker-server/echo-messenger-dev/docker-compose.yml \
+  exec postgres-dev psql -U echo -d echo_db_dev \
+  -c "UPDATE users SET is_admin = TRUE WHERE username = 'YOUR_USERNAME';"
+```

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -49,6 +49,18 @@ export default defineConfig({
       ],
       use: { browserName: 'chromium' },
     },
+    {
+      // Screenshots: one-shot tour for marketing / README / release notes.
+      // Run on demand:  npx playwright test --project=screenshots
+      // Requires a local server on :8080 + web build on :8081.  Output PNGs
+      // land in docs/screenshots/.
+      name: 'screenshots',
+      testMatch: ['screenshot_tour.spec.ts'],
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1920, height: 1080 },
+      },
+    },
   ],
   outputDir: './test-results',
 });

--- a/tests/e2e/screenshot_tour.spec.ts
+++ b/tests/e2e/screenshot_tour.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Screenshot tour spec — captures 15 UI surfaces for marketing / README /
+ * release notes / store listings.  NOT in the maintained suite; run on
+ * demand with `npx playwright test --project=screenshots`.
+ *
+ * Requirements:
+ *   - Local server running on :8080  (./scripts/run.sh)
+ *   - Web build served on :8081      (e.g. `cd apps/client/build/web && python3 -m http.server 8081`)
+ *
+ * Output:
+ *   - docs/screenshots/01-register.png ... 15-settings-about.png
+ *     (viewport-only, NOT fullPage — these are above-the-fold marketing shots)
+ *
+ * The spec is described.serial so a single login + seeded state carries
+ * across captures without re-logging-in each time.
+ */
+import { test, expect, Page } from '@playwright/test';
+import * as path from 'path';
+
+const LOCAL = 'http://localhost:8080';
+const APP_BASE = 'http://localhost:8081';
+const APP = `${APP_BASE}/?server=${encodeURIComponent(LOCAL)}`;
+const SHOTS_DIR = path.resolve(__dirname, '../../docs/screenshots');
+
+// Generate a unique username per run so the register screen always has a
+// fresh slate without bumping into the unique-username constraint.
+const RUN_ID = Date.now().toString(36);
+const TOUR_USER = `tour_${RUN_ID}`;
+const TOUR_PASS = 'tourpass123';
+
+async function shot(page: Page, name: string) {
+  await page.screenshot({
+    path: path.join(SHOTS_DIR, `${name}.png`),
+    fullPage: false,
+  });
+  // eslint-disable-next-line no-console
+  console.log(`captured ${name}.png`);
+}
+
+async function waitForFlutter(page: Page) {
+  await page.waitForSelector('flt-semantics', { timeout: 30000 });
+  await page.waitForTimeout(2000);
+}
+
+async function dismissDialogs(page: Page) {
+  for (const label of [/got it/i, /close/i, /dismiss/i]) {
+    const btn = page.getByRole('button', { name: label });
+    if (await btn.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await btn.click();
+      await page.waitForTimeout(400);
+    }
+  }
+}
+
+async function tryClickByText(page: Page, label: RegExp): Promise<boolean> {
+  const btn = page.getByRole('button', { name: label }).first();
+  if (await btn.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await btn.click();
+    return true;
+  }
+  const txt = page.getByText(label).first();
+  if (await txt.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await txt.click();
+    return true;
+  }
+  return false;
+}
+
+test.describe.serial('Screenshot tour', () => {
+  test('01 register screen (cold load)', async ({ page }) => {
+    await page.goto(APP);
+    await waitForFlutter(page);
+    // Most launches land on login; click through to the register screen.
+    await tryClickByText(page, /create account|sign up|register/i);
+    await page.waitForTimeout(1500);
+    await shot(page, '01-register');
+  });
+
+  test('02 login screen', async ({ page }) => {
+    await page.goto(APP);
+    await waitForFlutter(page);
+    await page.waitForTimeout(1500);
+    await shot(page, '02-login');
+  });
+
+  test('03 onboarding wizard — welcome', async ({ page }) => {
+    // Register a fresh user so the wizard runs.  If registration UI isn't
+    // reachable we still capture the current screen so the file exists.
+    await page.goto(APP);
+    await waitForFlutter(page);
+    if (await tryClickByText(page, /create account|sign up|register/i)) {
+      await page.waitForTimeout(1000);
+      const userInput = page.locator('input[aria-label="Username"]').first();
+      const passInput = page.locator('input[aria-label="Password"]').first();
+      if (await userInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await userInput.focus();
+        await page.keyboard.type(TOUR_USER, { delay: 10 });
+        await passInput.focus();
+        await page.keyboard.type(TOUR_PASS, { delay: 10 });
+        await tryClickByText(page, /^sign up$|^create account$|^register$/i);
+      }
+      await page.waitForTimeout(3500);
+    }
+    await shot(page, '03-onboarding-welcome');
+  });
+
+  test('04 onboarding — theme', async ({ page }) => {
+    await tryClickByText(page, /^next$|continue/i);
+    await page.waitForTimeout(1000);
+    await shot(page, '04-onboarding-theme');
+  });
+
+  test('05 onboarding — accessibility', async ({ page }) => {
+    await tryClickByText(page, /^next$|continue/i);
+    await page.waitForTimeout(1000);
+    await shot(page, '05-onboarding-accessibility');
+  });
+
+  test('06 onboarding — notifications', async ({ page }) => {
+    await tryClickByText(page, /^next$|continue/i);
+    await page.waitForTimeout(1000);
+    await shot(page, '06-onboarding-notifications');
+  });
+
+  test('07 home — empty conversations', async ({ page }) => {
+    // Finish wizard if still on it.
+    await tryClickByText(page, /finish|done|get started|let'?s go/i);
+    await page.waitForTimeout(2500);
+    await dismissDialogs(page);
+    await shot(page, '07-home-empty');
+  });
+
+  test('08 conversation — DM', async ({ page }) => {
+    // Best-effort: click first DM-shaped row if present.
+    const firstRow = page.locator('[role="button"]').filter({ hasText: /alice|bob|charlie|dev/i }).first();
+    if (await firstRow.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await firstRow.click();
+      await page.waitForTimeout(1500);
+    }
+    await shot(page, '08-conversation-dm');
+  });
+
+  test('09 conversation — group', async ({ page }) => {
+    // Try to find a group row.  Falls back to current screen.
+    const grp = page.getByText(/group|channel|#/i).first();
+    if (await grp.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await grp.click();
+      await page.waitForTimeout(1500);
+    }
+    await shot(page, '09-conversation-group');
+  });
+
+  test('10 discover groups', async ({ page }) => {
+    await tryClickByText(page, /discover/i);
+    await page.waitForTimeout(1500);
+    await shot(page, '10-discover-groups');
+  });
+
+  test('11 quick switcher (cmd+k)', async ({ page }) => {
+    await page.keyboard.press('Control+K');
+    await page.waitForTimeout(800);
+    await shot(page, '11-quick-switcher');
+    await page.keyboard.press('Escape');
+  });
+
+  test('12 global search', async ({ page }) => {
+    await page.keyboard.press('Control+Shift+F');
+    await page.waitForTimeout(800);
+    await shot(page, '12-global-search');
+    await page.keyboard.press('Escape');
+  });
+
+  test('13 settings — appearance', async ({ page }) => {
+    // Open settings — many builds expose this as an aria-labelled button.
+    const settingsBtn = page.locator('[aria-label*="Settings" i]').first();
+    if (await settingsBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await settingsBtn.click();
+    } else {
+      await tryClickByText(page, /settings/i);
+    }
+    await page.waitForTimeout(1200);
+    await tryClickByText(page, /appearance|theme/i);
+    await page.waitForTimeout(800);
+    await shot(page, '13-settings-appearance');
+  });
+
+  test('14 settings — language', async ({ page }) => {
+    await tryClickByText(page, /language/i);
+    await page.waitForTimeout(800);
+    await shot(page, '14-settings-language');
+  });
+
+  test('15 settings — about', async ({ page }) => {
+    await tryClickByText(page, /about/i);
+    await page.waitForTimeout(800);
+    await shot(page, '15-settings-about');
+  });
+});
+
+// Keep a trivial assertion so the project never reports "no tests run".
+test('tour sanity', () => {
+  expect(SHOTS_DIR).toContain('docs/screenshots');
+});


### PR DESCRIPTION
Beta launch prep, batched into one dev→main PR. 5 workstreams, 16 commits.

## Improved
- **App polls for new releases every 30 minutes while running**, not just once at login. Users on Linux/Windows no longer miss a release because they kept the app open all day.
- **Bug report button** in the sidebar next to the update banner — no Settings navigation needed when something breaks. Same dialog also reachable from Settings → About.
- **Coming-soon banner on the Language picker** (#791) so testers know only English is fully translated. Other locales still selectable for future-proofing.
- **Experimental badge on the group encryption indicator** (#434) — flags that group E2E is in development; plaintext is the supported path.
- **Beta warning on the onboarding welcome page** — testers know to expect bugs and a possible data reset before public release.

## New
- **Bug report dialog** (Settings → About): title + body + "OK to share publicly" checkbox. POST /api/feedback (rate-limited 5/24h per user).
- **Admin endpoints**: `GET /api/admin/stats` (user/message/group counts, online devices, feedback counters) + `GET /api/admin/feedback` (recent reports). Gated by new `users.is_admin` column.
- **Privacy policy** at `docs/PRIVACY.md`, linked from Settings → About.
- **Screenshot tour Playwright spec** (`tests/e2e/screenshot_tour.spec.ts`, in the new `screenshots` project). Walks 15 surfaces and writes to `docs/screenshots/`. Not in the maintained suite; run on demand.

## Infrastructure
- **`:dev` Docker tag**: every push to the `dev` branch builds and pushes `ghcr.io/NC1107/echo-messenger/server:dev` and `…/web:dev` to GHCR. Enables a separate `dev.echo-messenger.us` stack for pre-merge testing.
- **`docs/dev-environment.md`** documents the host-side compose snippet, Traefik labels for `dev.echo-messenger.us`, and the separate Postgres database needed.

## Test plan
- [x] \`flutter test\` — 1510 passed, 0 failed, 8 skipped
- [x] \`cargo test -p echo-server\` — all pass including 4 new \`api_feedback\` + 4 new \`api_admin_stats\` tests
- [x] \`flutter analyze --fatal-infos\` clean
- [x] \`dart format --set-exit-if-changed .\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [ ] Once \`dev.echo-messenger.us\` is up, run the screenshot tour locally and commit PNGs

## Verified live but not changed in this PR
- Account deletion: \`apps/server/src/routes/users.rs::delete_account\` — auth-gated, revokes refresh tokens, cascade-deletes related rows
- Password reset: \`forgot_password\` + \`reset_password\` in auth.rs — both rate-limited

Closes #791 (partial — picker shows accurate state for non-English locales). Updates #434 with the experimental marker.