### PR TITLE
Align settings + onboarding tests with shipped copy

### DIFF
--- a/apps/client/test/screens/onboarding_wizard_test.dart
+++ b/apps/client/test/screens/onboarding_wizard_test.dart
@@ -59,7 +59,7 @@ void main() {
   testWidgets('wizard shows a Skip control on the first page', (tester) async {
     await pumpWizard(tester);
 
-    expect(find.widgetWithText(TextButton, 'Skip'), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Skip step'), findsOneWidget);
     expect(find.widgetWithText(FilledButton, 'Next'), findsOneWidget);
   });
 }

--- a/apps/client/test/widgets/settings_screen_test.dart
+++ b/apps/client/test/widgets/settings_screen_test.dart
@@ -110,8 +110,8 @@ void main() {
       await tester.pumpWidget(_rootApp());
       await tester.pumpAndSettle();
 
-      expect(find.text('ACCOUNT PREFERENCES'), findsOneWidget);
-      expect(find.text('ECHO'), findsOneWidget);
+      expect(find.text('Account preferences'), findsOneWidget);
+      expect(find.text('Echo'), findsOneWidget);
     });
 
     testWidgets('renders Log out button', (tester) async {


### PR DESCRIPTION
## Summary

Two test assertions still matched the pre-#985 / pre-#992 copy and broke the post-merge CI run on main after #995:

- \`settings_screen_test\` expected \`'ACCOUNT PREFERENCES'\` / \`'ECHO'\` but #985 dropped the all-caps treatment.
- \`onboarding_wizard_test\` expected bare \`'Skip'\` but #992 renamed the button to \`'Skip step'\`.

No production code change. Both files updated to match what the app actually renders.

## Test plan

- [x] \`flutter test test/widgets/settings_screen_test.dart test/screens/onboarding_wizard_test.dart\` — 9/9 pass locally