### PR TITLE
Onboarding: honest time estimate + dignified Skip step

### DIFF
--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -392,7 +392,8 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
                     ),
                     const SizedBox(height: 8),
                     Text(
-                      'A few quick questions to set up your profile.',
+                      'About 90 seconds. Skip any step you don\'t need now '
+                      '— you can always come back from Settings.',
                       style: TextStyle(
                         fontSize: 14,
                         color: context.textSecondary,
@@ -1389,7 +1390,12 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
         if (!isLast)
           TextButton(
             onPressed: _saving ? null : _skip,
-            child: Text('Skip', style: TextStyle(color: context.textMuted)),
+            // Skip is a first-class option — drop the muted color so it
+            // doesn't read as a dead link. Same textSecondary as Back.
+            child: Text(
+              'Skip step',
+              style: TextStyle(color: context.textSecondary),
+            ),
           ),
         const Spacer(),
         FilledButton(


### PR DESCRIPTION
## Summary

Onboarding sells itself as "A few quick questions" but walks the user through six steps, and the existing Skip rendered in muted grey so it looked like a dead link instead of a real choice. F-032 in the 2026-05-19 UI audit; user asked to keep 6 steps but improve the progress UX.

## Improved

- Rail subtitle now says the actual time budget ("About 90 seconds") and tells the user they can come back from Settings — first-time users don't feel railroaded into finishing.
- Skip is renamed to "Skip step" and gets the same textSecondary color as Back, so it reads as a first-class option not a dead link.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual: onboarding step 1 — rail subtitle reads the new copy
- [ ] Visual: every non-final step — Skip step renders in standard secondary text color