### PR TITLE
Semantic labels: testability + a11y batch 1

### DIFF
--- a/apps/client/lib/src/screens/discover_groups_screen.dart
+++ b/apps/client/lib/src/screens/discover_groups_screen.dart
@@ -562,110 +562,120 @@ class _GroupDiscoveryItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
-      child: Material(
-        color: context.cardRowBg,
-        borderRadius: BorderRadius.circular(14),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final isNarrow = constraints.maxWidth < 400;
-                final joinButton = _buildJoinAffordance(context);
-                final nameColumn = Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        group.name,
-                        style: TextStyle(
-                          color: context.textPrimary,
-                          fontSize: 15,
-                          fontWeight: FontWeight.w700,
-                        ),
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      const SizedBox(height: 4),
-                      Row(
-                        children: [
-                          Container(
-                            width: 6,
-                            height: 6,
-                            decoration: const BoxDecoration(
-                              color: EchoTheme.online,
-                              shape: BoxShape.circle,
-                            ),
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            '${_onlineCount(group)}',
-                            style: const TextStyle(
-                              color: EchoTheme.online,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Text(
-                            '${group.memberCount} member${group.memberCount == 1 ? '' : 's'}',
-                            style: TextStyle(
-                              color: context.textMuted,
-                              fontSize: 12,
-                            ),
-                          ),
-                        ],
-                      ),
-                      if (group.description != null &&
-                          group.description!.isNotEmpty) ...[
-                        const SizedBox(height: 6),
+      child: Semantics(
+        label: 'discover group ${group.name} — tap to preview',
+        button: true,
+        child: Material(
+          color: context.cardRowBg,
+          borderRadius: BorderRadius.circular(14),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final isNarrow = constraints.maxWidth < 400;
+                  final joinButton = _buildJoinAffordance(context);
+                  final nameColumn = Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
                         Text(
-                          group.description!,
+                          group.name,
                           style: TextStyle(
-                            color: context.textSecondary,
-                            fontSize: 13,
-                            height: 1.35,
+                            color: context.textPrimary,
+                            fontSize: 15,
+                            fontWeight: FontWeight.w700,
                           ),
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
+                        const SizedBox(height: 4),
+                        Row(
+                          children: [
+                            Container(
+                              width: 6,
+                              height: 6,
+                              decoration: const BoxDecoration(
+                                color: EchoTheme.online,
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              '${_onlineCount(group)}',
+                              style: const TextStyle(
+                                color: EchoTheme.online,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              '${group.memberCount} member${group.memberCount == 1 ? '' : 's'}',
+                              style: TextStyle(
+                                color: context.textMuted,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                        if (group.description != null &&
+                            group.description!.isNotEmpty) ...[
+                          const SizedBox(height: 6),
+                          Text(
+                            group.description!,
+                            style: TextStyle(
+                              color: context.textSecondary,
+                              fontSize: 13,
+                              height: 1.35,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                        if (isNarrow) ...[
+                          const SizedBox(height: 10),
+                          joinButton,
+                        ],
                       ],
-                      if (isNarrow) ...[const SizedBox(height: 10), joinButton],
-                    ],
-                  ),
-                );
+                    ),
+                  );
 
-                return ConstrainedBox(
-                  constraints: const BoxConstraints(minHeight: 68),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Group avatar — bright solid background with white glyph,
-                      // deterministically picked from the group palette.
-                      Container(
-                        width: 44,
-                        height: 44,
-                        decoration: BoxDecoration(
-                          color: groupAvatarColor(group.name),
-                          borderRadius: BorderRadius.circular(22),
+                  return ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 68),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Group avatar — bright solid background with white glyph,
+                        // deterministically picked from the group palette.
+                        Container(
+                          width: 44,
+                          height: 44,
+                          decoration: BoxDecoration(
+                            color: groupAvatarColor(group.name),
+                            borderRadius: BorderRadius.circular(22),
+                          ),
+                          alignment: Alignment.center,
+                          child: const Icon(
+                            Icons.group,
+                            size: 22,
+                            color: Colors.white,
+                          ),
                         ),
-                        alignment: Alignment.center,
-                        child: const Icon(
-                          Icons.group,
-                          size: 22,
-                          color: Colors.white,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      // Name + stats + description (+ button on narrow)
-                      nameColumn,
-                      if (!isNarrow) ...[const SizedBox(width: 12), joinButton],
-                    ],
-                  ),
-                );
-              },
+                        const SizedBox(width: 12),
+                        // Name + stats + description (+ button on narrow)
+                        nameColumn,
+                        if (!isNarrow) ...[
+                          const SizedBox(width: 12),
+                          joinButton,
+                        ],
+                      ],
+                    ),
+                  );
+                },
+              ),
             ),
           ),
         ),

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -243,12 +243,16 @@ class SettingsRootView extends ConsumerWidget {
           const SizedBox(height: EchoSectionTokens.groupGap),
           _CardGroup(
             children: [
-              CardRow(
-                icon: Icons.logout,
-                iconColor: EchoTheme.danger,
-                label: 'Log out',
-                destructive: true,
-                onTap: onLogout,
+              Semantics(
+                label: 'settings log-out',
+                button: true,
+                child: CardRow(
+                  icon: Icons.logout,
+                  iconColor: EchoTheme.danger,
+                  label: 'Log out',
+                  destructive: true,
+                  onTap: onLogout,
+                ),
               ),
             ],
           ),
@@ -266,14 +270,20 @@ class SettingsRootView extends ConsumerWidget {
     String? trailing,
   }) {
     final isSelected = selected == section;
-    return Container(
-      color: isSelected ? context.accentLight : null,
-      child: CardRow(
-        icon: icon,
-        iconColor: iconColor,
-        label: settingsSectionLabel(section),
-        trailingValue: trailing,
-        onTap: () => onTap(section),
+    final slug = section.name.toLowerCase();
+    return Semantics(
+      label: 'settings tab $slug',
+      button: true,
+      selected: isSelected,
+      child: Container(
+        color: isSelected ? context.accentLight : null,
+        child: CardRow(
+          icon: icon,
+          iconColor: iconColor,
+          label: settingsSectionLabel(section),
+          trailingValue: trailing,
+          onTap: () => onTap(section),
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -682,25 +682,33 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           // Right: non-draggable action buttons.
           // All icons at 18px with uniform 44x44 tap targets per WCAG 2.5.5.
           if (widget.onScanQr != null)
-            IconButton(
-              icon: const Icon(Icons.qr_code_scanner, size: 18),
-              color: context.textSecondary,
-              tooltip: 'Scan QR to add contact',
-              onPressed: widget.onScanQr,
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+            Semantics(
+              label: 'scan QR to add contact',
+              button: true,
+              child: IconButton(
+                icon: const Icon(Icons.qr_code_scanner, size: 18),
+                color: context.textSecondary,
+                tooltip: 'Scan QR to add contact',
+                onPressed: widget.onScanQr,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              ),
             ),
           const SizedBox(width: 2),
           _buildNewActionMenu(context, pendingCount),
           if (!isMobile && widget.onShowKeyboardShortcuts != null) ...[
             const SizedBox(width: 2),
-            IconButton(
-              icon: const Icon(Icons.help_outline, size: 18),
-              color: context.textSecondary,
-              tooltip: 'Keyboard shortcuts (Ctrl+/)',
-              onPressed: widget.onShowKeyboardShortcuts,
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+            Semantics(
+              label: 'show keyboard shortcuts',
+              button: true,
+              child: IconButton(
+                icon: const Icon(Icons.help_outline, size: 18),
+                color: context.textSecondary,
+                tooltip: 'Keyboard shortcuts (Ctrl+/)',
+                onPressed: widget.onShowKeyboardShortcuts,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              ),
             ),
           ],
           // Global-search entrypoint on both mobile and desktop. The
@@ -710,26 +718,34 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           // (see the feedback_desktop_search memory rule).
           if (widget.onGlobalSearch != null) ...[
             const SizedBox(width: 2),
-            IconButton(
-              icon: const Icon(Icons.search_outlined, size: 18),
-              color: context.textSecondary,
-              tooltip: isMobile
-                  ? 'Search messages'
-                  : 'Search messages (Ctrl+Shift+F)',
-              onPressed: widget.onGlobalSearch,
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+            Semantics(
+              label: 'global search',
+              button: true,
+              child: IconButton(
+                icon: const Icon(Icons.search_outlined, size: 18),
+                color: context.textSecondary,
+                tooltip: isMobile
+                    ? 'Search messages'
+                    : 'Search messages (Ctrl+Shift+F)',
+                onPressed: widget.onGlobalSearch,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              ),
             ),
           ],
           if (widget.onCollapseSidebar != null) ...[
             const SizedBox(width: 2),
-            IconButton(
-              icon: const Icon(Icons.chevron_left, size: 18),
-              color: context.textSecondary,
-              tooltip: 'Collapse sidebar',
-              onPressed: widget.onCollapseSidebar,
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+            Semantics(
+              label: 'collapse sidebar',
+              button: true,
+              child: IconButton(
+                icon: const Icon(Icons.chevron_left, size: 18),
+                color: context.textSecondary,
+                tooltip: 'Collapse sidebar',
+                onPressed: widget.onCollapseSidebar,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              ),
             ),
           ],
         ],
@@ -746,100 +762,109 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     return Stack(
       clipBehavior: Clip.none,
       children: [
-        PopupMenuButton<String>(
-          icon: Icon(Icons.add, size: 18, color: context.textSecondary),
-          tooltip: 'New',
-          padding: EdgeInsets.zero,
-          // 44×44 tap target per WCAG 2.5.5
-          constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
-          // Menu minimum width so text never clips on narrow viewports
-          menuPadding: const EdgeInsets.symmetric(vertical: 4),
-          popUpAnimationStyle: AnimationStyle.noAnimation,
-          offset: const Offset(0, 36),
-          onSelected: (value) {
-            switch (value) {
-              case 'chat':
-                widget.onNewChat?.call();
-              case 'group':
-                widget.onNewGroup?.call();
-              case 'discover':
-                widget.onDiscover?.call();
-              case 'saved':
-                widget.onSavedMessages?.call();
-            }
-          },
-          itemBuilder: (context) => const [
-            PopupMenuItem(
-              value: 'chat',
-              child: SizedBox(
-                width: 200,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.person_add_outlined, size: 18),
-                    SizedBox(width: 10),
-                    Flexible(
-                      child: Text('New Chat', overflow: TextOverflow.ellipsis),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            PopupMenuItem(
-              value: 'group',
-              child: SizedBox(
-                width: 200,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.group_add_outlined, size: 18),
-                    SizedBox(width: 10),
-                    Flexible(
-                      child: Text('New Group', overflow: TextOverflow.ellipsis),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            PopupMenuItem(
-              value: 'discover',
-              child: SizedBox(
-                width: 200,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.explore_outlined, size: 18),
-                    SizedBox(width: 10),
-                    Flexible(
-                      child: Text(
-                        'Discover Groups',
-                        overflow: TextOverflow.ellipsis,
+        Semantics(
+          label: 'new chat menu',
+          button: true,
+          child: PopupMenuButton<String>(
+            icon: Icon(Icons.add, size: 18, color: context.textSecondary),
+            tooltip: 'New',
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+            // Menu minimum width so text never clips on narrow viewports
+            menuPadding: const EdgeInsets.symmetric(vertical: 4),
+            popUpAnimationStyle: AnimationStyle.noAnimation,
+            offset: const Offset(0, 36),
+            onSelected: (value) {
+              switch (value) {
+                case 'chat':
+                  widget.onNewChat?.call();
+                case 'group':
+                  widget.onNewGroup?.call();
+                case 'discover':
+                  widget.onDiscover?.call();
+                case 'saved':
+                  widget.onSavedMessages?.call();
+              }
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(
+                value: 'chat',
+                child: SizedBox(
+                  width: 200,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.person_add_outlined, size: 18),
+                      SizedBox(width: 10),
+                      Flexible(
+                        child: Text(
+                          'New Chat',
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-            PopupMenuItem(
-              value: 'saved',
-              child: SizedBox(
-                width: 200,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.bookmark_border_outlined, size: 18),
-                    SizedBox(width: 10),
-                    Flexible(
-                      child: Text(
-                        'Saved Messages',
-                        overflow: TextOverflow.ellipsis,
+              PopupMenuItem(
+                value: 'group',
+                child: SizedBox(
+                  width: 200,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.group_add_outlined, size: 18),
+                      SizedBox(width: 10),
+                      Flexible(
+                        child: Text(
+                          'New Group',
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ],
+              PopupMenuItem(
+                value: 'discover',
+                child: SizedBox(
+                  width: 200,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.explore_outlined, size: 18),
+                      SizedBox(width: 10),
+                      Flexible(
+                        child: Text(
+                          'Discover Groups',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              PopupMenuItem(
+                value: 'saved',
+                child: SizedBox(
+                  width: 200,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.bookmark_border_outlined, size: 18),
+                      SizedBox(width: 10),
+                      Flexible(
+                        child: Text(
+                          'Saved Messages',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
         if (pendingCount > 0 &&
             (kIsWeb ||
@@ -1262,16 +1287,20 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       child: Align(
         alignment: Alignment.centerLeft,
-        child: TextButton.icon(
-          icon: const Icon(Icons.bug_report_outlined, size: 14),
-          label: const Text('Report a bug'),
-          onPressed: () => showFeedbackDialog(context),
-          style: TextButton.styleFrom(
-            foregroundColor: context.textMuted,
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            minimumSize: Size.zero,
-            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            textStyle: const TextStyle(fontSize: 11),
+        child: Semantics(
+          label: 'report a bug',
+          button: true,
+          child: TextButton.icon(
+            icon: const Icon(Icons.bug_report_outlined, size: 14),
+            label: const Text('Report a bug'),
+            onPressed: () => showFeedbackDialog(context),
+            style: TextButton.styleFrom(
+              foregroundColor: context.textMuted,
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              textStyle: const TextStyle(fontSize: 11),
+            ),
           ),
         ),
       ),
@@ -1306,13 +1335,17 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
           ),
           const SizedBox(width: 10),
           _buildUserNameAndStatus(context, myUsername, wsConnected, wsReplaced),
-          IconButton(
-            icon: const Icon(Icons.settings_outlined, size: 18),
-            color: context.textSecondary,
-            tooltip: 'Settings',
-            onPressed: widget.onSettings,
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+          Semantics(
+            label: 'open settings',
+            button: true,
+            child: IconButton(
+              icon: const Icon(Icons.settings_outlined, size: 18),
+              color: context.textSecondary,
+              tooltip: 'Settings',
+              onPressed: widget.onSettings,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+            ),
           ),
         ],
       ),

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -360,7 +360,7 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
         widget.canRemove && !widget.isMe && _isHovered && !_isRemoving;
 
     return Semantics(
-      label: 'member: ${member.username}',
+      label: 'member ${member.username} — open profile',
       button: true,
       child: GestureDetector(
         onTap: () {


### PR DESCRIPTION
## Summary

Adds explicit \`Semantics\` labels to the surfaces the 2026-05-19 audit captured as uncapturable or brittle in Playwright (\`docs/ui-audit-2026-05-19/semantic-labels-needed.md\`). Same change satisfies the screen-reader/keyboard accessibility gap.

## Improved (9 of 14 from the doc)

- Settings sidebar items — \`settings tab <slug>\` labels + \`selected: <active>\` so tests/screen readers can target each tab
- Settings **Log out** row — \`settings log-out\` label
- **Member rows** in right rail — \`member <username> — open profile\` (scopes uniquely vs the panel header)
- **Settings cog** in bottom-left status row — \`open settings\`
- **Sidebar header icons** (scan-QR, help, search, collapse) — explicit per-icon labels
- **"+" header menu** — \`new chat menu\` label
- **Bug-report row** — \`report a bug\` label
- **Discover group cards** — \`discover group <name> — tap to preview\` (per-card scoped selectors)

## Deferred to a follow-up sprint

- Voice dock controls (mute/deafen/hangup) — M-effort, voice_dock.dart
- Channel chips — channel_bar.dart
- Mobile login form field labels (mobile selectors diverge from desktop)
- Onboarding Next button + the flt-semantics interceptor blocking step 4+ in tests

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Playwright: \`page.locator('flt-semantics[aria-label="settings tab status"]').click()\` flips selection
- [ ] Playwright: \`page.locator('flt-semantics[aria-label*="discover group Taco"]')\` matches exactly one card