### PR TITLE
Beta tester polish: reply count fix, theme tokens, reconnect race, reaction chevron

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -338,6 +338,28 @@ class Chat extends _$Chat {
     );
   }
 
+  /// Decrement the reply count on a parent message by 1 (floor at 0).
+  ChatState _decrementReplyCount(
+    ChatState s,
+    String conversationId,
+    String parentId,
+  ) {
+    final messages = s.messagesForConversation(conversationId);
+    final idx = messages.indexWhere((m) => m.id == parentId);
+    if (idx == -1) return s;
+    final parent = messages[idx];
+    if (parent.replyCount <= 0) return s;
+    final updated = parent.copyWith(replyCount: parent.replyCount - 1);
+    final newList = List<ChatMessage>.from(messages);
+    newList[idx] = updated;
+    return s.copyWith(
+      messagesByConversation: {
+        ...s.messagesByConversation,
+        conversationId: newList,
+      },
+    );
+  }
+
   /// Transition a pending message to failed status after send timeout.
   void _transitionToFailed(
     String conversationId,
@@ -357,12 +379,18 @@ class Chat extends _$Chat {
     );
     final updatedList = List<ChatMessage>.from(messages);
     updatedList[idx] = updated;
-    state = state.copyWith(
+    var newState = state.copyWith(
       messagesByConversation: {
         ...state.messagesByConversation,
         conversationId: updatedList,
       },
     );
+    // Roll back the optimistic replyCount bump on the parent so failed
+    // sends don't permanently inflate the thread badge (#830).
+    if (msg.replyToId != null) {
+      newState = _decrementReplyCount(newState, conversationId, msg.replyToId!);
+    }
+    state = newState;
   }
 
   void confirmSent(
@@ -789,6 +817,14 @@ class Chat extends _$Chat {
     final messages = state.messagesByConversation[conversationId];
     if (messages == null) return;
 
+    // Detect transitions involving a failed reply so we can keep the parent
+    // replyCount in sync with the optimistic-bump bookkeeping (#830):
+    //   failed -> sending  (user retried)  : re-increment parent
+    //   sending|sent|... -> failed         : decrement parent (e.g. ws send threw)
+    ChatMessage? before;
+    final idx = messages.indexWhere((m) => m.id == messageId);
+    if (idx != -1) before = messages[idx];
+
     final updated = messages.map((msg) {
       if (msg.id == messageId) {
         return msg.copyWith(status: status);
@@ -796,12 +832,32 @@ class Chat extends _$Chat {
       return msg;
     }).toList();
 
-    state = state.copyWith(
+    var newState = state.copyWith(
       messagesByConversation: {
         ...state.messagesByConversation,
         conversationId: updated,
       },
     );
+
+    if (before != null && before.replyToId != null) {
+      final wasFailed = before.status == MessageStatus.failed;
+      final isFailed = status == MessageStatus.failed;
+      if (wasFailed && !isFailed) {
+        newState = _incrementReplyCount(
+          newState,
+          conversationId,
+          before.replyToId!,
+        );
+      } else if (!wasFailed && isFailed) {
+        newState = _decrementReplyCount(
+          newState,
+          conversationId,
+          before.replyToId!,
+        );
+      }
+    }
+
+    state = newState;
   }
 
   /// Mark all of my sent/delivered messages in a conversation as read.

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -140,6 +140,12 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     final token = ref.read(authProvider).token;
     if (token == null) return;
 
+    // Cancel any pending reconnect timer before establishing a fresh
+    // connection — otherwise a queued backoff fire can race the manual
+    // connect and end up with two parallel channels (#830).
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+
     disconnect();
     _reconnectAttempts = 0;
     // wasReplaced is intentionally NOT cleared here. Only [reconnectAfterReplacement]

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -1027,6 +1027,13 @@ extension EchoColors on BuildContext {
   /// bubble at or near the accent color; promote to a dedicated
   /// [EchoColorExtension] field if a theme ever needs a non-onPrimary value.
   Color get onSentBubble => Theme.of(this).colorScheme.onPrimary;
+
+  /// Foreground color for content rendered on top of [accent]-coloured
+  /// surfaces (FAB icons, FilledButton labels, spinner-in-accent-button).
+  /// Resolves to `ColorScheme.onPrimary` so themes whose accent is light
+  /// (graphite/ember) get a dark foreground instead of unreadable white
+  /// (#830).
+  Color get onAccent => Theme.of(this).colorScheme.onPrimary;
   Color get cardRowBg => echo.resolvedCardRowBg;
   Gradient? get chatBgGradient => echo.chatBgGradient;
 

--- a/apps/client/lib/src/widgets/chat_panel/empty_message_placeholder.dart
+++ b/apps/client/lib/src/widgets/chat_panel/empty_message_placeholder.dart
@@ -24,7 +24,7 @@ class EmptyMessagePlaceholder extends StatelessWidget {
             backgroundColor: context.accent,
             child: Text(
               displayName.isNotEmpty ? displayName[0].toUpperCase() : '?',
-              style: const TextStyle(fontSize: 22, color: Colors.white),
+              style: TextStyle(fontSize: 22, color: context.onAccent),
             ),
           ),
           const SizedBox(height: 12),

--- a/apps/client/lib/src/widgets/chat_panel/no_conversation_placeholder.dart
+++ b/apps/client/lib/src/widgets/chat_panel/no_conversation_placeholder.dart
@@ -47,7 +47,7 @@ class NoConversationPlaceholder extends StatelessWidget {
                   label: const Text('Add Contact'),
                   style: FilledButton.styleFrom(
                     backgroundColor: context.accent,
-                    foregroundColor: Colors.white,
+                    foregroundColor: context.onAccent,
                     padding: const EdgeInsets.symmetric(
                       horizontal: 20,
                       vertical: 12,

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -574,10 +574,14 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           child: InkWell(
             onTap: widget.onNewChat,
             borderRadius: BorderRadius.circular(16),
-            child: const SizedBox(
+            child: SizedBox(
               width: 56,
               height: 56,
-              child: Icon(Icons.edit_outlined, color: Colors.white, size: 22),
+              child: Icon(
+                Icons.edit_outlined,
+                color: context.onAccent,
+                size: 22,
+              ),
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/feedback_dialog.dart
+++ b/apps/client/lib/src/widgets/feedback_dialog.dart
@@ -222,12 +222,12 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
           key: const Key('feedback-send-button'),
           onPressed: _canSend ? _send : null,
           icon: _sending
-              ? const SizedBox(
+              ? SizedBox(
                   width: 14,
                   height: 14,
                   child: CircularProgressIndicator(
                     strokeWidth: 2,
-                    color: Colors.white,
+                    color: context.onAccent,
                   ),
                 )
               : const Icon(Icons.send, size: 16),

--- a/apps/client/lib/src/widgets/message/quick_reaction_row.dart
+++ b/apps/client/lib/src/widgets/message/quick_reaction_row.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
+import 'package:flutter/material.dart';
+
+import '../../models/chat_message.dart';
+import '../../theme/echo_theme.dart';
+import '../message_item.dart' show reactionEmojis;
+
+/// Horizontal quick-reaction picker shown inside the mobile action sheet.
+///
+/// Wraps the emoji row in a fade `ShaderMask` so the leading + trailing edges
+/// hint at off-screen emojis. On desktop / web, where the fade is easy to
+/// miss, a 16px chevron overlay is rendered when the row actually overflows
+/// — tapping scrolls by ~80px (#577).
+class QuickReactionRow extends StatefulWidget {
+  final ChatMessage message;
+  final String myUserId;
+  final void Function(String emoji) onSelect;
+  final VoidCallback onMore;
+
+  const QuickReactionRow({
+    super.key,
+    required this.message,
+    required this.myUserId,
+    required this.onSelect,
+    required this.onMore,
+  });
+
+  @override
+  State<QuickReactionRow> createState() => _QuickReactionRowState();
+}
+
+class _QuickReactionRowState extends State<QuickReactionRow> {
+  final ScrollController _controller = ScrollController();
+  bool _canScrollLeft = false;
+  bool _canScrollRight = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onScroll);
+    // Recompute after first layout so initial chevron visibility is correct.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _onScroll();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onScroll);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_controller.hasClients) return;
+    final pos = _controller.position;
+    final left = pos.pixels > 0;
+    final right = pos.pixels < pos.maxScrollExtent;
+    if (left != _canScrollLeft || right != _canScrollRight) {
+      setState(() {
+        _canScrollLeft = left;
+        _canScrollRight = right;
+      });
+    }
+  }
+
+  void _nudge(int direction) {
+    if (!_controller.hasClients) return;
+    final target = (_controller.offset + 80 * direction).clamp(
+      0.0,
+      _controller.position.maxScrollExtent,
+    );
+    _controller.animateTo(
+      target,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+    );
+  }
+
+  /// Pointer devices (desktop / web). We hide chevrons on phones + tablets
+  /// where the existing fade hint is enough and the chevron would clutter
+  /// the touch picker.
+  bool get _isPointerDevice {
+    if (kIsWeb) return true;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return true;
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+      case TargetPlatform.fuchsia:
+        return false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textDir = Directionality.of(context);
+    final showChevrons = _isPointerDevice;
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        ShaderMask(
+          blendMode: BlendMode.dstIn,
+          shaderCallback: (bounds) => const LinearGradient(
+            begin: AlignmentDirectional.centerStart,
+            end: AlignmentDirectional.centerEnd,
+            stops: [0.0, 0.04, 0.96, 1.0],
+            colors: [
+              Colors.transparent,
+              Colors.black,
+              Colors.black,
+              Colors.transparent,
+            ],
+          ).createShader(bounds, textDirection: textDir),
+          child: SingleChildScrollView(
+            controller: _controller,
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            child: Row(
+              children: [
+                for (final emoji in reactionEmojis) ...[
+                  Builder(
+                    builder: (_) {
+                      final alreadyReacted = widget.message.reactions.any(
+                        (r) => r.emoji == emoji && r.userId == widget.myUserId,
+                      );
+                      return GestureDetector(
+                        onTap: () => widget.onSelect(emoji),
+                        child: Container(
+                          width: 44,
+                          height: 44,
+                          decoration: BoxDecoration(
+                            color: alreadyReacted
+                                ? context.accent.withValues(alpha: 0.2)
+                                : null,
+                            borderRadius: BorderRadius.circular(8),
+                            border: alreadyReacted
+                                ? Border.all(color: context.accent, width: 2)
+                                : null,
+                          ),
+                          alignment: Alignment.center,
+                          child: Text(
+                            emoji,
+                            style: const TextStyle(
+                              fontSize: 24,
+                              decoration: TextDecoration.none,
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  const SizedBox(width: 4),
+                ],
+                Semantics(
+                  button: true,
+                  label: 'More emojis',
+                  child: GestureDetector(
+                    onTap: widget.onMore,
+                    child: Container(
+                      width: 44,
+                      height: 44,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      alignment: Alignment.center,
+                      child: Icon(
+                        Icons.add_reaction_outlined,
+                        size: 24,
+                        color: context.accent,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (showChevrons && _canScrollLeft)
+          Positioned(
+            left: 0,
+            child: _ChevronButton(
+              icon: Icons.chevron_left,
+              label: 'Scroll reactions left',
+              onTap: () => _nudge(-1),
+            ),
+          ),
+        if (showChevrons && _canScrollRight)
+          Positioned(
+            right: 0,
+            child: _ChevronButton(
+              icon: Icons.chevron_right,
+              label: 'Scroll reactions right',
+              onTap: () => _nudge(1),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ChevronButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _ChevronButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: label,
+      child: Material(
+        color: context.surface.withValues(alpha: 0.9),
+        shape: const CircleBorder(),
+        elevation: 1,
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onTap,
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: Icon(icon, size: 16, color: context.textSecondary),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/retry_row.dart
+++ b/apps/client/lib/src/widgets/message/retry_row.dart
@@ -65,7 +65,7 @@ class RetryRow extends StatelessWidget {
                   'Retry',
                   style: GoogleFonts.inter(
                     fontSize: 12,
-                    color: Colors.white,
+                    color: context.onAccent,
                     fontWeight: FontWeight.w600,
                   ),
                 ),

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -27,6 +27,7 @@ import 'message/link_preview_card.dart';
 import 'message/media_content.dart';
 import 'message/message_status_icon.dart';
 import 'message/message_indicators.dart';
+import 'message/quick_reaction_row.dart';
 import 'message/reaction_bar.dart';
 import 'message/reply_count_badge.dart';
 import 'message/reply_quote.dart';
@@ -478,90 +479,20 @@ class _MessageItemState extends State<MessageItem>
   /// Quick reaction emoji row for the mobile action sheet.
   ///
   /// Wrapped in a horizontal-fade ShaderMask so the leading and trailing edges
-  /// hint at off-screen reactions (#508).
+  /// hint at off-screen reactions (#508). On desktop / web a chevron overlay
+  /// is rendered when the row actually overflows (#577).
   Widget _buildQuickReactionRow(BuildContext sheetContext, ChatMessage msg) {
-    final textDir = Directionality.of(sheetContext);
-    return ShaderMask(
-      blendMode: BlendMode.dstIn,
-      shaderCallback: (bounds) => const LinearGradient(
-        begin: AlignmentDirectional.centerStart,
-        end: AlignmentDirectional.centerEnd,
-        stops: [0.0, 0.04, 0.96, 1.0],
-        colors: [
-          Colors.transparent,
-          Colors.black,
-          Colors.black,
-          Colors.transparent,
-        ],
-      ).createShader(bounds, textDirection: textDir),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        child: Row(
-          children: [
-            for (final emoji in reactionEmojis) ...[
-              Builder(
-                builder: (_) {
-                  final alreadyReacted = msg.reactions.any(
-                    (r) => r.emoji == emoji && r.userId == widget.myUserId,
-                  );
-                  return GestureDetector(
-                    onTap: () {
-                      Navigator.pop(sheetContext);
-                      widget.onReactionSelect?.call(msg, emoji);
-                    },
-                    child: Container(
-                      width: 44,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        color: alreadyReacted
-                            ? context.accent.withValues(alpha: 0.2)
-                            : null,
-                        borderRadius: BorderRadius.circular(8),
-                        border: alreadyReacted
-                            ? Border.all(color: context.accent, width: 2)
-                            : null,
-                      ),
-                      alignment: Alignment.center,
-                      child: Text(
-                        emoji,
-                        style: const TextStyle(
-                          fontSize: 24,
-                          decoration: TextDecoration.none,
-                        ),
-                      ),
-                    ),
-                  );
-                },
-              ),
-              const SizedBox(width: 4),
-            ],
-            Semantics(
-              button: true,
-              label: 'More emojis',
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  widget.onMoreReactions?.call(msg);
-                },
-                child: Container(
-                  width: 44,
-                  height: 44,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  alignment: Alignment.center,
-                  child: Icon(
-                    Icons.add_reaction_outlined,
-                    size: 24,
-                    color: context.accent,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
+    return QuickReactionRow(
+      message: msg,
+      myUserId: widget.myUserId,
+      onSelect: (emoji) {
+        Navigator.pop(sheetContext);
+        widget.onReactionSelect?.call(msg, emoji);
+      },
+      onMore: () {
+        Navigator.pop(sheetContext);
+        widget.onMoreReactions?.call(msg);
+      },
     );
   }
 

--- a/apps/client/test/providers/chat_notifier_timer_test.dart
+++ b/apps/client/test/providers/chat_notifier_timer_test.dart
@@ -200,5 +200,97 @@ void main() {
       expect(conv1.first.status, MessageStatus.sending);
       expect(conv1.first.id, startsWith('pending_'));
     });
+
+    test('failed reply send rolls back the parent replyCount (#830)', () {
+      fakeAsync((async) {
+        final container = _createContainer();
+        addTearDown(container.dispose);
+        final notifier = container.read(chatProvider.notifier);
+
+        // Seed a parent message already on the server (replyCount=0).
+        const parent = ChatMessage(
+          id: 'parent-1',
+          fromUserId: 'peer-1',
+          fromUsername: 'peer',
+          conversationId: 'conv-1',
+          content: 'top-level',
+          timestamp: '2026-01-01T11:59:00Z',
+          isMine: false,
+          status: MessageStatus.sent,
+        );
+        notifier.addMessage(parent);
+        expect(
+          container
+              .read(chatProvider)
+              .messagesForConversation('conv-1')
+              .firstWhere((m) => m.id == 'parent-1')
+              .replyCount,
+          0,
+        );
+
+        // Optimistically reply — parent.replyCount bumps to 1.
+        notifier.addOptimistic(
+          'peer-1',
+          'reply that will fail',
+          'me',
+          conversationId: 'conv-1',
+          replyToId: 'parent-1',
+        );
+        expect(
+          container
+              .read(chatProvider)
+              .messagesForConversation('conv-1')
+              .firstWhere((m) => m.id == 'parent-1')
+              .replyCount,
+          1,
+        );
+
+        // Let the 15s send-timeout fire — message transitions to failed.
+        async.elapse(const Duration(seconds: 16));
+
+        // Parent replyCount must roll back to 0 (#830).
+        final afterFail = container
+            .read(chatProvider)
+            .messagesForConversation('conv-1');
+        expect(
+          afterFail.firstWhere((m) => m.id == 'parent-1').replyCount,
+          0,
+          reason: 'failed reply should not inflate parent replyCount',
+        );
+
+        // Retry: status flips back to sending — replyCount re-increments.
+        final failedReply = afterFail.firstWhere(
+          (m) => m.status == MessageStatus.failed,
+        );
+        notifier.updateMessageStatus(
+          'conv-1',
+          failedReply.id,
+          MessageStatus.sending,
+        );
+        expect(
+          container
+              .read(chatProvider)
+              .messagesForConversation('conv-1')
+              .firstWhere((m) => m.id == 'parent-1')
+              .replyCount,
+          1,
+        );
+
+        // Force the retry to fail again — count rolls back to 0 once more.
+        notifier.updateMessageStatus(
+          'conv-1',
+          failedReply.id,
+          MessageStatus.failed,
+        );
+        expect(
+          container
+              .read(chatProvider)
+              .messagesForConversation('conv-1')
+              .firstWhere((m) => m.id == 'parent-1')
+              .replyCount,
+          0,
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
Four user-visible fixes for beta testers. All from issue triage that focused on "things testers might run into."

## Fixed
- **Failed thread sends no longer inflate the parent's reply count** (#830). When a threaded reply fails to send, the parent's counter is decremented back; if the user retries from a `failed` state, it's re-incremented correctly.
- **Theme-token migration for hardcoded white on accent surfaces** (#830). New `context.onAccent` token (mirroring `onSentBubble`); five sites that drew `Colors.white` on `context.accent` now read from the token so they respect the active theme. Remaining `Colors.white` hits are intentional (overlays on `EchoTheme.danger`, video player on dark scrim, etc.).
- **Reconnect race when manual connect collides with a pending backoff timer** (#830). `connect()` now cancels any pending `_reconnectTimer` before kicking off a new attempt.

## Improved
- **Scroll chevrons on the reaction picker** (#577). Desktop users could miss off-screen reactions despite the `ShaderMask` fade. New `QuickReactionRow` widget shows 16px circular chevron buttons on each edge only when the row overflows AND the platform is pointer-based (desktop/web — gated to `kIsWeb` or `linux|macOS|windows`). Tap nudges 80px with 200ms ease-out.

## Closed
- **#405** flow polish backlog — every actionable item verified shipped (login error categorization, onboarding-contact await, pendingDeepLink Riverpod, safety-number route, saved-messages screen, settings server config, keyboard shortcuts, profile route redirects, About-section split via #895).

## Test plan
- [x] `flutter test` — 1511 passed, 0 failed, 8 skipped (new regression test in `chat_notifier_timer_test.dart` for the replyCount rollback)
- [x] `flutter analyze --fatal-infos` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [ ] Visual smoke on light theme + the reaction picker overflow with 10+ reactions

Closes #405. Closes #577. Partial close of #830 (3 items shipped; remaining audit items deferred).