### PR TITLE
fix: address top SonarQube issues

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -32,6 +32,12 @@ const _placeholderContents = <String>{
   '[Encrypted for another device of this account]',
 };
 
+/// Placeholder shown when an inbound GRP2 group message fails sender-
+/// signature verification (or we cannot fetch the sender's verify key).
+/// Distinct from "[Could not decrypt…]" because this is a *security*
+/// signal rather than a key-out-of-sync transient.
+const _kCouldNotVerifySender = '[Could not verify sender]';
+
 bool _isPlaceholderContent(String c) =>
     _placeholderContents.contains(c) || c.startsWith('[Could not decrypt');
 
@@ -144,62 +150,22 @@ class ChatState {
     var updatedFailures = consecutiveDecryptFailures;
     var updatedSigFailures = signatureFailures;
 
-    // Audit P0-3 + Phase 4: track decrypt-failure placeholders so the
-    // chat UI can surface a recovery banner. Two distinct buckets:
-    //   - `consecutiveDecryptFailures` — count "[Could not decrypt…]"
-    //     transients, reset on any genuine decrypt success.
-    //   - `signatureFailures` — sticky set of conversations where a
-    //     "[Could not verify sender]" landed. Cleared only when the
-    //     user closes / reopens the conversation OR an admin rotates
-    //     the key (which also drops the cached envelope).
     if (msg.conversationId.isNotEmpty) {
-      final isDecryptFailure = msg.content.startsWith('[Could not decrypt');
-      final isSigFailure = msg.content.startsWith('[Could not verify sender');
-      final prev = updatedFailures[msg.conversationId] ?? 0;
-      if (isDecryptFailure) {
-        updatedFailures = {...updatedFailures, msg.conversationId: prev + 1};
-      } else if (prev > 0 &&
-          !_isPlaceholderContent(msg.content) &&
-          !msg.isSystemEvent) {
-        // Genuine success after one or more failures — clear the counter.
-        updatedFailures = {...updatedFailures}..remove(msg.conversationId);
-      }
-      if (isSigFailure && !updatedSigFailures.contains(msg.conversationId)) {
-        updatedSigFailures = {...updatedSigFailures, msg.conversationId};
-      }
-    }
-
-    if (msg.conversationId.isNotEmpty) {
-      final ids = Set<String>.from(
-        updatedIndexMap[msg.conversationId] ?? <String>{},
+      final (nextFailures, nextSigFailures) = _trackDecryptFailures(
+        msg,
+        updatedFailures,
+        updatedSigFailures,
       );
-      // O(1) deduplicate by ID
-      if (!ids.contains(msg.id)) {
-        final existing = updatedConvMap[msg.conversationId] ?? [];
-        var updated = [...existing, msg];
-        // Trim to cap, keeping newest messages.
-        if (updated.length > _maxMessagesPerConv) {
-          updated = updated.sublist(updated.length - _maxMessagesPerConv);
-        }
-        ids.add(msg.id);
-        // Rebuild index from trimmed list to stay consistent.
-        final newIds = updated.map((m) => m.id).toSet();
-        updatedConvMap = {...updatedConvMap, msg.conversationId: updated};
-        updatedIndexMap = {...updatedIndexMap, msg.conversationId: newIds};
-      } else {
-        // Id collision: existing entry might be a decrypt-pending
-        // placeholder (#430).  Replace it in place when isEncrypted
-        // and the content matches a known placeholder string.  The
-        // index already contains msg.id so no map mutation is needed.
-        final existing = updatedConvMap[msg.conversationId] ?? const [];
-        final idx = existing.indexWhere((m) => m.id == msg.id);
-        if (idx >= 0 &&
-            existing[idx].isEncrypted &&
-            _isPlaceholderContent(existing[idx].content)) {
-          final replaced = [...existing]..[idx] = msg;
-          updatedConvMap = {...updatedConvMap, msg.conversationId: replaced};
-        }
-      }
+      updatedFailures = nextFailures;
+      updatedSigFailures = nextSigFailures;
+
+      final (nextConvMap, nextIndexMap) = _appendOrReplaceMessage(
+        msg,
+        updatedConvMap,
+        updatedIndexMap,
+      );
+      updatedConvMap = nextConvMap;
+      updatedIndexMap = nextIndexMap;
     }
 
     return ChatState(
@@ -211,6 +177,79 @@ class ChatState {
       consecutiveDecryptFailures: updatedFailures,
       signatureFailures: updatedSigFailures,
     );
+  }
+
+  /// Audit P0-3 + Phase 4: track decrypt-failure placeholders so the
+  /// chat UI can surface a recovery banner. Two distinct buckets:
+  ///   - `consecutiveDecryptFailures` — count "[Could not decrypt…]"
+  ///     transients, reset on any genuine decrypt success.
+  ///   - `signatureFailures` — sticky set of conversations where a
+  ///     "[Could not verify sender]" landed. Cleared only when the
+  ///     user closes / reopens the conversation OR an admin rotates
+  ///     the key (which also drops the cached envelope).
+  (Map<String, int>, Set<String>) _trackDecryptFailures(
+    ChatMessage msg,
+    Map<String, int> failures,
+    Set<String> sigFailures,
+  ) {
+    final isDecryptFailure = msg.content.startsWith('[Could not decrypt');
+    final isSigFailure = msg.content.startsWith('[Could not verify sender');
+    final prev = failures[msg.conversationId] ?? 0;
+
+    var nextFailures = failures;
+    if (isDecryptFailure) {
+      nextFailures = {...failures, msg.conversationId: prev + 1};
+    } else if (prev > 0 &&
+        !_isPlaceholderContent(msg.content) &&
+        !msg.isSystemEvent) {
+      // Genuine success after one or more failures — clear the counter.
+      nextFailures = {...failures}..remove(msg.conversationId);
+    }
+
+    var nextSigFailures = sigFailures;
+    if (isSigFailure && !sigFailures.contains(msg.conversationId)) {
+      nextSigFailures = {...sigFailures, msg.conversationId};
+    }
+    return (nextFailures, nextSigFailures);
+  }
+
+  /// Append `msg` to its conversation list (deduped + capped) or, when an
+  /// existing decrypt-pending placeholder shares the same id (#430),
+  /// replace it in place. Returns the updated conv-map and id-index map.
+  (Map<String, List<ChatMessage>>, Map<String, Set<String>>)
+  _appendOrReplaceMessage(
+    ChatMessage msg,
+    Map<String, List<ChatMessage>> convMap,
+    Map<String, Set<String>> indexMap,
+  ) {
+    final ids = Set<String>.from(indexMap[msg.conversationId] ?? <String>{});
+    if (!ids.contains(msg.id)) {
+      final existing = convMap[msg.conversationId] ?? [];
+      var updated = [...existing, msg];
+      // Trim to cap, keeping newest messages.
+      if (updated.length > _maxMessagesPerConv) {
+        updated = updated.sublist(updated.length - _maxMessagesPerConv);
+      }
+      // Rebuild index from trimmed list to stay consistent.
+      final newIds = updated.map((m) => m.id).toSet();
+      return (
+        {...convMap, msg.conversationId: updated},
+        {...indexMap, msg.conversationId: newIds},
+      );
+    }
+    // Id collision: existing entry might be a decrypt-pending placeholder
+    // (#430). Replace it in place when isEncrypted and the content
+    // matches a known placeholder string. The index already contains
+    // msg.id so no map mutation is needed.
+    final existing = convMap[msg.conversationId] ?? const <ChatMessage>[];
+    final idx = existing.indexWhere((m) => m.id == msg.id);
+    if (idx >= 0 &&
+        existing[idx].isEncrypted &&
+        _isPlaceholderContent(existing[idx].content)) {
+      final replaced = [...existing]..[idx] = msg;
+      return ({...convMap, msg.conversationId: replaced}, indexMap);
+    }
+    return (convMap, indexMap);
   }
 
   /// Reset the consecutive-decrypt-failures counter for a conversation.
@@ -835,7 +874,7 @@ class Chat extends _$Chat {
       if (msg.content.startsWith(groupEncryptedPrefixV2)) {
         if (crypto == null) {
           return msg.copyWith(
-            content: '[Could not verify sender]',
+            content: _kCouldNotVerifySender,
             isEncrypted: true,
           );
         }
@@ -845,7 +884,7 @@ class Chat extends _$Chat {
         );
         if (senderVerifyKey == null) {
           return msg.copyWith(
-            content: '[Could not verify sender]',
+            content: _kCouldNotVerifySender,
             isEncrypted: true,
           );
         }
@@ -866,7 +905,7 @@ class Chat extends _$Chat {
             'GRP2 signature failed for ${msg.id}: $e',
           );
           return msg.copyWith(
-            content: '[Could not verify sender]',
+            content: _kCouldNotVerifySender,
             isEncrypted: true,
           );
         }
@@ -874,10 +913,7 @@ class Chat extends _$Chat {
 
       // GRP1 path. Refuse when the envelope is pinned to GRP2.
       if (minWireVersion >= 2) {
-        return msg.copyWith(
-          content: '[Could not verify sender]',
-          isEncrypted: true,
-        );
+        return msg.copyWith(content: _kCouldNotVerifySender, isEncrypted: true);
       }
       final decrypted = await GroupCryptoService.decryptGroupMessage(
         msg.content,

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -33,6 +33,12 @@ part 'ws_handlers/presence_handlers.dart';
 part 'ws_handlers/voice_handlers.dart';
 part 'ws_handlers/crypto_handlers.dart';
 
+/// Placeholder content rendered when an inbound GRP2 group message fails
+/// sender signature verification (or the sender's verify key cannot be
+/// fetched). Distinct from "[Could not decrypt…]" because this is a
+/// security signal, not a key-out-of-sync transient.
+const _kCouldNotVerifySender = '[Could not verify sender]';
+
 /// State that tracks both connection status and typing indicators.
 class WebSocketState {
   final bool isConnected;
@@ -490,7 +496,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
                 'from=$fromUserId)',
             'WebSocket',
           );
-          return '[Could not verify sender]';
+          return _kCouldNotVerifySender;
         }
         final senderVerifyKey = await crypto.getSenderVerifyKeyForDevice(
           fromUserId,
@@ -502,7 +508,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
                 '$fromUserId:$fromDeviceId',
             'WebSocket',
           );
-          return '[Could not verify sender]';
+          return _kCouldNotVerifySender;
         }
         try {
           return await GroupCryptoService.verifyAndDecryptGroupMessageV2(
@@ -519,7 +525,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
             'GRP2 signature failed for $conversationId msg=$messageId: $e',
             'WebSocket',
           );
-          return '[Could not verify sender]';
+          return _kCouldNotVerifySender;
         }
       }
 
@@ -532,7 +538,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
               '(conv=$conversationId)',
           'WebSocket',
         );
-        return '[Could not verify sender]';
+        return _kCouldNotVerifySender;
       }
       return await GroupCryptoService.decryptGroupMessage(
         rawContent,

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -1503,24 +1503,8 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     // selected row, arrows move it, Escape closes the picker (without
     // also bubbling Escape through to message edit-cancel).
     if (_mentionController.showPicker) {
-      if (event.logicalKey == LogicalKeyboardKey.tab ||
-          (event.logicalKey == LogicalKeyboardKey.enter &&
-              !HardwareKeyboard.instance.isShiftPressed)) {
-        _acceptMentionSelection();
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-        _moveMentionSelection(_MentionMove.down);
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-        _moveMentionSelection(_MentionMove.up);
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.escape) {
-        _mentionController.dismiss();
-        return KeyEventResult.handled;
-      }
+      final mentionResult = _handleMentionPickerKey(event);
+      if (mentionResult != KeyEventResult.ignored) return mentionResult;
       // Space falls through — extractMentionQuery sees the space and
       // closes the picker, leaving the literal "@" in the text.
     }
@@ -1542,6 +1526,32 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       return _handleArrowUpEditLast();
     }
 
+    return KeyEventResult.ignored;
+  }
+
+  /// Keyboard handler for the mention picker overlay. Returns
+  /// [KeyEventResult.ignored] when the picker should *not* consume the
+  /// event (e.g. Space, so the picker auto-dismisses via the query
+  /// extractor).
+  KeyEventResult _handleMentionPickerKey(KeyDownEvent event) {
+    if (event.logicalKey == LogicalKeyboardKey.tab ||
+        (event.logicalKey == LogicalKeyboardKey.enter &&
+            !HardwareKeyboard.instance.isShiftPressed)) {
+      _acceptMentionSelection();
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      _moveMentionSelection(_MentionMove.down);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      _moveMentionSelection(_MentionMove.up);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.escape) {
+      _mentionController.dismiss();
+      return KeyEventResult.handled;
+    }
     return KeyEventResult.ignored;
   }
 

--- a/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
@@ -163,63 +163,70 @@ typedef _PickAndDispatchParams = ({
 
 Future<void> _pickAndDispatch(_PickAndDispatchParams params) async {
   final context = params.context;
-  final mounted = params.mounted;
-  final isPicking = params.isPicking;
-  final setIsPicking = params.setIsPicking;
-  final stage = params.stage;
-  final sendImmediately = params.sendImmediately;
-  final type = params.type;
-  final errorPrefix = params.errorPrefix;
-  if (isPicking()) return;
-  setIsPicking(true);
+  if (params.isPicking()) return;
+  params.setIsPicking(true);
   try {
     final result = await FilePicker.pickFiles(
-      type: type,
+      type: params.type,
       allowMultiple: true,
       withData: true,
     );
     if (result == null || result.files.isEmpty) return;
-    if (!mounted()) return;
-
-    // Single pick → preview flow (caption + send). Multi pick → send all
-    // immediately as separate messages; mixing the two creates races where
-    // the user may interact with the pending preview while the rest are
-    // still uploading in the background.
-    final isMulti = result.files.length > 1;
-    if (isMulti && context.mounted) {
-      ToastService.show(
-        context,
-        'Sending ${result.files.length} files...',
-        type: ToastType.info,
-      );
-    }
-
-    var sentCount = 0;
-    for (final file in result.files) {
-      if (!context.mounted) break;
-      final ok = await _dispatchFile(
-        context: context,
-        file: file,
-        isMulti: isMulti,
-        stage: stage,
-        sendImmediately: sendImmediately,
-      );
-      if (ok) sentCount++;
-    }
-
-    if (isMulti && context.mounted && sentCount < result.files.length) {
-      final failed = result.files.length - sentCount;
-      ToastService.show(
-        context,
-        '$failed of ${result.files.length} failed to send',
-        type: ToastType.error,
-      );
-    }
+    if (!params.mounted() || !context.mounted) return;
+    await _dispatchPickedFiles(context, params, result.files);
   } catch (e) {
     if (!context.mounted) return;
-    ToastService.show(context, '$errorPrefix error: $e', type: ToastType.error);
+    ToastService.show(
+      context,
+      '${params.errorPrefix} error: $e',
+      type: ToastType.error,
+    );
   } finally {
-    setIsPicking(false);
+    params.setIsPicking(false);
+  }
+}
+
+/// Dispatches a previously-picked list of files, surfacing toast feedback
+/// for multi-file sends. Extracted from [_pickAndDispatch] to keep its
+/// cognitive complexity below SonarCloud's threshold.
+Future<void> _dispatchPickedFiles(
+  BuildContext context,
+  _PickAndDispatchParams params,
+  List<PlatformFile> files,
+) async {
+  // Single pick → preview flow (caption + send). Multi pick → send all
+  // immediately as separate messages; mixing the two creates races where
+  // the user may interact with the pending preview while the rest are
+  // still uploading in the background.
+  final isMulti = files.length > 1;
+  if (isMulti && context.mounted) {
+    ToastService.show(
+      context,
+      'Sending ${files.length} files...',
+      type: ToastType.info,
+    );
+  }
+
+  var sentCount = 0;
+  for (final file in files) {
+    if (!context.mounted) break;
+    final ok = await _dispatchFile(
+      context: context,
+      file: file,
+      isMulti: isMulti,
+      stage: params.stage,
+      sendImmediately: params.sendImmediately,
+    );
+    if (ok) sentCount++;
+  }
+
+  if (isMulti && context.mounted && sentCount < files.length) {
+    final failed = files.length - sentCount;
+    ToastService.show(
+      context,
+      '$failed of ${files.length} failed to send',
+      type: ToastType.error,
+    );
   }
 }
 

--- a/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
@@ -13,6 +13,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../theme/echo_theme.dart';
 import 'echo_context_menu.dart';
 
+/// Toast label used by every "Copy *ID" demo action in the testbed.
+const String _kCopyIdToast = 'Copy ID';
+
 class ContextMenuTestbed extends ConsumerWidget {
   const ContextMenuTestbed({super.key});
 
@@ -210,7 +213,7 @@ ContextMenuModel _demoMessageModel(BuildContext context) {
           ContextMenuAction(
             label: 'Copy Message ID',
             icon: Icons.tag,
-            onTap: () => _toast(context, 'Copy ID'),
+            onTap: () => _toast(context, _kCopyIdToast),
           ),
         ],
       ),
@@ -250,7 +253,7 @@ ContextMenuModel _demoConversationModel(BuildContext context) {
           ContextMenuAction(
             label: 'Copy Channel ID',
             icon: Icons.tag,
-            onTap: () => _toast(context, 'Copy ID'),
+            onTap: () => _toast(context, _kCopyIdToast),
           ),
         ],
       ),
@@ -320,7 +323,7 @@ ContextMenuModel _demoMemberModel(BuildContext context) {
           ContextMenuAction(
             label: 'Copy User ID',
             icon: Icons.tag,
-            onTap: () => _toast(context, 'Copy ID'),
+            onTap: () => _toast(context, _kCopyIdToast),
           ),
         ],
       ),

--- a/apps/client/lib/src/widgets/message/reply_count_badge.dart
+++ b/apps/client/lib/src/widgets/message/reply_count_badge.dart
@@ -55,38 +55,45 @@ class ReplyCountBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final count = message.replyCount;
     final label = count == 1 ? '1 reply' : '$count replies';
-    if (inlineStyle) {
-      return Padding(
-        padding: EdgeInsets.only(top: 2, left: isMine ? 0 : 36),
-        child: Align(
-          alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
-          child: Semantics(
-            label: hasUnread ? 'View $label (new replies)' : 'View $label',
-            button: true,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(2),
-              onTap: onTap == null ? null : () => onTap!(message),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    label,
-                    style: GoogleFonts.inter(
-                      fontSize: 12,
-                      color: context.accent,
-                      fontWeight: FontWeight.w500,
-                      decoration: TextDecoration.underline,
-                      decorationColor: context.accent.withValues(alpha: 0.4),
-                    ),
+    return inlineStyle
+        ? _buildInline(context, label)
+        : _buildPill(context, label);
+  }
+
+  Widget _buildInline(BuildContext context, String label) {
+    return Padding(
+      padding: EdgeInsets.only(top: 2, left: isMine ? 0 : 36),
+      child: Align(
+        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+        child: Semantics(
+          label: hasUnread ? 'View $label (new replies)' : 'View $label',
+          button: true,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(2),
+            onTap: onTap == null ? null : () => onTap!(message),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  label,
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: context.accent,
+                    fontWeight: FontWeight.w500,
+                    decoration: TextDecoration.underline,
+                    decorationColor: context.accent.withValues(alpha: 0.4),
                   ),
-                  if (hasUnread) _unreadDot(context),
-                ],
-              ),
+                ),
+                if (hasUnread) _unreadDot(context),
+              ],
             ),
           ),
         ),
-      );
-    }
+      ),
+    );
+  }
+
+  Widget _buildPill(BuildContext context, String label) {
     return Padding(
       padding: EdgeInsets.only(top: 4, left: isMine ? 0 : 36),
       child: Align(

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -118,15 +118,7 @@ class WhatsNewModal extends ConsumerWidget {
                 IconButton(
                   icon: const Icon(Icons.close),
                   color: context.textMuted,
-                  onPressed: () async {
-                    await ref.read(releaseNotesProvider.notifier).markShown();
-                    if (!context.mounted) return;
-                    if (onClose != null) {
-                      onClose!();
-                    } else {
-                      Navigator.of(context).pop();
-                    }
-                  },
+                  onPressed: () => _dismiss(context, ref),
                 ),
             ],
           ),
@@ -181,15 +173,7 @@ class WhatsNewModal extends ConsumerWidget {
         Padding(
           padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
           child: FilledButton(
-            onPressed: () async {
-              await ref.read(releaseNotesProvider.notifier).markShown();
-              if (!context.mounted) return;
-              if (onClose != null) {
-                onClose!();
-              } else {
-                Navigator.of(context).pop();
-              }
-            },
+            onPressed: () => _dismiss(context, ref),
             style: FilledButton.styleFrom(
               backgroundColor: context.accent,
               minimumSize: const Size.fromHeight(48),
@@ -199,6 +183,16 @@ class WhatsNewModal extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  Future<void> _dismiss(BuildContext context, WidgetRef ref) async {
+    await ref.read(releaseNotesProvider.notifier).markShown();
+    if (!context.mounted) return;
+    if (onClose != null) {
+      onClose!();
+    } else {
+      Navigator.of(context).pop();
+    }
   }
 }
 

--- a/apps/server/src/db/mentions.rs
+++ b/apps/server/src/db/mentions.rs
@@ -64,43 +64,50 @@ fn extract_at_usernames(content: &str) -> Vec<String> {
     let bytes = content.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] != b'@' {
+        if bytes[i] != b'@' || !is_left_boundary(content, i) {
             i += 1;
             continue;
         }
-        // Boundary on the left: start-of-string or non-word.
-        let left_ok = i == 0
-            || !content[..i]
-                .chars()
-                .next_back()
-                .is_some_and(|c| c.is_alphanumeric() || c == '_');
-        if !left_ok {
-            i += 1;
-            continue;
-        }
-        // Read [A-Za-z0-9_]+ token after `@`.
-        let token_start = i + 1;
-        let mut token_end = token_start;
-        while token_end < bytes.len() {
-            let c = bytes[token_end];
-            let word = c.is_ascii_alphanumeric() || c == b'_';
-            if !word {
-                break;
-            }
-            token_end += 1;
-        }
-        if token_end > token_start {
-            let token = content[token_start..token_end].to_lowercase();
-            // Skip the broadcast keywords -- those are scanned separately
-            // and resolved against the full membership roster, not by
-            // username match.
-            if token != "everyone" && token != "here" && !out.contains(&token) {
-                out.push(token);
-            }
+        let token_end = scan_word_end(bytes, i + 1);
+        if token_end > i + 1 {
+            push_unique_non_broadcast(&content[i + 1..token_end], &mut out);
         }
         i = token_end.max(i + 1);
     }
     out
+}
+
+/// True when position `i` in `content` is at the start-of-string or
+/// preceded by a non-word character. Boundary check for `@mention`
+/// detection: prevents matching e.g. `email@host` as a mention.
+fn is_left_boundary(content: &str, i: usize) -> bool {
+    i == 0
+        || !content[..i]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Returns the byte index of the first non-word byte at or after `start`.
+fn scan_word_end(bytes: &[u8], start: usize) -> usize {
+    let mut end = start;
+    while end < bytes.len() {
+        let c = bytes[end];
+        if !(c.is_ascii_alphanumeric() || c == b'_') {
+            break;
+        }
+        end += 1;
+    }
+    end
+}
+
+/// Lowercase `token` and push onto `out` unless it is a broadcast keyword
+/// (`everyone` / `here`, resolved separately) or already present.
+fn push_unique_non_broadcast(token: &str, out: &mut Vec<String>) {
+    let lower = token.to_lowercase();
+    if lower != "everyone" && lower != "here" && !out.contains(&lower) {
+        out.push(lower);
+    }
 }
 
 /// Resolve broadcast keywords to all non-removed members of the conversation.

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -117,6 +117,63 @@ impl GroupKeyEnvelopeResponse {
 // POST /api/groups/:id/keys -- Upload group key envelopes (owner/admin only)
 // -------------------------------------------------------------------------
 
+/// Cap envelope count so a hostile admin can't pollute the table.
+const MAX_ENVELOPES_PER_REQUEST: usize = 10_000;
+/// Each envelope is a wrapped 32-byte AES-256 key (~124 base64 chars in
+/// practice). 512 bytes is generous headroom while blocking abuse —
+/// without this cap, a single 10K-envelope request could write up to
+/// ~10 GB of attacker-controlled TEXT.
+const MAX_ENCRYPTED_KEY_LEN: usize = 512;
+/// Audit reason string — bounded so a malicious admin can't write
+/// arbitrarily large blobs into the audit log that other admins
+/// re-download on every /encryption-activity GET.
+const MAX_TRIGGERED_BY_EVENT_LEN: usize = 128;
+
+/// Validates the body of an [`upload_group_key`] request. Extracted so the
+/// route handler stays under SonarCloud's cognitive-complexity threshold.
+fn validate_upload_request(body: &UploadGroupKeyRequest) -> Result<(), AppError> {
+    if body.envelopes.is_empty() {
+        return Err(AppError::bad_request("envelopes array cannot be empty"));
+    }
+    if body.key_version < 1 {
+        return Err(AppError::bad_request(
+            "key_version must be a positive integer",
+        ));
+    }
+    // The CHECK constraint on the column enforces 1..=255, but a clear
+    // 400 with a typed message beats the bare 23514 db error on the
+    // happy mistake (a client passing 0 to "disable" or a future GRPN
+    // value the server hasn't shipped support for yet).
+    if !(1..=255).contains(&body.min_wire_version) {
+        return Err(AppError::bad_request(
+            "min_wire_version must be between 1 and 255",
+        ));
+    }
+    if body.envelopes.len() > MAX_ENVELOPES_PER_REQUEST {
+        return Err(AppError::bad_request(format!(
+            "Too many envelopes (max {MAX_ENVELOPES_PER_REQUEST})"
+        )));
+    }
+    if body.triggered_by_event.len() > MAX_TRIGGERED_BY_EVENT_LEN {
+        return Err(AppError::bad_request(format!(
+            "triggered_by_event must be ≤{MAX_TRIGGERED_BY_EVENT_LEN} characters"
+        )));
+    }
+    for envelope in &body.envelopes {
+        if envelope.encrypted_key.is_empty() {
+            return Err(AppError::bad_request(
+                "encrypted_key cannot be empty in envelope",
+            ));
+        }
+        if envelope.encrypted_key.len() > MAX_ENCRYPTED_KEY_LEN {
+            return Err(AppError::bad_request(format!(
+                "encrypted_key must be ≤{MAX_ENCRYPTED_KEY_LEN} bytes"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub async fn upload_group_key(
     auth: AuthUser,
     State(state): State<Arc<AppState>>,
@@ -136,59 +193,7 @@ pub async fn upload_group_key(
         ));
     }
 
-    if body.envelopes.is_empty() {
-        return Err(AppError::bad_request("envelopes array cannot be empty"));
-    }
-    if body.key_version < 1 {
-        return Err(AppError::bad_request(
-            "key_version must be a positive integer",
-        ));
-    }
-    // The CHECK constraint on the column enforces 1..=255, but a clear
-    // 400 with a typed message beats the bare 23514 db error on the
-    // happy mistake (a client passing 0 to "disable" or a future GRPN
-    // value the server hasn't shipped support for yet).
-    if !(1..=255).contains(&body.min_wire_version) {
-        return Err(AppError::bad_request(
-            "min_wire_version must be between 1 and 255",
-        ));
-    }
-
-    // Cap envelope count so a hostile admin can't pollute the table.
-    const MAX_ENVELOPES_PER_REQUEST: usize = 10_000;
-    if body.envelopes.len() > MAX_ENVELOPES_PER_REQUEST {
-        return Err(AppError::bad_request(format!(
-            "Too many envelopes (max {MAX_ENVELOPES_PER_REQUEST})"
-        )));
-    }
-
-    // Each envelope is a wrapped 32-byte AES-256 key (~124 base64 chars in
-    // practice). 512 bytes is generous headroom while blocking abuse —
-    // without this cap, a single 10K-envelope request could write up to
-    // ~10 GB of attacker-controlled TEXT.
-    const MAX_ENCRYPTED_KEY_LEN: usize = 512;
-    // Audit reason string — bounded so a malicious admin can't write
-    // arbitrarily large blobs into the audit log that other admins
-    // re-download on every /encryption-activity GET.
-    const MAX_TRIGGERED_BY_EVENT_LEN: usize = 128;
-    if body.triggered_by_event.len() > MAX_TRIGGERED_BY_EVENT_LEN {
-        return Err(AppError::bad_request(format!(
-            "triggered_by_event must be ≤{MAX_TRIGGERED_BY_EVENT_LEN} characters"
-        )));
-    }
-
-    for envelope in &body.envelopes {
-        if envelope.encrypted_key.is_empty() {
-            return Err(AppError::bad_request(
-                "encrypted_key cannot be empty in envelope",
-            ));
-        }
-        if envelope.encrypted_key.len() > MAX_ENCRYPTED_KEY_LEN {
-            return Err(AppError::bad_request(format!(
-                "encrypted_key must be ≤{MAX_ENCRYPTED_KEY_LEN} bytes"
-            )));
-        }
-    }
+    validate_upload_request(&body)?;
 
     // Sentinel row + envelopes commit atomically; member-set read inside
     // the same tx so we see the committed view that matches the writes.


### PR DESCRIPTION
## Summary

Trims cognitive complexity in several Dart widgets / providers and one Rust
route handler, and pulls a few duplicated string literals up to named
constants. Behind-the-scenes only — no user-visible change.

### Sonar issues addressed

| Severity | Rule | File | Note |
|---|---|---|---|
| CRITICAL | dart:S1192 | `providers/chat_provider.dart` | `_kCouldNotVerifySender` constant for the GRP2 sig-fail placeholder |
| CRITICAL | dart:S1192 | `providers/ws_message_handler.dart` | same constant on the WS path |
| CRITICAL | dart:S1192 | `widgets/context_menu/context_menu_testbed.dart` | `_kCopyIdToast` constant |
| CRITICAL | dart:S3776 | `widgets/message/reply_count_badge.dart` | split `build()` into `_buildInline` / `_buildPill` |
| CRITICAL | dart:S3776 | `widgets/whats_new_modal.dart` | extracted shared `_dismiss(context, ref)` helper |
| CRITICAL | dart:S3776 | `widgets/chat_input_bar/file_pickers.dart` | split into `_pickAndDispatch` + `_dispatchPickedFiles` |
| CRITICAL | dart:S3776 | `widgets/chat_input_bar.dart` | extracted `_handleMentionPickerKey` |
| CRITICAL | dart:S3776 | `providers/chat_provider.dart::withMessage` | extracted `_trackDecryptFailures` + `_appendOrReplaceMessage` |
| CRITICAL | rust:S3776 | `server/src/db/mentions.rs::extract_at_usernames` | extracted `is_left_boundary` / `scan_word_end` / `push_unique_non_broadcast` |
| CRITICAL | rust:S3776 | `server/src/routes/group_keys.rs::upload_group_key` | extracted `validate_upload_request` |

### Skipped (left for a follow-up PR)

These remaining CRITICAL S3776 findings either touch the crypto orchestration layer or live in files the main worktree is editing for the mobile-drawer change. Flagged here so the next batch can pick them up without re-doing triage:

- `providers/crypto_provider.dart::_seedInitialGroupKeyInner` (21) — touches the group-key recovery flow; refactor needs careful review with the crypto audit notes.
- `services/group_crypto_service.dart` (24) — same reason; group key wrapping logic.
- `models/chat_message.dart` (27) — `fromJson` mega-method; deserves a dedicated refactor.
- `widgets/conversation_panel.dart` (26), `widgets/message_item.dart` (24 × 2), `screens/group_info_screen.dart` (21), `screens/splash_screen.dart` (30), `providers/websocket_provider.dart::_handleEvent` (23), `providers/chat_provider.dart::sendGroupMessage` (19) — each needs a non-trivial extraction pass; deferring to keep this PR reviewable.

No issues were marked false-positive; every remaining open finding is a real maintainability signal.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p echo-server --all-targets -- -D warnings` clean
- [x] `cargo test -p echo-server --lib db::mentions` — 12/12 pass
- [x] `dart format` clean on touched files
- [x] `flutter analyze` clean on touched files (full-tree only flags pre-existing unrelated warnings)
- [x] `flutter test test/providers/chat_provider_test.dart` — 48/48 pass
- [ ] SonarCloud re-scan on this PR confirms the 10 issues above are resolved