### PR TITLE
Avatar cropper: roomier on desktop + zoom slider for mouse users

### DIFF
--- a/apps/client/lib/src/widgets/avatar_crop_dialog.dart
+++ b/apps/client/lib/src/widgets/avatar_crop_dialog.dart
@@ -115,8 +115,12 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
   // The decoded image (nullable until async decode completes).
   img.Image? _decoded;
 
-  // Viewport dimensions for the preview area.
-  static const _previewSize = 280.0;
+  // Viewport dimensions for the preview area. Picked at runtime in
+  // [_resolvePreviewSize] so the desktop window gets a roomier cropper
+  // (mouse users can't pinch-zoom; they pan + use the zoom slider).
+  static const _previewSizeMobile = 280.0;
+  static const _previewSizeDesktop = 460.0;
+  double _previewSize = _previewSizeMobile;
 
   // Scale and offset of the image inside the preview square.
   // The image is scaled so its shorter side fills the preview initially.
@@ -135,6 +139,32 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
   void initState() {
     super.initState();
     _decodeImage();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Pick a roomier viewport on desktop where pinch isn't available.
+    // The phone-friendly default stays for narrow viewports.
+    final w = MediaQuery.sizeOf(context).width;
+    final isDesktop = w >= 800;
+    final desired = isDesktop ? _previewSizeDesktop : _previewSizeMobile;
+    if (_previewSize != desired) {
+      _previewSize = desired;
+      // Re-fit the image to the new viewport if it was already decoded.
+      if (_decoded != null) {
+        final imgW = _decoded!.width.toDouble();
+        final imgH = _decoded!.height.toDouble();
+        final initScale = _previewSize / (imgW < imgH ? imgW : imgH);
+        _scale = initScale;
+        final scaledW = imgW * _scale;
+        final scaledH = imgH * _scale;
+        _offset = Offset(
+          (_previewSize - scaledW) / 2,
+          (_previewSize - scaledH) / 2,
+        );
+      }
+    }
   }
 
   Future<void> _decodeImage() async {
@@ -184,6 +214,38 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
     _baseScale = _scale;
     _baseFocalPoint = details.focalPoint;
     _baseOffset = _offset;
+  }
+
+  /// Mouse / accessibility slider — bumps [_scale] without pinch.
+  /// Keeps the image centred on the new scale so the crop frame stays
+  /// sensible across the full range.
+  void _onZoomSliderChanged(double newScale) {
+    if (_decoded == null) return;
+    final imgW = _decoded!.width.toDouble();
+    final imgH = _decoded!.height.toDouble();
+    final minScale = _previewSize / (imgW < imgH ? imgW : imgH);
+    final clamped = newScale.clamp(minScale, 6.0);
+    // Anchor the zoom on the centre of the preview so the user's frame
+    // doesn't drift off-axis.
+    final centre = Offset(_previewSize / 2, _previewSize / 2);
+    final ratio = clamped / _scale;
+    final newOffset = Offset(
+      centre.dx - (centre.dx - _offset.dx) * ratio,
+      centre.dy - (centre.dy - _offset.dy) * ratio,
+    );
+    // Inline clamp using the new scale; _clampOffset reads _scale via
+    // closure, so apply the update first then clamp.
+    final scaledW = imgW * clamped;
+    final scaledH = imgH * clamped;
+    final minX = _previewSize - scaledW;
+    final minY = _previewSize - scaledH;
+    setState(() {
+      _scale = clamped;
+      _offset = Offset(
+        newOffset.dx.clamp(minX, 0.0),
+        newOffset.dy.clamp(minY, 0.0),
+      );
+    });
   }
 
   void _onScaleUpdate(ScaleUpdateDetails details) {
@@ -301,13 +363,48 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
                 ),
               ),
             Text(
-              'Pan and pinch to frame your avatar',
+              'Drag to frame · use the slider to zoom',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),
             ),
             const SizedBox(height: 12),
             _buildCropPreview(),
+            if (_decoded != null) ...[
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Icon(
+                    Icons.zoom_out,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  Expanded(
+                    child: Slider(
+                      min:
+                          _previewSize /
+                          (_decoded!.width < _decoded!.height
+                              ? _decoded!.width.toDouble()
+                              : _decoded!.height.toDouble()),
+                      max: 6.0,
+                      value: _scale.clamp(
+                        _previewSize /
+                            (_decoded!.width < _decoded!.height
+                                ? _decoded!.width.toDouble()
+                                : _decoded!.height.toDouble()),
+                        6.0,
+                      ),
+                      onChanged: _onZoomSliderChanged,
+                    ),
+                  ),
+                  Icon(
+                    Icons.zoom_in,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ],
+              ),
+            ],
           ],
         ),
       ),
@@ -365,7 +462,7 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
 
               // Circular mask overlay — darkened corners, bright circle border.
               CustomPaint(
-                size: const Size(_previewSize, _previewSize),
+                size: Size(_previewSize, _previewSize),
                 painter: _CircleMaskPainter(scrim: context.overlayScrim),
               ),
             ],


### PR DESCRIPTION
## Summary

Direct user feedback: avatar crop UI is small on desktop and difficult to use. Two related causes — viewport locked at 280×280 regardless of screen, and pinch was the only zoom gesture (no mouse / trackpad path).

## Fixed

- Preview viewport jumps to **460×460** on screens ≥ 800 px wide; keeps 280×280 below that. \`didChangeDependencies\` re-fits the image when the viewport changes.
- New **zoom Slider** with zoom-out / zoom-in glyphs below the preview. Anchors on the preview centre so framing stays put as you scrub.
- Caption updated from "Pan and pinch to frame your avatar" to "Drag to frame · use the slider to zoom".

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual on desktop: cropper renders at 460×460, slider visible, drag-pan + slider-zoom both work
- [ ] Visual on mobile: cropper stays at 280×280, slider visible, pinch + slider both work