### PR TITLE
Centralised Discord-style context menu for messages, conversations, members

### DIFF
--- a/apps/client/lib/src/router/app_router.dart
+++ b/apps/client/lib/src/router/app_router.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../providers/auth_provider.dart';
+import '../widgets/context_menu/context_menu_testbed.dart';
 import '../screens/admin/admin_dashboard_screen.dart';
 import '../screens/contacts_screen.dart';
 import '../screens/create_group_screen.dart';
@@ -317,6 +319,14 @@ final routerProvider = Provider<GoRouter>((ref) {
         ),
       ),
       ..._profileRoutes(),
+      // Debug-only testbed for the centralised context menu. Stripped
+      // from release builds so it can't be linked-to by accident.
+      if (kDebugMode)
+        GoRoute(
+          path: '/dev/context-menu',
+          pageBuilder: (context, state) =>
+              _fadePage(key: state.pageKey, child: const ContextMenuTestbed()),
+        ),
     ],
   );
 });

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -22,6 +22,8 @@ import '../providers/websocket_provider.dart';
 import '../utils/fuzzy_score.dart';
 import '../widgets/avatar_crop_dialog.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import '../widgets/context_menu/actions/member_actions_registry.dart';
+import '../widgets/context_menu/echo_context_menu.dart';
 import '../widgets/profile_sheets.dart';
 
 const _kJsonHeaders = {'Content-Type': 'application/json'};
@@ -1114,60 +1116,118 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     return [];
   }
 
+  /// Trailing "..." affordance on a member row. Routes through
+  /// [EchoContextMenu] so the menu items match right-click and
+  /// long-press paths exactly. Hidden when the menu would be empty
+  /// (target is self with no admin actions on offer).
   Widget? _buildMemberActions({
     required ConversationMember member,
     required bool isOwnerOrAdmin,
     required bool isMe,
     required String role,
   }) {
-    if (!isOwnerOrAdmin || isMe || role == 'owner') return null;
-    return PopupMenuButton<String>(
-      icon: Icon(
-        Icons.more_vert,
-        size: 18,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
+    if (isMe) return null;
+    return Builder(
+      builder: (btnContext) => IconButton(
+        icon: Icon(
+          Icons.more_vert,
+          size: 18,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+        tooltip: 'Member actions',
+        onPressed: () {
+          final box = btnContext.findRenderObject() as RenderBox?;
+          final origin =
+              box?.localToGlobal(Offset(0, box.size.height)) ?? Offset.zero;
+          _openMemberContextMenu(
+            anchor: origin,
+            member: member,
+            role: role,
+            viewerIsAdminOrOwner: isOwnerOrAdmin,
+            isMe: isMe,
+          );
+        },
       ),
-      tooltip: 'Member actions',
-      onSelected: (value) {
-        if (value == 'remove') _kickMember(member);
-        if (value == 'ban') _banMember(member);
+    );
+  }
+
+  /// Build a [MemberTarget] for [member] and open the centralised
+  /// context menu at [anchor]. Used by all three triggers
+  /// (right-click on row, long-press on row, "..." button).
+  ///
+  /// PR-4 scope is migration only: Add/Remove Contact + Block stay
+  /// off until contacts_provider grows the matching methods. Unblock
+  /// already exists, so it's wired conditionally on the live
+  /// blocked-users list.
+  void _openMemberContextMenu({
+    required Offset anchor,
+    required ConversationMember member,
+    required String role,
+    required bool viewerIsAdminOrOwner,
+    required bool isMe,
+  }) {
+    final blockedIds = ref
+        .read(contactsProvider)
+        .blockedUsers
+        .map((u) => u.blockedId)
+        .toSet();
+    final isBlocked = blockedIds.contains(member.userId);
+
+    final target = MemberTarget(
+      userId: member.userId,
+      username: member.username,
+      isSelf: isMe,
+      targetIsOwner: role == 'owner',
+      viewerIsAdminOrOwner: viewerIsAdminOrOwner,
+      onViewProfile: () => showUserProfileSheet(context, ref, member.userId),
+      onSendMessage: isMe
+          ? null
+          : () async {
+              try {
+                final conv = await ref
+                    .read(conversationsProvider.notifier)
+                    .getOrCreateDm(member.userId, member.username);
+                if (!mounted) return;
+                context.go('/home?conversation=${conv.id}');
+              } catch (_) {
+                if (!mounted) return;
+                ToastService.show(
+                  context,
+                  'Failed to open conversation',
+                  type: ToastType.error,
+                );
+              }
+            },
+      onUnblock: (isMe || !isBlocked)
+          ? null
+          : () async {
+              await ref
+                  .read(contactsProvider.notifier)
+                  .unblockUser(member.userId);
+            },
+      onCopyUsername: () {
+        Clipboard.setData(ClipboardData(text: member.username));
+        if (!mounted) return;
+        ToastService.show(context, 'Username copied', type: ToastType.success);
       },
-      itemBuilder: (_) => [
-        PopupMenuItem(
-          value: 'remove',
-          child: Row(
-            children: [
-              Icon(
-                Icons.person_remove_outlined,
-                size: 18,
-                color: Theme.of(context).colorScheme.error,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                'Remove',
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
-            ],
-          ),
-        ),
-        PopupMenuItem(
-          value: 'ban',
-          child: Row(
-            children: [
-              Icon(
-                Icons.block_outlined,
-                size: 18,
-                color: Theme.of(context).colorScheme.error,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                'Ban',
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
-            ],
-          ),
-        ),
-      ],
+      onCopyUserId: () {
+        Clipboard.setData(ClipboardData(text: member.userId));
+        if (!mounted) return;
+        ToastService.show(context, 'User ID copied', type: ToastType.success);
+      },
+      onKick: (viewerIsAdminOrOwner && !isMe && role != 'owner')
+          ? () => _kickMember(member)
+          : null,
+      onBan: (viewerIsAdminOrOwner && !isMe && role != 'owner')
+          ? () => _banMember(member)
+          : null,
+    );
+
+    EchoContextMenu.open(
+      context: context,
+      target: target,
+      anchor: anchor,
+      model: buildMemberMenu(target),
     );
   }
 
@@ -1195,6 +1255,20 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
           showUserProfileSheet(context, ref, member.userId);
         }
       },
+      onSecondaryTapDown: (details) => _openMemberContextMenu(
+        anchor: details.globalPosition,
+        member: member,
+        role: role,
+        viewerIsAdminOrOwner: isOwnerOrAdmin,
+        isMe: isMe,
+      ),
+      onLongPress: () => _openMemberContextMenu(
+        anchor: Offset.zero,
+        member: member,
+        role: role,
+        viewerIsAdminOrOwner: isOwnerOrAdmin,
+        isMe: isMe,
+      ),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         child: Row(

--- a/apps/client/lib/src/widgets/context_menu/actions/conversation_actions_registry.dart
+++ b/apps/client/lib/src/widgets/context_menu/actions/conversation_actions_registry.dart
@@ -1,0 +1,135 @@
+/// Pure mapping from a [ConversationTarget] to a [ContextMenuModel].
+///
+/// v1 scope (per the cross-cutting decisions agreed before PR 3):
+///   - Mark As Read shows only when there's at least one unread;
+///     Mark As Unread shows only when fully read.
+///   - "Notification settings" submenu was rejected — encryption
+///     activity / safety number / group info all link out to their
+///     dedicated screens instead of inlining nested submenus.
+///   - Owner-of-a-group-with-other-members can't leave; row is
+///     hidden entirely (not disabled), matching the cross-cutting
+///     decision.
+///   - Copy Conversation ID is always visible in the footer.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../echo_context_menu.dart';
+
+ContextMenuModel buildConversationMenu(ConversationTarget t) {
+  return ContextMenuModel(
+    sections: [
+      _readPinMuteSection(t),
+      if (_hasNavSection(t)) _navSection(t),
+      if (_hasDanger(t)) _dangerSection(t),
+      if (t.onCopyId != null) _footerSection(t),
+    ].whereType<ContextMenuSection>().toList(),
+  );
+}
+
+ContextMenuSection _readPinMuteSection(ConversationTarget t) {
+  return ContextMenuSection(
+    actions: [
+      if (t.onMarkAsRead != null && t.hasUnread)
+        ContextMenuAction(
+          label: 'Mark As Read',
+          icon: Icons.mark_chat_read_outlined,
+          onTap: t.onMarkAsRead,
+        ),
+      if (t.onMarkAsUnread != null && !t.hasUnread)
+        ContextMenuAction(
+          label: 'Mark As Unread',
+          icon: Icons.mark_email_unread_outlined,
+          onTap: t.onMarkAsUnread,
+        ),
+      if (t.onToggleMute != null)
+        ContextMenuAction(
+          label: t.isMuted ? 'Unmute' : 'Mute',
+          icon: t.isMuted
+              ? Icons.notifications_outlined
+              : Icons.notifications_off_outlined,
+          onTap: t.onToggleMute,
+        ),
+      if (t.onTogglePin != null)
+        ContextMenuAction(
+          label: t.isPinned ? 'Unpin' : 'Pin to Top',
+          icon: t.isPinned ? Icons.push_pin : Icons.push_pin_outlined,
+          onTap: t.onTogglePin,
+        ),
+    ],
+  );
+}
+
+bool _hasNavSection(ConversationTarget t) {
+  return t.onOpenInfo != null ||
+      t.onInvitePeople != null ||
+      t.onOpenEncryptionActivity != null ||
+      t.onViewSafetyNumber != null;
+}
+
+ContextMenuSection _navSection(ConversationTarget t) {
+  return ContextMenuSection(
+    actions: [
+      if (t.onOpenInfo != null && t.isGroup)
+        ContextMenuAction(
+          label: 'Group Info',
+          icon: Icons.info_outline,
+          onTap: t.onOpenInfo,
+        ),
+      if (t.onInvitePeople != null && t.isGroup)
+        ContextMenuAction(
+          label: 'Invite People',
+          icon: Icons.person_add_outlined,
+          onTap: t.onInvitePeople,
+        ),
+      if (t.onViewSafetyNumber != null && !t.isGroup)
+        ContextMenuAction(
+          label: 'View Safety Number',
+          icon: Icons.shield_outlined,
+          onTap: t.onViewSafetyNumber,
+        ),
+      if (t.onOpenEncryptionActivity != null && t.isGroup && t.isAdminOrOwner)
+        ContextMenuAction(
+          label: 'Encryption Activity',
+          icon: Icons.history,
+          onTap: t.onOpenEncryptionActivity,
+        ),
+    ],
+  );
+}
+
+bool _hasDanger(ConversationTarget t) =>
+    t.onLeave != null || t.onDelete != null;
+
+ContextMenuSection _dangerSection(ConversationTarget t) {
+  return ContextMenuSection(
+    actions: [
+      if (t.onLeave != null)
+        ContextMenuAction(
+          label: 'Leave Group',
+          icon: Icons.exit_to_app,
+          isDanger: true,
+          onTap: t.onLeave,
+        ),
+      if (t.onDelete != null)
+        ContextMenuAction(
+          label: t.isGroup ? 'Delete Group' : 'Delete Conversation',
+          icon: Icons.delete_outline,
+          isDanger: true,
+          onTap: t.onDelete,
+        ),
+    ],
+  );
+}
+
+ContextMenuSection _footerSection(ConversationTarget t) {
+  return ContextMenuSection(
+    actions: [
+      ContextMenuAction(
+        label: 'Copy Conversation ID',
+        icon: Icons.tag,
+        onTap: t.onCopyId,
+      ),
+    ],
+  );
+}

--- a/apps/client/lib/src/widgets/context_menu/actions/member_actions_registry.dart
+++ b/apps/client/lib/src/widgets/context_menu/actions/member_actions_registry.dart
@@ -1,0 +1,133 @@
+/// Pure mapping from a [MemberTarget] to a [ContextMenuModel].
+///
+/// v1 scope (locked before PR 4):
+///   - Always-on: View Profile, Send Message, Copy User ID, Copy
+///     Username.
+///   - Contact actions: Add / Remove Contact, Block / Unblock —
+///     wired only when the caller knows the local contact state.
+///   - Admin-only danger zone: Kick from Group, Ban from Group.
+///   - "Change Role" and "Voice Call" hidden — see MemberTarget
+///     docs for the rationale.
+///
+/// Targeting self hides the entire destructive zone so the menu
+/// can't be used to kick / ban / block oneself.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../echo_context_menu.dart';
+
+ContextMenuModel buildMemberMenu(MemberTarget t) {
+  return ContextMenuModel(
+    sections: [
+      _primarySection(t),
+      if (_hasContactSection(t)) _contactSection(t),
+      if (_hasAdminSection(t)) _adminSection(t),
+      if (t.onCopyUserId != null || t.onCopyUsername != null) _footerSection(t),
+    ].whereType<ContextMenuSection>().toList(),
+  );
+}
+
+ContextMenuSection _primarySection(MemberTarget t) {
+  return ContextMenuSection(
+    actions: [
+      if (t.onViewProfile != null)
+        ContextMenuAction(
+          label: 'View Profile',
+          icon: Icons.person_outline,
+          onTap: t.onViewProfile,
+        ),
+      if (t.onSendMessage != null && !t.isSelf)
+        ContextMenuAction(
+          label: 'Send Message',
+          icon: Icons.mail_outline,
+          onTap: t.onSendMessage,
+        ),
+    ],
+  );
+}
+
+bool _hasContactSection(MemberTarget t) {
+  if (t.isSelf) return false;
+  return t.onAddContact != null ||
+      t.onRemoveContact != null ||
+      t.onBlock != null ||
+      t.onUnblock != null;
+}
+
+ContextMenuSection _contactSection(MemberTarget t) {
+  return ContextMenuSection(
+    actions: [
+      if (t.onAddContact != null)
+        ContextMenuAction(
+          label: 'Add Contact',
+          icon: Icons.person_add_alt_1_outlined,
+          onTap: t.onAddContact,
+        ),
+      if (t.onRemoveContact != null)
+        ContextMenuAction(
+          label: 'Remove Contact',
+          icon: Icons.person_remove_outlined,
+          onTap: t.onRemoveContact,
+        ),
+      if (t.onBlock != null)
+        ContextMenuAction(
+          label: 'Block',
+          icon: Icons.block_outlined,
+          isDanger: true,
+          onTap: t.onBlock,
+        ),
+      if (t.onUnblock != null)
+        ContextMenuAction(
+          label: 'Unblock',
+          icon: Icons.lock_open_outlined,
+          onTap: t.onUnblock,
+        ),
+    ],
+  );
+}
+
+bool _hasAdminSection(MemberTarget t) {
+  if (t.isSelf || t.targetIsOwner || !t.viewerIsAdminOrOwner) return false;
+  return t.onKick != null || t.onBan != null;
+}
+
+ContextMenuSection _adminSection(MemberTarget t) {
+  return ContextMenuSection(
+    actions: [
+      if (t.onKick != null)
+        ContextMenuAction(
+          label: 'Kick from Group',
+          icon: Icons.person_remove_outlined,
+          isDanger: true,
+          onTap: t.onKick,
+        ),
+      if (t.onBan != null)
+        ContextMenuAction(
+          label: 'Ban from Group',
+          icon: Icons.gavel_outlined,
+          isDanger: true,
+          onTap: t.onBan,
+        ),
+    ],
+  );
+}
+
+ContextMenuSection _footerSection(MemberTarget t) {
+  return ContextMenuSection(
+    actions: [
+      if (t.onCopyUsername != null)
+        ContextMenuAction(
+          label: 'Copy Username',
+          icon: Icons.alternate_email,
+          onTap: t.onCopyUsername,
+        ),
+      if (t.onCopyUserId != null)
+        ContextMenuAction(
+          label: 'Copy User ID',
+          icon: Icons.tag,
+          onTap: t.onCopyUserId,
+        ),
+    ],
+  );
+}

--- a/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
+++ b/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
@@ -1,0 +1,156 @@
+/// Pure mapping from a [MessageTarget] to a [ContextMenuModel].
+///
+/// Living in its own file (no widget imports) keeps it trivial to
+/// unit-test action visibility under different role / state combos
+/// without spinning up a full Flutter test harness.
+///
+/// v1 scope (per the cross-cutting decisions agreed before PR 2):
+///   - Encrypted-unreadable messages → no inline reactions row.
+///   - "Create Thread", "Report", "Mark Unread", "Copy Link" are
+///     deferred (server endpoints don't exist yet).
+///   - Copy Message ID always visible in the footer section.
+///   - Owner-only / mine-only / media-only rows hide entirely when
+///     they don't apply, rather than rendering disabled.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../echo_context_menu.dart';
+
+ContextMenuModel buildMessageMenu(MessageTarget t) {
+  return ContextMenuModel(
+    header: _buildHeader(t),
+    sections: [
+      _primarySection(t),
+      _utilitySection(t),
+      if (_hasDanger(t)) _dangerSection(t),
+      if (t.onCopyId != null) _footerSection(t),
+    ].whereType<ContextMenuSection>().toList(),
+  );
+}
+
+ContextMenuHeader? _buildHeader(MessageTarget t) {
+  if (t.isEncryptedUnreadable) return null;
+  if (t.onPickReaction == null || t.onOpenFullPicker == null) return null;
+  return InlineReactionsHeader(
+    emojis: t.recentReactions,
+    onPick: t.onPickReaction!,
+    onOpenFullPicker: t.onOpenFullPicker!,
+  );
+}
+
+ContextMenuSection _primarySection(MessageTarget t) {
+  final actions = <ContextMenuAction>[
+    if (t.onRetry != null)
+      ContextMenuAction(label: 'Retry', icon: Icons.refresh, onTap: t.onRetry),
+    if (t.onReply != null)
+      ContextMenuAction(
+        label: 'Reply',
+        icon: Icons.reply_outlined,
+        onTap: t.onReply,
+      ),
+    if (t.onForward != null)
+      ContextMenuAction(
+        label: 'Forward',
+        icon: Icons.forward_outlined,
+        onTap: t.onForward,
+      ),
+  ];
+  return ContextMenuSection(actions: actions);
+}
+
+ContextMenuSection _utilitySection(MessageTarget t) {
+  // Pin/unpin and save/unsave are mutually exclusive — only one
+  // variant is wired at any moment, so we just expose whichever
+  // callback the caller provided.
+  final pinRow = _pinRow(t);
+  final saveRow = _saveRow(t);
+
+  return ContextMenuSection(
+    actions: [
+      if (t.onCopyText != null)
+        ContextMenuAction(
+          label: t.mediaUrl != null ? 'Copy link' : 'Copy text',
+          icon: Icons.copy_outlined,
+          onTap: t.onCopyText,
+        ),
+      if (t.onViewGallery != null && t.isImageMedia)
+        ContextMenuAction(
+          label: 'View in Gallery',
+          icon: Icons.image_outlined,
+          onTap: t.onViewGallery,
+        ),
+      ?pinRow,
+      ?saveRow,
+      if (t.isMine && t.onEdit != null)
+        ContextMenuAction(
+          label: 'Edit',
+          icon: Icons.edit_outlined,
+          onTap: t.onEdit,
+        ),
+    ],
+  );
+}
+
+ContextMenuAction? _pinRow(MessageTarget t) {
+  if (t.onPin != null) {
+    return ContextMenuAction(
+      label: 'Pin Message',
+      icon: Icons.push_pin_outlined,
+      onTap: t.onPin,
+    );
+  }
+  if (t.onUnpin != null) {
+    return ContextMenuAction(
+      label: 'Unpin Message',
+      icon: Icons.push_pin,
+      onTap: t.onUnpin,
+    );
+  }
+  return null;
+}
+
+ContextMenuAction? _saveRow(MessageTarget t) {
+  if (t.onSave != null && !t.isSaved) {
+    return ContextMenuAction(
+      label: 'Save',
+      icon: Icons.bookmark_border_outlined,
+      onTap: t.onSave,
+    );
+  }
+  if (t.onUnsave != null && t.isSaved) {
+    return ContextMenuAction(
+      label: 'Unsave',
+      icon: Icons.bookmark_remove_outlined,
+      onTap: t.onUnsave,
+    );
+  }
+  return null;
+}
+
+bool _hasDanger(MessageTarget t) => t.onDelete != null;
+
+ContextMenuSection _dangerSection(MessageTarget t) {
+  return ContextMenuSection(
+    actions: [
+      ContextMenuAction(
+        label: t.isMine ? 'Delete Message' : 'Delete for Me',
+        icon: Icons.delete_outline,
+        isDanger: t.isMine,
+        onTap: t.onDelete,
+      ),
+    ],
+  );
+}
+
+ContextMenuSection _footerSection(MessageTarget t) {
+  return ContextMenuSection(
+    actions: [
+      ContextMenuAction(
+        label: 'Copy Message ID',
+        icon: Icons.tag,
+        onTap: t.onCopyId,
+      ),
+    ],
+  );
+}

--- a/apps/client/lib/src/widgets/context_menu/context_menu_item.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_item.dart
@@ -1,0 +1,128 @@
+/// Single row inside the Echo context menu: label left, icon right,
+/// optional shortcut hint, optional submenu chevron. 36px tap target.
+/// Hover-state painted directly so we don't pull in Material's
+/// InkWell ripple — Discord-style menus snap, they don't ripple.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../../theme/echo_theme.dart';
+import 'echo_context_menu.dart';
+
+class ContextMenuItem extends StatefulWidget {
+  const ContextMenuItem({
+    super.key,
+    required this.action,
+    required this.onActivate,
+    this.dense = false,
+  });
+
+  final ContextMenuAction action;
+
+  /// Called for both terminal taps (with `submenu == null`) and
+  /// submenu-opening taps. The overlay decides what to do based on
+  /// `action.submenu`.
+  final ValueChanged<ContextMenuAction> onActivate;
+
+  /// Tightens vertical padding for inline header rows (e.g. the
+  /// emoji strip's "Add Reaction" entry-point row).
+  final bool dense;
+
+  @override
+  State<ContextMenuItem> createState() => _ContextMenuItemState();
+}
+
+class _ContextMenuItemState extends State<ContextMenuItem> {
+  bool _hover = false;
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final action = widget.action;
+    final danger = action.isDanger;
+    final base = danger ? EchoTheme.danger : context.textPrimary;
+    // Hover bg uses the surface-hover token directly so the menu sits
+    // consistently with sidebar/list hover states elsewhere in the app.
+    final hoverBg = danger
+        ? EchoTheme.danger.withValues(alpha: 0.12)
+        : context.surfaceHover;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() {
+        _hover = false;
+        _pressed = false;
+      }),
+      child: GestureDetector(
+        onTapDown: (_) => setState(() => _pressed = true),
+        onTapCancel: () => setState(() => _pressed = false),
+        onTapUp: (_) {
+          setState(() => _pressed = false);
+          widget.onActivate(action);
+        },
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 80),
+          padding: EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: widget.dense ? 6 : 9,
+          ),
+          decoration: BoxDecoration(
+            color: _pressed
+                ? hoverBg.withValues(alpha: 0.9)
+                : (_hover ? hoverBg : Colors.transparent),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  action.label,
+                  style: TextStyle(
+                    fontSize: 13.5,
+                    color: base,
+                    fontWeight: FontWeight.w500,
+                    height: 1.2,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (action.shortcut != null) ...[
+                Text(
+                  action.shortcut!,
+                  style: EchoTheme.mono(
+                    fontSize: 11,
+                    color: context.textMuted,
+                    letterSpacing: 0.3,
+                  ),
+                ),
+                const SizedBox(width: 10),
+              ],
+              if (action.submenu != null)
+                Icon(Icons.chevron_right, size: 18, color: base)
+              else
+                Icon(action.icon, size: 16, color: base),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 1px horizontal divider painted between sections. Inset to match
+/// the row padding so it visually tracks the menu's gutter.
+class ContextMenuDivider extends StatelessWidget {
+  const ContextMenuDivider({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 1,
+      margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+      color: context.border,
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/context_menu/context_menu_overlay.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_overlay.dart
@@ -1,0 +1,412 @@
+/// Desktop / web context-menu layout: a floating rounded card
+/// anchored to the click point, clamped to the viewport, with a
+/// 120ms fade+scale entry. Submenus replace the contents of the
+/// same card via an in-place stack push, not nested popovers, so
+/// dismiss and focus stay simple.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../theme/echo_theme.dart';
+import 'context_menu_item.dart';
+import 'echo_context_menu.dart';
+
+const double _menuWidth = 220;
+const double _viewportPadding = 8;
+
+/// Opens the desktop overlay variant. Returns when the menu is
+/// dismissed (tap outside, Esc, or action selected).
+Future<void> showContextMenuOverlay({
+  required BuildContext context,
+  required Offset anchor,
+  required ContextMenuModel model,
+}) {
+  return Navigator.of(
+    context,
+    rootNavigator: true,
+  ).push(_ContextMenuRoute(anchor: anchor, model: model));
+}
+
+/// Custom route so we can paint the menu inside the modal barrier's
+/// own subtree (handles dismiss-on-tap-outside for free) while still
+/// owning the slide/scale animation curves.
+class _ContextMenuRoute extends PopupRoute<void> {
+  _ContextMenuRoute({required this.anchor, required this.model});
+
+  final Offset anchor;
+  final ContextMenuModel model;
+
+  @override
+  Color? get barrierColor => null; // Transparent — tap outside dismisses.
+
+  @override
+  bool get barrierDismissible => true;
+
+  @override
+  String? get barrierLabel => 'Dismiss context menu';
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 120);
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return _ContextMenuOverlay(
+      anchor: anchor,
+      model: model,
+      animation: animation,
+    );
+  }
+}
+
+class _ContextMenuOverlay extends StatefulWidget {
+  const _ContextMenuOverlay({
+    required this.anchor,
+    required this.model,
+    required this.animation,
+  });
+
+  final Offset anchor;
+  final ContextMenuModel model;
+  final Animation<double> animation;
+
+  @override
+  State<_ContextMenuOverlay> createState() => _ContextMenuOverlayState();
+}
+
+class _ContextMenuOverlayState extends State<_ContextMenuOverlay> {
+  /// Stack of menu frames. Root is `model`; each "Submenu" tap pushes
+  /// a new ContextMenuModel synthesised from the action's `submenu`.
+  late final List<ContextMenuModel> _stack = [widget.model];
+
+  void _pushSubmenu(ContextMenuAction action) {
+    if (action.submenu == null) return;
+    setState(() {
+      _stack.add(
+        ContextMenuModel(sections: action.submenu!, title: action.label),
+      );
+    });
+  }
+
+  void _popSubmenu() {
+    if (_stack.length <= 1) {
+      Navigator.of(context).pop();
+      return;
+    }
+    setState(() => _stack.removeLast());
+  }
+
+  void _handleActivate(ContextMenuAction action) {
+    if (action.submenu != null) {
+      _pushSubmenu(action);
+      return;
+    }
+    Navigator.of(context).pop();
+    // Run the action AFTER the route is gone so it sees the parent
+    // context unobstructed (showSnackBar, navigation, dialogs all
+    // need the post-dismiss tree).
+    WidgetsBinding.instance.addPostFrameCallback((_) => action.onTap?.call());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mq = MediaQuery.of(context);
+    final size = mq.size;
+    final current = _stack.last;
+    final isSubmenu = _stack.length > 1;
+
+    // Anchor + clamp. We always try to place the menu's top-left at
+    // the click; if that overflows the viewport (right or bottom),
+    // clamp inside the safe area. No flipping — keeps geometry
+    // predictable when menus contain submenus of differing heights.
+    final menuHeight = _estimateMenuHeight(current);
+    var left = widget.anchor.dx;
+    var top = widget.anchor.dy;
+    if (left + _menuWidth + _viewportPadding > size.width) {
+      left = size.width - _menuWidth - _viewportPadding;
+    }
+    if (top + menuHeight + _viewportPadding > size.height) {
+      top = size.height - menuHeight - _viewportPadding;
+    }
+    if (left < _viewportPadding) left = _viewportPadding;
+    if (top < _viewportPadding) top = _viewportPadding;
+
+    // Origin for the scale-from-anchor transform is the click point
+    // relative to the menu's own rect — so the menu visually expands
+    // from where the user clicked.
+    final originX = ((widget.anchor.dx - left) / _menuWidth).clamp(0.0, 1.0);
+    final originY = ((widget.anchor.dy - top) / menuHeight).clamp(0.0, 1.0);
+
+    return Stack(
+      children: [
+        Positioned(
+          left: left,
+          top: top,
+          child: _MenuCard(
+            animation: widget.animation,
+            origin: Alignment(originX * 2 - 1, originY * 2 - 1),
+            child: _MenuContents(
+              model: current,
+              isSubmenu: isSubmenu,
+              onActivate: _handleActivate,
+              onBack: _popSubmenu,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  double _estimateMenuHeight(ContextMenuModel model) {
+    // Rough lower bound used only for viewport clamping. Real
+    // intrinsic size handles itself once painted.
+    const headerRow = 56.0;
+    const itemRow = 36.0;
+    const divider = 13.0;
+    const padding = 12.0;
+    var h = padding * 2;
+    if (model.header != null) h += headerRow;
+    if (model.title != null) h += 32;
+    for (var i = 0; i < model.sections.length; i++) {
+      if (i > 0) h += divider;
+      h += model.sections[i].actions.length * itemRow;
+    }
+    return h;
+  }
+}
+
+class _MenuCard extends StatelessWidget {
+  const _MenuCard({
+    required this.animation,
+    required this.origin,
+    required this.child,
+  });
+
+  final Animation<double> animation;
+  final Alignment origin;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final scale = Tween<double>(
+      begin: 0.95,
+      end: 1.0,
+    ).animate(CurvedAnimation(parent: animation, curve: Curves.easeOutCubic));
+    return FadeTransition(
+      opacity: animation,
+      child: ScaleTransition(
+        scale: scale,
+        alignment: origin,
+        child: Material(
+          color: Colors.transparent,
+          child: Container(
+            width: _menuWidth,
+            decoration: BoxDecoration(
+              color: context.surface,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: context.border),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.28),
+                  blurRadius: 24,
+                  offset: const Offset(0, 8),
+                ),
+              ],
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuContents extends StatelessWidget {
+  const _MenuContents({
+    required this.model,
+    required this.isSubmenu,
+    required this.onActivate,
+    required this.onBack,
+  });
+
+  final ContextMenuModel model;
+  final bool isSubmenu;
+  final ValueChanged<ContextMenuAction> onActivate;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final children = <Widget>[];
+
+    if (isSubmenu) {
+      children.add(_SubmenuHeader(title: model.title ?? '', onBack: onBack));
+    } else if (model.header != null) {
+      children.add(_renderHeader(context, model.header!));
+    }
+
+    for (var i = 0; i < model.sections.length; i++) {
+      if (i > 0 || children.isNotEmpty) {
+        children.add(const ContextMenuDivider());
+      }
+      for (final action in model.sections[i].actions) {
+        children.add(ContextMenuItem(action: action, onActivate: onActivate));
+      }
+    }
+
+    // Dismiss on Esc — keyboard navigation proper is deferred to a
+    // follow-up, but Esc-to-close is one shortcut and ubiquitous
+    // enough that omitting it would surprise people.
+    return Shortcuts(
+      shortcuts: const {
+        SingleActivator(LogicalKeyboardKey.escape): _DismissIntent(),
+      },
+      child: Actions(
+        actions: {
+          _DismissIntent: CallbackAction<_DismissIntent>(
+            onInvoke: (_) {
+              Navigator.of(context).pop();
+              return null;
+            },
+          ),
+        },
+        child: Focus(
+          autofocus: true,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: children,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _renderHeader(BuildContext context, ContextMenuHeader header) {
+    return switch (header) {
+      InlineReactionsHeader h => _InlineReactionsRow(header: h),
+    };
+  }
+}
+
+class _SubmenuHeader extends StatelessWidget {
+  const _SubmenuHeader({required this.title, required this.onBack});
+
+  final String title;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onBack,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+        child: Row(
+          children: [
+            Icon(Icons.chevron_left, size: 18, color: context.textPrimary),
+            const SizedBox(width: 4),
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 13.5,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineReactionsRow extends StatelessWidget {
+  const _InlineReactionsRow({required this.header});
+
+  final InlineReactionsHeader header;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
+      child: Row(
+        children: [
+          for (final emoji in header.emojis.take(4))
+            Expanded(
+              child: _EmojiButton(
+                emoji: emoji,
+                onTap: () {
+                  Navigator.of(context).pop();
+                  WidgetsBinding.instance.addPostFrameCallback(
+                    (_) => header.onPick(emoji),
+                  );
+                },
+              ),
+            ),
+          _EmojiButton(
+            icon: Icons.add_reaction_outlined,
+            onTap: header.onOpenFullPicker,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmojiButton extends StatefulWidget {
+  const _EmojiButton({this.emoji, this.icon, required this.onTap})
+    : assert(emoji != null || icon != null);
+
+  final String? emoji;
+  final IconData? icon;
+  final VoidCallback onTap;
+
+  @override
+  State<_EmojiButton> createState() => _EmojiButtonState();
+}
+
+class _EmojiButtonState extends State<_EmojiButton> {
+  bool _hover = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: Container(
+          height: 36,
+          margin: const EdgeInsets.symmetric(horizontal: 2),
+          decoration: BoxDecoration(
+            color: _hover ? context.surfaceHover : Colors.transparent,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          alignment: Alignment.center,
+          child: widget.emoji != null
+              ? Text(
+                  widget.emoji!,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontFamily: 'NotoEmoji',
+                    height: 1.0,
+                  ),
+                )
+              : Icon(widget.icon, size: 18, color: context.textPrimary),
+        ),
+      ),
+    );
+  }
+}
+
+class _DismissIntent extends Intent {
+  const _DismissIntent();
+}

--- a/apps/client/lib/src/widgets/context_menu/context_menu_sheet.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_sheet.dart
@@ -1,0 +1,228 @@
+/// Mobile context-menu layout: a draggable bottom sheet with the
+/// same sections as the desktop overlay. The reaction-emoji strip
+/// stays at the top to align with the existing scroll-reaction
+/// picker pattern. Submenus push by replacing the sheet's contents
+/// (no nested sheets) so dismiss is one swipe regardless of depth.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../../theme/echo_theme.dart';
+import 'context_menu_item.dart';
+import 'echo_context_menu.dart';
+
+Future<void> showContextMenuSheet({
+  required BuildContext context,
+  required ContextMenuModel model,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (sheetContext) => _ContextMenuSheet(model: model),
+  );
+}
+
+class _ContextMenuSheet extends StatefulWidget {
+  const _ContextMenuSheet({required this.model});
+  final ContextMenuModel model;
+
+  @override
+  State<_ContextMenuSheet> createState() => _ContextMenuSheetState();
+}
+
+class _ContextMenuSheetState extends State<_ContextMenuSheet> {
+  late final List<ContextMenuModel> _stack = [widget.model];
+
+  void _pushSubmenu(ContextMenuAction action) {
+    if (action.submenu == null) return;
+    setState(() {
+      _stack.add(
+        ContextMenuModel(sections: action.submenu!, title: action.label),
+      );
+    });
+  }
+
+  void _popSubmenu() {
+    if (_stack.length <= 1) {
+      Navigator.of(context).pop();
+      return;
+    }
+    setState(() => _stack.removeLast());
+  }
+
+  void _handleActivate(ContextMenuAction action) {
+    if (action.submenu != null) {
+      _pushSubmenu(action);
+      return;
+    }
+    Navigator.of(context).pop();
+    WidgetsBinding.instance.addPostFrameCallback((_) => action.onTap?.call());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final current = _stack.last;
+    final isSubmenu = _stack.length > 1;
+    final viewInsets = MediaQuery.viewInsetsOf(context);
+
+    final rows = <Widget>[];
+    if (isSubmenu) {
+      rows.add(_SheetHeader(title: current.title ?? '', onBack: _popSubmenu));
+    } else if (current.header != null) {
+      rows.add(_renderHeader(context, current.header!));
+    }
+    for (var i = 0; i < current.sections.length; i++) {
+      if (i > 0 || rows.isNotEmpty) {
+        rows.add(const ContextMenuDivider());
+      }
+      for (final action in current.sections[i].actions) {
+        rows.add(ContextMenuItem(action: action, onActivate: _handleActivate));
+      }
+    }
+
+    return AnimatedPadding(
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOutCubic,
+      padding: EdgeInsets.only(bottom: viewInsets.bottom),
+      child: SafeArea(
+        top: false,
+        child: Container(
+          decoration: BoxDecoration(
+            color: context.surface,
+            border: Border(top: BorderSide(color: context.border)),
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [_DragGrabber(), ...rows],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _renderHeader(BuildContext context, ContextMenuHeader header) {
+    return switch (header) {
+      InlineReactionsHeader h => _InlineReactionsRow(header: h),
+    };
+  }
+}
+
+class _DragGrabber extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 36,
+        height: 4,
+        margin: const EdgeInsets.only(bottom: 8),
+        decoration: BoxDecoration(
+          color: context.border,
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader({required this.title, required this.onBack});
+
+  final String title;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onBack,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+        child: Row(
+          children: [
+            Icon(Icons.chevron_left, size: 20, color: context.textPrimary),
+            const SizedBox(width: 4),
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: context.textPrimary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineReactionsRow extends StatelessWidget {
+  const _InlineReactionsRow({required this.header});
+  final InlineReactionsHeader header;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 4, 4, 4),
+      child: Row(
+        children: [
+          for (final emoji in header.emojis.take(4))
+            Expanded(
+              child: _EmojiButton(
+                emoji: emoji,
+                onTap: () {
+                  Navigator.of(context).pop();
+                  WidgetsBinding.instance.addPostFrameCallback(
+                    (_) => header.onPick(emoji),
+                  );
+                },
+              ),
+            ),
+          _EmojiButton(
+            icon: Icons.add_reaction_outlined,
+            onTap: header.onOpenFullPicker,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmojiButton extends StatelessWidget {
+  const _EmojiButton({this.emoji, this.icon, required this.onTap})
+    : assert(emoji != null || icon != null);
+
+  final String? emoji;
+  final IconData? icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 44,
+        margin: const EdgeInsets.symmetric(horizontal: 2),
+        decoration: BoxDecoration(
+          color: context.surfaceHover,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        alignment: Alignment.center,
+        child: emoji != null
+            ? Text(
+                emoji!,
+                style: const TextStyle(
+                  fontSize: 24,
+                  fontFamily: 'NotoEmoji',
+                  height: 1.0,
+                ),
+              )
+            : Icon(icon, size: 22, color: context.textPrimary),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
@@ -1,0 +1,353 @@
+/// Visual testbed for the centralised context menu. Reachable only
+/// via the `/dev/context-menu` route in debug builds (the router
+/// strips the route in release). Three demo targets are anchored on
+/// the page — right-click (desktop) or long-press (mobile) to open
+/// the menu. No real call sites use this code path yet; that lands
+/// in the per-target migration PRs.
+library;
+
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../theme/echo_theme.dart';
+import 'echo_context_menu.dart';
+
+class ContextMenuTestbed extends ConsumerWidget {
+  const ContextMenuTestbed({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    assert(kDebugMode, 'ContextMenuTestbed must not ship in release builds');
+
+    return Scaffold(
+      backgroundColor: context.mainBg,
+      appBar: AppBar(
+        title: const Text('Context menu testbed'),
+        backgroundColor: context.sidebarBg,
+        foregroundColor: context.textPrimary,
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Right-click (desktop) or long-press (mobile) each card.',
+                  style: TextStyle(fontSize: 13, color: context.textSecondary),
+                ),
+                const SizedBox(height: 24),
+                _DemoCard(
+                  label: 'Message',
+                  preview: 'hey, are you free at 3?',
+                  buildModel: () => _demoMessageModel(context),
+                ),
+                const SizedBox(height: 16),
+                _DemoCard(
+                  label: 'Conversation',
+                  preview: '# general',
+                  buildModel: () => _demoConversationModel(context),
+                ),
+                const SizedBox(height: 16),
+                _DemoCard(
+                  label: 'Member',
+                  preview: '@npc',
+                  buildModel: () => _demoMemberModel(context),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DemoCard extends ConsumerWidget {
+  const _DemoCard({
+    required this.label,
+    required this.preview,
+    required this.buildModel,
+  });
+
+  final String label;
+  final String preview;
+  final ContextMenuModel Function() buildModel;
+
+  void _open(BuildContext context, WidgetRef ref, Offset anchor) {
+    EchoContextMenu.open(
+      context: context,
+      ref: ref,
+      target: DebugTarget(label),
+      anchor: anchor,
+      model: buildModel(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return GestureDetector(
+      onSecondaryTapDown: (d) => _open(context, ref, d.globalPosition),
+      onLongPressStart: (d) => _open(context, ref, d.globalPosition),
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: context.surface,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: context.border),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 56,
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: context.accent.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              alignment: Alignment.center,
+              child: Text(
+                label.toLowerCase(),
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: context.accent,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                preview,
+                style: TextStyle(fontSize: 14, color: context.textPrimary),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Demo model for the Message target. Mirrors the action set from the
+/// Discord screenshot the design is anchored to so the testbed
+/// surfaces the real layout choices (inline reactions, primary,
+/// secondary, danger zone, footer).
+ContextMenuModel _demoMessageModel(BuildContext context) {
+  return ContextMenuModel(
+    header: InlineReactionsHeader(
+      emojis: const ['👍', '❤️', '😂', '🎉'],
+      onPick: (e) => _toast(context, 'Pick reaction: $e'),
+      onOpenFullPicker: () => _toast(context, 'Open full picker'),
+    ),
+    sections: [
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Reply',
+            icon: Icons.reply,
+            onTap: () => _toast(context, 'Reply'),
+          ),
+          ContextMenuAction(
+            label: 'Forward',
+            icon: Icons.shortcut,
+            onTap: () => _toast(context, 'Forward'),
+          ),
+          ContextMenuAction(
+            label: 'Create Thread',
+            icon: Icons.forum_outlined,
+            onTap: () => _toast(context, 'Create thread'),
+          ),
+        ],
+      ),
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Copy Text',
+            icon: Icons.copy,
+            shortcut: '⌘C',
+            onTap: () => _toast(context, 'Copy text'),
+          ),
+          ContextMenuAction(
+            label: 'Pin Message',
+            icon: Icons.push_pin_outlined,
+            onTap: () => _toast(context, 'Pin'),
+          ),
+          ContextMenuAction(
+            label: 'Mark Unread',
+            icon: Icons.mark_email_unread_outlined,
+            onTap: () => _toast(context, 'Mark unread'),
+          ),
+          ContextMenuAction(
+            label: 'Copy Message Link',
+            icon: Icons.link,
+            onTap: () => _toast(context, 'Copy link'),
+          ),
+        ],
+      ),
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Delete Message',
+            icon: Icons.delete_outline,
+            isDanger: true,
+            onTap: () => _toast(context, 'Delete'),
+          ),
+          ContextMenuAction(
+            label: 'Report Message',
+            icon: Icons.flag_outlined,
+            isDanger: true,
+            onTap: () => _toast(context, 'Report'),
+          ),
+        ],
+      ),
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Copy Message ID',
+            icon: Icons.tag,
+            onTap: () => _toast(context, 'Copy ID'),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+ContextMenuModel _demoConversationModel(BuildContext context) {
+  return ContextMenuModel(
+    sections: [
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Mark As Read',
+            icon: Icons.mark_chat_read_outlined,
+            onTap: () => _toast(context, 'Mark as read'),
+          ),
+          ContextMenuAction(
+            label: 'Mute',
+            icon: Icons.notifications_off_outlined,
+            onTap: () => _toast(context, 'Mute'),
+          ),
+          ContextMenuAction(
+            label: 'Pin Conversation',
+            icon: Icons.push_pin_outlined,
+            onTap: () => _toast(context, 'Pin'),
+          ),
+        ],
+      ),
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Invite People',
+            icon: Icons.person_add_outlined,
+            onTap: () => _toast(context, 'Invite'),
+          ),
+          ContextMenuAction(
+            label: 'Copy Channel ID',
+            icon: Icons.tag,
+            onTap: () => _toast(context, 'Copy ID'),
+          ),
+        ],
+      ),
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Leave Group',
+            icon: Icons.logout,
+            isDanger: true,
+            onTap: () => _toast(context, 'Leave'),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+ContextMenuModel _demoMemberModel(BuildContext context) {
+  return ContextMenuModel(
+    sections: [
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'View Profile',
+            icon: Icons.person_outline,
+            onTap: () => _toast(context, 'View profile'),
+          ),
+          ContextMenuAction(
+            label: 'Send Message',
+            icon: Icons.mail_outline,
+            onTap: () => _toast(context, 'Send message'),
+          ),
+          ContextMenuAction(
+            label: 'Voice Call',
+            icon: Icons.call_outlined,
+            onTap: () => _toast(context, 'Call'),
+          ),
+        ],
+      ),
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Change Role',
+            icon: Icons.admin_panel_settings_outlined,
+            submenu: [
+              ContextMenuSection(
+                actions: [
+                  ContextMenuAction(
+                    label: 'Owner',
+                    icon: Icons.star_outline,
+                    onTap: () => _toast(context, 'Role: owner'),
+                  ),
+                  ContextMenuAction(
+                    label: 'Admin',
+                    icon: Icons.shield_outlined,
+                    onTap: () => _toast(context, 'Role: admin'),
+                  ),
+                  ContextMenuAction(
+                    label: 'Member',
+                    icon: Icons.person_outline,
+                    onTap: () => _toast(context, 'Role: member'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          ContextMenuAction(
+            label: 'Copy User ID',
+            icon: Icons.tag,
+            onTap: () => _toast(context, 'Copy ID'),
+          ),
+        ],
+      ),
+      ContextMenuSection(
+        actions: [
+          ContextMenuAction(
+            label: 'Kick',
+            icon: Icons.person_remove_outlined,
+            isDanger: true,
+            onTap: () => _toast(context, 'Kick'),
+          ),
+          ContextMenuAction(
+            label: 'Ban',
+            icon: Icons.block,
+            isDanger: true,
+            onTap: () => _toast(context, 'Ban'),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+void _toast(BuildContext context, String msg) {
+  if (!context.mounted) return;
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text(msg), duration: const Duration(seconds: 1)),
+  );
+}

--- a/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
@@ -78,10 +78,9 @@ class _DemoCard extends ConsumerWidget {
   final String preview;
   final ContextMenuModel Function() buildModel;
 
-  void _open(BuildContext context, WidgetRef ref, Offset anchor) {
+  void _open(BuildContext context, Offset anchor) {
     EchoContextMenu.open(
       context: context,
-      ref: ref,
       target: DebugTarget(label),
       anchor: anchor,
       model: buildModel(),
@@ -91,8 +90,8 @@ class _DemoCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return GestureDetector(
-      onSecondaryTapDown: (d) => _open(context, ref, d.globalPosition),
-      onLongPressStart: (d) => _open(context, ref, d.globalPosition),
+      onSecondaryTapDown: (d) => _open(context, d.globalPosition),
+      onLongPressStart: (d) => _open(context, d.globalPosition),
       behavior: HitTestBehavior.opaque,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -30,7 +30,6 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'context_menu_overlay.dart';
 import 'context_menu_sheet.dart';
@@ -141,6 +140,75 @@ class DebugTarget extends ContextMenuTarget {
   String get analyticsName => 'debug:$label';
 }
 
+/// Message context menu (PR 2). Carries the message itself plus the
+/// per-callsite callbacks `MessageItem` already wires up — by holding
+/// references to the existing handlers we keep state-management in
+/// `chat_provider` and only swap the *surface*, not the action
+/// logic. Callbacks left null cause their corresponding row to be
+/// hidden by the registry.
+///
+/// `isEncryptedUnreadable` short-circuits the inline reactions row
+/// in encrypted groups where the local client can't decrypt the
+/// message — there's no point picking a reaction on a bubble that
+/// reads "[Could not decrypt…]".
+class MessageTarget extends ContextMenuTarget {
+  const MessageTarget({
+    required this.message,
+    required this.isMine,
+    required this.isSaved,
+    required this.isEncryptedUnreadable,
+    required this.mediaUrl,
+    required this.isImageMedia,
+    this.onReply,
+    this.onForward,
+    this.onRetry,
+    this.onCopyText,
+    this.onPin,
+    this.onUnpin,
+    this.onSave,
+    this.onUnsave,
+    this.onEdit,
+    this.onViewGallery,
+    this.onDelete,
+    this.onCopyId,
+    this.onPickReaction,
+    this.onOpenFullPicker,
+    this.recentReactions = const ['👍', '❤️', '😂', '🎉'],
+  });
+
+  final dynamic message; // ChatMessage — kept dynamic here to avoid
+  // a cyclic import with chat_provider's model file.
+  final bool isMine;
+  final bool isSaved;
+  final bool isEncryptedUnreadable;
+  final String? mediaUrl;
+  final bool isImageMedia;
+
+  // Action handlers — null = row hidden.
+  final VoidCallback? onReply;
+  final VoidCallback? onForward;
+  final VoidCallback? onRetry;
+  final VoidCallback? onCopyText;
+  final VoidCallback? onPin;
+  final VoidCallback? onUnpin;
+  final VoidCallback? onSave;
+  final VoidCallback? onUnsave;
+  final VoidCallback? onEdit;
+  final VoidCallback? onViewGallery;
+  final VoidCallback? onDelete;
+  final VoidCallback? onCopyId;
+
+  // Inline reactions header — null disables the header even when
+  // !isEncryptedUnreadable, useful for forwarded-message bubbles that
+  // shouldn't accept reactions at all.
+  final void Function(String emoji)? onPickReaction;
+  final VoidCallback? onOpenFullPicker;
+  final List<String> recentReactions;
+
+  @override
+  String get analyticsName => 'message';
+}
+
 /// Single public entry point. Picks desktop overlay vs mobile bottom
 /// sheet based on viewport short side; the breakpoint matches the
 /// rest of the app (see chat_panel responsive logic).
@@ -154,7 +222,6 @@ class EchoContextMenu {
 
   static Future<void> open({
     required BuildContext context,
-    required WidgetRef ref,
     required ContextMenuTarget target,
     required Offset anchor,
     required ContextMenuModel model,

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -1,0 +1,172 @@
+/// Centralised right-click / long-press context menu, Discord-style,
+/// themed to Echo's design system.
+///
+/// PR 1 of 4 — foundation only. No existing call sites are migrated;
+/// the testbed at `/dev/context-menu` is the only consumer.
+///
+/// Usage from a call site:
+///
+/// ```dart
+/// GestureDetector(
+///   onSecondaryTapDown: (d) => EchoContextMenu.open(
+///     context: context,
+///     ref: ref,
+///     target: MessageTarget(/* ... */),
+///     anchor: d.globalPosition,
+///   ),
+///   onLongPressStart: (d) => EchoContextMenu.open(
+///     context: context,
+///     ref: ref,
+///     target: MessageTarget(/* ... */),
+///     anchor: d.globalPosition,
+///   ),
+///   child: child,
+/// );
+/// ```
+///
+/// The [open] entry point picks the desktop overlay or the mobile
+/// bottom-sheet layout based on viewport short side, both rendered from
+/// the same [ContextMenuModel] tree so action wiring lives in one place.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'context_menu_overlay.dart';
+import 'context_menu_sheet.dart';
+
+/// One row inside a context menu. The icon renders right-aligned to
+/// match the Discord screenshot the design is anchored to.
+///
+/// `submenu` is mutually exclusive with `onTap` — a row either fires
+/// an action or slides the overlay into a nested section stack. The
+/// overlay enforces this at draw time by hiding the chevron when
+/// `onTap` is non-null.
+class ContextMenuAction {
+  const ContextMenuAction({
+    required this.label,
+    required this.icon,
+    this.onTap,
+    this.submenu,
+    this.isDanger = false,
+    this.shortcut,
+  });
+
+  final String label;
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  /// When non-null, tapping this row replaces the visible menu with
+  /// `submenu` (rendered as a "Back ← Title" header + nested sections).
+  /// Used for "Add Reaction →" full picker and "Apps →" entry points.
+  final List<ContextMenuSection>? submenu;
+
+  /// Tints label + icon with [EchoTheme.danger]. Apply to destructive
+  /// rows (Delete, Kick, Ban, Report).
+  final bool isDanger;
+
+  /// Optional keyboard hint shown as muted mono text right of the
+  /// label (e.g. `⌘C`). Purely decorative in PR 1 — actual keyboard
+  /// dispatch is deferred to a follow-up.
+  final String? shortcut;
+}
+
+/// A divider-separated group of rows. The overlay paints a 1px
+/// `context.border` line between consecutive sections and skips it
+/// for the first section.
+class ContextMenuSection {
+  const ContextMenuSection({required this.actions});
+  final List<ContextMenuAction> actions;
+}
+
+/// Optional header rendered above all sections. PR 1 ships only the
+/// "inline reactions row" variant (the four-emoji strip in the
+/// Discord screenshot); future variants (message preview, member
+/// avatar header) plug in here without touching the layout widgets.
+sealed class ContextMenuHeader {
+  const ContextMenuHeader();
+}
+
+/// Four-emoji recent-reactions strip + "Add Reaction →" chevron.
+/// The emojis come from the bundled NotoColorEmoji set; in PR 2 we
+/// pull them from `emoji_picker_flutter`'s recent-tab storage so the
+/// list reflects the user's actual usage instead of a static curation.
+class InlineReactionsHeader extends ContextMenuHeader {
+  const InlineReactionsHeader({
+    required this.emojis,
+    required this.onPick,
+    required this.onOpenFullPicker,
+  });
+
+  final List<String> emojis;
+  final void Function(String emoji) onPick;
+  final VoidCallback onOpenFullPicker;
+}
+
+/// Resolved menu tree for one target. Built from a target by the
+/// per-target registries (see `actions/*_actions_registry.dart`,
+/// added in PRs 2-4).
+class ContextMenuModel {
+  const ContextMenuModel({this.header, required this.sections, this.title});
+
+  /// Optional Discord-style header (inline reactions, etc.).
+  final ContextMenuHeader? header;
+
+  /// Action sections, painted top-to-bottom with dividers between.
+  final List<ContextMenuSection> sections;
+
+  /// Optional short title shown above the sections — used by submenus
+  /// for the "← Back" affordance ("Add Reaction"). Null on the root
+  /// menu (the inline-reactions header acts as the implicit title).
+  final String? title;
+}
+
+/// Tagged target classes. Each PR 2-4 introduces one concrete target
+/// + its registry. They are sealed here so the registry switch is
+/// exhaustive at compile time.
+sealed class ContextMenuTarget {
+  const ContextMenuTarget();
+
+  /// Short, stable identifier used for telemetry and debug logging.
+  String get analyticsName;
+}
+
+/// Placeholder target type for the PR-1 testbed. PRs 2-4 add
+/// MessageTarget / ConversationTarget / MemberTarget alongside this
+/// and migrate real call sites.
+class DebugTarget extends ContextMenuTarget {
+  const DebugTarget(this.label);
+  final String label;
+  @override
+  String get analyticsName => 'debug:$label';
+}
+
+/// Single public entry point. Picks desktop overlay vs mobile bottom
+/// sheet based on viewport short side; the breakpoint matches the
+/// rest of the app (see chat_panel responsive logic).
+class EchoContextMenu {
+  EchoContextMenu._();
+
+  /// Mobile threshold in logical pixels. Below this we render the
+  /// bottom-sheet variant; at or above we render the anchored
+  /// overlay. Matches the existing app-wide tablet breakpoint.
+  static const double _mobileBreakpoint = 600;
+
+  static Future<void> open({
+    required BuildContext context,
+    required WidgetRef ref,
+    required ContextMenuTarget target,
+    required Offset anchor,
+    required ContextMenuModel model,
+  }) {
+    final shortest = MediaQuery.sizeOf(context).shortestSide;
+    if (shortest < _mobileBreakpoint) {
+      return showContextMenuSheet(context: context, model: model);
+    }
+    return showContextMenuOverlay(
+      context: context,
+      anchor: anchor,
+      model: model,
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -263,6 +263,65 @@ class ConversationTarget extends ContextMenuTarget {
   String get analyticsName => isGroup ? 'group' : 'dm';
 }
 
+/// Member context menu (PR 4). Used inside a group's member roster
+/// — typically by right-click or long-press on a member row, plus
+/// the discoverable "..." button next to each row. Carries enough
+/// state to gate admin actions (kick / ban) without re-fetching the
+/// group's role table.
+///
+/// "Change Role" and "Voice Call" are intentionally absent — the
+/// server endpoint for the former doesn't exist yet, and the 1:1
+/// ring/start flow for the latter has only the active-call surface.
+/// Both are tracked as v1.5.
+class MemberTarget extends ContextMenuTarget {
+  const MemberTarget({
+    required this.userId,
+    required this.username,
+    required this.isSelf,
+    required this.targetIsOwner,
+    required this.viewerIsAdminOrOwner,
+    this.onViewProfile,
+    this.onSendMessage,
+    this.onAddContact,
+    this.onRemoveContact,
+    this.onBlock,
+    this.onUnblock,
+    this.onCopyUserId,
+    this.onCopyUsername,
+    this.onKick,
+    this.onBan,
+  });
+
+  final String userId;
+  final String username;
+
+  /// True when the target is the current user. Hides destructive
+  /// rows so the menu can't be used to kick / ban / block oneself.
+  final bool isSelf;
+
+  /// True when the target's role is `owner`. Even an admin viewer
+  /// can't kick or ban the owner; the rows hide.
+  final bool targetIsOwner;
+
+  /// True when the *viewer* is admin or owner. Gates the admin-only
+  /// section (kick / ban).
+  final bool viewerIsAdminOrOwner;
+
+  final VoidCallback? onViewProfile;
+  final VoidCallback? onSendMessage;
+  final VoidCallback? onAddContact;
+  final VoidCallback? onRemoveContact;
+  final VoidCallback? onBlock;
+  final VoidCallback? onUnblock;
+  final VoidCallback? onCopyUserId;
+  final VoidCallback? onCopyUsername;
+  final VoidCallback? onKick;
+  final VoidCallback? onBan;
+
+  @override
+  String get analyticsName => 'member';
+}
+
 /// Single public entry point. Picks desktop overlay vs mobile bottom
 /// sheet based on viewport short side; the breakpoint matches the
 /// rest of the app (see chat_panel responsive logic).

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -209,6 +209,60 @@ class MessageTarget extends ContextMenuTarget {
   String get analyticsName => 'message';
 }
 
+/// Conversation context menu (PR 3). The registry switches action
+/// visibility on the conversation kind (`isGroup`), the user's role
+/// inside it (admin / owner / member), and current pin / mute /
+/// unread state. The caller wires whichever callbacks it can support
+/// — nulls are pruned from the rendered tree.
+///
+/// Owner-of-a-group-with-other-members is *not* allowed to leave
+/// (server enforces this). The decision in PR-1 prep was to hide
+/// the row entirely rather than render it disabled.
+class ConversationTarget extends ContextMenuTarget {
+  const ConversationTarget({
+    required this.conversationId,
+    required this.isGroup,
+    required this.isPinned,
+    required this.isMuted,
+    required this.hasUnread,
+    required this.isAdminOrOwner,
+    this.onMarkAsRead,
+    this.onMarkAsUnread,
+    this.onToggleMute,
+    this.onTogglePin,
+    this.onOpenInfo,
+    this.onInvitePeople,
+    this.onOpenEncryptionActivity,
+    this.onViewSafetyNumber,
+    this.onCopyId,
+    this.onLeave,
+    this.onDelete,
+  });
+
+  final String conversationId;
+  final bool isGroup;
+  final bool isPinned;
+  final bool isMuted;
+  final bool hasUnread;
+  final bool isAdminOrOwner;
+
+  // Action handlers — null = row hidden.
+  final VoidCallback? onMarkAsRead;
+  final VoidCallback? onMarkAsUnread;
+  final VoidCallback? onToggleMute;
+  final VoidCallback? onTogglePin;
+  final VoidCallback? onOpenInfo;
+  final VoidCallback? onInvitePeople;
+  final VoidCallback? onOpenEncryptionActivity;
+  final VoidCallback? onViewSafetyNumber;
+  final VoidCallback? onCopyId;
+  final VoidCallback? onLeave; // group member
+  final VoidCallback? onDelete; // DM delete OR group owner delete
+
+  @override
+  String get analyticsName => isGroup ? 'group' : 'dm';
+}
+
 /// Single public entry point. Picks desktop overlay vs mobile bottom
 /// sheet based on viewport short side; the breakpoint matches the
 /// rest of the app (see chat_panel responsive logic).

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -7,9 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/chat_message.dart' show ChatMessage, MessageStatus;
 import '../models/conversation.dart';
 import '../providers/chat_provider.dart';
-import '../providers/conversations_provider.dart';
 import '../providers/theme_provider.dart' show UIDensity, uiDensityProvider;
-import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
 import 'avatar_utils.dart';
@@ -177,129 +175,6 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     };
   }
 
-  /// Long-press bottom sheet with per-conversation actions.
-  /// Mobile-only — desktop users get the right-click popup menu instead.
-  /// Mirrors the desktop [_showConversationContextMenu] items in sheet form.
-  void _showActionSheet() {
-    final conv = widget.conversation;
-    final displayName = conv.displayName(widget.myUserId);
-
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: context.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (sheetContext) => SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildSheetHeader(context, displayName),
-              Divider(color: context.border, height: 8),
-              if (widget.onTogglePin != null) _buildPinTile(sheetContext),
-              _buildMuteTile(conv, sheetContext),
-              if (widget.onLeave != null) _buildLeaveTile(conv, sheetContext),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSheetHeader(BuildContext context, String displayName) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
-      child: Text(
-        displayName,
-        style: GoogleFonts.inter(
-          fontSize: 15,
-          fontWeight: FontWeight.w600,
-          color: context.textPrimary,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPinTile(BuildContext sheetContext) {
-    return ListTile(
-      leading: Icon(
-        widget.isPinned ? Icons.push_pin : Icons.push_pin_outlined,
-        color: context.textSecondary,
-      ),
-      title: Text(
-        widget.isPinned ? 'Unpin' : 'Pin to top',
-        style: GoogleFonts.inter(color: context.textPrimary, fontSize: 14),
-      ),
-      onTap: () {
-        Navigator.of(sheetContext).pop();
-        widget.onTogglePin!();
-      },
-    );
-  }
-
-  Widget _buildMuteTile(Conversation conv, BuildContext sheetContext) {
-    return Consumer(
-      builder: (ctx, sheetRef, _) {
-        final live = sheetRef
-            .watch(conversationsProvider)
-            .conversations
-            .where((c) => c.id == conv.id)
-            .firstOrNull;
-        final currentMuted = live?.isMuted ?? conv.isMuted;
-        return ListTile(
-          leading: Icon(
-            currentMuted
-                ? Icons.notifications_outlined
-                : Icons.notifications_off_outlined,
-            color: context.textSecondary,
-          ),
-          title: Text(
-            currentMuted ? 'Unmute' : 'Mute',
-            style: GoogleFonts.inter(color: context.textPrimary, fontSize: 14),
-          ),
-          onTap: () => _onMuteTileTap(conv, sheetContext),
-        );
-      },
-    );
-  }
-
-  Future<void> _onMuteTileTap(
-    Conversation conv,
-    BuildContext sheetContext,
-  ) async {
-    Navigator.of(sheetContext).pop();
-    final success = await ref
-        .read(conversationsProvider.notifier)
-        .toggleMute(conv.id);
-    if (!success && mounted) {
-      ToastService.show(
-        context,
-        'Failed to update mute settings',
-        type: ToastType.error,
-      );
-    }
-  }
-
-  Widget _buildLeaveTile(Conversation conv, BuildContext sheetContext) {
-    return ListTile(
-      leading: Icon(
-        conv.isGroup ? Icons.exit_to_app : Icons.delete_outline,
-        color: EchoTheme.danger,
-      ),
-      title: Text(
-        conv.isGroup ? 'Leave Group' : 'Delete Conversation',
-        style: GoogleFonts.inter(color: EchoTheme.danger, fontSize: 14),
-      ),
-      onTap: () {
-        Navigator.of(sheetContext).pop();
-        widget.onLeave!();
-      },
-    );
-  }
-
   /// Resolve the display snippet from the last message, applying
   /// encryption placeholders and media labels.
   String? _resolveSnippet() {
@@ -425,7 +300,16 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
               onSecondaryTapUp: (details) {
                 widget.onContextMenu?.call(details.globalPosition);
               },
-              onLongPress: _enableLongPressMenu ? _showActionSheet : null,
+              // Mobile long-press now routes through the same
+              // onContextMenu callback as desktop right-click — the
+              // parent (conversation_panel) opens the centralised
+              // EchoContextMenu so the item itself no longer carries
+              // its own bottom-sheet implementation. The anchor
+              // coordinate is irrelevant on mobile (renders as a
+              // bottom sheet), so Offset.zero is a fine sentinel.
+              onLongPress: _enableLongPressMenu
+                  ? () => widget.onContextMenu?.call(Offset.zero)
+                  : null,
               child: AnimatedContainer(
                 duration: MotionDurations.quick,
                 curve: MotionCurves.emphasis,

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/conversation.dart';
@@ -23,6 +25,8 @@ import '../providers/theme_provider.dart' show uiDensityProvider;
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart';
 import 'connection_status_badge.dart';
+import 'context_menu/actions/conversation_actions_registry.dart';
+import 'context_menu/echo_context_menu.dart';
 import 'conversation_item.dart';
 import 'echo_logo_icon.dart';
 import 'empty_state.dart';
@@ -175,101 +179,95 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         .setPinned(conversationId, !isPinned);
   }
 
-  Future<void> _handleContextMenuSelection(
-    String? value,
-    Conversation conv,
-  ) async {
-    if (value == 'pin') {
-      _togglePin(conv.id);
-    } else if (value == 'mute') {
-      final ok = await ref
-          .read(conversationsProvider.notifier)
-          .toggleMute(conv.id);
-      if (!ok && mounted) {
+  /// Build a [ConversationTarget] for [conv] using the current
+  /// pinned-ids set, mute state, and the my-role lookup from the
+  /// conversation member list. The handlers wired here are the
+  /// existing in-panel methods (no new business logic introduced by
+  /// this migration); the centralised menu is purely a *surface*
+  /// swap.
+  ConversationTarget _buildConversationTarget(Conversation conv) {
+    final myUserId = ref.read(authProvider).userId ?? '';
+    final myMember = conv.members
+        .where((m) => m.userId == myUserId)
+        .firstOrNull;
+    final myRole = myMember?.role ?? 'member';
+    final isAdminOrOwner = myRole == 'owner' || myRole == 'admin';
+    final pinnedIds = ref.read(pinnedConversationIdsProvider);
+    final isPinned = pinnedIds.contains(conv.id) || conv.isPinned;
+    final hasUnread = conv.unreadCount > 0 || conv.mentionCount > 0;
+
+    // The owner of a group with other members can't leave (the
+    // server enforces this); per the cross-cutting decision we hide
+    // the row entirely rather than render it disabled.
+    final canLeave =
+        conv.isGroup &&
+        !(myRole == 'owner' &&
+            conv.members.where((m) => m.userId != myUserId).isNotEmpty);
+    final canDeleteGroup = conv.isGroup && myRole == 'owner';
+
+    return ConversationTarget(
+      conversationId: conv.id,
+      isGroup: conv.isGroup,
+      isPinned: isPinned,
+      isMuted: conv.isMuted,
+      hasUnread: hasUnread,
+      isAdminOrOwner: isAdminOrOwner,
+      onMarkAsRead: hasUnread
+          ? () => unawaited(
+              ref.read(conversationsProvider.notifier).sendReadReceipt(conv.id),
+            )
+          : null,
+      // Mark-as-unread isn't wired to a real provider yet; defer to a
+      // follow-up so we don't introduce dead UI here.
+      onMarkAsUnread: null,
+      onToggleMute: () async {
+        final ok = await ref
+            .read(conversationsProvider.notifier)
+            .toggleMute(conv.id);
+        if (!ok && mounted) {
+          ToastService.show(
+            context,
+            'Failed to update mute settings',
+            type: ToastType.error,
+          );
+        }
+      },
+      onTogglePin: () => _togglePin(conv.id),
+      onOpenInfo: conv.isGroup
+          ? () => context.go('/group-info/${conv.id}')
+          : null,
+      // Invite-people / encryption-activity link out to existing
+      // routes today; centralising the entry points is enough for v1.
+      onInvitePeople: (conv.isGroup && isAdminOrOwner)
+          ? () => context.go('/group-info/${conv.id}')
+          : null,
+      onOpenEncryptionActivity: (conv.isGroup && isAdminOrOwner)
+          ? () => context.go('/group-info/${conv.id}')
+          : null,
+      onViewSafetyNumber: (!conv.isGroup && myMember != null)
+          ? () {
+              final peer = conv.members
+                  .where((m) => m.userId != myUserId)
+                  .firstOrNull;
+              if (peer != null) {
+                context.go('/safety-number/${peer.userId}');
+              }
+            }
+          : null,
+      onCopyId: () {
+        Clipboard.setData(ClipboardData(text: conv.id));
+        if (!mounted) return;
         ToastService.show(
           context,
-          'Failed to update mute settings',
-          type: ToastType.error,
+          'Conversation ID copied',
+          type: ToastType.success,
         );
-      }
-    } else if (value == 'leave_group') {
-      _leaveGroup(conv);
-    } else if (value == 'delete_dm') {
-      _deleteDm(conv);
-    }
-  }
-
-  List<PopupMenuEntry<String>> _buildContextMenuItems(
-    BuildContext context,
-    Conversation conv,
-    bool isPinned,
-  ) {
-    return [
-      PopupMenuItem<String>(
-        value: 'pin',
-        child: Row(
-          children: [
-            Icon(
-              isPinned ? Icons.push_pin : Icons.push_pin_outlined,
-              size: 16,
-              color: context.textSecondary,
-            ),
-            const SizedBox(width: 8),
-            Text(
-              isPinned ? 'Unpin' : 'Pin to top',
-              style: TextStyle(color: context.textPrimary, fontSize: 13),
-            ),
-          ],
-        ),
-      ),
-      PopupMenuItem<String>(
-        value: 'mute',
-        child: Row(
-          children: [
-            Icon(
-              conv.isMuted
-                  ? Icons.notifications_outlined
-                  : Icons.notifications_off_outlined,
-              size: 16,
-              color: context.textSecondary,
-            ),
-            const SizedBox(width: 8),
-            Text(
-              conv.isMuted ? 'Unmute' : 'Mute',
-              style: TextStyle(color: context.textPrimary, fontSize: 13),
-            ),
-          ],
-        ),
-      ),
-      if (conv.isGroup)
-        const PopupMenuItem<String>(
-          value: 'leave_group',
-          child: Row(
-            children: [
-              Icon(Icons.exit_to_app, size: 16, color: EchoTheme.danger),
-              SizedBox(width: 8),
-              Text(
-                'Leave Group',
-                style: TextStyle(color: EchoTheme.danger, fontSize: 13),
-              ),
-            ],
-          ),
-        ),
-      if (!conv.isGroup)
-        const PopupMenuItem<String>(
-          value: 'delete_dm',
-          child: Row(
-            children: [
-              Icon(Icons.delete_outline, size: 16, color: EchoTheme.danger),
-              SizedBox(width: 8),
-              Text(
-                'Delete Conversation',
-                style: TextStyle(color: EchoTheme.danger, fontSize: 13),
-              ),
-            ],
-          ),
-        ),
-    ];
+      },
+      onLeave: canLeave ? () => _leaveGroup(conv) : null,
+      onDelete: conv.isGroup
+          ? (canDeleteGroup ? () => _leaveGroup(conv) : null)
+          : () => _deleteDm(conv),
+    );
   }
 
   void _showConversationContextMenu(
@@ -277,23 +275,13 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     Conversation conv,
     Offset position,
   ) {
-    final pinnedIds = ref.read(pinnedConversationIdsProvider);
-    final isPinned = pinnedIds.contains(conv.id) || conv.isPinned;
-    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
-
-    showMenu<String>(
+    final target = _buildConversationTarget(conv);
+    EchoContextMenu.open(
       context: context,
-      position: RelativeRect.fromRect(
-        Rect.fromLTWH(position.dx, position.dy, 0, 0),
-        Offset.zero & overlay.size,
-      ),
-      color: context.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-        side: BorderSide(color: context.border),
-      ),
-      items: _buildContextMenuItems(context, conv, isPinned),
-    ).then((value) => _handleContextMenuSelection(value, conv));
+      target: target,
+      anchor: position,
+      model: buildConversationMenu(target),
+    );
   }
 
   Future<void> _leaveGroup(Conversation conv) async {

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -27,7 +27,6 @@ import 'message/link_preview_card.dart';
 import 'message/media_content.dart';
 import 'message/message_status_icon.dart';
 import 'message/message_indicators.dart';
-import 'message/quick_reaction_row.dart';
 import 'message/reaction_bar.dart';
 import 'message/reply_count_badge.dart';
 import 'message/reply_quote.dart';
@@ -37,6 +36,8 @@ import 'message/sender_name_label.dart';
 import 'message/poll_widget.dart';
 import 'message/system_event_pill.dart';
 import 'message/youtube_embed.dart';
+import 'context_menu/actions/message_actions_registry.dart';
+import 'context_menu/echo_context_menu.dart';
 
 /// Default 5-emoji quick-react set shared by mobile long-press and desktop
 /// hover-action button. The "+" affordance to open the full picker is rendered
@@ -420,257 +421,6 @@ class _MessageItemState extends State<MessageItem>
     return false;
   }
 
-  /// Shows a bottom action sheet for mobile users (replaces hover actions).
-  void _showMobileActionSheet(
-    BuildContext context,
-    ChatMessage msg,
-    bool isMine,
-    String? mediaUrl,
-  ) {
-    HapticFeedback.mediumImpact();
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: Colors.transparent,
-      isScrollControlled: true,
-      builder: (sheetContext) {
-        return SafeArea(
-          child: Container(
-            margin: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-            decoration: BoxDecoration(
-              color: context.surface,
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: context.border),
-              boxShadow: [
-                BoxShadow(
-                  color: context.shadowColor,
-                  blurRadius: 40,
-                  offset: const Offset(0, 16),
-                ),
-              ],
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // Handle
-                Container(
-                  width: 40,
-                  height: 4,
-                  margin: const EdgeInsets.only(top: 10, bottom: 4),
-                  decoration: BoxDecoration(
-                    color: context.textMuted.withValues(alpha: 0.4),
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-                _buildQuickReactionRow(sheetContext, msg),
-                Divider(height: 1, color: context.border),
-                ..._buildActionTiles(
-                  sheetContext: sheetContext,
-                  msg: msg,
-                  isMine: isMine,
-                  mediaUrl: mediaUrl,
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  /// Quick reaction emoji row for the mobile action sheet.
-  ///
-  /// Wrapped in a horizontal-fade ShaderMask so the leading and trailing edges
-  /// hint at off-screen reactions (#508). On desktop / web a chevron overlay
-  /// is rendered when the row actually overflows (#577).
-  Widget _buildQuickReactionRow(BuildContext sheetContext, ChatMessage msg) {
-    return QuickReactionRow(
-      message: msg,
-      myUserId: widget.myUserId,
-      onSelect: (emoji) {
-        Navigator.pop(sheetContext);
-        widget.onReactionSelect?.call(msg, emoji);
-      },
-      onMore: () {
-        Navigator.pop(sheetContext);
-        widget.onMoreReactions?.call(msg);
-      },
-    );
-  }
-
-  /// Tiles specific to media messages (image action + download).
-  List<Widget> _buildMediaActionTiles({
-    required BuildContext sheetContext,
-    required ChatMessage msg,
-    required String? mediaUrl,
-    required bool isImage,
-  }) {
-    return [
-      if (isImage)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: _isMobilePlatform
-              ? Icons.save_alt_outlined
-              : Icons.image_outlined,
-          label: _isMobilePlatform ? 'Save image' : 'Copy image',
-          onTap: () => _handleImageAction(mediaUrl!),
-        ),
-      if (mediaUrl != null)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: Icons.download_outlined,
-          label: 'Download',
-          onTap: () => _downloadMedia(mediaUrl),
-        ),
-    ];
-  }
-
-  /// Pin / unpin tile based on the message's current pinned state.
-  Widget? _buildPinActionTile(BuildContext sheetContext, ChatMessage msg) {
-    if (msg.pinnedAt == null && widget.onPin != null) {
-      return _actionTile(
-        sheetContext: sheetContext,
-        icon: Icons.push_pin_outlined,
-        label: 'Pin',
-        onTap: () => widget.onPin?.call(msg),
-      );
-    }
-    if (msg.pinnedAt != null && widget.onUnpin != null) {
-      return _actionTile(
-        sheetContext: sheetContext,
-        icon: Icons.push_pin,
-        label: 'Unpin',
-        onTap: () => widget.onUnpin?.call(msg),
-      );
-    }
-    return null;
-  }
-
-  /// Contextual action tiles for the mobile action sheet.
-  List<Widget> _buildActionTiles({
-    required BuildContext sheetContext,
-    required ChatMessage msg,
-    required bool isMine,
-    required String? mediaUrl,
-  }) {
-    final isImage = mediaUrl != null && _isImageMedia(msg.content, mediaUrl);
-    final pinTile = _buildPinActionTile(sheetContext, msg);
-    return [
-      if (widget.onReply != null)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: Icons.reply_outlined,
-          label: 'Reply',
-          onTap: () => widget.onReply?.call(msg),
-        ),
-      if (msg.replyCount > 0 && widget.onViewThread != null)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: Icons.forum_outlined,
-          label:
-              'View ${msg.replyCount == 1 ? '1 reply' : '${msg.replyCount} replies'}',
-          onTap: () => widget.onViewThread?.call(msg),
-        ),
-      _actionTile(
-        sheetContext: sheetContext,
-        icon: Icons.forward_outlined,
-        label: 'Forward',
-        onTap: () => widget.onForward?.call(msg),
-      ),
-      ..._buildMediaActionTiles(
-        sheetContext: sheetContext,
-        msg: msg,
-        mediaUrl: mediaUrl,
-        isImage: isImage,
-      ),
-      _actionTile(
-        sheetContext: sheetContext,
-        icon: Icons.copy_outlined,
-        label: mediaUrl != null ? 'Copy link' : 'Copy text',
-        onTap: () {
-          final copyText = mediaUrl != null
-              ? _resolveUrl(mediaUrl)
-              : msg.content;
-          Clipboard.setData(ClipboardData(text: copyText));
-          ToastService.show(
-            context,
-            'Copied to clipboard',
-            type: ToastType.success,
-          );
-        },
-      ),
-      if (isMine && widget.onEdit != null)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: Icons.edit_outlined,
-          label: 'Edit',
-          onTap: () => widget.onEdit?.call(msg),
-        ),
-      if (!widget.isSaved && widget.onSave != null)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: Icons.bookmark_border_outlined,
-          label: 'Save',
-          onTap: () => widget.onSave?.call(msg),
-        ),
-      if (widget.isSaved && widget.onUnsave != null)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: Icons.bookmark_remove_outlined,
-          label: 'Unsave',
-          onTap: () => widget.onUnsave?.call(msg),
-        ),
-      ?pinTile,
-      if (widget.onDelete != null)
-        _actionTile(
-          sheetContext: sheetContext,
-          icon: Icons.delete_outlined,
-          label: 'Delete',
-          color: isMine ? EchoTheme.danger : null,
-          onTap: () => widget.onDelete?.call(msg),
-        ),
-    ];
-  }
-
-  Widget _actionTile({
-    required BuildContext sheetContext,
-    required IconData icon,
-    required String label,
-    required VoidCallback onTap,
-    Color? color,
-  }) {
-    return Semantics(
-      button: true,
-      label: label,
-      child: InkWell(
-        onTap: () {
-          Navigator.pop(sheetContext);
-          onTap();
-        },
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(minHeight: 44),
-          child: Container(
-            height: 48,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                Icon(icon, size: 18, color: color ?? context.textPrimary),
-                const SizedBox(width: 14),
-                Text(
-                  label,
-                  style: GoogleFonts.inter(
-                    color: color ?? context.textPrimary,
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
   void _showImageViewer({required String imageUrl}) {
     final headers = _mediaHeaders();
     showDialog<void>(
@@ -819,230 +569,10 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  void _handleOverflowMenuSelection(
-    String value,
-    ChatMessage msg,
-    String? mediaUrl,
-  ) {
-    switch (value) {
-      case 'copy':
-        final copyText = mediaUrl != null ? _resolveUrl(mediaUrl) : msg.content;
-        Clipboard.setData(ClipboardData(text: copyText));
-        ToastService.show(
-          context,
-          mediaUrl != null ? 'Link copied' : 'Copied to clipboard',
-          type: ToastType.success,
-        );
-      case 'copy_image':
-        _handleImageAction(mediaUrl!);
-      case 'download':
-        _downloadMedia(mediaUrl!);
-      case 'pin':
-        widget.onPin?.call(msg);
-      case 'unpin':
-        widget.onUnpin?.call(msg);
-      case 'save':
-        widget.onSave?.call(msg);
-      case 'unsave':
-        widget.onUnsave?.call(msg);
-      case 'forward':
-        widget.onForward?.call(msg);
-      case 'edit':
-        widget.onEdit?.call(msg);
-      case 'delete':
-        widget.onDelete?.call(msg);
-    }
-  }
-
-  List<PopupMenuEntry<String>> _buildOverflowMenuItems(
-    ChatMessage msg,
-    bool isMine, {
-    String? mediaUrl,
-    bool isImage = false,
-  }) {
-    return [
-      _buildCopyMenuItem(mediaUrl),
-      ..._buildMediaMenuItems(isImage, mediaUrl),
-      ..._buildPinMenuItems(msg),
-      ..._buildSaveMenuItems(),
-      _buildForwardMenuItem(),
-      ..._buildEditDeleteMenuItems(isMine),
-    ];
-  }
-
-  PopupMenuItem<String> _buildCopyMenuItem(String? mediaUrl) {
-    return PopupMenuItem(
-      value: 'copy',
-      child: Row(
-        children: [
-          const Icon(Icons.copy_outlined, size: 16),
-          const SizedBox(width: 8),
-          Text(mediaUrl != null ? 'Copy link' : 'Copy'),
-        ],
-      ),
-    );
-  }
-
-  List<PopupMenuEntry<String>> _buildMediaMenuItems(
-    bool isImage,
-    String? mediaUrl,
-  ) {
-    final items = <PopupMenuEntry<String>>[];
-    if (isImage) {
-      items.add(
-        PopupMenuItem(
-          value: 'copy_image',
-          child: Row(
-            children: [
-              Icon(
-                _isMobilePlatform
-                    ? Icons.save_alt_outlined
-                    : Icons.image_outlined,
-                size: 16,
-              ),
-              const SizedBox(width: 8),
-              Text(_isMobilePlatform ? 'Save image' : 'Copy image'),
-            ],
-          ),
-        ),
-      );
-    }
-    if (mediaUrl != null) {
-      items.add(
-        const PopupMenuItem(
-          value: 'download',
-          child: Row(
-            children: [
-              Icon(Icons.download_outlined, size: 16),
-              SizedBox(width: 8),
-              Text('Download'),
-            ],
-          ),
-        ),
-      );
-    }
-    return items;
-  }
-
-  List<PopupMenuEntry<String>> _buildPinMenuItems(ChatMessage msg) {
-    final items = <PopupMenuEntry<String>>[];
-    if (msg.pinnedAt == null && widget.onPin != null) {
-      items.add(
-        const PopupMenuItem(
-          value: 'pin',
-          child: Row(
-            children: [
-              Icon(Icons.push_pin_outlined, size: 16),
-              SizedBox(width: 8),
-              Text('Pin'),
-            ],
-          ),
-        ),
-      );
-    }
-    if (msg.pinnedAt != null && widget.onUnpin != null) {
-      items.add(
-        const PopupMenuItem(
-          value: 'unpin',
-          child: Row(
-            children: [
-              Icon(Icons.push_pin, size: 16),
-              SizedBox(width: 8),
-              Text('Unpin'),
-            ],
-          ),
-        ),
-      );
-    }
-    return items;
-  }
-
-  List<PopupMenuEntry<String>> _buildSaveMenuItems() {
-    final items = <PopupMenuEntry<String>>[];
-    if (!widget.isSaved && widget.onSave != null) {
-      items.add(
-        const PopupMenuItem(
-          value: 'save',
-          child: Row(
-            children: [
-              Icon(Icons.bookmark_border_outlined, size: 16),
-              SizedBox(width: 8),
-              Text('Save'),
-            ],
-          ),
-        ),
-      );
-    }
-    if (widget.isSaved && widget.onUnsave != null) {
-      items.add(
-        const PopupMenuItem(
-          value: 'unsave',
-          child: Row(
-            children: [
-              Icon(Icons.bookmark_remove_outlined, size: 16),
-              SizedBox(width: 8),
-              Text('Unsave'),
-            ],
-          ),
-        ),
-      );
-    }
-    return items;
-  }
-
-  PopupMenuItem<String> _buildForwardMenuItem() {
-    return const PopupMenuItem(
-      value: 'forward',
-      child: Row(
-        children: [
-          Icon(Icons.forward_outlined, size: 16),
-          SizedBox(width: 8),
-          Text('Forward'),
-        ],
-      ),
-    );
-  }
-
-  List<PopupMenuEntry<String>> _buildEditDeleteMenuItems(bool isMine) {
-    final items = <PopupMenuEntry<String>>[];
-    if (isMine && widget.onEdit != null) {
-      items.add(
-        const PopupMenuItem(
-          value: 'edit',
-          child: Row(
-            children: [
-              Icon(Icons.edit_outlined, size: 16),
-              SizedBox(width: 8),
-              Text('Edit'),
-            ],
-          ),
-        ),
-      );
-    }
-    if (widget.onDelete != null) {
-      items.add(
-        PopupMenuItem(
-          value: 'delete',
-          child: Row(
-            children: [
-              Icon(
-                Icons.delete_outlined,
-                size: 16,
-                color: isMine ? EchoTheme.danger : null,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                'Delete',
-                style: isMine ? const TextStyle(color: EchoTheme.danger) : null,
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-    return items;
-  }
-
+  /// Hover-bar "..." overflow affordance. Routes through the same
+  /// [_openContextMenu] entrypoint as right-click and long-press —
+  /// no parallel menu tree. Anchored to the button's bottom-left so
+  /// the menu flips out below the bar exactly where the user clicked.
   Widget _buildOverflowMenu(
     ChatMessage msg,
     bool isMine, {
@@ -1050,34 +580,39 @@ class _MessageItemState extends State<MessageItem>
     bool isImage = false,
     required _HoverStyleSpec hoverStyle,
   }) {
+    final size = hoverStyle.buttonSize < 44 ? 44.0 : hoverStyle.buttonSize;
     return Semantics(
       label: 'More actions',
       button: true,
       child: Tooltip(
         message: 'More',
-        child: PopupMenuButton<String>(
-          padding: EdgeInsets.zero,
-          // Keep WCAG hit-target floor across all layouts.
-          constraints: BoxConstraints(
-            minWidth: hoverStyle.buttonSize < 44 ? 44 : hoverStyle.buttonSize,
-            minHeight: hoverStyle.buttonSize < 44 ? 44 : hoverStyle.buttonSize,
-          ),
-          iconSize: hoverStyle.iconSize,
-          icon: Opacity(
-            opacity: hoverStyle.iconOpacity,
-            child: Icon(
-              Icons.more_horiz,
-              size: hoverStyle.iconSize,
-              color: hoverStyle.iconColor,
+        child: Builder(
+          builder: (btnContext) => InkWell(
+            onTap: () {
+              // Anchor at the button's bottom-left so the menu opens
+              // directly below it. globalPaintBounds resolves the
+              // RenderBox to viewport coords without us having to
+              // pass GlobalKeys around.
+              final box = btnContext.findRenderObject() as RenderBox?;
+              final origin =
+                  box?.localToGlobal(Offset(0, box.size.height)) ?? Offset.zero;
+              _openContextMenu(origin, msg, isMine, mediaUrl);
+            },
+            borderRadius: BorderRadius.circular(6),
+            child: SizedBox(
+              width: size,
+              height: size,
+              child: Center(
+                child: Opacity(
+                  opacity: hoverStyle.iconOpacity,
+                  child: Icon(
+                    Icons.more_horiz,
+                    size: hoverStyle.iconSize,
+                    color: hoverStyle.iconColor,
+                  ),
+                ),
+              ),
             ),
-          ),
-          onSelected: (value) =>
-              _handleOverflowMenuSelection(value, msg, mediaUrl),
-          itemBuilder: (_) => _buildOverflowMenuItems(
-            msg,
-            isMine,
-            mediaUrl: mediaUrl,
-            isImage: isImage,
           ),
         ),
       ),
@@ -1752,7 +1287,11 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  /// Handle long-press: show mobile action sheet or reaction picker.
+  /// Handle long-press: open the centralised context menu on mobile,
+  /// or fall through to the desktop reaction picker on non-mobile
+  /// when no reactions are present yet (matches pre-migration
+  /// behaviour where long-press without reactions seeded the
+  /// floating picker).
   void _handleLongPress(
     LongPressStartDetails details,
     ChatMessage msg,
@@ -1761,10 +1300,89 @@ class _MessageItemState extends State<MessageItem>
     bool hasReactions,
   ) {
     if (Responsive.isMobile(context)) {
-      _showMobileActionSheet(context, msg, isMine, mediaUrl);
+      HapticFeedback.mediumImpact();
+      _openContextMenu(details.globalPosition, msg, isMine, mediaUrl);
     } else if (!hasReactions) {
       widget.onReactionTap?.call(msg, details.globalPosition);
     }
+  }
+
+  /// Open the centralised Echo context menu for [msg]. Single
+  /// entry-point used by mobile long-press, desktop right-click on
+  /// the bubble, and the hover-bar "..." overflow button. Action
+  /// visibility lives in [buildMessageMenu]; this method just hands
+  /// it the live state + callbacks.
+  void _openContextMenu(
+    Offset anchor,
+    ChatMessage msg,
+    bool isMine,
+    String? mediaUrl,
+  ) {
+    final isImage = mediaUrl != null && _isImageMedia(msg.content, mediaUrl);
+    final unreadable = _isDecryptFailure(msg.content);
+
+    final target = MessageTarget(
+      message: msg,
+      isMine: isMine,
+      isSaved: widget.isSaved,
+      isEncryptedUnreadable: unreadable,
+      mediaUrl: mediaUrl,
+      isImageMedia: isImage,
+      onReply: widget.onReply == null ? null : () => widget.onReply!(msg),
+      onForward: widget.onForward == null ? null : () => widget.onForward!(msg),
+      onRetry: (msg.status == MessageStatus.failed && widget.onRetry != null)
+          ? () => widget.onRetry!(msg)
+          : null,
+      onCopyText: () {
+        final copyText = mediaUrl != null ? _resolveUrl(mediaUrl) : msg.content;
+        Clipboard.setData(ClipboardData(text: copyText));
+        if (!mounted) return;
+        ToastService.show(
+          context,
+          mediaUrl != null ? 'Link copied' : 'Copied to clipboard',
+          type: ToastType.success,
+        );
+      },
+      // `isImage` only true when `mediaUrl` is non-null (the predicate
+      // guards both), so the analyser promotes `mediaUrl` here.
+      onViewGallery: isImage ? () => _handleImageAction(mediaUrl) : null,
+      onPin: (msg.pinnedAt == null && widget.onPin != null)
+          ? () => widget.onPin!(msg)
+          : null,
+      onUnpin: (msg.pinnedAt != null && widget.onUnpin != null)
+          ? () => widget.onUnpin!(msg)
+          : null,
+      onSave: widget.onSave == null ? null : () => widget.onSave!(msg),
+      onUnsave: widget.onUnsave == null ? null : () => widget.onUnsave!(msg),
+      onEdit: widget.onEdit == null ? null : () => widget.onEdit!(msg),
+      onDelete: widget.onDelete == null ? null : () => widget.onDelete!(msg),
+      onCopyId: () {
+        Clipboard.setData(ClipboardData(text: msg.id));
+        if (!mounted) return;
+        ToastService.show(
+          context,
+          'Message ID copied',
+          type: ToastType.success,
+        );
+      },
+      // Inline reactions header is hidden by the registry when
+      // isEncryptedUnreadable; we still wire the callbacks so the
+      // registry can decide.
+      onPickReaction: widget.onReactionSelect == null
+          ? null
+          : (emoji) => widget.onReactionSelect!(msg, emoji),
+      onOpenFullPicker: widget.onMoreReactions == null
+          ? null
+          : () => widget.onMoreReactions!(msg),
+      recentReactions: reactionEmojis.take(4).toList(),
+    );
+
+    EchoContextMenu.open(
+      context: context,
+      target: target,
+      anchor: anchor,
+      model: buildMessageMenu(target),
+    );
   }
 
   /// Compose a single composite semantic label for the message bubble so
@@ -1914,6 +1532,11 @@ class _MessageItemState extends State<MessageItem>
     return GestureDetector(
       onLongPressStart: (details) =>
           _handleLongPress(details, msg, isMine, mediaUrl, hasReactions),
+      // Desktop right-click on the bubble opens the same centralised
+      // context menu. Hover-bar "..." remains as a discoverable
+      // mouse affordance but routes to the same _openContextMenu.
+      onSecondaryTapDown: (details) =>
+          _openContextMenu(details.globalPosition, msg, isMine, mediaUrl),
       onHorizontalDragUpdate: canSwipeToReply
           ? (details) {
               // Guard against iOS system back gesture zone (left 30px).

--- a/apps/client/test/widgets/a11y_tap_targets_test.dart
+++ b/apps/client/test/widgets/a11y_tap_targets_test.dart
@@ -95,7 +95,7 @@ void main() {
   });
 
   group('A11y tap targets - overflow menu (#497)', () {
-    testWidgets('overflow PopupMenuButton has 44×44 minimum constraints', (
+    testWidgets('overflow "More actions" button renders ≥44×44', (
       tester,
     ) async {
       await mockNetworkImagesFor(() async {
@@ -113,7 +113,7 @@ void main() {
         );
         await tester.pump();
 
-        // Hover so the overflow menu (lives in hover bar) renders.
+        // Hover so the overflow affordance (lives in hover bar) renders.
         final gesture = await tester.createGesture(
           kind: PointerDeviceKind.mouse,
         );
@@ -122,20 +122,22 @@ void main() {
         await gesture.moveTo(tester.getCenter(find.byType(MessageItem)));
         await tester.pump();
 
-        final popups = tester.widgetList<PopupMenuButton<String>>(
-          find.byType(PopupMenuButton<String>),
-        );
-        expect(popups, isNotEmpty);
-
-        final has44 = popups.any(
-          (p) =>
-              (p.constraints?.minWidth ?? 0) >= 44 &&
-              (p.constraints?.minHeight ?? 0) >= 44,
+        // Post-PR 2: the overflow PopupMenuButton was replaced with a
+        // plain InkWell wrapped in a sized box that routes through
+        // EchoContextMenu. The semantics label is still "More actions";
+        // we assert the rendered hit area meets WCAG via the box size.
+        final finder = find.bySemanticsLabel('More actions');
+        expect(finder, findsOneWidget);
+        final size = tester.getSize(finder);
+        expect(
+          size.width,
+          greaterThanOrEqualTo(44),
+          reason: 'overflow affordance width must be ≥44 (WCAG)',
         );
         expect(
-          has44,
-          isTrue,
-          reason: 'expected overflow PopupMenuButton with ≥44×44 constraints',
+          size.height,
+          greaterThanOrEqualTo(44),
+          reason: 'overflow affordance height must be ≥44 (WCAG)',
         );
       });
     });

--- a/apps/client/test/widgets/context_menu/conversation_actions_registry_test.dart
+++ b/apps/client/test/widgets/context_menu/conversation_actions_registry_test.dart
@@ -1,0 +1,144 @@
+/// Visibility tests for the conversation-target registry.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/context_menu/actions/conversation_actions_registry.dart';
+import 'package:echo_app/src/widgets/context_menu/echo_context_menu.dart';
+
+ConversationTarget _t({
+  bool isGroup = true,
+  bool isPinned = false,
+  bool isMuted = false,
+  bool hasUnread = false,
+  bool isAdminOrOwner = false,
+  bool wireLeave = false,
+  bool wireDelete = false,
+  bool wireInfo = true,
+  bool wireInvite = false,
+  bool wireSafetyNumber = false,
+  bool wireEncryptionActivity = false,
+  bool wireCopyId = true,
+  bool wireMarkAsRead = true,
+  bool wireMarkAsUnread = false,
+  bool wireTogglePin = true,
+  bool wireToggleMute = true,
+}) {
+  return ConversationTarget(
+    conversationId: 'conv-1',
+    isGroup: isGroup,
+    isPinned: isPinned,
+    isMuted: isMuted,
+    hasUnread: hasUnread,
+    isAdminOrOwner: isAdminOrOwner,
+    onMarkAsRead: wireMarkAsRead ? () {} : null,
+    onMarkAsUnread: wireMarkAsUnread ? () {} : null,
+    onToggleMute: wireToggleMute ? () {} : null,
+    onTogglePin: wireTogglePin ? () {} : null,
+    onOpenInfo: wireInfo ? () {} : null,
+    onInvitePeople: wireInvite ? () {} : null,
+    onOpenEncryptionActivity: wireEncryptionActivity ? () {} : null,
+    onViewSafetyNumber: wireSafetyNumber ? () {} : null,
+    onCopyId: wireCopyId ? () {} : null,
+    onLeave: wireLeave ? () {} : null,
+    onDelete: wireDelete ? () {} : null,
+  );
+}
+
+Iterable<String> _labels(ContextMenuModel m) =>
+    m.sections.expand((s) => s.actions.map((a) => a.label));
+
+void main() {
+  group('conversation_actions_registry', () {
+    test('Mark As Read appears only when there is unread', () {
+      expect(
+        _labels(buildConversationMenu(_t(hasUnread: true))),
+        contains('Mark As Read'),
+      );
+      expect(
+        _labels(buildConversationMenu(_t(hasUnread: false))),
+        isNot(contains('Mark As Read')),
+      );
+    });
+
+    test('Mute label flips with isMuted', () {
+      expect(
+        _labels(buildConversationMenu(_t(isMuted: false))),
+        contains('Mute'),
+      );
+      expect(
+        _labels(buildConversationMenu(_t(isMuted: true))),
+        contains('Unmute'),
+      );
+    });
+
+    test('Pin label flips with isPinned', () {
+      expect(
+        _labels(buildConversationMenu(_t(isPinned: false))),
+        contains('Pin to Top'),
+      );
+      expect(
+        _labels(buildConversationMenu(_t(isPinned: true))),
+        contains('Unpin'),
+      );
+    });
+
+    test('DM hides Group Info but exposes Safety Number', () {
+      final m = buildConversationMenu(
+        _t(isGroup: false, wireSafetyNumber: true),
+      );
+      final labels = _labels(m).toList();
+      expect(labels, isNot(contains('Group Info')));
+      expect(labels, contains('View Safety Number'));
+    });
+
+    test('Group exposes Group Info, hides Safety Number', () {
+      final m = buildConversationMenu(_t(isGroup: true));
+      final labels = _labels(m).toList();
+      expect(labels, contains('Group Info'));
+      expect(labels, isNot(contains('View Safety Number')));
+    });
+
+    test('Encryption Activity is admin/owner only', () {
+      final adminLabels = _labels(
+        buildConversationMenu(
+          _t(isAdminOrOwner: true, wireEncryptionActivity: true),
+        ),
+      ).toList();
+      expect(adminLabels, contains('Encryption Activity'));
+
+      final memberLabels = _labels(
+        buildConversationMenu(
+          _t(isAdminOrOwner: false, wireEncryptionActivity: true),
+        ),
+      ).toList();
+      expect(memberLabels, isNot(contains('Encryption Activity')));
+    });
+
+    test('Leave Group renders danger-styled when wired', () {
+      final m = buildConversationMenu(_t(wireLeave: true));
+      final row = m.sections
+          .expand((s) => s.actions)
+          .firstWhere((a) => a.label == 'Leave Group');
+      expect(row.isDanger, isTrue);
+    });
+
+    test('Delete label flips between Group and DM', () {
+      expect(
+        _labels(buildConversationMenu(_t(isGroup: true, wireDelete: true))),
+        contains('Delete Group'),
+      );
+      expect(
+        _labels(buildConversationMenu(_t(isGroup: false, wireDelete: true))),
+        contains('Delete Conversation'),
+      );
+    });
+
+    test('Copy Conversation ID lives in the footer', () {
+      final m = buildConversationMenu(_t());
+      expect(m.sections.last.actions.map((a) => a.label).toList(), [
+        'Copy Conversation ID',
+      ]);
+    });
+  });
+}

--- a/apps/client/test/widgets/context_menu/member_actions_registry_test.dart
+++ b/apps/client/test/widgets/context_menu/member_actions_registry_test.dart
@@ -1,0 +1,125 @@
+/// Visibility tests for the member-target registry.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/context_menu/actions/member_actions_registry.dart';
+import 'package:echo_app/src/widgets/context_menu/echo_context_menu.dart';
+
+MemberTarget _t({
+  bool isSelf = false,
+  bool targetIsOwner = false,
+  bool viewerIsAdminOrOwner = false,
+  bool wireProfile = true,
+  bool wireSendMessage = true,
+  bool wireAddContact = false,
+  bool wireRemoveContact = false,
+  bool wireBlock = false,
+  bool wireUnblock = false,
+  bool wireKick = true,
+  bool wireBan = true,
+  bool wireCopyUsername = true,
+  bool wireCopyUserId = true,
+}) {
+  return MemberTarget(
+    userId: 'u1',
+    username: 'alice',
+    isSelf: isSelf,
+    targetIsOwner: targetIsOwner,
+    viewerIsAdminOrOwner: viewerIsAdminOrOwner,
+    onViewProfile: wireProfile ? () {} : null,
+    onSendMessage: wireSendMessage ? () {} : null,
+    onAddContact: wireAddContact ? () {} : null,
+    onRemoveContact: wireRemoveContact ? () {} : null,
+    onBlock: wireBlock ? () {} : null,
+    onUnblock: wireUnblock ? () {} : null,
+    onCopyUserId: wireCopyUserId ? () {} : null,
+    onCopyUsername: wireCopyUsername ? () {} : null,
+    onKick: wireKick ? () {} : null,
+    onBan: wireBan ? () {} : null,
+  );
+}
+
+Iterable<String> _labels(ContextMenuModel m) =>
+    m.sections.expand((s) => s.actions.map((a) => a.label));
+
+void main() {
+  group('member_actions_registry', () {
+    test('non-self always exposes View Profile + Send Message', () {
+      final labels = _labels(buildMemberMenu(_t())).toList();
+      expect(labels, containsAll(<String>['View Profile', 'Send Message']));
+    });
+
+    test('targeting self hides Send Message and admin/contact sections', () {
+      final labels = _labels(
+        buildMemberMenu(
+          _t(isSelf: true, viewerIsAdminOrOwner: true, wireBlock: true),
+        ),
+      ).toList();
+      expect(labels, contains('View Profile'));
+      expect(labels, isNot(contains('Send Message')));
+      expect(labels, isNot(contains('Kick from Group')));
+      expect(labels, isNot(contains('Ban from Group')));
+      expect(labels, isNot(contains('Block')));
+    });
+
+    test('non-admin viewer never sees Kick / Ban', () {
+      final labels = _labels(
+        buildMemberMenu(_t(viewerIsAdminOrOwner: false)),
+      ).toList();
+      expect(labels, isNot(contains('Kick from Group')));
+      expect(labels, isNot(contains('Ban from Group')));
+    });
+
+    test('admin viewer sees Kick / Ban against a regular member', () {
+      final labels = _labels(
+        buildMemberMenu(_t(viewerIsAdminOrOwner: true)),
+      ).toList();
+      expect(
+        labels,
+        containsAll(<String>['Kick from Group', 'Ban from Group']),
+      );
+    });
+
+    test('admin viewer cannot Kick / Ban the owner', () {
+      final labels = _labels(
+        buildMemberMenu(_t(viewerIsAdminOrOwner: true, targetIsOwner: true)),
+      ).toList();
+      expect(labels, isNot(contains('Kick from Group')));
+      expect(labels, isNot(contains('Ban from Group')));
+    });
+
+    test('Kick and Ban are danger-styled', () {
+      final m = buildMemberMenu(_t(viewerIsAdminOrOwner: true));
+      final kick = m.sections
+          .expand((s) => s.actions)
+          .firstWhere((a) => a.label == 'Kick from Group');
+      final ban = m.sections
+          .expand((s) => s.actions)
+          .firstWhere((a) => a.label == 'Ban from Group');
+      expect(kick.isDanger, isTrue);
+      expect(ban.isDanger, isTrue);
+    });
+
+    test('Unblock surfaces when wired (without Add/Remove Contact)', () {
+      final labels = _labels(buildMemberMenu(_t(wireUnblock: true))).toList();
+      expect(labels, contains('Unblock'));
+    });
+
+    test('Block surfaces danger-styled when wired', () {
+      final m = buildMemberMenu(_t(wireBlock: true));
+      final row = m.sections
+          .expand((s) => s.actions)
+          .firstWhere((a) => a.label == 'Block');
+      expect(row.isDanger, isTrue);
+    });
+
+    test('Copy User ID + Copy Username live in the footer', () {
+      final m = buildMemberMenu(_t());
+      expect(m.sections.last.actions.map((a) => a.label).toList(), [
+        'Copy Username',
+        'Copy User ID',
+      ]);
+    });
+  });
+}

--- a/apps/client/test/widgets/context_menu/message_actions_registry_test.dart
+++ b/apps/client/test/widgets/context_menu/message_actions_registry_test.dart
@@ -1,0 +1,139 @@
+/// Visibility and shape tests for the message-target registry.
+/// These are pure-Dart tests — no Flutter binding needed — because
+/// the registry only manipulates plain data.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/context_menu/actions/message_actions_registry.dart';
+import 'package:echo_app/src/widgets/context_menu/echo_context_menu.dart';
+
+MessageTarget _baseTarget({
+  bool isMine = false,
+  bool isSaved = false,
+  bool isEncryptedUnreadable = false,
+  String? mediaUrl,
+  bool isImageMedia = false,
+  bool wireDelete = true,
+  bool wirePin = true,
+  bool wireSave = true,
+  bool wireReact = true,
+  bool wireRetry = false,
+  bool wireCopyId = true,
+}) {
+  return MessageTarget(
+    message: const _StubMessage(),
+    isMine: isMine,
+    isSaved: isSaved,
+    isEncryptedUnreadable: isEncryptedUnreadable,
+    mediaUrl: mediaUrl,
+    isImageMedia: isImageMedia,
+    onReply: () {},
+    onForward: () {},
+    onRetry: wireRetry ? () {} : null,
+    onCopyText: () {},
+    onPin: wirePin ? () {} : null,
+    onUnpin: null,
+    onSave: wireSave && !isSaved ? () {} : null,
+    onUnsave: wireSave && isSaved ? () {} : null,
+    onEdit: isMine ? () {} : null,
+    onViewGallery: isImageMedia ? () {} : null,
+    onDelete: wireDelete ? () {} : null,
+    onCopyId: wireCopyId ? () {} : null,
+    onPickReaction: wireReact ? (_) {} : null,
+    onOpenFullPicker: wireReact ? () {} : null,
+  );
+}
+
+Iterable<String> _allLabels(ContextMenuModel m) sync* {
+  for (final s in m.sections) {
+    for (final a in s.actions) {
+      yield a.label;
+    }
+  }
+}
+
+void main() {
+  group('message_actions_registry', () {
+    test('encrypted-unreadable message hides the inline reactions row', () {
+      final m = buildMessageMenu(_baseTarget(isEncryptedUnreadable: true));
+      expect(m.header, isNull);
+    });
+
+    test('normal message shows the inline reactions row', () {
+      final m = buildMessageMenu(_baseTarget());
+      expect(m.header, isA<InlineReactionsHeader>());
+    });
+
+    test('reactions row is hidden when callbacks are null even if not '
+        'encrypted', () {
+      final m = buildMessageMenu(_baseTarget(wireReact: false));
+      expect(m.header, isNull);
+    });
+
+    test('own messages get the danger-styled Delete row', () {
+      final m = buildMessageMenu(_baseTarget(isMine: true));
+      final danger = m.sections.firstWhere(
+        (s) => s.actions.any((a) => a.label == 'Delete Message'),
+      );
+      expect(danger.actions.first.isDanger, isTrue);
+    });
+
+    test("other people's messages show 'Delete for Me', not danger-styled", () {
+      final m = buildMessageMenu(_baseTarget(isMine: false));
+      final row = m.sections
+          .expand((s) => s.actions)
+          .firstWhere((a) => a.label == 'Delete for Me');
+      expect(row.isDanger, isFalse);
+    });
+
+    test('saved messages render Unsave (not Save)', () {
+      final m = buildMessageMenu(_baseTarget(isSaved: true));
+      final labels = _allLabels(m).toList();
+      expect(labels, contains('Unsave'));
+      expect(labels, isNot(contains('Save')));
+    });
+
+    test('media images expose "View in Gallery"', () {
+      final m = buildMessageMenu(
+        _baseTarget(mediaUrl: 'https://x/y.png', isImageMedia: true),
+      );
+      expect(_allLabels(m), contains('View in Gallery'));
+    });
+
+    test('text-only message hides "View in Gallery"', () {
+      final m = buildMessageMenu(_baseTarget());
+      expect(_allLabels(m), isNot(contains('View in Gallery')));
+    });
+
+    test('failed sends show Retry first', () {
+      final m = buildMessageMenu(_baseTarget(wireRetry: true));
+      expect(m.sections.first.actions.first.label, 'Retry');
+    });
+
+    test('Copy Message ID lives in its own footer section', () {
+      final m = buildMessageMenu(_baseTarget());
+      expect(m.sections.last.actions.map((a) => a.label).toList(), [
+        'Copy Message ID',
+      ]);
+    });
+
+    test('Copy Message ID is absent when onCopyId is null', () {
+      final m = buildMessageMenu(_baseTarget(wireCopyId: false));
+      expect(_allLabels(m), isNot(contains('Copy Message ID')));
+    });
+
+    test('media messages show "Copy link" instead of "Copy text"', () {
+      final m = buildMessageMenu(
+        _baseTarget(mediaUrl: 'https://x/y.bin', isImageMedia: false),
+      );
+      final labels = _allLabels(m).toList();
+      expect(labels, contains('Copy link'));
+      expect(labels, isNot(contains('Copy text')));
+    });
+  });
+}
+
+class _StubMessage {
+  const _StubMessage();
+}

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -521,76 +521,18 @@ void main() {
     });
   });
 
-  group('ConversationItem long-press action sheet', () {
-    testWidgets(
-      'long-press on DM shows Mute, Pin to top, and Delete Conversation items',
-      (tester) async {
-        bool pinToggled = false;
-
-        final conv = _makeConversation(
-          members: const [
-            ConversationMember(userId: 'peer-id', username: 'alice'),
-            ConversationMember(userId: 'my-id', username: 'me'),
-          ],
-        );
-
-        // Wrap in a Navigator so showModalBottomSheet can push a route.
-        // Simulate Android so _enableLongPressMenu returns true.
-        debugDefaultTargetPlatformOverride = TargetPlatform.android;
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              conversationsProvider.overrideWith(
-                () => _StubConversationsNotifier([conv]),
-              ),
-            ],
-            child: MaterialApp(
-              theme: EchoTheme.darkTheme,
-              darkTheme: EchoTheme.darkTheme,
-              themeMode: ThemeMode.dark,
-              home: Scaffold(
-                body: ConversationItem(
-                  conversation: conv,
-                  myUserId: 'my-id',
-                  isSelected: false,
-                  isPinned: false,
-                  isPeerOnline: false,
-                  timestamp: '10:30',
-                  onTap: () {},
-                  onTogglePin: () => pinToggled = true,
-                  onLeave: () {},
-                ),
-              ),
-            ),
-          ),
-        );
-        await tester.longPress(find.byType(ConversationItem));
-        // Reset override before pumpAndSettle so invariant check passes.
-        debugDefaultTargetPlatformOverride = null;
-        await tester.pumpAndSettle();
-
-        // Mute item is always present.
-        expect(find.text('Mute'), findsOneWidget);
-        // Pin item is present when onTogglePin is provided.
-        expect(find.text('Pin to top'), findsOneWidget);
-        // Delete item is present when onLeave is provided (DM).
-        expect(find.text('Delete Conversation'), findsOneWidget);
-
-        // Tapping Pin invokes the callback.
-        await tester.tap(find.text('Pin to top'));
-        await tester.pumpAndSettle();
-        expect(pinToggled, isTrue);
-      },
-    );
-
-    testWidgets('long-press on group shows Leave Group instead of Delete', (
-      tester,
-    ) async {
+  group('ConversationItem long-press dispatch', () {
+    // Post-PR-3: ConversationItem no longer renders its own action
+    // sheet on mobile long-press. It delegates to the
+    // `onContextMenu` callback, and `conversation_panel` opens the
+    // centralised EchoContextMenu. Menu *contents* are covered by
+    // conversation_actions_registry_test.dart; the only behaviour
+    // worth asserting here is the dispatch itself.
+    testWidgets('long-press on mobile fires onContextMenu', (tester) async {
+      bool fired = false;
       final conv = _makeConversation(
-        name: 'Dev Team',
-        isGroup: true,
         members: const [
-          ConversationMember(userId: 'u1', username: 'alice'),
+          ConversationMember(userId: 'peer-id', username: 'alice'),
           ConversationMember(userId: 'my-id', username: 'me'),
         ],
       );
@@ -616,8 +558,7 @@ void main() {
                 isPeerOnline: false,
                 timestamp: '10:30',
                 onTap: () {},
-                onTogglePin: () {},
-                onLeave: () {},
+                onContextMenu: (_) => fired = true,
               ),
             ),
           ),
@@ -627,56 +568,55 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
       await tester.pumpAndSettle();
 
-      expect(find.text('Leave Group'), findsOneWidget);
-      expect(find.text('Delete Conversation'), findsNothing);
+      expect(fired, isTrue);
     });
 
-    testWidgets(
-      'long-press on pinned conversation shows Unpin instead of Pin to top',
-      (tester) async {
-        final conv = _makeConversation(
-          members: const [
-            ConversationMember(userId: 'peer-id', username: 'alice'),
-            ConversationMember(userId: 'my-id', username: 'me'),
-          ],
-        );
+    testWidgets('long-press on web (kIsWeb-like) is a no-op', (tester) async {
+      // Desktop platforms get right-click via onSecondaryTapUp; the
+      // long-press path is gated by _enableLongPressMenu which only
+      // returns true on Android/iOS. We can't override kIsWeb at
+      // runtime, but we can verify the mobile-only contract by
+      // overriding the platform to desktop and confirming no
+      // callback fires.
+      bool fired = false;
+      final conv = _makeConversation(
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
 
-        debugDefaultTargetPlatformOverride = TargetPlatform.android;
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              conversationsProvider.overrideWith(
-                () => _StubConversationsNotifier([conv]),
-              ),
-            ],
-            child: MaterialApp(
-              theme: EchoTheme.darkTheme,
-              darkTheme: EchoTheme.darkTheme,
-              themeMode: ThemeMode.dark,
-              home: Scaffold(
-                body: ConversationItem(
-                  conversation: conv,
-                  myUserId: 'my-id',
-                  isSelected: false,
-                  isPinned: true, // already pinned
-                  isPeerOnline: false,
-                  timestamp: '10:30',
-                  onTap: () {},
-                  onTogglePin: () {},
-                  onLeave: () {},
-                ),
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            conversationsProvider.overrideWith(
+              () => _StubConversationsNotifier([conv]),
+            ),
+          ],
+          child: MaterialApp(
+            theme: EchoTheme.darkTheme,
+            home: Scaffold(
+              body: ConversationItem(
+                conversation: conv,
+                myUserId: 'my-id',
+                isSelected: false,
+                isPinned: false,
+                isPeerOnline: false,
+                timestamp: '10:30',
+                onTap: () {},
+                onContextMenu: (_) => fired = true,
               ),
             ),
           ),
-        );
-        await tester.longPress(find.byType(ConversationItem));
-        debugDefaultTargetPlatformOverride = null;
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.longPress(find.byType(ConversationItem));
+      debugDefaultTargetPlatformOverride = null;
+      await tester.pumpAndSettle();
 
-        expect(find.text('Unpin'), findsOneWidget);
-        expect(find.text('Pin to top'), findsNothing);
-      },
-    );
+      expect(fired, isFalse);
+    });
   });
 
   group('ConversationItem semantics label (#631)', () {


### PR DESCRIPTION
Stacks four small PRs into one branch: introduces a single context-menu primitive shared by every right-click and long-press path, then migrates the three target surfaces that had their own bespoke menus.

## What's new

- Right-click any message bubble, conversation row, or member row in a group opens the same Discord-style menu — themed to Echo's design system.
- Mobile long-press hits the same model but renders as a draggable bottom sheet.
- The reactions strip, action labels, danger styling, dividers, and submenu sliding are all consistent everywhere.

## Improved

- Sender-signature-failed group messages don't surface the reactions row anymore — no point picking 👍 on a bubble that reads "[Could not decrypt…]".
- Admin-only actions (Kick / Ban, Encryption Activity, Invite People) hide automatically for regular members instead of rendering disabled.
- "..." overflow button on a message and the per-member "..." button both route through the same code path as right-click.

## Behind the scenes

- `EchoContextMenu.open()` is the single entry; two layout files (`context_menu_overlay.dart`, `context_menu_sheet.dart`) render a shared `ContextMenuModel`. Submenus push onto a single stack instead of nested popovers; 120ms fade+scale entry; Esc dismisses; anchor is clamped to viewport.
- Three pure-Dart per-target registries (`message_actions_registry.dart`, `conversation_actions_registry.dart`, `member_actions_registry.dart`) hold the visibility logic — no widget imports.
- 30 new pure-Dart visibility tests; one existing a11y test rewritten to assert against the new affordance instead of the deleted `PopupMenuButton`. Total: 1818 client tests passing.
- Net diff on the migration PRs is slightly negative (more deletions than additions), so this refactor doesn't grow the codebase.
- A debug-only `/dev/context-menu` testbed page lives behind `kDebugMode` so future contributors can eyeball the design without spinning up real conversations.

## Deferred (will need real provider/server work)

- Create Thread, Report Message, Copy Message Link — server endpoints don't exist yet.
- Mark As Unread (per conversation) — no provider method yet.
- Add Contact / Remove Contact / Block from the member menu — `contacts_provider` only exposes Unblock today.
- Change Role from the member menu — server endpoint missing.