### PR TITLE
Collapse and expand channel categories in the side rail

### DIFF
--- a/apps/client/lib/src/providers/channel_categories_provider.dart
+++ b/apps/client/lib/src/providers/channel_categories_provider.dart
@@ -1,0 +1,40 @@
+/// Collapsed-category state for the Slack/Discord-style channel column.
+///
+/// Backed by SharedPreferences so the column remembers which category
+/// the user collapsed across app launches. Keys are stable strings
+/// (`text`, `voice`) rather than the display label so localized
+/// renames don't reset the preference.
+library;
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'channel_categories_provider.g.dart';
+
+const String _kCollapsedKey = 'channel_column_collapsed_categories';
+
+@Riverpod(keepAlive: true)
+class ChannelCategoryCollapsed extends _$ChannelCategoryCollapsed {
+  @override
+  Set<String> build() {
+    _load();
+    return const <String>{};
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_kCollapsedKey);
+    if (raw == null) return;
+    state = raw.toSet();
+  }
+
+  Future<void> toggle(String key) async {
+    final next = Set<String>.from(state);
+    if (!next.add(key)) next.remove(key);
+    state = next;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kCollapsedKey, next.toList());
+  }
+
+  bool isCollapsed(String key) => state.contains(key);
+}

--- a/apps/client/lib/src/providers/channel_categories_provider.g.dart
+++ b/apps/client/lib/src/providers/channel_categories_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'channel_categories_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$channelCategoryCollapsedHash() =>
+    r'9ea6163bb0d5a12dcfde724cdf3f34a90ee8fcbc';
+
+/// See also [ChannelCategoryCollapsed].
+@ProviderFor(ChannelCategoryCollapsed)
+final channelCategoryCollapsedProvider =
+    NotifierProvider<ChannelCategoryCollapsed, Set<String>>.internal(
+      ChannelCategoryCollapsed.new,
+      name: r'channelCategoryCollapsedProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$channelCategoryCollapsedHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ChannelCategoryCollapsed = Notifier<Set<String>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -17,10 +17,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/channel.dart';
 import '../models/conversation.dart';
+import '../providers/channel_categories_provider.dart';
 import '../providers/channels_provider.dart';
 import '../providers/livekit_voice/livekit_voice_provider.dart';
 import '../theme/echo_theme.dart';
 import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
+
+const String _kTextCategoryKey = 'text';
+const String _kVoiceCategoryKey = 'voice';
 
 class ChannelColumn extends ConsumerWidget {
   final Conversation conversation;
@@ -49,6 +53,9 @@ class ChannelColumn extends ConsumerWidget {
     final textChannels = channels.where((c) => c.isText).toList();
     final voiceChannels = channels.where((c) => c.isVoice).toList();
     final voiceState = ref.watch(livekitVoiceProvider);
+    final collapsed = ref.watch(channelCategoryCollapsedProvider);
+    final textCollapsed = collapsed.contains(_kTextCategoryKey);
+    final voiceCollapsed = collapsed.contains(_kVoiceCategoryKey);
 
     return Container(
       width: width,
@@ -66,27 +73,41 @@ class ChannelColumn extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(vertical: 8),
               children: [
                 if (textChannels.isNotEmpty) ...[
-                  const _CategoryHeader(label: 'Text Channels'),
-                  for (final c in textChannels)
-                    _TextChannelRow(
-                      channel: c,
-                      isSelected: c.id == selectedTextChannelId,
-                      onTap: () => onTextChannelChanged(c.id),
-                    ),
+                  _CategoryHeader(
+                    label: 'Text Channels',
+                    collapsed: textCollapsed,
+                    onToggle: () => ref
+                        .read(channelCategoryCollapsedProvider.notifier)
+                        .toggle(_kTextCategoryKey),
+                  ),
+                  if (!textCollapsed)
+                    for (final c in textChannels)
+                      _TextChannelRow(
+                        channel: c,
+                        isSelected: c.id == selectedTextChannelId,
+                        onTap: () => onTextChannelChanged(c.id),
+                      ),
                   const SizedBox(height: 12),
                 ],
                 if (voiceChannels.isNotEmpty) ...[
-                  const _CategoryHeader(label: 'Voice Channels'),
-                  for (final c in voiceChannels)
-                    _VoiceChannelGroup(
-                      channel: c,
-                      members: channelsState.voiceSessionsFor(c.id),
-                      isActive:
-                          voiceState.channelId == c.id &&
-                          voiceState.conversationId == conversation.id,
-                      onJoin: () => _join(ref, c),
-                      onOpenLounge: onShowLounge,
-                    ),
+                  _CategoryHeader(
+                    label: 'Voice Channels',
+                    collapsed: voiceCollapsed,
+                    onToggle: () => ref
+                        .read(channelCategoryCollapsedProvider.notifier)
+                        .toggle(_kVoiceCategoryKey),
+                  ),
+                  if (!voiceCollapsed)
+                    for (final c in voiceChannels)
+                      _VoiceChannelGroup(
+                        channel: c,
+                        members: channelsState.voiceSessionsFor(c.id),
+                        isActive:
+                            voiceState.channelId == c.id &&
+                            voiceState.conversationId == conversation.id,
+                        onJoin: () => _join(ref, c),
+                        onOpenLounge: onShowLounge,
+                      ),
                 ],
               ],
             ),
@@ -167,19 +188,44 @@ class _ColumnHeader extends StatelessWidget {
 
 class _CategoryHeader extends StatelessWidget {
   final String label;
-  const _CategoryHeader({required this.label});
+  final bool collapsed;
+  final VoidCallback onToggle;
+  const _CategoryHeader({
+    required this.label,
+    required this.collapsed,
+    required this.onToggle,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(14, 4, 8, 6),
-      child: Text(
-        label.toUpperCase(),
-        style: TextStyle(
-          color: context.textMuted,
-          fontSize: 10,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 0.6,
+    return Semantics(
+      label: '$label category, ${collapsed ? "collapsed" : "expanded"}',
+      button: true,
+      child: InkWell(
+        onTap: onToggle,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(8, 4, 8, 6),
+          child: Row(
+            children: [
+              Icon(
+                collapsed ? Icons.chevron_right : Icons.expand_more,
+                size: 14,
+                color: context.textMuted,
+              ),
+              const SizedBox(width: 2),
+              Expanded(
+                child: Text(
+                  label.toUpperCase(),
+                  style: TextStyle(
+                    color: context.textMuted,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.6,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/client/test/widgets/channel_column_test.dart
+++ b/apps/client/test/widgets/channel_column_test.dart
@@ -4,6 +4,7 @@ import 'package:echo_app/src/providers/channels_provider.dart';
 import 'package:echo_app/src/widgets/channel_column.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/pump_app.dart';
 
@@ -11,6 +12,10 @@ import '../helpers/pump_app.dart';
 /// Verifies rendering of categories, text + voice rows, voice-member
 /// nesting, and the selected-state highlight on the active text channel.
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   Conversation conv(String displayName) => Conversation(
     id: 'c1',
     isGroup: true,
@@ -142,6 +147,31 @@ void main() {
       expect(find.text('jane'), findsOneWidget);
       // Member count badge on the voice row.
       expect(find.text('1'), findsOneWidget);
+    });
+
+    testWidgets('tapping a category header collapses its rows', (tester) async {
+      await tester.pumpApp(
+        ChannelColumn(
+          conversation: conv('Echo Devs'),
+          selectedTextChannelId: 't1',
+          onTextChannelChanged: (_) {},
+        ),
+        overrides: [
+          channelsOverride(
+            channelsByConversation: {
+              'c1': [text('t1', 'general'), text('t2', 'releases', pos: 1)],
+            },
+          ),
+        ],
+      );
+      expect(find.text('general'), findsOneWidget);
+      expect(find.text('releases'), findsOneWidget);
+      await tester.tap(find.text('TEXT CHANNELS'));
+      await tester.pumpAndSettle();
+      expect(find.text('general'), findsNothing);
+      expect(find.text('releases'), findsNothing);
+      // Header still visible so the user can re-expand.
+      expect(find.text('TEXT CHANNELS'), findsOneWidget);
     });
 
     testWidgets('voice row with no members hides the count', (tester) async {


### PR DESCRIPTION
Final slice of the column-layout series. Polish on top of the rail
that PRs #1011-#1014 introduced.

## What the user sees
Each category header in the side rail (Text Channels, Voice Channels)
now has a chevron and is tappable. Tapping it folds the channels in
that category out of view; tapping it again unfolds them. The
chevron flips between `>` and `v` to match the state.

The collapsed/expanded choice is **remembered across app launches**
per category, so someone who lives in text and only occasionally
hops into voice can keep the Voice category folded by default.

## Behind the scenes
- New `channelCategoryCollapsedProvider` storing a `Set<String>` of
  collapsed category keys, persisted via SharedPreferences.
- Added a widget test covering the collapse/expand interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)