### PR TITLE
fix(ios): request mic permission before room.connect (real crash root cause)

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -291,6 +291,43 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
 
     String? attemptedUrl;
     try {
+      // ---- breadcrumb 0: pre-request microphone permission ------------------
+      // CRITICAL: iOS must grant mic permission BEFORE LiveKit's room.connect
+      // or any audio-track creation. LiveKit server logs from a real iOS
+      // crash showed: `room.connect` succeeded in 1.2s, then 22s later the
+      // peer connection died from watchdog SIGKILL. The 22s matches iOS
+      // killing the app for a blocked main thread, which is what happens
+      // when AVAudioSession activation in `setMicrophoneEnabled` collides
+      // with a TCC mic-permission prompt presented at the same time.
+      //
+      // Requesting permission FIRST drains the prompt into a clean idle
+      // context, so by the time room.connect/setMicrophoneEnabled run the
+      // permission is already .granted or .denied — no synchronous race.
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: pre-requesting microphone permission',
+      );
+      final micPermitted = await _requestMicrophonePermission();
+      if (!micPermitted) {
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'LiveKitVoice',
+          'joinChannel: microphone permission denied — aborting',
+        );
+        state = state.copyWith(
+          isJoining: false,
+          isActive: false,
+          error: 'Microphone access is required to join a voice channel',
+        );
+        return;
+      }
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'LiveKitVoice',
+        'joinChannel: microphone permission granted',
+      );
+
       // ---- breadcrumb 1: token fetch ----------------------------------------
       DebugLogService.instance.log(
         LogLevel.info,
@@ -420,32 +457,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       }
 
       // ---- breadcrumb 4: microphone enable ------------------------------------
-      // Pre-request microphone permission BEFORE LiveKit touches the audio
-      // session.  On iOS 17+, setMicrophoneEnabled triggers the native
-      // permission dialog mid-session-activation, which can deadlock the
-      // audio thread and cause the watchdog to kill the app ~27s later.
-      // Requesting permission in a clean context avoids that race entirely.
-      DebugLogService.instance.log(
-        LogLevel.info,
-        'LiveKitVoice',
-        'joinChannel: requesting microphone permission',
-      );
-      final micPermitted = await _requestMicrophonePermission();
-      if (!micPermitted) {
-        DebugLogService.instance.log(
-          LogLevel.error,
-          'LiveKitVoice',
-          'joinChannel: microphone permission denied — aborting',
-        );
-        await _cleanupRoom();
-        state = state.copyWith(
-          isJoining: false,
-          isActive: false,
-          error: 'Microphone access is required to join a voice channel',
-        );
-        return;
-      }
-
+      // Mic permission was already granted at the top of joinChannel
+      // (breadcrumb 0) so this call is non-blocking.
       final micEnabled = !startMuted;
       DebugLogService.instance.log(
         LogLevel.info,


### PR DESCRIPTION
## Summary

The sync-flush logs from PR #948 finally let us see the actual iOS crash path. The breadcrumbs we did get said:

\`\`\`
LiveKitVoice: joinChannel: calling room.connect(wss://livekit...)
*** 6 seconds of silence ***
*** app restarts ***
\`\`\`

But the LiveKit server logs (pulled via SSH) told the real story:
\`\`\`
22:33:32 participant joins (iPhone16,2, iOS 26.5)
22:33:33 participant ACTIVE, connectionType: udp, connectTime: 1.21s   ← room.connect succeeded
22:33:55 participant closing, reason: PEER_CONNECTION_DISCONNECTED, sessionDuration: 22.30s
\`\`\`

**The iOS client connected to LiveKit in 1.2s — successfully — then was killed by the iOS watchdog 22 seconds later.** 22s is the classic iOS main-thread-blocked watchdog timeout. The crash is at \`setMicrophoneEnabled(true)\` because:

1. \`room.connect\` completes fine.
2. \`setMicrophoneEnabled\` triggers AVAudioSession activation.
3. **At the same time** iOS presents the TCC mic-permission dialog (mic was \`.notDetermined\`).
4. Main thread blocks waiting for both → watchdog kill at ~22s.

### Fix
Move \`_requestMicrophonePermission()\` to the VERY TOP of \`joinChannel\`, **before** the token fetch / Room creation / room.connect. The permission prompt drains into a clean idle context instead of racing AVAudioSession activation.

This is what the iOS expert agent recommended yesterday and what I missed when wiring the original \`_requestMicrophonePermission()\` call — I put it between room.connect and setMicrophoneEnabled, which is still too late because the dialog can fire at any point in that window.

### Test plan
- [x] \`flutter analyze --fatal-infos\` clean
- [ ] CI green on dev
- [ ] Merge to main; iOS rebuild
- [ ] iOS beta tester:
  - Reinstall the app to reset TCC to .notDetermined
  - Tap voice channel — mic permission dialog should appear FIRST
  - After grant, join should complete to active call (Linux works end-to-end as evidence)