### PR TITLE
Release: Slack/Discord-style side-panel channel list

### DIFF
--- a/apps/client/lib/src/providers/channel_categories_provider.dart
+++ b/apps/client/lib/src/providers/channel_categories_provider.dart
@@ -1,0 +1,40 @@
+/// Collapsed-category state for the Slack/Discord-style channel column.
+///
+/// Backed by SharedPreferences so the column remembers which category
+/// the user collapsed across app launches. Keys are stable strings
+/// (`text`, `voice`) rather than the display label so localized
+/// renames don't reset the preference.
+library;
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'channel_categories_provider.g.dart';
+
+const String _kCollapsedKey = 'channel_column_collapsed_categories';
+
+@Riverpod(keepAlive: true)
+class ChannelCategoryCollapsed extends _$ChannelCategoryCollapsed {
+  @override
+  Set<String> build() {
+    _load();
+    return const <String>{};
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_kCollapsedKey);
+    if (raw == null) return;
+    state = raw.toSet();
+  }
+
+  Future<void> toggle(String key) async {
+    final next = Set<String>.from(state);
+    if (!next.add(key)) next.remove(key);
+    state = next;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_kCollapsedKey, next.toList());
+  }
+
+  bool isCollapsed(String key) => state.contains(key);
+}

--- a/apps/client/lib/src/providers/channel_categories_provider.g.dart
+++ b/apps/client/lib/src/providers/channel_categories_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'channel_categories_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$channelCategoryCollapsedHash() =>
+    r'9ea6163bb0d5a12dcfde724cdf3f34a90ee8fcbc';
+
+/// See also [ChannelCategoryCollapsed].
+@ProviderFor(ChannelCategoryCollapsed)
+final channelCategoryCollapsedProvider =
+    NotifierProvider<ChannelCategoryCollapsed, Set<String>>.internal(
+      ChannelCategoryCollapsed.new,
+      name: r'channelCategoryCollapsedProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$channelCategoryCollapsedHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ChannelCategoryCollapsed = Notifier<Set<String>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -1,0 +1,404 @@
+/// Slack/Discord-style vertical channel list.
+///
+/// An alternative to `channel_bar.dart`'s top-of-chat chip row, selected
+/// via the user-facing toggle in [channelLayoutProvider]. Renders the
+/// active group's channels grouped by category, with voice channels
+/// expanding to show their connected members beneath them. Text channels
+/// pick up the same accent-pill selected-state used elsewhere.
+///
+/// The widget defers to the same providers the bar uses
+/// (`channelsProvider` for the channel list, `channelsProvider.notifier`
+/// to join voice, `livekitVoiceProvider` for the active voice session),
+/// so the two layouts are interchangeable without server work.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/channel.dart';
+import '../models/conversation.dart';
+import '../providers/channels_provider.dart';
+import '../providers/livekit_voice/livekit_voice_provider.dart';
+import '../theme/echo_theme.dart';
+import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
+
+class ChannelColumn extends ConsumerWidget {
+  final Conversation conversation;
+  final String? selectedTextChannelId;
+  final ValueChanged<String?> onTextChannelChanged;
+  final VoidCallback? onShowLounge;
+
+  /// Fixed column width. 260 matches the Slack/Discord visual baseline
+  /// and lets a 1280 desktop window comfortably show
+  /// `sidebar + column + chat + members` without crowding.
+  static const double width = 260;
+
+  const ChannelColumn({
+    super.key,
+    required this.conversation,
+    required this.selectedTextChannelId,
+    required this.onTextChannelChanged,
+    this.onShowLounge,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final channelsState = ref.watch(channelsProvider);
+    final channels = channelsState.channelsFor(conversation.id)
+      ..sort((a, b) => a.position.compareTo(b.position));
+    final textChannels = channels.where((c) => c.isText).toList();
+    final voiceChannels = channels.where((c) => c.isVoice).toList();
+    final voiceState = ref.watch(livekitVoiceProvider);
+
+    return Container(
+      width: width,
+      decoration: BoxDecoration(
+        color: context.sidebarBg,
+        border: Border(right: BorderSide(color: context.border)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _ColumnHeader(conversation: conversation),
+          Divider(height: 1, color: context.border),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              children: [
+                if (textChannels.isNotEmpty) ...[
+                  const _CategoryHeader(label: 'Text Channels'),
+                  for (final c in textChannels)
+                    _TextChannelRow(
+                      channel: c,
+                      isSelected: c.id == selectedTextChannelId,
+                      onTap: () => onTextChannelChanged(c.id),
+                    ),
+                  const SizedBox(height: 12),
+                ],
+                if (voiceChannels.isNotEmpty) ...[
+                  const _CategoryHeader(label: 'Voice Channels'),
+                  for (final c in voiceChannels)
+                    _VoiceChannelGroup(
+                      channel: c,
+                      members: channelsState.voiceSessionsFor(c.id),
+                      isActive:
+                          voiceState.channelId == c.id &&
+                          voiceState.conversationId == conversation.id,
+                      onJoin: () => _join(ref, c),
+                      onOpenLounge: onShowLounge,
+                    ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _join(WidgetRef ref, GroupChannel channel) async {
+    // Channels notifier owns the HTTP + LiveKit-join handshake; this
+    // matches what channel_bar.dart does so behaviour is identical
+    // regardless of which layout the user picked.
+    await ref
+        .read(channelsProvider.notifier)
+        .joinVoiceChannel(conversation.id, channel.id);
+    onShowLounge?.call();
+  }
+}
+
+class _ColumnHeader extends StatelessWidget {
+  final Conversation conversation;
+  const _ColumnHeader({required this.conversation});
+
+  @override
+  Widget build(BuildContext context) {
+    final memberCount = conversation.members.length;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 14, 14, 12),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 12,
+            backgroundColor: groupAvatarColor(conversation.id),
+            child: Text(
+              (conversation.displayName('').isEmpty
+                      ? '?'
+                      : conversation.displayName(''))
+                  .characters
+                  .first
+                  .toUpperCase(),
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  conversation.displayName('').isEmpty
+                      ? 'Conversation'
+                      : conversation.displayName(''),
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: context.textPrimary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Text(
+                  '$memberCount member${memberCount == 1 ? '' : 's'}',
+                  style: TextStyle(color: context.textMuted, fontSize: 11),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CategoryHeader extends StatelessWidget {
+  final String label;
+  const _CategoryHeader({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 4, 8, 6),
+      child: Text(
+        label.toUpperCase(),
+        style: TextStyle(
+          color: context.textMuted,
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _TextChannelRow extends StatelessWidget {
+  final GroupChannel channel;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _TextChannelRow({
+    required this.channel,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'channel ${channel.name}',
+      button: true,
+      selected: isSelected,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+        child: Material(
+          color: isSelected ? context.accentLight : Colors.transparent,
+          borderRadius: BorderRadius.circular(6),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(6),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.tag,
+                    size: 16,
+                    color: isSelected ? context.accent : context.textMuted,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      channel.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: isSelected
+                            ? context.textPrimary
+                            : context.textSecondary,
+                        fontSize: 13,
+                        fontWeight: isSelected
+                            ? FontWeight.w600
+                            : FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _VoiceChannelGroup extends StatelessWidget {
+  final GroupChannel channel;
+  final List<VoiceSessionMember> members;
+  final bool isActive;
+  final VoidCallback onJoin;
+  final VoidCallback? onOpenLounge;
+
+  const _VoiceChannelGroup({
+    required this.channel,
+    required this.members,
+    required this.isActive,
+    required this.onJoin,
+    required this.onOpenLounge,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _VoiceChannelRow(
+          channel: channel,
+          memberCount: members.length,
+          isActive: isActive,
+          onTap: isActive ? (onOpenLounge ?? onJoin) : onJoin,
+        ),
+        if (members.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(left: 28, top: 2, bottom: 4),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (final m in members)
+                  _VoiceMemberRow(member: m, isSelf: false),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _VoiceChannelRow extends StatelessWidget {
+  final GroupChannel channel;
+  final int memberCount;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const _VoiceChannelRow({
+    required this.channel,
+    required this.memberCount,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'voice channel ${channel.name}',
+      button: true,
+      selected: isActive,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+        child: Material(
+          color: isActive ? context.accentLight : Colors.transparent,
+          borderRadius: BorderRadius.circular(6),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(6),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.volume_up_outlined,
+                    size: 16,
+                    color: isActive ? context.accent : context.textMuted,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      channel.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: isActive
+                            ? context.textPrimary
+                            : context.textSecondary,
+                        fontSize: 13,
+                        fontWeight: isActive
+                            ? FontWeight.w600
+                            : FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  if (memberCount > 0)
+                    Text(
+                      '$memberCount',
+                      style: TextStyle(color: context.textMuted, fontSize: 11),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _VoiceMemberRow extends StatelessWidget {
+  final VoiceSessionMember member;
+  final bool isSelf;
+  const _VoiceMemberRow({required this.member, required this.isSelf});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+      child: Row(
+        children: [
+          buildAvatar(
+            name: member.username,
+            radius: 10,
+            imageUrl: member.avatarUrl,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              member.username,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(color: context.textSecondary, fontSize: 12),
+            ),
+          ),
+          if (member.isMuted)
+            Padding(
+              padding: const EdgeInsets.only(left: 4),
+              child: Icon(
+                Icons.mic_off_outlined,
+                size: 12,
+                color: context.textMuted,
+              ),
+            ),
+          if (member.isDeafened)
+            Padding(
+              padding: const EdgeInsets.only(left: 4),
+              child: Icon(
+                Icons.headset_off_outlined,
+                size: 12,
+                color: context.textMuted,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -17,10 +17,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/channel.dart';
 import '../models/conversation.dart';
+import '../providers/channel_categories_provider.dart';
 import '../providers/channels_provider.dart';
 import '../providers/livekit_voice/livekit_voice_provider.dart';
 import '../theme/echo_theme.dart';
 import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
+
+const String _kTextCategoryKey = 'text';
+const String _kVoiceCategoryKey = 'voice';
 
 class ChannelColumn extends ConsumerWidget {
   final Conversation conversation;
@@ -49,6 +53,9 @@ class ChannelColumn extends ConsumerWidget {
     final textChannels = channels.where((c) => c.isText).toList();
     final voiceChannels = channels.where((c) => c.isVoice).toList();
     final voiceState = ref.watch(livekitVoiceProvider);
+    final collapsed = ref.watch(channelCategoryCollapsedProvider);
+    final textCollapsed = collapsed.contains(_kTextCategoryKey);
+    final voiceCollapsed = collapsed.contains(_kVoiceCategoryKey);
 
     return Container(
       width: width,
@@ -66,27 +73,41 @@ class ChannelColumn extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(vertical: 8),
               children: [
                 if (textChannels.isNotEmpty) ...[
-                  const _CategoryHeader(label: 'Text Channels'),
-                  for (final c in textChannels)
-                    _TextChannelRow(
-                      channel: c,
-                      isSelected: c.id == selectedTextChannelId,
-                      onTap: () => onTextChannelChanged(c.id),
-                    ),
+                  _CategoryHeader(
+                    label: 'Text Channels',
+                    collapsed: textCollapsed,
+                    onToggle: () => ref
+                        .read(channelCategoryCollapsedProvider.notifier)
+                        .toggle(_kTextCategoryKey),
+                  ),
+                  if (!textCollapsed)
+                    for (final c in textChannels)
+                      _TextChannelRow(
+                        channel: c,
+                        isSelected: c.id == selectedTextChannelId,
+                        onTap: () => onTextChannelChanged(c.id),
+                      ),
                   const SizedBox(height: 12),
                 ],
                 if (voiceChannels.isNotEmpty) ...[
-                  const _CategoryHeader(label: 'Voice Channels'),
-                  for (final c in voiceChannels)
-                    _VoiceChannelGroup(
-                      channel: c,
-                      members: channelsState.voiceSessionsFor(c.id),
-                      isActive:
-                          voiceState.channelId == c.id &&
-                          voiceState.conversationId == conversation.id,
-                      onJoin: () => _join(ref, c),
-                      onOpenLounge: onShowLounge,
-                    ),
+                  _CategoryHeader(
+                    label: 'Voice Channels',
+                    collapsed: voiceCollapsed,
+                    onToggle: () => ref
+                        .read(channelCategoryCollapsedProvider.notifier)
+                        .toggle(_kVoiceCategoryKey),
+                  ),
+                  if (!voiceCollapsed)
+                    for (final c in voiceChannels)
+                      _VoiceChannelGroup(
+                        channel: c,
+                        members: channelsState.voiceSessionsFor(c.id),
+                        isActive:
+                            voiceState.channelId == c.id &&
+                            voiceState.conversationId == conversation.id,
+                        onJoin: () => _join(ref, c),
+                        onOpenLounge: onShowLounge,
+                      ),
                 ],
               ],
             ),
@@ -167,19 +188,44 @@ class _ColumnHeader extends StatelessWidget {
 
 class _CategoryHeader extends StatelessWidget {
   final String label;
-  const _CategoryHeader({required this.label});
+  final bool collapsed;
+  final VoidCallback onToggle;
+  const _CategoryHeader({
+    required this.label,
+    required this.collapsed,
+    required this.onToggle,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(14, 4, 8, 6),
-      child: Text(
-        label.toUpperCase(),
-        style: TextStyle(
-          color: context.textMuted,
-          fontSize: 10,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 0.6,
+    return Semantics(
+      label: '$label category, ${collapsed ? "collapsed" : "expanded"}',
+      button: true,
+      child: InkWell(
+        onTap: onToggle,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(8, 4, 8, 6),
+          child: Row(
+            children: [
+              Icon(
+                collapsed ? Icons.chevron_right : Icons.expand_more,
+                size: 14,
+                color: context.textMuted,
+              ),
+              const SizedBox(width: 2),
+              Expanded(
+                child: Text(
+                  label.toUpperCase(),
+                  style: TextStyle(
+                    color: context.textMuted,
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.6,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -4,12 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../models/chat_message.dart';
 import '../../models/conversation.dart';
 import '../../providers/auth_provider.dart';
+import '../../providers/channel_layout_provider.dart';
 import '../../providers/chat_provider.dart';
 import '../../screens/safety_number_screen.dart';
 import '../../screens/user_profile_screen.dart';
 import '../../services/saved_messages_service.dart';
 import '../../theme/echo_theme.dart';
 import '../channel_bar.dart';
+import '../channel_column.dart';
 import '../chat_header_bar.dart';
 import '../chat_input_bar.dart';
 import '../encryption_status_banner.dart';
@@ -143,7 +145,17 @@ Widget buildChatContentBox(
   ChatPanelBodyParams p,
 ) {
   final chatGradient = context.chatBgGradient;
-  return DecoratedBox(
+  // Column-mode rail: render a Slack/Discord-style left rail listing
+  // text + voice channels instead of the top chip bar. Only kicks in
+  // for group chats on viewports wide enough to fit
+  // (sidebar + column + chat + members). Falls back to the bar layout
+  // on phones / narrow desktop windows so the rail doesn't crowd out
+  // the message list (#prod-column-layout-2026-05-20).
+  final layout = ref.watch(channelLayoutProvider);
+  final width = MediaQuery.of(context).size.width;
+  final useColumn =
+      layout == ChannelLayout.column && p.conv.isGroup && width >= 900;
+  final chatArea = DecoratedBox(
     decoration: chatGradient != null
         ? BoxDecoration(gradient: chatGradient)
         : BoxDecoration(color: context.chatBg),
@@ -171,7 +183,7 @@ Widget buildChatContentBox(
               onMembersToggle: p.onMembersToggle,
               onGroupInfo: p.onGroupInfo,
             ),
-            if (p.conv.isGroup)
+            if (p.conv.isGroup && !useColumn)
               ChannelBar(
                 conversationId: p.conv.id,
                 selectedTextChannelId: p.selectedTextChannelId,
@@ -308,5 +320,18 @@ Widget buildChatContentBox(
         if (p.isDragOver) DropOverlay(isDragOver: p.isDragOver),
       ],
     ),
+  );
+
+  if (!useColumn) return chatArea;
+  return Row(
+    children: [
+      ChannelColumn(
+        conversation: p.conv,
+        selectedTextChannelId: p.selectedTextChannelId,
+        onTextChannelChanged: p.onTextChannelChanged,
+        onShowLounge: p.onShowLounge,
+      ),
+      Expanded(child: chatArea),
+    ],
   );
 }

--- a/apps/client/test/widgets/channel_column_test.dart
+++ b/apps/client/test/widgets/channel_column_test.dart
@@ -1,0 +1,175 @@
+import 'package:echo_app/src/models/channel.dart';
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/providers/channels_provider.dart';
+import 'package:echo_app/src/widgets/channel_column.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/pump_app.dart';
+
+/// Smoke tests for the new Slack/Discord-style channel column.
+/// Verifies rendering of categories, text + voice rows, voice-member
+/// nesting, and the selected-state highlight on the active text channel.
+void main() {
+  Conversation conv(String displayName) => Conversation(
+    id: 'c1',
+    isGroup: true,
+    name: displayName,
+    members: const [
+      ConversationMember(userId: 'me', username: 'me'),
+      ConversationMember(userId: 'u2', username: 'jane'),
+    ],
+  );
+
+  GroupChannel text(String id, String name, {int pos = 0}) => GroupChannel(
+    id: id,
+    conversationId: 'c1',
+    name: name,
+    kind: 'text',
+    position: pos,
+    createdAt: '',
+  );
+
+  GroupChannel voice(String id, String name, {int pos = 0}) => GroupChannel(
+    id: id,
+    conversationId: 'c1',
+    name: name,
+    kind: 'voice',
+    position: pos,
+    category: 'Voice Channels',
+    createdAt: '',
+  );
+
+  Override channelsOverride({
+    required Map<String, List<GroupChannel>> channelsByConversation,
+    Map<String, List<VoiceSessionMember>> voiceSessionsByChannel = const {},
+  }) {
+    return channelsProvider.overrideWith(
+      () => _StubChannelsNotifier(
+        ChannelsState(
+          channelsByConversation: channelsByConversation,
+          voiceSessionsByChannel: voiceSessionsByChannel,
+        ),
+      ),
+    );
+  }
+
+  group('ChannelColumn', () {
+    testWidgets('renders text + voice category headers and channel rows', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChannelColumn(
+          conversation: conv('Echo Devs'),
+          selectedTextChannelId: 't1',
+          onTextChannelChanged: (_) {},
+        ),
+        overrides: [
+          channelsOverride(
+            channelsByConversation: {
+              'c1': [
+                text('t1', 'general'),
+                text('t2', 'releases', pos: 1),
+                voice('v1', 'lounge'),
+              ],
+            },
+          ),
+        ],
+      );
+
+      expect(find.text('TEXT CHANNELS'), findsOneWidget);
+      expect(find.text('VOICE CHANNELS'), findsOneWidget);
+      expect(find.text('general'), findsOneWidget);
+      expect(find.text('releases'), findsOneWidget);
+      expect(find.text('lounge'), findsOneWidget);
+    });
+
+    testWidgets(
+      'selected text channel fires onTextChannelChanged with its id',
+      (tester) async {
+        String? lastSelected;
+        await tester.pumpApp(
+          ChannelColumn(
+            conversation: conv('Echo Devs'),
+            selectedTextChannelId: null,
+            onTextChannelChanged: (id) => lastSelected = id,
+          ),
+          overrides: [
+            channelsOverride(
+              channelsByConversation: {
+                'c1': [text('t1', 'general'), text('t2', 'releases', pos: 1)],
+              },
+            ),
+          ],
+        );
+        await tester.tap(find.text('releases'));
+        await tester.pump();
+        expect(lastSelected, 't2');
+      },
+    );
+
+    testWidgets('voice members render nested under the voice row when active', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        ChannelColumn(
+          conversation: conv('Echo Devs'),
+          selectedTextChannelId: 't1',
+          onTextChannelChanged: (_) {},
+        ),
+        overrides: [
+          channelsOverride(
+            channelsByConversation: {
+              'c1': [text('t1', 'general'), voice('v1', 'lounge')],
+            },
+            voiceSessionsByChannel: {
+              'v1': const [
+                VoiceSessionMember(
+                  channelId: 'v1',
+                  userId: 'u2',
+                  username: 'jane',
+                  isMuted: false,
+                  isDeafened: false,
+                  pushToTalk: false,
+                  joinedAt: '',
+                  updatedAt: '',
+                ),
+              ],
+            },
+          ),
+        ],
+      );
+      expect(find.text('jane'), findsOneWidget);
+      // Member count badge on the voice row.
+      expect(find.text('1'), findsOneWidget);
+    });
+
+    testWidgets('voice row with no members hides the count', (tester) async {
+      await tester.pumpApp(
+        ChannelColumn(
+          conversation: conv('Echo Devs'),
+          selectedTextChannelId: 't1',
+          onTextChannelChanged: (_) {},
+        ),
+        overrides: [
+          channelsOverride(
+            channelsByConversation: {
+              'c1': [voice('v1', 'lounge')],
+            },
+          ),
+        ],
+      );
+      expect(find.text('lounge'), findsOneWidget);
+      // No '0' badge — the count only renders when at least one member.
+      expect(find.text('0'), findsNothing);
+    });
+  });
+}
+
+class _StubChannelsNotifier extends Channels {
+  _StubChannelsNotifier(this._initial);
+  final ChannelsState _initial;
+
+  @override
+  ChannelsState build() => _initial;
+}

--- a/apps/client/test/widgets/channel_column_test.dart
+++ b/apps/client/test/widgets/channel_column_test.dart
@@ -4,6 +4,7 @@ import 'package:echo_app/src/providers/channels_provider.dart';
 import 'package:echo_app/src/widgets/channel_column.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/pump_app.dart';
 
@@ -11,6 +12,10 @@ import '../helpers/pump_app.dart';
 /// Verifies rendering of categories, text + voice rows, voice-member
 /// nesting, and the selected-state highlight on the active text channel.
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   Conversation conv(String displayName) => Conversation(
     id: 'c1',
     isGroup: true,
@@ -142,6 +147,31 @@ void main() {
       expect(find.text('jane'), findsOneWidget);
       // Member count badge on the voice row.
       expect(find.text('1'), findsOneWidget);
+    });
+
+    testWidgets('tapping a category header collapses its rows', (tester) async {
+      await tester.pumpApp(
+        ChannelColumn(
+          conversation: conv('Echo Devs'),
+          selectedTextChannelId: 't1',
+          onTextChannelChanged: (_) {},
+        ),
+        overrides: [
+          channelsOverride(
+            channelsByConversation: {
+              'c1': [text('t1', 'general'), text('t2', 'releases', pos: 1)],
+            },
+          ),
+        ],
+      );
+      expect(find.text('general'), findsOneWidget);
+      expect(find.text('releases'), findsOneWidget);
+      await tester.tap(find.text('TEXT CHANNELS'));
+      await tester.pumpAndSettle();
+      expect(find.text('general'), findsNothing);
+      expect(find.text('releases'), findsNothing);
+      // Header still visible so the user can re-expand.
+      expect(find.text('TEXT CHANNELS'), findsOneWidget);
     });
 
     testWidgets('voice row with no members hides the count', (tester) async {


### PR DESCRIPTION
Ships the column-layout series (#1011 #1013 #1014 #1015).

## What the user gets
A new **Settings → Appearance → Channels** toggle to pick between two
layouts for group chats:

- **Bar** (default, unchanged): channel chips along the top of the
  chat panel.
- **Column**: Slack/Discord-style vertical rail down the left side of
  the chat panel, with `# TEXT CHANNELS` and `# VOICE CHANNELS`
  categories. Voice channels show their connected members nested
  underneath with mute/deafen glyphs. Each category can be collapsed
  with a chevron tap, and the collapsed state persists across launches.

Column mode only activates on group chats and on viewports ≥ 900px.
1:1 DMs and phone-sized windows transparently fall back to bar mode.

## Improved
- Side rail (#1013) reuses the existing channel + voice providers,
  so switching layouts mid-session keeps the active text channel
  and any in-progress voice session intact.
- Per-category collapse/expand with persistence (#1015).

## Behind the scenes
- New `channelLayoutProvider` (#1011): SharedPreferences-backed
  bar/column preference. Defaults to bar so existing users see no
  change until they opt in.
- New `ChannelColumn` widget (#1012): standalone vertical channel
  list, covered by 5 widget tests.
- New `channelCategoryCollapsedProvider` (#1015): persistent
  per-category collapse state.