### PR TITLE
Release: mobile channel drawer + sonar cleanup

### DIFF
--- a/apps/client/lib/src/providers/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat_provider.dart
@@ -32,6 +32,12 @@ const _placeholderContents = <String>{
   '[Encrypted for another device of this account]',
 };
 
+/// Placeholder shown when an inbound GRP2 group message fails sender-
+/// signature verification (or we cannot fetch the sender's verify key).
+/// Distinct from "[Could not decrypt…]" because this is a *security*
+/// signal rather than a key-out-of-sync transient.
+const _kCouldNotVerifySender = '[Could not verify sender]';
+
 bool _isPlaceholderContent(String c) =>
     _placeholderContents.contains(c) || c.startsWith('[Could not decrypt');
 
@@ -144,62 +150,22 @@ class ChatState {
     var updatedFailures = consecutiveDecryptFailures;
     var updatedSigFailures = signatureFailures;
 
-    // Audit P0-3 + Phase 4: track decrypt-failure placeholders so the
-    // chat UI can surface a recovery banner. Two distinct buckets:
-    //   - `consecutiveDecryptFailures` — count "[Could not decrypt…]"
-    //     transients, reset on any genuine decrypt success.
-    //   - `signatureFailures` — sticky set of conversations where a
-    //     "[Could not verify sender]" landed. Cleared only when the
-    //     user closes / reopens the conversation OR an admin rotates
-    //     the key (which also drops the cached envelope).
     if (msg.conversationId.isNotEmpty) {
-      final isDecryptFailure = msg.content.startsWith('[Could not decrypt');
-      final isSigFailure = msg.content.startsWith('[Could not verify sender');
-      final prev = updatedFailures[msg.conversationId] ?? 0;
-      if (isDecryptFailure) {
-        updatedFailures = {...updatedFailures, msg.conversationId: prev + 1};
-      } else if (prev > 0 &&
-          !_isPlaceholderContent(msg.content) &&
-          !msg.isSystemEvent) {
-        // Genuine success after one or more failures — clear the counter.
-        updatedFailures = {...updatedFailures}..remove(msg.conversationId);
-      }
-      if (isSigFailure && !updatedSigFailures.contains(msg.conversationId)) {
-        updatedSigFailures = {...updatedSigFailures, msg.conversationId};
-      }
-    }
-
-    if (msg.conversationId.isNotEmpty) {
-      final ids = Set<String>.from(
-        updatedIndexMap[msg.conversationId] ?? <String>{},
+      final (nextFailures, nextSigFailures) = _trackDecryptFailures(
+        msg,
+        updatedFailures,
+        updatedSigFailures,
       );
-      // O(1) deduplicate by ID
-      if (!ids.contains(msg.id)) {
-        final existing = updatedConvMap[msg.conversationId] ?? [];
-        var updated = [...existing, msg];
-        // Trim to cap, keeping newest messages.
-        if (updated.length > _maxMessagesPerConv) {
-          updated = updated.sublist(updated.length - _maxMessagesPerConv);
-        }
-        ids.add(msg.id);
-        // Rebuild index from trimmed list to stay consistent.
-        final newIds = updated.map((m) => m.id).toSet();
-        updatedConvMap = {...updatedConvMap, msg.conversationId: updated};
-        updatedIndexMap = {...updatedIndexMap, msg.conversationId: newIds};
-      } else {
-        // Id collision: existing entry might be a decrypt-pending
-        // placeholder (#430).  Replace it in place when isEncrypted
-        // and the content matches a known placeholder string.  The
-        // index already contains msg.id so no map mutation is needed.
-        final existing = updatedConvMap[msg.conversationId] ?? const [];
-        final idx = existing.indexWhere((m) => m.id == msg.id);
-        if (idx >= 0 &&
-            existing[idx].isEncrypted &&
-            _isPlaceholderContent(existing[idx].content)) {
-          final replaced = [...existing]..[idx] = msg;
-          updatedConvMap = {...updatedConvMap, msg.conversationId: replaced};
-        }
-      }
+      updatedFailures = nextFailures;
+      updatedSigFailures = nextSigFailures;
+
+      final (nextConvMap, nextIndexMap) = _appendOrReplaceMessage(
+        msg,
+        updatedConvMap,
+        updatedIndexMap,
+      );
+      updatedConvMap = nextConvMap;
+      updatedIndexMap = nextIndexMap;
     }
 
     return ChatState(
@@ -211,6 +177,79 @@ class ChatState {
       consecutiveDecryptFailures: updatedFailures,
       signatureFailures: updatedSigFailures,
     );
+  }
+
+  /// Audit P0-3 + Phase 4: track decrypt-failure placeholders so the
+  /// chat UI can surface a recovery banner. Two distinct buckets:
+  ///   - `consecutiveDecryptFailures` — count "[Could not decrypt…]"
+  ///     transients, reset on any genuine decrypt success.
+  ///   - `signatureFailures` — sticky set of conversations where a
+  ///     "[Could not verify sender]" landed. Cleared only when the
+  ///     user closes / reopens the conversation OR an admin rotates
+  ///     the key (which also drops the cached envelope).
+  (Map<String, int>, Set<String>) _trackDecryptFailures(
+    ChatMessage msg,
+    Map<String, int> failures,
+    Set<String> sigFailures,
+  ) {
+    final isDecryptFailure = msg.content.startsWith('[Could not decrypt');
+    final isSigFailure = msg.content.startsWith('[Could not verify sender');
+    final prev = failures[msg.conversationId] ?? 0;
+
+    var nextFailures = failures;
+    if (isDecryptFailure) {
+      nextFailures = {...failures, msg.conversationId: prev + 1};
+    } else if (prev > 0 &&
+        !_isPlaceholderContent(msg.content) &&
+        !msg.isSystemEvent) {
+      // Genuine success after one or more failures — clear the counter.
+      nextFailures = {...failures}..remove(msg.conversationId);
+    }
+
+    var nextSigFailures = sigFailures;
+    if (isSigFailure && !sigFailures.contains(msg.conversationId)) {
+      nextSigFailures = {...sigFailures, msg.conversationId};
+    }
+    return (nextFailures, nextSigFailures);
+  }
+
+  /// Append `msg` to its conversation list (deduped + capped) or, when an
+  /// existing decrypt-pending placeholder shares the same id (#430),
+  /// replace it in place. Returns the updated conv-map and id-index map.
+  (Map<String, List<ChatMessage>>, Map<String, Set<String>>)
+  _appendOrReplaceMessage(
+    ChatMessage msg,
+    Map<String, List<ChatMessage>> convMap,
+    Map<String, Set<String>> indexMap,
+  ) {
+    final ids = Set<String>.from(indexMap[msg.conversationId] ?? <String>{});
+    if (!ids.contains(msg.id)) {
+      final existing = convMap[msg.conversationId] ?? [];
+      var updated = [...existing, msg];
+      // Trim to cap, keeping newest messages.
+      if (updated.length > _maxMessagesPerConv) {
+        updated = updated.sublist(updated.length - _maxMessagesPerConv);
+      }
+      // Rebuild index from trimmed list to stay consistent.
+      final newIds = updated.map((m) => m.id).toSet();
+      return (
+        {...convMap, msg.conversationId: updated},
+        {...indexMap, msg.conversationId: newIds},
+      );
+    }
+    // Id collision: existing entry might be a decrypt-pending placeholder
+    // (#430). Replace it in place when isEncrypted and the content
+    // matches a known placeholder string. The index already contains
+    // msg.id so no map mutation is needed.
+    final existing = convMap[msg.conversationId] ?? const <ChatMessage>[];
+    final idx = existing.indexWhere((m) => m.id == msg.id);
+    if (idx >= 0 &&
+        existing[idx].isEncrypted &&
+        _isPlaceholderContent(existing[idx].content)) {
+      final replaced = [...existing]..[idx] = msg;
+      return ({...convMap, msg.conversationId: replaced}, indexMap);
+    }
+    return (convMap, indexMap);
   }
 
   /// Reset the consecutive-decrypt-failures counter for a conversation.
@@ -835,7 +874,7 @@ class Chat extends _$Chat {
       if (msg.content.startsWith(groupEncryptedPrefixV2)) {
         if (crypto == null) {
           return msg.copyWith(
-            content: '[Could not verify sender]',
+            content: _kCouldNotVerifySender,
             isEncrypted: true,
           );
         }
@@ -845,7 +884,7 @@ class Chat extends _$Chat {
         );
         if (senderVerifyKey == null) {
           return msg.copyWith(
-            content: '[Could not verify sender]',
+            content: _kCouldNotVerifySender,
             isEncrypted: true,
           );
         }
@@ -866,7 +905,7 @@ class Chat extends _$Chat {
             'GRP2 signature failed for ${msg.id}: $e',
           );
           return msg.copyWith(
-            content: '[Could not verify sender]',
+            content: _kCouldNotVerifySender,
             isEncrypted: true,
           );
         }
@@ -874,10 +913,7 @@ class Chat extends _$Chat {
 
       // GRP1 path. Refuse when the envelope is pinned to GRP2.
       if (minWireVersion >= 2) {
-        return msg.copyWith(
-          content: '[Could not verify sender]',
-          isEncrypted: true,
-        );
+        return msg.copyWith(content: _kCouldNotVerifySender, isEncrypted: true);
       }
       final decrypted = await GroupCryptoService.decryptGroupMessage(
         msg.content,

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -33,6 +33,12 @@ part 'ws_handlers/presence_handlers.dart';
 part 'ws_handlers/voice_handlers.dart';
 part 'ws_handlers/crypto_handlers.dart';
 
+/// Placeholder content rendered when an inbound GRP2 group message fails
+/// sender signature verification (or the sender's verify key cannot be
+/// fetched). Distinct from "[Could not decrypt…]" because this is a
+/// security signal, not a key-out-of-sync transient.
+const _kCouldNotVerifySender = '[Could not verify sender]';
+
 /// State that tracks both connection status and typing indicators.
 class WebSocketState {
   final bool isConnected;
@@ -490,7 +496,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
                 'from=$fromUserId)',
             'WebSocket',
           );
-          return '[Could not verify sender]';
+          return _kCouldNotVerifySender;
         }
         final senderVerifyKey = await crypto.getSenderVerifyKeyForDevice(
           fromUserId,
@@ -502,7 +508,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
                 '$fromUserId:$fromDeviceId',
             'WebSocket',
           );
-          return '[Could not verify sender]';
+          return _kCouldNotVerifySender;
         }
         try {
           return await GroupCryptoService.verifyAndDecryptGroupMessageV2(
@@ -519,7 +525,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
             'GRP2 signature failed for $conversationId msg=$messageId: $e',
             'WebSocket',
           );
-          return '[Could not verify sender]';
+          return _kCouldNotVerifySender;
         }
       }
 
@@ -532,7 +538,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
               '(conv=$conversationId)',
           'WebSocket',
         );
-        return '[Could not verify sender]';
+        return _kCouldNotVerifySender;
       }
       return await GroupCryptoService.decryptGroupMessage(
         rawContent,

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/conversation.dart';
+import '../providers/channel_layout_provider.dart';
 import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/crypto_provider.dart';
@@ -1393,6 +1394,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       );
     }
 
+    final layout = ref.watch(channelLayoutProvider);
+    // Discord-style channel drawer: kicks in on the same path the outer
+    // edge-swipe-back uses, but only when the user has opted into the
+    // column layout AND the open conversation is a group with channels.
+    // Otherwise we keep the existing swipe-to-conversations behaviour.
+    final useColumnDrawer =
+        layout == ChannelLayout.column &&
+        (_selectedConversation?.isGroup ?? false);
+
     Widget chatContent = ChatPanel(
       conversation: _selectedConversation,
       onGroupInfo: _showGroupInfo,
@@ -1402,6 +1412,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         _showingLounge = true;
         _userDismissedLounge = false;
       }),
+      onConversationSelected: useColumnDrawer
+          ? (id) {
+              final next = ref
+                  .read(conversationsProvider)
+                  .conversations
+                  .where((c) => c.id == id)
+                  .firstOrNull;
+              if (next != null) {
+                setState(() => _selectedConversation = next);
+              }
+            }
+          : null,
     );
 
     // Note: a "● <channel> — Tap to view voice" rejoin banner used to sit
@@ -1418,40 +1440,52 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             if (!didPop) setState(() => _narrowPanelIndex = 0);
           },
           child: GestureDetector(
-            onHorizontalDragStart: (startDetails) {
-              _swipeStartX = startDetails.globalPosition.dx;
-              _swipeSnapController.stop();
-            },
-            onHorizontalDragUpdate: (details) {
-              if (_swipeStartX == null) return;
-              if (_swipeStartX! >= _edgeSwipeZone) return;
+            // Suppressed in column mode so the channel-drawer's own
+            // edge-swipe wins. The drawer covers the same "go back to
+            // navigation" affordance for column users.
+            onHorizontalDragStart: useColumnDrawer
+                ? null
+                : (startDetails) {
+                    _swipeStartX = startDetails.globalPosition.dx;
+                    _swipeSnapController.stop();
+                  },
+            onHorizontalDragUpdate: useColumnDrawer
+                ? null
+                : (details) {
+                    if (_swipeStartX == null) return;
+                    if (_swipeStartX! >= _edgeSwipeZone) return;
 
-              final deltaX = details.globalPosition.dx - _swipeStartX!;
+                    final deltaX = details.globalPosition.dx - _swipeStartX!;
 
-              if (deltaX > _edgeSwipeThreshold) {
-                // Threshold crossed — complete navigation and reset.
-                _swipeStartX = null;
-                setState(() {
-                  _swipeProgress = 0.0;
-                  _narrowPanelIndex = 0;
-                });
-                return;
-              }
+                    if (deltaX > _edgeSwipeThreshold) {
+                      // Threshold crossed — complete navigation and reset.
+                      _swipeStartX = null;
+                      setState(() {
+                        _swipeProgress = 0.0;
+                        _narrowPanelIndex = 0;
+                      });
+                      return;
+                    }
 
-              // Update in-progress feedback.
-              final progress =
-                  (deltaX.clamp(0.0, _edgeSwipeThreshold) /
-                  _edgeSwipeThreshold);
-              setState(() => _swipeProgress = progress);
-            },
-            onHorizontalDragEnd: (_) {
-              if (_swipeProgress > 0.0) {
-                // Snap back from current progress to 0 over 150 ms.
-                _swipeSnapController.value = _swipeProgress;
-                _swipeSnapController.animateBack(0.0, curve: Curves.easeOut);
-              }
-              _swipeStartX = null;
-            },
+                    // Update in-progress feedback.
+                    final progress =
+                        (deltaX.clamp(0.0, _edgeSwipeThreshold) /
+                        _edgeSwipeThreshold);
+                    setState(() => _swipeProgress = progress);
+                  },
+            onHorizontalDragEnd: useColumnDrawer
+                ? null
+                : (_) {
+                    if (_swipeProgress > 0.0) {
+                      // Snap back from current progress to 0 over 150 ms.
+                      _swipeSnapController.value = _swipeProgress;
+                      _swipeSnapController.animateBack(
+                        0.0,
+                        curve: Curves.easeOut,
+                      );
+                    }
+                    _swipeStartX = null;
+                  },
             child: Stack(
               children: [
                 chatContent,

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -1503,24 +1503,8 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     // selected row, arrows move it, Escape closes the picker (without
     // also bubbling Escape through to message edit-cancel).
     if (_mentionController.showPicker) {
-      if (event.logicalKey == LogicalKeyboardKey.tab ||
-          (event.logicalKey == LogicalKeyboardKey.enter &&
-              !HardwareKeyboard.instance.isShiftPressed)) {
-        _acceptMentionSelection();
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-        _moveMentionSelection(_MentionMove.down);
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-        _moveMentionSelection(_MentionMove.up);
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.escape) {
-        _mentionController.dismiss();
-        return KeyEventResult.handled;
-      }
+      final mentionResult = _handleMentionPickerKey(event);
+      if (mentionResult != KeyEventResult.ignored) return mentionResult;
       // Space falls through — extractMentionQuery sees the space and
       // closes the picker, leaving the literal "@" in the text.
     }
@@ -1542,6 +1526,32 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       return _handleArrowUpEditLast();
     }
 
+    return KeyEventResult.ignored;
+  }
+
+  /// Keyboard handler for the mention picker overlay. Returns
+  /// [KeyEventResult.ignored] when the picker should *not* consume the
+  /// event (e.g. Space, so the picker auto-dismisses via the query
+  /// extractor).
+  KeyEventResult _handleMentionPickerKey(KeyDownEvent event) {
+    if (event.logicalKey == LogicalKeyboardKey.tab ||
+        (event.logicalKey == LogicalKeyboardKey.enter &&
+            !HardwareKeyboard.instance.isShiftPressed)) {
+      _acceptMentionSelection();
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      _moveMentionSelection(_MentionMove.down);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      _moveMentionSelection(_MentionMove.up);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.escape) {
+      _mentionController.dismiss();
+      return KeyEventResult.handled;
+    }
     return KeyEventResult.ignored;
   }
 

--- a/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
@@ -163,63 +163,70 @@ typedef _PickAndDispatchParams = ({
 
 Future<void> _pickAndDispatch(_PickAndDispatchParams params) async {
   final context = params.context;
-  final mounted = params.mounted;
-  final isPicking = params.isPicking;
-  final setIsPicking = params.setIsPicking;
-  final stage = params.stage;
-  final sendImmediately = params.sendImmediately;
-  final type = params.type;
-  final errorPrefix = params.errorPrefix;
-  if (isPicking()) return;
-  setIsPicking(true);
+  if (params.isPicking()) return;
+  params.setIsPicking(true);
   try {
     final result = await FilePicker.pickFiles(
-      type: type,
+      type: params.type,
       allowMultiple: true,
       withData: true,
     );
     if (result == null || result.files.isEmpty) return;
-    if (!mounted()) return;
-
-    // Single pick → preview flow (caption + send). Multi pick → send all
-    // immediately as separate messages; mixing the two creates races where
-    // the user may interact with the pending preview while the rest are
-    // still uploading in the background.
-    final isMulti = result.files.length > 1;
-    if (isMulti && context.mounted) {
-      ToastService.show(
-        context,
-        'Sending ${result.files.length} files...',
-        type: ToastType.info,
-      );
-    }
-
-    var sentCount = 0;
-    for (final file in result.files) {
-      if (!context.mounted) break;
-      final ok = await _dispatchFile(
-        context: context,
-        file: file,
-        isMulti: isMulti,
-        stage: stage,
-        sendImmediately: sendImmediately,
-      );
-      if (ok) sentCount++;
-    }
-
-    if (isMulti && context.mounted && sentCount < result.files.length) {
-      final failed = result.files.length - sentCount;
-      ToastService.show(
-        context,
-        '$failed of ${result.files.length} failed to send',
-        type: ToastType.error,
-      );
-    }
+    if (!params.mounted() || !context.mounted) return;
+    await _dispatchPickedFiles(context, params, result.files);
   } catch (e) {
     if (!context.mounted) return;
-    ToastService.show(context, '$errorPrefix error: $e', type: ToastType.error);
+    ToastService.show(
+      context,
+      '${params.errorPrefix} error: $e',
+      type: ToastType.error,
+    );
   } finally {
-    setIsPicking(false);
+    params.setIsPicking(false);
+  }
+}
+
+/// Dispatches a previously-picked list of files, surfacing toast feedback
+/// for multi-file sends. Extracted from [_pickAndDispatch] to keep its
+/// cognitive complexity below SonarCloud's threshold.
+Future<void> _dispatchPickedFiles(
+  BuildContext context,
+  _PickAndDispatchParams params,
+  List<PlatformFile> files,
+) async {
+  // Single pick → preview flow (caption + send). Multi pick → send all
+  // immediately as separate messages; mixing the two creates races where
+  // the user may interact with the pending preview while the rest are
+  // still uploading in the background.
+  final isMulti = files.length > 1;
+  if (isMulti && context.mounted) {
+    ToastService.show(
+      context,
+      'Sending ${files.length} files...',
+      type: ToastType.info,
+    );
+  }
+
+  var sentCount = 0;
+  for (final file in files) {
+    if (!context.mounted) break;
+    final ok = await _dispatchFile(
+      context: context,
+      file: file,
+      isMulti: isMulti,
+      stage: params.stage,
+      sendImmediately: params.sendImmediately,
+    );
+    if (ok) sentCount++;
+  }
+
+  if (isMulti && context.mounted && sentCount < files.length) {
+    final failed = files.length - sentCount;
+    ToastService.show(
+      context,
+      '$failed of ${files.length} failed to send',
+      type: ToastType.error,
+    );
   }
 }
 

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -75,6 +75,11 @@ class ChatPanel extends ConsumerStatefulWidget {
   /// after the conversation finishes loading.
   final String? initialMessageId;
 
+  /// Mobile-only: tapping a group in the channel drawer's left rail
+  /// bubbles up here so the host screen can swap the active
+  /// conversation. Desktop never renders that rail.
+  final ValueChanged<String>? onConversationSelected;
+
   const ChatPanel({
     super.key,
     this.conversation,
@@ -84,6 +89,7 @@ class ChatPanel extends ConsumerStatefulWidget {
     this.onShowLounge,
     this.hideVoiceDock = false,
     this.initialMessageId,
+    this.onConversationSelected,
   });
 
   @override
@@ -974,6 +980,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         onMembersToggle: widget.onMembersToggle,
         onGroupInfo: widget.onGroupInfo,
         onShowLounge: widget.onShowLounge,
+        onConversationSelected: widget.onConversationSelected,
         onTextChannelChanged: _onTextChannelChanged,
         onVoiceChannelChanged: (channelId) {
           if (mounted) setState(() => _activeVoiceChannelId = channelId);

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -16,6 +16,7 @@ import '../chat_header_bar.dart';
 import '../chat_input_bar.dart';
 import '../encryption_status_banner.dart';
 import '../message_search_overlay.dart';
+import '../mobile_channel_drawer.dart';
 import 'chat_message_list.dart';
 import 'drop_overlay.dart';
 import 'floating_date_pill.dart';
@@ -81,6 +82,7 @@ class ChatPanelBodyParams {
     required this.onScrollToBottom,
     required this.onMessageSent,
     required this.onMediaPickerChanged,
+    this.onConversationSelected,
   });
 
   final Conversation conv;
@@ -137,6 +139,11 @@ class ChatPanelBodyParams {
   final VoidCallback onScrollToBottom;
   final VoidCallback onMessageSent;
   final VoidCallback onMediaPickerChanged;
+
+  /// Optional: tapping a group in the mobile drawer's left rail bubbles
+  /// up here so the host screen can swap `_selectedConversation`. Not
+  /// set on desktop (the drawer never renders there).
+  final ValueChanged<String>? onConversationSelected;
 }
 
 Widget buildChatContentBox(
@@ -145,16 +152,20 @@ Widget buildChatContentBox(
   ChatPanelBodyParams p,
 ) {
   final chatGradient = context.chatBgGradient;
-  // Column-mode rail: render a Slack/Discord-style left rail listing
-  // text + voice channels instead of the top chip bar. Only kicks in
-  // for group chats on viewports wide enough to fit
-  // (sidebar + column + chat + members). Falls back to the bar layout
-  // on phones / narrow desktop windows so the rail doesn't crowd out
-  // the message list (#prod-column-layout-2026-05-20).
+  // Column-mode visibility branches on viewport width:
+  //
+  //   • >= 900 px → desktop side-rail beside the chat (`useColumn`).
+  //   • <  900 px → Discord-style edge-swipe drawer
+  //                 (`useColumnDrawer`).
+  //
+  // Both surfaces feed off the same channel state and the same join /
+  // text-channel callbacks, so behaviour is consistent between layouts
+  // (#prod-column-layout-2026-05-20).
   final layout = ref.watch(channelLayoutProvider);
   final width = MediaQuery.of(context).size.width;
-  final useColumn =
-      layout == ChannelLayout.column && p.conv.isGroup && width >= 900;
+  final columnRequested = layout == ChannelLayout.column && p.conv.isGroup;
+  final useColumn = columnRequested && width >= 900;
+  final useColumnDrawer = columnRequested && width < 900;
   final chatArea = DecoratedBox(
     decoration: chatGradient != null
         ? BoxDecoration(gradient: chatGradient)
@@ -183,7 +194,7 @@ Widget buildChatContentBox(
               onMembersToggle: p.onMembersToggle,
               onGroupInfo: p.onGroupInfo,
             ),
-            if (p.conv.isGroup && !useColumn)
+            if (p.conv.isGroup && !useColumn && !useColumnDrawer)
               ChannelBar(
                 conversationId: p.conv.id,
                 selectedTextChannelId: p.selectedTextChannelId,
@@ -322,16 +333,36 @@ Widget buildChatContentBox(
     ),
   );
 
-  if (!useColumn) return chatArea;
-  return Row(
-    children: [
-      ChannelColumn(
+  if (useColumn) {
+    return Row(
+      children: [
+        ChannelColumn(
+          conversation: p.conv,
+          selectedTextChannelId: p.selectedTextChannelId,
+          onTextChannelChanged: p.onTextChannelChanged,
+          onShowLounge: p.onShowLounge,
+        ),
+        Expanded(child: chatArea),
+      ],
+    );
+  }
+  if (useColumnDrawer && p.onConversationSelected != null) {
+    // Inner Scaffold so the Drawer's built-in edge-swipe gesture works
+    // without colliding with the outer narrow-layout Scaffold. The
+    // outer one already handles the back-to-conversations swipe; in
+    // column mode that gesture is suppressed by the home screen so
+    // this one wins.
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      drawer: MobileChannelDrawer(
         conversation: p.conv,
         selectedTextChannelId: p.selectedTextChannelId,
         onTextChannelChanged: p.onTextChannelChanged,
+        onConversationSelected: p.onConversationSelected!,
         onShowLounge: p.onShowLounge,
       ),
-      Expanded(child: chatArea),
-    ],
-  );
+      body: chatArea,
+    );
+  }
+  return chatArea;
 }

--- a/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_testbed.dart
@@ -13,6 +13,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../theme/echo_theme.dart';
 import 'echo_context_menu.dart';
 
+/// Toast label used by every "Copy *ID" demo action in the testbed.
+const String _kCopyIdToast = 'Copy ID';
+
 class ContextMenuTestbed extends ConsumerWidget {
   const ContextMenuTestbed({super.key});
 
@@ -210,7 +213,7 @@ ContextMenuModel _demoMessageModel(BuildContext context) {
           ContextMenuAction(
             label: 'Copy Message ID',
             icon: Icons.tag,
-            onTap: () => _toast(context, 'Copy ID'),
+            onTap: () => _toast(context, _kCopyIdToast),
           ),
         ],
       ),
@@ -250,7 +253,7 @@ ContextMenuModel _demoConversationModel(BuildContext context) {
           ContextMenuAction(
             label: 'Copy Channel ID',
             icon: Icons.tag,
-            onTap: () => _toast(context, 'Copy ID'),
+            onTap: () => _toast(context, _kCopyIdToast),
           ),
         ],
       ),
@@ -320,7 +323,7 @@ ContextMenuModel _demoMemberModel(BuildContext context) {
           ContextMenuAction(
             label: 'Copy User ID',
             icon: Icons.tag,
-            onTap: () => _toast(context, 'Copy ID'),
+            onTap: () => _toast(context, _kCopyIdToast),
           ),
         ],
       ),

--- a/apps/client/lib/src/widgets/message/reply_count_badge.dart
+++ b/apps/client/lib/src/widgets/message/reply_count_badge.dart
@@ -55,38 +55,45 @@ class ReplyCountBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final count = message.replyCount;
     final label = count == 1 ? '1 reply' : '$count replies';
-    if (inlineStyle) {
-      return Padding(
-        padding: EdgeInsets.only(top: 2, left: isMine ? 0 : 36),
-        child: Align(
-          alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
-          child: Semantics(
-            label: hasUnread ? 'View $label (new replies)' : 'View $label',
-            button: true,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(2),
-              onTap: onTap == null ? null : () => onTap!(message),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    label,
-                    style: GoogleFonts.inter(
-                      fontSize: 12,
-                      color: context.accent,
-                      fontWeight: FontWeight.w500,
-                      decoration: TextDecoration.underline,
-                      decorationColor: context.accent.withValues(alpha: 0.4),
-                    ),
+    return inlineStyle
+        ? _buildInline(context, label)
+        : _buildPill(context, label);
+  }
+
+  Widget _buildInline(BuildContext context, String label) {
+    return Padding(
+      padding: EdgeInsets.only(top: 2, left: isMine ? 0 : 36),
+      child: Align(
+        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+        child: Semantics(
+          label: hasUnread ? 'View $label (new replies)' : 'View $label',
+          button: true,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(2),
+            onTap: onTap == null ? null : () => onTap!(message),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  label,
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: context.accent,
+                    fontWeight: FontWeight.w500,
+                    decoration: TextDecoration.underline,
+                    decorationColor: context.accent.withValues(alpha: 0.4),
                   ),
-                  if (hasUnread) _unreadDot(context),
-                ],
-              ),
+                ),
+                if (hasUnread) _unreadDot(context),
+              ],
             ),
           ),
         ),
-      );
-    }
+      ),
+    );
+  }
+
+  Widget _buildPill(BuildContext context, String label) {
     return Padding(
       padding: EdgeInsets.only(top: 4, left: isMine ? 0 : 36),
       child: Align(

--- a/apps/client/lib/src/widgets/mobile_channel_drawer.dart
+++ b/apps/client/lib/src/widgets/mobile_channel_drawer.dart
@@ -1,0 +1,162 @@
+/// Discord-style channel drawer for mobile + tablet portrait windows.
+///
+/// On wide viewports the column-layout series renders `ChannelColumn` as
+/// a sticky left rail. That doesn't fit a phone, so on narrow viewports
+/// we put the same vertical list behind an edge-swipe drawer instead:
+/// the chat stays full-screen, swiping right from the left edge pulls
+/// the channel list in over the chat, and tapping a channel closes the
+/// drawer and switches the chat focus to that channel.
+///
+/// A 56-wide group rail on the far left mirrors Discord's "server bar"
+/// so users can also hop to another group without leaving the drawer.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/conversation.dart';
+import '../providers/conversations_provider.dart';
+import '../theme/echo_theme.dart';
+import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
+import 'channel_column.dart';
+
+class MobileChannelDrawer extends ConsumerWidget {
+  final Conversation conversation;
+  final String? selectedTextChannelId;
+  final ValueChanged<String?> onTextChannelChanged;
+  final ValueChanged<String> onConversationSelected;
+  final VoidCallback? onShowLounge;
+
+  /// Total drawer width on a phone: 56-wide group rail + 232-wide
+  /// channel column = 288. Stays under the 304 default that Flutter's
+  /// `Drawer` uses, so the swipe behaviour and Material defaults
+  /// continue to work without overrides.
+  static const double railWidth = 56;
+  static const double drawerWidth = railWidth + ChannelColumn.width - 28;
+
+  const MobileChannelDrawer({
+    super.key,
+    required this.conversation,
+    required this.selectedTextChannelId,
+    required this.onTextChannelChanged,
+    required this.onConversationSelected,
+    this.onShowLounge,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final convs = ref
+        .watch(conversationsProvider)
+        .conversations
+        .where((c) => c.isGroup)
+        .toList();
+    return Drawer(
+      width: drawerWidth,
+      backgroundColor: context.sidebarBg,
+      child: SafeArea(
+        child: Row(
+          children: [
+            _GroupRail(
+              groups: convs,
+              activeId: conversation.id,
+              onSelect: (id) {
+                onConversationSelected(id);
+                Navigator.of(context).maybePop();
+              },
+            ),
+            Expanded(
+              child: ChannelColumn(
+                conversation: conversation,
+                selectedTextChannelId: selectedTextChannelId,
+                onTextChannelChanged: (id) {
+                  onTextChannelChanged(id);
+                  Navigator.of(context).maybePop();
+                },
+                onShowLounge: () {
+                  onShowLounge?.call();
+                  Navigator.of(context).maybePop();
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupRail extends StatelessWidget {
+  final List<Conversation> groups;
+  final String activeId;
+  final ValueChanged<String> onSelect;
+
+  const _GroupRail({
+    required this.groups,
+    required this.activeId,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MobileChannelDrawer.railWidth,
+      decoration: BoxDecoration(
+        color: context.mainBg,
+        border: Border(right: BorderSide(color: context.border)),
+      ),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: groups.length,
+        itemBuilder: (_, i) {
+          final g = groups[i];
+          final active = g.id == activeId;
+          final name = g.displayName('');
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Stack(
+              children: [
+                if (active)
+                  Positioned(
+                    left: 0,
+                    top: 6,
+                    bottom: 6,
+                    child: Container(
+                      width: 3,
+                      decoration: BoxDecoration(
+                        color: context.accent,
+                        borderRadius: const BorderRadius.only(
+                          topRight: Radius.circular(2),
+                          bottomRight: Radius.circular(2),
+                        ),
+                      ),
+                    ),
+                  ),
+                Center(
+                  child: Semantics(
+                    label: 'group ${name.isEmpty ? "unnamed" : name}',
+                    button: true,
+                    selected: active,
+                    child: InkResponse(
+                      onTap: () => onSelect(g.id),
+                      radius: 24,
+                      child: buildAvatar(
+                        name: name,
+                        radius: 20,
+                        bgColor: groupAvatarColor(g.id),
+                        fallbackIcon: const Icon(
+                          Icons.group,
+                          size: 18,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -118,15 +118,7 @@ class WhatsNewModal extends ConsumerWidget {
                 IconButton(
                   icon: const Icon(Icons.close),
                   color: context.textMuted,
-                  onPressed: () async {
-                    await ref.read(releaseNotesProvider.notifier).markShown();
-                    if (!context.mounted) return;
-                    if (onClose != null) {
-                      onClose!();
-                    } else {
-                      Navigator.of(context).pop();
-                    }
-                  },
+                  onPressed: () => _dismiss(context, ref),
                 ),
             ],
           ),
@@ -181,15 +173,7 @@ class WhatsNewModal extends ConsumerWidget {
         Padding(
           padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
           child: FilledButton(
-            onPressed: () async {
-              await ref.read(releaseNotesProvider.notifier).markShown();
-              if (!context.mounted) return;
-              if (onClose != null) {
-                onClose!();
-              } else {
-                Navigator.of(context).pop();
-              }
-            },
+            onPressed: () => _dismiss(context, ref),
             style: FilledButton.styleFrom(
               backgroundColor: context.accent,
               minimumSize: const Size.fromHeight(48),
@@ -199,6 +183,16 @@ class WhatsNewModal extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  Future<void> _dismiss(BuildContext context, WidgetRef ref) async {
+    await ref.read(releaseNotesProvider.notifier).markShown();
+    if (!context.mounted) return;
+    if (onClose != null) {
+      onClose!();
+    } else {
+      Navigator.of(context).pop();
+    }
   }
 }
 

--- a/apps/client/test/widgets/mobile_channel_drawer_test.dart
+++ b/apps/client/test/widgets/mobile_channel_drawer_test.dart
@@ -1,0 +1,148 @@
+import 'package:echo_app/src/models/channel.dart';
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/providers/channels_provider.dart';
+import 'package:echo_app/src/providers/conversations_provider.dart';
+import 'package:echo_app/src/widgets/mobile_channel_drawer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/pump_app.dart';
+
+/// Smoke tests for the Discord-style mobile drawer: the group rail
+/// switches conversations and channel taps pop the drawer.
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Conversation conv(String id, String name) => Conversation(
+    id: id,
+    isGroup: true,
+    name: name,
+    members: const [ConversationMember(userId: 'me', username: 'me')],
+  );
+
+  GroupChannel text(String id, String name, {int pos = 0}) => GroupChannel(
+    id: id,
+    conversationId: 'c1',
+    name: name,
+    kind: 'text',
+    position: pos,
+    createdAt: '',
+  );
+
+  Override channelsOverride(Map<String, List<GroupChannel>> byConv) =>
+      channelsProvider.overrideWith(
+        () => _StubChannels(
+          ChannelsState(
+            channelsByConversation: byConv,
+            voiceSessionsByChannel: const {},
+          ),
+        ),
+      );
+
+  Override conversationsOverride(List<Conversation> convs) =>
+      conversationsProvider.overrideWith(
+        () => _StubConversations(ConversationsState(conversations: convs)),
+      );
+
+  Future<void> openDrawer(WidgetTester tester) async {
+    // `pumpApp` already wraps in an outer Scaffold(body: widget); the
+    // drawer lives on the inner one, so grab the LAST Scaffold to find
+    // a ScaffoldState that actually has a drawer attached.
+    final scaffoldFinder = find.byType(Scaffold);
+    final scaffoldState = tester.state<ScaffoldState>(scaffoldFinder.last);
+    scaffoldState.openDrawer();
+    await tester.pumpAndSettle();
+  }
+
+  group('MobileChannelDrawer', () {
+    testWidgets('tapping a text channel closes the drawer and fires '
+        'onTextChannelChanged', (tester) async {
+      String? lastChannel;
+      bool drawerOpen = true;
+      await tester.pumpApp(
+        Scaffold(
+          drawer: MobileChannelDrawer(
+            conversation: conv('c1', 'Echo Devs'),
+            selectedTextChannelId: null,
+            onTextChannelChanged: (id) => lastChannel = id,
+            onConversationSelected: (_) {},
+          ),
+          body: Builder(
+            builder: (ctx) {
+              return TextButton(
+                onPressed: () => Scaffold.of(ctx).openDrawer(),
+                child: const Text('open'),
+              );
+            },
+          ),
+          onDrawerChanged: (open) => drawerOpen = open,
+        ),
+        overrides: [
+          channelsOverride({
+            'c1': [text('t1', 'general'), text('t2', 'releases', pos: 1)],
+          }),
+          conversationsOverride([conv('c1', 'Echo Devs')]),
+        ],
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(drawerOpen, isTrue);
+      await tester.tap(find.text('releases'));
+      await tester.pumpAndSettle();
+      expect(lastChannel, 't2');
+      expect(drawerOpen, isFalse);
+    });
+
+    testWidgets('group rail lists other groups and forwards taps', (
+      tester,
+    ) async {
+      String? switched;
+      await tester.pumpApp(
+        Scaffold(
+          drawer: MobileChannelDrawer(
+            conversation: conv('c1', 'Echo Devs'),
+            selectedTextChannelId: null,
+            onTextChannelChanged: (_) {},
+            onConversationSelected: (id) => switched = id,
+          ),
+        ),
+        overrides: [
+          channelsOverride({
+            'c1': [text('t1', 'general')],
+          }),
+          conversationsOverride([
+            conv('c1', 'Echo Devs'),
+            conv('c2', 'Taco Lovers'),
+          ]),
+        ],
+      );
+      await openDrawer(tester);
+      // Both groups appear as avatars in the rail (initial letter only).
+      expect(find.bySemanticsLabel('group Echo Devs'), findsOneWidget);
+      expect(find.bySemanticsLabel('group Taco Lovers'), findsOneWidget);
+      await tester.tap(find.bySemanticsLabel('group Taco Lovers'));
+      await tester.pumpAndSettle();
+      expect(switched, 'c2');
+    });
+  });
+}
+
+class _StubChannels extends Channels {
+  _StubChannels(this._initial);
+  final ChannelsState _initial;
+
+  @override
+  ChannelsState build() => _initial;
+}
+
+class _StubConversations extends ConversationsNotifier {
+  _StubConversations(this._initial);
+  final ConversationsState _initial;
+
+  @override
+  ConversationsState build() => _initial;
+}

--- a/apps/server/src/db/mentions.rs
+++ b/apps/server/src/db/mentions.rs
@@ -64,43 +64,50 @@ fn extract_at_usernames(content: &str) -> Vec<String> {
     let bytes = content.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] != b'@' {
+        if bytes[i] != b'@' || !is_left_boundary(content, i) {
             i += 1;
             continue;
         }
-        // Boundary on the left: start-of-string or non-word.
-        let left_ok = i == 0
-            || !content[..i]
-                .chars()
-                .next_back()
-                .is_some_and(|c| c.is_alphanumeric() || c == '_');
-        if !left_ok {
-            i += 1;
-            continue;
-        }
-        // Read [A-Za-z0-9_]+ token after `@`.
-        let token_start = i + 1;
-        let mut token_end = token_start;
-        while token_end < bytes.len() {
-            let c = bytes[token_end];
-            let word = c.is_ascii_alphanumeric() || c == b'_';
-            if !word {
-                break;
-            }
-            token_end += 1;
-        }
-        if token_end > token_start {
-            let token = content[token_start..token_end].to_lowercase();
-            // Skip the broadcast keywords -- those are scanned separately
-            // and resolved against the full membership roster, not by
-            // username match.
-            if token != "everyone" && token != "here" && !out.contains(&token) {
-                out.push(token);
-            }
+        let token_end = scan_word_end(bytes, i + 1);
+        if token_end > i + 1 {
+            push_unique_non_broadcast(&content[i + 1..token_end], &mut out);
         }
         i = token_end.max(i + 1);
     }
     out
+}
+
+/// True when position `i` in `content` is at the start-of-string or
+/// preceded by a non-word character. Boundary check for `@mention`
+/// detection: prevents matching e.g. `email@host` as a mention.
+fn is_left_boundary(content: &str, i: usize) -> bool {
+    i == 0
+        || !content[..i]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Returns the byte index of the first non-word byte at or after `start`.
+fn scan_word_end(bytes: &[u8], start: usize) -> usize {
+    let mut end = start;
+    while end < bytes.len() {
+        let c = bytes[end];
+        if !(c.is_ascii_alphanumeric() || c == b'_') {
+            break;
+        }
+        end += 1;
+    }
+    end
+}
+
+/// Lowercase `token` and push onto `out` unless it is a broadcast keyword
+/// (`everyone` / `here`, resolved separately) or already present.
+fn push_unique_non_broadcast(token: &str, out: &mut Vec<String>) {
+    let lower = token.to_lowercase();
+    if lower != "everyone" && lower != "here" && !out.contains(&lower) {
+        out.push(lower);
+    }
 }
 
 /// Resolve broadcast keywords to all non-removed members of the conversation.

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -117,6 +117,63 @@ impl GroupKeyEnvelopeResponse {
 // POST /api/groups/:id/keys -- Upload group key envelopes (owner/admin only)
 // -------------------------------------------------------------------------
 
+/// Cap envelope count so a hostile admin can't pollute the table.
+const MAX_ENVELOPES_PER_REQUEST: usize = 10_000;
+/// Each envelope is a wrapped 32-byte AES-256 key (~124 base64 chars in
+/// practice). 512 bytes is generous headroom while blocking abuse —
+/// without this cap, a single 10K-envelope request could write up to
+/// ~10 GB of attacker-controlled TEXT.
+const MAX_ENCRYPTED_KEY_LEN: usize = 512;
+/// Audit reason string — bounded so a malicious admin can't write
+/// arbitrarily large blobs into the audit log that other admins
+/// re-download on every /encryption-activity GET.
+const MAX_TRIGGERED_BY_EVENT_LEN: usize = 128;
+
+/// Validates the body of an [`upload_group_key`] request. Extracted so the
+/// route handler stays under SonarCloud's cognitive-complexity threshold.
+fn validate_upload_request(body: &UploadGroupKeyRequest) -> Result<(), AppError> {
+    if body.envelopes.is_empty() {
+        return Err(AppError::bad_request("envelopes array cannot be empty"));
+    }
+    if body.key_version < 1 {
+        return Err(AppError::bad_request(
+            "key_version must be a positive integer",
+        ));
+    }
+    // The CHECK constraint on the column enforces 1..=255, but a clear
+    // 400 with a typed message beats the bare 23514 db error on the
+    // happy mistake (a client passing 0 to "disable" or a future GRPN
+    // value the server hasn't shipped support for yet).
+    if !(1..=255).contains(&body.min_wire_version) {
+        return Err(AppError::bad_request(
+            "min_wire_version must be between 1 and 255",
+        ));
+    }
+    if body.envelopes.len() > MAX_ENVELOPES_PER_REQUEST {
+        return Err(AppError::bad_request(format!(
+            "Too many envelopes (max {MAX_ENVELOPES_PER_REQUEST})"
+        )));
+    }
+    if body.triggered_by_event.len() > MAX_TRIGGERED_BY_EVENT_LEN {
+        return Err(AppError::bad_request(format!(
+            "triggered_by_event must be ≤{MAX_TRIGGERED_BY_EVENT_LEN} characters"
+        )));
+    }
+    for envelope in &body.envelopes {
+        if envelope.encrypted_key.is_empty() {
+            return Err(AppError::bad_request(
+                "encrypted_key cannot be empty in envelope",
+            ));
+        }
+        if envelope.encrypted_key.len() > MAX_ENCRYPTED_KEY_LEN {
+            return Err(AppError::bad_request(format!(
+                "encrypted_key must be ≤{MAX_ENCRYPTED_KEY_LEN} bytes"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub async fn upload_group_key(
     auth: AuthUser,
     State(state): State<Arc<AppState>>,
@@ -136,59 +193,7 @@ pub async fn upload_group_key(
         ));
     }
 
-    if body.envelopes.is_empty() {
-        return Err(AppError::bad_request("envelopes array cannot be empty"));
-    }
-    if body.key_version < 1 {
-        return Err(AppError::bad_request(
-            "key_version must be a positive integer",
-        ));
-    }
-    // The CHECK constraint on the column enforces 1..=255, but a clear
-    // 400 with a typed message beats the bare 23514 db error on the
-    // happy mistake (a client passing 0 to "disable" or a future GRPN
-    // value the server hasn't shipped support for yet).
-    if !(1..=255).contains(&body.min_wire_version) {
-        return Err(AppError::bad_request(
-            "min_wire_version must be between 1 and 255",
-        ));
-    }
-
-    // Cap envelope count so a hostile admin can't pollute the table.
-    const MAX_ENVELOPES_PER_REQUEST: usize = 10_000;
-    if body.envelopes.len() > MAX_ENVELOPES_PER_REQUEST {
-        return Err(AppError::bad_request(format!(
-            "Too many envelopes (max {MAX_ENVELOPES_PER_REQUEST})"
-        )));
-    }
-
-    // Each envelope is a wrapped 32-byte AES-256 key (~124 base64 chars in
-    // practice). 512 bytes is generous headroom while blocking abuse —
-    // without this cap, a single 10K-envelope request could write up to
-    // ~10 GB of attacker-controlled TEXT.
-    const MAX_ENCRYPTED_KEY_LEN: usize = 512;
-    // Audit reason string — bounded so a malicious admin can't write
-    // arbitrarily large blobs into the audit log that other admins
-    // re-download on every /encryption-activity GET.
-    const MAX_TRIGGERED_BY_EVENT_LEN: usize = 128;
-    if body.triggered_by_event.len() > MAX_TRIGGERED_BY_EVENT_LEN {
-        return Err(AppError::bad_request(format!(
-            "triggered_by_event must be ≤{MAX_TRIGGERED_BY_EVENT_LEN} characters"
-        )));
-    }
-
-    for envelope in &body.envelopes {
-        if envelope.encrypted_key.is_empty() {
-            return Err(AppError::bad_request(
-                "encrypted_key cannot be empty in envelope",
-            ));
-        }
-        if envelope.encrypted_key.len() > MAX_ENCRYPTED_KEY_LEN {
-            return Err(AppError::bad_request(format!(
-                "encrypted_key must be ≤{MAX_ENCRYPTED_KEY_LEN} bytes"
-            )));
-        }
-    }
+    validate_upload_request(&body)?;
 
     // Sentinel row + envelopes commit atomically; member-set read inside
     // the same tx so we see the committed view that matches the writes.


### PR DESCRIPTION
Ships two batches landed on dev since the last release:

## New (#1018)
A Discord-style channel drawer for mobile Column mode. Open a group
chat on a phone with **Settings → Appearance → Channels → Column**,
swipe right from the left edge, and the channel list slides in over
the chat: a 56px group-rail on the far left for hopping between
groups, and a vertical channel list to its right. Tap a channel to
focus it and close the drawer. The "back to conversations" edge
gesture is suppressed in this mode — the drawer covers that nav.

Before this PR, Column mode silently fell back to the top chip bar
on phones because a 260px desktop rail won't fit a 390px screen.

## Behind the scenes (#1017)
SonarCloud Critical-severity cleanup across both halves of the stack:
extracted 7 high-complexity functions (chat input, splash, group key
fetch, mention storage) and dedup'd 3 sets of literal strings into
named constants. No behavior change, but the affected files now sit
under SonarCloud's complexity threshold so future refactors don't
ratchet it up further. 19 issues flagged; 10 fixed, 9 deferred for
dedicated passes (crypto orchestration, message JSON deserialization,
WebSocket lifecycle — each needs its own design discussion).