### PR TITLE
Give Log out its own card in Settings

### DIFF
--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -233,6 +233,16 @@ class SettingsRootView extends ConsumerWidget {
                 section: SettingsSection.about,
                 trailing: 'v$appVersion',
               ),
+            ],
+          ),
+          // Log out lives in its own card so the destructive action sits
+          // alone, visually divorced from neutral chrome like "About".
+          // Pattern matches the standard "destructive action at the bottom"
+          // shape from iOS Settings / Discord / etc. F-039 in the
+          // 2026-05-19 UI audit.
+          const SizedBox(height: EchoSectionTokens.groupGap),
+          _CardGroup(
+            children: [
               CardRow(
                 icon: Icons.logout,
                 iconColor: EchoTheme.danger,


### PR DESCRIPTION
## Summary

Log out was glued inside the same card group as the neutral "About" row, so the destructive red action sat one tap below an informational link. F-039 in the 2026-05-19 UI audit.

## Improved

- Log out promoted to its own card with the same group-gap divider used between every other section group. Pattern matches iOS Settings / Discord / etc.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual: Settings root — About row and Log out row visually separated by the standard gap, not stacked in the same card