### PR TITLE
fix: close sonarqube medium and low findings

### DIFF
--- a/apps/client/lib/src/screens/admin/admin_dashboard_screen.dart
+++ b/apps/client/lib/src/screens/admin/admin_dashboard_screen.dart
@@ -101,7 +101,7 @@ class _StatsGrid extends StatelessWidget {
         final width = constraints.maxWidth;
         final colsIfSmall = width >= 480 ? 3 : 2;
         final cols = width >= 720 ? 4 : colsIfSmall;
-        final spacing = 12.0;
+        const spacing = 12.0;
         final cardWidth = (width - spacing * (cols - 1)) / cols;
         return Wrap(
           spacing: spacing,

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -388,16 +388,8 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
   Widget _stepIndicatorRow(BuildContext context, int index, String label) {
     final isActive = index == _currentPage;
     final isDone = index < _currentPage;
-    final dotColor = isActive
-        ? context.accent
-        : isDone
-        ? context.accent.withValues(alpha: 0.6)
-        : context.border;
-    final textColor = isActive
-        ? context.textPrimary
-        : isDone
-        ? context.textSecondary
-        : context.textMuted;
+    final dotColor = _resolveStepDotColor(context, isActive, isDone);
+    final textColor = _resolveStepTextColor(context, isActive, isDone);
     return Row(
       children: [
         Container(
@@ -416,6 +408,22 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
         ),
       ],
     );
+  }
+
+  Color _resolveStepDotColor(BuildContext context, bool isActive, bool isDone) {
+    if (isActive) return context.accent;
+    if (isDone) return context.accent.withValues(alpha: 0.6);
+    return context.border;
+  }
+
+  Color _resolveStepTextColor(
+    BuildContext context,
+    bool isActive,
+    bool isDone,
+  ) {
+    if (isActive) return context.textPrimary;
+    if (isDone) return context.textSecondary;
+    return context.textMuted;
   }
 
   Widget _buildPageView() {

--- a/apps/client/lib/src/services/crypto/init_extension.dart
+++ b/apps/client/lib/src/services/crypto/init_extension.dart
@@ -32,7 +32,7 @@ extension CryptoServiceInit on CryptoService {
     // secure storage. SecureKeyStore on web uses Web Crypto API encryption
     // which can fail to decrypt after page refresh in some browsers, so
     // SharedPreferences (plain localStorage) is the reliable fallback.
-    final removeFromPrefs = !kIsWeb;
+    const removeFromPrefs = !kIsWeb;
 
     final namedOk = await _migrateNamedKeys(prefs, store, removeFromPrefs);
     final prefixedOk = await _migratePrefixedKeys(

--- a/apps/client/lib/src/widgets/auth/auth_layout.dart
+++ b/apps/client/lib/src/widgets/auth/auth_layout.dart
@@ -235,11 +235,7 @@ class _FormCard extends StatelessWidget {
       builder: (context, constraints) {
         // Clamp the card width so it doesn't collide with the brand panel at
         // ~800px-wide tablets. 40% of available width keeps it proportional.
-        final cardWidth = constraints.maxWidth > 0
-            ? constraints.maxWidth * 0.4 < 440
-                  ? constraints.maxWidth * 0.4
-                  : 440.0
-            : 440.0;
+        final cardWidth = _resolveCardWidth(constraints.maxWidth);
         return SizedBox(
           width: cardWidth,
           child: Container(
@@ -279,5 +275,11 @@ class _FormCard extends StatelessWidget {
         );
       },
     );
+  }
+
+  double _resolveCardWidth(double maxWidth) {
+    if (maxWidth <= 0) return 440.0;
+    final scaled = maxWidth * 0.4;
+    return scaled < 440 ? scaled : 440.0;
   }
 }

--- a/apps/client/lib/src/widgets/connection_status_badge.dart
+++ b/apps/client/lib/src/widgets/connection_status_badge.dart
@@ -321,7 +321,7 @@ class _ConnectionStatusPopoverState
     required TargetPlatform platform,
   }) {
     final now = DateTime.now().toUtc().toIso8601String();
-    final version = appVersion;
+    const version = appVersion;
     return [
       'Echo connection diagnostics',
       '---------------------------',

--- a/apps/client/lib/src/widgets/context_menu/context_menu_item.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_item.dart
@@ -69,9 +69,7 @@ class _ContextMenuItemState extends State<ContextMenuItem> {
             vertical: widget.dense ? 6 : 9,
           ),
           decoration: BoxDecoration(
-            color: _pressed
-                ? hoverBg.withValues(alpha: 0.9)
-                : (_hover ? hoverBg : Colors.transparent),
+            color: _resolveBackground(hoverBg),
             borderRadius: BorderRadius.circular(6),
           ),
           child: Row(
@@ -109,6 +107,12 @@ class _ContextMenuItemState extends State<ContextMenuItem> {
         ),
       ),
     );
+  }
+
+  Color _resolveBackground(Color hoverBg) {
+    if (_pressed) return hoverBg.withValues(alpha: 0.9);
+    if (_hover) return hoverBg;
+    return Colors.transparent;
   }
 }
 

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -386,11 +386,13 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
   }
 
   double _resolveHorizontalPadding(bool isCozy, bool isCompact) {
-    return (isCozy ? 14 : (isCompact ? 10 : 12)).toDouble();
+    if (isCozy) return 14;
+    return isCompact ? 10 : 12;
   }
 
   double _resolveAvatarSpacing(bool isCozy, bool isCompact) {
-    return (isCozy ? 14 : (isCompact ? 8 : 12)).toDouble();
+    if (isCozy) return 14;
+    return isCompact ? 8 : 12;
   }
 
   Color _resolveTimestampColor(BuildContext context, bool hasUnread) {

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -265,10 +265,13 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
         );
       },
       onLeave: canLeave ? () => _leaveGroup(conv) : null,
-      onDelete: conv.isGroup
-          ? (canDeleteGroup ? () => _deleteGroup(conv) : null)
-          : () => _deleteDm(conv),
+      onDelete: _resolveDeleteCallback(conv, canDeleteGroup),
     );
+  }
+
+  VoidCallback? _resolveDeleteCallback(Conversation conv, bool canDeleteGroup) {
+    if (!conv.isGroup) return () => _deleteDm(conv);
+    return canDeleteGroup ? () => _deleteGroup(conv) : null;
   }
 
   void _showConversationContextMenu(

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -285,9 +285,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     final isMobile = Responsive.isMobile(context);
     final screenWidth = MediaQuery.of(context).size.width;
     // Responsive width: tablets (< 900) get screen-48, desktops get fixed 560
-    final width = isMobile
-        ? screenWidth - 32
-        : (screenWidth < 900 ? screenWidth - 48 : 560.0);
+    final width = _resolveOverlayWidth(isMobile, screenWidth);
 
     // A non-focusable Focus observer: it sees raw key events but never owns
     // primary focus, so it can't steal the user's first keystroke from the
@@ -391,6 +389,12 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
         ),
       ),
     );
+  }
+
+  double _resolveOverlayWidth(bool isMobile, double screenWidth) {
+    if (isMobile) return screenWidth - 32;
+    if (screenWidth < 900) return screenWidth - 48;
+    return 560.0;
   }
 
   /// Build the flat row list (headers + tiles) and render it lazily via

--- a/apps/client/lib/src/widgets/message/voice_message_widget.dart
+++ b/apps/client/lib/src/widgets/message/voice_message_widget.dart
@@ -271,6 +271,9 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
     );
   }
 
+  IconData get _playbackIcon =>
+      _isPlaying ? Icons.pause_rounded : Icons.play_arrow_rounded;
+
   // ---------------------------------------------------------------------------
   // Build
   // ---------------------------------------------------------------------------
@@ -313,13 +316,7 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
                         color: accentColor.withValues(alpha: 0.15),
                         shape: BoxShape.circle,
                       ),
-                      child: Icon(
-                        _isPlaying
-                            ? Icons.pause_rounded
-                            : Icons.play_arrow_rounded,
-                        size: 20,
-                        color: accentColor,
-                      ),
+                      child: Icon(_playbackIcon, size: 20, color: accentColor),
                     ),
                   ),
           ),

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1040,10 +1040,8 @@ class _MessageItemState extends State<MessageItem>
         : null;
     final showAvatar = widget.showHeader || forceShow;
 
-    final avatarWidth =
-        (widget._isCompact ? 32 : (widget.compactLayout ? 24 : 28)).toDouble();
-    final avatarRadius =
-        (widget._isCompact ? 16 : (widget.compactLayout ? 12 : 14)).toDouble();
+    final avatarWidth = _resolveAvatarWidth();
+    final avatarRadius = _resolveAvatarRadius();
 
     return Semantics(
       label: 'View profile of ${msg.fromUsername}',
@@ -1067,6 +1065,16 @@ class _MessageItemState extends State<MessageItem>
         ),
       ),
     );
+  }
+
+  double _resolveAvatarWidth() {
+    if (widget._isCompact) return 32;
+    return widget.compactLayout ? 24 : 28;
+  }
+
+  double _resolveAvatarRadius() {
+    if (widget._isCompact) return 16;
+    return widget.compactLayout ? 12 : 14;
   }
 
   /// Build the tiny green lock icon shown next to the timestamp on encrypted


### PR DESCRIPTION
## Summary

Closes a batch of SonarQube MEDIUM (MAJOR) and LOW (MINOR/INFO) findings against `NC1107_echo-messenger`.

## Fixed (real code changes)

- **dart:S3358 nested ternaries** — extracted to small helpers / getters for readability:
  - `widgets/context_menu/context_menu_item.dart` (background color resolve)
  - `widgets/conversation_panel.dart` (delete-callback resolve)
  - `screens/onboarding_wizard.dart` (step indicator dot + text color)
  - `widgets/global_search_overlay.dart` (responsive width)
  - `widgets/auth/auth_layout.dart` (form-card width)
  - `widgets/conversation_item.dart` (cozy/compact spacing)
  - `widgets/message_item.dart` (avatar width + radius)
  - `widgets/message/voice_message_widget.dart` (playback icon)
- **dart:S3962 final-that-could-be-const** — trivial `final` → `const`:
  - `screens/admin/admin_dashboard_screen.dart`
  - `widgets/connection_status_badge.dart`
  - `services/crypto/init_extension.dart` (key-migration helper, no protocol logic touched)

## Marked false-positive

- **dart:S1135 TODO** (5 hits) — all five are issue-tracked TODOs (#658 group-key rotation, web push-to-talk plumbing, iOS pasteboard plugin x2). They're our roadmap markers, not stale debt; flagging as FALSEPOSITIVE in SonarQube.

## Skipped (non-trivial)

- **dart:S107 function with > 7 parameters** (8 hits across `chat_provider`, `voice_dock`, `history_loaders`, `livekit_voice_provider`, `auth_provider`, `upload_client`, `canvas_models`, `privacy_provider`). Collapsing these would mean introducing parameter-object types and reshaping the call sites — out of scope for a "volume of easy wins" pass. Several touch crypto orchestration that is off-limits.

## Test plan

- [x] `flutter analyze` clean on all touched files
- [x] `dart format` clean
- [x] Pre-commit hook (lefthook) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)