### PR TITLE
ci: disable android release, verbose windows build (#357)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,7 +618,7 @@ jobs:
             ${{ runner.os }}-pubcache-
       - name: Build
         working-directory: apps/client
-        run: flutter build windows --release --dart-define=APP_VERSION=${{ needs.version.outputs.version }}
+        run: flutter build windows --release --verbose --dart-define=APP_VERSION=${{ needs.version.outputs.version }}
       - name: Create InnoSetup script
         shell: pwsh
         run: |
@@ -696,10 +696,13 @@ jobs:
     name: Build Android APK
     runs-on: ubuntu-latest
     needs: [paths, version, lint-test-flutter]
-    if: |
-      always()
-      && needs.version.result == 'success'
-      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
+    # Disabled until ANDROID_KEYSTORE_BASE64 + ANDROID_KEY_PROPERTIES repo
+    # secrets are configured (#357). The fail-fast guard below would otherwise
+    # block every release on a missing keystore. Re-enable by replacing the
+    # `false` gate with the original predicate:
+    #   always() && needs.version.result == 'success'
+    #   && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
+    if: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0


### PR DESCRIPTION
## Summary
- Disable the build-android release job until ANDROID_KEYSTORE_BASE64 + ANDROID_KEY_PROPERTIES repo secrets are configured. Job is marked `if: false` with a comment explaining how to re-enable it. The release job's gate already accepts `skipped` from build-android.
- Add `--verbose` to the Windows release build so the next failure surfaces the underlying cmake_install error (rather than the generic MSB3073 wrapper).

Followup to #357. The fail-fast Android guard correctly identified that no keystore secrets are configured on the repo, but every release was blocked. Disabling the job is the right move until signing is set up.

## Test plan
- [ ] Release workflow triggers on push to main
- [ ] build-android shows as skipped (not failed)
- [ ] Other build-* jobs run as before
- [ ] If Windows still fails, the verbose log reveals the cmake error