### PR TITLE
Drop redundant VoiceFooter on desktop (VoiceDock already covers it)

### DIFF
--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -572,8 +572,10 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               if (MediaQuery.sizeOf(context).width >= 600)
                 const SizedBox(height: 4),
               // On narrow (mobile), VoiceFooter is rendered at the Scaffold
-              // level in home_screen.dart above the bottom tab bar.
-              if (MediaQuery.sizeOf(context).width >= 600)
+              // level in home_screen.dart above the bottom tab bar — desktop
+              // exposes the same tap-to-return-to-lounge through VoiceDock
+              // above, so we don't double up on a second voice ribbon.
+              if (MediaQuery.sizeOf(context).width < 600)
                 VoiceFooter(onNavigateToLounge: widget.onNavigateToLounge),
               if (MediaQuery.sizeOf(context).width >= 600)
                 _buildUserStatusBar(


### PR DESCRIPTION
## Summary

After #994 moved VoiceDock into the sidebar column flow, both the dock and the slim VoiceFooter ribbon rendered simultaneously on desktop — two voice surfaces stacked with duplicate hangup glyphs. Direct user feedback flagged this.

## Fixed

- VoiceFooter limited to narrow/mobile (<600px) where it's still the only voice surface; desktop relies on VoiceDock alone (which already exposes tap-to-return-to-lounge via \`onNavigateToLounge\`).

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual: start a voice call on desktop → only VoiceDock visible, no green ribbon below
- [ ] Visual: mobile narrow viewport → VoiceFooter still appears as the single voice surface