### PR TITLE
Polish: section headers, Discover overflow, login layout

### DIFF
--- a/apps/client/lib/src/screens/discover_groups_screen.dart
+++ b/apps/client/lib/src/screens/discover_groups_screen.dart
@@ -324,6 +324,8 @@ class _DiscoverGroupsScreenState extends ConsumerState<DiscoverGroupsScreen> {
                   const SizedBox(height: 6),
                   Text(
                     group.description!,
+                    maxLines: 4,
+                    overflow: TextOverflow.ellipsis,
                     style: TextStyle(
                       color: context.textSecondary,
                       fontSize: 14,

--- a/apps/client/lib/src/screens/login_screen.dart
+++ b/apps/client/lib/src/screens/login_screen.dart
@@ -151,6 +151,34 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                               child: const Text('Forgot password?'),
                             ),
                           ),
+                          // Divider + label visually separates the recovery
+                          // affordance ("Forgot password?") from the
+                          // create-account CTA so they don't read as one
+                          // stacked block of links.
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 8,
+                              horizontal: 24,
+                            ),
+                            child: Row(
+                              children: [
+                                Expanded(child: Divider(color: context.border)),
+                                Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                  ),
+                                  child: Text(
+                                    'New here?',
+                                    style: TextStyle(
+                                      color: context.textMuted,
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ),
+                                Expanded(child: Divider(color: context.border)),
+                              ],
+                            ),
+                          ),
                           // TextButton + Text already produce a
                           // button-role accessibility node named "Create an
                           // account" — wrapping in another Semantics

--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -1105,13 +1105,15 @@ class EchoSectionTokens {
   /// Vertical gap above a [SectionHeader] label.
   static const double headerTopGap = 24;
 
-  /// All-caps muted section label text style.
+  /// Sentence-case muted section label text style. Bumped slightly from
+  /// the previous all-caps treatment (11/700/1.2 letter-spacing) so the
+  /// header still reads as a category divider without screaming.
   static TextStyle sectionLabelStyle(BuildContext context) {
     return TextStyle(
       color: context.textMuted,
-      fontSize: 11,
-      fontWeight: FontWeight.w700,
-      letterSpacing: 1.2,
+      fontSize: 12,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.2,
     );
   }
 }

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -83,9 +83,9 @@ class MembersPanel extends ConsumerWidget {
       }
     }
 
-    addGroup('OWNER — ${owners.length}', owners);
-    addGroup('ADMIN — ${admins.length}', admins);
-    addGroup('MEMBERS — ${regulars.length}', regulars);
+    addGroup('Owner · ${owners.length}', owners);
+    addGroup('Admins · ${admins.length}', admins);
+    addGroup('Members · ${regulars.length}', regulars);
 
     return Container(
       width: 280,
@@ -127,9 +127,9 @@ class MembersPanel extends ConsumerWidget {
                       item.headerLabel!,
                       style: TextStyle(
                         color: context.textMuted,
-                        fontSize: 11,
-                        fontWeight: FontWeight.w700,
-                        letterSpacing: 0.6,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 0.2,
                       ),
                     ),
                   );

--- a/apps/client/lib/src/widgets/settings/section_header.dart
+++ b/apps/client/lib/src/widgets/settings/section_header.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 import '../../theme/echo_theme.dart';
 
-/// All-caps muted label that introduces a card group in sectioned lists.
-/// Pairs with [CardRow] groups in the Settings redesign.
+/// Muted sentence-case label that introduces a card group in sectioned
+/// lists. Pairs with [CardRow] groups in the Settings redesign.
 class SectionHeader extends StatelessWidget {
-  /// Plain label text. Rendered uppercase.
+  /// Plain label text. Rendered as-given (no case transform); pass the
+  /// label in the case you want it to appear ("Account preferences",
+  /// not "ACCOUNT PREFERENCES").
   final String label;
 
   const SectionHeader(this.label, {super.key});
@@ -19,10 +21,7 @@ class SectionHeader extends StatelessWidget {
         16,
         8,
       ),
-      child: Text(
-        label.toUpperCase(),
-        style: EchoSectionTokens.sectionLabelStyle(context),
-      ),
+      child: Text(label, style: EchoSectionTokens.sectionLabelStyle(context)),
     );
   }
 }


### PR DESCRIPTION
## Summary

Audit batch tackling three medium-priority polish findings from the 2026-05-19 UI/UX audit. All low-risk, no behaviour changes.

## Improved

- Settings / new-message / members-panel section headers no longer shout in ALL CAPS — "ACCOUNT PREFERENCES" becomes "Account preferences", "OWNER — 1" becomes "Owner · 1", etc. (F-018)
- Discover group descriptions cap at 4 lines with ellipsis so long bios don't push the Join CTA off the card. (F-024)
- Login screen has a labelled divider ("New here?") between "Forgot password?" and "Create an account" so the two affordances stop reading as one stacked block of links. (F-023)

## Behind the scenes

- \`SectionHeader\` drops the \`toUpperCase()\` transform; call sites already pass Title Case strings.
- \`sectionLabelStyle\` bumped to 12/600/0.2 letter-spacing to retain visual weight without the uppercase crutch.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual check: settings root + members panel headers read as sentence case
- [ ] Visual check: discover card with a very long description ellipsizes
- [ ] Visual check: login screen shows the "New here?" divider