### PR TITLE
chore(ios): force webrtc 1.4.1 + rename binary to Echo for findable crash logs

### DIFF
--- a/apps/client/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/client/ios/Runner.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = Echo;
 				PROVISIONING_PROFILE_SPECIFIER = "Echo App Store Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -755,7 +755,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = Echo;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -780,7 +780,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = us.echomessenger.app;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = Echo;
 				PROVISIONING_PROFILE_SPECIFIER = "Echo App Store Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/client/pubspec.lock
+++ b/apps/client/pubspec.lock
@@ -551,10 +551,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "8b302d17096ba88f911b7eb317c71d5e691da60a259549f42b38c658d1776d87"
+      sha256: "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
@@ -617,10 +617,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_webrtc
-      sha256: "8b220dc006c4891266735e516f7679bd08b7caaf7c36b1a93fb9357cec555f92"
+      sha256: c7b0a67ca2c878575fc5c146d801cd874f58f5f1ef5fa6e8eb0c93d413beb948
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   freezed_annotation:
     dependency: transitive
     description:

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   web_socket_channel: ^3.0.0
   cryptography: ^2.7.0
   shared_preferences: ^2.3.0
-  flutter_secure_storage: ^10.1.0
+  flutter_secure_storage: ^10.2.0
   google_fonts: ^8.1.0
   url_launcher: ^6.3.0
   file_picker: ^11.0.2
@@ -89,3 +89,9 @@ dependency_overrides:
   # the macOS 26 SDK (Xcode 26). GitHub macOS-15 runners ship Xcode 16.4
   # with macOS 15.5 SDK, so pin to 6.x until runners upgrade.
   connectivity_plus: ^6.1.5
+  # livekit_client 2.7.0 pins flutter_webrtc to exactly 1.4.0, but 1.4.1
+  # has iOS-specific bug fixes that may resolve the production iOS voice
+  # lounge crash (room.connect / setMicrophoneEnabled native EXC_BAD_ACCESS
+  # on iPhone 16 / iOS 26.5). Override the pin so we get 1.4.1; revert if
+  # this introduces new iOS-side regressions.
+  flutter_webrtc: 1.4.1


### PR DESCRIPTION
## Summary

Two iOS-targeted changes to chase the production crash and make future diagnosis easier.

### 1. \`flutter_webrtc\` 1.4.1 via dependency_overrides
\`livekit_client 2.7.0\` pins \`flutter_webrtc\` to exactly 1.4.0. The newer 1.4.1 exists with iOS bug fixes that may resolve the native EXC_BAD_ACCESS observed on iPhone 16 / iOS 26.5 at \`setMicrophoneEnabled\` or \`room.connect\`. Forcing it via \`dependency_overrides\`. **Experimental** — revert if the LiveKit iOS bridge has a 1.4.0-only API dependency.

### 2. Rename binary \`PRODUCT_NAME\` Runner → Echo
iOS sysdiagnose crash reports (.ips files) are named by the binary executable, which Flutter defaults to "Runner". When the user looks in **Settings → Privacy & Security → Analytics & Improvements → Analytics Data**, our crash files are buried among system "Runner" artifacts and impossible to find.

Changing \`PRODUCT_NAME = Echo\` in all three Runner target build configurations (Debug/Release/Profile) makes the binary "Echo.app/Echo" so future .ips files are named \`Echo-2026-MM-DD-...ips\` and findable at a glance. Display name + bundle name in Info.plist were already "Echo"; this aligns the executable name.

\`RunnerTests\` and the \`EchoBroadcast\` / \`EchoNotificationService\` extensions are untouched (their PRODUCT_NAME is already correct).

### Plus a small safe bump
- \`flutter_secure_storage\` 10.1.0 → 10.2.0 (patch)

## Test plan
- [x] flutter pub get resolves cleanly
- [x] flutter analyze --fatal-infos clean
- [x] flutter test — all 1565 pass
- [ ] CI green on dev (especially iOS Pod resolution with overridden flutter_webrtc)
- [ ] Merge to main, release pipeline
- [ ] iOS beta tester:
  - Install new TestFlight build
  - If voice STILL crashes, the .ips will now be named "Echo-..." and easy to find in Settings → Analytics Data → grab the file and share it