### PR TITLE
Owner role pill no longer shares amber with warning state

### DIFF
--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -314,8 +314,13 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
 
     switch (role) {
       case 'owner':
-        bgColor = EchoTheme.warning.withValues(alpha: 0.15);
-        textColor = EchoTheme.warning;
+        // Reserve amber (EchoTheme.warning) for actual warnings —
+        // "Experimental" feature pill, away presence, etc. Owner is a
+        // positive role attribute, so use a brighter accent variant so
+        // it still distinguishes from Admin (same accent at lower alpha)
+        // without leaning on the warning palette.
+        bgColor = EchoTheme.accentHover.withValues(alpha: 0.22);
+        textColor = EchoTheme.accentHover;
         label = 'Owner';
       case 'admin':
         bgColor = context.accent.withValues(alpha: 0.15);


### PR DESCRIPTION
## Summary

The Owner role badge and the "Experimental" feature badge both used \`EchoTheme.warning\` amber. Amber should signal warning state — Experimental, Away presence, connection trouble — not a positive role attribute. F-019 in the 2026-05-19 UI audit.

## Improved

- Owner pill now uses a brighter accent variant (still distinct from Admin's standard accent at lower alpha) so the warning palette is reserved for actual warnings.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual check: Owner badge in members panel reads as accent (not amber); Experimental pill in create-group still reads as amber