### PR TITLE
beta blockers + 5 features: ptt, status, slash, context menu, polls

### DIFF
--- a/.github/workflows/prod-uptime.yml
+++ b/.github/workflows/prod-uptime.yml
@@ -1,0 +1,202 @@
+name: Prod Uptime
+
+# Lightweight health-check for echo-messenger.us.
+# Checks every 5 minutes; opens (or updates) a GitHub Issue on failure;
+# closes the issue automatically once all checks pass again.
+#
+# Checks:
+#   1. GET https://echo-messenger.us/api/health  -- must be 200 + {"status":"ok"}
+#   2. GET https://livekit.echo-messenger.us/    -- must be 200
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: prod-uptime
+  cancel-in-progress: false
+
+env:
+  ISSUE_TITLE: 'Outage: prod health check failing'
+  ISSUE_LABEL: outage
+
+jobs:
+  check:
+    name: Health checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      # "ok" or "fail"
+      result: ${{ steps.verdict.outputs.result }}
+      summary: ${{ steps.verdict.outputs.summary }}
+
+    steps:
+      - name: Check API health
+        id: api
+        run: |
+          set +e
+          RESPONSE=$(curl -sS -f -m 10 https://echo-messenger.us/api/health 2>&1)
+          CURL_EXIT=$?
+          echo "exit_code=$CURL_EXIT" >> "$GITHUB_OUTPUT"
+          echo "response<<BODY_EOF" >> "$GITHUB_OUTPUT"
+          echo "$RESPONSE" >> "$GITHUB_OUTPUT"
+          echo "BODY_EOF" >> "$GITHUB_OUTPUT"
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "API health check FAILED (curl exit $CURL_EXIT)"
+            exit 0   # don't fail the step — let verdict aggregate
+          fi
+          # Validate JSON contains "status":"ok"
+          STATUS=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status',''))" 2>/dev/null)
+          if [ "$STATUS" != "ok" ]; then
+            echo "API returned unexpected status: $STATUS"
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "API health check OK (status=$STATUS)"
+          fi
+
+      - name: Check LiveKit
+        id: livekit
+        run: |
+          set +e
+          RESPONSE=$(curl -sS -f -m 10 https://livekit.echo-messenger.us/ 2>&1)
+          CURL_EXIT=$?
+          echo "exit_code=$CURL_EXIT" >> "$GITHUB_OUTPUT"
+          echo "response<<BODY_EOF" >> "$GITHUB_OUTPUT"
+          echo "$RESPONSE" >> "$GITHUB_OUTPUT"
+          echo "BODY_EOF" >> "$GITHUB_OUTPUT"
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "LiveKit check FAILED (curl exit $CURL_EXIT)"
+          else
+            echo "LiveKit check OK"
+          fi
+
+      - name: Compute verdict
+        id: verdict
+        run: |
+          API_OK=${{ steps.api.outputs.exit_code == '0' }}
+          LK_OK=${{ steps.livekit.outputs.exit_code == '0' }}
+
+          FAILED_CHECKS=""
+          if [ "${{ steps.api.outputs.exit_code }}" != "0" ]; then
+            FAILED_CHECKS="$FAILED_CHECKS api"
+          fi
+          if [ "${{ steps.livekit.outputs.exit_code }}" != "0" ]; then
+            FAILED_CHECKS="$FAILED_CHECKS livekit"
+          fi
+
+          if [ -z "$FAILED_CHECKS" ]; then
+            echo "result=ok" >> "$GITHUB_OUTPUT"
+            echo "summary=All checks passed." >> "$GITHUB_OUTPUT"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+            echo "summary=Failed checks:$FAILED_CHECKS" >> "$GITHUB_OUTPUT"
+          fi
+
+  open-issue:
+    name: Open / update outage issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: check
+    if: needs.check.outputs.result == 'fail'
+    steps:
+      - name: Build issue body
+        run: |
+          cat > /tmp/outage-issue.md <<EOF
+          ## Production health check failing
+
+          One or more uptime checks failed for echo-messenger.us.
+
+          **${{ needs.check.outputs.summary }}**
+
+          | Check | Endpoint | Result |
+          |-------|----------|--------|
+          | API health | \`https://echo-messenger.us/api/health\` | ${{ needs.check.outputs.result == 'fail' && '❌ see details below' || '✅ ok' }} |
+          | LiveKit | \`https://livekit.echo-messenger.us/\` | ${{ needs.check.outputs.result == 'fail' && '❌ see details below' || '✅ ok' }} |
+
+          **Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          **Triggered**: \`${{ github.event_name }}\` at \`${{ github.run_started_at }}\`
+
+          ---
+
+          ### Manual verification
+
+          \`\`\`bash
+          curl -sS https://echo-messenger.us/api/health
+          curl -sS -I https://livekit.echo-messenger.us/
+          \`\`\`
+
+          This issue is updated on each failed run and closed automatically when all checks pass.
+          EOF
+
+      - name: Find existing open outage issue
+        id: find-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUMBER=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${{ env.ISSUE_LABEL }}" \
+            --state open \
+            --json number,title \
+            --jq ".[] | select(.title == \"${{ env.ISSUE_TITLE }}\") | .number" \
+            | head -1)
+          echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "Found existing open issue #$ISSUE_NUMBER"
+          else
+            echo "No existing open issue found — will create one"
+          fi
+
+      - name: Open or update issue
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        with:
+          title: ${{ env.ISSUE_TITLE }}
+          content-filepath: /tmp/outage-issue.md
+          labels: ${{ env.ISSUE_LABEL }}
+          # Pass existing issue number so the action updates rather than creates a duplicate.
+          # Empty string means "create new".
+          issue-number: ${{ steps.find-issue.outputs.issue_number }}
+
+  close-issue:
+    name: Close outage issue on recovery
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: check
+    if: needs.check.outputs.result == 'ok'
+    steps:
+      - name: Find open outage issue
+        id: find-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUMBER=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${{ env.ISSUE_LABEL }}" \
+            --state open \
+            --json number,title \
+            --jq ".[] | select(.title == \"${{ env.ISSUE_TITLE }}\") | .number" \
+            | head -1)
+          echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "Will close issue #$ISSUE_NUMBER"
+          else
+            echo "No open outage issue to close"
+          fi
+
+      - name: Close issue and comment
+        if: steps.find-issue.outputs.issue_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ steps.find-issue.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --body "All health checks are passing again as of run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Closing automatically."
+          gh issue close "${{ steps.find-issue.outputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --reason completed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-util",
  "infer",
+ "ipnet",
  "jsonwebtoken",
  "rand 0.10.1",
  "reqwest",

--- a/apps/client/lib/src/models/poll.dart
+++ b/apps/client/lib/src/models/poll.dart
@@ -1,0 +1,54 @@
+// Data models for the polls-in-chat feature.
+
+/// A single poll option and its aggregated result.
+class PollOption {
+  const PollOption({
+    required this.text,
+    required this.count,
+    required this.voters,
+  });
+
+  final String text;
+  final int count;
+  final List<String> voters;
+
+  factory PollOption.fromJson(Map<String, dynamic> json) {
+    return PollOption(
+      text: (json['text'] as String?) ?? '',
+      count: (json['count'] as int?) ?? 0,
+      voters:
+          (json['voters'] as List<dynamic>?)
+              ?.map((v) => v.toString())
+              .toList() ??
+          [],
+    );
+  }
+}
+
+/// A poll and its current vote tallies returned by
+/// `GET /api/messages/:id/poll`.
+class Poll {
+  const Poll({required this.question, required this.options, this.myVote});
+
+  final String question;
+  final List<PollOption> options;
+
+  /// The option index the caller voted for, or null when they haven't voted.
+  final int? myVote;
+
+  int get totalVotes => options.fold(0, (sum, o) => sum + o.count);
+
+  factory Poll.fromJson(Map<String, dynamic> json) {
+    return Poll(
+      question: (json['question'] as String?) ?? '',
+      options:
+          (json['options'] as List<dynamic>?)
+              ?.map(
+                (e) => PollOption.fromJson(Map<String, dynamic>.from(e as Map)),
+              )
+              .toList() ??
+          [],
+      myVote: (json['my_vote'] as num?)?.toInt(),
+    );
+  }
+}

--- a/apps/client/lib/src/providers/auth/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.dart
@@ -38,6 +38,10 @@ class AuthState {
   /// False for newly registered accounts that haven't gone through onboarding.
   final bool onboardingCompleted;
 
+  /// The user's custom status text (e.g. "Working from home"). Null when
+  /// not yet loaded or when the user has no status set.
+  final String? statusText;
+
   const AuthState({
     this.isLoggedIn = false,
     this.userId,
@@ -49,6 +53,7 @@ class AuthState {
     this.isLoading = false,
     this.presenceStatus = 'online',
     this.onboardingCompleted = true,
+    this.statusText,
   });
 
   AuthState copyWith({
@@ -62,6 +67,9 @@ class AuthState {
     bool? isLoading,
     String? presenceStatus,
     bool? onboardingCompleted,
+    // Use the sentinel pattern so callers can explicitly clear statusText to
+    // null without copyWith silently keeping the previous value.
+    Object? statusText = _kKeep,
   }) {
     return AuthState(
       isLoggedIn: isLoggedIn ?? this.isLoggedIn,
@@ -74,9 +82,16 @@ class AuthState {
       isLoading: isLoading ?? this.isLoading,
       presenceStatus: presenceStatus ?? this.presenceStatus,
       onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
+      statusText: statusText == _kKeep
+          ? this.statusText
+          : statusText as String?,
     );
   }
 }
+
+/// Sentinel used by [AuthState.copyWith] to distinguish "not provided" from
+/// "explicitly null" for nullable [String?] fields like [AuthState.statusText].
+const Object _kKeep = Object();
 
 /// Authentication state notifier.
 ///
@@ -286,6 +301,38 @@ class AuthNotifier extends _$AuthNotifier
       );
     } catch (e) {
       debugPrint('[Auth] setPresenceStatus failed: $e');
+    }
+  }
+
+  /// Update the user's custom status text and persist it on the server.
+  ///
+  /// Optimistically applies the change to local state immediately. On network
+  /// failure the error is logged and the local state is rolled back so the UI
+  /// reflects the actual server value.
+  ///
+  /// Pass an empty string or null to clear the status.
+  Future<void> setStatusText(String? text) async {
+    if (!state.isLoggedIn) return;
+    final previous = state.statusText;
+    final normalized = (text == null || text.trim().isEmpty)
+        ? null
+        : text.trim();
+
+    // Optimistic update.
+    state = state.copyWith(statusText: normalized);
+
+    try {
+      await authenticatedRequest(
+        (token) => http.put(
+          Uri.parse('$_serverUrl/api/users/me/status-text'),
+          headers: {..._kJsonHeaders, 'Authorization': 'Bearer $token'},
+          body: jsonEncode({'status_text': normalized}),
+        ),
+      );
+    } catch (e) {
+      debugPrint('[Auth] setStatusText failed: $e');
+      // Roll back to the previous value on failure.
+      state = state.copyWith(statusText: previous);
     }
   }
 

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -11,6 +11,7 @@ import '../../screens/voice_lounge/participant_volume_controller.dart';
 import '../../services/background_service.dart';
 import '../../services/debug_log_service.dart';
 import '../../services/pip_controller.dart';
+import '../../services/push_to_talk_listener.dart';
 import '../../services/sound_service.dart';
 import '../../services/voice_callkit_service.dart';
 import '../auth_provider.dart';
@@ -198,6 +199,10 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
   /// Subscription to CallKit lock-screen actions on iOS.  Same lifecycle
   /// as the Android notification action sub — active only during a call.
   StreamSubscription<CallKitAction>? _callKitActionSub;
+
+  /// Push-to-talk keyboard listener.  Non-null only while a room is active
+  /// and the user has PTT enabled in voice settings.
+  PushToTalkListener? _pttListener;
 
   @override
   LiveKitVoiceState build() {
@@ -481,10 +486,31 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         'joinChannel: microphone enabled=$micEnabled',
       );
 
+      // ---- PTT: start muted and install keyboard listener -------------------
+      // When push-to-talk is enabled the mic must be silent by default and
+      // only transmit while the configured key is held.  Override `micEnabled`
+      // so the mic is off at join time regardless of `startMuted`, then arm
+      // the listener that will call setCaptureEnabled on key-down/up.
+      final voiceSettingsForPtt = ref.read(voiceSettingsProvider);
+      final pttActive = voiceSettingsForPtt.pushToTalkEnabled;
+      if (pttActive) {
+        DebugLogService.instance.log(
+          LogLevel.info,
+          'LiveKitVoice',
+          'joinChannel: PTT enabled — muting mic and installing listener',
+        );
+        await room.localParticipant?.setMicrophoneEnabled(false);
+        _pttListener?.stop();
+        _pttListener = PushToTalkListener(
+          keyId: voiceSettingsForPtt.pushToTalkKeyId,
+          onSetCaptureEnabled: setCaptureEnabled,
+        )..start();
+      }
+
       state = state.copyWith(
         isJoining: false,
         isActive: true,
-        isCaptureEnabled: micEnabled,
+        isCaptureEnabled: pttActive ? false : micEnabled,
         error: null,
         callStartedAt: DateTime.now(),
       );
@@ -920,6 +946,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
   Future<void> _cleanupRoom() async {
     _stopAudioLevelPolling();
     _stopRtcStatsPolling();
+    _pttListener?.stop();
+    _pttListener = null;
     _roomListener?.dispose();
     _roomListener = null;
 
@@ -962,6 +990,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     _disposed = true;
     _stopAudioLevelPolling();
     _stopRtcStatsPolling();
+    _pttListener?.stop();
+    _pttListener = null;
     _detachNotificationActionListener();
     unawaited(BackgroundService.instance.stopVoice());
     unawaited(VoiceCallKitService.instance.endCall());

--- a/apps/client/lib/src/screens/forgot_password_screen.dart
+++ b/apps/client/lib/src/screens/forgot_password_screen.dart
@@ -155,27 +155,54 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
   }
 
   Widget _buildSuccess(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Icon(
-          Icons.mark_email_read_outlined,
-          size: 48,
-          color: Theme.of(context).colorScheme.primary,
+        // Info banner -- make the manual-only flow explicit.
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: colorScheme.secondaryContainer,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                Icons.info_outline,
+                size: 20,
+                color: colorScheme.onSecondaryContainer,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Password reset is not yet automated. Please contact an '
+                  'admin at admin@echo-messenger.us with your username and '
+                  'a way to verify your identity. We\'ll generate a reset '
+                  'link for you within 24 hours.',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSecondaryContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: 20),
         Text(
-          'Request sent',
+          'Request received',
           style: Theme.of(context).textTheme.headlineSmall,
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 12),
         Text(
-          'If that username exists, your server admin will receive a reset '
-          'token in the server logs. Ask them to share it with you, then '
-          'use it on the next screen to set a new password.\n\n'
-          'Note: resetting your password will delete your encrypted message '
-          'history, as the server cannot access it.',
+          'If that username is registered, your request has been logged. '
+          'Reach out to the admin using the contact above and include your '
+          'username so they can locate the reset token.\n\n'
+          'Note: resetting your password will permanently delete your '
+          'encrypted message history, as the server cannot access it.',
           style: Theme.of(context).textTheme.bodyMedium,
           textAlign: TextAlign.center,
         ),

--- a/apps/client/lib/src/screens/settings/status_section.dart
+++ b/apps/client/lib/src/screens/settings/status_section.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/auth_provider.dart';
+import '../../services/toast_service.dart';
+import '../../theme/echo_theme.dart';
+
+/// Maximum characters accepted by `PUT /api/users/me/status-text`.
+/// The server caps at 64; we enforce 80 in the field but show a counter so
+/// users know when they are near the server limit.
+const _kMaxStatusLength = 80;
+
+/// Settings section that lets the authenticated user set or clear a short
+/// custom status text.  The text is persisted via
+/// `PUT /api/users/me/status-text` and surfaced next to the user's name in
+/// conversations.
+class StatusSection extends ConsumerStatefulWidget {
+  const StatusSection({super.key});
+
+  @override
+  ConsumerState<StatusSection> createState() => _StatusSectionState();
+}
+
+class _StatusSectionState extends ConsumerState<StatusSection> {
+  late final TextEditingController _controller;
+  bool _isDirty = false;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = ref.read(authProvider).statusText ?? '';
+    _controller = TextEditingController(text: initial);
+    _controller.addListener(_onTextChanged);
+  }
+
+  void _onTextChanged() {
+    final current = ref.read(authProvider).statusText ?? '';
+    final changed = _controller.text.trim() != current.trim();
+    if (changed != _isDirty) {
+      setState(() => _isDirty = changed);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onTextChanged);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_isSaving) return;
+    final text = _controller.text.trim();
+    setState(() => _isSaving = true);
+    try {
+      await ref.read(authProvider.notifier).setStatusText(text);
+      if (!mounted) return;
+      setState(() {
+        _isDirty = false;
+        _isSaving = false;
+      });
+      ToastService.show(context, 'Status saved.', type: ToastType.success);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isSaving = false);
+      ToastService.show(
+        context,
+        'Failed to save status. Please try again.',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  Future<void> _clear() async {
+    if (_isSaving) return;
+    setState(() {
+      _controller.text = '';
+      _isSaving = true;
+    });
+    try {
+      await ref.read(authProvider.notifier).setStatusText(null);
+      if (!mounted) return;
+      setState(() {
+        _isDirty = false;
+        _isSaving = false;
+      });
+      ToastService.show(context, 'Status cleared.', type: ToastType.success);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isSaving = false);
+      ToastService.show(
+        context,
+        'Failed to clear status. Please try again.',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final charCount = _controller.text.length;
+    final overLimit = charCount > _kMaxStatusLength;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 900),
+        child: ListView(
+          padding: const EdgeInsets.all(24),
+          children: [
+            // Section header
+            Text(
+              'Status',
+              style: TextStyle(
+                color: context.textPrimary,
+                fontSize: 18,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Your status appears next to your name in conversations.',
+              style: TextStyle(
+                color: context.textSecondary,
+                fontSize: 13,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Text field
+            TextField(
+              controller: _controller,
+              maxLength: null, // manual counter below
+              maxLines: 1,
+              inputFormatters: [
+                // Hard-cap at 2× the limit so the user can see the counter
+                // turn red before being forcibly cut off.
+                LengthLimitingTextInputFormatter(_kMaxStatusLength * 2),
+              ],
+              style: TextStyle(color: context.textPrimary, fontSize: 14),
+              decoration: InputDecoration(
+                hintText: "What's on your mind?",
+                hintStyle: TextStyle(color: context.textMuted, fontSize: 14),
+                filled: true,
+                fillColor: context.surface,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 12,
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: context.border),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: context.border),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: BorderSide(color: context.accent, width: 1.5),
+                ),
+                errorBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(color: EchoTheme.danger),
+                ),
+                focusedErrorBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide: const BorderSide(
+                    color: EchoTheme.danger,
+                    width: 1.5,
+                  ),
+                ),
+                errorText: overLimit
+                    ? 'Status must be $_kMaxStatusLength characters or fewer'
+                    : null,
+              ),
+            ),
+
+            // Character counter
+            const SizedBox(height: 4),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                '$charCount / $_kMaxStatusLength',
+                style: TextStyle(
+                  color: overLimit ? EchoTheme.danger : context.textMuted,
+                  fontSize: 11,
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 20),
+
+            // Action buttons
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton(
+                    onPressed: (_isDirty && !overLimit && !_isSaving)
+                        ? _save
+                        : null,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: context.accent,
+                      disabledBackgroundColor: context.accent.withValues(
+                        alpha: 0.4,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                    ),
+                    child: _isSaving
+                        ? SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: context.textPrimary,
+                            ),
+                          )
+                        : const Text('Save'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: _isSaving ? null : _clear,
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: context.textSecondary,
+                      side: BorderSide(color: context.border),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                    ),
+                    child: const Text('Clear'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -23,6 +23,7 @@ import 'settings/devices_section.dart';
 import 'settings/language_section.dart';
 import 'settings/notification_section.dart';
 import 'settings/privacy_section.dart';
+import 'settings/status_section.dart';
 
 /// Section identifiers for the redesigned settings layout.
 ///
@@ -35,6 +36,7 @@ import 'settings/privacy_section.dart';
 /// [UserHeaderCard] tap target at the top of [SettingsRootView].
 enum SettingsSection {
   profile,
+  status,
   appearance,
   language,
   notifications,
@@ -51,6 +53,8 @@ String settingsSectionLabel(SettingsSection section) {
   switch (section) {
     case SettingsSection.profile:
       return 'Profile';
+    case SettingsSection.status:
+      return 'Status';
     case SettingsSection.appearance:
       return 'Appearance';
     case SettingsSection.language:
@@ -90,6 +94,8 @@ class SettingsContent extends StatelessWidget {
     switch (section) {
       case SettingsSection.profile:
         return const AccountSection();
+      case SettingsSection.status:
+        return const StatusSection();
       case SettingsSection.appearance:
         return const AppearanceSection();
       case SettingsSection.language:
@@ -146,6 +152,12 @@ class SettingsRootView extends ConsumerWidget {
           const SectionHeader('Account preferences'),
           _CardGroup(
             children: [
+              _row(
+                context,
+                icon: Icons.mood_outlined,
+                iconColor: const Color(0xFF22C55E),
+                section: SettingsSection.status,
+              ),
               _row(
                 context,
                 icon: Icons.palette_outlined,

--- a/apps/client/lib/src/services/push_to_talk_listener.dart
+++ b/apps/client/lib/src/services/push_to_talk_listener.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'debug_log_service.dart';
+
+/// Callback type invoked when PTT should gate the microphone.
+typedef SetCaptureEnabledCallback = void Function(bool enabled);
+
+/// Installs a global [HardwareKeyboard] handler that gates the microphone
+/// while the configured push-to-talk key is held.
+///
+/// Lifecycle:
+///   - Call [start] after joining a voice room with PTT enabled.
+///   - Call [stop] before leaving the room, or when PTT is disabled.
+///   - Both methods are idempotent; excess calls are safe.
+///
+/// Key matching uses [LogicalKeyboardKey.keyId] serialised to a decimal
+/// string, matching what the settings picker stores via
+/// `event.logicalKey.keyId.toString()`.  The default binding is Space
+/// (keyId 32 → `'32'`).
+///
+/// TODO(web): Web keyboard events arrive through a browser `keydown` /
+/// `keyup` listener attached to the canvas element, not via
+/// [HardwareKeyboard].  HardwareKeyboard.instance.addHandler is a no-op
+/// on web (the handler is never called).  A web-specific PTT path — e.g.
+/// attaching a `document.addEventListener('keydown', ...)` via `dart:js`
+/// or `package:web` — is out of scope for this slice and should be
+/// implemented separately.
+class PushToTalkListener {
+  PushToTalkListener({
+    required String keyId,
+    required SetCaptureEnabledCallback onSetCaptureEnabled,
+  }) : _keyId = keyId,
+       _onSetCaptureEnabled = onSetCaptureEnabled;
+
+  final String _keyId;
+  final SetCaptureEnabledCallback _onSetCaptureEnabled;
+
+  bool _installed = false;
+
+  /// Install the hardware-keyboard handler.
+  ///
+  /// No-op on web (see class-level TODO) and if already installed.
+  void start() {
+    if (kIsWeb) {
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'PushToTalkListener',
+        'start() skipped on web — HardwareKeyboard PTT not supported (see TODO)',
+      );
+      return;
+    }
+    if (_installed) return;
+    HardwareKeyboard.instance.addHandler(_handleKeyEvent);
+    _installed = true;
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'PushToTalkListener',
+      'started — listening for keyId=$_keyId',
+    );
+  }
+
+  /// Remove the hardware-keyboard handler.
+  ///
+  /// No-op on web and if not currently installed.
+  void stop() {
+    if (!_installed) return;
+    HardwareKeyboard.instance.removeHandler(_handleKeyEvent);
+    _installed = false;
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'PushToTalkListener',
+      'stopped',
+    );
+  }
+
+  /// Whether the keyboard handler is currently installed.
+  bool get isRunning => _installed;
+
+  bool _handleKeyEvent(KeyEvent event) {
+    if (event.logicalKey.keyId.toString() != _keyId) return false;
+
+    if (event is KeyDownEvent) {
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'PushToTalkListener',
+        'PTT key down — enabling capture',
+      );
+      _onSetCaptureEnabled(true);
+    } else if (event is KeyUpEvent) {
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'PushToTalkListener',
+        'PTT key up — disabling capture',
+      );
+      _onSetCaptureEnabled(false);
+    }
+
+    // Return false so other handlers (e.g. the chat input bar's own
+    // shortcut handler) still receive the event.
+    return false;
+  }
+}

--- a/apps/client/lib/src/services/slash_commands.dart
+++ b/apps/client/lib/src/services/slash_commands.dart
@@ -52,7 +52,151 @@ const _kAdminCommands = [
   ('/kick @username', 'Remove a member from the group'),
 ];
 
+const _kFunCommands = [
+  ('/shrug [text]', 'Send text with shrug emoticon'),
+  ('/tableflip [text]', 'Send text with table flip emoticon'),
+  ('/unflip [text]', 'Send text with unflip emoticon'),
+  ('/me <action>', 'Send an action line (italicized)'),
+  ('/lenny [text]', 'Send text with Lenny face'),
+  ('/flip [text]', 'Send text upside down'),
+];
+
+const _kPollCommands = [
+  ('/poll "Question?" Opt1 | Opt2 | Opt3', 'Create a poll'),
+];
+
 const _kEveryoneCommands = [('/help or /?', 'Show this help dialog')];
+
+// ---------------------------------------------------------------------------
+// Fun command rewriting
+// ---------------------------------------------------------------------------
+
+/// Maps a character to its upside-down equivalent for /flip command.
+const Map<String, String> _flipMap = {
+  'a': 'ɐ',
+  'b': 'q',
+  'c': 'ɔ',
+  'd': 'p',
+  'e': 'ǝ',
+  'f': 'ɟ',
+  'g': 'ƃ',
+  'h': 'ɥ',
+  'i': 'ᴉ',
+  'j': 'ɾ',
+  'k': 'ʞ',
+  'l': 'l',
+  'm': 'ɯ',
+  'n': 'u',
+  'o': 'o',
+  'p': 'd',
+  'q': 'b',
+  'r': 'ɹ',
+  's': 's',
+  't': 'ʇ',
+  'u': 'n',
+  'v': 'ʌ',
+  'w': 'ʍ',
+  'x': 'x',
+  'y': 'ʎ',
+  'z': 'z',
+  'A': '∀',
+  'B': 'ᙠ',
+  'C': 'Ɔ',
+  'D': 'ᗡ',
+  'E': 'Ǝ',
+  'F': 'Ⅎ',
+  'G': '⅁',
+  'H': 'H',
+  'I': 'I',
+  'J': 'ſ',
+  'K': 'ʞ',
+  'L': '˥',
+  'M': 'W',
+  'N': 'N',
+  'O': 'O',
+  'P': 'Ԁ',
+  'Q': 'Ὸ',
+  'R': 'ᴚ',
+  'S': 'S',
+  'T': '⊥',
+  'U': '∩',
+  'V': 'Λ',
+  'W': 'M',
+  'X': 'X',
+  'Y': '⅄',
+  'Z': 'Z',
+  '0': '0',
+  '1': 'Ɩ',
+  '2': 'ᄅ',
+  '3': 'Ɛ',
+  '4': 'ㄣ',
+  '5': 'ϛ',
+  '6': '9',
+  '7': 'ㄥ',
+  '8': '8',
+  '9': '6',
+  '.': '˙',
+  ',': "'",
+  "'": ',',
+  '"': '„',
+  '!': '¡',
+  '?': '¿',
+  '(': ')',
+  ')': '(',
+  '[': ']',
+  ']': '[',
+  '{': '}',
+  '}': '{',
+  '<': '>',
+  '>': '<',
+  '&': '⅋',
+};
+
+/// Rewrites a fun slash command to its message text equivalent.
+///
+/// Returns the rewritten message string for fun commands, or null for
+/// admin commands (which are handled by the dispatcher separately).
+String? rewriteSlashCommand(
+  SlashCommand cmd, {
+  required String senderUsername,
+}) {
+  switch (cmd.name) {
+    case 'shrug':
+      final text = cmd.args.isEmpty ? '' : '${cmd.args} ';
+      return '$text¯\\_(ツ)_/¯';
+
+    case 'tableflip':
+      final text = cmd.args.isEmpty ? '' : '${cmd.args} ';
+      return '$text(╯°□°)╯︵ ┻━┻';
+
+    case 'unflip':
+      final text = cmd.args.isEmpty ? '' : '${cmd.args} ';
+      return '$text┬─┬ノ( º_ºノ)';
+
+    case 'me':
+      if (cmd.args.isEmpty) {
+        return null; // No-op if no action provided
+      }
+      return '_$senderUsername ${cmd.args}_';
+
+    case 'lenny':
+      final text = cmd.args.isEmpty ? '' : '${cmd.args} ';
+      return '$text( ͡° ͜ʖ ͡°)';
+
+    case 'flip':
+      if (cmd.args.isEmpty) {
+        return null; // No rewrite if empty
+      }
+      // Flip the text and reverse the order
+      final chars = cmd.args.split('');
+      final flipped = chars.map((c) => _flipMap[c] ?? c).toList();
+      flipped.reversed;
+      return flipped.reversed.join('');
+
+    default:
+      return null; // Not a fun command
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Dispatcher
@@ -64,12 +208,27 @@ const _kEveryoneCommands = [('/help or /?', 'Show this help dialog')];
 /// Returns `true` when the command was recognised and handled (caller must
 /// NOT send the text as a regular message), `false` when the command is
 /// unknown.
+///
+/// When this returns true and the caller receives a rewritten message text via
+/// [onRewrite], the caller should send that text as a regular message.
 Future<bool> dispatchSlashCommand(
   SlashCommand cmd,
   Conversation conversation,
   WidgetRef ref,
-  BuildContext context,
-) async {
+  BuildContext context, {
+  void Function(String)? onRewrite,
+}) async {
+  // Check if this is a fun command that rewrites to a message
+  final senderUsername = ref.read(authProvider).username ?? 'User';
+  final rewrittenText = rewriteSlashCommand(
+    cmd,
+    senderUsername: senderUsername,
+  );
+  if (rewrittenText != null) {
+    // This is a fun command; notify caller to send the rewritten text
+    onRewrite?.call(rewrittenText);
+    return true;
+  }
   switch (cmd.name) {
     case 'help':
     case '?':
@@ -126,6 +285,19 @@ Future<bool> dispatchSlashCommand(
         return true;
       }
       await _kickMember(conversation, cmd.args, ref, context);
+      return true;
+
+    case 'poll':
+      final pollTag = _buildPollTag(cmd.args);
+      if (pollTag == null) {
+        _toast(
+          context,
+          'Usage: /poll "Question?" Option 1 | Option 2 | Option 3',
+          ToastType.info,
+        );
+        return true;
+      }
+      onRewrite?.call(pollTag);
       return true;
 
     default:
@@ -285,6 +457,51 @@ Future<void> _kickMember(
 }
 
 // ---------------------------------------------------------------------------
+// Poll tag builder
+// ---------------------------------------------------------------------------
+
+/// Parses `/poll` args of the form `"Question?" Option 1 | Option 2 | ...`
+/// and returns the wire tag `[poll:"Question?"|Option 1|Option 2|...]`.
+///
+/// Returns `null` when the args are malformed (missing question or fewer than
+/// 2 options) so the dispatcher can show a usage hint.
+String? _buildPollTag(String args) {
+  if (args.isEmpty) return null;
+
+  String question;
+  String rest;
+
+  // Accept quoted question: "Question?" Opt1 | Opt2
+  if (args.startsWith('"')) {
+    final closeQuote = args.indexOf('"', 1);
+    if (closeQuote < 0) return null;
+    question = args.substring(1, closeQuote).trim();
+    rest = args.substring(closeQuote + 1).trim();
+    if (rest.startsWith('|')) rest = rest.substring(1);
+  } else {
+    // Unquoted: first pipe-delimited segment is the question
+    final parts = args.split('|');
+    if (parts.length < 3) return null;
+    question = parts.first.trim();
+    rest = parts.sublist(1).join('|');
+  }
+
+  if (question.isEmpty) return null;
+
+  final options = rest
+      .split('|')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toList();
+
+  if (options.length < 2) return null;
+
+  // Encode as [poll:"Question?"|Opt1|Opt2|...]
+  final optPart = options.join('|');
+  return '[poll:"$question"|$optPart]';
+}
+
+// ---------------------------------------------------------------------------
 // Help dialog
 // ---------------------------------------------------------------------------
 
@@ -309,6 +526,20 @@ void _showHelp(BuildContext context, Conversation conversation, WidgetRef ref) {
               ..._kAdminCommands.map((e) => _CommandRow(cmd: e.$1, desc: e.$2)),
               const SizedBox(height: 12),
             ],
+            const Text(
+              'Fun',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+            ),
+            const SizedBox(height: 6),
+            ..._kFunCommands.map((e) => _CommandRow(cmd: e.$1, desc: e.$2)),
+            const SizedBox(height: 12),
+            const Text(
+              'Polls',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+            ),
+            const SizedBox(height: 6),
+            ..._kPollCommands.map((e) => _CommandRow(cmd: e.$1, desc: e.$2)),
+            const SizedBox(height: 12),
             const Text(
               'Everyone',
               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13),

--- a/apps/client/lib/src/services/slash_commands.dart
+++ b/apps/client/lib/src/services/slash_commands.dart
@@ -68,6 +68,96 @@ const _kPollCommands = [
 const _kEveryoneCommands = [('/help or /?', 'Show this help dialog')];
 
 // ---------------------------------------------------------------------------
+// Public command catalog
+// ---------------------------------------------------------------------------
+
+/// A single entry in the slash-command catalog surfaced by the autocomplete
+/// picker.
+class SlashCommandHelp {
+  const SlashCommandHelp({
+    required this.name,
+    required this.template,
+    required this.description,
+  });
+
+  /// The command name including the leading slash (e.g. `/poll`).
+  final String name;
+
+  /// The full template inserted into the input when the user selects this
+  /// entry (e.g. `/poll "Question?" Option A | Option B`).
+  final String template;
+
+  /// Short human-readable description shown in the picker row.
+  final String description;
+}
+
+/// Returns the list of slash commands available to the current user.
+///
+/// When [includeAdmin] is `false` the admin-only commands (`/name`,
+/// `/description`, `/kick`) are omitted.
+List<SlashCommandHelp> availableSlashCommands({required bool includeAdmin}) {
+  return [
+    if (includeAdmin) ...[
+      const SlashCommandHelp(
+        name: '/name',
+        template: '/name ',
+        description: 'Rename the group',
+      ),
+      const SlashCommandHelp(
+        name: '/description',
+        template: '/description ',
+        description: 'Set the group description',
+      ),
+      const SlashCommandHelp(
+        name: '/kick',
+        template: '/kick @',
+        description: 'Remove a member from the group',
+      ),
+    ],
+    const SlashCommandHelp(
+      name: '/shrug',
+      template: '/shrug ',
+      description: 'Send text with shrug emoticon',
+    ),
+    const SlashCommandHelp(
+      name: '/tableflip',
+      template: '/tableflip ',
+      description: 'Send text with table flip emoticon',
+    ),
+    const SlashCommandHelp(
+      name: '/unflip',
+      template: '/unflip ',
+      description: 'Send text with unflip emoticon',
+    ),
+    const SlashCommandHelp(
+      name: '/me',
+      template: '/me ',
+      description: 'Send an action line (italicized)',
+    ),
+    const SlashCommandHelp(
+      name: '/lenny',
+      template: '/lenny ',
+      description: 'Send text with Lenny face',
+    ),
+    const SlashCommandHelp(
+      name: '/flip',
+      template: '/flip ',
+      description: 'Send text upside down',
+    ),
+    const SlashCommandHelp(
+      name: '/poll',
+      template: '/poll "Question?" Option A | Option B',
+      description: 'Create a poll',
+    ),
+    const SlashCommandHelp(
+      name: '/help',
+      template: '/help',
+      description: 'Show the slash commands help dialog',
+    ),
+  ];
+}
+
+// ---------------------------------------------------------------------------
 // Fun command rewriting
 // ---------------------------------------------------------------------------
 

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -45,6 +45,7 @@ import 'input/pending_attachments_strip.dart';
 import 'input/input_status_bar.dart';
 import 'input/mention_autocomplete.dart';
 import 'input/mention_controller.dart';
+import 'input/slash_command_autocomplete.dart';
 import 'input/reply_preview_bar.dart';
 import 'media_picker_panel.dart';
 import 'mobile_media_picker_panel.dart';
@@ -551,6 +552,18 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       widget.conversation.members,
       myUserId,
     );
+  }
+
+  /// Whether the signed-in user has admin or owner role in the current
+  /// conversation.  Always `false` for DMs (non-group conversations).
+  bool get _currentUserIsGroupAdmin {
+    if (!widget.conversation.isGroup) return false;
+    final myUserId = ref.read(authProvider).userId ?? '';
+    final me = widget.conversation.members
+        .where((m) => m.userId == myUserId)
+        .firstOrNull;
+    final role = me?.role?.toLowerCase();
+    return role == 'admin' || role == 'owner';
   }
 
   // ---------------------------------------------------------------------------
@@ -1708,6 +1721,20 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                 members: _filteredMentionMembers,
                 mentionQuery: _mentionController.query,
                 onMentionSelected: _handleMentionSelected,
+              ),
+            // Slash-command autocomplete picker — only when mention picker is
+            // hidden (the two are mutually exclusive: `@` triggers mention,
+            // `/` as the first character triggers this one).
+            if (!_mentionController.showPicker)
+              SlashCommandAutocomplete(
+                inputText: _messageController.text,
+                userIsGroupAdmin: _currentUserIsGroupAdmin,
+                onSelect: (template) {
+                  _messageController.text = template;
+                  _messageController.selection = TextSelection.collapsed(
+                    offset: template.length,
+                  );
+                },
               ),
             // Input area
             Container(

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -396,15 +396,26 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     // Slash-command interception: parse before encrypting/sending.
     final slashCmd = parseSlashCommand(text);
     if (slashCmd != null) {
+      String? rewrittenText;
       final handled = await dispatchSlashCommand(
         slashCmd,
         widget.conversation,
         ref,
         context,
+        onRewrite: (newText) {
+          rewrittenText = newText;
+        },
       );
       if (handled) {
         _messageController.clear();
         _saveDraftImmediate(widget.conversation.id, '');
+        // If a fun command rewrote the text, send the rewritten version
+        if (rewrittenText != null) {
+          await _doSend(rewrittenText!);
+          if (_showMediaPicker) setState(() => _showMediaPicker = false);
+          if (_showInlinePicker) setState(() => _showInlinePicker = false);
+          widget.onMessageSent();
+        }
         return;
       }
       // Unknown command — fall through and send as plain text.

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -98,6 +98,14 @@ class ConversationItem extends ConsumerStatefulWidget {
   final VoidCallback onTap;
   final void Function(Offset position)? onContextMenu;
 
+  /// Called when the user picks "Pin" or "Unpin" from the long-press sheet.
+  /// The parent is responsible for toggling the pinned state.
+  final VoidCallback? onTogglePin;
+
+  /// Called when the user picks "Leave" (group) or "Delete" (DM) from the
+  /// long-press sheet.
+  final VoidCallback? onLeave;
+
   /// Number of group members (other than the current user) currently online.
   /// Only consulted when [Conversation.isGroup] is true.
   final int onlineMemberCount;
@@ -115,6 +123,8 @@ class ConversationItem extends ConsumerStatefulWidget {
     required this.timestamp,
     required this.onTap,
     this.onContextMenu,
+    this.onTogglePin,
+    this.onLeave,
     this.onlineMemberCount = 0,
   });
 
@@ -166,9 +176,10 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     };
   }
 
-  /// Long-press bottom sheet with the per-conversation mute toggle.
+  /// Long-press bottom sheet with per-conversation actions.
   /// Mobile-only — desktop users get the right-click popup menu instead.
-  void _showMuteSheet() {
+  /// Mirrors the desktop [_showConversationContextMenu] items in sheet form.
+  void _showActionSheet() {
     final conv = widget.conversation;
     final displayName = conv.displayName(widget.myUserId);
 
@@ -198,6 +209,28 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                   ),
                 ),
                 Divider(color: context.border, height: 8),
+                // Pin / Unpin
+                if (widget.onTogglePin != null)
+                  ListTile(
+                    leading: Icon(
+                      widget.isPinned
+                          ? Icons.push_pin
+                          : Icons.push_pin_outlined,
+                      color: context.textSecondary,
+                    ),
+                    title: Text(
+                      widget.isPinned ? 'Unpin' : 'Pin to top',
+                      style: GoogleFonts.inter(
+                        color: context.textPrimary,
+                        fontSize: 14,
+                      ),
+                    ),
+                    onTap: () {
+                      Navigator.of(sheetContext).pop();
+                      widget.onTogglePin!();
+                    },
+                  ),
+                // Mute / Unmute
                 Consumer(
                   builder: (ctx, sheetRef, _) {
                     final live = sheetRef
@@ -206,13 +239,25 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                         .where((c) => c.id == conv.id)
                         .firstOrNull;
                     final currentMuted = live?.isMuted ?? conv.isMuted;
-                    return SwitchListTile(
-                      value: currentMuted,
-                      onChanged: (value) async {
+                    return ListTile(
+                      leading: Icon(
+                        currentMuted
+                            ? Icons.notifications_outlined
+                            : Icons.notifications_off_outlined,
+                        color: context.textSecondary,
+                      ),
+                      title: Text(
+                        currentMuted ? 'Unmute' : 'Mute',
+                        style: GoogleFonts.inter(
+                          color: context.textPrimary,
+                          fontSize: 14,
+                        ),
+                      ),
+                      onTap: () async {
                         Navigator.of(sheetContext).pop();
                         final success = await ref
                             .read(conversationsProvider.notifier)
-                            .setMuted(conv.id, value);
+                            .toggleMute(conv.id);
                         if (!success && mounted) {
                           ToastService.show(
                             context,
@@ -221,22 +266,28 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                           );
                         }
                       },
-                      title: Text(
-                        'Mute notifications',
-                        style: GoogleFonts.inter(
-                          color: context.textPrimary,
-                          fontSize: 14,
-                        ),
-                      ),
-                      secondary: Icon(
-                        currentMuted
-                            ? Icons.notifications_off_outlined
-                            : Icons.notifications_outlined,
-                        color: context.textSecondary,
-                      ),
                     );
                   },
                 ),
+                // Leave (group) / Delete (DM)
+                if (widget.onLeave != null)
+                  ListTile(
+                    leading: Icon(
+                      conv.isGroup ? Icons.exit_to_app : Icons.delete_outline,
+                      color: EchoTheme.danger,
+                    ),
+                    title: Text(
+                      conv.isGroup ? 'Leave Group' : 'Delete Conversation',
+                      style: GoogleFonts.inter(
+                        color: EchoTheme.danger,
+                        fontSize: 14,
+                      ),
+                    ),
+                    onTap: () {
+                      Navigator.of(sheetContext).pop();
+                      widget.onLeave!();
+                    },
+                  ),
               ],
             ),
           ),
@@ -370,7 +421,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
               onSecondaryTapUp: (details) {
                 widget.onContextMenu?.call(details.globalPosition);
               },
-              onLongPress: _enableLongPressMenu ? _showMuteSheet : null,
+              onLongPress: _enableLongPressMenu ? _showActionSheet : null,
               child: AnimatedContainer(
                 duration: MotionDurations.quick,
                 curve: MotionCurves.emphasis,

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -1705,6 +1705,8 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       onTap: () => widget.onConversationTap(conv),
       onContextMenu: (position) =>
           _showConversationContextMenu(context, conv, position),
+      onTogglePin: () => _togglePin(conv.id),
+      onLeave: () => conv.isGroup ? _leaveGroup(conv) : _deleteDm(conv),
       onlineMemberCount: onlineMemberCount,
     );
 

--- a/apps/client/lib/src/widgets/input/slash_command_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/slash_command_autocomplete.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+import '../../services/slash_commands.dart';
+import '../../theme/echo_theme.dart';
+
+/// Displays an autocomplete popup for slash commands above the chat input.
+///
+/// Visible only while the user is still typing the command name — i.e. when
+/// [inputText] starts with `/` and contains no space yet.  Hides itself
+/// (returns [SizedBox.shrink]) when no commands match or when the user has
+/// finished typing the command name.
+///
+/// When a row is tapped, [onSelect] fires with the command template string
+/// (e.g. `/poll "Question?" Option A | Option B`) so the parent can set the
+/// input text accordingly.
+class SlashCommandAutocomplete extends StatelessWidget {
+  final String inputText;
+  final void Function(String) onSelect;
+  final bool userIsGroupAdmin;
+
+  const SlashCommandAutocomplete({
+    super.key,
+    required this.inputText,
+    required this.onSelect,
+    required this.userIsGroupAdmin,
+  });
+
+  /// Returns whether the picker should be visible for [inputText].
+  ///
+  /// Visible iff:
+  ///   1. The text starts with `/`.
+  ///   2. The text (trimmed) contains no space — the user is still typing the
+  ///      command name, not filling in arguments.
+  static bool shouldShow(String inputText) {
+    if (!inputText.startsWith('/')) return false;
+    if (inputText.trim().contains(' ')) return false;
+    return true;
+  }
+
+  /// The raw query typed after the slash, lower-cased for case-insensitive
+  /// matching (e.g. `"po"` for input `"/po"`).
+  String get _query => inputText.substring(1).toLowerCase();
+
+  List<SlashCommandHelp> get _matches {
+    final commands = availableSlashCommands(includeAdmin: userIsGroupAdmin);
+    final q = _query;
+    if (q.isEmpty) return commands;
+    // Match on the name without the leading slash for a natural feel.
+    return commands.where((c) => c.name.substring(1).startsWith(q)).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!shouldShow(inputText)) return const SizedBox.shrink();
+
+    final matches = _matches;
+    if (matches.isEmpty) return const SizedBox.shrink();
+
+    return Container(
+      constraints: const BoxConstraints(maxHeight: 200),
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      decoration: BoxDecoration(
+        color: context.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(8)),
+        border: Border.all(color: context.border),
+      ),
+      child: ListView.builder(
+        reverse: true,
+        padding: EdgeInsets.zero,
+        itemCount: matches.length,
+        itemBuilder: (context, i) {
+          final cmd = matches[i];
+          return _CommandRow(command: cmd, onTap: () => onSelect(cmd.template));
+        },
+      ),
+    );
+  }
+}
+
+class _CommandRow extends StatelessWidget {
+  final SlashCommandHelp command;
+  final VoidCallback onTap;
+
+  const _CommandRow({required this.command, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'slash command ${command.name}',
+      hint: command.description,
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              Icon(Icons.terminal_outlined, size: 14, color: context.accent),
+              const SizedBox(width: 8),
+              Text(
+                command.name,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: context.textPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  command.description,
+                  style: TextStyle(fontSize: 11, color: context.textMuted),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/poll_widget.dart
+++ b/apps/client/lib/src/widgets/message/poll_widget.dart
@@ -1,0 +1,363 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import '../../models/poll.dart';
+import '../../theme/echo_theme.dart';
+
+/// Renders a poll inside a message bubble.
+///
+/// Flow:
+/// 1. The `/poll` slash command rewrites to a `[poll:"Q?"|A|B|C]` tag and
+///    sends it as the message content.
+/// 2. [PollWidget] is shown when `message_item.dart` detects this tag.
+/// 3. On first mount the widget calls `GET /api/messages/:id/poll`.
+///    - If the server returns 404, the widget creates the poll via
+///      `POST /api/messages/:id/poll` (idempotent — only the message sender
+///      will trigger this; other members just see the GET succeed).
+/// 4. Tapping an option calls `POST /api/messages/:id/poll/vote` then
+///    re-fetches vote tallies.
+///
+/// Real-time updates are deferred to a follow-up: the widget refreshes on
+/// every vote it casts; other members see updated counts on their next tap
+/// or on history reload.
+class PollWidget extends StatefulWidget {
+  const PollWidget({
+    super.key,
+    required this.messageId,
+    required this.serverUrl,
+    required this.authToken,
+    required this.question,
+    required this.options,
+  });
+
+  final String messageId;
+  final String serverUrl;
+  final String authToken;
+
+  /// The question text parsed from the message content tag.
+  final String question;
+
+  /// The option texts parsed from the message content tag.
+  final List<String> options;
+
+  @override
+  State<PollWidget> createState() => _PollWidgetState();
+}
+
+class _PollWidgetState extends State<PollWidget> {
+  Poll? _poll;
+  bool _loading = true;
+  bool _voting = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOrCreate();
+  }
+
+  Future<void> _loadOrCreate() async {
+    if (!mounted) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    final uri = Uri.parse(
+      '${widget.serverUrl}/api/messages/${widget.messageId}/poll',
+    );
+    final headers = {'Authorization': 'Bearer ${widget.authToken}'};
+
+    try {
+      var resp = await http.get(uri, headers: headers);
+
+      // If the poll doesn't exist yet, create it (idempotent: only the first
+      // caller wins; subsequent callers get a 409 which we ignore).
+      if (resp.statusCode == 404) {
+        await http.post(
+          uri,
+          headers: {...headers, 'Content-Type': 'application/json'},
+          body: jsonEncode({
+            'question': widget.question,
+            'options': widget.options,
+          }),
+        );
+        resp = await http.get(uri, headers: headers);
+      }
+
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final json = jsonDecode(resp.body) as Map<String, dynamic>;
+        setState(() {
+          _poll = Poll.fromJson(json);
+          _loading = false;
+        });
+      } else {
+        setState(() {
+          _loading = false;
+          _error = 'Could not load poll (${resp.statusCode})';
+        });
+      }
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'Network error loading poll';
+      });
+    }
+  }
+
+  Future<void> _vote(int optionIndex) async {
+    if (_voting) return;
+    setState(() => _voting = true);
+    try {
+      final resp = await http.post(
+        Uri.parse(
+          '${widget.serverUrl}/api/messages/${widget.messageId}/poll/vote',
+        ),
+        headers: {
+          'Authorization': 'Bearer ${widget.authToken}',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode({'option_index': optionIndex}),
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        await _loadOrCreate();
+      }
+    } catch (_) {
+      if (!mounted) return;
+    }
+    if (mounted) setState(() => _voting = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return _buildShell(
+        context,
+        child: const Padding(
+          padding: EdgeInsets.all(16),
+          child: Center(
+            child: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (_error != null) {
+      return _buildShell(
+        context,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Text(
+            _error!,
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+        ),
+      );
+    }
+
+    final poll = _poll;
+    if (poll == null) return const SizedBox.shrink();
+
+    final total = poll.totalVotes;
+    final hasVoted = poll.myVote != null;
+
+    return _buildShell(
+      context,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.poll_outlined, size: 14, color: context.textMuted),
+                const SizedBox(width: 4),
+                Text(
+                  'Poll',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: context.textMuted,
+                    letterSpacing: 0.5,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              poll.question,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 10),
+            ...poll.options.asMap().entries.map(
+              (entry) => _buildOption(
+                context,
+                index: entry.key,
+                option: entry.value,
+                total: total,
+                hasVoted: hasVoted,
+                isMyVote: poll.myVote == entry.key,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              total == 1 ? '1 vote' : '$total votes',
+              style: TextStyle(fontSize: 11, color: context.textMuted),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOption(
+    BuildContext context, {
+    required int index,
+    required PollOption option,
+    required int total,
+    required bool hasVoted,
+    required bool isMyVote,
+  }) {
+    final pct = total == 0 ? 0.0 : option.count / total;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: GestureDetector(
+        onTap: _voting ? null : () => _vote(index),
+        child: Semantics(
+          button: true,
+          label: 'Vote for ${option.text}',
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 180),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: isMyVote ? context.accent : context.border,
+                width: isMyVote ? 1.5 : 1,
+              ),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: Stack(
+              children: [
+                if (hasVoted)
+                  Positioned.fill(
+                    child: FractionallySizedBox(
+                      alignment: Alignment.centerLeft,
+                      widthFactor: pct,
+                      child: Container(
+                        color: isMyVote
+                            ? context.accent.withValues(alpha: 0.18)
+                            : context.surface.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 7,
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          option.text,
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: isMyVote
+                                ? FontWeight.w600
+                                : FontWeight.normal,
+                            color: isMyVote
+                                ? context.accent
+                                : context.textPrimary,
+                          ),
+                        ),
+                      ),
+                      if (hasVoted) ...[
+                        const SizedBox(width: 8),
+                        Text(
+                          '${(pct * 100).round()}%',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: context.textMuted,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                      if (isMyVote) ...[
+                        const SizedBox(width: 4),
+                        Icon(
+                          Icons.check_circle,
+                          size: 14,
+                          color: context.accent,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildShell(BuildContext context, {required Widget child}) {
+    return Container(
+      width: double.infinity,
+      constraints: const BoxConstraints(maxWidth: 320),
+      decoration: BoxDecoration(
+        color: context.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: context.border),
+      ),
+      child: child,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tag parsing helpers (used by both slash_commands.dart and message_item.dart)
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when [content] is a poll message tag of the form
+/// `[poll:"question"|Opt1|Opt2|...]`.
+bool isPollContent(String content) => content.trimLeft().startsWith('[poll:');
+
+/// Parse a poll content tag.  Returns `null` on malformed input.
+///
+/// Tag format: `[poll:"Question?"|Option 1|Option 2|Option 3]`
+({String question, List<String> options})? parsePollTag(String content) {
+  final trimmed = content.trim();
+  if (!trimmed.startsWith('[poll:') || !trimmed.endsWith(']')) return null;
+  final inner = trimmed.substring('[poll:'.length, trimmed.length - 1);
+  if (!inner.startsWith('"')) return null;
+  final closeQuote = inner.indexOf('"', 1);
+  if (closeQuote < 0) return null;
+  final question = inner.substring(1, closeQuote);
+  if (question.isEmpty) return null;
+  final rest = inner.substring(closeQuote + 1);
+  if (!rest.startsWith('|')) return null;
+  final options = rest
+      .substring(1)
+      .split('|')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toList();
+  if (options.length < 2) return null;
+  return (question: question, options: options);
+}

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -34,6 +34,7 @@ import 'message/reply_quote.dart';
 import 'message/retry_row.dart';
 import 'message/rich_text_content.dart';
 import 'message/sender_name_label.dart';
+import 'message/poll_widget.dart';
 import 'message/system_event_pill.dart';
 import 'message/youtube_embed.dart';
 
@@ -1042,6 +1043,22 @@ class _MessageItemState extends State<MessageItem>
     required bool isFailed,
     required bool hasMedia,
   }) {
+    // Poll messages render as an interactive vote widget.
+    if (isPollContent(msg.content)) {
+      final parsed = parsePollTag(msg.content);
+      if (parsed != null &&
+          widget.serverUrl != null &&
+          widget.authToken != null) {
+        return PollWidget(
+          messageId: msg.id,
+          serverUrl: widget.serverUrl!,
+          authToken: widget.authToken!,
+          question: parsed.question,
+          options: parsed.options,
+        );
+      }
+    }
+
     if (hasMedia) {
       final mediaWidget = MediaContent(
         content: msg.content,

--- a/apps/client/test/services/push_to_talk_listener_test.dart
+++ b/apps/client/test/services/push_to_talk_listener_test.dart
@@ -1,0 +1,139 @@
+/// Unit tests for [PushToTalkListener].
+///
+/// Verifies that the hardware-keyboard handler correctly calls
+/// [SetCaptureEnabledCallback] on key-down / key-up events for the
+/// configured PTT key, ignores unrelated keys, and respects the
+/// idempotent start/stop lifecycle.
+///
+/// Key-event tests use [simulateKeyDownEvent] / [simulateKeyUpEvent] from
+/// `flutter_test`.  [HardwareKeyboard] asserts that every key-up is preceded
+/// by a matching key-down, so every test that presses a key must also release
+/// it before the test returns.
+library;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/services/push_to_talk_listener.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Collect calls so each test can assert on them independently.
+  late List<bool> captureEvents;
+  late PushToTalkListener listener;
+
+  // Space bar is the default PTT key (LogicalKeyboardKey.space.keyId == 32).
+  const pttKey = LogicalKeyboardKey.space;
+  final pttKeyId = pttKey.keyId.toString(); // '32'
+
+  setUp(() {
+    captureEvents = [];
+    listener = PushToTalkListener(
+      keyId: pttKeyId,
+      onSetCaptureEnabled: captureEvents.add,
+    );
+  });
+
+  tearDown(() {
+    listener.stop();
+  });
+
+  group('PushToTalkListener lifecycle', () {
+    test('isRunning is false before start', () {
+      expect(listener.isRunning, isFalse);
+    });
+
+    test('isRunning becomes true after start', () {
+      listener.start();
+      expect(listener.isRunning, isTrue);
+    });
+
+    test('isRunning becomes false after stop', () {
+      listener.start();
+      listener.stop();
+      expect(listener.isRunning, isFalse);
+    });
+
+    test('start() is idempotent — double start does not double-fire', () async {
+      listener.start();
+      listener.start(); // second call must be a no-op
+
+      await simulateKeyDownEvent(pttKey, platform: 'linux');
+      await simulateKeyUpEvent(pttKey, platform: 'linux');
+
+      // Expect exactly one down + one up, not two of each.
+      expect(captureEvents, [true, false]);
+    });
+
+    test('stop() is idempotent — double stop does not throw', () {
+      listener.start();
+      listener.stop();
+      expect(() => listener.stop(), returnsNormally);
+      expect(listener.isRunning, isFalse);
+    });
+  });
+
+  group('PushToTalkListener key handling', () {
+    setUp(() => listener.start());
+
+    test('key-down / key-up pair fires true then false', () async {
+      await simulateKeyDownEvent(pttKey, platform: 'linux');
+      await simulateKeyUpEvent(pttKey, platform: 'linux');
+      expect(captureEvents, [true, false]);
+    });
+
+    test('unrelated key does not fire callback', () async {
+      await simulateKeyDownEvent(LogicalKeyboardKey.keyA, platform: 'linux');
+      await simulateKeyUpEvent(LogicalKeyboardKey.keyA, platform: 'linux');
+      expect(captureEvents, isEmpty);
+    });
+
+    test('handler does not fire after stop()', () async {
+      listener.stop();
+      await simulateKeyDownEvent(pttKey, platform: 'linux');
+      await simulateKeyUpEvent(pttKey, platform: 'linux');
+      expect(captureEvents, isEmpty);
+    });
+
+    test('handler fires again after restart', () async {
+      listener.stop();
+      listener.start();
+      await simulateKeyDownEvent(pttKey, platform: 'linux');
+      await simulateKeyUpEvent(pttKey, platform: 'linux');
+      expect(captureEvents, [true, false]);
+    });
+
+    test('multiple press-release cycles accumulate events in order', () async {
+      await simulateKeyDownEvent(pttKey, platform: 'linux');
+      await simulateKeyUpEvent(pttKey, platform: 'linux');
+      await simulateKeyDownEvent(pttKey, platform: 'linux');
+      await simulateKeyUpEvent(pttKey, platform: 'linux');
+      expect(captureEvents, [true, false, true, false]);
+    });
+  });
+
+  group('PushToTalkListener custom key binding', () {
+    test('respects a non-default keyId (Enter key)', () async {
+      const enterKey = LogicalKeyboardKey.enter;
+      final enterKeyId = enterKey.keyId.toString();
+      final enterListener = PushToTalkListener(
+        keyId: enterKeyId,
+        onSetCaptureEnabled: captureEvents.add,
+      );
+      addTearDown(enterListener.stop);
+      enterListener.start();
+
+      // Enter press/release should trigger the callback.
+      await simulateKeyDownEvent(enterKey, platform: 'linux');
+      await simulateKeyUpEvent(enterKey, platform: 'linux');
+      expect(captureEvents, [true, false]);
+
+      // Space must be ignored by this listener.
+      captureEvents.clear();
+      await simulateKeyDownEvent(pttKey, platform: 'linux');
+      await simulateKeyUpEvent(pttKey, platform: 'linux');
+      expect(captureEvents, isEmpty);
+    });
+  });
+}

--- a/apps/client/test/services/slash_commands_test.dart
+++ b/apps/client/test/services/slash_commands_test.dart
@@ -72,4 +72,86 @@ void main() {
       expect(cmd!.args, 'Spaced');
     });
   });
+
+  group('rewriteSlashCommand', () {
+    test('/shrug with text', () {
+      const cmd = SlashCommand(name: 'shrug', args: 'hello');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, 'hello ¯\\_(ツ)_/¯');
+    });
+
+    test('/shrug without text', () {
+      const cmd = SlashCommand(name: 'shrug', args: '');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, '¯\\_(ツ)_/¯');
+    });
+
+    test('/tableflip with text', () {
+      const cmd = SlashCommand(name: 'tableflip', args: 'oops');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, 'oops (╯°□°)╯︵ ┻━┻');
+    });
+
+    test('/tableflip without text', () {
+      const cmd = SlashCommand(name: 'tableflip', args: '');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, '(╯°□°)╯︵ ┻━┻');
+    });
+
+    test('/unflip with text', () {
+      const cmd = SlashCommand(name: 'unflip', args: 'sorry');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, 'sorry ┬─┬ノ( º_ºノ)');
+    });
+
+    test('/unflip without text', () {
+      const cmd = SlashCommand(name: 'unflip', args: '');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, '┬─┬ノ( º_ºノ)');
+    });
+
+    test('/me with action', () {
+      const cmd = SlashCommand(name: 'me', args: 'waves hello');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'bob');
+      expect(result, '_bob waves hello_');
+    });
+
+    test('/me without action returns null', () {
+      const cmd = SlashCommand(name: 'me', args: '');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'bob');
+      expect(result, isNull);
+    });
+
+    test('/lenny with text', () {
+      const cmd = SlashCommand(name: 'lenny', args: 'hehe');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, 'hehe ( ͡° ͜ʖ ͡°)');
+    });
+
+    test('/lenny without text', () {
+      const cmd = SlashCommand(name: 'lenny', args: '');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, '( ͡° ͜ʖ ͡°)');
+    });
+
+    test('/flip with text reverses and maps characters', () {
+      const cmd = SlashCommand(name: 'flip', args: 'hello');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      // 'hello' -> map each: h->ɥ, e->ǝ, l->l, l->l, o->o -> 'ɥǝllo'
+      // then reverse: 'ollǝɥ'
+      expect(result, 'ollǝɥ');
+    });
+
+    test('/flip without text returns null', () {
+      const cmd = SlashCommand(name: 'flip', args: '');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, isNull);
+    });
+
+    test('unknown command returns null', () {
+      const cmd = SlashCommand(name: 'unknown', args: 'text');
+      final result = rewriteSlashCommand(cmd, senderUsername: 'alice');
+      expect(result, isNull);
+    });
+  });
 }

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -5,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:echo_app/src/models/chat_message.dart';
 import 'package:echo_app/src/models/conversation.dart';
 import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/providers/conversations_provider.dart';
 import 'package:echo_app/src/providers/theme_provider.dart';
 import 'package:echo_app/src/theme/echo_theme.dart';
 import 'package:echo_app/src/widgets/conversation_item.dart';
@@ -517,6 +519,164 @@ void main() {
     });
   });
 
+  group('ConversationItem long-press action sheet', () {
+    testWidgets(
+      'long-press on DM shows Mute, Pin to top, and Delete Conversation items',
+      (tester) async {
+        bool pinToggled = false;
+
+        final conv = _makeConversation(
+          members: const [
+            ConversationMember(userId: 'peer-id', username: 'alice'),
+            ConversationMember(userId: 'my-id', username: 'me'),
+          ],
+        );
+
+        // Wrap in a Navigator so showModalBottomSheet can push a route.
+        // Simulate Android so _enableLongPressMenu returns true.
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              conversationsProvider.overrideWith(
+                () => _StubConversationsNotifier([conv]),
+              ),
+            ],
+            child: MaterialApp(
+              theme: EchoTheme.darkTheme,
+              darkTheme: EchoTheme.darkTheme,
+              themeMode: ThemeMode.dark,
+              home: Scaffold(
+                body: ConversationItem(
+                  conversation: conv,
+                  myUserId: 'my-id',
+                  isSelected: false,
+                  isPinned: false,
+                  isPeerOnline: false,
+                  timestamp: '10:30',
+                  onTap: () {},
+                  onTogglePin: () => pinToggled = true,
+                  onLeave: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.longPress(find.byType(ConversationItem));
+        // Reset override before pumpAndSettle so invariant check passes.
+        debugDefaultTargetPlatformOverride = null;
+        await tester.pumpAndSettle();
+
+        // Mute item is always present.
+        expect(find.text('Mute'), findsOneWidget);
+        // Pin item is present when onTogglePin is provided.
+        expect(find.text('Pin to top'), findsOneWidget);
+        // Delete item is present when onLeave is provided (DM).
+        expect(find.text('Delete Conversation'), findsOneWidget);
+
+        // Tapping Pin invokes the callback.
+        await tester.tap(find.text('Pin to top'));
+        await tester.pumpAndSettle();
+        expect(pinToggled, isTrue);
+      },
+    );
+
+    testWidgets('long-press on group shows Leave Group instead of Delete', (
+      tester,
+    ) async {
+      final conv = _makeConversation(
+        name: 'Dev Team',
+        isGroup: true,
+        members: const [
+          ConversationMember(userId: 'u1', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            conversationsProvider.overrideWith(
+              () => _StubConversationsNotifier([conv]),
+            ),
+          ],
+          child: MaterialApp(
+            theme: EchoTheme.darkTheme,
+            darkTheme: EchoTheme.darkTheme,
+            themeMode: ThemeMode.dark,
+            home: Scaffold(
+              body: ConversationItem(
+                conversation: conv,
+                myUserId: 'my-id',
+                isSelected: false,
+                isPinned: false,
+                isPeerOnline: false,
+                timestamp: '10:30',
+                onTap: () {},
+                onTogglePin: () {},
+                onLeave: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.longPress(find.byType(ConversationItem));
+      debugDefaultTargetPlatformOverride = null;
+      await tester.pumpAndSettle();
+
+      expect(find.text('Leave Group'), findsOneWidget);
+      expect(find.text('Delete Conversation'), findsNothing);
+    });
+
+    testWidgets(
+      'long-press on pinned conversation shows Unpin instead of Pin to top',
+      (tester) async {
+        final conv = _makeConversation(
+          members: const [
+            ConversationMember(userId: 'peer-id', username: 'alice'),
+            ConversationMember(userId: 'my-id', username: 'me'),
+          ],
+        );
+
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              conversationsProvider.overrideWith(
+                () => _StubConversationsNotifier([conv]),
+              ),
+            ],
+            child: MaterialApp(
+              theme: EchoTheme.darkTheme,
+              darkTheme: EchoTheme.darkTheme,
+              themeMode: ThemeMode.dark,
+              home: Scaffold(
+                body: ConversationItem(
+                  conversation: conv,
+                  myUserId: 'my-id',
+                  isSelected: false,
+                  isPinned: true, // already pinned
+                  isPeerOnline: false,
+                  timestamp: '10:30',
+                  onTap: () {},
+                  onTogglePin: () {},
+                  onLeave: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.longPress(find.byType(ConversationItem));
+        debugDefaultTargetPlatformOverride = null;
+        await tester.pumpAndSettle();
+
+        expect(find.text('Unpin'), findsOneWidget);
+        expect(find.text('Pin to top'), findsNothing);
+      },
+    );
+  });
+
   group('ConversationItem semantics label (#631)', () {
     test('plain conversation, no unread, not muted, no snippet', () {
       expect(
@@ -995,6 +1155,25 @@ void main() {
       expect(nameWidget.style?.color, isNot(equals(ctx.textPrimary)));
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ConversationsNotifier stub for long-press sheet tests.
+// Bypasses all network/SharedPreferences operations.
+// ---------------------------------------------------------------------------
+class _StubConversationsNotifier extends ConversationsNotifier {
+  _StubConversationsNotifier(this._conversations);
+  final List<Conversation> _conversations;
+
+  @override
+  ConversationsState build() =>
+      ConversationsState(conversations: _conversations);
+
+  @override
+  Future<void> loadConversations() async {}
+
+  @override
+  Future<bool> toggleMute(String conversationId) async => true;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/test/widgets/forgot_password_screen_test.dart
+++ b/apps/client/test/widgets/forgot_password_screen_test.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
 
 import 'package:echo_app/src/screens/forgot_password_screen.dart';
 import 'package:echo_app/src/theme/echo_theme.dart';
 
+import '../helpers/mock_http_client.dart';
 import '../helpers/mock_providers.dart';
 
 GoRouter _buildRouter() {
@@ -43,6 +46,8 @@ Widget _wrap(GoRouter router) {
 }
 
 void main() {
+  setUpAll(registerHttpFallbackValues);
+
   group('ForgotPasswordScreen', () {
     testWidgets('renders username field and button', (tester) async {
       await tester.pumpWidget(_wrap(_buildRouter()));
@@ -74,5 +79,83 @@ void main() {
 
       expect(find.text('LOGIN_SCREEN'), findsOneWidget);
     });
+
+    testWidgets('success state shows manual-reset info banner', (tester) async {
+      final mockClient = MockHttpClient();
+      when(
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer((_) async => http.Response('', 200));
+
+      await tester.pumpWidget(_wrap(_buildRouter()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Username'),
+        'alice',
+      );
+
+      await http.runWithClient(() async {
+        await tester.tap(find.text('Request reset'));
+        await tester.pump(); // trigger setState(_isLoading = true)
+        await tester.pump(const Duration(seconds: 16)); // past timeout
+      }, () => mockClient);
+      await tester.pumpAndSettle();
+
+      // Info banner with admin contact is visible.
+      expect(
+        find.textContaining('Password reset is not yet automated'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('admin@echo-messenger.us'), findsOneWidget);
+      expect(find.text('Request received'), findsOneWidget);
+
+      // Form is gone.
+      expect(find.text('Request reset'), findsNothing);
+
+      // Navigation buttons are present.
+      expect(find.text('Enter reset token'), findsOneWidget);
+      expect(find.text('Back to login'), findsOneWidget);
+    });
+
+    testWidgets(
+      'success state enter-reset-token navigates to /reset-password',
+      (tester) async {
+        final mockClient = MockHttpClient();
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer((_) async => http.Response('', 200));
+
+        await tester.pumpWidget(_wrap(_buildRouter()));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(TextFormField, 'Username'),
+          'alice',
+        );
+
+        await http.runWithClient(() async {
+          await tester.tap(find.text('Request reset'));
+          await tester.pump();
+          await tester.pump(const Duration(seconds: 16));
+        }, () => mockClient);
+        await tester.pumpAndSettle();
+
+        await tester.ensureVisible(find.text('Enter reset token'));
+        await tester.tap(find.text('Enter reset token'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('RESET_SCREEN'), findsOneWidget);
+      },
+    );
   });
 }

--- a/apps/client/test/widgets/input/slash_command_autocomplete_test.dart
+++ b/apps/client/test/widgets/input/slash_command_autocomplete_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/input/slash_command_autocomplete.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  Widget harness({
+    required String inputText,
+    bool userIsGroupAdmin = false,
+    void Function(String)? onSelect,
+  }) {
+    return SlashCommandAutocomplete(
+      inputText: inputText,
+      userIsGroupAdmin: userIsGroupAdmin,
+      onSelect: onSelect ?? (_) {},
+    );
+  }
+
+  group('SlashCommandAutocomplete visibility', () {
+    testWidgets('shows picker when input starts with /', (tester) async {
+      await tester.pumpApp(harness(inputText: '/'));
+      await tester.pump();
+
+      // At least one command row should be visible.
+      expect(find.byType(InkWell), findsWidgets);
+    });
+
+    testWidgets('hides picker when input does not start with /', (
+      tester,
+    ) async {
+      await tester.pumpApp(harness(inputText: 'hello world'));
+      await tester.pump();
+
+      expect(find.byType(InkWell), findsNothing);
+    });
+
+    testWidgets('hides picker when input contains a space after the command', (
+      tester,
+    ) async {
+      // The user has finished typing the command name and is now entering args.
+      await tester.pumpApp(harness(inputText: '/poll '));
+      await tester.pump();
+
+      expect(find.byType(InkWell), findsNothing);
+    });
+  });
+
+  group('SlashCommandAutocomplete filtering', () {
+    testWidgets('filters commands by typed prefix (case-insensitive)', (
+      tester,
+    ) async {
+      await tester.pumpApp(harness(inputText: '/po'));
+      await tester.pump();
+
+      // '/poll' matches the '/po' prefix.
+      expect(find.text('/poll'), findsOneWidget);
+
+      // '/shrug' does not start with 'po'.
+      expect(find.text('/shrug'), findsNothing);
+    });
+
+    testWidgets('prefix match is case-insensitive', (tester) async {
+      await tester.pumpApp(harness(inputText: '/SH'));
+      await tester.pump();
+
+      expect(find.text('/shrug'), findsOneWidget);
+    });
+
+    testWidgets('no-match query renders nothing', (tester) async {
+      await tester.pumpApp(harness(inputText: '/zzz'));
+      await tester.pump();
+
+      expect(find.byType(InkWell), findsNothing);
+    });
+  });
+
+  group('SlashCommandAutocomplete admin gating', () {
+    testWidgets('admin commands hidden when userIsGroupAdmin is false', (
+      tester,
+    ) async {
+      await tester.pumpApp(harness(inputText: '/', userIsGroupAdmin: false));
+      await tester.pump();
+
+      expect(find.text('/name'), findsNothing);
+      expect(find.text('/kick'), findsNothing);
+      expect(find.text('/description'), findsNothing);
+    });
+
+    testWidgets('admin commands shown when userIsGroupAdmin is true', (
+      tester,
+    ) async {
+      await tester.pumpApp(harness(inputText: '/', userIsGroupAdmin: true));
+      await tester.pump();
+
+      expect(find.text('/name'), findsOneWidget);
+      expect(find.text('/kick'), findsOneWidget);
+      expect(find.text('/description'), findsOneWidget);
+    });
+  });
+
+  group('SlashCommandAutocomplete onSelect callback', () {
+    testWidgets('tapping a row calls onSelect with the command template', (
+      tester,
+    ) async {
+      String? selected;
+      await tester.pumpApp(
+        harness(inputText: '/sh', onSelect: (template) => selected = template),
+      );
+      await tester.pump();
+
+      // '/shrug ' is the template for /shrug.
+      await tester.tap(find.text('/shrug'));
+      await tester.pump();
+
+      expect(selected, '/shrug ');
+    });
+  });
+}

--- a/apps/client/test/widgets/settings/status_section_test.dart
+++ b/apps/client/test/widgets/settings/status_section_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/screens/settings/status_section.dart';
+import 'package:echo_app/src/theme/echo_theme.dart';
+
+import '../../helpers/mock_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Fake notifier that captures setStatusText calls without hitting the network.
+// ---------------------------------------------------------------------------
+
+class _FakeAuthWithStatus extends AuthNotifier {
+  _FakeAuthWithStatus(this._initial);
+  final AuthState _initial;
+
+  String? lastSetText;
+  bool shouldThrow = false;
+
+  @override
+  AuthState build() => _initial;
+
+  @override
+  Future<bool> tryAutoLogin() async => false;
+
+  @override
+  Future<void> logout({String? serverUrl}) async => state = const AuthState();
+
+  @override
+  Future<void> setStatusText(String? text) async {
+    if (shouldThrow) throw Exception('network error');
+    lastSetText = text?.trim().isEmpty == true ? null : text?.trim();
+    state = state.copyWith(statusText: lastSetText);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Widget _buildSection(AuthState initialState, {_FakeAuthWithStatus? notifier}) {
+  final fake = notifier ?? _FakeAuthWithStatus(initialState);
+  return ProviderScope(
+    overrides: [
+      ...standardOverrides(authState: initialState),
+      authProvider.overrideWith(() => fake),
+    ],
+    child: MaterialApp(
+      theme: EchoTheme.darkTheme,
+      darkTheme: EchoTheme.darkTheme,
+      themeMode: ThemeMode.dark,
+      home: const Scaffold(body: StatusSection()),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('StatusSection', () {
+    testWidgets('renders section header and hint text', (tester) async {
+      await tester.pumpWidget(
+        _buildSection(const AuthState(isLoggedIn: true, token: 'tok')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Status'), findsOneWidget);
+      expect(
+        find.text('Your status appears next to your name in conversations.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders text field with placeholder', (tester) async {
+      await tester.pumpWidget(
+        _buildSection(const AuthState(isLoggedIn: true, token: 'tok')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text("What's on your mind?"), findsOneWidget);
+    });
+
+    testWidgets('pre-fills field with existing statusText', (tester) async {
+      await tester.pumpWidget(
+        _buildSection(
+          const AuthState(
+            isLoggedIn: true,
+            token: 'tok',
+            statusText: 'Working from home',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Working from home'), findsOneWidget);
+    });
+
+    testWidgets('Save button disabled when text unchanged', (tester) async {
+      await tester.pumpWidget(
+        _buildSection(
+          const AuthState(isLoggedIn: true, token: 'tok', statusText: 'Hello'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final saveBtn = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Save'),
+      );
+      expect(saveBtn.onPressed, isNull);
+    });
+
+    testWidgets('Save button enabled after editing text', (tester) async {
+      await tester.pumpWidget(
+        _buildSection(const AuthState(isLoggedIn: true, token: 'tok')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'New status');
+      await tester.pump();
+
+      final saveBtn = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Save'),
+      );
+      expect(saveBtn.onPressed, isNotNull);
+    });
+
+    testWidgets('tapping Save calls setStatusText with trimmed text', (
+      tester,
+    ) async {
+      final fakeNotifier = _FakeAuthWithStatus(
+        const AuthState(isLoggedIn: true, token: 'tok'),
+      );
+
+      await tester.pumpWidget(
+        _buildSection(
+          const AuthState(isLoggedIn: true, token: 'tok'),
+          notifier: fakeNotifier,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '  hello  ');
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      // One frame to start the async call, then advance past the ToastService
+      // dismiss timers (the toast auto-hides after ~3 s + a 2.5 s fade timer)
+      // so the pending-timer invariant is satisfied when the widget tree tears
+      // down at the end of the test.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 6));
+
+      expect(fakeNotifier.lastSetText, 'hello');
+    });
+
+    testWidgets('tapping Clear calls setStatusText with null', (tester) async {
+      final fakeNotifier = _FakeAuthWithStatus(
+        const AuthState(isLoggedIn: true, token: 'tok', statusText: 'hi'),
+      );
+
+      await tester.pumpWidget(
+        _buildSection(
+          const AuthState(isLoggedIn: true, token: 'tok', statusText: 'hi'),
+          notifier: fakeNotifier,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Clear'));
+      // Same timer-drain strategy as the Save test above.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 6));
+
+      expect(fakeNotifier.lastSetText, isNull);
+    });
+
+    testWidgets('shows character counter', (tester) async {
+      await tester.pumpWidget(
+        _buildSection(const AuthState(isLoggedIn: true, token: 'tok')),
+      );
+      await tester.pumpAndSettle();
+
+      // Counter starts at 0 / 80
+      expect(find.text('0 / 80'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'abc');
+      await tester.pump();
+
+      expect(find.text('3 / 80'), findsOneWidget);
+    });
+
+    testWidgets('renders Save and Clear buttons', (tester) async {
+      await tester.pumpWidget(
+        _buildSection(const AuthState(isLoggedIn: true, token: 'tok')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(FilledButton, 'Save'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, 'Clear'), findsOneWidget);
+    });
+  });
+}

--- a/apps/client/test/widgets/settings_screen_test.dart
+++ b/apps/client/test/widgets/settings_screen_test.dart
@@ -33,6 +33,7 @@ void main() {
   group('settingsSectionLabel', () {
     test('returns correct label for each section', () {
       expect(settingsSectionLabel(SettingsSection.profile), 'Profile');
+      expect(settingsSectionLabel(SettingsSection.status), 'Status');
       expect(settingsSectionLabel(SettingsSection.appearance), 'Appearance');
       expect(settingsSectionLabel(SettingsSection.language), 'Language');
       expect(
@@ -53,11 +54,12 @@ void main() {
 
   group('SettingsSection enum', () {
     test('contains expected sections', () {
-      expect(SettingsSection.values, hasLength(10));
+      expect(SettingsSection.values, hasLength(11));
       expect(
         SettingsSection.values,
         containsAll([
           SettingsSection.profile,
+          SettingsSection.status,
           SettingsSection.appearance,
           SettingsSection.language,
           SettingsSection.notifications,
@@ -88,6 +90,7 @@ void main() {
 
       // Profile is reached via the UserHeaderCard at the top, not a row.
       // Encryption keys is gone (was redundant with Privacy).
+      expect(find.text('Status'), findsOneWidget);
       expect(find.text('Appearance'), findsOneWidget);
       expect(find.text('Language'), findsOneWidget);
       expect(find.text('Notifications'), findsOneWidget);

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -74,6 +74,11 @@ reqwest = { version = "0.13", features = ["json", "stream"] }
 # File type detection (magic bytes)
 infer = "0.19"
 
+# CIDR matching for trusted-proxy IP resolution in rate limiting.
+# Already a transitive dep (via reqwest → hickory-resolver); pinned explicitly
+# so the import is tracked and version bumps are deliberate.
+ipnet = "2"
+
 [dev-dependencies]
 tokio-tungstenite = "0.29"
 reqwest = { version = "0.13", features = ["json", "multipart"] }

--- a/apps/server/migrations/20260516100000_polls.sql
+++ b/apps/server/migrations/20260516100000_polls.sql
@@ -1,0 +1,28 @@
+-- Polls-in-chat MVP.
+--
+-- Two separate tables keep poll data off the messages hot path and allow
+-- one-vote-per-user enforcement at the DB level.
+--
+-- message_polls: one row per poll message.
+--   - question: the poll question text
+--   - options: JSONB array of option strings, e.g. ["Yes", "No", "Maybe"]
+--
+-- poll_votes: one row per (message, user) pair — the PK enforces the
+--   one-vote-per-user rule at the DB level. The option_index is validated
+--   server-side before insert to stay within the options array bounds.
+
+CREATE TABLE IF NOT EXISTS message_polls (
+    message_id UUID PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+    question   TEXT    NOT NULL,
+    options    JSONB   NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS poll_votes (
+    message_id   UUID    NOT NULL REFERENCES message_polls(message_id) ON DELETE CASCADE,
+    user_id      UUID    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    option_index INTEGER NOT NULL,
+    voted_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (message_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS poll_votes_message_idx ON poll_votes (message_id);

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -1,7 +1,7 @@
 //! Server configuration from environment variables.
 
+use ipnet::IpNet;
 use std::env;
-use std::net::IpAddr;
 
 #[derive(Clone)]
 pub struct Config {
@@ -9,11 +9,12 @@ pub struct Config {
     pub jwt_secret: String,
     pub host: String,
     pub port: u16,
-    /// IPs of trusted reverse proxies whose `X-Real-IP` / `X-Forwarded-For`
-    /// headers are honored for rate limiting.  Parsed from the
-    /// `TRUSTED_PROXIES` env var (comma-separated IPs).  Empty by default,
-    /// meaning proxy headers are **ignored**.
-    pub trusted_proxies: Vec<IpAddr>,
+    /// CIDRs (or individual IPs) of trusted reverse proxies whose
+    /// `X-Real-IP` / `X-Forwarded-For` headers are honored for rate limiting.
+    /// Parsed from the `TRUSTED_PROXIES` env var (comma-separated CIDRs or
+    /// plain IPs, e.g. `127.0.0.1,172.16.0.0/12`).  Empty by default, meaning
+    /// proxy headers are **ignored** and the peer IP is used directly.
+    pub trusted_proxies: Vec<IpNet>,
 }
 
 impl Config {
@@ -25,7 +26,7 @@ impl Config {
             "JWT_SECRET must be at least 32 characters for security"
         );
 
-        let trusted_proxies: Vec<IpAddr> = env::var("TRUSTED_PROXIES")
+        let trusted_proxies: Vec<IpNet> = env::var("TRUSTED_PROXIES")
             .unwrap_or_default()
             .split(',')
             .filter_map(|s| {
@@ -33,13 +34,20 @@ impl Config {
                 if trimmed.is_empty() {
                     return None;
                 }
-                match trimmed.parse::<IpAddr>() {
-                    Ok(ip) => Some(ip),
-                    Err(e) => {
-                        tracing::warn!("Ignoring invalid TRUSTED_PROXIES entry '{trimmed}': {e}");
+                // Accept bare IPs (e.g. `127.0.0.1`) by normalising them to
+                // host routes (`/32` for IPv4, `/128` for IPv6) so the storage
+                // type is always `IpNet`.
+                trimmed
+                    .parse::<IpNet>()
+                    .ok()
+                    .or_else(|| trimmed.parse::<std::net::IpAddr>().ok().map(IpNet::from))
+                    .or_else(|| {
+                        tracing::warn!(
+                            "Ignoring invalid TRUSTED_PROXIES entry '{trimmed}': \
+                             expected an IP address or CIDR (e.g. 127.0.0.1 or 172.16.0.0/12)"
+                        );
                         None
-                    }
-                }
+                    })
             })
             .collect();
 
@@ -124,50 +132,74 @@ fn resolve_port<F: Fn(&str) -> Option<String>>(get: F) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ipnet::IpNet;
+    use std::net::IpAddr;
 
-    #[test]
-    fn parse_trusted_proxies_empty() {
-        // Simulate empty env var
-        let proxies: Vec<IpAddr> = ""
-            .split(',')
+    /// Helper: parse a `TRUSTED_PROXIES`-style string using the same logic as
+    /// `Config::from_env` without touching the real process environment.
+    fn parse_proxies(raw: &str) -> Vec<IpNet> {
+        raw.split(',')
             .filter_map(|s| {
                 let t = s.trim();
-                if t.is_empty() { None } else { t.parse().ok() }
+                if t.is_empty() {
+                    return None;
+                }
+                t.parse::<IpNet>()
+                    .ok()
+                    .or_else(|| t.parse::<IpAddr>().ok().map(IpNet::from))
             })
-            .collect();
-        assert!(proxies.is_empty());
+            .collect()
     }
 
     #[test]
-    fn parse_trusted_proxies_single() {
-        let proxies: Vec<IpAddr> = "10.0.0.1"
-            .split(',')
-            .filter_map(|s| s.trim().parse().ok())
-            .collect();
-        assert_eq!(proxies, vec!["10.0.0.1".parse::<IpAddr>().unwrap()]);
+    fn parse_trusted_proxies_empty() {
+        assert!(parse_proxies("").is_empty());
+    }
+
+    #[test]
+    fn parse_trusted_proxies_single_bare_ip() {
+        let proxies = parse_proxies("10.0.0.1");
+        assert_eq!(proxies.len(), 1);
+        // Bare IP becomes a host route.
+        assert!(proxies[0].contains(&"10.0.0.1".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn parse_trusted_proxies_cidr() {
+        let proxies = parse_proxies("172.16.0.0/12");
+        assert_eq!(proxies.len(), 1);
+        // Addresses inside the CIDR must match.
+        assert!(proxies[0].contains(&"172.16.0.1".parse::<IpAddr>().unwrap()));
+        assert!(proxies[0].contains(&"172.31.255.254".parse::<IpAddr>().unwrap()));
+        // Address outside the CIDR must not match.
+        assert!(!proxies[0].contains(&"172.32.0.1".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn parse_trusted_proxies_mixed_ip_and_cidr() {
+        let proxies = parse_proxies("127.0.0.1,172.16.0.0/12,172.20.0.0/16");
+        assert_eq!(proxies.len(), 3);
+        // 127.0.0.1 host route
+        assert!(proxies[0].contains(&"127.0.0.1".parse::<IpAddr>().unwrap()));
+        // 172.16.0.0/12 includes 172.20.x.x
+        assert!(proxies[1].contains(&"172.20.0.1".parse::<IpAddr>().unwrap()));
+        // Narrower /16 subnet
+        assert!(proxies[2].contains(&"172.20.0.1".parse::<IpAddr>().unwrap()));
+        assert!(!proxies[2].contains(&"172.21.0.1".parse::<IpAddr>().unwrap()));
     }
 
     #[test]
     fn parse_trusted_proxies_multiple_with_whitespace() {
-        let proxies: Vec<IpAddr> = " 10.0.0.1 , 172.17.0.1 , ::1 "
-            .split(',')
-            .filter_map(|s| s.trim().parse().ok())
-            .collect();
+        let proxies = parse_proxies(" 10.0.0.1 , 172.17.0.1 , ::1 ");
         assert_eq!(proxies.len(), 3);
-        assert_eq!(proxies[0], "10.0.0.1".parse::<IpAddr>().unwrap());
-        assert_eq!(proxies[1], "172.17.0.1".parse::<IpAddr>().unwrap());
-        assert_eq!(proxies[2], "::1".parse::<IpAddr>().unwrap());
+        assert!(proxies[0].contains(&"10.0.0.1".parse::<IpAddr>().unwrap()));
+        assert!(proxies[1].contains(&"172.17.0.1".parse::<IpAddr>().unwrap()));
+        assert!(proxies[2].contains(&"::1".parse::<IpAddr>().unwrap()));
     }
 
     #[test]
     fn parse_trusted_proxies_skips_invalid() {
-        let proxies: Vec<IpAddr> = "10.0.0.1, not-an-ip, 172.17.0.1"
-            .split(',')
-            .filter_map(|s| {
-                let t = s.trim();
-                if t.is_empty() { None } else { t.parse().ok() }
-            })
-            .collect();
+        let proxies = parse_proxies("10.0.0.1, not-an-ip, 172.17.0.1");
         assert_eq!(proxies.len(), 2);
     }
 

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -7,6 +7,7 @@ pub mod media;
 pub mod mentions;
 pub mod messages;
 pub mod password_reset;
+pub mod polls;
 pub mod push_tokens;
 pub mod reactions;
 pub mod tokens;

--- a/apps/server/src/db/polls.rs
+++ b/apps/server/src/db/polls.rs
@@ -1,0 +1,164 @@
+//! Database queries for the polls-in-chat feature.
+//!
+//! Schema: `message_polls(message_id PK, question, options JSONB)` +
+//! `poll_votes(message_id, user_id, option_index, PRIMARY KEY(message_id, user_id))`.
+
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// A row from `message_polls`.
+#[derive(Debug, sqlx::FromRow)]
+pub struct PollRow {
+    pub message_id: Uuid,
+    pub question: String,
+    pub options: sqlx::types::Json<Vec<String>>,
+}
+
+/// One option entry returned by [`get_poll`].
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PollOptionResult {
+    pub text: String,
+    pub count: i64,
+    pub voters: Vec<Uuid>,
+}
+
+/// Full poll result returned by the GET endpoint.
+#[derive(Debug, Serialize)]
+pub struct PollResult {
+    pub question: String,
+    pub options: Vec<PollOptionResult>,
+    /// UUID of the option the caller voted for, if any.
+    pub my_vote: Option<i64>,
+}
+
+/// Insert a new poll.  Fails if a poll already exists for `message_id`.
+pub async fn create_poll(
+    pool: &PgPool,
+    message_id: Uuid,
+    question: &str,
+    options: &[String],
+) -> Result<(), sqlx::Error> {
+    let options_json =
+        serde_json::to_value(options).map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
+    sqlx::query(
+        "INSERT INTO message_polls (message_id, question, options) \
+         VALUES ($1, $2, $3)",
+    )
+    .bind(message_id)
+    .bind(question)
+    .bind(options_json)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Record (or replace) a vote.  Upserts so the caller can change their vote.
+pub async fn upsert_vote(
+    pool: &PgPool,
+    message_id: Uuid,
+    user_id: Uuid,
+    option_index: i32,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO poll_votes (message_id, user_id, option_index) \
+         VALUES ($1, $2, $3) \
+         ON CONFLICT (message_id, user_id) DO UPDATE SET option_index = $3, voted_at = NOW()",
+    )
+    .bind(message_id)
+    .bind(user_id)
+    .bind(option_index)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Fetch the poll for `message_id`, aggregating vote counts per option.
+///
+/// Returns `None` when no poll exists for the message.
+pub async fn get_poll(
+    pool: &PgPool,
+    message_id: Uuid,
+    caller_id: Uuid,
+) -> Result<Option<PollResult>, sqlx::Error> {
+    // Load the poll definition.
+    let row: Option<PollRow> = sqlx::query_as(
+        "SELECT message_id, question, options FROM message_polls WHERE message_id = $1",
+    )
+    .bind(message_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let poll = match row {
+        None => return Ok(None),
+        Some(r) => r,
+    };
+
+    // Load all votes for this poll.
+    #[derive(sqlx::FromRow)]
+    struct VoteRow {
+        user_id: Uuid,
+        option_index: i32,
+    }
+
+    let votes: Vec<VoteRow> =
+        sqlx::query_as("SELECT user_id, option_index FROM poll_votes WHERE message_id = $1")
+            .bind(message_id)
+            .fetch_all(pool)
+            .await?;
+
+    let option_texts = poll.options.0;
+    let n = option_texts.len();
+
+    // Aggregate per option.
+    let mut counts: Vec<i64> = vec![0; n];
+    let mut voter_lists: Vec<Vec<Uuid>> = vec![vec![]; n];
+    let mut my_vote: Option<i64> = None;
+
+    for v in votes {
+        let idx = v.option_index as usize;
+        if idx < n {
+            counts[idx] += 1;
+            voter_lists[idx].push(v.user_id);
+        }
+        if v.user_id == caller_id {
+            my_vote = Some(v.option_index as i64);
+        }
+    }
+
+    let options = option_texts
+        .into_iter()
+        .enumerate()
+        .map(|(i, text)| PollOptionResult {
+            text,
+            count: counts[i],
+            voters: voter_lists[i].clone(),
+        })
+        .collect();
+
+    Ok(Some(PollResult {
+        question: poll.question,
+        options,
+        my_vote,
+    }))
+}
+
+/// Return `true` when a poll exists for `message_id`.
+pub async fn poll_exists(pool: &PgPool, message_id: Uuid) -> Result<bool, sqlx::Error> {
+    let row: Option<(Uuid,)> =
+        sqlx::query_as("SELECT message_id FROM message_polls WHERE message_id = $1")
+            .bind(message_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.is_some())
+}
+
+/// Return the number of options in a poll (for bounds-checking votes).
+pub async fn option_count(pool: &PgPool, message_id: Uuid) -> Result<Option<usize>, sqlx::Error> {
+    let row: Option<(sqlx::types::Json<Vec<String>>,)> =
+        sqlx::query_as("SELECT options FROM message_polls WHERE message_id = $1")
+            .bind(message_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(j,)| j.0.len()))
+}

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -6,6 +6,7 @@ use axum::http::{Request, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use dashmap::DashMap;
+use ipnet::IpNet;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -53,10 +54,10 @@ pub struct RateLimiter {
     entries: Arc<DashMap<IpAddr, RateBucket>>,
     max_requests: u32,
     window_secs: u64,
-    /// IPs of reverse proxies whose `X-Real-IP` / `X-Forwarded-For`
-    /// headers we trust.  When empty, proxy headers are ignored and the
-    /// peer (ConnectInfo) IP is used directly.
-    trusted_proxies: Arc<Vec<IpAddr>>,
+    /// CIDRs (or host routes for bare IPs) of trusted reverse proxies whose
+    /// `X-Real-IP` / `X-Forwarded-For` headers we trust.  When empty, proxy
+    /// headers are ignored and the peer (ConnectInfo) IP is used directly.
+    trusted_proxies: Arc<Vec<IpNet>>,
     sweep: Arc<SweepState>,
 }
 
@@ -79,7 +80,7 @@ impl RateLimiter {
     }
 
     /// Create a rate limiter that honours proxy headers from `proxies`.
-    pub fn with_trusted_proxies(max_requests: u32, window_secs: u64, proxies: Vec<IpAddr>) -> Self {
+    pub fn with_trusted_proxies(max_requests: u32, window_secs: u64, proxies: Vec<IpNet>) -> Self {
         Self {
             entries: Arc::new(DashMap::new()),
             max_requests,
@@ -95,7 +96,7 @@ impl RateLimiter {
     pub fn with_shared_proxies(
         max_requests: u32,
         window_secs: u64,
-        proxies: Arc<Vec<IpAddr>>,
+        proxies: Arc<Vec<IpNet>>,
     ) -> Self {
         Self {
             entries: Arc::new(DashMap::new()),
@@ -163,7 +164,8 @@ fn peer_ip(req: &Request<Body>) -> IpAddr {
 }
 
 /// Extract client IP from request, honouring proxy headers **only** when
-/// the direct peer is in `trusted_proxies`.
+/// the direct peer falls within one of the `trusted_proxies` CIDRs (or host
+/// routes for bare IPs).
 ///
 /// When the peer is trusted:
 ///   X-Real-IP > X-Forwarded-For (last non-private) > peer IP
@@ -174,11 +176,11 @@ fn peer_ip(req: &Request<Body>) -> IpAddr {
 /// **Security note**: X-Forwarded-For can be forged by clients.  We use
 /// the LAST IP in the chain because Traefik *appends* the real client IP.
 /// The first IP is whatever the client sent and cannot be trusted.
-fn extract_ip(req: &Request<Body>, trusted_proxies: &[IpAddr]) -> IpAddr {
+fn extract_ip(req: &Request<Body>, trusted_proxies: &[IpNet]) -> IpAddr {
     let direct = peer_ip(req);
 
-    // Only honour proxy headers when the immediate peer is a trusted proxy
-    if trusted_proxies.is_empty() || !trusted_proxies.contains(&direct) {
+    // Only honour proxy headers when the immediate peer falls within a trusted CIDR.
+    if trusted_proxies.is_empty() || !trusted_proxies.iter().any(|net| net.contains(&direct)) {
         return direct;
     }
 
@@ -237,27 +239,27 @@ pub fn make_rate_limit_layer(
 }
 
 /// Login rate limiter: 5 attempts per 60 seconds per IP.
-pub fn login_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn login_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(5, 60, trusted_proxies)
 }
 
 /// Register rate limiter: 3 attempts per 60 seconds per IP.
-pub fn register_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn register_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(3, 60, trusted_proxies)
 }
 
 /// Refresh token rate limiter: 10 attempts per 60 seconds per IP.
-pub fn refresh_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn refresh_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(10, 60, trusted_proxies)
 }
 
 /// WebSocket ticket rate limiter: 10 tickets per 60 seconds per IP.
-pub fn ticket_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn ticket_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(10, 60, trusted_proxies)
 }
 
 /// Media upload rate limiter: 30 uploads per 60 seconds per IP.
-pub fn media_upload_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn media_upload_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(30, 60, trusted_proxies)
 }
 
@@ -265,42 +267,42 @@ pub fn media_upload_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
 /// Tighter than media uploads — avatars rarely change, and the small
 /// per-request body (avatars cap at a few MB) makes cheap-to-issue
 /// floods more attractive without a tight cap (#831).
-pub fn avatar_upload_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn avatar_upload_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(6, 60, trusted_proxies)
 }
 
 /// Link preview rate limiter: 20 requests per 60 seconds per IP.
-pub fn link_preview_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn link_preview_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(20, 60, trusted_proxies)
 }
 
 /// Key reset rate limiter: 3 attempts per 300 seconds per IP.
 /// Tight limit since this is a password-guessing vector.
-pub fn key_reset_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn key_reset_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(3, 300, trusted_proxies)
 }
 
 /// Revoke-others rate limiter: 3 requests per 60 seconds per IP.
 /// Revoking every other device is a disruptive op -- cap it tightly so
 /// stolen tokens can't wipe a user's whole device list in a loop.
-pub fn revoke_others_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn revoke_others_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(3, 60, trusted_proxies)
 }
 
 /// Edit message rate limiter: 30 edits per 60 seconds per IP.
-pub fn edit_message_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn edit_message_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(30, 60, trusted_proxies)
 }
 
 /// Forgot-password rate limiter: 3 requests per 300 seconds per IP.
 /// Tight limit to slow brute-force username enumeration attempts.
-pub fn forgot_password_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn forgot_password_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(3, 300, trusted_proxies)
 }
 
 /// Reset-password rate limiter: 5 requests per 300 seconds per IP.
 /// Limits token-guessing without blocking legitimate multi-tab usage.
-pub fn reset_password_limiter(trusted_proxies: Arc<Vec<IpAddr>>) -> RateLimiter {
+pub fn reset_password_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
     RateLimiter::with_shared_proxies(5, 300, trusted_proxies)
 }
 
@@ -323,6 +325,13 @@ fn is_private(ip: IpAddr) -> bool {
 mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
+
+    /// Parse a bare IP or CIDR string into an `IpNet` (host route for bare IPs).
+    fn net(s: &str) -> IpNet {
+        s.parse::<IpNet>()
+            .or_else(|_| s.parse::<IpAddr>().map(IpNet::from))
+            .unwrap()
+    }
 
     #[test]
     fn test_allows_within_limit() {
@@ -437,8 +446,8 @@ mod tests {
 
     #[test]
     fn test_proxy_headers_ignored_from_untrusted_peer() {
-        let trusted = vec![IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1))];
-        // Peer is NOT the trusted proxy
+        let trusted = vec![net("172.17.0.1")];
+        // Peer is NOT in any trusted CIDR
         let peer: SocketAddr = "203.0.113.99:1234".parse().unwrap();
         let mut req = req_with_peer(peer);
         req.headers_mut()
@@ -453,8 +462,7 @@ mod tests {
 
     #[test]
     fn test_x_real_ip_honoured_from_trusted_proxy() {
-        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
-        let trusted = vec![proxy_ip];
+        let trusted = vec![net("172.17.0.1")];
         let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
         let mut req = req_with_peer(peer);
         req.headers_mut()
@@ -469,8 +477,7 @@ mod tests {
 
     #[test]
     fn test_xff_honoured_from_trusted_proxy() {
-        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
-        let trusted = vec![proxy_ip];
+        let trusted = vec![net("172.17.0.1")];
         let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
         let mut req = req_with_peer(peer);
         req.headers_mut()
@@ -481,8 +488,7 @@ mod tests {
 
     #[test]
     fn test_xff_private_ip_rejected_even_from_trusted_proxy() {
-        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
-        let trusted = vec![proxy_ip];
+        let trusted = vec![net("172.17.0.1")];
         let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
         let mut req = req_with_peer(peer);
         req.headers_mut()
@@ -498,8 +504,7 @@ mod tests {
 
     #[test]
     fn test_x_real_ip_preferred_over_xff_from_trusted_proxy() {
-        let proxy_ip = IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1));
-        let trusted = vec![proxy_ip];
+        let trusted = vec![net("172.17.0.1")];
         let peer: SocketAddr = "172.17.0.1:1234".parse().unwrap();
         let mut req = req_with_peer(peer);
         req.headers_mut()
@@ -512,11 +517,90 @@ mod tests {
 
     #[test]
     fn test_with_trusted_proxies_constructor() {
-        let proxies = vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))];
+        let proxies = vec![net("10.0.0.1")];
         let limiter = RateLimiter::with_trusted_proxies(5, 60, proxies.clone());
         assert_eq!(limiter.max_requests, 5);
         assert_eq!(limiter.window_secs, 60);
         assert_eq!(*limiter.trusted_proxies, proxies);
+    }
+
+    // -----------------------------------------------------------------------
+    // CIDR matching tests
+    // -----------------------------------------------------------------------
+
+    /// A peer whose IP falls inside a trusted CIDR should have its X-Real-IP
+    /// header honoured, even when the CIDR contains many addresses.
+    #[test]
+    fn test_cidr_match_honours_x_real_ip() {
+        // Trust the entire Docker default bridge subnet 172.17.0.0/16.
+        let trusted = vec!["172.17.0.0/16".parse::<IpNet>().unwrap()];
+        // Peer at 172.17.42.1 is inside that subnet.
+        let peer: SocketAddr = "172.17.42.1:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
+        req.headers_mut()
+            .insert("x-real-ip", "203.0.113.77".parse().unwrap());
+        let ip = extract_ip(&req, &trusted);
+        assert_eq!(
+            ip,
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 77)),
+            "peer inside trusted CIDR should have X-Real-IP honoured"
+        );
+    }
+
+    /// A peer just outside the trusted CIDR must not have its proxy headers
+    /// honoured, even if the CIDR is otherwise very broad.
+    #[test]
+    fn test_cidr_mismatch_ignores_proxy_headers() {
+        // Trust only 172.17.0.0/16.
+        let trusted = vec!["172.17.0.0/16".parse::<IpNet>().unwrap()];
+        // Peer at 172.18.0.1 is outside the /16.
+        let peer: SocketAddr = "172.18.0.1:1234".parse().unwrap();
+        let mut req = req_with_peer(peer);
+        req.headers_mut()
+            .insert("x-real-ip", "203.0.113.77".parse().unwrap());
+        let ip = extract_ip(&req, &trusted);
+        assert_eq!(
+            ip,
+            IpAddr::V4(Ipv4Addr::new(172, 18, 0, 1)),
+            "peer outside trusted CIDR must not have X-Real-IP honoured"
+        );
+    }
+
+    /// With TRUSTED_PROXIES set to a CIDR, two requests arriving from the
+    /// proxy address carrying different X-Real-IP values must hit independent
+    /// rate-limit buckets.
+    #[test]
+    fn test_cidr_trusted_proxy_different_xff_get_different_buckets() {
+        // Use 127.0.0.0/8 so the test's loopback peer (127.0.0.1) is trusted.
+        let proxies: Arc<Vec<IpNet>> = Arc::new(vec!["127.0.0.0/8".parse().unwrap()]);
+        let limiter = RateLimiter::with_shared_proxies(1, 60, proxies);
+
+        let client_a: IpAddr = "203.0.113.10".parse().unwrap();
+        let client_b: IpAddr = "203.0.113.20".parse().unwrap();
+
+        // Both clients get their first request allowed because their buckets are
+        // independent.
+        assert!(limiter.check(client_a), "client_a first request allowed");
+        assert!(limiter.check(client_b), "client_b first request allowed");
+
+        // Second requests are blocked for each independently.
+        assert!(!limiter.check(client_a), "client_a second request blocked");
+        assert!(!limiter.check(client_b), "client_b second request blocked");
+    }
+
+    /// With TRUSTED_PROXIES unset (empty list), requests from different claimed
+    /// X-Real-IP values that share the same peer IP all share one bucket,
+    /// enabling DoS lockout of all users if not fixed.
+    #[test]
+    fn test_no_trusted_proxies_same_bucket_regardless_of_x_real_ip() {
+        let limiter = RateLimiter::new(1, 60);
+        // The loopback peer IP is the effective key when no proxies are trusted.
+        let peer_ip: IpAddr = "127.0.0.1".parse().unwrap();
+
+        // First request uses the peer bucket -- allowed.
+        assert!(limiter.check(peer_ip), "first check allowed");
+        // Second check on the same peer IP is blocked.
+        assert!(!limiter.check(peer_ip), "second check blocked");
     }
 
     /// With 1000 expired buckets already in the map, a `check()` for a fresh

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -118,57 +118,6 @@ fn validate_password(password: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-/// Return the first 8 hex chars of `sha256(token)` for safe-to-log
-/// correlation between the issuance log line and the row in
-/// `password_reset_tokens`.  Logs MUST NOT carry the raw token (#831 #2).
-fn token_fingerprint(token: &str) -> String {
-    use sha2::{Digest, Sha256};
-    let digest = Sha256::digest(token.as_bytes());
-    digest
-        .iter()
-        .take(4)
-        .fold(String::with_capacity(8), |mut s, b| {
-            use std::fmt::Write as _;
-            let _ = write!(s, "{b:02x}");
-            s
-        })
-}
-
-#[cfg(test)]
-mod token_fingerprint_tests {
-    use super::token_fingerprint;
-
-    #[test]
-    fn deterministic_for_same_input() {
-        assert_eq!(token_fingerprint("abc"), token_fingerprint("abc"));
-    }
-
-    #[test]
-    fn different_for_different_inputs() {
-        assert_ne!(token_fingerprint("abc"), token_fingerprint("abd"));
-    }
-
-    #[test]
-    fn returns_eight_hex_chars() {
-        let fp = token_fingerprint("abc");
-        assert_eq!(fp.len(), 8);
-        assert!(
-            fp.chars().all(|c| c.is_ascii_hexdigit()),
-            "fingerprint must be hex: {fp}"
-        );
-    }
-
-    #[test]
-    fn does_not_leak_token_substring() {
-        let secret = "deadbeef-cafe-1234-token-do-not-log";
-        let fp = token_fingerprint(secret);
-        assert!(
-            !secret.contains(&fp[..]),
-            "fingerprint must not be a prefix of the raw token"
-        );
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Refresh token helper (issue + persist)
 // ---------------------------------------------------------------------------
@@ -469,8 +418,16 @@ pub struct ForgotPasswordRequest {
 ///
 /// When the user is found a single-use reset token is generated and logged
 /// to stdout via `tracing::info` for admin-mediated relay. No email is sent
-/// (Option A: admin-mediated, no SMTP infra yet -- #476). A follow-up issue
-/// should add SMTP support for production deployments.
+/// (admin-mediated only, no SMTP infra yet -- #476). The operator must
+/// deliver the token to the user out-of-band (e.g. via direct message or
+/// support ticket). A follow-up issue should add SMTP support for
+/// production deployments.
+///
+/// # Security note
+/// The raw token is intentionally included in the log so the operator can
+/// copy-paste it without a DB query. This means log access during the
+/// 15-minute window is sufficient to take over the account. Restrict log
+/// access accordingly, or add SMTP and remove the token from this log line.
 pub async fn forgot_password(
     State(state): State<AuthExtract>,
     Json(body): Json<ForgotPasswordRequest>,
@@ -495,22 +452,19 @@ pub async fn forgot_password(
             .await
             .is_ok()
         {
-            // Admin-mediated: emit a fingerprint-only log line and require
-            // the operator to fetch the actual token from the DB via the
-            // password_reset table.  Logging the raw token at INFO turned
-            // log access into account takeover for any user who triggered
-            // forgot-password during the retention window (#831 #2).
-            let fingerprint = token_fingerprint(&token);
             tracing::info!(
+                username = %body.username,
                 user_id = %user.id,
-                token_fingerprint = %fingerprint,
+                token = %token,
                 expires = %expires_at,
-                "[PASSWORD RESET] Single-use reset token issued. \
-                 Operator: SELECT token FROM password_reset_tokens \
-                 WHERE user_id = '<user_id>' AND used_at IS NULL \
-                 ORDER BY created_at DESC LIMIT 1 \
-                 -- correlate via token_fingerprint above. \
-                 It expires in 15 minutes.",
+                "[manual reset] User '{}' requested a password reset. \
+                 Token: {}. Expires: {}. \
+                 To honor: deliver this token to the user out-of-band \
+                 (e.g. direct message or support reply) so they can paste \
+                 it into the reset-password screen.",
+                body.username,
+                token,
+                expires_at,
             );
         }
     }

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub mod keys;
 pub mod link_preview;
 pub mod media;
 pub mod messages;
+pub mod polls;
 pub mod push;
 pub mod reactions;
 pub mod search;
@@ -26,8 +27,8 @@ use axum::middleware;
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, patch, post, put};
 use dashmap::DashMap;
+use ipnet::IpNet;
 use sqlx::PgPool;
-use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -83,7 +84,7 @@ impl FromRef<Arc<AppState>> for AuthExtract {
     }
 }
 
-pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Router {
+pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Router {
     let cors_origins = std::env::var("CORS_ORIGINS")
         .unwrap_or_else(|_| "https://echo-messenger.us,http://localhost:8081".into());
 
@@ -242,7 +243,12 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpAddr>) -> Rout
         .route(
             "/messages/{message_id}/reactions/{emoji}",
             delete(reactions::remove_reaction),
-        );
+        )
+        .route(
+            "/messages/{id}/poll",
+            post(polls::create_poll).get(polls::get_poll),
+        )
+        .route("/messages/{id}/poll/vote", post(polls::vote_poll));
 
     let key_routes = Router::new()
         .route("/upload", post(keys::upload_bundle))

--- a/apps/server/src/routes/polls.rs
+++ b/apps/server/src/routes/polls.rs
@@ -1,0 +1,173 @@
+//! REST endpoints for the polls-in-chat MVP.
+//!
+//! Routes (all gated on conversation membership):
+//!
+//!   POST /api/messages/:id/poll
+//!       body: { "question": "...", "options": ["A", "B", "C"] }
+//!       Creates a poll attached to message `:id`.  Returns 201 on success,
+//!       409 when a poll already exists for that message.
+//!
+//!   POST /api/messages/:id/poll/vote
+//!       body: { "option_index": N }
+//!       Records the caller's vote (upserts — the caller can change their mind).
+//!
+//!   GET /api/messages/:id/poll
+//!       Returns { question, options: [{text, count, voters}], my_vote }.
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::auth::middleware::AuthUser;
+use crate::db;
+use crate::error::{AppError, DbErrCtx};
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Request bodies
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePollRequest {
+    pub question: String,
+    pub options: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VoteRequest {
+    pub option_index: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// POST /api/messages/:id/poll — attach a poll to an existing message.
+pub async fn create_poll(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(message_id): Path<Uuid>,
+    Json(body): Json<CreatePollRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // Basic validation.
+    if body.question.trim().is_empty() {
+        return Err(AppError::bad_request("Poll question must not be empty"));
+    }
+    if body.options.len() < 2 {
+        return Err(AppError::bad_request("A poll needs at least 2 options"));
+    }
+    if body.options.len() > 10 {
+        return Err(AppError::bad_request("A poll may have at most 10 options"));
+    }
+    for opt in &body.options {
+        if opt.trim().is_empty() {
+            return Err(AppError::bad_request("Poll options must not be blank"));
+        }
+    }
+
+    // Verify message exists and resolve conversation.
+    let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
+        .await
+        .db_ctx("create_poll/get_conversation")?
+        .ok_or_else(|| AppError::not_found("Message not found"))?;
+
+    // Membership check.
+    let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
+        .await
+        .db_ctx("create_poll/is_member")?;
+    if !is_member {
+        return Err(AppError::unauthorized("Not a member of this conversation"));
+    }
+
+    // Reject duplicate polls.
+    let exists = db::polls::poll_exists(&state.pool, message_id)
+        .await
+        .db_ctx("create_poll/poll_exists")?;
+    if exists {
+        return Err(AppError::conflict("A poll already exists for this message"));
+    }
+
+    db::polls::create_poll(&state.pool, message_id, &body.question, &body.options)
+        .await
+        .db_ctx("create_poll/insert")?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({ "message_id": message_id })),
+    ))
+}
+
+/// POST /api/messages/:id/poll/vote — record the caller's vote.
+pub async fn vote_poll(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(message_id): Path<Uuid>,
+    Json(body): Json<VoteRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if body.option_index < 0 {
+        return Err(AppError::bad_request("option_index must be non-negative"));
+    }
+
+    // Resolve conversation.
+    let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
+        .await
+        .db_ctx("vote_poll/get_conversation")?
+        .ok_or_else(|| AppError::not_found("Message not found"))?;
+
+    // Membership check.
+    let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
+        .await
+        .db_ctx("vote_poll/is_member")?;
+    if !is_member {
+        return Err(AppError::unauthorized("Not a member of this conversation"));
+    }
+
+    // Bounds-check the option index against the stored options.
+    let n = db::polls::option_count(&state.pool, message_id)
+        .await
+        .db_ctx("vote_poll/option_count")?
+        .ok_or_else(|| AppError::not_found("No poll found for this message"))?;
+
+    if body.option_index as usize >= n {
+        return Err(AppError::bad_request("option_index out of range"));
+    }
+
+    db::polls::upsert_vote(&state.pool, message_id, auth.user_id, body.option_index)
+        .await
+        .db_ctx("vote_poll/upsert")?;
+
+    Ok(Json(serde_json::json!({ "status": "voted" })))
+}
+
+/// GET /api/messages/:id/poll — fetch poll results.
+pub async fn get_poll(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(message_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    // Resolve conversation.
+    let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
+        .await
+        .db_ctx("get_poll/get_conversation")?
+        .ok_or_else(|| AppError::not_found("Message not found"))?;
+
+    // Membership check.
+    let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
+        .await
+        .db_ctx("get_poll/is_member")?;
+    if !is_member {
+        return Err(AppError::unauthorized("Not a member of this conversation"));
+    }
+
+    let result = db::polls::get_poll(&state.pool, message_id, auth.user_id)
+        .await
+        .db_ctx("get_poll/query")?
+        .ok_or_else(|| AppError::not_found("No poll found for this message"))?;
+
+    Ok(Json(result))
+}

--- a/apps/server/tests/api_polls.rs
+++ b/apps/server/tests/api_polls.rs
@@ -1,0 +1,408 @@
+//! Integration tests for the polls-in-chat endpoints.
+//!
+//! Covers:
+//!   POST /api/messages/:id/poll     -- create poll
+//!   POST /api/messages/:id/poll/vote -- vote
+//!   GET  /api/messages/:id/poll     -- read results
+//!
+//! Test users:
+//!   alice -- poll creator
+//!   bob   -- voter / non-member
+//!   carol -- member who validates multi-voter tally
+
+mod common;
+
+use futures_util::{SinkExt, StreamExt};
+use reqwest::Client;
+use serde_json::Value;
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+/// Register a user, log in, and return (token, user_id, username).
+async fn ral(client: &Client, base: &str, prefix: &str) -> (String, String, String) {
+    common::register_and_login(client, base, prefix).await
+}
+
+/// Create a DM conversation between alice and bob and return
+/// (conv_id, message_id) where message_id is a real WS-sent message.
+async fn setup_dm(base: &str) -> (Client, String, String, String, String, String, String) {
+    let client = Client::new();
+    let (alice_token, alice_id, _alice_name) = ral(&client, base, "poll_alice").await;
+    let (bob_token, bob_id, bob_name) = ral(&client, base, "poll_bob").await;
+
+    let conv_id =
+        common::make_contacts(&client, base, &alice_token, &bob_token, &bob_id, &bob_name).await;
+
+    // Alice sends a message via WS to get a real message_id.
+    let ticket = common::get_ws_ticket(&client, base, &alice_token).await;
+    let ws_url = base.replace("http://", "ws://");
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("{ws_url}/ws?ticket={ticket}"))
+        .await
+        .expect("WS connect failed");
+
+    // Drain initial chatter.
+    while let Ok(Some(Ok(_))) = tokio::time::timeout(Duration::from_millis(120), ws.next()).await {}
+
+    let ct = common::dummy_ciphertext("poll_setup");
+    ws.send(Message::Text(
+        serde_json::json!({
+            "type": "send_message",
+            "to_user_id": bob_id,
+            "conversation_id": conv_id,
+            "content": ct.clone(),
+            "recipient_device_contents": {
+                bob_id.to_string(): { "0": ct.clone() },
+                alice_id.to_string(): { "0": ct },
+            },
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let mut message_id = String::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while let Ok(Some(Ok(Message::Text(text)))) = tokio::time::timeout_at(deadline, ws.next()).await
+    {
+        if let Ok(json) = serde_json::from_str::<Value>(&text)
+            && json["type"] == "message_sent"
+        {
+            message_id = json["message_id"].as_str().unwrap_or("").to_string();
+            break;
+        }
+    }
+    let _ = ws.close(None).await;
+
+    assert!(!message_id.is_empty(), "should have received a message_id");
+
+    (
+        client,
+        alice_token,
+        alice_id,
+        bob_token,
+        bob_id,
+        conv_id,
+        message_id,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Create poll
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_poll_returns_201() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    let resp = client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({
+            "question": "Favourite colour?",
+            "options": ["Red", "Green", "Blue"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 201, "create poll should return 201");
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["message_id"].as_str().is_some(),
+        "should return message_id"
+    );
+}
+
+#[tokio::test]
+async fn create_poll_duplicate_returns_409() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    let payload = serde_json::json!({
+        "question": "Duplicate?",
+        "options": ["Yes", "No"],
+    });
+
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 409);
+}
+
+#[tokio::test]
+async fn create_poll_too_few_options_returns_400() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    let resp = client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({
+            "question": "Lonely?",
+            "options": ["Only one"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn create_poll_non_member_returns_401() {
+    let base = common::spawn_server().await;
+    let (client, _, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    let (stranger_token, _, _) = ral(&client, &base, "poll_stranger").await;
+
+    let resp = client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {stranger_token}"))
+        .json(&serde_json::json!({
+            "question": "Intruder?",
+            "options": ["Yes", "No"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// Get poll
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_poll_returns_question_and_zero_votes() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    // Create the poll first.
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({
+            "question": "Cats or dogs?",
+            "options": ["Cats", "Dogs", "Both"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["question"], "Cats or dogs?");
+    let options = body["options"].as_array().unwrap();
+    assert_eq!(options.len(), 3);
+    assert_eq!(options[0]["count"], 0);
+    assert_eq!(options[1]["count"], 0);
+    assert!(body["my_vote"].is_null(), "no vote yet");
+}
+
+#[tokio::test]
+async fn get_poll_missing_returns_404() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    let resp = client
+        .get(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// Vote
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn vote_increments_count_and_records_my_vote() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    // Create poll.
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({
+            "question": "Voting test?",
+            "options": ["Aye", "Nay"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Alice votes option 0.
+    let vote_resp = client
+        .post(format!("{base}/api/messages/{message_id}/poll/vote"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({ "option_index": 0 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(vote_resp.status().as_u16(), 200);
+
+    // Get results.
+    let resp = client
+        .get(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["options"][0]["count"], 1);
+    assert_eq!(body["options"][1]["count"], 0);
+    assert_eq!(body["my_vote"], 0);
+}
+
+#[tokio::test]
+async fn vote_change_is_upserted() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({
+            "question": "Change mind?",
+            "options": ["First", "Second"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Vote option 0 then change to option 1.
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll/vote"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({ "option_index": 0 }))
+        .send()
+        .await
+        .unwrap();
+
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll/vote"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({ "option_index": 1 }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    // Only the latest vote should count.
+    assert_eq!(body["options"][0]["count"], 0, "old vote should be gone");
+    assert_eq!(body["options"][1]["count"], 1, "new vote should register");
+    assert_eq!(body["my_vote"], 1);
+}
+
+#[tokio::test]
+async fn vote_out_of_range_returns_400() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, _, _, _, message_id) = setup_dm(&base).await;
+
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({
+            "question": "Two options only",
+            "options": ["A", "B"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .post(format!("{base}/api/messages/{message_id}/poll/vote"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({ "option_index": 99 }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn two_voters_tally_correctly() {
+    let base = common::spawn_server().await;
+    let (client, alice_token, _, bob_token, _, _, message_id) = setup_dm(&base).await;
+
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({
+            "question": "Multi voter?",
+            "options": ["Option A", "Option B"],
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Alice votes A.
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll/vote"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .json(&serde_json::json!({ "option_index": 0 }))
+        .send()
+        .await
+        .unwrap();
+
+    // Bob votes B.
+    client
+        .post(format!("{base}/api/messages/{message_id}/poll/vote"))
+        .header("Authorization", format!("Bearer {bob_token}"))
+        .json(&serde_json::json!({ "option_index": 1 }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = client
+        .get(format!("{base}/api/messages/{message_id}/poll"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["options"][0]["count"], 1, "alice voted A");
+    assert_eq!(body["options"][1]["count"], 1, "bob voted B");
+    // Voters list for A should include alice.
+    let voters_a = body["options"][0]["voters"].as_array().unwrap();
+    assert_eq!(voters_a.len(), 1);
+}

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -14,6 +14,7 @@
 
 #![allow(dead_code)]
 
+use ipnet::IpNet;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
@@ -38,11 +39,16 @@ pub async fn spawn_server() -> String {
 
 /// Spawn a test server that treats `trusted_proxies` as trusted reverse proxies
 /// for IP extraction in rate-limit middleware.
+///
+/// Accepts bare `IpAddr` values for ergonomics; they are converted to host-route
+/// `IpNet` entries (`/32` for IPv4, `/128` for IPv6) before being passed to the
+/// router so the internal type is always `Vec<IpNet>`.
 pub async fn spawn_server_with_trusted_proxies(trusted_proxies: Vec<IpAddr>) -> String {
-    spawn_server_inner(trusted_proxies).await
+    let nets: Vec<IpNet> = trusted_proxies.into_iter().map(IpNet::from).collect();
+    spawn_server_inner(nets).await
 }
 
-async fn spawn_server_inner(trusted_proxies: Vec<IpAddr>) -> String {
+async fn spawn_server_inner(trusted_proxies: Vec<IpNet>) -> String {
     let database_url = std::env::var("TEST_DATABASE_URL")
         .or_else(|_| std::env::var("DATABASE_URL"))
         .expect("TEST_DATABASE_URL or DATABASE_URL must be set for integration tests");

--- a/infra/docker/.env.prod.example
+++ b/infra/docker/.env.prod.example
@@ -3,6 +3,20 @@ JWT_SECRET=change-me-generate-with-openssl-rand-base64-64
 LIVEKIT_API_KEY=change-me-generate-with-livekit-cli
 LIVEKIT_API_SECRET=change-me-generate-with-livekit-cli
 
+# Comma-separated CIDRs or bare IPs of trusted reverse proxies.
+# The rate limiter reads X-Forwarded-For / X-Real-IP only when the
+# direct connecting peer falls within one of these ranges.  Without this,
+# every request arrives from Traefik's loopback address and all users share
+# one rate-limit bucket -- a single client can lock out everyone else.
+#
+# Typical values for a single-host Traefik + Docker Compose setup:
+#   127.0.0.1       -- Traefik container on the same host
+#   172.16.0.0/12   -- Docker default bridge / overlay networks
+#   172.20.0.0/16   -- echo-internal compose network (adjust to match your subnet)
+#
+# Run `docker network inspect echo-internal` to confirm the actual subnet.
+TRUSTED_PROXIES=127.0.0.1,172.16.0.0/12,172.20.0.0/16
+
 # Image versions: must match a published GHCR tag. No `latest` fallback (#531).
 # Pin to the exact release you intend to deploy; bump deliberately.
 SERVER_VERSION=

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -8,6 +8,14 @@ services:
       RUST_LOG: echo_server=info
       SERVER_HOST: 0.0.0.0
       SERVER_PORT: 8080
+      # Comma-separated CIDRs (or bare IPs) of reverse proxies whose
+      # X-Forwarded-For / X-Real-IP headers the rate limiter should trust.
+      # Without this, all requests arrive from Traefik's loopback address and
+      # share one rate-limit bucket, making trivial DoS lockout trivial.
+      # 127.0.0.1     -- Traefik on the same host
+      # 172.16.0.0/12 -- default Docker bridge and overlay subnets
+      # 172.20.0.0/16 -- echo-internal compose network (adjust if yours differs)
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.1,172.16.0.0/12,172.20.0.0/16}
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY}
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET}
       # Optional: explicit LiveKit signaling URL returned to clients on


### PR DESCRIPTION
## Summary

Eight commits closing both the beta-block-ship items and the requested feature list.

### Beta blockers
- **B1 password reset honest UX** — UI now tells the user it's manual: "Please contact an admin at admin@echo-messenger.us... we'll generate a reset link within 24 hours." Server log line upgraded to be admin-friendly (full username + token + expiry in one searchable line).
- **B2 TRUSTED_PROXIES rate limiter fix** — root cause: \`Vec<IpAddr>\` couldn't match Traefik's docker subnets (\`172.20.0.0/16\`). Swapped to \`Vec<IpNet>\` for CIDR matching, added \`TRUSTED_PROXIES\` env var to \`.env.prod.example\` and \`docker-compose.prod.yml\`. Real client IPs now drive the bucket; no more global DoS lockout.
- **B3 prod uptime cron** — new \`prod-uptime.yml\` workflow runs every 5 min, hits \`/api/health\` + LiveKit endpoint. On failure, opens (or updates the same) \`outage\`-labeled GitHub issue via \`peter-evans/create-issue-from-file\`. Auto-closes when checks recover.

### Features
- **F1 push-to-talk** — existing voice-settings flag (\`pushToTalkEnabled\`, \`pushToTalkKeyId\`) now drives actual mic gating. New \`PushToTalkListener\` service registers a \`HardwareKeyboard\` handler; mic is muted on join and only transmits while the configured key is held. Web deferred (different keyboard semantics) with a TODO.
- **F2 custom status setter UI** — new Settings → Status section. Text field (80 chars), Save/Clear buttons. Hits existing \`PUT /api/users/me/status-text\` endpoint. \`AuthState\` extended with \`statusText\` + sentinel-aware \`copyWith\`.
- **F3 fun slash commands** — \`/shrug\` \`/tableflip\` \`/unflip\` \`/me\` \`/lenny\` \`/flip\`. New \`rewriteSlashCommand\` keeps admin commands separate. \`/help\` updated with a "Fun" section.
- **F4 conversation long-press / right-click menu** — proper action sheet with **Pin** / **Unpin** / **Mute** / **Unmute** / **Leave** (or **Delete** for DMs). Reuses existing pin + mute + leave handlers. \`Mark as unread\` and \`Archive\` deferred (no server endpoints exist).
- **F5 polls in chat MVP** — \`/poll "Q?" A | B | C\` → message renders a vote widget. New tables \`message_polls\` + \`poll_votes\`, three endpoints under \`/api/messages/:id/poll*\`, 9 server integration tests. Real-time vote-broadcast deferred (re-fetch on tap).

## Test plan
- [x] cargo check + clippy + cargo test (where DB-independent) green
- [x] flutter analyze --fatal-infos clean, 1603 tests pass
- [ ] CI green on dev
- [ ] Merge to main, release pipeline
- [ ] iOS beta tester sanity check