### PR TITLE
Center the lounge tile when only you're in the call

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -209,6 +209,20 @@ class ParticipantGrid extends StatelessWidget {
   }
 
   Widget _buildGridLayout(List<Widget> tiles) {
+    // Single-participant case: a 2- or 3-column grid leaves the lone tile
+    // pinned to the top-left of an empty grid. Render a centred, sized tile
+    // so a solo user sees themselves in the middle of the lounge.
+    if (tiles.length == 1) {
+      return Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: 320,
+            maxHeight: 320 * 136 / 112,
+          ),
+          child: AspectRatio(aspectRatio: 112 / 136, child: tiles.first),
+        ),
+      );
+    }
     return OrientationBuilder(
       builder: (context, orientation) {
         final crossAxisCount = orientation == Orientation.portrait ? 2 : 3;


### PR DESCRIPTION
## Summary

Direct user feedback: the voice lounge UI isn't centered when only one user is in the call. The grid was always a 2- (portrait) / 3-column (landscape) GridView, so a solo user saw their tile pinned to the top-left with empty space stretching across the rest of the lounge.

## Fixed

- Special-case \`tiles.length == 1\` in \`_buildGridLayout\` — bypass the grid and render a centred, aspect-correct tile capped at 320 px wide.

## Test plan

- [x] \`flutter analyze\` passes
- [ ] Visual: join a voice channel alone → tile sits centered
- [ ] Visual: a second peer joins → grid expands to 2/3 columns as before