### PR TITLE
Unify decrypt + send-failure copy across surfaces

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -554,7 +554,7 @@ class Chat extends _$Chat {
 
     final updated = msg.copyWith(
       status: MessageStatus.failed,
-      content: 'Message may not have been delivered. Tap to retry.',
+      content: "Couldn't send · Tap to retry",
       failedContent: originalContent,
     );
     final updatedList = List<ChatMessage>.from(messages);

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -524,7 +524,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       return 'Group encryption key not available yet. Tap to retry.';
     }
     if (msg.contains('cannot decrypt') || msg.contains('Could not decrypt')) {
-      return 'Message could not be decrypted.';
+      return "Couldn't decrypt this message";
     }
     if (msg.contains('OTP key_id') && msg.contains('not found')) {
       return 'Encryption key mismatch. Ask the other person to resend.';
@@ -532,7 +532,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     if (msg.contains('Auth expired')) {
       return 'Session expired. Please try again.';
     }
-    return 'Message could not be secured. Tap to retry.';
+    return "Couldn't send · Tap to retry";
   }
 
   /// Add a failed message to the chat so the user can see the error.

--- a/apps/client/lib/src/widgets/message/message_indicators.dart
+++ b/apps/client/lib/src/widgets/message/message_indicators.dart
@@ -122,7 +122,7 @@ class DecryptFailurePill extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      label: 'Message could not be decrypted',
+      label: "Couldn't decrypt this message",
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
         decoration: BoxDecoration(
@@ -135,7 +135,7 @@ class DecryptFailurePill extends StatelessWidget {
             Icon(Icons.lock_outline, size: 16, color: context.textSecondary),
             const SizedBox(width: 6),
             Text(
-              'Message could not be decrypted',
+              "Couldn't decrypt this message",
               style: GoogleFonts.inter(
                 fontStyle: FontStyle.italic,
                 color: context.textSecondary,

--- a/apps/client/lib/src/widgets/message/retry_row.dart
+++ b/apps/client/lib/src/widgets/message/retry_row.dart
@@ -36,12 +36,13 @@ class RetryRow extends StatelessWidget {
         children: [
           const Icon(Icons.error_rounded, size: 16, color: EchoTheme.danger),
           const SizedBox(width: 6),
-          Flexible(
+          const Flexible(
             child: Text(
-              message.content.contains('not have been delivered')
-                  ? 'Message may not have been delivered'
-                  : 'Failed to send',
-              style: const TextStyle(
+              // Unified failure label across voice + text. Retry / Delete
+              // sit right next to this text, so the previous "Tap to retry"
+              // suffix was redundant. See F-030 in the 2026-05-19 UI audit.
+              "Couldn't send",
+              style: TextStyle(
                 fontSize: 12,
                 color: EchoTheme.danger,
                 fontWeight: FontWeight.w500,

--- a/apps/client/test/providers/chat_notifier_timer_test.dart
+++ b/apps/client/test/providers/chat_notifier_timer_test.dart
@@ -70,10 +70,7 @@ void main() {
         // Original content preserved in failedContent for retry.
         expect(afterMsgs.first.failedContent, 'hello world');
         // User-facing content is the timeout message.
-        expect(
-          afterMsgs.first.content,
-          contains('may not have been delivered'),
-        );
+        expect(afterMsgs.first.content, contains("Couldn't send"));
       });
     });
 

--- a/apps/client/test/widgets/message_item_test.dart
+++ b/apps/client/test/widgets/message_item_test.dart
@@ -831,7 +831,7 @@ void main() {
           await tester.pump();
 
           expect(find.byIcon(Icons.lock_outline), findsOneWidget);
-          expect(find.text('Message could not be decrypted'), findsOneWidget);
+          expect(find.text("Couldn't decrypt this message"), findsOneWidget);
         });
       },
     );
@@ -854,7 +854,7 @@ void main() {
         await tester.pump();
 
         expect(find.byIcon(Icons.lock_outline), findsOneWidget);
-        expect(find.text('Message could not be decrypted'), findsOneWidget);
+        expect(find.text("Couldn't decrypt this message"), findsOneWidget);
       });
     });
 
@@ -877,7 +877,7 @@ void main() {
         await tester.pump();
 
         expect(find.byIcon(Icons.lock_outline), findsNothing);
-        expect(find.text('Message could not be decrypted'), findsNothing);
+        expect(find.text("Couldn't decrypt this message"), findsNothing);
         expect(find.byType(SizedBox), findsWidgets);
       });
     });


### PR DESCRIPTION
## Summary

Echo was emitting five user-visible strings for two underlying states (one decrypt, one send). The audit (F-030, 2026-05-19) and direct user feedback called this out — \"different texts and multiple errors appear when a message fails to send or fails to be decrypted; I'd like to sync that up.\"

## Improved

- Decrypt-failure pill and semantic label now read **\"Couldn't decrypt this message\"** everywhere it appears.
- Send-failure copy collapses to **\"Couldn't send · Tap to retry\"** in the bubble body and **\"Couldn't send\"** inside the inline retry row (where Retry/Delete sit right next to the label, so the suffix was redundant).

## Behind the scenes

- \`websocket_provider.dart\` send-error router collapses the two generic fallbacks (\`Message could not be secured\` / \`Message could not be decrypted.\`) to the new copy. Specific error states (session expired, OTP mismatch, group key unavailable) keep their detailed strings — those are diagnostic, not fallback.
- \`chat_provider.dart\` send-timeout sets the same canonical content.
- Tests updated to match.

## Test plan

- [x] \`flutter analyze\` passes
- [x] \`flutter test test/widgets/message_item_test.dart test/providers/chat_notifier_timer_test.dart\` — all 42 tests pass
- [ ] Visual check post-release: forced send-failure shows \"Couldn't send · Tap to retry\" not the old verbose copy