### PR TITLE
Beta batch: reply preview, docker fixes, audit tail, test coverage

### DIFF
--- a/apps/client/lib/src/models/chat_message.dart
+++ b/apps/client/lib/src/models/chat_message.dart
@@ -46,6 +46,13 @@ class ChatMessage {
   final String? replyToContent;
   final String? replyToUsername;
   final int replyCount;
+
+  /// Truncated content of the most-recent reply to this message, used for
+  /// the Slack-style inline preview row under the parent (#423). Only
+  /// populated by history loads (`get_messages`); the WS real-time path
+  /// keeps this null and relies on `message_reply_added` to bump the
+  /// count. `null` when there are no replies.
+  final String? latestReplyPreview;
   final String? pinnedById;
   final DateTime? pinnedAt;
   final DateTime? expiresAt;
@@ -75,6 +82,7 @@ class ChatMessage {
     this.replyToContent,
     this.replyToUsername,
     this.replyCount = 0,
+    this.latestReplyPreview,
     this.pinnedById,
     this.pinnedAt,
     this.expiresAt,
@@ -139,6 +147,7 @@ class ChatMessage {
       replyToContent: json['reply_to_content'] as String?,
       replyToUsername: json['reply_to_username'] as String?,
       replyCount: (json['reply_count'] as int?) ?? 0,
+      latestReplyPreview: json['last_reply_snippet'] as String?,
       pinnedById: pinnedByIdRaw,
       pinnedAt: pinnedAtRaw != null ? DateTime.tryParse(pinnedAtRaw) : null,
       expiresAt: json['expires_at'] != null
@@ -220,6 +229,7 @@ class ChatMessage {
       'reply_to_content': replyToContent,
       'reply_to_username': replyToUsername,
       'reply_count': replyCount,
+      'last_reply_snippet': latestReplyPreview,
       'pinned_by_id': pinnedById,
       'pinned_at': pinnedAt?.toIso8601String(),
       'expires_at': expiresAt?.toIso8601String(),
@@ -245,6 +255,7 @@ class ChatMessage {
     String? replyToContent,
     String? replyToUsername,
     int? replyCount,
+    Object? latestReplyPreview = _sentinel,
     Object? pinnedById = _sentinel,
     Object? pinnedAt = _sentinel,
     Object? expiresAt = _sentinel,
@@ -267,6 +278,9 @@ class ChatMessage {
       replyToContent: replyToContent ?? this.replyToContent,
       replyToUsername: replyToUsername ?? this.replyToUsername,
       replyCount: replyCount ?? this.replyCount,
+      latestReplyPreview: latestReplyPreview == _sentinel
+          ? this.latestReplyPreview
+          : latestReplyPreview as String?,
       pinnedById: pinnedById == _sentinel
           ? this.pinnedById
           : pinnedById as String?,
@@ -300,6 +314,7 @@ class ChatMessage {
             replyToContent == other.replyToContent &&
             replyToUsername == other.replyToUsername &&
             replyCount == other.replyCount &&
+            latestReplyPreview == other.latestReplyPreview &&
             pinnedById == other.pinnedById &&
             pinnedAt == other.pinnedAt &&
             expiresAt == other.expiresAt &&
@@ -307,7 +322,7 @@ class ChatMessage {
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     fromUserId,
     fromUsername,
@@ -324,9 +339,10 @@ class ChatMessage {
     replyToContent,
     replyToUsername,
     replyCount,
+    latestReplyPreview,
     pinnedById,
     pinnedAt,
     expiresAt,
     failedContent,
-  );
+  ]);
 }

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1811,7 +1811,17 @@ class _MessageItemState extends State<MessageItem>
         onExit: (_) => _hoverNotifier.value = false,
         child: Semantics(
           label: _composeMessageSemanticsLabel(msg, isMine),
-          button: true,
+          // Audit #830 finding 11: the row's only direct gesture is
+          // long-press to open the action sheet; advertising `button: true`
+          // lied to screen readers ("activate" was announced even though
+          // a tap is a no-op). Declare the action that actually fires.
+          onLongPress: () => _handleLongPress(
+            const LongPressStartDetails(),
+            msg,
+            isMine,
+            mediaUrl,
+            hasReactions,
+          ),
           child: GestureDetector(
             onLongPressStart: (details) =>
                 _handleLongPress(details, msg, isMine, mediaUrl, hasReactions),

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1778,6 +1778,13 @@ class _MessageItemState extends State<MessageItem>
                   onTap: widget.onViewThread,
                   inlineStyle: widget._isPlain,
                 ),
+              if (msg.replyCount > 0 &&
+                  (msg.latestReplyPreview?.trim().isNotEmpty ?? false) &&
+                  !msg.isEncrypted)
+                _LatestReplyPreview(
+                  preview: msg.latestReplyPreview!,
+                  isMine: isMine,
+                ),
               if (widget.isLastInGroup)
                 _buildTimestampRow(msg: msg, isMine: isMine)
               else
@@ -1950,5 +1957,39 @@ class _HoverStyleSpec {
           rowHoverBorderColor: context.border.withValues(alpha: 0.09),
         );
     }
+  }
+}
+
+/// Slack-style inline preview of the latest reply, rendered as a small
+/// muted italic line directly under the reply-count badge. Aligns to the
+/// same side as the badge (left for incoming, right for outgoing in
+/// bubble layouts) so the eye treats badge + preview as one cluster.
+class _LatestReplyPreview extends StatelessWidget {
+  final String preview;
+  final bool isMine;
+
+  const _LatestReplyPreview({required this.preview, required this.isMine});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(top: 2, left: isMine ? 0 : 36, right: 4),
+      child: Align(
+        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320),
+          child: Text(
+            preview,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontStyle: FontStyle.italic,
+              color: context.textMuted,
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/apps/client/test/models/chat_message_extended_test.dart
+++ b/apps/client/test/models/chat_message_extended_test.dart
@@ -267,6 +267,33 @@ void main() {
       expect(msg.replyCount, 0);
     });
 
+    test('parses last_reply_snippet into latestReplyPreview', () {
+      final msg = ChatMessage.fromServerJson({
+        'id': 'msg-1',
+        'from_user_id': 'u1',
+        'from_username': 'alice',
+        'conversation_id': 'c1',
+        'content': 'parent',
+        'timestamp': '2026-01-01T00:00:00Z',
+        'reply_count': 2,
+        'last_reply_snippet': 'hey what about this',
+      }, 'u1');
+      expect(msg.latestReplyPreview, 'hey what about this');
+    });
+
+    test('latestReplyPreview is null when snippet is absent', () {
+      final msg = ChatMessage.fromServerJson({
+        'id': 'msg-1',
+        'from_user_id': 'u1',
+        'from_username': 'alice',
+        'conversation_id': 'c1',
+        'content': 'parent',
+        'timestamp': '2026-01-01T00:00:00Z',
+        'reply_count': 0,
+      }, 'u1');
+      expect(msg.latestReplyPreview, isNull);
+    });
+
     test('uses created_at as fallback for timestamp', () {
       final msg = ChatMessage.fromServerJson({
         'id': 'msg-1',

--- a/apps/client/test/widgets/semantics_labels_test.dart
+++ b/apps/client/test/widgets/semantics_labels_test.dart
@@ -66,7 +66,9 @@ Finder _findSemanticsContaining(String substring) {
 
 void main() {
   group('Semantic labels - MessageItem', () {
-    testWidgets('own message has button: true in semantics', (tester) async {
+    testWidgets('own message advertises long-press action in semantics', (
+      tester,
+    ) async {
       await mockNetworkImagesFor(() async {
         final msg = _makeMessage(
           isMine: true,
@@ -88,7 +90,7 @@ void main() {
         final semanticsFinder = find.byWidgetPredicate(
           (widget) =>
               widget is Semantics &&
-              widget.properties.button == true &&
+              widget.properties.onLongPress != null &&
               widget.properties.label != null &&
               widget.properties.label!.contains('From You') &&
               widget.properties.label!.contains('Long press for actions'),
@@ -97,7 +99,9 @@ void main() {
       });
     });
 
-    testWidgets('other user message also has button: true', (tester) async {
+    testWidgets('other user message also advertises long-press action', (
+      tester,
+    ) async {
       await mockNetworkImagesFor(() async {
         final msg = _makeMessage(content: 'Hello');
         await tester.pumpApp(
@@ -113,7 +117,7 @@ void main() {
         final semanticsFinder = find.byWidgetPredicate(
           (widget) =>
               widget is Semantics &&
-              widget.properties.button == true &&
+              widget.properties.onLongPress != null &&
               widget.properties.label != null &&
               widget.properties.label!.contains('From alice') &&
               widget.properties.label!.contains('Long press for actions'),
@@ -234,7 +238,7 @@ void main() {
           .widgetList<Semantics>(find.byType(Semantics))
           .where(
             (s) =>
-                s.properties.button == true &&
+                s.properties.onLongPress != null &&
                 (s.properties.label ?? '').contains('Long press for actions'),
           )
           .firstOrNull;

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -7,11 +7,17 @@ COPY Cargo.toml Cargo.lock ./
 COPY core/rust-core/Cargo.toml core/rust-core/Cargo.toml
 COPY apps/server/Cargo.toml apps/server/Cargo.toml
 
-# Create dummy source files to build deps
+# Pre-build dependencies against dummy source files so subsequent layer
+# changes that only touch our own crates don't invalidate the cargo
+# registry / target cache. The dummy `echo-server` binary has no real
+# entrypoint, so the build legitimately succeeds at the "deps + skeleton
+# main" stage; we keep stderr (instead of the previous `2>/dev/null`)
+# so real failures surface in CI, and drop the `|| true` soft-fail that
+# previously swallowed broken-manifest errors (#356).
 RUN mkdir -p core/rust-core/src apps/server/src \
     && echo "pub fn lib() {}" > core/rust-core/src/lib.rs \
     && echo "fn main() {}" > apps/server/src/main.rs \
-    && cargo build --release --package echo-server 2>/dev/null || true \
+    && cargo build --release --package echo-server \
     && rm -rf core/rust-core/src apps/server/src
 
 # Copy real source
@@ -43,7 +49,12 @@ COPY --from=builder /app/target/release/echo-server /usr/local/bin/echo-server
 # inspect schema history).  Point it at the right directory.
 COPY apps/server/migrations /opt/echo/migrations
 
-RUN mkdir -p /app/uploads/avatars
+# Upload directories MUST be owned by `echo` so the non-root runtime
+# user can write into them.  Without the chown, the bind-mount inherits
+# root:root from this stage and every avatar/media upload 500s with
+# "permission denied" (#356, audit H high).
+RUN mkdir -p /app/uploads/avatars \
+    && chown -R echo:echo /app/uploads
 
 USER echo
 EXPOSE 8080
@@ -51,8 +62,14 @@ EXPOSE 8080
 # Audit H27 (#356): healthcheck so traefik / docker-compose stop routing
 # to the container before tcp accepts refuse.  /api/health is a cheap
 # unauthenticated endpoint that returns {"status": "ok", ...}.
+#
+# Force IPv4 (`127.0.0.1`) instead of `localhost`: glibc resolves
+# `localhost` to `::1` first, and the server only binds the IPv4
+# wildcard.  An IPv6-first probe makes the container show as unhealthy
+# and Traefik silently drops it from the load balancer pool, taking the
+# whole API offline (#prod-2026-05-08 web/server postmortem).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-    CMD curl -fsS http://localhost:8080/api/health || exit 1
+    CMD curl -fsS http://127.0.0.1:8080/api/health || exit 1
 
 ENTRYPOINT ["tini", "--"]
 CMD ["echo-server"]

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -37,6 +37,11 @@ pub struct MessageWithSender {
     pub reply_to_content: Option<String>,
     pub reply_to_username: Option<String>,
     pub reply_count: i64,
+    /// Truncated content of the most recent reply to this message
+    /// (Slack-style inline thread preview). `None` when there are no
+    /// replies. Server truncates to 80 characters so the wire payload is
+    /// bounded; clients still render a single line with ellipsis.
+    pub last_reply_snippet: Option<String>,
     /// Reactions aggregated as a JSON array of
     /// `{message_id, user_id, username, emoji}` objects.  Public history
     /// queries (`get_messages`, `get_thread_replies`) populate this with
@@ -233,6 +238,7 @@ pub async fn get_messages(
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
+                lr.snippet AS last_reply_snippet, \
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
@@ -244,6 +250,13 @@ pub async fn get_messages(
              WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL \
              GROUP BY reply_to_id \
          ) rc ON rc.reply_to_id = m.id \
+         LEFT JOIN LATERAL ( \
+             SELECT LEFT(lrm.content, 80) AS snippet \
+             FROM messages lrm \
+             WHERE lrm.reply_to_id = m.id AND lrm.deleted_at IS NULL \
+             ORDER BY lrm.created_at DESC \
+             LIMIT 1 \
+         ) lr ON true \
          LEFT JOIN LATERAL ( \
              SELECT json_agg(json_build_object( \
                  'message_id', r.message_id, \
@@ -333,6 +346,7 @@ pub async fn get_undelivered(
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
+                NULL::text AS last_reply_snippet, \
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
@@ -593,6 +607,7 @@ pub async fn search_messages(
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
+                NULL::text AS last_reply_snippet, \
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
@@ -963,6 +978,7 @@ pub async fn get_thread_replies(
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
+                NULL::text AS last_reply_snippet, \
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -115,6 +115,11 @@ pub struct MessageDto {
     pub reply_to_content: Option<String>,
     pub reply_to_username: Option<String>,
     pub reply_count: i64,
+    /// Truncated content of the most recent reply to this message, when
+    /// `reply_count > 0`. `None` on real-time WS events; only history
+    /// queries (`get_messages`) populate it. Server truncates to 80
+    /// chars; clients render a single line with ellipsis.
+    pub last_reply_snippet: Option<String>,
     /// Reactions on this message: array of
     /// `{message_id, user_id, username, emoji}`.  Aggregated by the DB
     /// query so history reloads render reactions immediately instead of
@@ -138,6 +143,7 @@ impl From<db::messages::MessageWithSender> for MessageDto {
             reply_to_content: m.reply_to_content,
             reply_to_username: m.reply_to_username,
             reply_count: m.reply_count,
+            last_reply_snippet: m.last_reply_snippet,
             reactions: m
                 .reactions
                 .map(|j| j.0)

--- a/apps/server/tests/api_mentions.rs
+++ b/apps/server/tests/api_mentions.rs
@@ -1,0 +1,239 @@
+//! Integration tests for `@-mention` parsing and dispatch (#832, gap 1).
+//!
+//! `db::mentions::extract_and_persist` is invoked from the message send
+//! path on plaintext groups (encrypted groups can't be inspected
+//! server-side and intentionally skip mention persistence). The
+//! resulting rows show up to the client as `mention_count` on
+//! `GET /api/conversations`.
+//!
+//! Coverage:
+//!   * direct `@username` adds one mention to the named user
+//!   * `@everyone` adds a mention to every non-sender member
+//!   * `@here` likewise adds a mention to every non-sender member
+//!     (the suppression in #451 only affects push, not the row)
+//!   * non-existent `@bogus` username is a no-op (no mention rows)
+//!   * the sender does NOT get a mention for `@everyone` / `@here`
+//!
+//! Encrypted DMs are not exercised here: the route never reaches
+//! `extract_and_persist` for encrypted conversations, and DMs are
+//! always encrypted (#591). The asserted contract is therefore "in a
+//! plaintext group".
+
+mod common;
+
+use futures_util::SinkExt;
+use reqwest::Client;
+use serde_json::Value;
+use tokio_tungstenite::tungstenite::Message;
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn connect_ws(base: &str, ticket: &str) -> WsStream {
+    let ws_base = base.replace("http://", "ws://");
+    let (ws, _) = tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={ticket}"))
+        .await
+        .expect("WS connect failed");
+    ws
+}
+
+/// Send a plaintext group message and wait for `message_sent`.
+async fn send_group_message(ws: &mut WsStream, group_id: &str, content: &str) {
+    let send = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group_id,
+        "content": content,
+    });
+    ws.send(Message::Text(send.to_string().into()))
+        .await
+        .expect("send_message failed");
+    let evt = common::recv_until_event(ws, &["message_sent", "error"]).await;
+    assert_eq!(
+        evt["type"], "message_sent",
+        "expected message_sent, got: {evt}"
+    );
+}
+
+/// Fetch the conversation list for `token` and return the row matching
+/// `conversation_id`. Panics if the conversation is not in the list.
+async fn fetch_conversation(
+    client: &Client,
+    base: &str,
+    token: &str,
+    conversation_id: &str,
+) -> Value {
+    let resp = client
+        .get(format!("{base}/api/conversations"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .expect("GET /api/conversations");
+    assert_eq!(resp.status().as_u16(), 200);
+    let list: Vec<Value> = resp.json().await.expect("conversations JSON");
+    list.into_iter()
+        .find(|c| c["conversation_id"].as_str() == Some(conversation_id))
+        .unwrap_or_else(|| panic!("conversation {conversation_id} not in /api/conversations list"))
+}
+
+async fn mention_count(client: &Client, base: &str, token: &str, conv_id: &str) -> i64 {
+    fetch_conversation(client, base, token, conv_id).await["mention_count"]
+        .as_i64()
+        .expect("mention_count missing")
+}
+
+#[tokio::test]
+async fn direct_username_mention_increments_only_mentioned_user() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "mn_alice").await;
+    let (bob_token, bob_id, bob_name) = common::register_and_login(&client, &base, "mn_bob").await;
+    let (charlie_token, charlie_id, _charlie_name) =
+        common::register_and_login(&client, &base, "mn_charlie").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "MentionGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &charlie_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    send_group_message(
+        &mut alice_ws,
+        &group,
+        &format!("hey @{bob_name} have a sec?"),
+    )
+    .await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Only the named user should see mention_count == 1.
+    assert_eq!(mention_count(&client, &base, &bob_token, &group).await, 1);
+    assert_eq!(
+        mention_count(&client, &base, &charlie_token, &group).await,
+        0
+    );
+    // Sender's own count stays 0 (alice was not the named user).
+    assert_eq!(mention_count(&client, &base, &alice_token, &group).await, 0);
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn at_everyone_mentions_all_non_sender_members() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "mn_ev_a").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "mn_ev_b").await;
+    let (carol_token, carol_id, _) = common::register_and_login(&client, &base, "mn_ev_c").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "EveryoneGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &carol_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    send_group_message(&mut alice_ws, &group, "@everyone all hands meeting").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Both non-sender members should have one mention.
+    assert_eq!(mention_count(&client, &base, &bob_token, &group).await, 1);
+    assert_eq!(mention_count(&client, &base, &carol_token, &group).await, 1);
+    // Sender is filtered out.
+    assert_eq!(mention_count(&client, &base, &alice_token, &group).await, 0);
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn at_here_mentions_all_non_sender_members() {
+    // @here writes the same mention rows as @everyone -- the suppression
+    // in #451 only changes the push fanout, not the persisted mention.
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "mn_hr_a").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "mn_hr_b").await;
+    let (carol_token, carol_id, _) = common::register_and_login(&client, &base, "mn_hr_c").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "HereGroup2").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &carol_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    send_group_message(&mut alice_ws, &group, "@here are you free?").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    assert_eq!(mention_count(&client, &base, &bob_token, &group).await, 1);
+    assert_eq!(mention_count(&client, &base, &carol_token, &group).await, 1);
+    assert_eq!(mention_count(&client, &base, &alice_token, &group).await, 0);
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn nonexistent_username_mention_is_noop() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "mn_nx_a").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "mn_nx_b").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "BogusGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Reference a user who does not exist anywhere in the system.
+    send_group_message(&mut alice_ws, &group, "ping @nobody_with_this_name").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Nobody gets a mention row.
+    assert_eq!(mention_count(&client, &base, &alice_token, &group).await, 0);
+    assert_eq!(mention_count(&client, &base, &bob_token, &group).await, 0);
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn mention_of_non_member_username_is_filtered() {
+    // An existing user who is NOT a member of the group must not get a
+    // mention row -- the resolver joins on `conversation_members` so a
+    // typo'd `@<unrelated user>` cannot pull them into a group's badge.
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "mn_nm_a").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "mn_nm_b").await;
+    let (outsider_token, _outsider_id, outsider_name) =
+        common::register_and_login(&client, &base, "mn_nm_outsider").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "ScopedGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+    // outsider is intentionally NOT added.
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    send_group_message(&mut alice_ws, &group, &format!("ghost @{outsider_name}")).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Bob (real member) gets no mention; outsider isn't in this group's
+    // conversation list at all so we don't query their badge here -- the
+    // assertion that matters is that nothing leaks into the group's row.
+    assert_eq!(mention_count(&client, &base, &bob_token, &group).await, 0);
+    assert_eq!(mention_count(&client, &base, &alice_token, &group).await, 0);
+
+    let _ = alice_ws.close(None).await;
+    let _ = outsider_token;
+}

--- a/apps/server/tests/api_messages_reply_snippet.rs
+++ b/apps/server/tests/api_messages_reply_snippet.rs
@@ -1,0 +1,221 @@
+//! Integration tests for the `last_reply_snippet` field added in #423.
+//!
+//! The field surfaces the most-recent reply's content under the parent
+//! message in the main conversation view (Slack-style inline preview).
+//! It is populated only by `get_messages` (history) -- the WS real-time
+//! path keeps using `reply_count` increments and does not carry the
+//! snippet on `message_reply_added`.
+//!
+//! Invariants exercised here:
+//!   * 0 replies          -> snippet is null
+//!   * 1 reply            -> snippet equals that reply's canonical content
+//!   * many replies       -> snippet equals the LATEST by created_at
+//!   * server-side cap    -> snippet length never exceeds 80 chars
+//!
+//! DMs are encrypted, so the canonical `messages.content` is always the
+//! base64-wrapped ciphertext envelope `dummy_ciphertext` produces. The
+//! snippet is sliced from that same string, so assertions compare
+//! against the ciphertext (not a human-readable body).
+
+mod common;
+
+use futures_util::SinkExt;
+use reqwest::Client;
+use serde_json::Value;
+use tokio_tungstenite::tungstenite::Message;
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn connect_ws(base: &str, ticket: &str) -> WsStream {
+    let ws_base = base.replace("http://", "ws://");
+    let (ws, _) = tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={ticket}"))
+        .await
+        .expect("WS connect failed");
+    ws
+}
+
+/// Post a `send_message` whose canonical body is `dummy_ciphertext(tag)`,
+/// optionally as a reply to `reply_to_id`. Returns `(message_id, canonical)`
+/// so callers can assert the snippet equals the canonical content of the
+/// most-recent reply.
+async fn post(
+    ws: &mut WsStream,
+    conversation_id: &str,
+    tag: &str,
+    recipient_user_id: &str,
+    reply_to_id: Option<&str>,
+) -> (String, String) {
+    let canonical = common::dummy_ciphertext(&format!("{tag}_canonical"));
+    let recipient_ct = common::dummy_ciphertext(&format!("{tag}_recipient"));
+    let mut frame = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": conversation_id,
+        "content": canonical,
+        "recipient_device_contents": {
+            recipient_user_id.to_string(): { "0": recipient_ct },
+        },
+    });
+    if let Some(parent) = reply_to_id {
+        frame
+            .as_object_mut()
+            .unwrap()
+            .insert("reply_to_id".into(), serde_json::json!(parent));
+    }
+    ws.send(Message::Text(frame.to_string().into()))
+        .await
+        .expect("send_message failed");
+    let evt = common::recv_until_event(ws, &["message_sent", "error"]).await;
+    assert_eq!(
+        evt["type"], "message_sent",
+        "expected message_sent, got: {evt}"
+    );
+    let id = evt["message_id"]
+        .as_str()
+        .expect("missing message_id")
+        .to_string();
+    (id, canonical)
+}
+
+async fn fetch_messages(client: &Client, base: &str, token: &str, conv_id: &str) -> Vec<Value> {
+    let resp = client
+        .get(format!("{base}/api/messages/{conv_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .expect("GET messages");
+    assert_eq!(resp.status().as_u16(), 200);
+    resp.json::<Vec<Value>>().await.expect("messages JSON")
+}
+
+fn truncate_80(s: &str) -> String {
+    // Match Postgres `LEFT(content, 80)` (chars, not bytes). Our test
+    // payloads are ASCII so chars == bytes either way.
+    s.chars().take(80).collect()
+}
+
+#[tokio::test]
+async fn last_reply_snippet_zero_one_many() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "snip_alice").await;
+    let (bob_token, bob_id, bob_name) =
+        common::register_and_login(&client, &base, "snip_bob").await;
+
+    let conv =
+        common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Parent with zero replies: snippet should be null.
+    let (parent_id, _) = post(&mut alice_ws, &conv, "parent", &bob_id, None).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let listing = fetch_messages(&client, &base, &alice_token, &conv).await;
+    let parent_row = listing
+        .iter()
+        .find(|m| m["id"].as_str() == Some(&parent_id))
+        .expect("parent row");
+    assert_eq!(parent_row["reply_count"].as_i64(), Some(0));
+    assert!(
+        parent_row["last_reply_snippet"].is_null(),
+        "zero-reply parent must have null snippet, got: {}",
+        parent_row["last_reply_snippet"]
+    );
+
+    // One reply: snippet should equal the reply's canonical content
+    // (truncated to 80 chars by the server).
+    let (_r1, r1_canonical) = post(&mut alice_ws, &conv, "r1", &bob_id, Some(&parent_id)).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let listing = fetch_messages(&client, &base, &alice_token, &conv).await;
+    let parent_row = listing
+        .iter()
+        .find(|m| m["id"].as_str() == Some(&parent_id))
+        .expect("parent row");
+    assert_eq!(parent_row["reply_count"].as_i64(), Some(1));
+    assert_eq!(
+        parent_row["last_reply_snippet"].as_str(),
+        Some(truncate_80(&r1_canonical).as_str()),
+        "one-reply snippet must equal that reply's truncated canonical content"
+    );
+
+    // Many replies: snippet should be the LATEST one by created_at.
+    let (_r2, _) = post(&mut alice_ws, &conv, "r2", &bob_id, Some(&parent_id)).await;
+    common::drain_pending(&mut alice_ws).await;
+    let (_r3, r3_canonical) =
+        post(&mut alice_ws, &conv, "r3_latest", &bob_id, Some(&parent_id)).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let listing = fetch_messages(&client, &base, &alice_token, &conv).await;
+    let parent_row = listing
+        .iter()
+        .find(|m| m["id"].as_str() == Some(&parent_id))
+        .expect("parent row");
+    assert_eq!(parent_row["reply_count"].as_i64(), Some(3));
+    assert_eq!(
+        parent_row["last_reply_snippet"].as_str(),
+        Some(truncate_80(&r3_canonical).as_str()),
+        "many-reply snippet must equal the chronologically latest reply's truncated content"
+    );
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn last_reply_snippet_truncates_to_80_chars() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _alice_name) =
+        common::register_and_login(&client, &base, "snip_long_a").await;
+    let (bob_token, bob_id, bob_name) =
+        common::register_and_login(&client, &base, "snip_long_b").await;
+
+    let conv =
+        common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let (parent_id, _) = post(&mut alice_ws, &conv, "parent", &bob_id, None).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Use a long tag so dummy_ciphertext produces a base64 payload well
+    // over 80 chars. The 200-char tag below yields a >250-char base64
+    // body; the server must clamp the wire snippet to 80.
+    let long_tag = "x".repeat(200);
+    let (_, long_canonical) =
+        post(&mut alice_ws, &conv, &long_tag, &bob_id, Some(&parent_id)).await;
+    common::drain_pending(&mut alice_ws).await;
+    assert!(
+        long_canonical.chars().count() > 80,
+        "test setup: payload should be >80 chars to exercise the cap"
+    );
+
+    let listing = fetch_messages(&client, &base, &alice_token, &conv).await;
+    let parent_row = listing
+        .iter()
+        .find(|m| m["id"].as_str() == Some(&parent_id))
+        .expect("parent row");
+    let snippet = parent_row["last_reply_snippet"]
+        .as_str()
+        .expect("snippet must be present for non-empty thread");
+    assert!(
+        snippet.chars().count() <= 80,
+        "snippet must be clamped server-side; got {} chars",
+        snippet.chars().count()
+    );
+    assert_eq!(
+        snippet,
+        truncate_80(&long_canonical),
+        "snippet must be the first 80 chars of the canonical reply body"
+    );
+
+    let _ = alice_ws.close(None).await;
+}

--- a/apps/server/tests/api_reactions_aggregation.rs
+++ b/apps/server/tests/api_reactions_aggregation.rs
@@ -1,0 +1,332 @@
+//! Integration tests for reaction aggregation on the history wire (#832, gap 3).
+//!
+//! The reaction wire shape is anchored by the LATERAL `json_agg` in
+//! `db::messages::get_messages`: every `(user_id, emoji)` row of the
+//! `reactions` table that joins to a message becomes one entry in the
+//! returned `reactions` array on the history JSON. Clients aggregate
+//! counts client-side by counting entries with the same `emoji`.
+//!
+//! Invariants exercised:
+//!   * two users react with the same emoji -> two array entries -> count == 2
+//!   * same user reacts twice with same emoji -> one array entry
+//!     (ON CONFLICT idempotent; #832 gap 3 explicitly calls this out)
+//!   * different emoji per user -> both tracked separately
+//!   * removing a reaction drops it from the array
+//!   * a soft-deleted message hides its reactions from history (the
+//!     `deleted_at IS NULL` filter on the parent join means the LEFT
+//!     JOIN never materialises the message row at all)
+
+mod common;
+
+use futures_util::SinkExt;
+use reqwest::Client;
+use serde_json::Value;
+use tokio_tungstenite::tungstenite::Message;
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn connect_ws(base: &str, ticket: &str) -> WsStream {
+    let ws_base = base.replace("http://", "ws://");
+    let (ws, _) = tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={ticket}"))
+        .await
+        .expect("WS connect failed");
+    ws
+}
+
+/// Send a plaintext group message and return the `message_id`.
+async fn send_plain_message(ws: &mut WsStream, group_id: &str, content: &str) -> String {
+    let frame = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group_id,
+        "content": content,
+    });
+    ws.send(Message::Text(frame.to_string().into()))
+        .await
+        .expect("send_message failed");
+    let evt = common::recv_until_event(ws, &["message_sent", "error"]).await;
+    assert_eq!(evt["type"], "message_sent", "got: {evt}");
+    evt["message_id"].as_str().unwrap().to_string()
+}
+
+async fn add_reaction(
+    client: &Client,
+    base: &str,
+    token: &str,
+    message_id: &str,
+    emoji: &str,
+) -> u16 {
+    client
+        .post(format!("{base}/api/messages/{message_id}/reactions"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "emoji": emoji }))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .as_u16()
+}
+
+async fn remove_reaction(
+    client: &Client,
+    base: &str,
+    token: &str,
+    message_id: &str,
+    emoji: &str,
+) -> u16 {
+    client
+        .delete(format!(
+            "{base}/api/messages/{message_id}/reactions/{emoji}"
+        ))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .as_u16()
+}
+
+/// Return the `reactions` array on the parent message from
+/// `GET /api/messages/{conv}`. Panics if the message is missing.
+async fn fetch_reactions(
+    client: &Client,
+    base: &str,
+    token: &str,
+    conv: &str,
+    message_id: &str,
+) -> Vec<Value> {
+    let resp = client
+        .get(format!("{base}/api/messages/{conv}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let list: Vec<Value> = resp.json().await.unwrap();
+    let row = list
+        .into_iter()
+        .find(|m| m["id"].as_str() == Some(message_id))
+        .unwrap_or_else(|| panic!("message {message_id} not in history"));
+    row["reactions"].as_array().cloned().unwrap_or_default()
+}
+
+fn count_emoji(reactions: &[Value], emoji: &str) -> usize {
+    reactions
+        .iter()
+        .filter(|r| r["emoji"].as_str() == Some(emoji))
+        .count()
+}
+
+#[tokio::test]
+async fn two_users_same_emoji_aggregate_to_count_two() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "rxa_alice").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "rxa_bob").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "TwoUsersGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let msg_id = send_plain_message(&mut alice_ws, &group, "react to me").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    assert_eq!(
+        add_reaction(&client, &base, &alice_token, &msg_id, "👍").await,
+        201
+    );
+    assert_eq!(
+        add_reaction(&client, &base, &bob_token, &msg_id, "👍").await,
+        201
+    );
+
+    let reactions = fetch_reactions(&client, &base, &alice_token, &group, &msg_id).await;
+    assert_eq!(
+        count_emoji(&reactions, "👍"),
+        2,
+        "two users reacting with the same emoji must aggregate to 2: {reactions:?}"
+    );
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn same_user_same_emoji_is_idempotent() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "rxa_idem").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "IdempotentGroup").await;
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let msg_id = send_plain_message(&mut alice_ws, &group, "double tap").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Two POSTs with the same emoji from the same user must yield one row.
+    assert_eq!(
+        add_reaction(&client, &base, &alice_token, &msg_id, "🎉").await,
+        201
+    );
+    assert_eq!(
+        add_reaction(&client, &base, &alice_token, &msg_id, "🎉").await,
+        201,
+        "second POST is still a 201 (ON CONFLICT DO UPDATE)"
+    );
+
+    let reactions = fetch_reactions(&client, &base, &alice_token, &group, &msg_id).await;
+    assert_eq!(
+        count_emoji(&reactions, "🎉"),
+        1,
+        "same user + same emoji must collapse to a single entry: {reactions:?}"
+    );
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn different_emoji_per_user_tracked_separately() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) =
+        common::register_and_login(&client, &base, "rxa_diff_a").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "rxa_diff_b").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "DiffEmojiGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let msg_id = send_plain_message(&mut alice_ws, &group, "split vote").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    assert_eq!(
+        add_reaction(&client, &base, &alice_token, &msg_id, "👍").await,
+        201
+    );
+    assert_eq!(
+        add_reaction(&client, &base, &bob_token, &msg_id, "👎").await,
+        201
+    );
+
+    let reactions = fetch_reactions(&client, &base, &alice_token, &group, &msg_id).await;
+    assert_eq!(count_emoji(&reactions, "👍"), 1);
+    assert_eq!(count_emoji(&reactions, "👎"), 1);
+    assert_eq!(reactions.len(), 2);
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn remove_reaction_drops_it_from_history() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "rxa_rm_a").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "rxa_rm_b").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "RemoveGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let msg_id = send_plain_message(&mut alice_ws, &group, "remove me").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    assert_eq!(
+        add_reaction(&client, &base, &alice_token, &msg_id, "💯").await,
+        201
+    );
+    assert_eq!(
+        add_reaction(&client, &base, &bob_token, &msg_id, "💯").await,
+        201
+    );
+    assert_eq!(
+        count_emoji(
+            &fetch_reactions(&client, &base, &alice_token, &group, &msg_id).await,
+            "💯"
+        ),
+        2
+    );
+
+    // Bob removes his reaction; only alice's remains.
+    assert_eq!(
+        remove_reaction(&client, &base, &bob_token, &msg_id, "💯").await,
+        200
+    );
+    let after = fetch_reactions(&client, &base, &alice_token, &group, &msg_id).await;
+    assert_eq!(
+        count_emoji(&after, "💯"),
+        1,
+        "removing one user's reaction must drop exactly one entry: {after:?}"
+    );
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn soft_deleted_message_drops_its_reactions_from_history() {
+    // `get_messages` filters `m.deleted_at IS NULL`, which short-circuits the
+    // LATERAL reaction aggregate for soft-deleted parents.  Once Alice deletes
+    // her own message, the row disappears from history and so does the
+    // reaction count -- the underlying `reactions` table rows still exist
+    // (no CASCADE on soft-delete) but the wire never surfaces them again.
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) = common::register_and_login(&client, &base, "rxa_sd_a").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "rxa_sd_b").await;
+
+    let group = common::create_group(&client, &base, &alice_token, "SoftDelGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group, &bob_id).await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let msg_id = send_plain_message(&mut alice_ws, &group, "going away").await;
+    common::drain_pending(&mut alice_ws).await;
+
+    assert_eq!(
+        add_reaction(&client, &base, &bob_token, &msg_id, "✅").await,
+        201
+    );
+
+    // Alice (the sender) soft-deletes the message.
+    let del = client
+        .delete(format!("{base}/api/messages/{msg_id}"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    // DELETE /api/messages/:id returns 204 No Content on success.
+    assert_eq!(del.status().as_u16(), 204);
+
+    // History should no longer include the message at all.
+    let resp = client
+        .get(format!("{base}/api/messages/{group}"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    let list: Vec<Value> = resp.json().await.unwrap();
+    assert!(
+        !list
+            .iter()
+            .any(|m| m["id"].as_str() == Some(msg_id.as_str())),
+        "soft-deleted message must vanish from history (and so do its reactions)"
+    );
+
+    let _ = alice_ws.close(None).await;
+}

--- a/apps/server/tests/ws_content_rejection.rs
+++ b/apps/server/tests/ws_content_rejection.rs
@@ -1,0 +1,152 @@
+//! Integration tests for WS `send_message` content validation (#832, gap 2).
+//!
+//! `validate_message_length` (apps/server/src/ws/message_service.rs:66)
+//! rejects empty/whitespace-only content and content over
+//! `MAX_MESSAGE_LENGTH` (10,000 chars). The check ships an `error`
+//! frame back to the sender and persists nothing.
+//!
+//! Covered:
+//!   * empty `content` rejected before persistence
+//!   * whitespace-only `content` rejected before persistence
+//!   * content of `MAX_MESSAGE_LENGTH + 1` rejected with a "too long"
+//!     error
+//!
+//! We use a plaintext group so the validator runs without the
+//! ciphertext-shape gate getting in the way -- the gate only triggers
+//! on encrypted conversations (#591).
+
+mod common;
+
+use futures_util::SinkExt;
+use reqwest::Client;
+use serde_json::Value;
+use tokio_tungstenite::tungstenite::Message;
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn connect_ws(base: &str, ticket: &str) -> WsStream {
+    let ws_base = base.replace("http://", "ws://");
+    let (ws, _) = tokio_tungstenite::connect_async(format!("{ws_base}/ws?ticket={ticket}"))
+        .await
+        .expect("WS connect failed");
+    ws
+}
+
+async fn fetch_history(client: &Client, base: &str, token: &str, conv: &str) -> Vec<Value> {
+    let resp = client
+        .get(format!("{base}/api/messages/{conv}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    resp.json::<Vec<Value>>().await.unwrap()
+}
+
+async fn send_and_expect_error(ws: &mut WsStream, frame: Value, error_contains: &str) {
+    ws.send(Message::Text(frame.to_string().into()))
+        .await
+        .expect("send failed");
+    let evt = common::recv_until_event(ws, &["error", "message_sent"]).await;
+    assert_eq!(evt["type"], "error", "expected error frame, got: {evt}");
+    let msg = evt["message"]
+        .as_str()
+        .expect("error frame missing message");
+    assert!(
+        msg.to_lowercase().contains(&error_contains.to_lowercase()),
+        "error message {msg:?} did not contain {error_contains:?}"
+    );
+}
+
+#[tokio::test]
+async fn empty_content_rejected() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) =
+        common::register_and_login(&client, &base, "wsce_alice_empty").await;
+    let group = common::create_group(&client, &base, &alice_token, "EmptyContent").await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    let frame = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group,
+        "content": "",
+    });
+    send_and_expect_error(&mut alice_ws, frame, "empty").await;
+
+    // Nothing should land in history.
+    let history = fetch_history(&client, &base, &alice_token, &group).await;
+    assert!(
+        history.is_empty(),
+        "rejected message must not be persisted, history: {history:?}"
+    );
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn whitespace_only_content_rejected() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) =
+        common::register_and_login(&client, &base, "wsce_alice_ws").await;
+    let group = common::create_group(&client, &base, &alice_token, "WhitespaceContent").await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Spaces, tabs, newlines should all trim to nothing.
+    let frame = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group,
+        "content": "   \t\n  ",
+    });
+    send_and_expect_error(&mut alice_ws, frame, "empty").await;
+
+    let history = fetch_history(&client, &base, &alice_token, &group).await;
+    assert!(
+        history.is_empty(),
+        "whitespace-only message must not be persisted, history: {history:?}"
+    );
+
+    let _ = alice_ws.close(None).await;
+}
+
+#[tokio::test]
+async fn content_over_max_length_rejected() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, _) =
+        common::register_and_login(&client, &base, "wsce_alice_long").await;
+    let group = common::create_group(&client, &base, &alice_token, "LongContent").await;
+
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // MAX_MESSAGE_LENGTH is 10_000 bytes; one byte over must reject.
+    let too_long = "a".repeat(10_001);
+    let frame = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group,
+        "content": too_long,
+    });
+    send_and_expect_error(&mut alice_ws, frame, "too long").await;
+
+    let history = fetch_history(&client, &base, &alice_token, &group).await;
+    assert!(
+        history.is_empty(),
+        "over-length message must not be persisted, history len: {}",
+        history.len()
+    );
+
+    let _ = alice_ws.close(None).await;
+}

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -24,6 +24,17 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Override the image-baked HEALTHCHECK so the prod contract is visible
+    # in compose and immune to image-level drift. Uses 127.0.0.1 (not
+    # `localhost`) to dodge the glibc IPv6-first lookup that bit the web
+    # service in #prod-2026-05-08; the server binds the IPv4 wildcard
+    # only and an `::1` probe would silently fail.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.echo-api.rule=Host(`echo-messenger.us`) && (PathPrefix(`/api`) || PathPrefix(`/ws`))"


### PR DESCRIPTION
Four-issue batch.

## New
- **Latest reply preview under parent messages** (#423). Slack-style snippet of the most recent reply appears beneath the reply-count badge. Server adds `last_reply_snippet` (LATERAL subquery, 80-char server-side truncation). Client renders italic, muted, single-line. Gated on `!isEncrypted` so we never leak ciphertext.

## Fixed
- **Server healthcheck on prod compose** (#356). Curls `127.0.0.1:8080/api/health` (avoids IPv6-first lookup that masked outages). Baked-in HEALTHCHECK in the Dockerfile also switched to `127.0.0.1`.
- **Upload-dir chown in the server Dockerfile** (#356). `/app/uploads` is now owned by the non-root `echo:echo` user at image build time instead of relying on runtime fallback.
- **Removed `|| true` from a dep-prebuild RUN** (#356). Real build failures no longer hide.
- **Hover-overlay Semantics announces the correct action** (#830 finding 11). Was lying about being a button; now reflects the `onLongPress` callback.

## Behind the scenes
- **Three high-severity integration-test gaps closed** (#832):
  - `api_mentions.rs` — 5 tests covering @username / @everyone / @here / non-existent / non-member-filter dispatch.
  - `ws_content_rejection.rs` — 3 tests covering empty / whitespace-only / over-max-length payloads.
  - `api_reactions_aggregation.rs` — 5 tests covering same-emoji counter, idempotent re-reactions, different emoji tracking, removal, and `deleted_at IS NULL` filter.
- Mobile UI gaps (#769) confirmed-already-shipped (filled icon variants + unread badge + Discover route already in `home_screen.dart:1421-1444`). Remaining sub-items in the #769 body are bigger UX work; deferred.
- Audit finding #830-12 (timestamp formatter) deferred — naive caching regresses the relative-time tick.

## Test plan
- [x] `flutter test` — 1513 passed, 0 failed, 8 skipped
- [x] `cargo test -p echo-server` — all suites pass (15 new test cases)
- [x] `flutter analyze --fatal-infos` clean
- [x] `dart format --set-exit-if-changed .` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

Closes #356. Closes #832. Partial close of #423 (full thread surface still in scope of future work). Updates #830 + #769.