### PR TITLE
Fix the update popup so it sits flush inside the splash window

### DIFF
--- a/apps/client/lib/src/services/window_state_service.dart
+++ b/apps/client/lib/src/services/window_state_service.dart
@@ -143,19 +143,18 @@ class WindowStateService {
     }
   }
 
-  /// Resize the chromeless splash window to a size that comfortably fits
-  /// the update prompt (logo, version cycle, progress bar, full-width
-  /// action button, error text, Skip). The splash's 320×440 is too tight
-  /// for an actionable screen — buttons crowd the edges and longer error
-  /// strings wrap awkwardly. Keeps the splash chrome (transparent
-  /// background, hidden title bar) so the swap stays seamless.
+  /// Keep the update prompt in the same chromeless 320×440 window the
+  /// splash uses, so the two screens read as the same surface and the
+  /// swap stays seamless. Previously this widened the window to 400×520,
+  /// which left a visible band of empty space around the centred card
+  /// because the splash background is transparent at the OS level.
   static Future<void> enterUpdatePrompt() async {
     if (!_isDesktop) return;
     try {
-      await windowManager.setSize(const Size(400, 520));
+      await windowManager.setSize(const Size(320, 440));
     } catch (_) {
-      // Resize failure is non-fatal — the user still sees the 320×440
-      // splash-sized prompt, just a bit cramped.
+      // Resize failure is non-fatal — the user still sees the prompt
+      // at whatever size the splash left the window at.
     }
   }
 


### PR DESCRIPTION
Before this PR the splash window opened at 320×440 and then resized
to 400×520 as soon as the update prompt was about to show. The
splash window is OS-transparent (the rounded card uses Flutter's
own background), so the extra 80×80 of window real estate read as a
band of empty desktop to the right of the centred update card — the
popup looked off-centre even though every widget inside was
positioned correctly.

## What the user sees
The update prompt now shares the exact same 320×440 chromeless
window the splash uses, so opening it is a true content swap
instead of a visible window resize. The card fills its window, no
more desktop bleeding through around it.

## Behind the scenes
- `WindowStateService.enterUpdatePrompt` now keeps the splash size
  instead of widening to 400×520. The prompt body was already laid
  out against the splash's compact dimensions (220-wide button,
  28-px outer padding, 64-px logo), so no body changes are needed
  for the smaller window.