### PR TITLE
Audit high-tier: TD-1 parallel rotation, TD-2 server gate, TD-3 atomic create, TD-4 TOFU guard

### DIFF
--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -526,6 +526,16 @@ class CryptoNotifier extends _$CryptoNotifier {
         }
         return crypto.fetchPeerIdentityKey(userId, forceRefresh: true);
       },
+      // TD-4: refuse to wrap the group secret under a changed peer
+      // identity key. The force-refresh above silently updates the
+      // TOFU cache to whatever the server returned; the rotation
+      // checks the per-user "changed" flag and aborts if anyone's
+      // key is unconfirmed. Self is never flagged (we generate our
+      // own key) so the check is a no-op for myUserId.
+      hasIdentityKeyChanged: (userId) async {
+        if (userId == myUserId) return false;
+        return crypto.hasPeerIdentityKeyChanged(userId);
+      },
     );
   }
 

--- a/apps/client/lib/src/providers/ws_handlers/crypto_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/crypto_handlers.dart
@@ -143,6 +143,13 @@ extension CryptoHandlersOn on WsMessageHandler {
           }
           return crypto.fetchPeerIdentityKey(userId, forceRefresh: true);
         },
+        // TD-4: same TOFU-bypass guard as seedInitialGroupKey. If any
+        // peer's identity key changed on the most recent refresh,
+        // refuse to wrap the new group key under it.
+        hasIdentityKeyChanged: (userId) async {
+          if (userId == myUserId) return false;
+          return crypto.hasPeerIdentityKeyChanged(userId);
+        },
       ),
     );
   }

--- a/apps/client/lib/src/services/group_crypto_service.dart
+++ b/apps/client/lib/src/services/group_crypto_service.dart
@@ -650,6 +650,7 @@ class GroupCryptoService {
     int keyVersion, {
     required Future<List<Map<String, dynamic>>> Function() fetchMembers,
     required Future<Uint8List?> Function(String userId) fetchIdentityKey,
+    Future<bool> Function(String userId)? hasIdentityKeyChanged,
     String triggeredByEvent = 'unspecified',
   }) {
     // Audit P1-4: timeline event captures the full rotation cost (member
@@ -662,6 +663,7 @@ class GroupCryptoService {
         keyVersion,
         fetchMembers: fetchMembers,
         fetchIdentityKey: fetchIdentityKey,
+        hasIdentityKeyChanged: hasIdentityKeyChanged,
         triggeredByEvent: triggeredByEvent,
       ),
       args: {'conversation': conversationId, 'keyVersion': keyVersion},
@@ -673,6 +675,7 @@ class GroupCryptoService {
     int keyVersion, {
     required Future<List<Map<String, dynamic>>> Function() fetchMembers,
     required Future<Uint8List?> Function(String userId) fetchIdentityKey,
+    Future<bool> Function(String userId)? hasIdentityKeyChanged,
     required String triggeredByEvent,
   }) async {
     // Drop the stale key first so we never encrypt with the now-revoked
@@ -691,11 +694,49 @@ class GroupCryptoService {
     final newKeyBytes = Uint8List.fromList(base64Decode(generateGroupKey()));
     final newKeyB64 = base64Encode(newKeyBytes);
 
+    // Fetch all identity keys concurrently. The previous serial for-loop
+    // was O(N) round-trips before any envelope could be built — a
+    // 100-member group took 5–10s on mobile. Future.wait parallelises
+    // the N requests; the server's /api/keys/bundle endpoint is per-user
+    // but the calls overlap on the wire so the wall time collapses to
+    // roughly one RTT regardless of N. (TD-1 in TECHNICAL_DEBT.md.)
+    final userIds = members
+        .map((m) => m['user_id'] as String?)
+        .where((id) => id != null && id.isNotEmpty)
+        .cast<String>()
+        .toList();
+    final identityKeys = await Future.wait(userIds.map(fetchIdentityKey));
+
+    // TD-4: TOFU bypass guard. fetchPeerIdentityKey(forceRefresh: true)
+    // silently trusts whatever the server returned, so wrapping the
+    // group secret under a changed identity key would hand a fresh
+    // envelope to a key the user has never confirmed. Abort the
+    // rotation when any participant's TOFU flag is set — admins can
+    // acknowledge the change in the chat header and retry. Skipped
+    // when the caller didn't supply the checker (preserves the legacy
+    // performRotation contract).
+    if (hasIdentityKeyChanged != null) {
+      final changedFlags = await Future.wait(
+        userIds.map(hasIdentityKeyChanged),
+      );
+      final changedUsers = <String>[
+        for (var i = 0; i < userIds.length; i++)
+          if (changedFlags[i]) userIds[i],
+      ];
+      if (changedUsers.isNotEmpty) {
+        debugPrint(
+          '[GroupCrypto] performRotation aborted: identity key '
+          'changed for ${changedUsers.join(', ')} (TOFU flag set). '
+          'Acknowledge the change and retry.',
+        );
+        return null;
+      }
+    }
+
     final envelopes = <Map<String, dynamic>>[];
-    for (final m in members) {
-      final userId = m['user_id'] as String?;
-      if (userId == null || userId.isEmpty) continue;
-      final identityKey = await fetchIdentityKey(userId);
+    for (var i = 0; i < userIds.length; i++) {
+      final userId = userIds[i];
+      final identityKey = identityKeys[i];
       if (identityKey == null) {
         debugPrint(
           '[GroupCrypto] performRotation: missing identity key for $userId',

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -106,6 +106,27 @@ pub async fn create_group_with_visibility(
         .execute(&mut *tx)
         .await?;
 
+    // Seed the default text + voice channels in the same transaction.
+    // Before TD-3, channel inserts ran AFTER tx.commit(); a partial
+    // failure (e.g. voice channel insert errors) left the group rows
+    // committed but with a missing channel, surfacing to the client as
+    // a 500 with no way to recover. Folding them in means the entire
+    // group either exists with both channels or doesn't exist at all.
+    sqlx::query(
+        "INSERT INTO channels (conversation_id, name, kind, topic, position, category) \
+         VALUES ($1, 'general', 'text', NULL, 0, 'Text Channels')",
+    )
+    .bind(group.id)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "INSERT INTO channels (conversation_id, name, kind, topic, position, category) \
+         VALUES ($1, 'lounge', 'voice', NULL, 0, 'Voice Channels')",
+    )
+    .bind(group.id)
+    .execute(&mut *tx)
+    .await?;
+
     tx.commit().await?;
     Ok(group)
 }

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -601,6 +601,30 @@ pub async fn count_one_time_prekeys(
     Ok(row.0)
 }
 
+/// True when [`user_id`] has published at least one identity key on any
+/// device AND has unused one-time prekeys available. Used by encrypted-
+/// group create to refuse `is_encrypted = true` for clients that haven't
+/// completed the X3DH key upload yet — otherwise the group lands in a
+/// wedged state with no recoverable key (TD-2 in TECHNICAL_DEBT.md).
+pub async fn has_publishable_keys(pool: &PgPool, user_id: Uuid) -> Result<bool, sqlx::Error> {
+    let row: (bool,) = sqlx::query_as(
+        "SELECT EXISTS ( \
+             SELECT 1 FROM identity_keys ik \
+             WHERE ik.user_id = $1 \
+               AND EXISTS ( \
+                   SELECT 1 FROM one_time_prekeys o \
+                   WHERE o.user_id = $1 \
+                     AND o.device_id = ik.device_id \
+                     AND NOT o.used \
+               ) \
+         )",
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
+}
+
 // -------------------------------------------------------------------------
 // Group encryption keys
 // -------------------------------------------------------------------------

--- a/apps/server/src/routes/groups/create.rs
+++ b/apps/server/src/routes/groups/create.rs
@@ -26,6 +26,24 @@ pub async fn create_group(
         ));
     }
 
+    // Refuse encrypted-group creation when the caller hasn't published
+    // identity + one-time prekeys yet. Without keys the group lands in
+    // a wedged state on day one — the creator can't decrypt its own
+    // messages and no admin can rotate (no key material exists to wrap
+    // envelopes against). TD-2 in TECHNICAL_DEBT.md.
+    if body.is_encrypted {
+        let has_keys = db::keys::has_publishable_keys(&state.pool, auth.user_id)
+            .await
+            .db_ctx("create_group/has_keys")?;
+        if !has_keys {
+            return Err(AppError::bad_request(
+                "Cannot create an end-to-end-encrypted group before \
+                 publishing your identity and one-time prekeys. Open the \
+                 app, finish key setup, and try again.",
+            ));
+        }
+    }
+
     // Prevent duplicate public group names per creator
     if body.is_public {
         let already_exists =
@@ -51,29 +69,10 @@ pub async fn create_group(
     .await
     .db_ctx("create_group/create")?;
 
-    // Seed default channels for new groups.
-    db::channels::create_channel(
-        &state.pool,
-        group.id,
-        "general",
-        "text",
-        None,
-        0,
-        Some("Text Channels"),
-    )
-    .await
-    .db_ctx("create_group/create_text_channel")?;
-    db::channels::create_channel(
-        &state.pool,
-        group.id,
-        "lounge",
-        "voice",
-        None,
-        0,
-        Some("Voice Channels"),
-    )
-    .await
-    .db_ctx("create_group/create_voice_channel")?;
+    // Default channels (`general` text + `lounge` voice) are now seeded
+    // inside `create_group_with_visibility` so they share the same
+    // transaction. TD-3 closes the partial-state window where a channel
+    // insert failure used to leave an orphan group committed.
 
     let members = db::groups::get_group_members(&state.pool, group.id)
         .await


### PR DESCRIPTION
## Summary

Lands the four high-severity items from \`TECHNICAL_DEBT.md\` (TD-1..TD-4) as two commits — one server-side, one client-side — in a single PR for review symmetry.

## TD-2 — server gate on \`is_encrypted=true\`

Reject \`POST /api/groups { is_encrypted: true }\` when the caller hasn't published an identity key + one-time prekeys yet. Without them the group lands in a permanently wedged state the moment the creator tries to send (no key material to wrap envelopes against, no UPDATE endpoint to flip \`is_encrypted\` back).

New helper \`db::keys::has_publishable_keys\` runs a single EXISTS check.

## TD-3 — transactional group create

Fold the two default-channel inserts (\`general\` text, \`lounge\` voice) into the same transaction as the group + member rows. Before this, channel-create ran AFTER \`tx.commit()\`; a partial failure left the group rows committed with a missing channel, surfacing as a 500 with no client-side recovery. The group either exists fully or doesn't exist at all now.

## TD-1 — parallel identity-key fetch in \`performRotation\`

Replace the serial for-loop with \`Future.wait\`. A 100-member rotation that used to chain 100 sequential HTTP RTTs (5–10s on mobile) now overlaps them on the wire so wall time collapses to roughly one RTT.

## TD-4 — refuse to wrap under drifted identity keys

\`performRotation\` now accepts an optional \`hasIdentityKeyChanged\` callback. After the parallel identity-key fetch, the rotation calls the checker per user and aborts when any TOFU flag is set, rather than silently wrapping the new group secret under whatever the server most recently returned.

\`forceRefresh: true\` by design bypasses the TOFU cache — without this guard, a compromised server could substitute a key the user has never confirmed and receive a valid envelope back. Both rotation call sites (\`seedInitialGroupKey\` + \`group_key_rotation_requested\` WS handler) wire the callback to \`CryptoService.hasPeerIdentityKeyChanged\`. Self never trips the check.

Callback is optional so the public \`performRotation\` contract is preserved.

## Test plan

- [x] \`cargo check -p echo-server\` clean
- [x] \`cargo clippy -p echo-server -- -D warnings\` clean
- [x] \`flutter analyze\` clean
- [x] \`flutter test test/services/\` — 368 tests pass
- [ ] Manual: create encrypted group without keys → 400 with helpful message
- [ ] Manual: encrypted group with 50+ members → rotation completes in seconds, not minutes
- [ ] Manual: peer rekeys their device → next rotation aborts until acknowledged in chat header