### PR TITLE
Polish batch 2: deeper backdrops + cleaner copy

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -376,7 +376,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   void _showQuickSwitcher() {
     showDialog(
       context: context,
-      barrierColor: Colors.black12,
+      barrierColor: Colors.black54,
       builder: (ctx) =>
           QuickSwitcherOverlay(onSelect: (conv) => _selectConversation(conv)),
     );
@@ -385,7 +385,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   void _showGlobalSearch() {
     showDialog(
       context: context,
-      barrierColor: Colors.black12,
+      barrierColor: Colors.black54,
       builder: (ctx) => GlobalSearchOverlay(
         onResultTap: (conversationId, messageId) {
           final conversations = ref.read(conversationsProvider).conversations;
@@ -402,7 +402,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   void _showKeyboardShortcuts() {
     showDialog<void>(
       context: context,
-      barrierColor: Colors.black12,
+      barrierColor: Colors.black54,
       builder: (_) => const KeyboardShortcutsOverlay(),
     );
   }

--- a/apps/client/lib/src/screens/login_screen.dart
+++ b/apps/client/lib/src/screens/login_screen.dart
@@ -118,8 +118,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
               children: [
                 const AuthBackground(),
                 AuthLayout(
+                  // Brand-panel tagline stays as the welcoming line; form
+                  // card title is the action verb so the wide layout doesn't
+                  // print "Welcome back." twice side-by-side.
                   tagline: 'Welcome back.',
-                  formTitle: 'Welcome back.',
+                  formTitle: 'Log in to Echo',
                   compactHeader: _buildHeader(serverUrl),
                   narrowPadding: const EdgeInsets.fromLTRB(
                     24,

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -103,8 +103,12 @@ class MembersPanel extends ConsumerWidget {
             ),
             child: Align(
               alignment: Alignment.centerLeft,
+              // The conversation header already shows "<N> members" as a
+              // subtitle (chat_header_bar.dart). Repeating the count on the
+              // right-rail header was redundant; keep the count off this
+              // surface and just label what the panel is.
               child: Text(
-                '${members.length} ${members.length == 1 ? 'member' : 'members'}',
+                'Members',
                 style: TextStyle(
                   color: context.textPrimary,
                   fontSize: 14,


### PR DESCRIPTION
## Summary

Audit batch covering three low-risk polish items from the 2026-05-19 UI/UX review.

## Improved

- Quick switcher / global search / keyboard-shortcuts overlays now sit on a properly dimmed backdrop (Colors.black54 ≈ 54% black) instead of the barely-there \`Colors.black12\` so the underlying empty-state CTAs don't read as click targets behind the modal. (F-007)
- Members-panel right-rail header drops the redundant member count — the chat header already shows "<N> members" as a subtitle, repeating it on the right rail was noise. Now reads simply "Members". (F-017)
- Login screen no longer prints "Welcome back." twice side-by-side in wide mode. Brand panel keeps the tagline; form card heading becomes the action verb "Log in to Echo". (F-014)

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual check: Ctrl+K and Ctrl+Shift+F overlays — backdrop is noticeably darker
- [ ] Visual check: members panel right rail header says "Members" not "2 members"
- [ ] Visual check: login screen wide mode shows two distinct strings