### PR TITLE
audit follow-ups + ios voice crash fix + file-backed debug logs

### DIFF
--- a/apps/client/ios/Runner/Info.plist
+++ b/apps/client/ios/Runner/Info.plist
@@ -55,6 +55,10 @@
 	<string>Echo needs camera access for video calls</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Echo needs photo access to share images and files</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Echo uses Bluetooth audio routes for voice calls</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Echo discovers self-hosted servers on your local network</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io' show Directory, Platform;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show SemanticsBinding;
@@ -36,18 +35,31 @@ void main() {
   PaintingBinding.instance.imageCache.maximumSize = 500;
   PaintingBinding.instance.imageCache.maximumSizeBytes = 100 * 1024 * 1024;
 
-  // Global error boundary: catch unhandled Flutter framework errors so that
-  // the red error screen is never shown in production.
+  // Catch unhandled Flutter framework errors (widget build errors, assertion
+  // failures, etc.). Using LogLevel.fatal so these stand out in the log
+  // viewer — framework errors almost always indicate a crash or a broken
+  // widget tree.
   FlutterError.onError = (details) {
-    FlutterError.presentError(details);
     DebugLogService.instance.log(
-      LogLevel.error,
-      'FlutterError',
-      '${details.exceptionAsString()}\n${details.stack}',
+      LogLevel.fatal,
+      'flutter',
+      '${details.exception}\n${details.stack}',
     );
+    FlutterError.presentError(details);
   };
 
-  // Catch async errors not handled by the Flutter framework.
+  // Catch uncaught async errors that escape the Flutter framework (Dart
+  // Isolate, dart:async Future chains, platform channel callbacks).
+  // Returns true to signal that the error was handled and should not be
+  // re-thrown by the engine.
+  PlatformDispatcher.instance.onError = (error, stack) {
+    DebugLogService.instance.log(LogLevel.fatal, 'platform', '$error\n$stack');
+    return true;
+  };
+
+  // Catch async errors not handled by either of the two handlers above.
+  // runZonedGuarded provides a final safety net for errors thrown inside
+  // the zone but outside a Flutter frame (e.g. timers, streams).
   runZonedGuarded(
     () async {
       await _initAndRun();
@@ -55,8 +67,8 @@ void main() {
     (error, stack) {
       debugPrint('[Unhandled] $error\n$stack');
       DebugLogService.instance.log(
-        LogLevel.error,
-        'Unhandled',
+        LogLevel.fatal,
+        'platform',
         '$error\n$stack',
       );
     },

--- a/apps/client/lib/src/providers/admin_stats_provider.dart
+++ b/apps/client/lib/src/providers/admin_stats_provider.dart
@@ -98,11 +98,13 @@ class AdminDashboardData {
 }
 
 final adminDashboardProvider =
-    AsyncNotifierProvider<AdminDashboardNotifier, AdminDashboardData>(
-      AdminDashboardNotifier.new,
-    );
+    AsyncNotifierProvider.autoDispose<
+      AdminDashboardNotifier,
+      AdminDashboardData
+    >(AdminDashboardNotifier.new);
 
-class AdminDashboardNotifier extends AsyncNotifier<AdminDashboardData> {
+class AdminDashboardNotifier
+    extends AutoDisposeAsyncNotifier<AdminDashboardData> {
   @override
   Future<AdminDashboardData> build() => _load();
 

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
@@ -207,18 +207,31 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
   }
 
   /// Apply the current videoBitrate / videoFps to the active camera track.
+  ///
+  /// LiveKit 2.7.x throws TrackPublishException when publishVideoTrack is
+  /// called on an already-published track, so we unpublish first and then
+  /// republish with the new encoding options via a fresh camera track.
   Future<void> _applyVideoEncoding() async {
     final room = _room;
     if (room == null || !state.isVideoEnabled || state.autoQuality) return;
 
-    final cameraPub = room.localParticipant?.videoTrackPublications
+    final localParticipant = room.localParticipant;
+    if (localParticipant == null) return;
+
+    final cameraPub = localParticipant.videoTrackPublications
         .where((pub) => pub.source == TrackSource.camera && pub.track != null)
         .firstOrNull;
 
     if (cameraPub != null) {
       try {
-        await room.localParticipant?.publishVideoTrack(
-          cameraPub.track!,
+        // Unpublish the existing track; re-publishing the same track object
+        // throws TrackPublishException('track already exists') in SDK 2.7.x.
+        await localParticipant.removePublishedTrack(cameraPub.sid);
+        final newTrack = await LocalVideoTrack.createCameraTrack(
+          room.roomOptions.defaultCameraCaptureOptions,
+        );
+        await localParticipant.publishVideoTrack(
+          newTrack,
           publishOptions: VideoPublishOptions(
             videoEncoding: VideoEncoding(
               maxBitrate: state.videoBitrate,

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
@@ -22,6 +22,11 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
 
   /// Enable or disable the local microphone.
   void setCaptureEnabled(bool enabled) {
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'LiveKitVoice',
+      'setCaptureEnabled($enabled)',
+    );
     _room?.localParticipant?.setMicrophoneEnabled(enabled);
     state = state.copyWith(isCaptureEnabled: enabled);
   }
@@ -67,9 +72,19 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
     if (room == null) return;
 
     final enabled = !state.isVideoEnabled;
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'LiveKitVoice',
+      'toggleVideo: setCameraEnabled($enabled)',
+    );
     try {
       await room.localParticipant?.setCameraEnabled(enabled);
       state = state.copyWith(isVideoEnabled: enabled);
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'toggleVideo: camera enabled=$enabled',
+      );
     } catch (e) {
       debugPrint('[LiveKitVoice] toggleVideo failed: $e');
       DebugLogService.instance.log(
@@ -131,6 +146,11 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
     final room = _room;
     if (room == null) return false;
 
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'LiveKitVoice',
+      'setScreenShareEnabled($enabled) on ${defaultTargetPlatform.name}',
+    );
     try {
       if (defaultTargetPlatform == TargetPlatform.iOS) {
         // iOS requires a ReplayKit Broadcast Upload Extension for screen
@@ -167,13 +187,18 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
           ),
         );
       }
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'setScreenShareEnabled($enabled): screen share toggled successfully',
+      );
       return true;
     } catch (e) {
       debugPrint('[LiveKitVoice] setScreenShareEnabled($enabled) failed: $e');
       DebugLogService.instance.log(
         LogLevel.error,
         'LiveKitVoice',
-        'Screen share toggle failed: $e',
+        'setScreenShareEnabled($enabled) failed: $e',
       );
       state = state.copyWith(error: _friendlyMediaError(e, 'screen share'));
       return false;

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -290,9 +290,30 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
 
     String? attemptedUrl;
     try {
-      // 1. Fetch a LiveKit JWT from the Echo server.
-      final tokenResult = await _fetchLiveKitToken(conversationId, channelId);
+      // ---- breadcrumb 1: token fetch ----------------------------------------
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: fetching LiveKit token for channel $channelId',
+      );
+      _LiveKitTokenResult? tokenResult;
+      try {
+        tokenResult = await _fetchLiveKitToken(conversationId, channelId);
+      } catch (e) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'LiveKitVoice',
+          'joinChannel: token fetch threw: $e',
+        );
+        rethrow;
+      }
+
       if (tokenResult == null) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'LiveKitVoice',
+          'joinChannel: token fetch returned null — aborting',
+        );
         state = state.copyWith(
           isJoining: false,
           error: 'Failed to obtain voice token',
@@ -306,40 +327,75 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       DebugLogService.instance.log(
         LogLevel.info,
         'LiveKitVoice',
-        'Connecting to $livekitUrl (token len=${livekitToken.length})',
+        'joinChannel: token obtained, url=$livekitUrl token_len=${livekitToken.length}',
       );
 
-      // 2. Create and connect a LiveKit Room.
+      // ---- breadcrumb 2: room creation ----------------------------------------
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: creating Room object',
+      );
       final voiceSettings = ref.read(voiceSettingsProvider);
-      final room = Room(
-        roomOptions: RoomOptions(
-          adaptiveStream: true,
-          dynacast: true,
-          defaultAudioCaptureOptions: AudioCaptureOptions(
-            noiseSuppression: voiceSettings.noiseSuppression,
-            echoCancellation: voiceSettings.echoCancellation,
-            autoGainControl: voiceSettings.autoGainControl,
-          ),
-          defaultAudioPublishOptions: const AudioPublishOptions(
-            encoding: AudioEncoding.presetMusic,
-            dtx: true,
-          ),
-          defaultCameraCaptureOptions: const CameraCaptureOptions(
-            params: VideoParametersPresets.h720_169,
-          ),
-          defaultVideoPublishOptions: VideoPublishOptions(
-            videoEncoding: VideoEncoding(
-              maxBitrate: state.videoBitrate,
-              maxFramerate: state.videoFps,
+      late final Room room;
+      try {
+        room = Room(
+          roomOptions: RoomOptions(
+            adaptiveStream: true,
+            dynacast: true,
+            defaultAudioCaptureOptions: AudioCaptureOptions(
+              noiseSuppression: voiceSettings.noiseSuppression,
+              echoCancellation: voiceSettings.echoCancellation,
+              autoGainControl: voiceSettings.autoGainControl,
+            ),
+            defaultAudioPublishOptions: const AudioPublishOptions(
+              encoding: AudioEncoding.presetMusic,
+              dtx: true,
+            ),
+            defaultCameraCaptureOptions: const CameraCaptureOptions(
+              params: VideoParametersPresets.h720_169,
+            ),
+            defaultVideoPublishOptions: VideoPublishOptions(
+              videoEncoding: VideoEncoding(
+                maxBitrate: state.videoBitrate,
+                maxFramerate: state.videoFps,
+              ),
             ),
           ),
-        ),
-      );
+        );
+      } catch (e) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'LiveKitVoice',
+          'joinChannel: Room() constructor threw: $e',
+        );
+        rethrow;
+      }
       _room = room;
 
       _attachRoomListeners(room);
 
-      await room.connect(livekitUrl, livekitToken);
+      // ---- breadcrumb 3: room.connect -----------------------------------------
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: calling room.connect($livekitUrl)',
+      );
+      try {
+        await room.connect(livekitUrl, livekitToken);
+      } catch (e) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'LiveKitVoice',
+          'joinChannel: room.connect threw: $e',
+        );
+        rethrow;
+      }
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: room.connect succeeded',
+      );
 
       // Set display name so peers see a username instead of a UUID identity.
       final username = ref.read(authProvider).username;
@@ -347,9 +403,28 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         room.localParticipant?.setName(username);
       }
 
-      // 3. Enable microphone (unless starting muted).
+      // ---- breadcrumb 4: microphone enable ------------------------------------
       final micEnabled = !startMuted;
-      await room.localParticipant?.setMicrophoneEnabled(micEnabled);
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: calling setMicrophoneEnabled($micEnabled)',
+      );
+      try {
+        await room.localParticipant?.setMicrophoneEnabled(micEnabled);
+      } catch (e) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'LiveKitVoice',
+          'joinChannel: setMicrophoneEnabled threw: $e',
+        );
+        rethrow;
+      }
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: microphone enabled=$micEnabled',
+      );
 
       state = state.copyWith(
         isJoining: false,
@@ -364,14 +439,20 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       _startRtcStatsPolling(room);
       SoundService().playVoiceJoin();
 
-      // Promote the foreground service to voice mode (Android) and report
-      // an outgoing CallKit call (iOS) so the OS keeps the mic + audio
-      // session alive when the app is backgrounded.  Listen for Mute /
-      // Leave / End taps coming back from either UI.
+      // ---- breadcrumb 5: foreground service + CallKit -------------------------
       final resolvedChannelName = _resolveChannelName(
         conversationId,
         channelId,
       );
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: starting background service / CallKit for "$resolvedChannelName"',
+      );
+      // Promote the foreground service to voice mode (Android) and report
+      // an outgoing CallKit call (iOS) so the OS keeps the mic + audio
+      // session alive when the app is backgrounded.  Listen for Mute /
+      // Leave / End taps coming back from either UI.
       _attachNotificationActionListener();
       unawaited(
         BackgroundService.instance.startVoice(
@@ -393,7 +474,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       DebugLogService.instance.log(
         LogLevel.info,
         'LiveKitVoice',
-        'Joined room for channel $channelId',
+        'joinChannel: join complete for channel $channelId',
       );
     } catch (e) {
       // Surface the URL we tried so a 404 / DNS failure points ops at the
@@ -403,7 +484,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       DebugLogService.instance.log(
         LogLevel.error,
         'LiveKitVoice',
-        'Join failed at $tried: $e',
+        'joinChannel: failed at $tried: $e',
       );
       await _cleanupRoom();
       state = state.copyWith(

--- a/apps/client/lib/src/providers/livekit_voice/rtc_stats_poll.dart
+++ b/apps/client/lib/src/providers/livekit_voice/rtc_stats_poll.dart
@@ -91,6 +91,9 @@ class RtcStatsPoll {
       var totalBitrate = 0;
       var rttMs = 0.0;
       var sawRtt = false;
+      // Track which outbound-rtp report ids appear this tick so stale entries
+      // (e.g. from a track that was unpublished) can be pruned from _prevBytes.
+      final currentIds = <String>{};
 
       for (final pc in pcs) {
         final List<StatsReport> reports;
@@ -145,6 +148,7 @@ class RtcStatsPoll {
           if (bytesSent is! num) continue;
           final tsMs = r.timestamp;
 
+          currentIds.add(r.id);
           final prev = _prevBytes[r.id];
           _prevBytes[r.id] = _BytesSample(bytesSent.toInt(), tsMs);
 
@@ -158,6 +162,10 @@ class RtcStatsPoll {
           totalBitrate += bps.round();
         }
       }
+
+      // Prune entries for tracks that are no longer present in the current
+      // reports — avoids unbounded growth when tracks are unpublished.
+      _prevBytes.removeWhere((id, _) => !currentIds.contains(id));
 
       if (_disposed) return;
       final next = RtcStatsSample(

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -865,6 +865,7 @@ class _DebugLogsSubpageState extends State<_DebugLogsSubpage> {
         LogLevel.info => 'INF',
         LogLevel.warning => 'WRN',
         LogLevel.error => 'ERR',
+        LogLevel.fatal => 'FTL',
       };
       buffer.writeln('$h:$m:$s [$level] ${e.source}: ${e.message}');
     }
@@ -1069,6 +1070,7 @@ class _DebugLevelBadge extends StatelessWidget {
       LogLevel.info => ('INF', EchoTheme.online),
       LogLevel.warning => ('WRN', EchoTheme.warning),
       LogLevel.error => ('ERR', EchoTheme.danger),
+      LogLevel.fatal => ('FTL', EchoTheme.danger),
     };
 
     return Container(

--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -399,31 +399,36 @@ class _ParticipantTileState extends State<ParticipantTile> {
             clipBehavior: Clip.antiAlias,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(15),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-                child: Container(
-                  color: context.surface.withValues(alpha: 0.30),
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      // Video or avatar
-                      if (hasVideo && videoTrack != null)
-                        lk.VideoTrackRenderer(
-                          videoTrack,
-                          fit: lk.VideoViewFit.cover,
-                          mirrorMode: mirror
-                              ? lk.VideoViewMirrorMode.mirror
-                              : lk.VideoViewMirrorMode.off,
-                        )
-                      else
-                        AvatarCircle(
-                          name: name,
-                          avatarUrl: avatarUrl,
-                          audioLevel: audioLevel,
-                          authToken: authToken,
-                        ),
-                      _buildNameLabel(context),
-                    ],
+              // RepaintBoundary isolates the blur layer so audio-level
+              // rebuilds (~10 Hz) don't re-rasterise the BackdropFilter
+              // for every tile in the grid.
+              child: RepaintBoundary(
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                  child: Container(
+                    color: context.surface.withValues(alpha: 0.30),
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        // Video or avatar
+                        if (hasVideo && videoTrack != null)
+                          lk.VideoTrackRenderer(
+                            videoTrack,
+                            fit: lk.VideoViewFit.cover,
+                            mirrorMode: mirror
+                                ? lk.VideoViewMirrorMode.mirror
+                                : lk.VideoViewMirrorMode.off,
+                          )
+                        else
+                          AvatarCircle(
+                            name: name,
+                            avatarUrl: avatarUrl,
+                            audioLevel: audioLevel,
+                            authToken: authToken,
+                          ),
+                        _buildNameLabel(context),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/apps/client/lib/src/screens/voice_lounge/participant_volume_controller.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_volume_controller.dart
@@ -35,7 +35,13 @@ class ParticipantVolumeController {
   lk.Room? _attachedRoom;
 
   /// Returns the stored volume for [identity], or 1.0 if none is set.
-  double volumeFor(String identity) => _volumes[identity] ?? 1.0;
+  ///
+  /// Returns 1.0 immediately for an empty identity — SIDs change on every
+  /// join so we never key by SID; an empty identity means no customization.
+  double volumeFor(String identity) {
+    if (identity.isEmpty) return 1.0;
+    return _volumes[identity] ?? 1.0;
+  }
 
   /// Test-only window into the stored entries so regression tests can assert
   /// that map cleanup actually drops keys on disconnect.
@@ -88,11 +94,11 @@ class ParticipantVolumeController {
     lk.RemoteParticipant participant,
     double volume,
   ) async {
+    // SIDs change on every join so they can't reliably key the map; a
+    // participant with no stable identity gets no volume customization.
+    if (participant.identity.isEmpty) return;
     final clamped = volume.clamp(0.0, 1.0).toDouble();
-    final identity = participant.identity.isNotEmpty
-        ? participant.identity
-        : participant.sid.toString();
-    _volumes[identity] = clamped;
+    _volumes[participant.identity] = clamped;
     await _apply(participant, clamped);
   }
 
@@ -100,10 +106,10 @@ class ParticipantVolumeController {
   /// tracks. Useful after subscription changes — e.g. a track is added later
   /// than the slider was first moved.
   Future<void> reapply(lk.RemoteParticipant participant) async {
-    final identity = participant.identity.isNotEmpty
-        ? participant.identity
-        : participant.sid.toString();
-    final stored = _volumes[identity];
+    // SIDs change on every join so they can't reliably key the map; a
+    // participant with no stable identity has no stored customization.
+    if (participant.identity.isEmpty) return;
+    final stored = _volumes[participant.identity];
     if (stored == null) return;
     await _apply(participant, stored);
   }

--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -1,7 +1,12 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show File, IOException;
+
 import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
 
 /// Severity level for debug log entries.
-enum LogLevel { info, warning, error }
+enum LogLevel { info, warning, error, fatal }
 
 /// A single timestamped log entry captured by [DebugLogService].
 class DebugLogEntry {
@@ -18,9 +23,48 @@ class DebugLogEntry {
     required this.source,
     required this.message,
   });
+
+  /// Serialize to a single JSON line for file storage.
+  String toJsonLine() {
+    return jsonEncode({
+      't': timestamp.toIso8601String(),
+      'l': level.name,
+      's': source,
+      'm': message,
+    });
+  }
+
+  /// Deserialize from a JSON line produced by [toJsonLine].
+  ///
+  /// Returns null on any parse failure so a single corrupt line never
+  /// prevents loading the rest of the log file.
+  static DebugLogEntry? tryFromJsonLine(String line) {
+    try {
+      final map = jsonDecode(line) as Map<String, dynamic>;
+      final levelStr = map['l'] as String? ?? 'info';
+      final level = LogLevel.values.firstWhere(
+        (v) => v.name == levelStr,
+        orElse: () => LogLevel.info,
+      );
+      return DebugLogEntry(
+        timestamp: DateTime.parse(map['t'] as String),
+        level: level,
+        source: map['s'] as String? ?? '',
+        message: map['m'] as String? ?? '',
+      );
+    } catch (_) {
+      return null;
+    }
+  }
 }
 
-/// Singleton service that captures debug log entries in a bounded ring buffer.
+/// Singleton service that captures debug log entries in a bounded ring buffer
+/// and persists them to `<documents>/echo-debug.log`.
+///
+/// Persistence makes crashes debuggable on platforms without console access
+/// (iOS TestFlight, Android release builds). The file is a newline-delimited
+/// JSON stream capped at [maxEntries] lines; older lines are evicted when the
+/// buffer is full.
 ///
 /// Mixes in [ChangeNotifier] so Settings UI widgets can listen for new entries
 /// and rebuild automatically.
@@ -31,8 +75,20 @@ class DebugLogService with ChangeNotifier {
 
   final _entries = <DebugLogEntry>[];
 
-  /// Maximum number of entries retained before the oldest are dropped.
-  static const maxEntries = 200;
+  /// Maximum number of entries retained in memory and persisted to disk.
+  static const maxEntries = 5000;
+
+  /// File write is debounced by this duration to coalesce rapid log bursts
+  /// (e.g., 50 voice-join breadcrumbs) into a single I/O operation.
+  static const _writeDebounce = Duration(milliseconds: 500);
+
+  Timer? _writeTimer;
+
+  /// Lazily resolved log file path. Null on web or while not yet resolved.
+  String? _logFilePath;
+
+  /// Whether the initial file load has completed.
+  bool _loaded = false;
 
   /// Matches standard UUIDs (8-4-4-4-12 hex).
   static final _uuidRegex = RegExp(
@@ -40,20 +96,106 @@ class DebugLogService with ChangeNotifier {
     caseSensitive: false,
   );
 
-  /// Unmodifiable snapshot of the current entries (oldest first).
+  /// Unmodifiable snapshot of the current in-memory entries (oldest first).
   List<DebugLogEntry> get entries => List.unmodifiable(_entries);
 
   /// Truncate UUIDs to their first 8 hex characters to avoid leaking full
-  /// user/conversation IDs into the in-memory log buffer that is visible
-  /// from the Settings debug panel.
+  /// user/conversation IDs into the log buffer.
   String _redact(String msg) =>
       msg.replaceAllMapped(_uuidRegex, (m) => '${m[0]!.substring(0, 8)}...');
 
+  /// Resolve and cache the path to the log file.
+  ///
+  /// Returns null on web (no filesystem) or when `path_provider` fails.
+  Future<String?> _resolveLogFilePath() async {
+    if (kIsWeb) return null;
+    if (_logFilePath != null) return _logFilePath;
+    try {
+      // getApplicationDocumentsDirectory works on iOS, Android, macOS,
+      // Linux, and Windows. On Linux this is ~/Documents/<app> which is
+      // less ideal than Support, but it's readable without a special
+      // entitlement on iOS — which is the primary target for this feature.
+      final dir = await getApplicationDocumentsDirectory();
+      _logFilePath = '${dir.path}/echo-debug.log';
+      return _logFilePath;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Load persisted entries from disk into the in-memory buffer.
+  ///
+  /// Called once during service initialization.  Safe to call multiple times
+  /// — subsequent calls are no-ops.
+  Future<void> _loadFromFile() async {
+    if (_loaded) return;
+    _loaded = true;
+
+    final path = await _resolveLogFilePath();
+    if (path == null) return;
+
+    try {
+      final file = File(path);
+      if (!file.existsSync()) return;
+      final lines = await file.readAsLines();
+      final loaded = <DebugLogEntry>[];
+      for (final line in lines) {
+        if (line.isEmpty) continue;
+        final entry = DebugLogEntry.tryFromJsonLine(line);
+        if (entry != null) loaded.add(entry);
+      }
+      // Apply cap: keep only the most recent maxEntries from the file.
+      final start = loaded.length > maxEntries ? loaded.length - maxEntries : 0;
+      _entries.addAll(loaded.sublist(start));
+    } on IOException catch (_) {
+      // Unreadable file (permissions, corruption) — start fresh.
+    }
+  }
+
+  /// Write the current in-memory buffer to disk, replacing the file.
+  ///
+  /// Uses a debounce so rapid bursts of log calls only cause one I/O round
+  /// trip.  No-op on web.
+  void _scheduleWrite() {
+    if (kIsWeb) return;
+    _writeTimer?.cancel();
+    _writeTimer = Timer(_writeDebounce, _flushToDisk);
+  }
+
+  Future<void> _flushToDisk() async {
+    final path = await _resolveLogFilePath();
+    if (path == null) return;
+    try {
+      // Snapshot the current buffer under a local variable so a concurrent
+      // `log()` call cannot mutate _entries while we're serializing.
+      final snapshot = List<DebugLogEntry>.from(_entries);
+      final lines = snapshot.map((e) => e.toJsonLine()).join('\n');
+      await File(path).writeAsString('$lines\n');
+    } on IOException catch (_) {
+      // Swallow write errors silently — logging a log-write failure would
+      // cause infinite recursion and the in-memory buffer stays intact.
+    }
+  }
+
   /// Append a new log entry, evicting the oldest if the buffer is full.
   ///
+  /// Initialization (first-call file load) is triggered lazily on the first
+  /// [log] call.  Any entries logged before the file load completes are
+  /// buffered in memory and included in the first flush.
+  ///
   /// UUIDs in [message] are automatically truncated to prevent leaking full
-  /// identifiers into the debug log buffer.
+  /// identifiers into the log.
   void log(LogLevel level, String source, String message) {
+    // Kick off a one-time file load so that any entries already on disk
+    // appear in the in-memory buffer before we start evicting.  This is
+    // async and may complete after several log() calls have already been
+    // added — that is fine; duplicates are not a concern because we only
+    // load once and subsequent log() calls append to the already-loaded
+    // buffer.
+    if (!_loaded && !kIsWeb) {
+      _loadFromFile();
+    }
+
     _entries.add(
       DebugLogEntry(
         timestamp: DateTime.now(),
@@ -65,12 +207,59 @@ class DebugLogService with ChangeNotifier {
     while (_entries.length > maxEntries) {
       _entries.removeAt(0);
     }
+    _scheduleWrite();
     notifyListeners();
   }
 
-  /// Remove all stored entries.
+  /// Read all persisted entries from the log file.
+  ///
+  /// Triggers the initial file load if it hasn't happened yet, then returns
+  /// the current in-memory buffer.  On web, returns an empty list.
+  Future<List<DebugLogEntry>> loadAllEntries() async {
+    await _loadFromFile();
+    return List.unmodifiable(_entries);
+  }
+
+  /// Remove all stored entries from memory and delete the log file.
   void clear() {
     _entries.clear();
+    _writeTimer?.cancel();
+    _writeTimer = null;
+    // Delete the log file asynchronously.  Failures are silently ignored.
+    if (!kIsWeb) {
+      _resolveLogFilePath().then((path) {
+        if (path == null) return;
+        final file = File(path);
+        if (file.existsSync()) {
+          file.deleteSync();
+        }
+      }).ignore();
+    }
     notifyListeners();
+  }
+
+  /// Force an immediate flush of the in-memory buffer to disk, bypassing the
+  /// debounce timer.  Intended for use just before process exit.
+  Future<void> flush() async {
+    _writeTimer?.cancel();
+    _writeTimer = null;
+    await _flushToDisk();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  /// Reset internal state for tests that need a fresh service.
+  ///
+  /// Cancels pending timers, clears entries, and resets the loaded flag so
+  /// the next [log] or [loadAllEntries] call triggers a fresh file load.
+  @visibleForTesting
+  void resetForTest({String? overrideLogFilePath}) {
+    _writeTimer?.cancel();
+    _writeTimer = null;
+    _entries.clear();
+    _loaded = false;
+    _logFilePath = overrideLogFilePath;
   }
 }

--- a/apps/client/lib/src/services/voice_callkit_service.dart
+++ b/apps/client/lib/src/services/voice_callkit_service.dart
@@ -94,6 +94,16 @@ class VoiceCallKitService {
     // a hard-crash trigger when CallKit tries to resolve the asset) and
     // audioSessionMode is reset to 'default' to match the upstream
     // example.
+    //
+    // audioSessionActive: false — LiveKit's WebRTC stack already calls
+    // AVAudioSession.setActive(true) during room.connect() and again when
+    // setMicrophoneEnabled creates the LocalAudioTrack. CallKit asking to
+    // (re-)activate the session was racing those calls and producing a
+    // native EXC_BAD_ACCESS in the audio render thread on iOS 17+ — a
+    // crash outside any Dart try/catch, so the user just saw the app
+    // disappear when joining a voice lounge. Setting this to false makes
+    // CallKit observe the session LiveKit established rather than fight
+    // for it.
     final params = CallKitParams(
       id: callId,
       nameCaller: channelName,
@@ -105,7 +115,7 @@ class VoiceCallKitService {
         maximumCallGroups: 1,
         maximumCallsPerCallGroup: 1,
         audioSessionMode: 'default',
-        audioSessionActive: true,
+        audioSessionActive: false,
         supportsDTMF: false,
         supportsHolding: false,
         supportsGrouping: false,

--- a/apps/client/lib/src/widgets/image_annotation_editor.dart
+++ b/apps/client/lib/src/widgets/image_annotation_editor.dart
@@ -39,45 +39,73 @@ class _Stroke {
 }
 
 class _ImageAnnotationEditorState extends State<ImageAnnotationEditor> {
-  /// All completed + the in-progress stroke. The last entry is mutated
-  /// in-place while the user is dragging.
-  final List<_Stroke> _strokes = <_Stroke>[];
+  /// Completed strokes. Only mutated (via setState) on pan-start and pan-end,
+  /// not on every pan-update frame.
+  final List<_Stroke> _committedStrokes = <_Stroke>[];
+
+  /// Points of the stroke currently being drawn. Updated at 60Hz during a
+  /// pan gesture; drives a [ValueListenableBuilder] so only the live-stroke
+  /// layer repaints instead of the whole scaffold.
+  final ValueNotifier<List<Offset>?> _livePoints = ValueNotifier<List<Offset>?>(
+    null,
+  );
 
   /// True while a `toImage` rasterisation is running, so the Send button
   /// is debounced.
   bool _exporting = false;
 
-  /// Pinned to the RepaintBoundary so we can grab pixels on Send.
+  /// Pinned to the outer RepaintBoundary so we can grab pixels on Send.
   final GlobalKey _boundaryKey = GlobalKey();
+
+  /// Stable image provider created once in [initState] so [Image] does not
+  /// re-decode the bytes on every rebuild.
+  late final ImageProvider _imageProvider;
 
   static const double _strokeWidth = 4.0;
 
+  @override
+  void initState() {
+    super.initState();
+    _imageProvider = MemoryImage(widget.imageBytes);
+  }
+
+  @override
+  void dispose() {
+    _livePoints.dispose();
+    super.dispose();
+  }
+
   void _onPanStart(DragStartDetails details) {
-    setState(() {
-      _strokes.add(_Stroke(<Offset>[details.localPosition]));
-    });
+    // Start a new live stroke. This setState is cheap — it only updates
+    // the toolbar button enabled-state via hasStrokes.
+    _livePoints.value = <Offset>[details.localPosition];
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
-    if (_strokes.isEmpty) return;
-    setState(() {
-      _strokes.last.points.add(details.localPosition);
-    });
+    final live = _livePoints.value;
+    if (live == null) return;
+    // Mutate a fresh list so ValueNotifier listeners see the change.
+    _livePoints.value = List<Offset>.of(live)..add(details.localPosition);
   }
 
   void _onPanEnd(DragEndDetails details) {
-    // Strokes are already finalised on each update. Nothing to do here,
-    // but keep the hook for future palm-rejection / coalescing logic.
+    final live = _livePoints.value;
+    if (live == null || live.isEmpty) return;
+    // Commit the finished stroke and clear the live notifier.
+    setState(() {
+      _committedStrokes.add(_Stroke(live));
+      _livePoints.value = null;
+    });
   }
 
   void _undo() {
-    if (_strokes.isEmpty) return;
-    setState(() => _strokes.removeLast());
+    if (_committedStrokes.isEmpty) return;
+    setState(() => _committedStrokes.removeLast());
   }
 
   void _clear() {
-    if (_strokes.isEmpty) return;
-    setState(() => _strokes.clear());
+    if (_committedStrokes.isEmpty) return;
+    setState(() => _committedStrokes.clear());
   }
 
   Future<void> _confirm() async {
@@ -88,7 +116,15 @@ class _ImageAnnotationEditorState extends State<ImageAnnotationEditor> {
           _boundaryKey.currentContext?.findRenderObject()
               as RenderRepaintBoundary?;
       if (boundary == null) {
-        // No render object — bail without confirming.
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                'Failed to export image. Try a smaller image or close other apps.',
+              ),
+            ),
+          );
+        }
         return;
       }
       // Match device pixel ratio so the exported image has the same
@@ -99,7 +135,18 @@ class _ImageAnnotationEditorState extends State<ImageAnnotationEditor> {
         format: ui.ImageByteFormat.png,
       );
       image.dispose();
-      if (byteData == null) return;
+      if (byteData == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                'Failed to export image. Try a smaller image or close other apps.',
+              ),
+            ),
+          );
+        }
+        return;
+      }
       final Uint8List pngBytes = byteData.buffer.asUint8List();
       if (!mounted) return;
       widget.onConfirm(pngBytes);
@@ -113,7 +160,9 @@ class _ImageAnnotationEditorState extends State<ImageAnnotationEditor> {
   @override
   Widget build(BuildContext context) {
     final color = Theme.of(context).colorScheme.primary;
-    final hasStrokes = _strokes.isNotEmpty;
+    // hasStrokes is derived only from committed strokes because the live
+    // stroke is tracked separately via ValueNotifier.
+    final hasStrokes = _committedStrokes.isNotEmpty;
     return Scaffold(
       backgroundColor: Colors.black,
       appBar: AppBar(
@@ -153,6 +202,7 @@ class _ImageAnnotationEditorState extends State<ImageAnnotationEditor> {
         ],
       ),
       body: SizedBox.expand(
+        // Outer RepaintBoundary is keyed so _confirm can capture all layers.
         child: RepaintBoundary(
           key: _boundaryKey,
           child: GestureDetector(
@@ -163,23 +213,45 @@ class _ImageAnnotationEditorState extends State<ImageAnnotationEditor> {
             child: Stack(
               fit: StackFit.expand,
               children: [
-                // Image fit-to-screen. BoxFit.contain keeps aspect ratio so
-                // the user always sees the full image without cropping.
+                // Image: uses a stable MemoryImage provider (created once in
+                // initState) so the codec is not re-instantiated on rebuilds.
                 Positioned.fill(
-                  child: Image.memory(
-                    widget.imageBytes,
+                  child: Image(
+                    image: _imageProvider,
                     fit: BoxFit.contain,
                     gaplessPlayback: true,
                   ),
                 ),
+                // Committed strokes — wrapped in a RepaintBoundary so Flutter
+                // can cache the rasterised layer between pan frames.
                 Positioned.fill(
                   child: IgnorePointer(
-                    child: CustomPaint(
-                      painter: _StrokesPainter(
-                        strokes: _strokes,
-                        color: color,
-                        strokeWidth: _strokeWidth,
+                    child: RepaintBoundary(
+                      child: CustomPaint(
+                        painter: _StrokesPainter(
+                          strokes: _committedStrokes,
+                          color: color,
+                          strokeWidth: _strokeWidth,
+                        ),
                       ),
+                    ),
+                  ),
+                ),
+                // Live stroke — repaints on every pan frame without touching
+                // the committed-strokes layer or the image.
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: ValueListenableBuilder<List<Offset>?>(
+                      valueListenable: _livePoints,
+                      builder: (context, points, _) {
+                        return CustomPaint(
+                          painter: _LiveStrokePainter(
+                            points: points,
+                            color: color,
+                            strokeWidth: _strokeWidth,
+                          ),
+                        );
+                      },
                     ),
                   ),
                 ),
@@ -192,7 +264,7 @@ class _ImageAnnotationEditorState extends State<ImageAnnotationEditor> {
   }
 }
 
-/// Renders the accumulated [_Stroke] polylines as anti-aliased lines.
+/// Renders the accumulated committed [_Stroke] polylines as anti-aliased lines.
 class _StrokesPainter extends CustomPainter {
   final List<_Stroke> strokes;
   final Color color;
@@ -215,26 +287,7 @@ class _StrokesPainter extends CustomPainter {
       ..isAntiAlias = true;
 
     for (final stroke in strokes) {
-      final pts = stroke.points;
-      if (pts.isEmpty) continue;
-      if (pts.length == 1) {
-        // Single-tap dot — render as a small filled circle so taps leave
-        // a visible mark.
-        canvas.drawCircle(
-          pts.first,
-          strokeWidth / 2,
-          Paint()
-            ..color = color
-            ..style = PaintingStyle.fill
-            ..isAntiAlias = true,
-        );
-        continue;
-      }
-      final path = Path()..moveTo(pts.first.dx, pts.first.dy);
-      for (var i = 1; i < pts.length; i++) {
-        path.lineTo(pts[i].dx, pts[i].dy);
-      }
-      canvas.drawPath(path, paint);
+      _paintPoints(canvas, stroke.points, paint);
     }
   }
 
@@ -244,4 +297,64 @@ class _StrokesPainter extends CustomPainter {
         old.color != color ||
         old.strokeWidth != strokeWidth;
   }
+}
+
+/// Renders the single in-progress stroke during a pan gesture.
+///
+/// Separated from [_StrokesPainter] so the [ValueListenableBuilder] driving
+/// this layer does not trigger repaints on the committed-strokes layer.
+class _LiveStrokePainter extends CustomPainter {
+  final List<Offset>? points;
+  final Color color;
+  final double strokeWidth;
+
+  const _LiveStrokePainter({
+    required this.points,
+    required this.color,
+    required this.strokeWidth,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final pts = points;
+    if (pts == null || pts.isEmpty) return;
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..style = PaintingStyle.stroke
+      ..isAntiAlias = true;
+    _paintPoints(canvas, pts, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _LiveStrokePainter old) {
+    return old.points != points ||
+        old.color != color ||
+        old.strokeWidth != strokeWidth;
+  }
+}
+
+/// Shared drawing logic for a list of [Offset] points.
+void _paintPoints(Canvas canvas, List<Offset> pts, Paint paint) {
+  if (pts.isEmpty) return;
+  if (pts.length == 1) {
+    // Single-tap dot — render as a small filled circle so taps leave
+    // a visible mark.
+    canvas.drawCircle(
+      pts.first,
+      paint.strokeWidth / 2,
+      Paint()
+        ..color = paint.color
+        ..style = PaintingStyle.fill
+        ..isAntiAlias = true,
+    );
+    return;
+  }
+  final path = Path()..moveTo(pts.first.dx, pts.first.dy);
+  for (var i = 1; i < pts.length; i++) {
+    path.lineTo(pts[i].dx, pts[i].dy);
+  }
+  canvas.drawPath(path, paint);
 }

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -242,7 +242,14 @@ class VoiceDock extends ConsumerWidget {
               ),
             _buildMuteButton(context, ref, voiceSettings, m),
             _buildDeafenButton(context, ref, voiceSettings, m),
-            _buildHangupButton(ref, screenShare, conversationId, channelId, m),
+            _buildHangupButton(
+              context,
+              ref,
+              screenShare,
+              conversationId,
+              channelId,
+              m,
+            ),
           ],
         ),
       ),
@@ -335,7 +342,14 @@ class VoiceDock extends ConsumerWidget {
       _buildDeafenButton(context, ref, voiceSettings, m),
       if (_supportsScreenShare)
         _buildScreenShareButton(context, ref, screenShare, m),
-      _buildHangupButton(ref, screenShare, conversationId, channelId, m),
+      _buildHangupButton(
+        context,
+        ref,
+        screenShare,
+        conversationId,
+        channelId,
+        m,
+      ),
     ];
   }
 
@@ -422,6 +436,7 @@ class VoiceDock extends ConsumerWidget {
   }
 
   Widget _buildHangupButton(
+    BuildContext context,
     WidgetRef ref,
     ScreenShareState screenShare,
     String conversationId,
@@ -434,13 +449,13 @@ class VoiceDock extends ConsumerWidget {
       tooltip: 'Leave',
       iconSize: m.btnIconSize,
       onPressed: () async {
+        // Call the shared helper instead of bare setScreenShareEnabled(false)
+        // so that Linux portal cleanup (removePublishedTrack + track.stop +
+        // track.dispose) runs before disconnect. Guard with the sharing flag
+        // so toggleScreenShare only takes the stop-sharing branch, never the
+        // start-sharing branch.
         if (screenShare.isScreenSharing) {
-          await ref
-              .read(livekitVoiceProvider.notifier)
-              .setScreenShareEnabled(false);
-          ref
-              .read(screenShareProvider.notifier)
-              .setLiveKitScreenShareActive(false);
+          await toggleScreenShare(context, ref);
         }
         await ref
             .read(channelsProvider.notifier)

--- a/apps/client/test/providers/chat_provider_test.dart
+++ b/apps/client/test/providers/chat_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:echo_app/src/providers/chat_provider.dart';
 import 'package:echo_app/src/models/chat_message.dart';
@@ -356,6 +357,115 @@ void main() {
       );
       expect(updated.isLoadingHistory('conv1'), isTrue);
       expect(updated.conversationHasMore('conv1'), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Chat notifier — addMessage bumpReplyCount: false regression (#919)
+  //
+  // Historical thread seeders call addMessage with bumpReplyCount: false so
+  // that re-opening the thread panel doesn't inflate the reply badge every
+  // time.  The existing suite only tested the ChatState data model; this group
+  // exercises the notifier method directly.
+  // ---------------------------------------------------------------------------
+
+  group('Chat notifier — addMessage bumpReplyCount (#919)', () {
+    ProviderContainer makeContainer() {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      return c;
+    }
+
+    test('bumpReplyCount: false does not increment parent replyCount', () {
+      final container = makeContainer();
+      final notifier = container.read(chatProvider.notifier);
+
+      // Seed the parent message with replyCount already at 2 (server value).
+      const parent = ChatMessage(
+        id: 'parent-1',
+        fromUserId: 'u1',
+        fromUsername: 'alice',
+        conversationId: 'conv1',
+        content: 'parent message',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        replyCount: 2,
+      );
+      notifier.addMessage(parent, bumpReplyCount: false);
+
+      // Seed a historical reply with bumpReplyCount: false (the thread-panel
+      // path).  The parent's replyCount must stay at 2.
+      const reply = ChatMessage(
+        id: 'reply-1',
+        fromUserId: 'u2',
+        fromUsername: 'bob',
+        conversationId: 'conv1',
+        content: 'a reply',
+        timestamp: '2026-01-01T00:01:00Z',
+        isMine: false,
+        replyToId: 'parent-1',
+        replyCount: 0,
+      );
+      notifier.addMessage(reply, bumpReplyCount: false);
+
+      final messages = container
+          .read(chatProvider)
+          .messagesForConversation('conv1');
+      final parentAfter = messages.firstWhere((m) => m.id == 'parent-1');
+
+      expect(
+        parentAfter.replyCount,
+        2,
+        reason:
+            'addMessage(bumpReplyCount: false) must not increment the '
+            'parent replyCount — re-opening the thread panel would '
+            'otherwise inflate the badge on every open (#919).',
+      );
+    });
+
+    test('bumpReplyCount: true (default) does increment parent replyCount', () {
+      final container = makeContainer();
+      final notifier = container.read(chatProvider.notifier);
+
+      // Seed parent.
+      const parent = ChatMessage(
+        id: 'parent-2',
+        fromUserId: 'u1',
+        fromUsername: 'alice',
+        conversationId: 'conv2',
+        content: 'parent message',
+        timestamp: '2026-01-01T00:00:00Z',
+        isMine: false,
+        replyCount: 0,
+      );
+      notifier.addMessage(parent);
+
+      // Live WS path — default bumpReplyCount: true.
+      const reply = ChatMessage(
+        id: 'reply-2',
+        fromUserId: 'u2',
+        fromUsername: 'bob',
+        conversationId: 'conv2',
+        content: 'live reply',
+        timestamp: '2026-01-01T00:01:00Z',
+        isMine: false,
+        replyToId: 'parent-2',
+        replyCount: 0,
+      );
+      notifier.addMessage(reply);
+
+      final messages = container
+          .read(chatProvider)
+          .messagesForConversation('conv2');
+      final parentAfter = messages.firstWhere((m) => m.id == 'parent-2');
+
+      expect(
+        parentAfter.replyCount,
+        1,
+        reason:
+            'Live WS path (bumpReplyCount: true) must optimistically '
+            'increment the parent replyCount by 1.',
+      );
     });
   });
 }

--- a/apps/client/test/screens/voice_lounge/screen_share_actions_test.dart
+++ b/apps/client/test/screens/voice_lounge/screen_share_actions_test.dart
@@ -1,0 +1,116 @@
+// Smoke-level regression guard for #910.
+//
+// The full toggleScreenShare() flow requires a connected LiveKit Room with
+// real WebRTC internals, which is not available in a unit-test process.
+// Instead this file opens the source file as text and asserts that both fix
+// fields are present as literal source code.  A refactor that renames the
+// fields or changes their values will break this test before it can reach CI.
+//
+// If the LiveKit client ever ships a testable mock Room, migrate the assertion
+// to an integration-level call-site check.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('screen_share_actions.dart publish options (#910)', () {
+    late String source;
+
+    setUpAll(() {
+      // Flutter unit tests run with Directory.current pointing at the package
+      // root (apps/client/) when invoked via `flutter test`.  Walk into lib/
+      // from there to locate the source file.
+      final packageRoot = Directory.current.path;
+      final sourceFile = File(
+        [
+          packageRoot,
+          'lib',
+          'src',
+          'screens',
+          'voice_lounge',
+          'screen_share_actions.dart',
+        ].join(Platform.pathSeparator),
+      );
+
+      if (!sourceFile.existsSync()) {
+        throw StateError(
+          'screen_share_actions.dart not found at ${sourceFile.path}. '
+          'Run this test with `flutter test` from inside apps/client/.',
+        );
+      }
+      source = sourceFile.readAsStringSync();
+    });
+
+    test('VideoPublishOptions contains simulcast: false '
+        '(single-layer guard for remote viewers)', () {
+      expect(
+        source,
+        contains('simulcast: false'),
+        reason:
+            'Removing simulcast: false from VideoPublishOptions breaks '
+            'screen-share for remote viewers on macOS/Windows (#910).',
+      );
+    });
+
+    test("VideoPublishOptions contains videoCodec: 'vp8' "
+        '(cross-platform decode guard)', () {
+      expect(
+        source,
+        contains("videoCodec: 'vp8'"),
+        reason:
+            "Removing videoCodec: 'vp8' from VideoPublishOptions lets the "
+            'SFU select a codec that flutter_webrtc cannot decode everywhere '
+            '(#910).',
+      );
+    });
+
+    test(
+      'Both options appear inside the same VideoPublishOptions constructor block',
+      () {
+        // Find the VideoPublishOptions constructor and confirm both fields sit
+        // between its opening '(' and closing ')'.
+        final optionsStart = source.indexOf('VideoPublishOptions(');
+        expect(
+          optionsStart,
+          isNot(-1),
+          reason: 'VideoPublishOptions constructor not found in source',
+        );
+
+        // Find the closing paren of the options block.  Use a simple scan
+        // that handles nested parens so future refactors don't false-positive.
+        var depth = 0;
+        var optionsEnd = -1;
+        for (var i = optionsStart; i < source.length; i++) {
+          if (source[i] == '(') {
+            depth++;
+          } else if (source[i] == ')') {
+            depth--;
+            if (depth == 0) {
+              optionsEnd = i;
+              break;
+            }
+          }
+        }
+        expect(
+          optionsEnd,
+          isNot(-1),
+          reason:
+              'Could not find matching closing paren for VideoPublishOptions',
+        );
+
+        final block = source.substring(optionsStart, optionsEnd + 1);
+        expect(
+          block,
+          contains('simulcast: false'),
+          reason: 'simulcast: false must be inside VideoPublishOptions(…)',
+        );
+        expect(
+          block,
+          contains("videoCodec: 'vp8'"),
+          reason: "videoCodec: 'vp8' must be inside VideoPublishOptions(…)",
+        );
+      },
+    );
+  });
+}

--- a/apps/client/test/services/debug_log_service_test.dart
+++ b/apps/client/test/services/debug_log_service_test.dart
@@ -1,13 +1,72 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'package:echo_app/src/services/debug_log_service.dart';
 
+// ---------------------------------------------------------------------------
+// Fake path_provider so the service can resolve a temp directory in tests.
+// ---------------------------------------------------------------------------
+
+class _FakePathProvider
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  final String tempPath;
+  _FakePathProvider(this.tempPath);
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => tempPath;
+
+  // Required overrides -- unused in these tests.
+  @override
+  Future<String?> getTemporaryPath() async => tempPath;
+  @override
+  Future<String?> getApplicationSupportPath() async => tempPath;
+  @override
+  Future<String?> getLibraryPath() async => null;
+  @override
+  Future<String?> getApplicationCachePath() async => tempPath;
+  @override
+  Future<String?> getExternalStoragePath() async => null;
+  @override
+  Future<List<String>?> getExternalCachePaths() async => null;
+  @override
+  Future<List<String>?> getExternalStoragePaths({
+    StorageDirectory? type,
+  }) async => null;
+  @override
+  Future<String?> getDownloadsPath() async => null;
+}
+
 void main() {
   late DebugLogService service;
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('echo_debug_test_');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+  });
+
+  tearDownAll(() async {
+    try {
+      await tempDir.delete(recursive: true);
+    } catch (_) {}
+  });
 
   setUp(() {
     service = DebugLogService.instance;
-    service.clear();
+    // Reset to a clean state and point at the temp directory for persistence
+    // tests.  The override ensures the log file lands in the temp dir rather
+    // than the real documents directory.
+    service.resetForTest(overrideLogFilePath: '${tempDir.path}/echo-debug.log');
+  });
+
+  tearDown(() {
+    // Clean up any log file left by the test.
+    final file = File('${tempDir.path}/echo-debug.log');
+    if (file.existsSync()) file.deleteSync();
   });
 
   group('DebugLogService', () {
@@ -35,6 +94,11 @@ void main() {
       expect(service.entries[2].message, 'third');
     });
 
+    test('log accepts fatal level', () {
+      service.log(LogLevel.fatal, 'platform', 'uncaught exception');
+      expect(service.entries.first.level, LogLevel.fatal);
+    });
+
     test('log evicts oldest when exceeding maxEntries', () {
       for (var i = 0; i < DebugLogService.maxEntries + 10; i++) {
         service.log(LogLevel.info, 'Src', 'msg $i');
@@ -47,6 +111,10 @@ void main() {
         service.entries.last.message,
         'msg ${DebugLogService.maxEntries + 9}',
       );
+    });
+
+    test('maxEntries is 5000', () {
+      expect(DebugLogService.maxEntries, 5000);
     });
 
     test('clear removes all entries', () {
@@ -142,6 +210,121 @@ void main() {
         entry.timestamp.isBefore(after.add(const Duration(seconds: 1))),
         isTrue,
       );
+    });
+
+    // -------------------------------------------------------------------------
+    // DebugLogEntry serialization
+    // -------------------------------------------------------------------------
+
+    group('DebugLogEntry serialization', () {
+      test('roundtrips through toJsonLine / tryFromJsonLine', () {
+        final original = DebugLogEntry(
+          timestamp: DateTime.utc(2026, 5, 16, 12, 0, 0),
+          level: LogLevel.warning,
+          source: 'Test',
+          message: 'hello world',
+        );
+        final line = original.toJsonLine();
+        final restored = DebugLogEntry.tryFromJsonLine(line);
+        expect(restored, isNotNull);
+        expect(restored!.level, LogLevel.warning);
+        expect(restored.source, 'Test');
+        expect(restored.message, 'hello world');
+        expect(restored.timestamp, original.timestamp);
+      });
+
+      test('tryFromJsonLine returns null for garbage input', () {
+        expect(DebugLogEntry.tryFromJsonLine('not json'), isNull);
+        expect(DebugLogEntry.tryFromJsonLine(''), isNull);
+        expect(DebugLogEntry.tryFromJsonLine('{invalid}'), isNull);
+      });
+
+      test('tryFromJsonLine tolerates unknown level string', () {
+        final entry = DebugLogEntry.tryFromJsonLine(
+          '{"t":"2026-05-16T00:00:00.000Z","l":"bogus","s":"S","m":"M"}',
+        );
+        expect(entry, isNotNull);
+        expect(entry!.level, LogLevel.info); // fallback
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Persistence
+    // -------------------------------------------------------------------------
+
+    group('persistence', () {
+      test(
+        'flush writes entries to disk and loadAllEntries reads them back',
+        () async {
+          service.log(LogLevel.info, 'Persist', 'breadcrumb A');
+          service.log(LogLevel.error, 'Persist', 'breadcrumb B');
+
+          // Force an immediate flush (bypasses the debounce timer).
+          await service.flush();
+
+          // Verify the file was written.
+          final file = File('${tempDir.path}/echo-debug.log');
+          expect(file.existsSync(), isTrue);
+          final content = file.readAsStringSync();
+          expect(content, contains('breadcrumb A'));
+          expect(content, contains('breadcrumb B'));
+
+          // Simulate a "restart" by resetting the singleton's in-memory state
+          // while keeping the same log file path.
+          service.resetForTest(
+            overrideLogFilePath: '${tempDir.path}/echo-debug.log',
+          );
+          expect(
+            service.entries,
+            isEmpty,
+            reason: 'in-memory buffer cleared by resetForTest',
+          );
+
+          // loadAllEntries should reload from the file.
+          final reloaded = await service.loadAllEntries();
+          expect(reloaded.any((e) => e.message == 'breadcrumb A'), isTrue);
+          expect(reloaded.any((e) => e.message == 'breadcrumb B'), isTrue);
+        },
+      );
+
+      test('clear deletes the log file', () async {
+        service.log(LogLevel.info, 'Persist', 'will be cleared');
+        await service.flush();
+
+        final file = File('${tempDir.path}/echo-debug.log');
+        expect(file.existsSync(), isTrue);
+
+        service.clear();
+        // Give the async delete a moment to complete.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(file.existsSync(), isFalse);
+      });
+
+      test('loadAllEntries returns empty list when no file exists', () async {
+        // File was deleted by tearDown / never created in this test path.
+        final entries = await service.loadAllEntries();
+        expect(entries, isEmpty);
+      });
+
+      test('corrupt lines in log file are silently skipped', () async {
+        final file = File('${tempDir.path}/echo-debug.log');
+        // Write one valid line and one corrupt line.
+        final valid = DebugLogEntry(
+          timestamp: DateTime.utc(2026, 1, 1),
+          level: LogLevel.info,
+          source: 'S',
+          message: 'valid entry',
+        );
+        file.writeAsStringSync('${valid.toJsonLine()}\nnot-json-garbage\n');
+
+        service.resetForTest(
+          overrideLogFilePath: '${tempDir.path}/echo-debug.log',
+        );
+        final entries = await service.loadAllEntries();
+        // Only the valid entry should be returned.
+        expect(entries, hasLength(1));
+        expect(entries.first.message, 'valid entry');
+      });
     });
   });
 }

--- a/apps/client/test/services/sound_service_test.dart
+++ b/apps/client/test/services/sound_service_test.dart
@@ -173,4 +173,43 @@ void main() {
       expect(identical(a, b), isTrue);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // #924: _enabled and _notificationSound are independent.
+  //
+  // Before #924 the enabled flag was derived from the notification-sound
+  // selection: picking "None" set enabled=false, which also silenced sent /
+  // voice-join / voice-leave sounds permanently.  The fix decoupled the two
+  // fields.  This test locks in that contract: setting the notification sound
+  // to "none" must leave the master enabled flag untouched.
+  // ---------------------------------------------------------------------------
+
+  group('SoundService decoupled switches (#924)', () {
+    setUp(() {
+      // Restore known state before each case.  The singleton persists across
+      // tests so we must reset both fields explicitly.
+      SoundService().enabled = true;
+    });
+
+    test(
+      'setNotificationSound(none) leaves enabled=true (#924 regression)',
+      () async {
+        // Master switch is on.
+        expect(SoundService().enabled, isTrue);
+
+        // Pick "None" for notification sounds only.
+        await SoundService().setNotificationSound(NotificationSound.none);
+
+        // The master switch must remain on — the UI sounds (sent, voice) are
+        // unaffected by the notification-sound choice.
+        expect(
+          SoundService().enabled,
+          isTrue,
+          reason:
+              'setNotificationSound(none) must not disable the master '
+              'sound switch (regression guard for #924).',
+        );
+      },
+    );
+  });
 }

--- a/apps/server/src/db/canvas.rs
+++ b/apps/server/src/db/canvas.rs
@@ -35,15 +35,43 @@ pub async fn get(pool: &PgPool, channel_id: Uuid) -> Result<CanvasRow, sqlx::Err
     }))
 }
 
+/// Maximum number of strokes stored per canvas channel.
+///
+/// Each stroke object is a JSON value bounded by the 64 KB per-frame WS guard.
+/// 2 000 strokes caps cumulative JSONB column growth at a predictable ceiling
+/// without requiring periodic cleanup.
+pub const MAX_STROKES: i64 = 2_000;
+
+/// Maximum number of images stored per canvas channel.
+pub const MAX_IMAGES: i64 = 2_000;
+
 /// Append a drawing stroke to the channel canvas.
 ///
 /// The stroke must be a JSON object with at least `{ "id": "...", ... }`.
 /// Idempotent: if a stroke with the same `id` already exists it is ignored.
+///
+/// Returns `Err(sqlx::Error::RowNotFound)` when the canvas has reached
+/// [`MAX_STROKES`] (reusing `RowNotFound` as a sentinel; callers convert
+/// this to a user-facing error via [`CanvasCapError`]).
 pub async fn append_stroke(
     pool: &PgPool,
     channel_id: Uuid,
     stroke: serde_json::Value,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), CanvasCapError> {
+    // Check current stroke count before appending to bound cumulative growth.
+    let current_len: Option<i64> = sqlx::query_scalar(
+        "SELECT jsonb_array_length(drawing_data)
+         FROM channel_canvas
+         WHERE channel_id = $1",
+    )
+    .bind(channel_id)
+    .fetch_optional(pool)
+    .await?;
+
+    if current_len.unwrap_or(0) >= MAX_STROKES {
+        return Err(CanvasCapError::CapReached);
+    }
+
     sqlx::query(
         "INSERT INTO channel_canvas (channel_id, drawing_data, images_data)
          VALUES ($1, jsonb_build_array($2::jsonb), '[]')
@@ -63,6 +91,30 @@ pub async fn append_stroke(
     .await?;
 
     Ok(())
+}
+
+/// Error type for canvas append operations that enforce a row-count cap.
+#[derive(Debug)]
+pub enum CanvasCapError {
+    /// The canvas has reached the maximum allowed number of entries.
+    CapReached,
+    /// An underlying database error occurred.
+    Db(sqlx::Error),
+}
+
+impl std::fmt::Display for CanvasCapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CanvasCapError::CapReached => write!(f, "canvas row-count cap reached"),
+            CanvasCapError::Db(e) => write!(f, "database error: {e}"),
+        }
+    }
+}
+
+impl From<sqlx::Error> for CanvasCapError {
+    fn from(e: sqlx::Error) -> Self {
+        CanvasCapError::Db(e)
+    }
 }
 
 /// Erase all drawing strokes for a channel, keeping images intact.
@@ -99,11 +151,28 @@ pub async fn clear_all(pool: &PgPool, channel_id: Uuid) -> Result<(), sqlx::Erro
 }
 
 /// Add an image to the canvas (appends; duplicates are filtered by `id`).
+///
+/// Returns [`CanvasCapError::CapReached`] when the images array has reached
+/// [`MAX_IMAGES`].
 pub async fn add_image(
     pool: &PgPool,
     channel_id: Uuid,
     image: serde_json::Value,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), CanvasCapError> {
+    // Check current image count before appending to bound cumulative growth.
+    let current_len: Option<i64> = sqlx::query_scalar(
+        "SELECT jsonb_array_length(images_data)
+         FROM channel_canvas
+         WHERE channel_id = $1",
+    )
+    .bind(channel_id)
+    .fetch_optional(pool)
+    .await?;
+
+    if current_len.unwrap_or(0) >= MAX_IMAGES {
+        return Err(CanvasCapError::CapReached);
+    }
+
     sqlx::query(
         "INSERT INTO channel_canvas (channel_id, drawing_data, images_data)
          VALUES ($1, '[]', jsonb_build_array($2::jsonb))

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -58,6 +58,11 @@ pub struct MessageWithSender {
 pub struct ConversationSecurityRow {
     pub kind: String,
     pub is_encrypted: bool,
+    /// Disappearing-message TTL configured on the conversation.
+    /// `None` means disappearing messages are disabled.
+    /// Folded in here so `store_and_confirm` avoids a second `get_conversation_ttl`
+    /// round-trip on every outbound message.
+    pub disappearing_ttl_seconds: Option<i32>,
 }
 
 pub async fn find_or_create_dm_conversation(
@@ -338,8 +343,32 @@ pub async fn get_undelivered(
     // device (either successfully decryptable or as an undecryptable marker).
     // Without it a device that can't decrypt a frame would receive the same
     // placeholder on every reconnect.
+    // reply_count is scoped to the specific message IDs being returned rather
+    // than a full-table GROUP BY.  The CTE `batch` captures the IDs first;
+    // the reply_count subquery filters `WHERE reply_to_id = ANY(SELECT id FROM batch)`
+    // which is O(batch_size) instead of O(total messages).
     sqlx::query_as::<_, MessageWithSender>(
-        "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
+        "WITH batch AS ( \
+             SELECT m.id \
+             FROM messages m \
+             JOIN conversation_members cm \
+                  ON cm.conversation_id = m.conversation_id \
+                 AND cm.user_id = $1 \
+                 AND cm.is_removed = false \
+             WHERE m.sender_id != $1 \
+               AND m.deleted_at IS NULL \
+               AND m.content NOT LIKE '\\_\\_system\\_\\_:%' ESCAPE '\\' \
+               AND NOT EXISTS ( \
+                   SELECT 1 FROM message_deliveries md \
+                   WHERE md.message_id = m.id \
+                     AND md.recipient_user_id = $1 \
+                     AND md.device_id = $2 \
+               ) \
+               AND ($3::timestamptz IS NULL OR (m.created_at, m.id) > ($3, $4)) \
+             ORDER BY m.created_at ASC, m.id ASC \
+             LIMIT $5 \
+         ) \
+         SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
                 u.username AS sender_username, \
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
@@ -349,28 +378,18 @@ pub async fn get_undelivered(
                 NULL::text AS last_reply_snippet, \
                 '[]'::json AS reactions \
          FROM messages m \
+         JOIN batch ON batch.id = m.id \
          JOIN users u ON u.id = m.sender_id \
          LEFT JOIN messages rm ON rm.id = m.reply_to_id AND rm.conversation_id = m.conversation_id AND rm.deleted_at IS NULL \
          LEFT JOIN users ru ON ru.id = rm.sender_id \
          LEFT JOIN ( \
              SELECT reply_to_id, COUNT(*) AS reply_count \
              FROM messages \
-             WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL \
+             WHERE reply_to_id = ANY(SELECT id FROM batch) \
+               AND deleted_at IS NULL \
              GROUP BY reply_to_id \
          ) rc ON rc.reply_to_id = m.id \
-         JOIN conversation_members cm ON cm.conversation_id = m.conversation_id AND cm.user_id = $1 \
-                  AND cm.is_removed = false \
-         WHERE m.sender_id != $1 AND m.deleted_at IS NULL \
-                  AND m.content NOT LIKE '\\_\\_system\\_\\_:%' ESCAPE '\\' \
-                  AND NOT EXISTS ( \
-                      SELECT 1 FROM message_deliveries md \
-                      WHERE md.message_id = m.id \
-                        AND md.recipient_user_id = $1 \
-                        AND md.device_id = $2 \
-                  ) \
-                  AND ($3::timestamptz IS NULL OR (m.created_at, m.id) > ($3, $4)) \
-         ORDER BY m.created_at ASC, m.id ASC \
-         LIMIT $5",
+         ORDER BY m.created_at ASC, m.id ASC",
     )
     .bind(user_id)
     .bind(device_id)
@@ -699,7 +718,7 @@ pub async fn get_conversation_security(
     conversation_id: Uuid,
 ) -> Result<Option<ConversationSecurityRow>, sqlx::Error> {
     sqlx::query_as::<_, ConversationSecurityRow>(
-        "SELECT kind, is_encrypted FROM conversations WHERE id = $1",
+        "SELECT kind, is_encrypted, disappearing_ttl_seconds FROM conversations WHERE id = $1",
     )
     .bind(conversation_id)
     .fetch_optional(pool)

--- a/apps/server/src/ws/events/canvas.rs
+++ b/apps/server/src/ws/events/canvas.rs
@@ -50,6 +50,17 @@ pub(in crate::ws) async fn handle_canvas_event(
         }
     };
 
+    // Reject canvas events sent to non-voice channels (canvas is a sub-feature
+    // of voice lounges; text channels do not have a canvas).
+    if channel.kind != "voice" {
+        send_error(
+            state,
+            sender_id,
+            "Canvas events are only valid for voice channels",
+        );
+        return;
+    }
+
     let conversation_id = channel.conversation_id;
 
     // Verify sender is a member.
@@ -68,10 +79,17 @@ pub(in crate::ws) async fn handle_canvas_event(
     // Persist state for non-ephemeral kinds.
     match kind.as_str() {
         "stroke" => {
-            if let Err(e) =
-                db::canvas::append_stroke(&state.pool, channel_id, payload.clone()).await
-            {
-                tracing::error!("canvas: failed to persist stroke for channel {channel_id}: {e:?}");
+            match db::canvas::append_stroke(&state.pool, channel_id, payload.clone()).await {
+                Ok(()) => {}
+                Err(db::canvas::CanvasCapError::CapReached) => {
+                    send_error(state, sender_id, "Canvas stroke limit reached");
+                    return;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "canvas: failed to persist stroke for channel {channel_id}: {e:?}"
+                    );
+                }
             }
         }
         "clear" => {
@@ -80,8 +98,17 @@ pub(in crate::ws) async fn handle_canvas_event(
             }
         }
         "image_add" => {
-            if let Err(e) = db::canvas::add_image(&state.pool, channel_id, payload.clone()).await {
-                tracing::error!("canvas: failed to persist image for channel {channel_id}: {e:?}");
+            match db::canvas::add_image(&state.pool, channel_id, payload.clone()).await {
+                Ok(()) => {}
+                Err(db::canvas::CanvasCapError::CapReached) => {
+                    send_error(state, sender_id, "Canvas image limit reached");
+                    return;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "canvas: failed to persist image for channel {channel_id}: {e:?}"
+                    );
+                }
             }
         }
         "image_move" => {

--- a/apps/server/src/ws/message_service.rs
+++ b/apps/server/src/ws/message_service.rs
@@ -11,7 +11,8 @@ use uuid::Uuid;
 use crate::db;
 use crate::routes::AppState;
 use crate::types::ConversationKind;
-use crate::ws::handler::{ServerMessage, send_error};
+use crate::ws::error::send_error;
+use crate::ws::protocol::ServerMessage;
 use crate::ws::typing_service::get_member_ids_cached;
 
 pub(super) const MAX_MESSAGE_LENGTH: usize = 10_000;
@@ -372,6 +373,7 @@ pub(super) async fn handle_send_message(
         reply_to_id,
         parsed_rdc.as_ref(),
         ttl_seconds,
+        conv_security.disappearing_ttl_seconds,
         conv_security.is_encrypted,
     )
     .await
@@ -413,6 +415,10 @@ pub(super) async fn handle_send_message(
 /// a `message_sent` confirmation to the originating device, and relay the
 /// message to the sender's other devices.  Returns the stored message row
 /// on success, or `None` after sending an error to the client.
+///
+/// `conv_ttl_seconds` is the conversation-level disappearing-messages TTL
+/// already fetched by `get_conversation_security`; passing it here avoids a
+/// second `get_conversation_ttl` round-trip per outbound message.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn store_and_confirm(
     state: &AppState,
@@ -424,6 +430,7 @@ pub(super) async fn store_and_confirm(
     reply_to_id: Option<Uuid>,
     recipient_device_contents: Option<&ParsedRecipientDeviceContents>,
     ttl_seconds: Option<i64>,
+    conv_ttl_seconds: Option<i32>,
     is_encrypted: bool,
 ) -> Option<db::messages::MessageRow> {
     // Resolve TTL: use per-message override first, then fall back to conversation setting.
@@ -432,9 +439,7 @@ pub(super) async fn store_and_confirm(
     let effective_ttl = if ttl_seconds.is_some() {
         ttl_seconds
     } else {
-        db::messages::get_conversation_ttl(&state.pool, conv_id)
-            .await
-            .unwrap_or(None)
+        conv_ttl_seconds.map(|v| v as i64)
     };
 
     // Store message in DB. `RowNotFound` from `store_message` means the

--- a/apps/server/tests/ws_canvas_fanout.rs
+++ b/apps/server/tests/ws_canvas_fanout.rs
@@ -259,3 +259,65 @@ async fn canvas_avatar_move_relayed_but_not_persisted() {
     let _ = alice_ws.close(None).await;
     let _ = bob_ws.close(None).await;
 }
+
+/// Sending a canvas event to a text channel (not a voice channel) returns an
+/// error frame and does NOT fan out the event.  Exercises the channel-kind guard
+/// added by audit fix 1.
+#[tokio::test]
+async fn canvas_event_to_text_channel_returns_error() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _, _) =
+        common::register_and_login(&client, &base, "cvs_textguard_alice").await;
+    let group_id = common::create_group(&client, &base, &alice_token, "CanvasTextGuardGroup").await;
+
+    // Find the default "general" text channel.
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/channels"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let channels: Vec<Value> = resp.json().await.unwrap();
+    let text_channel_id = channels
+        .iter()
+        .find(|c| c["kind"] == "text")
+        .expect("default text channel must exist")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Connect Alice.
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Send a canvas_event to the text channel.
+    alice_ws
+        .send(Message::Text(
+            serde_json::json!({
+                "type": "canvas_event",
+                "channel_id": text_channel_id,
+                "kind": "stroke",
+                "payload": {"id": "s1"},
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("alice canvas send failed");
+
+    // The server must reply with an error frame.
+    let error_frame = common::recv_until_event(&mut alice_ws, &["error"]).await;
+    assert!(
+        error_frame["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("voice"),
+        "error message should mention voice channels, got: {error_frame}"
+    );
+
+    let _ = alice_ws.close(None).await;
+}


### PR DESCRIPTION
## Summary

Two bundles in this PR:

### Audit follow-ups (5 commits) — all 14 findings from /audit-project
- **HIGH**: voice participant grid blur storm → RepaintBoundary
- **MEDIUM**: canvas events now kind+cap guarded; volume controller no longer SID-leaks; TTL cached in conversation_security; reply-count subquery scoped to batch; image annotation pan repaint-cached; voice dock leave reuses toggleScreenShare
- **LOW**: admin provider autoDispose; livekit republish video on encoding change; rtc_stats_poll map pruned; image annotation snackbar on export failure; message_service imports protocol/error directly
- **Tests**: screen-share publish options regression, thread reply bumpReplyCount false branch, sound service decouple, canvas channel-kind guard

### iOS crash fix + observability (3 commits)
- **iOS voice lounge crash**: CallKit was setting \`audioSessionActive: true\` while LiveKit's WebRTC stack was also activating AVAudioSession during \`room.connect\` → native EXC_BAD_ACCESS in the audio render thread on iOS 17+ (outside any Dart try/catch — looked like an instant app exit). Set to \`false\` so CallKit observes the session LiveKit established.
- **iOS Info.plist hygiene**: added \`NSBluetoothAlwaysUsageDescription\` and \`NSLocalNetworkUsageDescription\` (App Store review hits on these when the audio session uses \`.allowBluetooth\`).
- **Analytics tab on iOS**: DebugLogService was pure in-memory — iOS users habitually kill apps, every cold launch reset the buffer to empty. Now file-backed at \`<documents>/echo-debug.log\` (NDJSON, 5000-entry cap, 500ms debounced writes). Loads on settings → debug logs.
- **Crash debuggability**: installed top-level \`FlutterError.onError\`, \`PlatformDispatcher.onError\`, and \`runZonedGuarded\` handlers — all uncaught errors now log at \`fatal\` level. Added 9 breadcrumb logs to \`joinChannel\` (one per await + one per error-catch) so the next iOS voice crash will leave a visible trail in the analytics tab pointing at the exact step that failed.

## Test plan
- [ ] CI green on dev
- [ ] Merge to main, release pipeline passes
- [ ] iOS beta tester: try joining a voice lounge; if it still crashes, the analytics tab should now show breadcrumbs identifying the failure step