### PR TITLE
Own-message text readable in Compact layout on Graphite

### DIFF
--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -660,11 +660,14 @@ class _MessageItemState extends State<MessageItem>
   /// Resolve text color for message content.
   Color _contentTextColor({required bool isMine, required bool isFailed}) {
     if (isFailed) return EchoTheme.danger;
-    // Plain (Slack) layout drops the bubble fill (#564) so the message sits
-    // directly on the chat background. The primary's onColor would be picked
-    // for an accent-coloured bubble that no longer exists, so use textPrimary
-    // for readable contrast on every theme (#790).
-    if (widget._isPlain) return context.textPrimary;
+    // Plain (Slack) AND Compact (Discord) layouts both drop the bubble
+    // fill (#564, see _bubbleColor → Colors.transparent), so the message
+    // sits directly on the chat background. onPrimary is calibrated for
+    // an accent-coloured bubble that no longer exists — using it against
+    // chatBg produces near-black-on-near-black on dark themes such as
+    // Graphite (#13AF9D bubble's onPrimary is #0A1114). Fall back to
+    // textPrimary so own messages stay readable in bubble-less layouts.
+    if (widget._isPlain || widget._isCompact) return context.textPrimary;
     if (isMine) return Theme.of(context).colorScheme.onPrimary;
     return context.textPrimary;
   }


### PR DESCRIPTION
## Summary

Direct user feedback: in the Graphite theme, sent messages render as near-black text on the chat background (Compact / Discord layout). Caught from a screenshot showing "bruh" message vanishing into chatBg.

## Root cause

\`_bubbleColor\` (message_item.dart:629) drops the bubble entirely for both Plain (Slack) and Compact (Discord) layouts. \`_contentTextColor\` (line 667-668) had a special case for Plain — fall back to \`textPrimary\` so text reads on \`chatBg\` — but **missed Compact**. So own messages in Compact still picked \`colorScheme.onPrimary\`, which is calibrated for the accent bubble that no longer exists.

For Graphite: \`onPrimary = graphiteOnAccent = #0A1114\` (near-black). \`chatBg = #142026\` (also near-black). Result: invisible text.

## Fixed

- Extend the Plain-fallback to also cover Compact: \`if (widget._isPlain || widget._isCompact) return context.textPrimary;\`

## Test plan

- [x] \`flutter analyze\` passes
- [x] \`flutter test test/widgets/message_item_test.dart\` — 37 tests pass
- [ ] Visual on Graphite: send a message in Compact layout — text reads as light primary against chatBg
- [ ] Visual on other dark themes (Indigo, Ember): no regression — text still readable
- [ ] Visual in Bubbles layout (Graphite): sent bubble still teal with dark onPrimary text — no change