### PR TITLE
Audit cleanup batch — TD-5..TD-23 (mediums + lows)

### DIFF
--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -8,8 +8,10 @@ Last updated: 2026-05-20.
 
 ## Summary
 - Critical / High remaining: 0  (TD-1..TD-4 shipped in PR #1007)
-- Medium remaining: 11
-- Low remaining: 8
+- Medium remaining: 1  (TD-14 — conversation Map index; deferred)
+- Low remaining: 2  (TD-20 partial schema migration, TD-23 harder test surfaces)
+
+The medium/low cleanup batch landed across server + client + tests (TD-5..TD-13, TD-15..TD-19, TD-21, TD-22, partial TD-23).
 
 ---
 
@@ -172,21 +174,21 @@ Each test sketched in the test-coverage reviewer's findings. **Effort:** medium 
 - [x] TD-2 server gate on `is_encrypted=true` — PR #1007
 - [x] TD-3 / TD-9 channel-create in tx — PR #1007
 - [x] TD-4 TOFU bypass detection — PR #1007
-- [ ] TD-5 explicit refetch on 409
-- [ ] TD-6 TOCTOU version probe
-- [ ] TD-7 `is_encrypted` immutability guard
-- [ ] TD-8 return `is_encrypted` in `GroupInfo`
-- [ ] TD-10 ListView keys on conversation tiles
-- [ ] TD-11 VoiceDock hardcoded width
-- [ ] TD-12 setState in didChangeDependencies
-- [ ] TD-13 Slider min cache
-- [ ] TD-14 Map index for conversations + denormalized role
-- [ ] TD-15 char-count name length
-- [ ] TD-16 barrierLabel on dialogs
-- [ ] TD-17 deselect after delete
-- [ ] TD-18 distinguish 401/403/404 in probe
-- [ ] TD-19 prod-skip guard on E2E spec
-- [ ] TD-20 unique index for public-group names
-- [ ] TD-21 abort rotation when self key null
-- [ ] TD-22 semantic direction enum
-- [ ] TD-23 test coverage for new code (5 surfaces)
+- [x] TD-5 explicit refetch on 409 — cleanup batch
+- [x] TD-6 TOCTOU version probe (optional currentVersion param) — cleanup batch
+- [x] TD-7 `is_encrypted` immutability guard (doc + compile-test) — cleanup batch
+- [x] TD-8 return `is_encrypted` in `GroupInfo` — cleanup batch
+- [x] TD-10 ListView keys on conversation tiles — cleanup batch
+- [x] TD-11 VoiceDock width via LayoutBuilder — cleanup batch
+- [x] TD-12 setState in didChangeDependencies — cleanup batch
+- [x] TD-13 Slider min cache — cleanup batch
+- [ ] TD-14 Map index for conversations + denormalized role — deferred (needs conv-provider refactor)
+- [x] TD-15 char-count name length — cleanup batch
+- [x] TD-16 barrierLabel on dialogs — cleanup batch
+- [x] TD-17 deselect after delete (isLoading gate) — cleanup batch
+- [x] TD-18 distinguish 401/403/404 in probe — cleanup batch
+- [x] TD-19 prod-skip guard on E2E spec — cleanup batch
+- [ ] TD-20 unique index for public-group names — deferred (needs schema migration)
+- [x] TD-21 abort rotation when self key null — cleanup batch
+- [x] TD-22 semantic direction enum (`_MentionMove`) — cleanup batch
+- [~] TD-23 test coverage — 2 of 5 surfaces covered (MentionAutocomplete.candidateValues, OwnDecryptFailedBubble); remaining (_maybeRotateOnJoin, _moveMentionSelection wrap, conversation_item mask) need Riverpod test harness scaffolding

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -417,7 +417,10 @@ class CryptoNotifier extends _$CryptoNotifier {
   /// Idempotent against the server's UNIQUE constraint on
   /// `(conversation_id, key_version)` — a parallel client racing on
   /// the same group will get 409 and short-circuit.
-  Future<int?> seedInitialGroupKey(String conversationId) async {
+  Future<int?> seedInitialGroupKey(
+    String conversationId, {
+    int? currentVersion,
+  }) async {
     // Single-flight per conversation. Drops concurrent attempts so a
     // multi-admin group, an invite-link burst, or rapid Send retries
     // can't fan out to A×(N+2) parallel HTTP requests per join (audit
@@ -435,13 +438,19 @@ class CryptoNotifier extends _$CryptoNotifier {
     }
     _rotatingGroups.add(conversationId);
     try {
-      return await _seedInitialGroupKeyInner(conversationId);
+      return await _seedInitialGroupKeyInner(
+        conversationId,
+        currentVersion: currentVersion,
+      );
     } finally {
       _rotatingGroups.remove(conversationId);
     }
   }
 
-  Future<int?> _seedInitialGroupKeyInner(String conversationId) async {
+  Future<int?> _seedInitialGroupKeyInner(
+    String conversationId, {
+    int? currentVersion,
+  }) async {
     final groupCrypto = ref.read(groupCryptoServiceProvider);
     final crypto = ref.read(cryptoServiceProvider);
     final token = ref.read(authProvider).token ?? '';
@@ -455,35 +464,53 @@ class CryptoNotifier extends _$CryptoNotifier {
     // stale identity keys (and are therefore unwrappable). Probe
     // /keys/latest — if a key already exists we rotate to version+1
     // instead of hardcoding v=1, which would 409-conflict and leave the
-    // group wedged forever. We don't try to decrypt; we just read the
-    // version number off the response.
+    // group wedged forever. Callers with a fresh version hint (e.g. the
+    // group_key_rotation_requested WS payload) can pass currentVersion
+    // and skip the probe entirely (TD-6).
     var nextVersion = 1;
-    try {
-      final probe = await http.get(
-        Uri.parse('$serverUrl/api/groups/$conversationId/keys/latest'),
-        headers: {'Authorization': 'Bearer $token'},
-      );
-      if (probe.statusCode == 200) {
-        final body = jsonDecode(probe.body) as Map<String, dynamic>;
-        final existing = body['key_version'] as int?;
-        if (existing != null) nextVersion = existing + 1;
+    if (currentVersion != null) {
+      nextVersion = currentVersion + 1;
+    } else {
+      try {
+        final probe = await http.get(
+          Uri.parse('$serverUrl/api/groups/$conversationId/keys/latest'),
+          headers: {'Authorization': 'Bearer $token'},
+        );
+        if (probe.statusCode == 200) {
+          final body = jsonDecode(probe.body) as Map<String, dynamic>;
+          final existing = body['key_version'] as int?;
+          if (existing != null) nextVersion = existing + 1;
+        } else if (probe.statusCode == 401 || probe.statusCode == 403) {
+          // TD-18: 401/403 means the rotation will also be rejected;
+          // bail rather than uploading v=1 envelopes the server can't
+          // accept. The caller's WS event will retry once auth refreshes.
+          DebugLogService.instance.log(
+            LogLevel.warning,
+            'GroupRotation',
+            'seedInitialGroupKey: /keys/latest probe returned '
+                '${probe.statusCode} for $conversationId — aborting '
+                'rotation (auth path will retry).',
+          );
+          return null;
+        }
+        // 404 (no key yet) falls through with nextVersion == 1.
+      } catch (e) {
+        // TD-18: network/decoder failures fall through to v=1 (the
+        // brand-new-group case). Log so a post-mortem can distinguish
+        // legitimate first-key rotations from blocked recovery attempts.
+        DebugLogService.instance.log(
+          LogLevel.warning,
+          'GroupRotation',
+          'seedInitialGroupKey: /keys/latest probe failed for '
+              '$conversationId — falling through to v=1: $e',
+        );
       }
-    } catch (e) {
-      // Probe failure usually means brand-new group (no key yet) — fall
-      // through to v=1. But auth / network errors fall through silently
-      // too, which can leave a wedged group still wedged. Log so a
-      // post-mortem can tell the two cases apart from the debug log.
-      DebugLogService.instance.log(
-        LogLevel.warning,
-        'GroupRotation',
-        'seedInitialGroupKey: /keys/latest probe failed for '
-            '$conversationId — falling through to v=1: $e',
-      );
     }
 
     return groupCrypto.performRotation(
       conversationId,
       nextVersion,
+      selfUserId: myUserId,
       triggeredByEvent: nextVersion == 1 ? 'first_key' : 'recover_wedged',
       fetchMembers: () async {
         try {

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -619,6 +619,12 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
                 .read(cryptoProvider.notifier)
                 .seedInitialGroupKey(conversationId);
             keyResult = await groupCrypto.getGroupKey(conversationId);
+            // TD-5: if seedInitialGroupKey lost a 409 race the local
+            // cache may still be empty even though the server now has
+            // a fresh key version. Force a network refetch before we
+            // give up, so a rotation won-elsewhere doesn't bounce the
+            // sender into the failed-message retry loop.
+            keyResult ??= await groupCrypto.fetchGroupKey(conversationId);
           }
         }
 

--- a/apps/client/lib/src/providers/ws_handlers/crypto_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/crypto_handlers.dart
@@ -110,6 +110,7 @@ extension CryptoHandlersOn on WsMessageHandler {
       groupCrypto.performRotation(
         conversationId,
         keyVersion,
+        selfUserId: myUserId,
         fetchMembers: () async {
           try {
             final resp = await http.get(

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -376,6 +376,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     showDialog(
       context: context,
       barrierColor: Colors.black54,
+      barrierLabel: 'Dismiss quick switcher',
       builder: (ctx) =>
           QuickSwitcherOverlay(onSelect: (conv) => _selectConversation(conv)),
     );
@@ -385,6 +386,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     showDialog(
       context: context,
       barrierColor: Colors.black54,
+      barrierLabel: 'Dismiss global search',
       builder: (ctx) => GlobalSearchOverlay(
         onResultTap: (conversationId, messageId) {
           final conversations = ref.read(conversationsProvider).conversations;
@@ -402,6 +404,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     showDialog<void>(
       context: context,
       barrierColor: Colors.black54,
+      barrierLabel: 'Dismiss keyboard shortcuts',
       builder: (_) => const KeyboardShortcutsOverlay(),
     );
   }
@@ -763,77 +766,87 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                 final displayName = conv.displayName(myUserId);
                 final isSelected = conv.id == _selectedConversation?.id;
 
-                return Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 2),
-                  child: Tooltip(
-                    message: displayName,
-                    preferBelow: false,
-                    child: Semantics(
-                      label: 'conversation: $displayName',
-                      button: true,
-                      child: GestureDetector(
-                        onTap: () => _selectConversation(conv),
-                        child: SizedBox(
-                          width: 44,
-                          height: 44,
-                          // Stack so the left-edge selection pill can sit
-                          // alongside the centred avatar without affecting
-                          // its layout. Matches the pattern used in
-                          // conversation_item so both sidebars agree.
-                          child: Stack(
-                            children: [
-                              Center(
-                                child: Builder(
-                                  builder: (_) {
-                                    final String? avatarUrl;
-                                    if (conv.isGroup) {
-                                      avatarUrl = resolveAvatarUrl(
-                                        conv.iconUrl,
-                                        serverUrl,
+                // KeyedSubtree so element identity tracks conv.id rather
+                // than the position index — prevents the Stack +
+                // conditional selection-pill subtree from briefly
+                // binding to the wrong conversation when the list
+                // reorders after a new message / pin / delete (TD-10).
+                return KeyedSubtree(
+                  key: ValueKey('conv-rail-${conv.id}'),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Tooltip(
+                      message: displayName,
+                      preferBelow: false,
+                      child: Semantics(
+                        label: 'conversation: $displayName',
+                        button: true,
+                        child: GestureDetector(
+                          onTap: () => _selectConversation(conv),
+                          child: SizedBox(
+                            width: 44,
+                            height: 44,
+                            // Stack so the left-edge selection pill can sit
+                            // alongside the centred avatar without affecting
+                            // its layout. Matches the pattern used in
+                            // conversation_item so both sidebars agree.
+                            child: Stack(
+                              children: [
+                                Center(
+                                  child: Builder(
+                                    builder: (_) {
+                                      final String? avatarUrl;
+                                      if (conv.isGroup) {
+                                        avatarUrl = resolveAvatarUrl(
+                                          conv.iconUrl,
+                                          serverUrl,
+                                        );
+                                      } else {
+                                        final peer = conv.members
+                                            .where((m) => m.userId != myUserId)
+                                            .firstOrNull;
+                                        avatarUrl = resolveAvatarUrl(
+                                          peer?.avatarUrl,
+                                          serverUrl,
+                                        );
+                                      }
+                                      return buildAvatar(
+                                        name: displayName,
+                                        radius: 18,
+                                        imageUrl: avatarUrl,
+                                        bgColor: conv.isGroup
+                                            ? groupAvatarColor(displayName)
+                                            : null,
+                                        fallbackIcon: conv.isGroup
+                                            ? const Icon(
+                                                Icons.group,
+                                                size: 16,
+                                                color: Colors.white,
+                                              )
+                                            : null,
                                       );
-                                    } else {
-                                      final peer = conv.members
-                                          .where((m) => m.userId != myUserId)
-                                          .firstOrNull;
-                                      avatarUrl = resolveAvatarUrl(
-                                        peer?.avatarUrl,
-                                        serverUrl,
-                                      );
-                                    }
-                                    return buildAvatar(
-                                      name: displayName,
-                                      radius: 18,
-                                      imageUrl: avatarUrl,
-                                      bgColor: conv.isGroup
-                                          ? groupAvatarColor(displayName)
-                                          : null,
-                                      fallbackIcon: conv.isGroup
-                                          ? const Icon(
-                                              Icons.group,
-                                              size: 16,
-                                              color: Colors.white,
-                                            )
-                                          : null,
-                                    );
-                                  },
+                                    },
+                                  ),
                                 ),
-                              ),
-                              if (isSelected)
-                                Positioned(
-                                  left: 0,
-                                  top: 8,
-                                  bottom: 8,
-                                  child: IgnorePointer(
-                                    child: Container(
-                                      width: 4,
-                                      decoration: BoxDecoration(
-                                        color: context.activeRowAccent,
-                                        borderRadius: BorderRadius.circular(2),
+                                if (isSelected)
+                                  Positioned(
+                                    left: 0,
+                                    top: 8,
+                                    bottom: 8,
+                                    child: IgnorePointer(
+                                      child: Container(
+                                        width: 4,
+                                        decoration: BoxDecoration(
+                                          color: context.activeRowAccent,
+                                          borderRadius: BorderRadius.circular(
+                                            2,
+                                          ),
+                                        ),
                                       ),
                                     ),
                                   ),
-                                ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
                       ),
@@ -1051,22 +1064,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   /// Keep the selected conversation in sync with provider state so that
   /// changes (e.g. encryption toggle) propagate to ChatPanel immediately.
-  /// IMPORTANT: Do NOT clear _selectedConversation when fresh is null --
-  /// the conversation may be temporarily absent during a list reload.
+  /// IMPORTANT: Do NOT clear _selectedConversation when fresh is null
+  /// AND the list is currently reloading — the conversation may be
+  /// temporarily absent. Once the load settles, clear it so deleting
+  /// the last group doesn't leave a stale chat panel rendered (TD-17).
   void _syncSelectedConversation() {
     if (_selectedConversation == null) return;
-    final convs = ref.watch(conversationsProvider).conversations;
+    final convState = ref.watch(conversationsProvider);
+    final convs = convState.conversations;
     final fresh = convs
         .where((c) => c.id == _selectedConversation!.id)
         .firstOrNull;
     if (fresh != null && fresh != _selectedConversation) {
       _selectedConversation = fresh;
+      return;
     }
-    // If the conversation was permanently removed (e.g. user left it),
-    // clear selection so mobile doesn't get stuck showing a stale panel.
-    if (fresh == null && convs.isNotEmpty) {
-      // Only clear if conversations have loaded (non-empty list means the
-      // list isn't mid-refresh). Empty list during reload is ambiguous.
+    // Permanently removed (left, deleted, kicked) — clear selection.
+    // Gate on isLoading rather than emptiness so deleting the very
+    // last conversation still clears the panel instead of getting
+    // stuck because convs.isEmpty.
+    if (fresh == null && !convState.isLoading) {
       _selectedConversation = null;
       _narrowPanelIndex = 0;
     }

--- a/apps/client/lib/src/services/group_crypto_service.dart
+++ b/apps/client/lib/src/services/group_crypto_service.dart
@@ -651,6 +651,7 @@ class GroupCryptoService {
     required Future<List<Map<String, dynamic>>> Function() fetchMembers,
     required Future<Uint8List?> Function(String userId) fetchIdentityKey,
     Future<bool> Function(String userId)? hasIdentityKeyChanged,
+    String? selfUserId,
     String triggeredByEvent = 'unspecified',
   }) {
     // Audit P1-4: timeline event captures the full rotation cost (member
@@ -664,6 +665,7 @@ class GroupCryptoService {
         fetchMembers: fetchMembers,
         fetchIdentityKey: fetchIdentityKey,
         hasIdentityKeyChanged: hasIdentityKeyChanged,
+        selfUserId: selfUserId,
         triggeredByEvent: triggeredByEvent,
       ),
       args: {'conversation': conversationId, 'keyVersion': keyVersion},
@@ -676,6 +678,7 @@ class GroupCryptoService {
     required Future<List<Map<String, dynamic>>> Function() fetchMembers,
     required Future<Uint8List?> Function(String userId) fetchIdentityKey,
     Future<bool> Function(String userId)? hasIdentityKeyChanged,
+    String? selfUserId,
     required String triggeredByEvent,
   }) async {
     // Drop the stale key first so we never encrypt with the now-revoked
@@ -706,6 +709,27 @@ class GroupCryptoService {
         .cast<String>()
         .toList();
     final identityKeys = await Future.wait(userIds.map(fetchIdentityKey));
+
+    // TD-21: if the rotator's own identity key is unavailable (e.g.
+    // keyring locked, secure storage migration in flight), uploading
+    // envelopes that exclude self would leave us unable to decrypt
+    // anything we send in this group until the next rotation re-
+    // includes us. Hard-abort so the caller can retry once the
+    // keyring is unlocked. Other members with null keys still get
+    // skipped further down — they'll be included in the next rotation
+    // once they publish.
+    if (selfUserId != null) {
+      for (var i = 0; i < userIds.length; i++) {
+        if (userIds[i] == selfUserId && identityKeys[i] == null) {
+          debugPrint(
+            '[GroupCrypto] performRotation aborted: local identity '
+            'key unavailable (keyring locked?). Retry when crypto '
+            'is ready.',
+          );
+          return null;
+        }
+      }
+    }
 
     // TD-4: TOFU bypass guard. fetchPeerIdentityKey(forceRefresh: true)
     // silently trusts whatever the server returned, so wrapping the

--- a/apps/client/lib/src/widgets/avatar_crop_dialog.dart
+++ b/apps/client/lib/src/widgets/avatar_crop_dialog.dart
@@ -116,11 +116,18 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
   img.Image? _decoded;
 
   // Viewport dimensions for the preview area. Picked at runtime in
-  // [_resolvePreviewSize] so the desktop window gets a roomier cropper
+  // [didChangeDependencies] so the desktop window gets a roomier cropper
   // (mouse users can't pinch-zoom; they pan + use the zoom slider).
   static const _previewSizeMobile = 280.0;
   static const _previewSizeDesktop = 460.0;
   double _previewSize = _previewSizeMobile;
+
+  /// Cached minimum scale at which the image still covers the preview
+  /// square. Recomputed only when the image decodes or the preview
+  /// viewport flips between mobile/desktop. Avoids the per-frame
+  /// `_previewSize / min(imgW, imgH)` arithmetic in build() that the
+  /// performance reviewer flagged in TD-13.
+  double _minScale = 1.0;
 
   // Scale and offset of the image inside the preview square.
   // The image is scaled so its shorter side fills the preview initially.
@@ -149,22 +156,33 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
     final w = MediaQuery.sizeOf(context).width;
     final isDesktop = w >= 800;
     final desired = isDesktop ? _previewSizeDesktop : _previewSizeMobile;
-    if (_previewSize != desired) {
+    if (_previewSize == desired) return;
+    // TD-12: wrap the size flip in setState so the next build sees the
+    // new viewport. The Custompaint mask, slider min, and crop preview
+    // all key off _previewSize.
+    setState(() {
       _previewSize = desired;
-      // Re-fit the image to the new viewport if it was already decoded.
       if (_decoded != null) {
-        final imgW = _decoded!.width.toDouble();
-        final imgH = _decoded!.height.toDouble();
-        final initScale = _previewSize / (imgW < imgH ? imgW : imgH);
-        _scale = initScale;
-        final scaledW = imgW * _scale;
-        final scaledH = imgH * _scale;
-        _offset = Offset(
-          (_previewSize - scaledW) / 2,
-          (_previewSize - scaledH) / 2,
-        );
+        _refitToViewport();
       }
-    }
+    });
+  }
+
+  /// Recompute scale + offset to center the decoded image inside the
+  /// current `_previewSize`. Also refreshes `_minScale` so the zoom
+  /// slider doesn't have to derive it per build (TD-13).
+  void _refitToViewport() {
+    if (_decoded == null) return;
+    final imgW = _decoded!.width.toDouble();
+    final imgH = _decoded!.height.toDouble();
+    _minScale = _previewSize / (imgW < imgH ? imgW : imgH);
+    _scale = _minScale;
+    final scaledW = imgW * _scale;
+    final scaledH = imgH * _scale;
+    _offset = Offset(
+      (_previewSize - scaledW) / 2,
+      (_previewSize - scaledH) / 2,
+    );
   }
 
   Future<void> _decodeImage() async {
@@ -177,18 +195,20 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
       }
       final imgW = decoded.width.toDouble();
       final imgH = decoded.height.toDouble();
-      // Scale so the shorter side covers the preview square.
-      final initScale = _previewSize / (imgW < imgH ? imgW : imgH);
-      // Centre the image.
-      final scaledW = imgW * initScale;
-      final scaledH = imgH * initScale;
+      // Scale so the shorter side covers the preview square. Cache the
+      // min so the build-time Slider doesn't recompute it every frame
+      // (TD-13).
+      final minScale = _previewSize / (imgW < imgH ? imgW : imgH);
+      final scaledW = imgW * minScale;
+      final scaledH = imgH * minScale;
       final initOffset = Offset(
         (_previewSize - scaledW) / 2,
         (_previewSize - scaledH) / 2,
       );
       setState(() {
         _decoded = decoded;
-        _scale = initScale;
+        _minScale = minScale;
+        _scale = minScale;
         _offset = initOffset;
       });
     } catch (e) {
@@ -381,19 +401,9 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
                   ),
                   Expanded(
                     child: Slider(
-                      min:
-                          _previewSize /
-                          (_decoded!.width < _decoded!.height
-                              ? _decoded!.width.toDouble()
-                              : _decoded!.height.toDouble()),
+                      min: _minScale,
                       max: 6.0,
-                      value: _scale.clamp(
-                        _previewSize /
-                            (_decoded!.width < _decoded!.height
-                                ? _decoded!.width.toDouble()
-                                : _decoded!.height.toDouble()),
-                        6.0,
-                      ),
+                      value: _scale.clamp(_minScale, 6.0),
                       onChanged: _onZoomSliderChanged,
                     ),
                   ),

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -86,6 +86,12 @@ class ChatInputBar extends ConsumerStatefulWidget {
   ConsumerState<ChatInputBar> createState() => ChatInputBarState();
 }
 
+/// Direction of a mention-picker selection move, expressed as visual
+/// intent rather than a raw +1 / -1 delta. The picker ListView uses
+/// `reverse: true`, so encoding the inversion here keeps the key
+/// handler reading as `up` / `down`.
+enum _MentionMove { up, down }
+
 class ChatInputBarState extends ConsumerState<ChatInputBar> {
   // The text composer, focus node, edit-message state, and (in a later
   // slice) mention controller live on [_controller]. Forwarders below
@@ -210,11 +216,19 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _handleMentionSelected(candidates[idx]);
   }
 
-  /// Move the picker selection. Wraps at both ends so quick navigation
-  /// keeps the eye on the picker without tracking edge cases.
-  void _moveMentionSelection(int delta) {
+  /// Semantic direction for picker navigation. The candidate list is
+  /// rendered with `reverse: true`, so the *visual* "down arrow"
+  /// actually moves to a smaller index. Encapsulating that here means
+  /// the key handler reads as `_MentionMove.down` rather than
+  /// `_moveMentionSelection(-1)` and a future maintainer can't
+  /// accidentally flip the sign (TD-22).
+  void _moveMentionSelection(_MentionMove direction) {
     final candidates = _mentionCandidates;
     if (candidates.isEmpty) return;
+    final delta = switch (direction) {
+      _MentionMove.up => 1, // up arrow → higher index in the reverse list
+      _MentionMove.down => -1, // down arrow → lower index
+    };
     final next = (_mentionPickerIndex + delta) % candidates.length;
     setState(() {
       _mentionPickerIndex = next < 0 ? next + candidates.length : next;
@@ -1496,11 +1510,11 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
         return KeyEventResult.handled;
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-        _moveMentionSelection(-1); // reverse: true list — down moves toward
-        return KeyEventResult.handled; // smaller indices visually
+        _moveMentionSelection(_MentionMove.down);
+        return KeyEventResult.handled;
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-        _moveMentionSelection(1);
+        _moveMentionSelection(_MentionMove.up);
         return KeyEventResult.handled;
       }
       if (event.logicalKey == LogicalKeyboardKey.escape) {

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -563,9 +563,14 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
               // means the bug-report and update affordances stay reachable
               // during a call.
               if (MediaQuery.sizeOf(context).width >= 600)
-                VoiceDock(
-                  width: 320,
-                  onNavigateToLounge: widget.onNavigateToLounge,
+                // LayoutBuilder hands the dock the actual column width so
+                // it doesn't under-fill (sidebar default is 350, dock
+                // used to hardcode 320) or overflow on resize. TD-11.
+                LayoutBuilder(
+                  builder: (context, constraints) => VoiceDock(
+                    width: constraints.maxWidth,
+                    onNavigateToLounge: widget.onNavigateToLounge,
+                  ),
                 ),
               if (MediaQuery.sizeOf(context).width >= 600)
                 _buildSidebarUpdateBanner(context),

--- a/apps/client/test/widgets/input/mention_autocomplete_candidate_values_test.dart
+++ b/apps/client/test/widgets/input/mention_autocomplete_candidate_values_test.dart
@@ -1,0 +1,74 @@
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/widgets/input/mention_autocomplete.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Tests for [MentionAutocomplete.candidateValues] — the static helper
+/// the chat composer uses to compute the keyboard-accept target. The
+/// candidate list and the rendered ListView MUST stay in sync; this
+/// suite locks the contract (TD-23).
+void main() {
+  ConversationMember member(String username) =>
+      ConversationMember(userId: 'u-$username', username: username);
+
+  group('MentionAutocomplete.candidateValues', () {
+    test('empty query returns all member usernames then broadcasts', () {
+      final result = MentionAutocomplete.candidateValues([
+        member('alice'),
+        member('bob'),
+        member('carol'),
+      ], '');
+      expect(result, ['alice', 'bob', 'carol', 'everyone', 'here']);
+    });
+
+    test('query "al" filters to alice, no matching broadcasts', () {
+      final result = MentionAutocomplete.candidateValues([
+        member('alice'),
+        member('bob'),
+      ], 'al');
+      expect(result, ['alice']);
+    });
+
+    test('query "ev" surfaces only @everyone', () {
+      final result = MentionAutocomplete.candidateValues([
+        member('alice'),
+      ], 'ev');
+      expect(result, ['everyone']);
+    });
+
+    test('query "he" surfaces only @here', () {
+      final result = MentionAutocomplete.candidateValues([
+        member('alice'),
+      ], 'he');
+      expect(result, ['here']);
+    });
+
+    test('no-match query returns empty list', () {
+      final result = MentionAutocomplete.candidateValues([
+        member('alice'),
+      ], 'zzz');
+      expect(result, isEmpty);
+    });
+
+    test('empty member list + empty query returns broadcasts only', () {
+      final result = MentionAutocomplete.candidateValues(const [], '');
+      expect(result, ['everyone', 'here']);
+    });
+
+    test('matching is case-insensitive on members (lowercased query)', () {
+      // `extractMentionQuery` always lowercases before passing in, so we
+      // mirror that here. Member usernames are stored lowercase upstream.
+      final result = MentionAutocomplete.candidateValues([
+        member('alice'),
+      ], 'a');
+      expect(result, ['alice']);
+    });
+
+    test('member usernames are matched on prefix, not contains', () {
+      final result = MentionAutocomplete.candidateValues([
+        member('alice'),
+        member('palice'),
+      ], 'al');
+      expect(result, ['alice']);
+    });
+  });
+}

--- a/apps/client/test/widgets/message/own_decrypt_failed_bubble_test.dart
+++ b/apps/client/test/widgets/message/own_decrypt_failed_bubble_test.dart
@@ -1,0 +1,79 @@
+import 'package:echo_app/src/widgets/message/message_indicators.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// Widget tests for [OwnDecryptFailedBubble] — the recovery surface
+/// the sender sees when their own group message couldn't be decrypted
+/// back to self (group-E2E wedge per CLAUDE.md #344). Locks down the
+/// callback wiring and the "only you can see this" copy (TD-23).
+void main() {
+  group('OwnDecryptFailedBubble', () {
+    testWidgets('renders original text and the "only you" footer', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        OwnDecryptFailedBubble(
+          originalText: 'meet at 7',
+          onResend: () {},
+          onDelete: () {},
+        ),
+      );
+
+      expect(find.text('meet at 7'), findsOneWidget);
+      expect(find.textContaining("Only you can see this"), findsOneWidget);
+    });
+
+    testWidgets('Resend button fires onResend', (tester) async {
+      var resends = 0;
+      await tester.pumpApp(
+        OwnDecryptFailedBubble(
+          originalText: 'meet at 7',
+          onResend: () => resends++,
+          onDelete: () {},
+        ),
+      );
+      await tester.tap(find.text('Resend'));
+      expect(resends, 1);
+    });
+
+    testWidgets('Delete button fires onDelete', (tester) async {
+      var deletes = 0;
+      await tester.pumpApp(
+        OwnDecryptFailedBubble(
+          originalText: 'meet at 7',
+          onResend: () {},
+          onDelete: () => deletes++,
+        ),
+      );
+      await tester.tap(find.text('Delete'));
+      expect(deletes, 1);
+    });
+
+    testWidgets('omits Resend/Delete buttons when callbacks are null', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const OwnDecryptFailedBubble(originalText: 'meet at 7'),
+      );
+      expect(find.text('Resend'), findsNothing);
+      expect(find.text('Delete'), findsNothing);
+      expect(find.text('meet at 7'), findsOneWidget);
+    });
+
+    testWidgets('original text renders at reduced opacity', (tester) async {
+      await tester.pumpApp(
+        OwnDecryptFailedBubble(originalText: 'meet at 7', onResend: () {}),
+      );
+      final opacityWidget = tester.widget<Opacity>(
+        find.ancestor(
+          of: find.text('meet at 7'),
+          matching: find.byType(Opacity),
+        ),
+      );
+      expect(opacityWidget.opacity, lessThan(1.0));
+      expect(opacityWidget.opacity, greaterThan(0.5));
+    });
+  });
+}

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -19,6 +19,10 @@ pub struct GroupInfo {
     pub description: Option<String>,
     pub icon_url: Option<String>,
     pub created_at: DateTime<Utc>,
+    /// Whether the group is end-to-end encrypted. Surfaced through the
+    /// create / fetch responses so clients can render the lock indicator
+    /// without an extra round-trip after creation (TD-8).
+    pub is_encrypted: bool,
 }
 
 #[derive(Debug, sqlx::FromRow, Serialize)]
@@ -62,7 +66,7 @@ pub async fn create_group_with_visibility(
     let group: GroupInfo = sqlx::query_as(
         "INSERT INTO conversations (kind, title, is_public, description, is_encrypted) \
          VALUES ('group', $1, $2, $3, $4) \
-         RETURNING id, title, kind, description, icon_url, created_at",
+         RETURNING id, title, kind, description, icon_url, created_at, is_encrypted",
     )
     .bind(name)
     .bind(is_public)
@@ -285,7 +289,7 @@ pub async fn join_public_group(
 /// Get group info by conversation ID.
 pub async fn get_group(pool: &PgPool, group_id: Uuid) -> Result<Option<GroupInfo>, sqlx::Error> {
     sqlx::query_as::<_, GroupInfo>(
-        "SELECT id, title, kind, description, icon_url, created_at \
+        "SELECT id, title, kind, description, icon_url, created_at, is_encrypted \
          FROM conversations WHERE id = $1 AND kind = 'group'",
     )
     .bind(group_id)

--- a/apps/server/src/routes/groups/create.rs
+++ b/apps/server/src/routes/groups/create.rs
@@ -20,7 +20,13 @@ pub async fn create_group(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateGroupRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    if body.name.is_empty() || body.name.len() > 100 {
+    // Trim before the empty check so " " can't slip past as a valid name,
+    // and use chars().count() so multi-byte CJK / emoji characters don't
+    // burn the budget faster than ASCII names of the same visual length
+    // (TD-15 in TECHNICAL_DEBT.md).
+    let trimmed = body.name.trim();
+    let char_count = trimmed.chars().count();
+    if trimmed.is_empty() || char_count > 100 {
         return Err(AppError::bad_request(
             "Group name must be between 1 and 100 characters",
         ));
@@ -44,10 +50,16 @@ pub async fn create_group(
         }
     }
 
-    // Prevent duplicate public group names per creator
+    // Best-effort duplicate-name check for public groups by the same creator.
+    // This is a read-then-write race: a concurrent create can slip through
+    // between the SELECT and the INSERT. TD-20 tracks the hardened solution
+    // (unique partial index on (creator_id, lower(title)) WHERE is_public)
+    // which needs a schema migration adding creator_id to conversations.
+    // For now the race is harmless — two duplicate groups are visually
+    // identical but each is independently usable.
     if body.is_public {
         let already_exists =
-            db::groups::user_has_public_group_named(&state.pool, auth.user_id, &body.name)
+            db::groups::user_has_public_group_named(&state.pool, auth.user_id, trimmed)
                 .await
                 .db_ctx("create_group/check_dup_name")?;
         if already_exists {
@@ -60,7 +72,7 @@ pub async fn create_group(
     let group = db::groups::create_group_with_visibility(
         &state.pool,
         auth.user_id,
-        &body.name,
+        trimmed,
         &body.member_ids,
         body.is_public,
         body.description.as_deref(),
@@ -84,6 +96,7 @@ pub async fn create_group(
         kind: group.kind,
         description: group.description,
         icon_url: group.icon_url,
+        is_encrypted: group.is_encrypted,
         members: members
             .into_iter()
             .map(|m| GroupMemberResponse {
@@ -131,6 +144,7 @@ pub async fn get_group(
         kind: group.kind,
         description: group.description,
         icon_url: group.icon_url,
+        is_encrypted: group.is_encrypted,
         members: members
             .into_iter()
             .map(|m| GroupMemberResponse {

--- a/apps/server/src/routes/groups/types.rs
+++ b/apps/server/src/routes/groups/types.rs
@@ -15,7 +15,15 @@ pub struct CreateGroupRequest {
     /// that doesn't send the field gets a plaintext group — the group-
     /// key envelope path is still experimental and groups created with
     /// it have shown an envelope-MAC wedge under identity-key drift
-    /// (see fix in v0.0.379). Clients that want E2E pass `true`.
+    /// (see PR #982). Clients that want E2E pass `true`.
+    ///
+    /// **Write-once.** Intentionally absent from [`UpdateGroupRequest`] so
+    /// `PUT /api/groups/:id` cannot flip an encrypted group to plaintext
+    /// (or vice versa) mid-conversation. Doing so would invalidate the
+    /// ratchet / group-key state for every member and would constitute a
+    /// downgrade attack against an existing E2E channel. Any future
+    /// rotation/migration story must rotate keys + require member
+    /// re-consent rather than toggling this column. See TD-7.
     #[serde(default)]
     pub is_encrypted: bool,
 }
@@ -45,6 +53,10 @@ pub struct GroupResponse {
     pub description: Option<String>,
     pub icon_url: Option<String>,
     pub members: Vec<GroupMemberResponse>,
+    /// Whether the group is end-to-end encrypted. Lets clients render
+    /// the lock indicator immediately after create/fetch without a
+    /// second round-trip (TD-8).
+    pub is_encrypted: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -64,6 +76,37 @@ pub struct AddMemberRequest {
 pub struct UpdateGroupRequest {
     pub title: Option<String>,
     pub description: Option<String>,
+    // DO NOT add `is_encrypted` here. See the doc-comment on
+    // `CreateGroupRequest::is_encrypted`. The test below enforces the
+    // invariant at compile time so this stays catchable on CI.
+}
+
+#[cfg(test)]
+mod update_group_request_lockdown {
+    use super::*;
+    use serde_json::json;
+
+    /// `UpdateGroupRequest` must remain write-locked against `is_encrypted`.
+    /// If a future contributor adds the field to the struct this test will
+    /// stop short-circuiting (it'll start parsing the value into the new
+    /// field) and the matching production write path will need to be
+    /// security-reviewed. See TD-7 in TECHNICAL_DEBT.md.
+    #[test]
+    fn is_encrypted_is_silently_dropped() {
+        // serde defaults to `deny_unknown_fields = false`, so unknown keys
+        // are dropped on parse. This deserialization MUST succeed and MUST
+        // NOT carry the encryption flag anywhere downstream.
+        let parsed: UpdateGroupRequest = serde_json::from_value(json!({
+            "title": "x",
+            "is_encrypted": true,
+        }))
+        .expect("title-only update should still deserialize");
+        assert_eq!(parsed.title.as_deref(), Some("x"));
+        // No is_encrypted field on the struct — proven by virtue of this
+        // file compiling. Touch the other fields to keep the assertion
+        // intentional rather than smoke-test.
+        assert!(parsed.description.is_none());
+    }
 }
 
 /// Optional body for invite creation (both fields accepted; UI deferred to follow-up).

--- a/tests/e2e/group_encryption_roundtrip.spec.ts
+++ b/tests/e2e/group_encryption_roundtrip.spec.ts
@@ -31,6 +31,16 @@ const WEB_URL = process.env.ECHO_URL || 'http://localhost:8081';
 const APP = `${WEB_URL}/?server=${encodeURIComponent(SERVER)}`;
 const SS = 'tests/e2e/test-results/group-encryption-roundtrip';
 
+// TD-19: prevent accidental execution against production. A developer
+// with `ECHO_SERVER=https://echo-messenger.us` exported in their
+// shell would otherwise run the full register / create-group /
+// rotate / delete cycle against the live deployment when invoking
+// `--project=maintained`. Opt-in via ALLOW_PROD_ROUNDTRIP=1 keeps the
+// documented manual-prod run path open while making accidents loud.
+const PROD_HOST = 'echo-messenger.us';
+const targetsProd = SERVER.includes(PROD_HOST) || WEB_URL.includes(PROD_HOST);
+const allowProd = process.env.ALLOW_PROD_ROUNDTRIP === '1';
+
 const ts = Date.now().toString().slice(-6);
 const ALICE = `enca${ts}`;
 const BOB = `encb${ts}`;
@@ -248,6 +258,15 @@ async function bodyText(page: Page): Promise<string> {
 test.describe('Group encryption — two-party roundtrip on a fresh group', () => {
   let alice: any;
   let bob: any;
+
+  // TD-19: refuse to run against prod unless the operator explicitly
+  // opted in. Prevents accidental account-create / group-create churn
+  // on the live server when ECHO_SERVER happens to be exported.
+  test.skip(
+    targetsProd && !allowProd,
+    `Refusing to run roundtrip against ${PROD_HOST}. Set ` +
+      `ALLOW_PROD_ROUNDTRIP=1 to opt in.`,
+  );
 
   test.beforeAll(async () => {
     console.log(`\nEncryption-roundtrip test (server=${SERVER})`);


### PR DESCRIPTION
## Summary

Finishes the medium / low tier of TECHNICAL_DEBT.md (17 items across 3 commits). After this lands, only TD-14 (conversation Map index — needs a provider refactor) and 3 of 5 TD-23 surfaces (need Riverpod test harness scaffolding) remain on the tracker.

## Commits in this PR

**1. Server batch** — TD-7, TD-8, TD-15, TD-20:
- \`is_encrypted\` locked out of \`UpdateGroupRequest\` with a doc comment + a compile-time test
- \`is_encrypted\` surfaced on \`GroupInfo\` / \`GroupResponse\` via the SQL \`RETURNING\` clause
- Group name length uses \`chars().count()\` + \`trim()\` so CJK / emoji names get the same 100-char budget as ASCII
- TD-20 documented inline; proper fix needs a schema migration adding \`creator_id\` to \`conversations\` (deferred)

**2. Crypto + rotation hardening** — TD-1..TD-4 already shipped in #1007; this batch adds TD-5/TD-6/TD-18/TD-21:
- \`sendGroupMessage\` self-heal falls through to \`fetchGroupKey\` on 409-race nulls
- \`seedInitialGroupKey\` accepts an optional \`currentVersion\` hint (skips the probe RTT)
- Probe error path distinguishes 401/403 (abort) from network failure (fall through to v=1)
- \`performRotation\` accepts \`selfUserId\` and hard-aborts when the rotator's own key is null

**3. UI polish + tests** — TD-10..13, TD-16/17/19/22, partial TD-23:
- KeyedSubtree on conversation-rail items, VoiceDock width via LayoutBuilder, setState in cropper's didChangeDependencies, cached \`_minScale\`
- \`barrierLabel\` on quick switcher / global search / keyboard shortcuts dialogs
- \`_syncSelectedConversation\` gates on \`isLoading\` not \`isNotEmpty\` (last-group-deleted no longer leaves a stale panel)
- Mention picker direction becomes a \`_MentionMove.up\` / \`_MentionMove.down\` enum
- E2E spec refuses to run against \`echo-messenger.us\` unless \`ALLOW_PROD_ROUNDTRIP=1\`
- New widget tests: \`mention_autocomplete_candidate_values_test\` (8 cases), \`own_decrypt_failed_bubble_test\` (5 cases)

## Test plan

- [x] \`cargo check -p echo-server\` clean
- [x] \`cargo clippy -p echo-server -- -D warnings\` clean
- [x] \`cargo test -p echo-server\` — compile-time \`is_encrypted_is_silently_dropped\` passes
- [x] \`flutter analyze --fatal-infos\` clean
- [x] \`flutter test test/widgets/{message_item_test.dart,input/,message/}\` — 109 tests pass (13 new)