### PR TITLE
Drop the in-app local-network permission explainer

### DIFF
--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -14,7 +14,6 @@ import '../providers/crypto_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/websocket_provider.dart';
-import '../services/local_network_permission_service.dart';
 import '../services/message_cache.dart';
 import '../services/push_token_service.dart';
 import '../services/update_service.dart' as update_svc;
@@ -76,18 +75,11 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     // last-known size after navigation lands on home/login.
     await WindowStateService.enterSplash();
 
-    // Prime the iOS/macOS local-network permission popup with an in-app
-    // explainer BEFORE any non-loopback request — auto-login below contacts
-    // the server, which is what triggers the OS popup. Running the
-    // explainer after auto-login (the previous ordering) was a no-op:
-    // testers hit "Don't Allow" on the bare OS dialog and silently broke
-    // server connectivity. No-op on other platforms and after the first
-    // run. Not gated on login state so first-launch unauthenticated users
-    // also see the context before the register/login form's first request.
-    if (mounted) {
-      await LocalNetworkPermissionService.showIfNeeded(context);
-      if (!mounted) return;
-    }
+    // The iOS/macOS local-network permission explainer used to fire here
+    // before auto-login. Removed per direct user feedback — the bare OS
+    // dialog is enough, and the in-app overlay added friction on the
+    // splash that users didn't want. The service file is kept in case
+    // we want to restore a friendlier variant later.
 
     _setStatus('Checking session…');
     final loggedIn = await _attemptAutoLogin();


### PR DESCRIPTION
## Summary

The iOS/macOS local-network permission overlay fired on splash before auto-login to "prime" the OS dialog with context. User feedback: it adds friction without value; the bare OS prompt is enough.

## Removed

- Splash-time \`LocalNetworkPermissionService.showIfNeeded\` call and the now-unused import.

The service file itself is kept on disk in case we want to restore a friendlier variant later.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual: cold start on iOS/macOS — no in-app explainer overlay; only the native OS prompt appears