### PR TITLE
fix(client): custom theme colors now update message bubbles and contrast

### DIFF
--- a/apps/client/lib/src/app.dart
+++ b/apps/client/lib/src/app.dart
@@ -18,12 +18,39 @@ ThemeData _applyCustomColors(ThemeData base, CustomColorsState custom) {
   final scheme = base.colorScheme;
   final primary = custom.primaryColor ?? scheme.primary;
   final accent = custom.accentColor ?? scheme.secondary;
+  // Recompute on-color contrast for the new primary so text on sent bubbles
+  // + buttons stays readable on a custom accent.
+  final onPrimary =
+      ThemeData.estimateBrightnessForColor(primary) == Brightness.dark
+      ? Colors.white
+      : Colors.black;
+  final onSecondary =
+      ThemeData.estimateBrightnessForColor(accent) == Brightness.dark
+      ? Colors.white
+      : Colors.black;
+  // Propagate the override into EchoColorExtension so old + new message
+  // bubbles (sentBubble) and any accent-derived surface (accentLight) reflect
+  // the picker choice. Locked rule: sentBubble = primary.
+  final echoExt = base.extension<EchoColorExtension>();
+  final updatedEcho = echoExt?.copyWith(
+    sentBubble: primary,
+    accentLight: primary.withValues(alpha: 0.2),
+  );
   return base.copyWith(
-    colorScheme: scheme.copyWith(primary: primary, secondary: accent),
+    colorScheme: scheme.copyWith(
+      primary: primary,
+      onPrimary: onPrimary,
+      secondary: accent,
+      onSecondary: onSecondary,
+    ),
+    extensions: [
+      ...base.extensions.values.where((e) => e is! EchoColorExtension),
+      ?updatedEcho,
+    ],
     filledButtonTheme: FilledButtonThemeData(
       style: FilledButton.styleFrom(
         backgroundColor: accent,
-        foregroundColor: scheme.onPrimary,
+        foregroundColor: onSecondary,
       ),
     ),
     textButtonTheme: TextButtonThemeData(

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -182,7 +182,7 @@ class _DraggableScreenShareWindowState
                 color: Colors.black.withValues(alpha: 0.85),
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(
-                  color: (widget.isLocal ? EchoTheme.danger : EchoTheme.accent)
+                  color: (widget.isLocal ? EchoTheme.danger : context.accent)
                       .withValues(alpha: 0.6),
                   width: 1.5,
                 ),

--- a/apps/client/lib/src/services/toast_service.dart
+++ b/apps/client/lib/src/services/toast_service.dart
@@ -128,7 +128,7 @@ class _ToastWidgetState extends State<_ToastWidget>
     super.dispose();
   }
 
-  Color _backgroundColor() {
+  Color _backgroundColor(BuildContext context) {
     switch (widget.type) {
       case ToastType.success:
         return EchoTheme.online;
@@ -137,7 +137,7 @@ class _ToastWidgetState extends State<_ToastWidget>
       case ToastType.warning:
         return EchoTheme.warning;
       case ToastType.info:
-        return EchoTheme.accent;
+        return context.accent;
     }
   }
 
@@ -170,7 +170,7 @@ class _ToastWidgetState extends State<_ToastWidget>
               constraints: const BoxConstraints(maxWidth: 360),
               padding: const EdgeInsets.all(10),
               decoration: BoxDecoration(
-                color: _backgroundColor(),
+                color: _backgroundColor(context),
                 borderRadius: BorderRadius.circular(20),
                 boxShadow: [
                   BoxShadow(


### PR DESCRIPTION
When the Settings → Appearance → Advanced color pickers override the active theme's primary/accent, message bubbles (and a few other accent-derived tokens) were stuck on the base theme's colors.

## Root cause
`_applyCustomColors` in `apps/client/lib/src/app.dart` was only updating `ColorScheme.primary` and `.secondary`. It left two key surfaces untouched:

1. **`EchoColorExtension.sentBubble`** — pinned to the theme's accent at load time; the override path never re-baked it. So existing AND new sent bubbles kept the base theme's accent, not the user-chosen one.
2. **`ColorScheme.onPrimary` / `onSecondary`** — the contrast colors text-on-accent reads from. `context.onSentBubble` and `context.onAccent` (added in PR #898) were potentially unreadable on a custom accent.

## Fix
- Recompute `onPrimary` / `onSecondary` from the new primary/accent via `ThemeData.estimateBrightnessForColor` (returns `Colors.white` or `Colors.black` for max contrast).
- Pull the current `EchoColorExtension` from the base theme, call `.copyWith(sentBubble: primary, accentLight: primary.withValues(alpha: 0.2))`, and merge it back via `base.copyWith(extensions: [...])`.
- FilledButton's `foregroundColor` now uses the recomputed `onSecondary` instead of the original-theme `scheme.onPrimary`.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test` — 1511 passed, 0 failed, 8 skipped
- [ ] Manual: override primary to e.g. red — confirm existing message bubbles flip to red and the text on them stays readable

Live-bug fix; ships independently.