### PR TITLE
fix(voice): grant canUpdateOwnMetadata in livekit token (ios crash root cause)

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -399,9 +399,24 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       );
 
       // Set display name so peers see a username instead of a UUID identity.
+      // Wrap in try/catch: setName triggers an UpdateOwnMetadata signal request
+      // that needs the `canUpdateOwnMetadata` grant in the LiveKit token. If
+      // the server-issued token is missing it, the SFU returns NOT_ALLOWED
+      // which closes the signal channel and cascades into every subsequent
+      // call (setMicrophoneEnabled, publish) failing. Server fix lives in
+      // routes/voice.rs but this guard stops a future grant regression from
+      // bricking the whole join flow.
       final username = ref.read(authProvider).username;
       if (username != null && username.isNotEmpty) {
-        room.localParticipant?.setName(username);
+        try {
+          room.localParticipant?.setName(username);
+        } catch (e) {
+          DebugLogService.instance.log(
+            LogLevel.warning,
+            'LiveKitVoice',
+            'joinChannel: setName failed (non-fatal): $e',
+          );
+        }
       }
 
       // ---- breadcrumb 4: microphone enable ------------------------------------

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -42,6 +42,12 @@ struct VideoGrant {
     room_join: bool,
     can_publish: bool,
     can_subscribe: bool,
+    /// Required so `LocalParticipant.setName(username)` can update the
+    /// display name on the SFU. Without this the client's metadata update
+    /// fails with NOT_ALLOWED, which then closes the signal channel and
+    /// makes every subsequent operation (setMicrophoneEnabled, publish)
+    /// fail — surfacing as an "iOS crash on voice lounge join" report.
+    can_update_own_metadata: bool,
 }
 
 /// Full LiveKit JWT claims.
@@ -133,6 +139,7 @@ pub async fn generate_token(
             room_join: true,
             can_publish: true,
             can_subscribe: true,
+            can_update_own_metadata: true,
         },
     };
 
@@ -201,6 +208,7 @@ mod tests {
                 room_join: true,
                 can_publish: true,
                 can_subscribe: true,
+                can_update_own_metadata: true,
             },
         };
 
@@ -210,6 +218,7 @@ mod tests {
         assert_eq!(json["video"]["room"], "room:channel");
         assert_eq!(json["video"]["roomJoin"], true);
         assert_eq!(json["video"]["canPublish"], true);
+        assert_eq!(json["video"]["canUpdateOwnMetadata"], true);
         assert_eq!(json["video"]["canSubscribe"], true);
     }
 


### PR DESCRIPTION
## Summary

The breadcrumb logging from PR #946 paid off — the actual iOS voice crash root cause is captured verbatim:

\`\`\`
[FTL] platform: LiveKit Exception: [UnexpectedStateException]
  Signal request failed: NOT_ALLOWED - does not have permission to update own metadata
\`\`\`

### What was happening
1. \`room.connect\` succeeds.
2. Client calls \`room.localParticipant.setName(username)\` to show readable names instead of UUIDs.
3. The LiveKit SDK translates that to an \`UpdateOwnMetadata\` signal request.
4. The SFU rejects with \`NOT_ALLOWED\` because the token grants we issue (\`canPublish\`, \`canSubscribe\`, \`roomJoin\`) don't include \`canUpdateOwnMetadata\`.
5. The signal channel closes.
6. Every subsequent operation — \`setMicrophoneEnabled\`, \`publishTrack\` — fails because they all go through the same dead signal channel.
7. The cascading failure surfaces as the visible "iOS voice lounge crash" report.

This explains why my earlier AVAudioSession + CallKit + mic permission fixes didn't help: the actual failure was on the LiveKit signaling layer, not the iOS audio layer.

### Fix
- **Server** (\`routes/voice.rs\`): added \`can_update_own_metadata: true\` to the JWT \`VideoGrant\`. Updated the existing test to assert it.
- **Client** (\`livekit_voice_provider.dart\`): wrapped \`setName\` in try/catch logged as warning. If the server-issued token ever loses this grant again (e.g. a misconfigured deploy), the join no longer cascades into total failure — peers just see a UUID instead of a username until reload.

## Test plan
- [ ] CI green on dev
- [ ] Merge to main; release pipeline rebuilds the server with the new grant
- [ ] iOS beta tester: try joining a voice lounge. Should now succeed all the way through to active call.