### PR TITLE
Pull channels in over the chat on mobile with an edge-swipe drawer

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/conversation.dart';
+import '../providers/channel_layout_provider.dart';
 import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/crypto_provider.dart';
@@ -1393,6 +1394,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       );
     }
 
+    final layout = ref.watch(channelLayoutProvider);
+    // Discord-style channel drawer: kicks in on the same path the outer
+    // edge-swipe-back uses, but only when the user has opted into the
+    // column layout AND the open conversation is a group with channels.
+    // Otherwise we keep the existing swipe-to-conversations behaviour.
+    final useColumnDrawer =
+        layout == ChannelLayout.column &&
+        (_selectedConversation?.isGroup ?? false);
+
     Widget chatContent = ChatPanel(
       conversation: _selectedConversation,
       onGroupInfo: _showGroupInfo,
@@ -1402,6 +1412,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         _showingLounge = true;
         _userDismissedLounge = false;
       }),
+      onConversationSelected: useColumnDrawer
+          ? (id) {
+              final next = ref
+                  .read(conversationsProvider)
+                  .conversations
+                  .where((c) => c.id == id)
+                  .firstOrNull;
+              if (next != null) {
+                setState(() => _selectedConversation = next);
+              }
+            }
+          : null,
     );
 
     // Note: a "● <channel> — Tap to view voice" rejoin banner used to sit
@@ -1418,40 +1440,52 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             if (!didPop) setState(() => _narrowPanelIndex = 0);
           },
           child: GestureDetector(
-            onHorizontalDragStart: (startDetails) {
-              _swipeStartX = startDetails.globalPosition.dx;
-              _swipeSnapController.stop();
-            },
-            onHorizontalDragUpdate: (details) {
-              if (_swipeStartX == null) return;
-              if (_swipeStartX! >= _edgeSwipeZone) return;
+            // Suppressed in column mode so the channel-drawer's own
+            // edge-swipe wins. The drawer covers the same "go back to
+            // navigation" affordance for column users.
+            onHorizontalDragStart: useColumnDrawer
+                ? null
+                : (startDetails) {
+                    _swipeStartX = startDetails.globalPosition.dx;
+                    _swipeSnapController.stop();
+                  },
+            onHorizontalDragUpdate: useColumnDrawer
+                ? null
+                : (details) {
+                    if (_swipeStartX == null) return;
+                    if (_swipeStartX! >= _edgeSwipeZone) return;
 
-              final deltaX = details.globalPosition.dx - _swipeStartX!;
+                    final deltaX = details.globalPosition.dx - _swipeStartX!;
 
-              if (deltaX > _edgeSwipeThreshold) {
-                // Threshold crossed — complete navigation and reset.
-                _swipeStartX = null;
-                setState(() {
-                  _swipeProgress = 0.0;
-                  _narrowPanelIndex = 0;
-                });
-                return;
-              }
+                    if (deltaX > _edgeSwipeThreshold) {
+                      // Threshold crossed — complete navigation and reset.
+                      _swipeStartX = null;
+                      setState(() {
+                        _swipeProgress = 0.0;
+                        _narrowPanelIndex = 0;
+                      });
+                      return;
+                    }
 
-              // Update in-progress feedback.
-              final progress =
-                  (deltaX.clamp(0.0, _edgeSwipeThreshold) /
-                  _edgeSwipeThreshold);
-              setState(() => _swipeProgress = progress);
-            },
-            onHorizontalDragEnd: (_) {
-              if (_swipeProgress > 0.0) {
-                // Snap back from current progress to 0 over 150 ms.
-                _swipeSnapController.value = _swipeProgress;
-                _swipeSnapController.animateBack(0.0, curve: Curves.easeOut);
-              }
-              _swipeStartX = null;
-            },
+                    // Update in-progress feedback.
+                    final progress =
+                        (deltaX.clamp(0.0, _edgeSwipeThreshold) /
+                        _edgeSwipeThreshold);
+                    setState(() => _swipeProgress = progress);
+                  },
+            onHorizontalDragEnd: useColumnDrawer
+                ? null
+                : (_) {
+                    if (_swipeProgress > 0.0) {
+                      // Snap back from current progress to 0 over 150 ms.
+                      _swipeSnapController.value = _swipeProgress;
+                      _swipeSnapController.animateBack(
+                        0.0,
+                        curve: Curves.easeOut,
+                      );
+                    }
+                    _swipeStartX = null;
+                  },
             child: Stack(
               children: [
                 chatContent,

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -75,6 +75,11 @@ class ChatPanel extends ConsumerStatefulWidget {
   /// after the conversation finishes loading.
   final String? initialMessageId;
 
+  /// Mobile-only: tapping a group in the channel drawer's left rail
+  /// bubbles up here so the host screen can swap the active
+  /// conversation. Desktop never renders that rail.
+  final ValueChanged<String>? onConversationSelected;
+
   const ChatPanel({
     super.key,
     this.conversation,
@@ -84,6 +89,7 @@ class ChatPanel extends ConsumerStatefulWidget {
     this.onShowLounge,
     this.hideVoiceDock = false,
     this.initialMessageId,
+    this.onConversationSelected,
   });
 
   @override
@@ -974,6 +980,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         onMembersToggle: widget.onMembersToggle,
         onGroupInfo: widget.onGroupInfo,
         onShowLounge: widget.onShowLounge,
+        onConversationSelected: widget.onConversationSelected,
         onTextChannelChanged: _onTextChannelChanged,
         onVoiceChannelChanged: (channelId) {
           if (mounted) setState(() => _activeVoiceChannelId = channelId);

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -16,6 +16,7 @@ import '../chat_header_bar.dart';
 import '../chat_input_bar.dart';
 import '../encryption_status_banner.dart';
 import '../message_search_overlay.dart';
+import '../mobile_channel_drawer.dart';
 import 'chat_message_list.dart';
 import 'drop_overlay.dart';
 import 'floating_date_pill.dart';
@@ -81,6 +82,7 @@ class ChatPanelBodyParams {
     required this.onScrollToBottom,
     required this.onMessageSent,
     required this.onMediaPickerChanged,
+    this.onConversationSelected,
   });
 
   final Conversation conv;
@@ -137,6 +139,11 @@ class ChatPanelBodyParams {
   final VoidCallback onScrollToBottom;
   final VoidCallback onMessageSent;
   final VoidCallback onMediaPickerChanged;
+
+  /// Optional: tapping a group in the mobile drawer's left rail bubbles
+  /// up here so the host screen can swap `_selectedConversation`. Not
+  /// set on desktop (the drawer never renders there).
+  final ValueChanged<String>? onConversationSelected;
 }
 
 Widget buildChatContentBox(
@@ -145,16 +152,20 @@ Widget buildChatContentBox(
   ChatPanelBodyParams p,
 ) {
   final chatGradient = context.chatBgGradient;
-  // Column-mode rail: render a Slack/Discord-style left rail listing
-  // text + voice channels instead of the top chip bar. Only kicks in
-  // for group chats on viewports wide enough to fit
-  // (sidebar + column + chat + members). Falls back to the bar layout
-  // on phones / narrow desktop windows so the rail doesn't crowd out
-  // the message list (#prod-column-layout-2026-05-20).
+  // Column-mode visibility branches on viewport width:
+  //
+  //   • >= 900 px → desktop side-rail beside the chat (`useColumn`).
+  //   • <  900 px → Discord-style edge-swipe drawer
+  //                 (`useColumnDrawer`).
+  //
+  // Both surfaces feed off the same channel state and the same join /
+  // text-channel callbacks, so behaviour is consistent between layouts
+  // (#prod-column-layout-2026-05-20).
   final layout = ref.watch(channelLayoutProvider);
   final width = MediaQuery.of(context).size.width;
-  final useColumn =
-      layout == ChannelLayout.column && p.conv.isGroup && width >= 900;
+  final columnRequested = layout == ChannelLayout.column && p.conv.isGroup;
+  final useColumn = columnRequested && width >= 900;
+  final useColumnDrawer = columnRequested && width < 900;
   final chatArea = DecoratedBox(
     decoration: chatGradient != null
         ? BoxDecoration(gradient: chatGradient)
@@ -183,7 +194,7 @@ Widget buildChatContentBox(
               onMembersToggle: p.onMembersToggle,
               onGroupInfo: p.onGroupInfo,
             ),
-            if (p.conv.isGroup && !useColumn)
+            if (p.conv.isGroup && !useColumn && !useColumnDrawer)
               ChannelBar(
                 conversationId: p.conv.id,
                 selectedTextChannelId: p.selectedTextChannelId,
@@ -322,16 +333,36 @@ Widget buildChatContentBox(
     ),
   );
 
-  if (!useColumn) return chatArea;
-  return Row(
-    children: [
-      ChannelColumn(
+  if (useColumn) {
+    return Row(
+      children: [
+        ChannelColumn(
+          conversation: p.conv,
+          selectedTextChannelId: p.selectedTextChannelId,
+          onTextChannelChanged: p.onTextChannelChanged,
+          onShowLounge: p.onShowLounge,
+        ),
+        Expanded(child: chatArea),
+      ],
+    );
+  }
+  if (useColumnDrawer && p.onConversationSelected != null) {
+    // Inner Scaffold so the Drawer's built-in edge-swipe gesture works
+    // without colliding with the outer narrow-layout Scaffold. The
+    // outer one already handles the back-to-conversations swipe; in
+    // column mode that gesture is suppressed by the home screen so
+    // this one wins.
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      drawer: MobileChannelDrawer(
         conversation: p.conv,
         selectedTextChannelId: p.selectedTextChannelId,
         onTextChannelChanged: p.onTextChannelChanged,
+        onConversationSelected: p.onConversationSelected!,
         onShowLounge: p.onShowLounge,
       ),
-      Expanded(child: chatArea),
-    ],
-  );
+      body: chatArea,
+    );
+  }
+  return chatArea;
 }

--- a/apps/client/lib/src/widgets/mobile_channel_drawer.dart
+++ b/apps/client/lib/src/widgets/mobile_channel_drawer.dart
@@ -1,0 +1,162 @@
+/// Discord-style channel drawer for mobile + tablet portrait windows.
+///
+/// On wide viewports the column-layout series renders `ChannelColumn` as
+/// a sticky left rail. That doesn't fit a phone, so on narrow viewports
+/// we put the same vertical list behind an edge-swipe drawer instead:
+/// the chat stays full-screen, swiping right from the left edge pulls
+/// the channel list in over the chat, and tapping a channel closes the
+/// drawer and switches the chat focus to that channel.
+///
+/// A 56-wide group rail on the far left mirrors Discord's "server bar"
+/// so users can also hop to another group without leaving the drawer.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/conversation.dart';
+import '../providers/conversations_provider.dart';
+import '../theme/echo_theme.dart';
+import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
+import 'channel_column.dart';
+
+class MobileChannelDrawer extends ConsumerWidget {
+  final Conversation conversation;
+  final String? selectedTextChannelId;
+  final ValueChanged<String?> onTextChannelChanged;
+  final ValueChanged<String> onConversationSelected;
+  final VoidCallback? onShowLounge;
+
+  /// Total drawer width on a phone: 56-wide group rail + 232-wide
+  /// channel column = 288. Stays under the 304 default that Flutter's
+  /// `Drawer` uses, so the swipe behaviour and Material defaults
+  /// continue to work without overrides.
+  static const double railWidth = 56;
+  static const double drawerWidth = railWidth + ChannelColumn.width - 28;
+
+  const MobileChannelDrawer({
+    super.key,
+    required this.conversation,
+    required this.selectedTextChannelId,
+    required this.onTextChannelChanged,
+    required this.onConversationSelected,
+    this.onShowLounge,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final convs = ref
+        .watch(conversationsProvider)
+        .conversations
+        .where((c) => c.isGroup)
+        .toList();
+    return Drawer(
+      width: drawerWidth,
+      backgroundColor: context.sidebarBg,
+      child: SafeArea(
+        child: Row(
+          children: [
+            _GroupRail(
+              groups: convs,
+              activeId: conversation.id,
+              onSelect: (id) {
+                onConversationSelected(id);
+                Navigator.of(context).maybePop();
+              },
+            ),
+            Expanded(
+              child: ChannelColumn(
+                conversation: conversation,
+                selectedTextChannelId: selectedTextChannelId,
+                onTextChannelChanged: (id) {
+                  onTextChannelChanged(id);
+                  Navigator.of(context).maybePop();
+                },
+                onShowLounge: () {
+                  onShowLounge?.call();
+                  Navigator.of(context).maybePop();
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupRail extends StatelessWidget {
+  final List<Conversation> groups;
+  final String activeId;
+  final ValueChanged<String> onSelect;
+
+  const _GroupRail({
+    required this.groups,
+    required this.activeId,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MobileChannelDrawer.railWidth,
+      decoration: BoxDecoration(
+        color: context.mainBg,
+        border: Border(right: BorderSide(color: context.border)),
+      ),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: groups.length,
+        itemBuilder: (_, i) {
+          final g = groups[i];
+          final active = g.id == activeId;
+          final name = g.displayName('');
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Stack(
+              children: [
+                if (active)
+                  Positioned(
+                    left: 0,
+                    top: 6,
+                    bottom: 6,
+                    child: Container(
+                      width: 3,
+                      decoration: BoxDecoration(
+                        color: context.accent,
+                        borderRadius: const BorderRadius.only(
+                          topRight: Radius.circular(2),
+                          bottomRight: Radius.circular(2),
+                        ),
+                      ),
+                    ),
+                  ),
+                Center(
+                  child: Semantics(
+                    label: 'group ${name.isEmpty ? "unnamed" : name}',
+                    button: true,
+                    selected: active,
+                    child: InkResponse(
+                      onTap: () => onSelect(g.id),
+                      radius: 24,
+                      child: buildAvatar(
+                        name: name,
+                        radius: 20,
+                        bgColor: groupAvatarColor(g.id),
+                        fallbackIcon: const Icon(
+                          Icons.group,
+                          size: 18,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/apps/client/test/widgets/mobile_channel_drawer_test.dart
+++ b/apps/client/test/widgets/mobile_channel_drawer_test.dart
@@ -1,0 +1,148 @@
+import 'package:echo_app/src/models/channel.dart';
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/providers/channels_provider.dart';
+import 'package:echo_app/src/providers/conversations_provider.dart';
+import 'package:echo_app/src/widgets/mobile_channel_drawer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/pump_app.dart';
+
+/// Smoke tests for the Discord-style mobile drawer: the group rail
+/// switches conversations and channel taps pop the drawer.
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Conversation conv(String id, String name) => Conversation(
+    id: id,
+    isGroup: true,
+    name: name,
+    members: const [ConversationMember(userId: 'me', username: 'me')],
+  );
+
+  GroupChannel text(String id, String name, {int pos = 0}) => GroupChannel(
+    id: id,
+    conversationId: 'c1',
+    name: name,
+    kind: 'text',
+    position: pos,
+    createdAt: '',
+  );
+
+  Override channelsOverride(Map<String, List<GroupChannel>> byConv) =>
+      channelsProvider.overrideWith(
+        () => _StubChannels(
+          ChannelsState(
+            channelsByConversation: byConv,
+            voiceSessionsByChannel: const {},
+          ),
+        ),
+      );
+
+  Override conversationsOverride(List<Conversation> convs) =>
+      conversationsProvider.overrideWith(
+        () => _StubConversations(ConversationsState(conversations: convs)),
+      );
+
+  Future<void> openDrawer(WidgetTester tester) async {
+    // `pumpApp` already wraps in an outer Scaffold(body: widget); the
+    // drawer lives on the inner one, so grab the LAST Scaffold to find
+    // a ScaffoldState that actually has a drawer attached.
+    final scaffoldFinder = find.byType(Scaffold);
+    final scaffoldState = tester.state<ScaffoldState>(scaffoldFinder.last);
+    scaffoldState.openDrawer();
+    await tester.pumpAndSettle();
+  }
+
+  group('MobileChannelDrawer', () {
+    testWidgets('tapping a text channel closes the drawer and fires '
+        'onTextChannelChanged', (tester) async {
+      String? lastChannel;
+      bool drawerOpen = true;
+      await tester.pumpApp(
+        Scaffold(
+          drawer: MobileChannelDrawer(
+            conversation: conv('c1', 'Echo Devs'),
+            selectedTextChannelId: null,
+            onTextChannelChanged: (id) => lastChannel = id,
+            onConversationSelected: (_) {},
+          ),
+          body: Builder(
+            builder: (ctx) {
+              return TextButton(
+                onPressed: () => Scaffold.of(ctx).openDrawer(),
+                child: const Text('open'),
+              );
+            },
+          ),
+          onDrawerChanged: (open) => drawerOpen = open,
+        ),
+        overrides: [
+          channelsOverride({
+            'c1': [text('t1', 'general'), text('t2', 'releases', pos: 1)],
+          }),
+          conversationsOverride([conv('c1', 'Echo Devs')]),
+        ],
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(drawerOpen, isTrue);
+      await tester.tap(find.text('releases'));
+      await tester.pumpAndSettle();
+      expect(lastChannel, 't2');
+      expect(drawerOpen, isFalse);
+    });
+
+    testWidgets('group rail lists other groups and forwards taps', (
+      tester,
+    ) async {
+      String? switched;
+      await tester.pumpApp(
+        Scaffold(
+          drawer: MobileChannelDrawer(
+            conversation: conv('c1', 'Echo Devs'),
+            selectedTextChannelId: null,
+            onTextChannelChanged: (_) {},
+            onConversationSelected: (id) => switched = id,
+          ),
+        ),
+        overrides: [
+          channelsOverride({
+            'c1': [text('t1', 'general')],
+          }),
+          conversationsOverride([
+            conv('c1', 'Echo Devs'),
+            conv('c2', 'Taco Lovers'),
+          ]),
+        ],
+      );
+      await openDrawer(tester);
+      // Both groups appear as avatars in the rail (initial letter only).
+      expect(find.bySemanticsLabel('group Echo Devs'), findsOneWidget);
+      expect(find.bySemanticsLabel('group Taco Lovers'), findsOneWidget);
+      await tester.tap(find.bySemanticsLabel('group Taco Lovers'));
+      await tester.pumpAndSettle();
+      expect(switched, 'c2');
+    });
+  });
+}
+
+class _StubChannels extends Channels {
+  _StubChannels(this._initial);
+  final ChannelsState _initial;
+
+  @override
+  ChannelsState build() => _initial;
+}
+
+class _StubConversations extends ConversationsNotifier {
+  _StubConversations(this._initial);
+  final ConversationsState _initial;
+
+  @override
+  ConversationsState build() => _initial;
+}


### PR DESCRIPTION
Adds the mobile UX for Column mode. Previously, Column mode silently
fell back to the bar layout on phones because a 260px side rail
doesn't fit on a 390px screen. Now mobile users in Column mode get
the same Discord-style channel drawer the desktop side rail surfaces,
just slid in over the chat instead of pinned beside it.

## What the user sees
- Open a group chat on a phone with Column mode on.
- Swipe right from the left edge → the channel list slides in over
  the chat. The 56px far-left strip lists your other groups so you
  can hop sideways without backing out to the conversation list.
- Tap a text channel to focus it; tap a voice channel to join.
  Either action closes the drawer and updates the chat.

The "back to conversation list" edge gesture that existed before is
suppressed while the drawer is on, because the drawer's own swipe
takes that role. Users reach the conversation list via the back
button in the chat header or the bottom Chats tab.

## Behind the scenes
- 2 widget tests cover the drawer's text-channel tap → close-drawer
  + fire-callback path and the group-rail switch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)