### PR TITLE
@-mention picker: Tab/Enter accept, arrows navigate, Space keeps literal

### DIFF
--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -170,8 +170,53 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _loadDraft(widget.conversation.id);
   }
 
+  /// Index of the selected row in the mention picker. Reset to 0 each time
+  /// the picker opens or the query changes so the first match is always
+  /// the keyboard-accept target.
+  int _mentionPickerIndex = 0;
+  String _lastMentionQuery = '';
+  bool _lastMentionShowing = false;
+
   void _onMentionChanged() {
-    if (mounted) setState(() {});
+    if (!mounted) return;
+    final showing = _mentionController.showPicker;
+    final query = _mentionController.query;
+    // Reset selection on open or on query change so the first row is
+    // always the accept target as the user types.
+    if (showing != _lastMentionShowing || query != _lastMentionQuery) {
+      _mentionPickerIndex = 0;
+    }
+    _lastMentionShowing = showing;
+    _lastMentionQuery = query;
+    setState(() {});
+  }
+
+  /// Candidate values currently rendered by the mention picker. Stays in
+  /// sync with [MentionAutocomplete.candidateValues] so the keyboard
+  /// accept-path lands on the same row the user sees highlighted.
+  List<String> get _mentionCandidates => MentionAutocomplete.candidateValues(
+    _filteredMentionMembers,
+    _mentionController.query,
+  );
+
+  /// Accept the currently-selected mention candidate (Tab/Enter pressed
+  /// while the picker is open). No-op when there are no candidates.
+  void _acceptMentionSelection() {
+    final candidates = _mentionCandidates;
+    if (candidates.isEmpty) return;
+    final idx = _mentionPickerIndex.clamp(0, candidates.length - 1);
+    _handleMentionSelected(candidates[idx]);
+  }
+
+  /// Move the picker selection. Wraps at both ends so quick navigation
+  /// keeps the eye on the picker without tracking edge cases.
+  void _moveMentionSelection(int delta) {
+    final candidates = _mentionCandidates;
+    if (candidates.isEmpty) return;
+    final next = (_mentionPickerIndex + delta) % candidates.length;
+    setState(() {
+      _mentionPickerIndex = next < 0 ? next + candidates.length : next;
+    });
   }
 
   @override
@@ -1438,6 +1483,32 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
 
     if (event is! KeyDownEvent) return KeyEventResult.ignored;
 
+    // Mention picker keyboard nav takes precedence — Tab/Enter accept the
+    // selected row, arrows move it, Escape closes the picker (without
+    // also bubbling Escape through to message edit-cancel).
+    if (_mentionController.showPicker) {
+      if (event.logicalKey == LogicalKeyboardKey.tab ||
+          (event.logicalKey == LogicalKeyboardKey.enter &&
+              !HardwareKeyboard.instance.isShiftPressed)) {
+        _acceptMentionSelection();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+        _moveMentionSelection(-1); // reverse: true list — down moves toward
+        return KeyEventResult.handled; // smaller indices visually
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+        _moveMentionSelection(1);
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.escape) {
+        _mentionController.dismiss();
+        return KeyEventResult.handled;
+      }
+      // Space falls through — extractMentionQuery sees the space and
+      // closes the picker, leaving the literal "@" in the text.
+    }
+
     if (event.logicalKey == LogicalKeyboardKey.escape) {
       _handleEscapeKey();
     }
@@ -1825,6 +1896,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       return MentionAutocomplete(
         members: _filteredMentionMembers,
         mentionQuery: _mentionController.query,
+        selectedIndex: _mentionPickerIndex,
         onMentionSelected: _handleMentionSelected,
       );
     }

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -3,6 +3,22 @@ import 'package:flutter/material.dart';
 import '../../models/conversation.dart';
 import '../../theme/echo_theme.dart';
 
+/// Mention candidates the picker renders. Members come before broadcasts
+/// — Discord pattern, mirrors the listView reverse order so members sit
+/// closest to the composer.
+class MentionCandidate {
+  /// `username` for a member row, broadcast keyword (`everyone`/`here`)
+  /// for a broadcast row. This is what gets passed back to
+  /// [MentionAutocomplete.onMentionSelected].
+  final String value;
+  final bool isBroadcast;
+  final ConversationMember? member;
+  const MentionCandidate.member(this.member) : value = '', isBroadcast = false;
+  const MentionCandidate.broadcast(this.value)
+    : isBroadcast = true,
+      member = null;
+}
+
 /// Displays an autocomplete popup for @-mentioning conversation members.
 ///
 /// Sits above the input bar and filters members based on [mentionQuery].
@@ -13,12 +29,41 @@ class MentionAutocomplete extends StatelessWidget {
   final String mentionQuery;
   final ValueChanged<String> onMentionSelected;
 
+  /// Index into the visible candidate list (members + broadcasts) that
+  /// should render with the selected-row highlight. Driven by the parent
+  /// composer's arrow-key navigation. Clamped internally so out-of-range
+  /// values render as "no row selected".
+  final int selectedIndex;
+
   const MentionAutocomplete({
     super.key,
     required this.members,
     required this.mentionQuery,
     required this.onMentionSelected,
+    this.selectedIndex = 0,
   });
+
+  /// Computes the candidate list the picker would render for [members]
+  /// and [mentionQuery]. Same ordering as the rendered ListView:
+  /// member rows first (closer to composer), broadcasts last.
+  /// Returns the *display* order (members 0..N, broadcasts N..M).
+  static List<String> candidateValues(
+    List<ConversationMember> members,
+    String mentionQuery,
+  ) {
+    final memberRows = mentionQuery.isEmpty
+        ? members
+        : members
+              .where((m) => m.username.toLowerCase().startsWith(mentionQuery))
+              .toList();
+    final broadcastRows = mentionQuery.isEmpty
+        ? const ['everyone', 'here']
+        : const [
+            'everyone',
+            'here',
+          ].where((b) => b.startsWith(mentionQuery.toLowerCase())).toList();
+    return [...memberRows.map((m) => m.username), ...broadcastRows];
+  }
 
   /// Broadcast keywords (`@everyone`, `@here`) surfaced alongside member rows.
   static const List<_BroadcastMention> _broadcasts = [
@@ -78,16 +123,19 @@ class MentionAutocomplete extends StatelessWidget {
         padding: EdgeInsets.zero,
         itemCount: total,
         itemBuilder: (context, i) {
+          final isSelected = i == selectedIndex;
           if (i < memberRows.length) {
             final member = memberRows[i];
             return _MentionItem(
               member: member,
+              selected: isSelected,
               onTap: () => onMentionSelected(member.username),
             );
           }
           final broadcast = broadcastRows[i - memberRows.length];
           return _BroadcastMentionItem(
             broadcast: broadcast,
+            selected: isSelected,
             onTap: () => onMentionSelected(broadcast.keyword),
           );
         },
@@ -111,8 +159,13 @@ class _BroadcastMention {
 class _BroadcastMentionItem extends StatelessWidget {
   final _BroadcastMention broadcast;
   final VoidCallback onTap;
+  final bool selected;
 
-  const _BroadcastMentionItem({required this.broadcast, required this.onTap});
+  const _BroadcastMentionItem({
+    required this.broadcast,
+    required this.onTap,
+    this.selected = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -120,31 +173,35 @@ class _BroadcastMentionItem extends StatelessWidget {
       label: 'mention @${broadcast.keyword}',
       hint: broadcast.subtitle,
       button: true,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            children: [
-              Icon(broadcast.icon, size: 14, color: context.accent),
-              const SizedBox(width: 8),
-              Text(
-                '@${broadcast.keyword}',
-                style: TextStyle(
-                  fontSize: 13,
-                  color: context.textPrimary,
-                  fontWeight: FontWeight.w600,
+      selected: selected,
+      child: Container(
+        color: selected ? context.accentLight : null,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              children: [
+                Icon(broadcast.icon, size: 14, color: context.accent),
+                const SizedBox(width: 8),
+                Text(
+                  '@${broadcast.keyword}',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: context.textPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
-              ),
-              const SizedBox(width: 6),
-              Expanded(
-                child: Text(
-                  broadcast.subtitle,
-                  style: TextStyle(fontSize: 11, color: context.textMuted),
-                  overflow: TextOverflow.ellipsis,
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    broadcast.subtitle,
+                    style: TextStyle(fontSize: 11, color: context.textMuted),
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -155,38 +212,47 @@ class _BroadcastMentionItem extends StatelessWidget {
 class _MentionItem extends StatelessWidget {
   final ConversationMember member;
   final VoidCallback onTap;
+  final bool selected;
 
-  const _MentionItem({required this.member, required this.onTap});
+  const _MentionItem({
+    required this.member,
+    required this.onTap,
+    this.selected = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       label: 'mention ${member.username}',
       button: true,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            children: [
-              Icon(Icons.alternate_email, size: 14, color: context.accent),
-              const SizedBox(width: 8),
-              Text(
-                member.username,
-                style: TextStyle(
-                  fontSize: 13,
-                  color: context.textPrimary,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              if (member.role != null) ...[
-                const SizedBox(width: 6),
+      selected: selected,
+      child: Container(
+        color: selected ? context.accentLight : null,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              children: [
+                Icon(Icons.alternate_email, size: 14, color: context.accent),
+                const SizedBox(width: 8),
                 Text(
-                  member.role!,
-                  style: TextStyle(fontSize: 11, color: context.textMuted),
+                  member.username,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: context.textPrimary,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
+                if (member.role != null) ...[
+                  const SizedBox(width: 6),
+                  Text(
+                    member.role!,
+                    style: TextStyle(fontSize: 11, color: context.textMuted),
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary

The @-mention picker was render-only since #513 — you could only accept a candidate by tap. Direct user feedback added the keyboard contract that brings it to Discord-parity.

## Improved

- **Tab** and **Enter** accept the highlighted candidate.
- **Arrow Up / Down** move the selection (wraps at both ends).
- **Escape** closes the picker without inserting anything.
- **Space** implicitly closes the picker via the existing whitespace-trigger check, so typing \`@ \` keeps the literal \`@\` as part of the draft.

## Behind the scenes

- \`MentionAutocomplete\` now accepts \`selectedIndex\` and highlights the matching row with the accent surface.
- New static \`MentionAutocomplete.candidateValues(members, query)\` lets the composer compute the same ordered list the picker renders — the keyboard-accept path always lands on the row the user sees.
- \`ChatInputBarState\` tracks \`_mentionPickerIndex\`, resets it on picker open / query change, and intercepts the relevant keys in the existing \`Focus.onKeyEvent\` before they hit the \`TextField\`.

## Test plan

- [x] \`flutter analyze\` passes
- [x] \`flutter test test/widgets/chat_input_bar_test.dart test/widgets/input/mention_*\` — all 35+17 tests pass
- [ ] Visual: type \`@\` in a group composer → picker opens with first row highlighted
- [ ] Tab autofills the focused name
- [ ] ↑/↓ move the highlight, wrapping at the edges
- [ ] Space after \`@\` keeps the literal \`@\` and closes the picker
- [ ] Esc closes the picker without modifying the draft