### PR TITLE
fix(ios): CallKit UUID + mobile header connection-dot anchor

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -518,9 +518,16 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       );
       unawaited(
         VoiceCallKitService.instance.startCall(
-          // CallKit identifies the call by id; use the room's conversation
-          // + channel pair so a future "rejoin same room" call is a no-op.
-          callId: '$conversationId:$channelId',
+          // CallKit's iOS CXCall ID is required to be a valid UUID.
+          // flutter_callkit_incoming's Swift handler does
+          // `UUID(uuidString: params.id)!` and force-unwraps — passing the
+          // previous `"$conversationId:$channelId"` composite was not a
+          // valid UUID, so the force-unwrap crashed with EXC_BREAKPOINT
+          // (Swift fatal error) inside CallManager.startCall, killing the
+          // app every iOS voice join. channelId is already a UUID and is
+          // unique per voice room, which preserves the "rejoin same room
+          // is a no-op" dedup semantic.
+          callId: channelId,
           channelName: resolvedChannelName,
           isMuted: !micEnabled,
         ),

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -613,32 +613,22 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           Expanded(
             child: Row(
               children: [
-                if (!isMobile) ...[
-                  const ConnectionStatusBadge(child: EchoLogoIcon(size: 22)),
-                  const SizedBox(width: 8),
-                ],
-                if (isMobile)
-                  ConnectionStatusBadge(
-                    child: Text(
-                      'Chats',
-                      style: TextStyle(
-                        color: context.textPrimary,
-                        fontSize: titleSize,
-                        fontWeight: titleWeight,
-                        letterSpacing: -0.5,
-                      ),
-                    ),
-                  )
-                else
-                  Text(
-                    'Echo',
-                    style: TextStyle(
-                      color: context.textPrimary,
-                      fontSize: titleSize,
-                      fontWeight: titleWeight,
-                      letterSpacing: 0,
-                    ),
+                // Anchor the connection status dot to a small fixed-size
+                // icon on every layout. Wrapping it around the large
+                // "Chats" text on mobile placed the dot at the lower-right
+                // of the "s" — visually awkward; the icon variant matches
+                // desktop and gives the dot a predictable anchor.
+                const ConnectionStatusBadge(child: EchoLogoIcon(size: 22)),
+                const SizedBox(width: 10),
+                Text(
+                  isMobile ? 'Chats' : 'Echo',
+                  style: TextStyle(
+                    color: context.textPrimary,
+                    fontSize: titleSize,
+                    fontWeight: titleWeight,
+                    letterSpacing: isMobile ? -0.5 : 0,
                   ),
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary

Two ship-now fixes from this round of debugging.

### 1. iOS CallKit crash — actual root cause (.ips decoded)
The user's iOS sysdiagnose .ips revealed the real native crash:

\`\`\`
Thread 0 (com.apple.main-thread) crashed with EXC_BREAKPOINT (SIGTRAP) / brk 1
Frame 0: CallManager.startCall(_:)   in flutter_callkit_incoming
Frame 1: SwiftFlutterCallkitIncomingPlugin.handle(_:result:)
\`\`\`

Registers showed \`type metadata for UUID\` and \`value witness table for UUID\` — a Swift force-unwrap of a \`UUID(uuidString:)\` parse. The plugin's iOS code expects \`params.id\` to be a valid UUID; we were passing \`"$conversationId:$channelId"\` (e.g. \`cb1071b7-...:1609c73b-...\`), which is two UUIDs joined by \`:\` — not a single valid UUID. Swift parse returns nil, force-unwrap crashes the process. Linux silently accepts the composite string which is why every other platform worked.

**Fix**: use \`channelId\` alone (already a UUID, globally unique per voice room — preserves the "rejoin same room is a no-op" dedup semantic). One-line change.

This is the bug that's been crashing every iOS voice join all day. Every theory I shipped (CallKit audioSessionActive, AppDelegate audio session pre-activation, mic permission ordering, flutter_webrtc 1.4.1 bump) was treating symptoms. The .ips named this in one read.

### 2. Mobile header connection dot anchor
The green/red connection status dot was anchored to the bottom-right of the large "Chats" title text on mobile — sat awkwardly off the lower-right of the "s". Wrapped the small 22px Echo logo icon instead, matching the desktop pattern; title text renders separately to the right.

## Test plan
- [x] flutter analyze --fatal-infos clean
- [ ] CI green on dev
- [ ] Merge to main, release pipeline
- [ ] iOS beta tester: voice join should succeed end-to-end. If it still crashes, the .ips will be findable as Echo-... (from PR #951's binary rename) and we'll have a new native frame to diagnose.