### PR TITLE
Onboarding: stop the logo crashing into the iOS dynamic island

### DIFF
--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -267,7 +267,9 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
           const AppTitleBar(),
           Expanded(
             child: SafeArea(
-              top: false,
+              // top: true so the page content (and the narrow-layout
+              // EchoLogoIcon) doesn't collide with the iOS status bar /
+              // dynamic island. Bottom safe area continues to apply.
               child: Center(
                 child: LayoutBuilder(
                   builder: (context, outerConstraints) {
@@ -295,9 +297,11 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         child: Column(
           children: [
-            const SizedBox(height: 12),
-            const EchoLogoIcon(size: 36),
-            const SizedBox(height: 20),
+            // Standalone EchoLogoIcon removed from narrow layout — the
+            // Welcome page header already brands the screen and on iOS
+            // the logo collided with the dynamic island. The wide-layout
+            // brand panel still renders its own logo because it has the
+            // horizontal space to do so cleanly.
             Expanded(child: _buildPageView()),
             const SizedBox(height: 16),
             _buildBottomControls(context),


### PR DESCRIPTION
## Summary

Direct user report: the Echo logo at the top of the onboarding narrow layout was clipped by the iOS status bar / dynamic island.

Two related issues:
1. \`SafeArea(top: false)\` let content render up into the status bar.
2. A redundant \`EchoLogoIcon(size: 36)\` sat at the very top of the narrow column, overlapping system UI.

## Fixed

- Enable top safe area on onboarding so content sits below the status bar.
- Drop the standalone narrow-layout logo — the Welcome page header already brands the screen. Wide layout's brand panel keeps its logo (has the horizontal space).

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual on iPhone with dynamic island: no logo overlapping the island
- [ ] Visual on desktop wide: brand panel logo unchanged