### PR TITLE
small wins: inline quick reactions on hover bar + InvalidCredentials rename

### DIFF
--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -758,9 +758,19 @@ class _MessageItemState extends State<MessageItem>
                 onPressed: () => widget.onReply?.call(msg),
               ),
             ),
+          // Inline quick-reaction emojis (Slack/Discord style). One tap
+          // dispatches the reaction directly; the full picker is still
+          // reachable via the "+" button to the right of this row.
+          if (widget.onReactionSelect != null)
+            for (final emoji in reactionEmojis)
+              _QuickReactionButton(
+                emoji: emoji,
+                size: style.buttonSize,
+                onPressed: () => widget.onReactionSelect?.call(msg, emoji),
+              ),
           HoverActionButton(
             icon: Icons.add_reaction_outlined,
-            tooltip: 'React',
+            tooltip: 'More reactions',
             iconSize: style.iconSize,
             iconOpacity: style.iconOpacity,
             iconColor: style.iconColor,
@@ -1857,6 +1867,49 @@ class _MessageItemState extends State<MessageItem>
               canSwipe: canSwipeToReply,
               msg: msg,
               messageWidget: messageWidget,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Inline quick-reaction button: renders a single emoji with the same hit
+/// area as [HoverActionButton] so the hover bar stays visually consistent.
+/// Sized to honor the WCAG 24px minimum even when the bar uses a compact
+/// 21×21 visual chip (the 44×44 ink target stays full-width).
+class _QuickReactionButton extends StatelessWidget {
+  final String emoji;
+  final double size;
+  final VoidCallback onPressed;
+
+  const _QuickReactionButton({
+    required this.emoji,
+    required this.size,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final minTarget = size < 44 ? 44.0 : size;
+    return Semantics(
+      label: 'React with $emoji',
+      button: true,
+      child: Tooltip(
+        message: emoji,
+        waitDuration: const Duration(milliseconds: 600),
+        child: SizedBox(
+          width: minTarget,
+          height: minTarget,
+          child: Material(
+            type: MaterialType.transparency,
+            child: InkWell(
+              onTap: onPressed,
+              borderRadius: BorderRadius.circular(4),
+              child: Center(
+                child: Text(emoji, style: TextStyle(fontSize: size * 0.6)),
+              ),
             ),
           ),
         ),

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 ///
 /// Generic variants (e.g. `BadRequest`) are emitted when the plain
 /// `AppError::bad_request(msg)` constructor is used.  Domain-specific variants
-/// (e.g. `WrongPassword`) are set explicitly via `AppError::with_code`.
+/// (e.g. `InvalidCredentials`) are set explicitly via `AppError::with_code`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorCode {
     // ---- Generic HTTP-status mirrors ----
@@ -27,7 +27,7 @@ pub enum ErrorCode {
 
     // ---- Auth domain ----
     /// Provided password does not match the stored hash.
-    WrongPassword,
+    InvalidCredentials,
     /// Username is already registered.
     UsernameTaken,
     /// Registration is administratively disabled.
@@ -67,7 +67,7 @@ impl ErrorCode {
             ErrorCode::Internal => "internal",
             ErrorCode::Validation => "validation",
             ErrorCode::Unsupported => "unsupported",
-            ErrorCode::WrongPassword => "wrong-password",
+            ErrorCode::InvalidCredentials => "invalid-credentials",
             ErrorCode::UsernameTaken => "username-taken",
             ErrorCode::RegistrationDisabled => "registration-disabled",
             ErrorCode::TokenExpired => "token-expired",
@@ -157,7 +157,7 @@ impl AppError {
     /// - `NotMember` → 401 (was `AppError::unauthorized` at all call sites)
     /// - `RegistrationDisabled` → 403 (was `AppError::forbidden`)
     /// - `AlreadyMember` → 409 (was `AppError::conflict`)
-    /// - `WrongPassword` / `TokenExpired` / `TokenRevoked` → 401
+    /// - `InvalidCredentials` / `TokenExpired` / `TokenRevoked` → 401
     pub fn with_code(code: ErrorCode, msg: impl Into<String>) -> Self {
         let status = match code {
             ErrorCode::BadRequest
@@ -165,7 +165,7 @@ impl AppError {
             | ErrorCode::InvalidCiphertextShape
             | ErrorCode::UnsupportedMediaType => StatusCode::BAD_REQUEST,
             ErrorCode::Unauthorized
-            | ErrorCode::WrongPassword
+            | ErrorCode::InvalidCredentials
             | ErrorCode::TokenExpired
             | ErrorCode::TokenRevoked
             // NotMember was `AppError::unauthorized` at all existing call sites;
@@ -369,9 +369,12 @@ mod tests {
 
     #[test]
     fn with_code_wrong_password_is_401() {
-        let err = AppError::with_code(ErrorCode::WrongPassword, "Invalid username or password");
+        let err = AppError::with_code(
+            ErrorCode::InvalidCredentials,
+            "Invalid username or password",
+        );
         assert_eq!(err.status, StatusCode::UNAUTHORIZED);
-        assert_eq!(err.code, ErrorCode::WrongPassword);
+        assert_eq!(err.code, ErrorCode::InvalidCredentials);
         assert_eq!(err.message, "Invalid username or password");
     }
 
@@ -410,7 +413,10 @@ mod tests {
 
     #[test]
     fn error_code_as_str_snapshot() {
-        assert_eq!(ErrorCode::WrongPassword.as_str(), "wrong-password");
+        assert_eq!(
+            ErrorCode::InvalidCredentials.as_str(),
+            "invalid-credentials"
+        );
         assert_eq!(ErrorCode::UsernameTaken.as_str(), "username-taken");
         assert_eq!(
             ErrorCode::RegistrationDisabled.as_str(),
@@ -433,12 +439,15 @@ mod tests {
 
     #[test]
     fn into_response_json_shape_includes_code_field() {
-        let err = AppError::with_code(ErrorCode::WrongPassword, "Invalid username or password");
+        let err = AppError::with_code(
+            ErrorCode::InvalidCredentials,
+            "Invalid username or password",
+        );
         let body = serde_json::json!({
             "error": err.message,
             "code": err.code.as_str(),
         });
         assert_eq!(body["error"], "Invalid username or password");
-        assert_eq!(body["code"], "wrong-password");
+        assert_eq!(body["code"], "invalid-credentials");
     }
 }

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -257,7 +257,7 @@ pub async fn login(
         Some(u) if valid => u,
         _ => {
             return Err(AppError::with_code(
-                ErrorCode::WrongPassword,
+                ErrorCode::InvalidCredentials,
                 "Invalid username or password",
             ));
         }

--- a/apps/server/tests/api_auth.rs
+++ b/apps/server/tests/api_auth.rs
@@ -514,7 +514,7 @@ async fn refresh_cookie_rotation_invalidates_prior_body_token() {
 // ErrorCode field assertions (#633)
 // ---------------------------------------------------------------------------
 
-/// Login with wrong password should return code="wrong-password".
+/// Login with wrong password should return code="invalid-credentials".
 #[tokio::test]
 async fn login_wrong_password_returns_wrong_password_code() {
     let base = common::spawn_server().await;
@@ -528,8 +528,8 @@ async fn login_wrong_password_returns_wrong_password_code() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(
         body["code"].as_str(),
-        Some("wrong-password"),
-        "wrong-password error must carry code=wrong-password; got: {body}"
+        Some("invalid-credentials"),
+        "invalid-credentials error must carry code=invalid-credentials; got: {body}"
     );
     // Original "error" field still present for backward compat.
     assert!(


### PR DESCRIPTION
Two small commits ready while CI was building.

## Changes
- **feat(client)**: 5-emoji quick-reaction buttons inline on the desktop hover action bar. The same 5 emojis (\`👍 ❤️ 😂 🔥 🙏\`) already showed in the mobile long-press action sheet via \`QuickReactionRow\`; this gives desktop parity — one click reacts without opening a picker. The \`+\` button still opens the full picker.
- **refactor(server) (#830)**: rename \`ErrorCode::WrongPassword\` → \`InvalidCredentials\` and wire string \`"wrong-password"\` → \`"invalid-credentials"\`. Eliminates the minor enumeration-information hint Copilot flagged in PR #935's review.

## Test plan
- [x] flutter test test/widgets/message_item_test.dart — 37/37 pass
- [x] cargo test -p echo-server — passes
- [ ] CI green on dev
- [ ] Merge to main, release pipeline passes