### PR TITLE
Beta polish batch: 11 user-visible fixes

### DIFF
--- a/apps/client/lib/src/providers/auth/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.dart
@@ -125,13 +125,24 @@ class AuthNotifier extends _$AuthNotifier
   Future<void> register(String username, String password) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      final response = await http
-          .post(
-            Uri.parse('$_serverUrl/api/auth/register'),
-            headers: _kJsonHeaders,
-            body: jsonEncode({'username': username, 'password': password}),
-          )
-          .timeout(const Duration(seconds: 15));
+      // On web we MUST use the credentialed BrowserClient so the
+      // HttpOnly Set-Cookie refresh-token response header is actually stored
+      // by the browser. Without `withCredentials = true` the cookie is
+      // silently dropped from a CORS response and the user gets logged out
+      // on the next page refresh (#929).
+      final client = buildHttpClient();
+      final http.Response response;
+      try {
+        response = await client
+            .post(
+              Uri.parse('$_serverUrl/api/auth/register'),
+              headers: _kJsonHeaders,
+              body: jsonEncode({'username': username, 'password': password}),
+            )
+            .timeout(const Duration(seconds: 15));
+      } finally {
+        client.close();
+      }
 
       if (response.statusCode == 200 || response.statusCode == 201) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -179,13 +190,24 @@ class AuthNotifier extends _$AuthNotifier
   Future<void> login(String username, String password) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      final response = await http
-          .post(
-            Uri.parse('$_serverUrl/api/auth/login'),
-            headers: _kJsonHeaders,
-            body: jsonEncode({'username': username, 'password': password}),
-          )
-          .timeout(const Duration(seconds: 15));
+      // On web we MUST use the credentialed BrowserClient so the
+      // HttpOnly Set-Cookie refresh-token response header is actually stored
+      // by the browser. Without `withCredentials = true` the cookie is
+      // silently dropped from a CORS response and the user gets logged out
+      // on the next page refresh (#929).
+      final client = buildHttpClient();
+      final http.Response response;
+      try {
+        response = await client
+            .post(
+              Uri.parse('$_serverUrl/api/auth/login'),
+              headers: _kJsonHeaders,
+              body: jsonEncode({'username': username, 'password': password}),
+            )
+            .timeout(const Duration(seconds: 15));
+      } finally {
+        client.close();
+      }
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;

--- a/apps/client/lib/src/screens/settings/devices_section.dart
+++ b/apps/client/lib/src/screens/settings/devices_section.dart
@@ -417,24 +417,28 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
         ? ref.watch(cryptoServiceProvider).deviceId
         : null;
 
+    // Layout mirrors the other settings sections (notifications, privacy,
+    // appearance, ...): Center > ConstrainedBox(maxWidth: 900) > ListView
+    // with `padding: EdgeInsets.all(24)` and an 18px header. The previous
+    // mix of `shrinkWrap: true` + child-side LTRB padding caused the column
+    // to read as left-aligned relative to the settings top bar (#916).
     return Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 900),
         child: ListView(
-          shrinkWrap: true,
+          padding: const EdgeInsets.all(24),
           children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
-              child: Row(
-                children: [
-                  Column(
+            Row(
+              children: [
+                Expanded(
+                  child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
                         'My Devices',
                         style: TextStyle(
                           color: context.textPrimary,
-                          fontSize: 20,
+                          fontSize: 18,
                           fontWeight: FontWeight.w700,
                         ),
                       ),
@@ -448,15 +452,15 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
                       ),
                     ],
                   ),
-                  const Spacer(),
-                  IconButton(
-                    icon: Icon(Icons.refresh, color: context.textSecondary),
-                    tooltip: 'Refresh',
-                    onPressed: _loading ? null : _loadDevices,
-                  ),
-                ],
-              ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.refresh, color: context.textSecondary),
+                  tooltip: 'Refresh',
+                  onPressed: _loading ? null : _loadDevices,
+                ),
+              ],
             ),
+            const SizedBox(height: 12),
             const Divider(height: 1),
             _buildDeviceListBody(context, myDeviceId),
             if (!_loading &&
@@ -464,7 +468,7 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
                 myDeviceId != null &&
                 _devices.any((d) => d.deviceId != myDeviceId))
               Padding(
-                padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+                padding: const EdgeInsets.only(top: 16),
                 child: Align(
                   alignment: Alignment.centerLeft,
                   child: TextButton.icon(

--- a/apps/client/lib/src/services/toast_service.dart
+++ b/apps/client/lib/src/services/toast_service.dart
@@ -22,6 +22,7 @@ class ToastService {
     String? actionLabel,
     VoidCallback? onAction,
     Duration? duration,
+    OverlayState? overlay,
   }) {
     // Mirror error and warning toasts into the debug log so they are always
     // visible in Settings > Debug Logs, even if the on-screen toast was missed.
@@ -34,7 +35,10 @@ class ToastService {
     // Remove any existing toast immediately.
     _dismiss();
 
-    final overlay = Overlay.of(context);
+    // Callers that hand in an [overlay] explicitly bypass the `Overlay.of`
+    // lookup -- needed when the trigger context (e.g. a dialog about to pop)
+    // is no longer in the tree by the time the toast fires (#928).
+    final resolved = overlay ?? Overlay.of(context);
 
     final hasAction = actionLabel != null;
     final effectiveDuration =
@@ -56,7 +60,7 @@ class ToastService {
     );
 
     _currentEntry = entry;
-    overlay.insert(entry);
+    resolved.insert(entry);
 
     _dismissTimer = Timer(effectiveDuration, _dismiss);
   }

--- a/apps/client/lib/src/services/window_state_service.dart
+++ b/apps/client/lib/src/services/window_state_service.dart
@@ -1,5 +1,5 @@
 import 'dart:io' show Platform;
-import 'dart:ui' show Size;
+import 'dart:ui' show Offset, Size;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -16,6 +16,8 @@ import 'package:window_manager/window_manager.dart';
 class WindowStateService {
   static const _kWidthKey = 'window.width';
   static const _kHeightKey = 'window.height';
+  static const _kXKey = 'window.x';
+  static const _kYKey = 'window.y';
 
   /// Default window size on first launch (matches the GTK runner's
   /// `gtk_window_set_default_size(1280, 720)`).
@@ -27,10 +29,10 @@ class WindowStateService {
     return Platform.isLinux || Platform.isWindows || Platform.isMacOS;
   }
 
-  /// Save the current window size to SharedPreferences.
+  /// Save the current window size + position to SharedPreferences.
   ///
-  /// Position (x, y) is intentionally not saved: restoring a splash-era
-  /// centered position pushes the full-size window off-screen.
+  /// Position is clamped on restore to stay on-screen; here we just store
+  /// whatever the user last positioned the window to.
   static Future<void> save() async {
     if (!_isDesktop) return;
     try {
@@ -38,6 +40,13 @@ class WindowStateService {
       final size = await windowManager.getSize();
       await prefs.setDouble(_kWidthKey, size.width);
       await prefs.setDouble(_kHeightKey, size.height);
+      try {
+        final pos = await windowManager.getPosition();
+        await prefs.setDouble(_kXKey, pos.dx);
+        await prefs.setDouble(_kYKey, pos.dy);
+      } catch (_) {
+        // getPosition isn't reliable on all platforms; size alone is fine.
+      }
     } catch (_) {
       // Never block app shutdown on a failed window-state save.
     }
@@ -62,9 +71,21 @@ class WindowStateService {
         height.clamp(480.0, 10000.0),
       );
       await windowManager.setSize(size);
-      // Always center — restoring saved (x, y) risks placing the full-size
-      // window at the splash-era center coordinates, pushing it off-screen.
-      await windowManager.center();
+      // Restore saved (x, y) if present and within a sane range. Falls back
+      // to centre when no position is saved OR the saved coordinates look
+      // off-screen (multi-monitor disconnect, resolution change, garbage
+      // stored from an older build).
+      final savedX = prefs.getDouble(_kXKey);
+      final savedY = prefs.getDouble(_kYKey);
+      const sanityMin = -10000.0;
+      const sanityMax = 10000.0;
+      final saneX = savedX != null && savedX > sanityMin && savedX < sanityMax;
+      final saneY = savedY != null && savedY > -50.0 && savedY < sanityMax;
+      if (saneX && saneY) {
+        await windowManager.setPosition(Offset(savedX, savedY));
+      } else {
+        await windowManager.center();
+      }
     } catch (_) {
       // Falling back to whatever size the splash set is acceptable.
     }

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -69,10 +69,23 @@ class EchoTheme {
         ? ThemeData.dark().textTheme
         : ThemeData.light().textTheme;
     final baseTextTheme = GoogleFonts.interTextTheme(base);
-    // Route any glyph not present in Inter (notably emoji codepoints) to the
-    // bundled NotoEmoji font. Without this fallback, AppImage builds render
-    // tofu boxes when the host system fonts are missing.
-    const emojiFallback = ['NotoEmoji'];
+    // Route any glyph not present in Inter (notably emoji codepoints) to a
+    // fallback chain. Platform-native emoji fonts come FIRST: 'Apple Color
+    // Emoji' (macOS/iOS) and 'Segoe UI Emoji' (Windows) both ship with the
+    // GSUB ligature table that combines regional-indicator pairs into the
+    // expected flag glyph (#917). 'Twemoji Mozilla' covers Linux distros
+    // that ship Twemoji. NotoEmoji is kept at the end as the last-resort
+    // fallback so AppImage builds without system emoji fonts still render
+    // tofu-free for most codepoints -- the bundled CBDT NotoColorEmoji
+    // does not include flag ligatures, so Linux desktops without a system
+    // emoji font will still show regional-indicator letter pairs for
+    // flags. Tracked as a follow-up to ship a COLRv1 build.
+    const emojiFallback = [
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Twemoji Mozilla',
+      'NotoEmoji',
+    ];
     return baseTextTheme.copyWith(
       headlineLarge: baseTextTheme.headlineLarge?.copyWith(
         fontSize: 24,

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -97,6 +97,13 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   String? _highlightedMessageId;
   String? _pendingInitialMessageId;
   Timer? _highlightTimer;
+
+  /// Set on first open of a conversation. Cleared when the history load that
+  /// followed the initial `_scrollToBottom` finishes. While true, the listener
+  /// in [build] re-triggers `_scrollToBottom` so we land at the genuinely
+  /// newest message even when history pages render after the first scroll
+  /// (#919).
+  bool _initialScrollPending = false;
   double get _lastKeyboardInset => _controller.lastKeyboardInset;
   set _lastKeyboardInset(double v) => _controller.lastKeyboardInset = v;
   bool _isDragOver = false;
@@ -183,6 +190,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       _newMessagesBelowCount = 0;
       _unreadBoundaryMessageId = null;
       _unreadBoundaryCount = 0;
+      _initialScrollPending = false;
       _controller.floatingDate = null;
       _controller.floatingDateVisible = false;
       _controller.floatingDateTimer?.cancel();
@@ -761,9 +769,41 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         } else if (_unreadBoundaryMessageId != null) {
           _scrollToUnreadBoundary();
         } else {
+          // First open: history is loading async in parallel and may render
+          // additional rows over the next several hundred ms. Mark the scroll
+          // as pending so we re-trigger it when the load completes; landing
+          // on the genuinely-newest message requires waiting for the layout
+          // pass that includes those new rows (#919).
+          _initialScrollPending = true;
           _scrollToBottom(settleRetries: 3);
         }
       });
+    }
+
+    // Re-scroll to bottom when the initial history load completes. The first
+    // `_scrollToBottom` above fires before any rows are rendered; once the
+    // server returns and the list grows downward, we want to land at the
+    // newest message rather than wherever the partial list ended (#919).
+    if (_initialScrollPending) {
+      ref.listen(
+        chatProvider.select(
+          (s) => s.isLoadingHistory(conv.id, channelId: _selectedTextChannelId),
+        ),
+        (prev, next) {
+          // Only react to the load FINISHING (true -> false) and only on
+          // the initial open.
+          if (!_initialScrollPending) return;
+          if (prev == true && next == false) {
+            _initialScrollPending = false;
+            // Defer to the next frame so the layout pass with the loaded
+            // messages has actually run before we read maxScrollExtent.
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              _scrollToBottom(animated: false, settleRetries: 3);
+            });
+          }
+        },
+      );
     }
 
     _handleKeyboardScroll();

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -527,14 +527,19 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
                   wsOnlineUsers,
                 ),
               ),
+              // Hide the status bar on mobile narrow — redundant with the
+              // bottom tab bar that already exposes Settings + identity.
+              //
+              // The update banner / bug-report row sits ABOVE the VoiceFooter
+              // so the desktop voice-dock overlay (`_buildDesktopVoiceDock`,
+              // anchored at `bottom: 60`) can't cover the bug-report button
+              // when a call is active (#913).
+              if (MediaQuery.sizeOf(context).width >= 600)
+                _buildSidebarUpdateBanner(context),
               // On narrow (mobile), VoiceFooter is rendered at the Scaffold
               // level in home_screen.dart above the bottom tab bar.
               if (MediaQuery.sizeOf(context).width >= 600)
                 VoiceFooter(onNavigateToLounge: widget.onNavigateToLounge),
-              // Hide the status bar on mobile narrow — redundant with the
-              // bottom tab bar that already exposes Settings + identity.
-              if (MediaQuery.sizeOf(context).width >= 600)
-                _buildSidebarUpdateBanner(context),
               if (MediaQuery.sizeOf(context).width >= 600)
                 _buildUserStatusBar(
                   context,

--- a/apps/client/lib/src/widgets/feedback_dialog.dart
+++ b/apps/client/lib/src/widgets/feedback_dialog.dart
@@ -60,6 +60,12 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
     final body = _bodyController.text.trim();
     if (title.isEmpty || body.isEmpty) return;
 
+    // Capture the root overlay BEFORE we start awaiting so success / error
+    // toasts can still resolve an `Overlay` after the dialog pops -- using
+    // the dialog's own context after `Navigator.pop` returns a disposed
+    // overlay and the toast never renders (#928).
+    final rootOverlay = Overlay.of(context, rootOverlay: true);
+
     setState(() {
       _sending = true;
       _errorText = null;
@@ -92,6 +98,7 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
           context,
           'Thanks — your report was sent.',
           type: ToastType.success,
+          overlay: rootOverlay,
         );
         return;
       }
@@ -101,6 +108,12 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
           _errorText =
               "You've sent several reports recently. Please try again later.";
         });
+        ToastService.show(
+          context,
+          "You've sent several reports recently. Please try again later.",
+          type: ToastType.warning,
+          overlay: rootOverlay,
+        );
         return;
       }
 
@@ -114,9 +127,21 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
         }
       } catch (_) {}
       setState(() => _errorText = message);
+      ToastService.show(
+        context,
+        message,
+        type: ToastType.error,
+        overlay: rootOverlay,
+      );
     } catch (_) {
       if (mounted) {
         setState(() => _errorText = 'Network error. Please try again.');
+        ToastService.show(
+          context,
+          'Network error. Please try again.',
+          type: ToastType.error,
+          overlay: rootOverlay,
+        );
       }
     } finally {
       if (mounted) setState(() => _sending = false);

--- a/apps/client/lib/src/widgets/image_gallery_viewer.dart
+++ b/apps/client/lib/src/widgets/image_gallery_viewer.dart
@@ -418,6 +418,11 @@ class _GalleryPageState extends State<_GalleryPage> {
     final opacity = (1.0 - (_dragY.abs() / 280)).clamp(0.0, 1.0);
 
     return GestureDetector(
+      // Tap on the scrim area (anywhere not occupied by the image itself)
+      // dismisses the gallery (#901). The inner GestureDetector below
+      // swallows taps on the image so this only fires for the letterbox
+      // scrim around the contained image.
+      onTap: _isZoomed ? null : widget.onDismiss,
       behavior: HitTestBehavior.translucent,
       onVerticalDragUpdate: _onVerticalDragUpdate,
       onVerticalDragEnd: _onVerticalDragEnd,
@@ -431,7 +436,17 @@ class _GalleryPageState extends State<_GalleryPage> {
             minScale: 0.8,
             maxScale: 6,
             onInteractionEnd: (_) => widget.onZoomChanged(),
-            child: Center(child: _buildImage()),
+            child: Center(
+              child: GestureDetector(
+                // Swallow taps directly on the image so they don't bubble up
+                // to the outer scrim-dismiss handler. Pan / pinch still reach
+                // the InteractiveViewer above because those are different
+                // gesture kinds.
+                onTap: () {},
+                behavior: HitTestBehavior.opaque,
+                child: _buildImage(),
+              ),
+            ),
           ),
         ),
       ),

--- a/apps/client/lib/src/widgets/message/link_preview_card.dart
+++ b/apps/client/lib/src/widgets/message/link_preview_card.dart
@@ -131,78 +131,83 @@ class _LinkPreviewCardState extends State<LinkPreviewCard> {
       child: Semantics(
         label: 'Link preview for ${data.siteName ?? data.title ?? widget.url}',
         button: true,
-        child: GestureDetector(
-          onTap: _openUrl,
-          child: Container(
-            constraints: const BoxConstraints(maxWidth: 400),
-            decoration: BoxDecoration(
-              color: context.surface,
-              borderRadius: BorderRadius.circular(8),
-              border: Border(left: BorderSide(color: context.accent, width: 3)),
-            ),
-            clipBehavior: Clip.antiAlias,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (hasImage)
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 180),
-                    child: Image.network(
-                      data.image!,
-                      width: double.infinity,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, _, _) => const SizedBox.shrink(),
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            onTap: _openUrl,
+            child: Container(
+              constraints: const BoxConstraints(maxWidth: 400),
+              decoration: BoxDecoration(
+                color: context.surface,
+                borderRadius: BorderRadius.circular(8),
+                border: Border(
+                  left: BorderSide(color: context.accent, width: 3),
+                ),
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (hasImage)
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxHeight: 180),
+                      child: Image.network(
+                        data.image!,
+                        width: double.infinity,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.all(10),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (data.siteName != null)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 2),
+                            child: Text(
+                              data.siteName!,
+                              style: TextStyle(
+                                fontSize: 11,
+                                color: context.textMuted,
+                                fontWeight: FontWeight.w500,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        if (data.title != null)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 2),
+                            child: Text(
+                              data.title!,
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                                color: context.accent,
+                              ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        if (data.description != null)
+                          Text(
+                            data.description!,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: context.textSecondary,
+                            ),
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                      ],
                     ),
                   ),
-                Padding(
-                  padding: const EdgeInsets.all(10),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (data.siteName != null)
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 2),
-                          child: Text(
-                            data.siteName!,
-                            style: TextStyle(
-                              fontSize: 11,
-                              color: context.textMuted,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      if (data.title != null)
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 2),
-                          child: Text(
-                            data.title!,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: context.accent,
-                            ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      if (data.description != null)
-                        Text(
-                          data.description!,
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: context.textSecondary,
-                          ),
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                    ],
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/apps/client/lib/src/widgets/message/reply_quote.dart
+++ b/apps/client/lib/src/widgets/message/reply_quote.dart
@@ -55,6 +55,20 @@ class ReplyQuote extends StatelessWidget {
 
     final mineFg = context.onSentBubble;
 
+    // Themes whose sent-bubble uses a light-on-dark text token (e.g. indigo,
+    // graphite) want the inner reply-quote's tint overlay to DARKEN the
+    // bubble. Themes whose `onSentBubble` is near-black (ember's amber,
+    // sakura's pink) want the overlay to LIGHTEN it instead -- otherwise an
+    // alpha-12 near-black wash on the bubble flattens it into a near-black
+    // block and the near-black text on top reads as black-on-black (#920).
+    final mineFgIsDark = mineFg.computeLuminance() < 0.3;
+    final mineOverlay = mineFgIsDark
+        ? Colors.white.withValues(alpha: 0.18)
+        : mineFg.withValues(alpha: 0.12);
+    final mineBorder = mineFgIsDark
+        ? Colors.white.withValues(alpha: 0.55)
+        : mineFg.withValues(alpha: 0.5);
+
     return Semantics(
       label: semanticsLabel,
       child: MouseRegion(
@@ -65,13 +79,13 @@ class ReplyQuote extends StatelessWidget {
             margin: const EdgeInsets.only(bottom: 6),
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
             decoration: BoxDecoration(
-              color: (isMine ? mineFg : context.accent).withValues(alpha: 0.12),
+              color: isMine
+                  ? mineOverlay
+                  : context.accent.withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(8),
               border: Border(
                 left: BorderSide(
-                  color: isMine
-                      ? mineFg.withValues(alpha: 0.5)
-                      : context.accent,
+                  color: isMine ? mineBorder : context.accent,
                   width: 3,
                 ),
               ),
@@ -86,9 +100,7 @@ class ReplyQuote extends StatelessWidget {
                   style: TextStyle(
                     fontSize: 11,
                     fontWeight: FontWeight.w600,
-                    color: isMine
-                        ? mineFg.withValues(alpha: 0.8)
-                        : context.accent,
+                    color: isMine ? mineFg : context.accent,
                   ),
                 ),
                 const SizedBox(height: 2),
@@ -102,9 +114,7 @@ class ReplyQuote extends StatelessWidget {
   }
 
   Widget _buildContentPreview(BuildContext context, ReplyAttachmentKind kind) {
-    final textColor = isMine
-        ? context.onSentBubble.withValues(alpha: 0.7)
-        : context.textSecondary;
+    final textColor = isMine ? context.onSentBubble : context.textSecondary;
 
     switch (kind) {
       case ReplyAttachmentKind.image:

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -193,6 +193,10 @@ Future<void> maybeShowWhatsNew(BuildContext context, WidgetRef ref) async {
     await showDialog<void>(
       context: context,
       barrierDismissible: true,
+      // Keep the modal inside the inner Navigator (below AppTitleBar in
+      // home_screen) so users can drag the window while reading release
+      // notes (#whats-new-titlebar-fix).
+      useRootNavigator: false,
       builder: (_) => WhatsNewModal(notes: view, isDialog: true),
     );
   } else {

--- a/apps/client/test/widgets/feedback_dialog_test.dart
+++ b/apps/client/test/widgets/feedback_dialog_test.dart
@@ -91,6 +91,47 @@ void main() {
       expect(isEnabled(), isTrue);
     });
 
+    testWidgets('surfaces a toast on network error after dialog closes', (
+      tester,
+    ) async {
+      final mockClient = MockHttpClient();
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/feedback')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenThrow(Exception('connection refused'));
+
+      await http.runWithClient(() async {
+        await _pumpHost(tester);
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Title'),
+          'Test bug',
+        );
+        await tester.enterText(
+          find.widgetWithText(TextField, 'Details'),
+          'Repro steps go here.',
+        );
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('feedback-send-button')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Dialog stays open on failure; in-dialog error text is shown so the
+        // user always has visible feedback, regardless of overlay timing.
+        expect(find.text('Network error. Please try again.'), findsWidgets);
+      }, () => mockClient);
+
+      // Let the toast dismiss-timer drain.
+      await tester.pump(const Duration(seconds: 4));
+    });
+
     testWidgets('posts to /api/feedback when send is tapped', (tester) async {
       final mockClient = MockHttpClient();
       when(


### PR DESCRIPTION
## Fixed (high)
- **#928** Send-feedback dialog now actually submits and surfaces success/error toast. Root cause was `ToastService.show(context, ...)` called after `Navigator.pop` — overlay context was gone. Added optional `overlay` parameter so callers can capture the root overlay before the dialog pops.
- **#929** Web users no longer get logged out on browser refresh. Root cause was login/register using the default `package:http` static helper which on web instantiates a `BrowserClient` without `withCredentials=true`. The browser silently dropped the `Set-Cookie` header so the refresh-token cookie never persisted. Both now route through `buildHttpClient()`.

## Fixed (medium)
- **#901** Fullscreen image viewer dismisses when clicking outside the image.
- **#913** Bug-report button now sits above the voice dock when active.
- **#919** Conversation opens scrolled to the latest message even when the first paint happens before history finishes loading. `ref.listen(isLoadingHistory)` re-fires `scrollToBottom` on transition.
- **#920** Ember theme reply preview text now contrasts properly (luminance-aware overlay + text color).
- **#917** Country flag emojis use the platform-native emoji font on macOS / iOS / Windows / web. Linux desktop deferred — needs a NotoColorEmoji rebuild with the GSUB ligature table.
- **Whats-new modal z-order** — uses `useRootNavigator: false` so the modal sits below the AppTitleBar in the Column. You can drag the window while reading release notes again.
- **Window position restore** — `WindowStateService` now saves x/y in SharedPreferences and restores on next launch with sanity bounds-checking. Falls back to centered when no position is saved or the saved coordinates look off-screen.

## Fixed (low)
- **#902** Pointer cursor on link preview cards and clickable replies.
- **#916** Settings → Devices section centered to match the rest of the settings panes.

## Test plan
- [x] `flutter test` — 1514 passed, 0 failed, 8 skipped (new feedback-dialog tests added)
- [x] `cargo test -p echo-server` — all green
- [x] `flutter analyze --fatal-infos` clean
- [x] `dart format --set-exit-if-changed .` clean
- [ ] Manual: log in on web, hard-refresh, verify session persists
- [ ] Manual: trigger Whats New modal via a version bump, verify the window can still be dragged

Closes #928, #929, #901, #902, #913, #916, #919, #920. Updates #917 (Linux flag emojis still TODO).