### PR TITLE
Own-message decrypt failures show what you wrote + Resend

### DIFF
--- a/apps/client/lib/src/widgets/message/message_indicators.dart
+++ b/apps/client/lib/src/widgets/message/message_indicators.dart
@@ -148,3 +148,93 @@ class DecryptFailurePill extends StatelessWidget {
     );
   }
 }
+
+/// Recovery affordance for the sender's OWN message when decrypt-back-to-
+/// self fails (group-E2E wedge case, CLAUDE.md note #344). Renders the
+/// user's preserved [originalText] at reduced opacity so they see what
+/// they actually wrote, with a footer that points out only they can see
+/// it locally + Resend/Delete callbacks.
+///
+/// Other messengers (Signal, iMessage, WhatsApp) never surface this case
+/// to the sender because they keep the plaintext locally; Element X
+/// added an in-thread retry-with-key-refresh affordance. Echo's approach
+/// matches Element's because the wedge can happen between identity-key
+/// drifts that we can recover from via [seedInitialGroupKey].
+class OwnDecryptFailedBubble extends StatelessWidget {
+  final String originalText;
+  final VoidCallback? onResend;
+  final VoidCallback? onDelete;
+
+  const OwnDecryptFailedBubble({
+    super.key,
+    required this.originalText,
+    this.onResend,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Opacity(
+          opacity: 0.7,
+          child: Text(
+            originalText,
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+        ),
+        const SizedBox(height: 6),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 14,
+              color: EchoTheme.warning.withValues(alpha: 0.9),
+            ),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                "Only you can see this — recipients couldn't decrypt",
+                style: TextStyle(fontSize: 11, color: context.textMuted),
+              ),
+            ),
+            if (onResend != null) ...[
+              const SizedBox(width: 8),
+              TextButton(
+                onPressed: onResend,
+                style: TextButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  foregroundColor: context.accent,
+                ),
+                child: const Text('Resend', style: TextStyle(fontSize: 11)),
+              ),
+            ],
+            if (onDelete != null) ...[
+              TextButton(
+                onPressed: onDelete,
+                style: TextButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  foregroundColor: context.textMuted,
+                ),
+                child: const Text('Delete', style: TextStyle(fontSize: 11)),
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -806,6 +806,21 @@ class _MessageItemState extends State<MessageItem>
       );
     }
     if (_isDecryptFailure(msg.content)) {
+      // Sender side: if WE drafted this message and the system preserved
+      // the original text in failedContent, show the user what they wrote
+      // (dimmed) with a Resend/Delete footer rather than the generic
+      // "couldn't decrypt" pill — the pill makes it look like the message
+      // was sent by someone else. F-006 / expert recommendation in the
+      // 2026-05-19 UI audit.
+      if (isMine && (msg.failedContent ?? '').isNotEmpty) {
+        return OwnDecryptFailedBubble(
+          originalText: msg.failedContent!,
+          onResend: widget.onRetry == null ? null : () => widget.onRetry!(msg),
+          onDelete: widget.onDelete == null
+              ? null
+              : () => widget.onDelete!(msg),
+        );
+      }
       return const DecryptFailurePill();
     }
 


### PR DESCRIPTION
## Summary

When your own message failed to decrypt-back-to-self (group-E2E wedge case, CLAUDE.md note #344), the bubble rendered the same generic "Couldn't decrypt" lozenge that receivers see — making your message look like someone else sent it and now it's permanently lost.

F-006 in the 2026-05-19 UI audit. The uiux expert pulled the right precedent: Element X added an in-thread retry-with-key-refresh because their threat model matches Echo's (group key can wedge under identity drift). Signal/WhatsApp/iMessage never hit this case because they keep plaintext locally.

## Fixed

- Sender-side decrypt failures now render \`OwnDecryptFailedBubble\` instead of the generic pill. The user sees:
  - Their drafted text (\`failedContent\`) at 70% opacity so they know what they actually wrote
  - A clarifying footer: "Only you can see this — recipients couldn't decrypt"
  - Inline **Resend** (re-encrypt + send as new message) and **Delete** actions

Receiver side is unchanged (generic pill).

## Test plan

- [x] \`flutter analyze\` passes
- [x] \`flutter test test/widgets/message_item_test.dart\` — all 37 tests pass
- [ ] Visual: trigger an own-message wedge → bubble shows drafted text + footer + Resend works
- [ ] Visual: receiver-side wedge still shows generic pill (no regression)