### PR TITLE
Cap settings content at 960px (no more ultrawide desert)

### DIFF
--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -552,11 +552,21 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             ),
           ),
           Container(width: 1, color: context.border),
-          // Content area -- fills remaining width
+          // Content area — caps at 960px so the form columns don't sprawl
+          // across an ultrawide display with a desert of empty pixels
+          // between the sidebar and the actual fields. Wider screens get
+          // the form left-aligned against the sidebar; the surplus space
+          // sits on the trailing edge.
           Expanded(
-            child: SettingsContent(
-              key: ValueKey(_selectedSection),
-              section: _selectedSection,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 960),
+                child: SettingsContent(
+                  key: ValueKey(_selectedSection),
+                  section: _selectedSection,
+                ),
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary

At 1920×1080 the settings content column stretched to fill all available width, but the actual form fields only consumed ~600px — leaving a desert of empty pixels between the sidebar and the content. F-036 in the 2026-05-19 UI audit.

## Improved

- Settings content now caps at 960px and left-aligns against the sidebar; surplus width sits on the trailing edge.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual: 1920×1080 — form fields no longer float in the middle with empty space on both sides
- [ ] Visual: 1280×720 — no regression; content still uses what space is available