### PR TITLE
Resize Update Available window so buttons stop crowding

### DIFF
--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -123,6 +123,11 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     // instead of navigating immediately.
     final updateState = ref.read(updateProvider);
     if (!kIsWeb && update_svc.canAutoUpdate && updateState.updateAvailable) {
+      // Grow the chromeless splash window to a size that comfortably fits
+      // the actionable update prompt — the 320×440 splash dimensions
+      // crowded the Download/Restart/Skip stack.
+      await WindowStateService.enterUpdatePrompt();
+      if (!mounted) return;
       setState(() {
         _showUpdatePrompt = true;
         _loggedIn = loggedIn;

--- a/apps/client/lib/src/services/window_state_service.dart
+++ b/apps/client/lib/src/services/window_state_service.dart
@@ -143,6 +143,22 @@ class WindowStateService {
     }
   }
 
+  /// Resize the chromeless splash window to a size that comfortably fits
+  /// the update prompt (logo, version cycle, progress bar, full-width
+  /// action button, error text, Skip). The splash's 320×440 is too tight
+  /// for an actionable screen — buttons crowd the edges and longer error
+  /// strings wrap awkwardly. Keeps the splash chrome (transparent
+  /// background, hidden title bar) so the swap stays seamless.
+  static Future<void> enterUpdatePrompt() async {
+    if (!_isDesktop) return;
+    try {
+      await windowManager.setSize(const Size(400, 520));
+    } catch (_) {
+      // Resize failure is non-fatal — the user still sees the 320×440
+      // splash-sized prompt, just a bit cramped.
+    }
+  }
+
   /// Shrink the window to a 320×440 chromeless splash and anchor it near
   /// the top-left of the primary display so it lines up with where the
   /// post-splash window will appear (eliminating the small-to-large jump


### PR DESCRIPTION
## Summary

The desktop "Update available" prompt was reusing the 320×440 chromeless splash window. That size is fine for the boot splash (logo + status caption), but the update prompt has actionable content — version cycle, progress bar, full-width Download/Restart button, error text, Skip — and the edges crowded.

Bumps the window to **400×520** right before the prompt renders. The splash transition into the prompt is still seamless (same transparent chrome, same hidden title bar).

## Fixed

- Update Available popup window is no longer cramped — buttons and error strings now have room to breathe.

## Test plan

- [ ] Trigger an update on a desktop build and confirm the prompt's buttons + Skip aren't crowded
- [ ] Confirm the splash → update-prompt transition still looks seamless
- [ ] Verify the post-prompt navigation still restores the user's saved window geometry