### PR TITLE
Scope encryption claims to what we actually ship

### DIFF
--- a/apps/client/lib/src/screens/create_group_screen.dart
+++ b/apps/client/lib/src/screens/create_group_screen.dart
@@ -230,11 +230,11 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
           ),
           subtitle: Text(
             _isEncrypted
-                ? 'Messages are encrypted per-member with the Signal-style '
-                      'group key. May fail to decrypt under certain identity-'
-                      'key changes.'
-                : 'Messages are stored on the server in plaintext. Standard '
-                      'auth still protects access.',
+                ? 'On (beta): end-to-end encrypted with a per-member group '
+                      'key. No server-side search; new joiners may need a '
+                      'key refresh.'
+                : 'Off: server can read messages, supports search and '
+                      'moderation. Your account auth still protects access.',
             style: TextStyle(color: context.textMuted, fontSize: 12),
           ),
           activeThumbColor: context.accent,

--- a/apps/client/lib/src/screens/discover_groups_screen.dart
+++ b/apps/client/lib/src/screens/discover_groups_screen.dart
@@ -417,7 +417,7 @@ class _DiscoverGroupsScreenState extends ConsumerState<DiscoverGroupsScreen> {
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
               child: Text(
-                'Public groups. Join with one tap — your messages stay encrypted.',
+                'Public groups. Server-stored — open a DM for end-to-end encryption.',
                 style: TextStyle(color: context.textMuted, fontSize: 13),
               ),
             ),

--- a/apps/client/lib/src/widgets/auth/auth_layout.dart
+++ b/apps/client/lib/src/widgets/auth/auth_layout.dart
@@ -147,8 +147,8 @@ class _BrandPanel extends StatelessWidget {
         const SizedBox(height: 32),
         const _FeatureRow(
           icon: Icons.lock_outline,
-          title: 'End-to-end encrypted',
-          body: 'Signal Protocol with X3DH + Double Ratchet',
+          title: 'Encrypted direct messages',
+          body: 'Signal Protocol (X3DH + Double Ratchet)',
         ),
         const SizedBox(height: 16),
         const _FeatureRow(


### PR DESCRIPTION
## Summary

The login pillar, Discover hero, and Create-group toggle each promised universal E2E that plaintext-default groups (#980) cannot deliver. F-005 / F-025 in the 2026-05-19 UI audit; expert recommendation was to fix the copy and keep the off-default until wedge-recovery UX stabilises.

## Improved

- **Login pillar** — "Encrypted direct messages" + "Signal Protocol (X3DH + Double Ratchet)" so the universal promise scopes to where it's true.
- **Discover hero** — drops the "stay encrypted" promise for public groups; points users to DMs for E2E.
- **Create-group toggle** — off-state framed as supported default with server-side moderation; on-state explicitly labelled beta with the wedge case mentioned up front.

## Behind the scenes

- No mechanical behaviour change. Copy only.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual check: login wide-mode brand panel shows new copy
- [ ] Visual check: Discover hero subtitle reads as expected
- [ ] Visual check: Create group screen toggle subtitle matches in both states