### PR TITLE
ci: fix dev-build web step + tag docker jobs with environments

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -415,6 +415,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    environment:
+      name: development
+      url: https://dev.echo-messenger.us
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
@@ -453,6 +456,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    environment:
+      name: development
+      url: https://dev.echo-messenger.us
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -455,6 +455,25 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: .flutter-version
+          channel: stable
+          cache: true
+      - name: Cache pub-cache + .dart_tool
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            apps/client/.dart_tool
+          key: ${{ runner.os }}-pubcache-${{ hashFiles('apps/client/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pubcache-
+      - name: Build Flutter web
+        working-directory: apps/client
+        run: |
+          flutter pub get
+          flutter build web --release --pwa-strategy=none --dart-define=APP_VERSION=dev
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -960,6 +960,9 @@ jobs:
       always()
       && needs.version.result == 'success'
       && (needs.lint-test-rust.result == 'success' || needs.lint-test-rust.result == 'skipped')
+    environment:
+      name: production
+      url: https://echo-messenger.us
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -1032,6 +1035,9 @@ jobs:
       always()
       && needs.version.result == 'success'
       && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
+    environment:
+      name: production
+      url: https://echo-messenger.us
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0


### PR DESCRIPTION
Two small follow-ups to PR #895:

1. **`flutter pub get` + `flutter build web` step** added to the new `docker-build-dev-web` job in `dev-build.yml`. Without it, the docker step couldn't find `apps/client/build/web`, which is why the first `:dev` web push failed.

2. **`environment:` block** added to all four docker-push jobs (`build-server`, `build-web` in release.yml; `docker-build-dev-server`, `docker-build-dev-web` in dev-build.yml). Enables the deployment-status badges in the Actions UI (`✓ Deployed to production: echo-messenger.us` etc.). No new secrets needed — repo-level secrets cascade down.

Operator action: create the `development` environment in Settings → Environments and optionally set its URL to `https://dev.echo-messenger.us`. The `production` environment already exists.