### PR TITLE
Voice dock flows inline above sidebar chrome (no more bug-report occlusion)

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -34,7 +34,6 @@ import '../widgets/keyboard_shortcuts_overlay.dart';
 import '../widgets/global_search_overlay.dart';
 import '../widgets/whats_new_modal.dart';
 import '../widgets/quick_switcher_overlay.dart';
-import '../widgets/voice_dock.dart';
 import '../widgets/voice_footer.dart';
 import '../widgets/window_chrome.dart';
 import 'contacts_screen.dart';
@@ -1109,8 +1108,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                     ..._buildMembersPanel(),
                   ],
                 ),
-                if (voiceActive && !_showSettings)
-                  _buildDesktopVoiceDock(animatedSidebarWidth),
+                // Voice dock used to float here as an AnimatedPositioned
+                // overlay at bottom: 60, which made it occlude the sidebar
+                // chrome (bug-report row, update banner). It now renders
+                // inline inside ConversationPanel just above the bottom
+                // chrome so everything flows naturally and nothing is
+                // covered. F-029 in the 2026-05-19 UI audit.
                 if (_whatsNewNotes != null)
                   WhatsNewInlineOverlay(
                     notes: _whatsNewNotes!,
@@ -1276,26 +1279,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     ];
   }
 
-  /// Voice dock positioned above the user status bar.
-  Widget _buildDesktopVoiceDock(double animatedSidebarWidth) {
-    return AnimatedPositioned(
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeInOut,
-      bottom: 60,
-      left: 0,
-      width: animatedSidebarWidth,
-      child: VoiceDock(
-        width: animatedSidebarWidth,
-        collapsed: _sidebarCollapsed,
-        onNavigateToLounge: () {
-          setState(() {
-            _showingLounge = true;
-            _userDismissedLounge = false;
-          });
-        },
-      ),
-    );
-  }
+  // _buildDesktopVoiceDock removed — VoiceDock now renders inline inside
+  // ConversationPanel above the bottom chrome (status bar, update banner,
+  // bug-report row) so the dock no longer occludes those rows.
+  // F-029 in the 2026-05-19 UI audit.
 
   /// Tablet layout (600-899px): sidebar + flex chat
   Widget _buildWideLayout() {

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -32,6 +32,7 @@ import 'echo_logo_icon.dart';
 import 'empty_state.dart';
 import 'feedback_dialog.dart';
 import 'skeleton_loader.dart';
+import 'voice_dock.dart';
 import 'voice_footer.dart';
 
 // Re-export avatar utilities so existing `show` imports keep working.
@@ -549,14 +550,25 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               // Hide the status bar on mobile narrow — redundant with the
               // bottom tab bar that already exposes Settings + identity.
               //
-              // The update banner / bug-report row sits ABOVE the VoiceFooter
-              // so the desktop voice-dock overlay (`_buildDesktopVoiceDock`,
-              // anchored at `bottom: 60`) can't cover the bug-report button
-              // when a call is active (#913).
+              // Stack from top → bottom of the sidebar bottom chrome:
+              //   1. VoiceDock — full call controls when voice is active
+              //      (renders SizedBox.shrink() otherwise)
+              //   2. Update banner / bug-report row
+              //   3. VoiceFooter — slim "tap to return to lounge" handle
+              //      while voice is active (collapses when inactive)
+              //   4. User status bar
+              // VoiceDock used to be a floating AnimatedPositioned overlay
+              // at `bottom: 60` which occluded everything beneath it
+              // (F-029 in the 2026-05-19 UI audit) — flowing it inline
+              // means the bug-report and update affordances stay reachable
+              // during a call.
+              if (MediaQuery.sizeOf(context).width >= 600)
+                VoiceDock(
+                  width: 320,
+                  onNavigateToLounge: widget.onNavigateToLounge,
+                ),
               if (MediaQuery.sizeOf(context).width >= 600)
                 _buildSidebarUpdateBanner(context),
-              // Explicit gap between bug-report row and voice dock to prevent
-              // visual occlusion when corners round.
               if (MediaQuery.sizeOf(context).width >= 600)
                 const SizedBox(height: 4),
               // On narrow (mobile), VoiceFooter is rendered at the Scaffold


### PR DESCRIPTION
## Summary

VoiceDock used to render as an \`AnimatedPositioned\` overlay anchored at \`bottom: 60\` inside the home screen Stack, which floated it over whatever sat at the bottom of the sidebar — status bar, update banner, bug-report row — occluding those rows entirely during a call. F-029 in the 2026-05-19 UI audit; user explicitly asked for the dock to "stack up above whatever appears below it instead of a fixed position".

## Fixed

- VoiceDock moves into the ConversationPanel column flow. Stack order (top→bottom of bottom chrome): VoiceDock → Update banner / bug-report row → VoiceFooter (slim return-to-lounge handle) → User status bar.
- VoiceDock returns \`SizedBox.shrink()\` when voice is inactive, so the column is unchanged when no call is in progress.
- Drops the \`_buildDesktopVoiceDock\` helper + AnimatedPositioned overlay in home_screen.dart.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual: start a voice call → VoiceDock visible at bottom of sidebar with mute/deafen/hangup controls
- [ ] Visual: bug-report row + update banner still visible and tappable during a call
- [ ] Visual: end the call → dock collapses, no layout shift on the rest of the sidebar