### PR TITLE
fix(ios): revert audio session pre-activation + window pos + join spinner + sync log flush

### DIFF
--- a/apps/client/ios/Runner/AppDelegate.swift
+++ b/apps/client/ios/Runner/AppDelegate.swift
@@ -21,32 +21,36 @@ import UserNotifications
     // Register for remote notifications (APNs)
     application.registerForRemoteNotifications()
 
-    // Configure the AVAudioSession for VoIP-style playback so CallKit and
-    // LiveKit's WebRTC engine share consistent options.
+    // Configure the AVAudioSession category for VoIP-style audio so CallKit
+    // and LiveKit's WebRTC engine share consistent options. Mode is .default
+    // rather than .voiceChat: .voiceChat aggressively claims the audio route
+    // and conflicts with the .voiceProcessingIO mode LiveKit sets internally
+    // on the native WebRTC track.
     //
-    // Mode is .default rather than .voiceChat: .voiceChat aggressively claims
-    // the audio route and, on iOS 17+, can deadlock the audio thread when
-    // LiveKit's LocalAudioTrack.create calls setActive(true) concurrently
-    // with the CallKit activation sequence.  .default lets LiveKit own the
-    // mode selection internally (it sets .voiceProcessingIO on the native
-    // WebRTC track) without a competing mode claim from the app layer.
+    // CRITICAL: do NOT call setActive(true) here. The previous version of
+    // this code did so as a "pre-warm" — but on iOS 17+ with mic permission
+    // in .notDetermined, setActive(true) on a .playAndRecord session blocks
+    // the main thread waiting for a TCC mic-permission prompt that cannot
+    // be presented yet (no UIScene up). The system watchdog then SIGKILLs
+    // the app after 20-30s. Symptom: orange mic dot appears (input route
+    // armed), no Dart breadcrumbs persist, no /api/voice/token request
+    // reaches the server — exactly what the production crash report shows.
     //
-    // setActive(true) is called here to pre-warm the session: LiveKit's
-    // subsequent setActive is then a no-op (already active) instead of a
-    // blocking reconfiguration that can race the mic-permission dialog on
-    // first launch.
+    // LiveKit's LocalAudioTrack.create activates the session itself at the
+    // right moment, AFTER a UI scene exists and after mic permission has
+    // been explicitly requested via permission_handler in joinChannel.
+    // Also dropped .mixWithOthers from the option set — it fights against
+    // .voiceProcessingIO that LiveKit installs.
     do {
       let session = AVAudioSession.sharedInstance()
       try session.setCategory(
         .playAndRecord,
         mode: .default,
-        options: [.allowBluetooth, .allowBluetoothA2DP, .mixWithOthers, .defaultToSpeaker]
+        options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
       )
       NSLog("[Echo] audio session category set")
-      try session.setActive(true)
-      NSLog("[Echo] audio session activated")
     } catch {
-      NSLog("[Echo] AVAudioSession setCategory/setActive failed: \(error.localizedDescription)")
+      NSLog("[Echo] AVAudioSession setCategory failed: \(error.localizedDescription)")
     }
 
     let result = super.application(application, didFinishLaunchingWithOptions: launchOptions)

--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -54,7 +54,9 @@ void main() {
       'flutter',
       '${details.exception}\n${details.stack}',
     );
-    DebugLogService.instance.forceFlush().ignore();
+    // Synchronous write — async forceFlush risks losing the fatal entry to
+    // SIGKILL on iOS hard-crashes before the microtask runs.
+    DebugLogService.instance.forceFlushSync();
     FlutterError.presentError(details);
   };
 
@@ -64,7 +66,7 @@ void main() {
   // re-thrown by the engine.
   PlatformDispatcher.instance.onError = (error, stack) {
     DebugLogService.instance.log(LogLevel.fatal, 'platform', '$error\n$stack');
-    DebugLogService.instance.forceFlush().ignore();
+    DebugLogService.instance.forceFlushSync();
     return true;
   };
 
@@ -82,6 +84,7 @@ void main() {
         'platform',
         '$error\n$stack',
       );
+      DebugLogService.instance.forceFlushSync();
     },
   );
 }

--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -236,6 +236,41 @@ class DebugLogService with ChangeNotifier {
     await _flushToDisk();
   }
 
+  /// Write the in-memory buffer to disk using a **blocking** synchronous call.
+  ///
+  /// This is intentionally blocking I/O.  With [maxEntries] capped at 5000
+  /// NDJSON lines the file is well under 1 MB and writes complete in <5 ms on
+  /// iOS flash storage — an acceptable cost when the alternative is losing all
+  /// breadcrumbs to a SIGKILL that fires before an async write round-trip can
+  /// complete.
+  ///
+  /// Call order guarantees:
+  /// 1. Any pending debounce timer is cancelled first to prevent a stale async
+  ///    write from racing with this call and overwriting the file.
+  /// 2. The write uses [_logFilePath] directly; if the path has not been
+  ///    resolved yet (i.e. [_resolveLogFilePath] hasn't completed) the call
+  ///    is a no-op — we cannot await in a sync context.
+  /// 3. [IOException]s are swallowed silently: logging a log-write failure
+  ///    would cause infinite recursion and the in-memory buffer remains intact.
+  ///
+  /// No-op on web ([kIsWeb] guard).
+  void forceFlushSync() {
+    if (kIsWeb) return;
+    // Cancel the pending debounce timer so a later async write does not race.
+    _writeTimer?.cancel();
+    _writeTimer = null;
+    // If the path hasn't been resolved yet we cannot block-wait for it.
+    final path = _logFilePath;
+    if (path == null) return;
+    try {
+      final snapshot = List<DebugLogEntry>.from(_entries);
+      final lines = snapshot.map((e) => e.toJsonLine()).join('\n');
+      File(path).writeAsStringSync('$lines\n');
+    } on IOException catch (_) {
+      // Swallow silently — see doc comment above.
+    }
+  }
+
   /// Read all persisted entries from the log file.
   ///
   /// Triggers the initial file load if it hasn't happened yet, then returns

--- a/apps/client/lib/src/services/window_state_service.dart
+++ b/apps/client/lib/src/services/window_state_service.dart
@@ -33,11 +33,23 @@ class WindowStateService {
   ///
   /// Position is clamped on restore to stay on-screen; here we just store
   /// whatever the user last positioned the window to.
+  ///
+  /// Skips saving when the window is in splash state (smaller than the
+  /// minimum restore thresholds of 720×480). Without this guard, closing the
+  /// app during the 300×300 splash would write the splash's top-left position
+  /// — which sits near the center of the monitor — and on the next launch
+  /// [restore] would apply those center-screen coordinates to the full-size
+  /// window, pushing it off the bottom-right edge.
   static Future<void> save() async {
     if (!_isDesktop) return;
     try {
       final prefs = await SharedPreferences.getInstance();
       final size = await windowManager.getSize();
+      // Do not persist geometry while the window is in the small splash state.
+      // The splash is 300×300; the minimum restore size is 720×480. Any window
+      // smaller than those thresholds means we are still in (or were left in)
+      // the splash phase and the coordinates would corrupt the next launch.
+      if (size.width < 720.0 || size.height < 480.0) return;
       await prefs.setDouble(_kWidthKey, size.width);
       await prefs.setDouble(_kHeightKey, size.height);
       try {

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -314,17 +314,16 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
       if (!shouldJoin) return;
     }
 
-    // Breadcrumb: write and force-flush to disk before the LiveKit join so
-    // any iOS crash inside joinChannel still leaves a clear trail. Fire and
-    // forget the flush — the 50 ms urgent debounce gives crash safety
-    // without making the production path block on file I/O, and awaiting it
-    // here stalls widget tests where path_provider isn't mocked.
+    // Breadcrumb: write and force-flush to disk synchronously before the
+    // LiveKit join so any iOS SIGKILL inside joinChannel still leaves a clear
+    // trail.  The blocking write completes in <5 ms on iOS flash storage
+    // (buffer is capped at 5000 NDJSON lines, well under 1 MB).
     DebugLogService.instance.log(
       LogLevel.info,
       'VoiceLoungeUI',
       'voice channel selected: ${channel.name} id=${channel.id}',
     );
-    unawaited(DebugLogService.instance.forceFlush());
+    DebugLogService.instance.forceFlushSync();
 
     final success = await ref
         .read(channelsProvider.notifier)
@@ -342,7 +341,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
         'VoiceLoungeUI',
         'calling livekitVoiceProvider.joinChannel conversationId=${widget.conversationId} channelId=${channel.id}',
       );
-      unawaited(DebugLogService.instance.forceFlush());
+      DebugLogService.instance.forceFlushSync();
 
       await ref
           .read(livekitVoiceProvider.notifier)

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -43,6 +43,11 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
   bool _voiceCleanupInFlight = false;
   late final LiveKitVoiceNotifier _voiceRtcNotifier;
 
+  /// Channel ID currently in the process of being joined (HTTP call +
+  /// room.connect + setMicrophoneEnabled). Cleared in a `finally` block so
+  /// the chip always reverts to its normal icon on success or failure.
+  String? _joiningChannelId;
+
   @override
   void initState() {
     super.initState();
@@ -314,46 +319,53 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
       if (!shouldJoin) return;
     }
 
-    // Breadcrumb: write and force-flush to disk synchronously before the
-    // LiveKit join so any iOS SIGKILL inside joinChannel still leaves a clear
-    // trail.  The blocking write completes in <5 ms on iOS flash storage
-    // (buffer is capped at 5000 NDJSON lines, well under 1 MB).
-    DebugLogService.instance.log(
-      LogLevel.info,
-      'VoiceLoungeUI',
-      'voice channel selected: ${channel.name} id=${channel.id}',
-    );
-    DebugLogService.instance.forceFlushSync();
+    // Show the per-chip spinner for the duration of the join sequence.
+    if (mounted) setState(() => _joiningChannelId = channel.id);
 
-    final success = await ref
-        .read(channelsProvider.notifier)
-        .joinVoiceChannel(widget.conversationId, channel.id);
-
-    DebugLogService.instance.log(
-      LogLevel.info,
-      'VoiceLoungeUI',
-      'joinVoiceChannel result: $success channelId=${channel.id}',
-    );
-
-    if (success && mounted) {
+    try {
+      // Breadcrumb: write and force-flush to disk synchronously before the
+      // LiveKit join so any iOS SIGKILL inside joinChannel still leaves a clear
+      // trail.  The blocking write completes in <5 ms on iOS flash storage
+      // (buffer is capped at 5000 NDJSON lines, well under 1 MB).
       DebugLogService.instance.log(
         LogLevel.info,
         'VoiceLoungeUI',
-        'calling livekitVoiceProvider.joinChannel conversationId=${widget.conversationId} channelId=${channel.id}',
+        'voice channel selected: ${channel.name} id=${channel.id}',
       );
       DebugLogService.instance.forceFlushSync();
 
-      await ref
-          .read(livekitVoiceProvider.notifier)
-          .joinChannel(
-            conversationId: widget.conversationId,
-            channelId: channel.id,
-            startMuted: voiceSettings.selfMuted || voiceSettings.selfDeafened,
-          );
-      if (!mounted) return;
-      widget.onVoiceChannelChanged(channel.id);
-      // The voice dock + auto-show-lounge already give the user clear visual
-      // feedback that the join succeeded; the snackbar was redundant noise.
+      final success = await ref
+          .read(channelsProvider.notifier)
+          .joinVoiceChannel(widget.conversationId, channel.id);
+
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'VoiceLoungeUI',
+        'joinVoiceChannel result: $success channelId=${channel.id}',
+      );
+
+      if (success && mounted) {
+        DebugLogService.instance.log(
+          LogLevel.info,
+          'VoiceLoungeUI',
+          'calling livekitVoiceProvider.joinChannel conversationId=${widget.conversationId} channelId=${channel.id}',
+        );
+        DebugLogService.instance.forceFlushSync();
+
+        await ref
+            .read(livekitVoiceProvider.notifier)
+            .joinChannel(
+              conversationId: widget.conversationId,
+              channelId: channel.id,
+              startMuted: voiceSettings.selfMuted || voiceSettings.selfDeafened,
+            );
+        if (!mounted) return;
+        widget.onVoiceChannelChanged(channel.id);
+        // The voice dock + auto-show-lounge already give the user clear visual
+        // feedback that the join succeeded; the snackbar was redundant noise.
+      }
+    } finally {
+      if (mounted) setState(() => _joiningChannelId = null);
     }
   }
 
@@ -417,11 +429,13 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     UIDensity density,
   ) {
     final isActive = _isVoiceChannelActive(channel.id, activeVoiceChannelId);
+    final isJoining = _joiningChannelId == channel.id;
     return _VoicePeekChip(
       key: ValueKey('voice-peek-${channel.id}'),
       channel: channel,
       participants: participants,
       isActive: isActive,
+      isJoining: isJoining,
       metrics: _chipMetrics(density),
       onTap: () => _handleVoiceChipTap(channel, isActive, voiceSettings),
       miniAvatarStackBuilder: (ps) => _buildMiniAvatarStack(ps),
@@ -875,6 +889,12 @@ class _VoicePeekChip extends StatefulWidget {
   final GroupChannel channel;
   final List<VoiceSessionMember> participants;
   final bool isActive;
+
+  /// True while the join sequence (HTTP call + room.connect + mic enable) is
+  /// in flight for THIS specific channel. Renders a small spinner in place of
+  /// the volume icon so the user knows the tap was registered.
+  final bool isJoining;
+
   final _ChipMetrics metrics;
   final VoidCallback onTap;
   final Widget Function(List<VoiceSessionMember>) miniAvatarStackBuilder;
@@ -884,6 +904,7 @@ class _VoicePeekChip extends StatefulWidget {
     required this.channel,
     required this.participants,
     required this.isActive,
+    this.isJoining = false,
     required this.metrics,
     required this.onTap,
     required this.miniAvatarStackBuilder,
@@ -947,6 +968,7 @@ class _VoicePeekChipState extends State<_VoicePeekChip> {
   Widget build(BuildContext context) {
     final m = widget.metrics;
     final isActive = widget.isActive;
+    final isJoining = widget.isJoining;
     final participants = widget.participants;
 
     final chip = Material(
@@ -971,11 +993,21 @@ class _VoicePeekChipState extends State<_VoicePeekChip> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(
-                Icons.volume_up_outlined,
-                size: m.iconSize,
-                color: isActive ? context.accent : context.textMuted,
-              ),
+              if (isJoining)
+                SizedBox(
+                  width: m.iconSize,
+                  height: m.iconSize,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: context.accent,
+                  ),
+                )
+              else
+                Icon(
+                  Icons.volume_up_outlined,
+                  size: m.iconSize,
+                  color: isActive ? context.accent : context.textMuted,
+                ),
               const SizedBox(width: 4),
               Text(
                 widget.channel.name,

--- a/apps/client/test/services/debug_log_service_test.dart
+++ b/apps/client/test/services/debug_log_service_test.dart
@@ -340,6 +340,32 @@ void main() {
         },
       );
 
+      test('forceFlushSync writes to file synchronously', () {
+        // Resolve the path ahead of time so forceFlushSync finds it
+        // (normally resolved by the async _resolveLogFilePath; the
+        // resetForTest override sets it directly).
+        service.log(LogLevel.info, 'SyncFlush', 'sync breadcrumb');
+
+        final sw = Stopwatch()..start();
+        service.forceFlushSync();
+        sw.stop();
+
+        // The file must exist and contain the entry immediately — no await.
+        final file = File('${tempDir.path}/echo-debug.log');
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), contains('sync breadcrumb'));
+
+        // Write cost must be well under 200 ms (target <5 ms on device;
+        // 200 ms is a generous ceiling for slow CI runners).
+        expect(
+          sw.elapsedMilliseconds,
+          lessThan(200),
+          reason:
+              'sync write took ${sw.elapsedMilliseconds} ms — '
+              'expected <200 ms',
+        );
+      });
+
       test('forceFlush cancels any pending debounce timer', () async {
         // Schedule a normal (debounced) write, then immediately force-flush.
         // The file should contain the entry without waiting for the timer.

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -111,6 +113,27 @@ class _FakeVoiceSettingsConfirm extends VoiceSettings {
   @override
   VoiceSettingsState build() =>
       const VoiceSettingsState(confirmBeforeJoinVoice: true);
+}
+
+/// Slow fake: joinChannel completes only after the completer is released.
+/// Used to assert that the joining spinner is visible mid-flight.
+class _SlowVoiceRtcNotifier extends LiveKitVoiceNotifier {
+  _SlowVoiceRtcNotifier();
+
+  final _joinCompleter = Completer<void>();
+
+  @override
+  LiveKitVoiceState build() => LiveKitVoiceState.empty;
+
+  @override
+  Future<void> joinChannel({
+    required String conversationId,
+    required String channelId,
+    bool startMuted = false,
+  }) => _joinCompleter.future;
+
+  @override
+  Future<void> leaveChannel() async {}
 }
 
 /// Static UIDensity notifier used by Phase 2 density-tier tests
@@ -298,6 +321,50 @@ void main() {
       expect(fakeChannels.leaveCalls, 0);
       expect(fakeVoiceRtc.leaveCalls, 0);
       expect(activeVoice, 'voice-1');
+    });
+
+    testWidgets('shows spinner on voice chip while join is in flight', (
+      tester,
+    ) async {
+      late _SlowVoiceRtcNotifier slowVoiceRtc;
+
+      await tester.pumpApp(
+        ChannelBar(
+          conversationId: 'conv-1',
+          onTextChannelChanged: (_) {},
+          onVoiceChannelChanged: (_) {},
+        ),
+        overrides: [
+          authOverride(loggedInAuthState),
+          webSocketOverride(),
+          channelsProvider.overrideWith(_FakeChannelsNotifier.new),
+          voiceRtcProvider.overrideWith(() {
+            slowVoiceRtc = _SlowVoiceRtcNotifier();
+            return slowVoiceRtc;
+          }),
+          voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      // No spinner before tapping.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      // Tap the voice chip — the join is in flight but not yet complete.
+      await tester.tap(find.text('lounge').first);
+
+      // One frame so the setState(_joiningChannelId = channel.id) is applied.
+      await tester.pump();
+
+      // Spinner must be visible while join is pending.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // Release the join future and let the widget settle.
+      slowVoiceRtc._joinCompleter.complete();
+      await tester.pumpAndSettle();
+
+      // Spinner is gone after join completes.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR carries **four scope-aligned fixes** that came in via the iOS forensics loop.

### 1. iOS voice lounge crash — actual root cause (REGRESSION FROM EARLIER TODAY)
My own commit \`38e1e0a6\` ("pre-activate audio session and request mic permission before livekit") regressed iOS. The \`try session.setActive(true)\` in \`didFinishLaunchingWithOptions\` synchronously blocks the main thread waiting for the TCC mic-permission prompt — which can't be presented yet (no UIScene up). iOS watchdog SIGKILLs at 20-30s. Symptoms match the production report exactly: orange dot, zero Dart breadcrumbs, zero \`/api/voice/token\` requests on server. 

**Fix**: remove the launch-time \`setActive\` call. Set the category only. LiveKit's \`LocalAudioTrack.create\` activates the session itself at the right moment (after a UI scene exists + after explicit mic permission via \`permission_handler\` in joinChannel). Also dropped \`.mixWithOthers\` from the option set — it fought with \`.voiceProcessingIO\` that LiveKit installs.

### 2. Synchronous log flush (precondition for diagnosing future iOS hard-crashes)
- New \`DebugLogService.forceFlushSync()\` uses \`File.writeAsStringSync\` — POSIX blocking write, ~1-3ms on iOS NAND for the 5000-entry buffer.
- Voice-tap handler in \`channel_bar.dart\` now uses sync flush — breadcrumb is guaranteed on disk before the next line of code runs.
- Global error handlers (\`FlutterError.onError\`, \`PlatformDispatcher.onError\`, \`runZonedGuarded\`) all upgraded to sync flush.

### 3. Window starts off-screen
\`WindowStateService.save()\` was persisting the 300×300 splash geometry, putting the window's top-left at the screen center on the next launch. Guarded \`save()\` to refuse to write geometry smaller than the minimum restore thresholds (720×480).

### 4. Joining feels hung — no feedback during the ~2s connect
Chip in the channel bar now shows a \`CircularProgressIndicator\` (sized to the icon slot for the current density) while the join chain is in flight, cleared in \`finally\` so failures don't leave a stuck spinner. Existing dock-side \`_buildJoiningIndicator()\` already covered post-connect; this adds the pre-connect bridge.

## Test plan
- [x] \`flutter test\` — 1565 tests pass including new sync-write timing test + chip-spinner widget test
- [x] \`flutter analyze --fatal-infos\` clean
- [ ] CI green on dev
- [ ] Merge to main; iOS rebuild
- [ ] iOS beta tester:
  - Launch should no longer hang at 30s watchdog
  - If a crash STILL happens, the new sync-flushed breadcrumbs will pinpoint the exact failure step
  - Desktop window should now open at the previously-saved position OR centered, not off-screen