### PR TITLE
Stop protocol-state string leaking into sidebar snippet

### DIFF
--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -218,10 +218,13 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
 
   String? _maskEncryptedSnippet(String? snippet) {
     if (snippet != null &&
-        (snippet.startsWith('[Could not decrypt]') ||
+        (snippet.startsWith('[Could not decrypt') ||
             snippet.startsWith('[Encrypted'))) {
       // The DM context already implies encryption; saying "encrypted" here
-      // looks like an error state. Use a neutral placeholder instead.
+      // looks like an error state. Match any "[Could not decrypt..." variant
+      // (the WS handler emits at least four: bare, "waiting for group key",
+      // "group message", "encryption keys may be out of sync") so the
+      // protocol-state string never leaks into the sidebar snippet.
       return '[E2E] Message';
     }
     return snippet;


### PR DESCRIPTION
## Summary

The conversation-list snippet mask only matched the bare \`[Could not decrypt]\` form. The WS handler actually emits four parameterised variants:

- \`[Could not decrypt - waiting for group key]\` (\`ws_message_handler.dart:479\`)
- \`[Could not decrypt group message]\` (\`ws_message_handler.dart:543\`, \`chat_provider.dart:895\`)
- \`[Could not decrypt - encryption keys may be out of sync]\` (\`ws_message_handler.dart:567\`)
- bare \`[Could not decrypt]\`

So the literal protocol-state string was leaking into the sidebar preview as the truncated banner \`"npc: [Could not decrypt - waiting for group …"\`. P0 finding F-001 in the 2026-05-19 audit.

## Fixed

- Sidebar preview now renders \`[E2E] Message\` for any decrypt-failure variant, matching the bare-bracket behaviour.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visually verify: a wedged encrypted group's sidebar row shows \`[E2E] Message\` not the raw placeholder