### PR TITLE
Audit follow-ups: rotation single-flight, dead code, server caps

### DIFF
--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -1,0 +1,185 @@
+# Technical Debt — Echo Messenger
+
+Captured from the 2026-05-20 multi-agent audit of the 26 PRs (#980–#1005) shipped on the same day. The mechanical / low-risk items were applied in the audit follow-up PR; this file tracks the remaining work that needed design judgment, larger refactors, or test infrastructure beyond a single follow-up commit.
+
+Audit baseline commit range: `628e623ebd6108b230f313ccebdcb922e6f09e3d^..HEAD` (40 files, +1838/-756 lines). 6 reviewers ran in parallel (code-quality, security, performance, frontend, backend, test-coverage). ~66 findings total; 3 critical, 11 high, 28 medium, 24 low. Convergent risk across all reviewers: the rotation-storm on `member_added` and the lack of single-flight in self-heal — partially addressed in the follow-up PR with a per-conversation in-flight set, but the parallel identity-key fetch optimization remains.
+
+Last updated: 2026-05-20.
+
+## Summary
+- Critical / High remaining: 4
+- Medium remaining: 11
+- Low remaining: 8
+
+---
+
+## Critical / High — outstanding
+
+### TD-1 — Parallel identity-key fetch in `performRotation`
+**File:** `apps/client/lib/src/services/group_crypto_service.dart:695`
+**Severity:** high
+**Source:** performance, frontend, security reviewers
+**What:** `performRotation` fetches each member's identity key serially in a for-loop, one HTTP round-trip per member. With `forceRefresh=true` the TOFU cache is bypassed unconditionally. A 100-member group triggers 100 sequential awaits before the POST.
+**Fix:** Batch via `Future.wait([...members.map(fetchIdentityKey)])`. Eventually add a server-side batch endpoint `GET /api/keys/bundles?ids=...`. **Effort:** medium.
+
+### TD-2 — Server gate: validate creator has keys before `is_encrypted=true`
+**File:** `apps/server/src/routes/groups/create.rs:42-50`
+**Severity:** medium (rated up because of cascading wedge risk)
+**Source:** backend reviewer
+**What:** A malicious or buggy client can `POST /api/groups` with `is_encrypted=true` even without published prekeys/identity keys, permanently bricking the conversation (no UPDATE endpoint exists to flip it back).
+**Fix:** Before calling `create_group_with_visibility`, when `body.is_encrypted == true`, validate creator has ≥1 prekey + current identity via `db::keys`. Reject 400. **Effort:** small.
+
+### TD-3 — Transactional consistency of group creation
+**File:** `apps/server/src/routes/groups/create.rs:54-76`
+**Severity:** high
+**Source:** backend reviewer
+**What:** `create_group_with_visibility` commits its own tx; then two `create_channel` calls run outside any tx. Partial failure leaves an orphan group with one channel.
+**Fix:** Move channel seeds inside `create_group_with_visibility` or wrap the trio in a single `create_group_full` helper that commits atomically. **Effort:** medium.
+
+### TD-4 — TOFU bypass in group key rotation silently trusts changed identity keys
+**File:** `apps/client/lib/src/services/crypto/peer_identity_extension.dart:22-44` (consumed at `apps/client/lib/src/providers/crypto_provider.dart:486-489`, `ws_handlers/crypto_handlers.dart:144`)
+**Severity:** high
+**Source:** security reviewer
+**What:** When `forceRefresh=true`, the cache is bypassed and the server-fetched key is wrapped into the new group key envelope — even when the server-supplied key differs from the previously-trusted TOFU key. A compromised server could substitute a key it controls and silently receive a valid group-key envelope.
+**Fix:** After `fetchPeerIdentityKey(..., forceRefresh: true)` returns, call `crypto.hasPeerIdentityKeyChanged(userId)` and either abort the rotation or surface an explicit admin confirmation flow when the flag is set. **Effort:** medium.
+
+---
+
+## Medium — outstanding
+
+### TD-5 — Self-heal in `sendGroupMessage` lacks explicit refetch on 409
+**File:** `apps/client/lib/src/providers/websocket_provider.dart:593-622`
+**What:** When `seedInitialGroupKey` returns `null` from losing a 409 race, the follow-up `getGroupKey` may still see an empty local cache. Send fails; user retries; self-heal fires again.
+**Fix:** After `seedInitialGroupKey` returns null, call `groupCrypto.fetchGroupKey(conversationId)` explicitly to pull the winning rotation before falling through to `_addFailedMessage`. **Effort:** small.
+
+### TD-6 — TOCTOU race in version probe
+**File:** `apps/client/lib/src/providers/crypto_provider.dart:428-437`
+**What:** Between the GET `/keys/latest` probe and the POST rotation, another client can bump the version. The POST 409s and the caller returns `null` without refetching.
+**Fix:** Accept an optional `currentVersion` parameter so callers with a fresh hint (e.g. WS `group_key_rotation_requested`) can skip the probe. On 409, refetch explicitly. **Effort:** small.
+
+### TD-7 — `is_encrypted` lacks server-side immutability guard
+**File:** `apps/server/src/routes/groups/types.rs:14-20`, `apps/server/src/routes/groups/settings.rs`
+**What:** Today `UpdateGroupRequest` doesn't include `is_encrypted`, so it can't be flipped post-creation. But there's no defense-in-depth: a future contributor could trivially add it and silently allow a downgrade attack.
+**Fix:** Add a code comment in `types.rs` locking down the intent and a compile-time test asserting `UpdateGroupRequest` has no `is_encrypted` field. Optionally add a DB trigger preventing the column from being changed from `true` to `false`. **Effort:** small.
+
+### TD-8 — `is_encrypted` not returned in `GroupInfo`
+**File:** `apps/server/src/db/groups.rs:62-72`
+**What:** The INSERT doesn't RETURN `is_encrypted` so the response object after group creation has no encryption indicator. Clients must round-trip a GET to confirm encryption was actually enabled.
+**Fix:** Add `is_encrypted` to both the RETURNING clause and the `GroupInfo` struct, surface it on `GroupResponse`. **Effort:** small.
+
+### TD-9 — Channel-create runs outside group-create tx (see TD-3)
+Tracked above. Same finding from a different reviewer.
+
+### TD-10 — Conversation tile ListView missing keys
+**File:** `apps/client/lib/src/screens/home_screen.dart:758`
+**What:** ListView.builder over conversations builds no `key` on items. With the Stack + conditional selection pill wrapping each row, element recycling can briefly bind to the wrong conversation after a reorder (flash wrong avatar).
+**Fix:** Wrap returned Padding in `KeyedSubtree(key: ValueKey(conv.id), ...)`. **Effort:** small.
+
+### TD-11 — VoiceDock hardcoded width: 320 inside flex column
+**File:** `apps/client/lib/src/widgets/conversation_panel.dart:566`
+**What:** Dock takes a hardcoded 320px in a column that can be a different width when the sidebar is collapsed / resized.
+**Fix:** Drop the width argument; let the dock take `double.infinity` from the column, or pass through `LayoutBuilder` constraints. **Effort:** small.
+
+### TD-12 — `didChangeDependencies` in avatar cropper mutates state without `setState`
+**File:** `apps/client/lib/src/widgets/avatar_crop_dialog.dart:144-168`
+**What:** Mutates `_previewSize`, `_scale`, `_offset` outside the `setState` cycle. Follow-up build runs but the mutation races with concurrent setStates from the async decode.
+**Fix:** Wrap the mutation in `setState`. Optionally compute breakpoint via `LayoutBuilder` for a declarative path. **Effort:** small.
+
+### TD-13 — Avatar cropper Slider min/max recomputed every build
+**File:** `apps/client/lib/src/widgets/avatar_crop_dialog.dart:371-389`
+**What:** Slider `min` and the value clamp recompute the min-scale formula on every paint, including during drag ticks.
+**Fix:** Cache `_minScale` field updated only in `_decodeImage` + the breakpoint-flip branch. **Effort:** small.
+
+### TD-14 — `_maybeRotateOnJoin` linear scans on every member_added
+**File:** `apps/client/lib/src/providers/ws_handlers/presence_handlers.dart:108-118`
+**What:** Two `.where(...).firstOrNull` scans on full conversation list + full member list per event. WS event path; high-frequency.
+**Fix:** Add a `Map<String, Conversation>` index to `conversationsProvider`; denormalize local user role onto `Conversation`. **Effort:** medium.
+
+### TD-15 — Group name length cap uses byte count, not char count
+**File:** `apps/server/src/routes/groups/create.rs:23-27`
+**What:** `body.name.len() > 100` counts bytes. A single emoji is 4 bytes; CJK characters are 3 bytes. Users get inconsistent feedback.
+**Fix:** Use `body.name.chars().count()` or document the byte cap explicitly. Also `trim()` before the empty check. **Effort:** small.
+
+---
+
+## Low — outstanding
+
+### TD-16 — Missing barrierLabel on quick-switcher / global-search / shortcuts dialogs
+**File:** `apps/client/lib/src/screens/home_screen.dart:377-407`
+**What:** Backdrop dim was bumped to `Colors.black54` in PR #988, making the modal layer perceptible. Screen readers announce a generic "dismiss" because no `barrierLabel` was set.
+**Fix:** Add `barrierLabel: 'Dismiss <surface>'` to all three. **Effort:** small.
+
+### TD-17 — `_deleteGroup` doesn't deselect the active conversation
+**File:** `apps/client/lib/src/widgets/conversation_panel.dart:409+`
+**What:** After successful delete the user remains on the stale chat panel until the provider rebuild fires.
+**Fix:** Call `widget.onConversationSelected?.call(null)` (or equivalent) immediately on success. Also fix the `convs.isNotEmpty` guard in `_syncSelectedConversation` to handle the last-conversation-deleted case. **Effort:** small.
+
+### TD-18 — Probe error swallow could mask auth failures (partially addressed)
+The audit follow-up PR now logs the failure. Open follow-up: distinguish 401/403 from 404 explicitly so the rotation can abort vs proceed with `version=1`.
+
+### TD-19 — E2E spec accidentally runnable against prod
+**File:** `tests/e2e/group_encryption_roundtrip.spec.ts:22-31`
+**What:** `process.env.ECHO_SERVER` default of `localhost:8080` is safe, but a developer with `ECHO_SERVER=https://echo-messenger.us` exported in their shell would unintentionally run the round-trip against prod when they invoke `--project=maintained`.
+**Fix:** Add `test.skip(... !!process.env.ECHO_SERVER?.includes('echo-messenger.us') && process.env.ALLOW_PROD_ROUNDTRIP !== '1', ...)`. **Effort:** small.
+
+### TD-20 — Duplicate-name check is read-then-write race
+**File:** `apps/server/src/routes/groups/create.rs:30-40`
+**What:** `user_has_public_group_named` returning false then the insert is not atomic. Concurrent requests can race and both succeed.
+**Fix:** Unique partial index + map `23505` to 409 in `DbErrCtx`. **Effort:** medium.
+
+### TD-21 — `getIdentityPublicKey()` returning null silently omits self
+**File:** `apps/client/lib/src/providers/crypto_provider.dart:483-487`
+**What:** If the keyring is locked, `getIdentityPublicKey()` returns null. The for-loop in `performRotation` skips self silently, so the rotator uploads envelopes that exclude themselves — they can't decrypt their own group messages until the next rotation re-includes them.
+**Fix:** When the self key is null, abort the whole rotation with a "keyring locked" error. **Effort:** small.
+
+### TD-22 — `seedInitialGroupKey` reverse-list arrow direction is fragile
+**File:** `apps/client/lib/src/widgets/chat_input_bar.dart:1496` (now ~1505 after the audit follow-up)
+**What:** ArrowDown passes `delta=-1` because the picker uses `reverse: true`. A maintainer reading the code is likely to "fix" the sign.
+**Fix:** Introduce a `kDown = -1` constant or take a semantic direction enum so the inversion is named. **Effort:** small.
+
+### TD-23 — Test coverage gaps from new code
+Five untested surfaces from PR-batch:
+- `_maybeRotateOnJoin` (role/encrypted guards) — `apps/client/lib/src/providers/ws_handlers/presence_handlers.dart:94-128`
+- `OwnDecryptFailedBubble` widget — `apps/client/lib/src/widgets/message/message_indicators.dart:151+`
+- `MessageItem` own-message → `OwnDecryptFailedBubble` branch — `apps/client/lib/src/widgets/message_item.dart`
+- `MentionAutocomplete.candidateValues` static helper
+- `_moveMentionSelection` wrap-around (off-by-one prone)
+
+Each test sketched in the test-coverage reviewer's findings. **Effort:** medium total.
+
+---
+
+## Already addressed in audit follow-up PR
+
+- ✅ Rotation-storm single-flight per conversation in `seedInitialGroupKey` (critical)
+- ✅ Cached `_mentionCandidates` (no allocation per keystroke)
+- ✅ Logged probe failure in `seedInitialGroupKey`
+- ✅ Removed double `markShown()` call in WhatsNewInlineOverlay
+- ✅ Replaced AnimatedContainer with Container in debug log row + RepaintBoundary
+- ✅ Deleted `_presenceStatus` dead field + unreachable `setPresenceStatus` branch
+- ✅ Deleted `MentionCandidate` dead class
+- ✅ Server-side length caps: `encrypted_key` ≤ 512 bytes, `triggered_by_event` ≤ 128 chars
+
+## Progress tracking
+- [ ] TD-1 parallel identity-key fetch
+- [ ] TD-2 server gate on `is_encrypted=true`
+- [ ] TD-3 / TD-9 channel-create in tx
+- [ ] TD-4 TOFU bypass detection
+- [ ] TD-5 explicit refetch on 409
+- [ ] TD-6 TOCTOU version probe
+- [ ] TD-7 `is_encrypted` immutability guard
+- [ ] TD-8 return `is_encrypted` in `GroupInfo`
+- [ ] TD-10 ListView keys on conversation tiles
+- [ ] TD-11 VoiceDock hardcoded width
+- [ ] TD-12 setState in didChangeDependencies
+- [ ] TD-13 Slider min cache
+- [ ] TD-14 Map index for conversations + denormalized role
+- [ ] TD-15 char-count name length
+- [ ] TD-16 barrierLabel on dialogs
+- [ ] TD-17 deselect after delete
+- [ ] TD-18 distinguish 401/403/404 in probe
+- [ ] TD-19 prod-skip guard on E2E spec
+- [ ] TD-20 unique index for public-group names
+- [ ] TD-21 abort rotation when self key null
+- [ ] TD-22 semantic direction enum
+- [ ] TD-23 test coverage for new code (5 surfaces)

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -85,6 +85,14 @@ class CryptoState {
 /// not change.
 @Riverpod(keepAlive: true)
 class CryptoNotifier extends _$CryptoNotifier {
+  /// Per-conversation single-flight tracker for [seedInitialGroupKey].
+  /// Without this, multiple admins joining a group simultaneously (or one
+  /// admin firing the self-heal repeatedly) issue concurrent rotations:
+  /// each does probe + member fetch + N identity-key fetches + envelope
+  /// POST, and N-1 of those POSTs lose a 409 race. Audit P2 critical
+  /// finding (rotation storm).
+  final Set<String> _rotatingGroups = <String>{};
+
   @override
   CryptoState build() {
     return const CryptoState();
@@ -410,6 +418,30 @@ class CryptoNotifier extends _$CryptoNotifier {
   /// `(conversation_id, key_version)` — a parallel client racing on
   /// the same group will get 409 and short-circuit.
   Future<int?> seedInitialGroupKey(String conversationId) async {
+    // Single-flight per conversation. Drops concurrent attempts so a
+    // multi-admin group, an invite-link burst, or rapid Send retries
+    // can't fan out to A×(N+2) parallel HTTP requests per join (audit
+    // critical finding — rotation storm). The first caller does the
+    // work; subsequent callers get `null` and rely on the next
+    // group_key_rotated WS event to populate the local cache.
+    if (_rotatingGroups.contains(conversationId)) {
+      DebugLogService.instance.log(
+        LogLevel.info,
+        'GroupRotation',
+        'seedInitialGroupKey: rotation already in flight for '
+            '$conversationId — skipping',
+      );
+      return null;
+    }
+    _rotatingGroups.add(conversationId);
+    try {
+      return await _seedInitialGroupKeyInner(conversationId);
+    } finally {
+      _rotatingGroups.remove(conversationId);
+    }
+  }
+
+  Future<int?> _seedInitialGroupKeyInner(String conversationId) async {
     final groupCrypto = ref.read(groupCryptoServiceProvider);
     final crypto = ref.read(cryptoServiceProvider);
     final token = ref.read(authProvider).token ?? '';
@@ -436,9 +468,17 @@ class CryptoNotifier extends _$CryptoNotifier {
         final existing = body['key_version'] as int?;
         if (existing != null) nextVersion = existing + 1;
       }
-    } catch (_) {
-      // Probe failure is fine — we fall through to v=1, which is the
-      // correct value for a brand-new group.
+    } catch (e) {
+      // Probe failure usually means brand-new group (no key yet) — fall
+      // through to v=1. But auth / network errors fall through silently
+      // too, which can leave a wedged group still wedged. Log so a
+      // post-mortem can tell the two cases apart from the debug log.
+      DebugLogService.instance.log(
+        LogLevel.warning,
+        'GroupRotation',
+        'seedInitialGroupKey: /keys/latest probe failed for '
+            '$conversationId — falling through to v=1: $e',
+      );
     }
 
     return groupCrypto.performRotation(

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -48,9 +48,8 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
   final _statusController = TextEditingController();
   String _selectedTimezone = '';
 
-  /// Selected presence status. Mirrors the values used by the in-app status
-  /// picker (see `conversation_panel.dart`). Defaults to "online".
-  final String _presenceStatus = 'online';
+  // Presence/status field was removed from the onboarding wizard in #999
+  // — defaults to 'online' on the server, editable later from Settings.
 
   // Notifications wizard page state. Mirrors prefs used by Settings >
   // Notifications so the user's choices here are picked up the same way.
@@ -163,18 +162,6 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
           );
     } catch (e) {
       debugPrint('[Onboarding] profile save failed: $e');
-    }
-
-    // Presence status is a separate endpoint -- push only if the user
-    // changed it from the default to avoid spurious WS broadcasts.
-    if (_presenceStatus != 'online') {
-      try {
-        await ref
-            .read(authProvider.notifier)
-            .setPresenceStatus(_presenceStatus);
-      } catch (e) {
-        debugPrint('[Onboarding] presence save failed: $e');
-      }
     }
   }
 

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -1033,68 +1033,74 @@ class _DebugLogEntryTileState extends State<_DebugLogEntryTile> {
     // Hovering a log entry tints the row so users can track which line
     // they're pointing at when scanning a dense list. Cursor reverts to
     // basic so it doesn't read as clickable beyond the Copy button.
-    return MouseRegion(
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 80),
-        decoration: BoxDecoration(
-          color: _hovered ? context.surfaceHover : Colors.transparent,
-          borderRadius: BorderRadius.circular(4),
-        ),
-        padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SizedBox(
-              width: 72,
-              child: Text(
-                _formatTime(entry.timestamp),
-                style: GoogleFonts.jetBrainsMono(
-                  color: context.textMuted,
-                  fontSize: 11,
+    // RepaintBoundary so hover state on this row doesn't invalidate the
+    // entire log list's paint layer (debug log can hold up to 5000
+    // entries). Plain Container instead of AnimatedContainer — the 80ms
+    // fade is imperceptible and AnimatedContainer allocates an implicit
+    // animation controller per row.
+    return RepaintBoundary(
+      child: MouseRegion(
+        onEnter: (_) => setState(() => _hovered = true),
+        onExit: (_) => setState(() => _hovered = false),
+        child: Container(
+          decoration: BoxDecoration(
+            color: _hovered ? context.surfaceHover : Colors.transparent,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: 72,
+                child: Text(
+                  _formatTime(entry.timestamp),
+                  style: GoogleFonts.jetBrainsMono(
+                    color: context.textMuted,
+                    fontSize: 11,
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(width: 6),
-            _DebugLevelBadge(level: entry.level),
-            const SizedBox(width: 8),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-              decoration: BoxDecoration(
-                color: context.surfaceHover,
-                borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                entry.source,
-                style: GoogleFonts.jetBrainsMono(
-                  color: context.textSecondary,
-                  fontSize: 11,
-                  fontWeight: FontWeight.w500,
+              const SizedBox(width: 6),
+              _DebugLevelBadge(level: entry.level),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                decoration: BoxDecoration(
+                  color: context.surfaceHover,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  entry.source,
+                  style: GoogleFonts.jetBrainsMono(
+                    color: context.textSecondary,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                entry.message,
-                style: GoogleFonts.jetBrainsMono(
-                  color: context.textPrimary,
-                  fontSize: 12,
-                  height: 1.4,
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  entry.message,
+                  style: GoogleFonts.jetBrainsMono(
+                    color: context.textPrimary,
+                    fontSize: 12,
+                    height: 1.4,
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(width: 8),
-            IconButton(
-              icon: const Icon(Icons.copy_outlined, size: 14),
-              color: context.textMuted,
-              tooltip: 'Copy entry',
-              onPressed: () => _copySingleEntry(context),
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
-            ),
-          ],
+              const SizedBox(width: 8),
+              IconButton(
+                icon: const Icon(Icons.copy_outlined, size: 14),
+                color: context.textMuted,
+                tooltip: 'Copy entry',
+                onPressed: () => _copySingleEntry(context),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -176,28 +176,30 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   int _mentionPickerIndex = 0;
   String _lastMentionQuery = '';
   bool _lastMentionShowing = false;
+  // Cached candidate list — recomputed only when picker state changes.
+  // Reading _mentionCandidates per keystroke was allocating a new filtered
+  // list each time (audit perf + frontend findings).
+  List<String> _cachedMentionCandidates = const [];
 
   void _onMentionChanged() {
     if (!mounted) return;
     final showing = _mentionController.showPicker;
     final query = _mentionController.query;
-    // Reset selection on open or on query change so the first row is
-    // always the accept target as the user types.
-    if (showing != _lastMentionShowing || query != _lastMentionQuery) {
-      _mentionPickerIndex = 0;
-    }
+    final changed =
+        showing != _lastMentionShowing || query != _lastMentionQuery;
+    if (!changed) return; // skip rebuild when nothing visible changed
+    _mentionPickerIndex = 0;
+    _cachedMentionCandidates = showing
+        ? MentionAutocomplete.candidateValues(_filteredMentionMembers, query)
+        : const [];
     _lastMentionShowing = showing;
     _lastMentionQuery = query;
     setState(() {});
   }
 
-  /// Candidate values currently rendered by the mention picker. Stays in
-  /// sync with [MentionAutocomplete.candidateValues] so the keyboard
-  /// accept-path lands on the same row the user sees highlighted.
-  List<String> get _mentionCandidates => MentionAutocomplete.candidateValues(
-    _filteredMentionMembers,
-    _mentionController.query,
-  );
+  /// Candidate values currently rendered by the mention picker. Cached
+  /// in [_cachedMentionCandidates] and updated only in [_onMentionChanged].
+  List<String> get _mentionCandidates => _cachedMentionCandidates;
 
   /// Accept the currently-selected mention candidate (Tab/Enter pressed
   /// while the picker is open). No-op when there are no candidates.

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -3,22 +3,6 @@ import 'package:flutter/material.dart';
 import '../../models/conversation.dart';
 import '../../theme/echo_theme.dart';
 
-/// Mention candidates the picker renders. Members come before broadcasts
-/// — Discord pattern, mirrors the listView reverse order so members sit
-/// closest to the composer.
-class MentionCandidate {
-  /// `username` for a member row, broadcast keyword (`everyone`/`here`)
-  /// for a broadcast row. This is what gets passed back to
-  /// [MentionAutocomplete.onMentionSelected].
-  final String value;
-  final bool isBroadcast;
-  final ConversationMember? member;
-  const MentionCandidate.member(this.member) : value = '', isBroadcast = false;
-  const MentionCandidate.broadcast(this.value)
-    : isBroadcast = true,
-      member = null;
-}
-
 /// Displays an autocomplete popup for @-mentioning conversation members.
 ///
 /// Sits above the input bar and filters members based on [mentionQuery].

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -241,13 +241,14 @@ class WhatsNewInlineOverlay extends ConsumerWidget {
             // the dim layer above.
             behavior: HitTestBehavior.opaque,
             onTap: () {},
+            // The modal's own button handlers call markShown(); this
+            // callback only needs to clear the overlay state. Calling
+            // markShown twice doesn't corrupt anything (idempotent
+            // SharedPreferences write), but signals broken ownership.
             child: WhatsNewModal(
               notes: notes,
               isDialog: true,
-              onClose: () async {
-                await ref.read(releaseNotesProvider.notifier).markShown();
-                onDismiss();
-              },
+              onClose: onDismiss,
             ),
           ),
         ),

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -162,11 +162,31 @@ pub async fn upload_group_key(
         )));
     }
 
+    // Each envelope is a wrapped 32-byte AES-256 key (~124 base64 chars in
+    // practice). 512 bytes is generous headroom while blocking abuse —
+    // without this cap, a single 10K-envelope request could write up to
+    // ~10 GB of attacker-controlled TEXT.
+    const MAX_ENCRYPTED_KEY_LEN: usize = 512;
+    // Audit reason string — bounded so a malicious admin can't write
+    // arbitrarily large blobs into the audit log that other admins
+    // re-download on every /encryption-activity GET.
+    const MAX_TRIGGERED_BY_EVENT_LEN: usize = 128;
+    if body.triggered_by_event.len() > MAX_TRIGGERED_BY_EVENT_LEN {
+        return Err(AppError::bad_request(format!(
+            "triggered_by_event must be ≤{MAX_TRIGGERED_BY_EVENT_LEN} characters"
+        )));
+    }
+
     for envelope in &body.envelopes {
         if envelope.encrypted_key.is_empty() {
             return Err(AppError::bad_request(
                 "encrypted_key cannot be empty in envelope",
             ));
+        }
+        if envelope.encrypted_key.len() > MAX_ENCRYPTED_KEY_LEN {
+            return Err(AppError::bad_request(format!(
+                "encrypted_key must be ≤{MAX_ENCRYPTED_KEY_LEN} bytes"
+            )));
         }
     }
 


### PR DESCRIPTION
## Summary

Aggregated **~66 findings** from a 6-reviewer multi-agent audit (code-quality, security, performance, frontend, backend, test-coverage) on today's 26 PRs (#980-#1005). This PR applies the mechanical / low-risk fixes; larger refactors are tracked in \`TECHNICAL_DEBT.md\` (TD-1 .. TD-23).

## Critical risk addressed

**Rotation storm on \`member_added\`** — flagged by 5 of 6 reviewers. \`seedInitialGroupKey\` had no concurrency control, so M online admins × N members = M×(N+2) parallel HTTP requests per join. Same surface on rapid Send self-heal retries.

\`CryptoNotifier\` now keeps a per-conversation \`Set<String> _rotatingGroups\`. Concurrent calls short-circuit to \`null\` and rely on the next \`group_key_rotated\` WS event to populate the local cache.

## Other fixes

- Drop dead \`_presenceStatus\` field + the unreachable \`setPresenceStatus\` branch left over from #999.
- Delete unreferenced \`MentionCandidate\` class.
- Cache mention candidate list on the composer; skip \`setState\` when no visible state changed.
- Probe error in \`seedInitialGroupKey\` now logs to \`DebugLogService\` instead of silently swallowing (auth failures were invisible before).
- \`WhatsNewInlineOverlay\` no longer calls \`markShown\` twice.
- Debug log row: swap \`AnimatedContainer\` for plain \`Container\` + add \`RepaintBoundary\` so hover state on a 5000-entry list doesn't invalidate the whole list's paint layer.
- \`/api/group_keys\`: cap \`encrypted_key\` at 512 bytes and \`triggered_by_event\` at 128 chars so a hostile admin can't bloat envelopes or the audit log.

## Tracked for follow-up (\`TECHNICAL_DEBT.md\`)

23 items including:
- Parallel identity-key fetch (\`Future.wait\`) in \`performRotation\` (high)
- TOFU-bypass detection on \`forceRefresh\` (high, security)
- Server-side gate validating creator has keys before \`is_encrypted=true\` (medium)
- Channel-create inside the group-create transaction (high)
- 5 untested-new-code surfaces (\`_maybeRotateOnJoin\`, \`OwnDecryptFailedBubble\`, \`MentionAutocomplete.candidateValues\`, \`_moveMentionSelection\`, conversation snippet mask)

## Test plan

- [x] \`flutter analyze\` — clean
- [x] \`flutter test test/widgets/message_item_test.dart test/widgets/input/\` — 96 tests pass
- [x] \`cargo check -p echo-server\` — clean
- [ ] Visual: trigger an encrypted-group join → single rotation fires (not M)
- [ ] Visual: debug log scroll + hover on a long list → smooth