### PR TITLE
Release: channel-rail polish

### DIFF
--- a/apps/client/lib/src/providers/auth/auth_provider.g.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.g.dart
@@ -6,7 +6,7 @@ part of 'auth_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authNotifierHash() => r'595afa498e5ed1cbff07368ae09f2447eb4a71ab';
+String _$authNotifierHash() => r'086b4292c3a381a598a0ab5fcb47f29e7ce6d551';
 
 /// Authentication state notifier.
 ///

--- a/apps/client/lib/src/providers/biometric_provider.g.dart
+++ b/apps/client/lib/src/providers/biometric_provider.g.dart
@@ -6,7 +6,7 @@ part of 'biometric_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$biometricHash() => r'67c498962f61c6ab6f9994b667f14206fb883d1e';
+String _$biometricHash() => r'22e5a4d37814e4baa62ee300b968c5a24069d01e';
 
 /// Migrated from `StateNotifier` to `@riverpod` Notifier (audit 2026-04-30).
 /// Singleton lifetime via `keepAlive: true` because the lock-session timer

--- a/apps/client/lib/src/providers/canvas_provider.g.dart
+++ b/apps/client/lib/src/providers/canvas_provider.g.dart
@@ -6,7 +6,7 @@ part of 'canvas_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$canvasControllerHash() => r'63bd641d1dcd98d6cc6bbcad3811594079aad7f4';
+String _$canvasControllerHash() => r'986f62b66aded43670c20785c0d34ffa8918c3ec';
 
 /// See also [CanvasController].
 @ProviderFor(CanvasController)

--- a/apps/client/lib/src/providers/channel_column_width_provider.dart
+++ b/apps/client/lib/src/providers/channel_column_width_provider.dart
@@ -1,0 +1,46 @@
+/// Persisted width of the Slack/Discord-style channel column.
+///
+/// The column lives between the conversation sidebar and the chat
+/// panel on viewports >= 900 px (`useColumn` in chat_panel_body.dart).
+/// Users can drag its right edge to resize it; the chosen width is
+/// stored in SharedPreferences so each launch restores the same
+/// layout.
+library;
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'channel_column_width_provider.g.dart';
+
+const String _kColumnWidthKey = 'channel_column_width';
+
+/// Default column width — matches the Slack / Discord visual baseline
+/// and fits comfortably on a 1280-wide desktop window alongside the
+/// conversation sidebar, chat panel and members panel.
+const double channelColumnDefaultWidth = 260;
+const double channelColumnMinWidth = 180;
+const double channelColumnMaxWidth = 420;
+
+@Riverpod(keepAlive: true)
+class ChannelColumnWidth extends _$ChannelColumnWidth {
+  @override
+  double build() {
+    _load();
+    return channelColumnDefaultWidth;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getDouble(_kColumnWidthKey);
+    if (raw == null) return;
+    state = raw.clamp(channelColumnMinWidth, channelColumnMaxWidth);
+  }
+
+  Future<void> setWidth(double width) async {
+    final clamped = width.clamp(channelColumnMinWidth, channelColumnMaxWidth);
+    if (clamped == state) return;
+    state = clamped;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_kColumnWidthKey, clamped);
+  }
+}

--- a/apps/client/lib/src/providers/channel_column_width_provider.g.dart
+++ b/apps/client/lib/src/providers/channel_column_width_provider.g.dart
@@ -1,27 +1,27 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'conversations_provider.dart';
+part of 'channel_column_width_provider.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$conversationsNotifierHash() =>
-    r'a30764e9b9225d971c2703db43fc9324ef227fcc';
+String _$channelColumnWidthHash() =>
+    r'509459c8dd641675f521b100417c9038ea91a344';
 
-/// See also [ConversationsNotifier].
-@ProviderFor(ConversationsNotifier)
-final conversationsNotifierProvider =
-    NotifierProvider<ConversationsNotifier, ConversationsState>.internal(
-      ConversationsNotifier.new,
-      name: r'conversationsNotifierProvider',
+/// See also [ChannelColumnWidth].
+@ProviderFor(ChannelColumnWidth)
+final channelColumnWidthProvider =
+    NotifierProvider<ChannelColumnWidth, double>.internal(
+      ChannelColumnWidth.new,
+      name: r'channelColumnWidthProvider',
       debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
           ? null
-          : _$conversationsNotifierHash,
+          : _$channelColumnWidthHash,
       dependencies: null,
       allTransitiveDependencies: null,
     );
 
-typedef _$ConversationsNotifier = Notifier<ConversationsState>;
+typedef _$ChannelColumnWidth = Notifier<double>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/chat_provider.g.dart
+++ b/apps/client/lib/src/providers/chat_provider.g.dart
@@ -6,7 +6,7 @@ part of 'chat_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatHash() => r'29f82287a3528cfdc19a7fb979c64d2e5882b00c';
+String _$chatHash() => r'ac4dcf761ef68f89384758856b08abc43529b677';
 
 /// See also [Chat].
 @ProviderFor(Chat)

--- a/apps/client/lib/src/providers/crypto_provider.g.dart
+++ b/apps/client/lib/src/providers/crypto_provider.g.dart
@@ -6,7 +6,7 @@ part of 'crypto_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$cryptoNotifierHash() => r'44d8eb500679de4b3a4f4f293a348dcef1a3b549';
+String _$cryptoNotifierHash() => r'c34b9c381c7b5ac44bad85e8ded029c98e634678';
 
 /// Migrated from `StateNotifier` to `@riverpod`-annotated `Notifier`
 /// (audit 2026-05-14, Riverpod modernization slice — #770). The exported

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.g.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.g.dart
@@ -7,7 +7,7 @@ part of 'livekit_voice_provider.dart';
 // **************************************************************************
 
 String _$liveKitVoiceNotifierHash() =>
-    r'4bdfa3d3a403e4b2d3edbee76ede9f4ccc890e85';
+    r'f7784f2573e268d599005fc357a5fe912def314e';
 
 /// Facade for the LiveKit voice notifier — owns shared state, connection
 /// lifecycle (`joinChannel` / `leaveChannel` / `dispose`), the room event

--- a/apps/client/lib/src/providers/privacy_provider.g.dart
+++ b/apps/client/lib/src/providers/privacy_provider.g.dart
@@ -6,7 +6,7 @@ part of 'privacy_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$privacyHash() => r'68bd1ada98140fdd9a0f9c2d0c84d2b66df6b5eb';
+String _$privacyHash() => r'7233aefee7ba1631da4bcfee8501b4140a035f76';
 
 /// See also [Privacy].
 @ProviderFor(Privacy)

--- a/apps/client/lib/src/providers/update_provider.g.dart
+++ b/apps/client/lib/src/providers/update_provider.g.dart
@@ -6,7 +6,7 @@ part of 'update_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$updateHash() => r'b1d9a6b1822ecf677de3a27f39aa4282abc966d3';
+String _$updateHash() => r'ea2a7021b3d3cc8c01a963979153122fb7d7f852';
 
 /// See also [Update].
 @ProviderFor(Update)

--- a/apps/client/lib/src/providers/websocket_provider.g.dart
+++ b/apps/client/lib/src/providers/websocket_provider.g.dart
@@ -6,7 +6,7 @@ part of 'websocket_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$webSocketNotifierHash() => r'0cb8be6191dcdcfadc6c74791eaff2e017681877';
+String _$webSocketNotifierHash() => r'35e1fc3cf6aa99d51abd8d3d5ca7842344e54abf';
 
 /// See also [WebSocketNotifier].
 @ProviderFor(WebSocketNotifier)

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -10,6 +10,10 @@
 /// (`channelsProvider` for the channel list, `channelsProvider.notifier`
 /// to join voice, `livekitVoiceProvider` for the active voice session),
 /// so the two layouts are interchangeable without server work.
+///
+/// The right edge is a draggable resize handle; the chosen width is
+/// persisted via [channelColumnWidthProvider]. Right-clicking the rail
+/// body surfaces a context menu for creating new text/voice channels.
 library;
 
 import 'package:flutter/material.dart';
@@ -18,24 +22,28 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/channel.dart';
 import '../models/conversation.dart';
 import '../providers/channel_categories_provider.dart';
+import '../providers/channel_column_width_provider.dart';
 import '../providers/channels_provider.dart';
 import '../providers/livekit_voice/livekit_voice_provider.dart';
+import '../providers/voice_settings_provider.dart';
+import '../services/debug_log_service.dart';
+import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
 
 const String _kTextCategoryKey = 'text';
 const String _kVoiceCategoryKey = 'voice';
 
-class ChannelColumn extends ConsumerWidget {
+class ChannelColumn extends ConsumerStatefulWidget {
   final Conversation conversation;
   final String? selectedTextChannelId;
   final ValueChanged<String?> onTextChannelChanged;
   final VoidCallback? onShowLounge;
 
-  /// Fixed column width. 260 matches the Slack/Discord visual baseline
-  /// and lets a 1280 desktop window comfortably show
-  /// `sidebar + column + chat + members` without crowding.
-  static const double width = 260;
+  /// Legacy fixed-width constant kept for the mobile drawer which still
+  /// needs a known column width to size its parent Row. The desktop
+  /// rail no longer uses this — see [channelColumnWidthProvider].
+  static const double width = channelColumnDefaultWidth;
 
   const ChannelColumn({
     super.key,
@@ -46,9 +54,20 @@ class ChannelColumn extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ChannelColumn> createState() => _ChannelColumnState();
+}
+
+class _ChannelColumnState extends ConsumerState<ChannelColumn> {
+  /// Width while a drag is in progress. Kept in widget state so the rail
+  /// follows the cursor at full frame rate without writing through to
+  /// SharedPreferences on every onHorizontalDragUpdate. Committed to the
+  /// provider on drag end.
+  double? _dragWidth;
+
+  @override
+  Widget build(BuildContext context) {
     final channelsState = ref.watch(channelsProvider);
-    final channels = channelsState.channelsFor(conversation.id)
+    final channels = channelsState.channelsFor(widget.conversation.id)
       ..sort((a, b) => a.position.compareTo(b.position));
     final textChannels = channels.where((c) => c.isText).toList();
     final voiceChannels = channels.where((c) => c.isVoice).toList();
@@ -56,75 +75,247 @@ class ChannelColumn extends ConsumerWidget {
     final collapsed = ref.watch(channelCategoryCollapsedProvider);
     final textCollapsed = collapsed.contains(_kTextCategoryKey);
     final voiceCollapsed = collapsed.contains(_kVoiceCategoryKey);
+    final storedWidth = ref.watch(channelColumnWidthProvider);
+    final effectiveWidth = _dragWidth ?? storedWidth;
 
-    return Container(
-      width: width,
+    final rail = Container(
+      width: effectiveWidth,
       decoration: BoxDecoration(
         color: context.sidebarBg,
         border: Border(right: BorderSide(color: context.border)),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _ColumnHeader(conversation: conversation),
-          Divider(height: 1, color: context.border),
-          Expanded(
-            child: ListView(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              children: [
-                if (textChannels.isNotEmpty) ...[
-                  _CategoryHeader(
-                    label: 'Text Channels',
-                    collapsed: textCollapsed,
-                    onToggle: () => ref
-                        .read(channelCategoryCollapsedProvider.notifier)
-                        .toggle(_kTextCategoryKey),
-                  ),
-                  if (!textCollapsed)
-                    for (final c in textChannels)
-                      _TextChannelRow(
-                        channel: c,
-                        isSelected: c.id == selectedTextChannelId,
-                        onTap: () => onTextChannelChanged(c.id),
-                      ),
-                  const SizedBox(height: 12),
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onSecondaryTapUp: (details) =>
+            _showCreateMenu(details.globalPosition),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _ColumnHeader(conversation: widget.conversation),
+            Divider(height: 1, color: context.border),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                children: [
+                  if (textChannels.isNotEmpty) ...[
+                    _CategoryHeader(
+                      label: 'Text Channels',
+                      collapsed: textCollapsed,
+                      onToggle: () => ref
+                          .read(channelCategoryCollapsedProvider.notifier)
+                          .toggle(_kTextCategoryKey),
+                      onCreate: () => _createChannel('text'),
+                    ),
+                    if (!textCollapsed)
+                      for (final c in textChannels)
+                        _TextChannelRow(
+                          channel: c,
+                          isSelected: c.id == widget.selectedTextChannelId,
+                          onTap: () => widget.onTextChannelChanged(c.id),
+                        ),
+                    const SizedBox(height: 12),
+                  ],
+                  if (voiceChannels.isNotEmpty) ...[
+                    _CategoryHeader(
+                      label: 'Voice Channels',
+                      collapsed: voiceCollapsed,
+                      onToggle: () => ref
+                          .read(channelCategoryCollapsedProvider.notifier)
+                          .toggle(_kVoiceCategoryKey),
+                      onCreate: () => _createChannel('voice'),
+                    ),
+                    if (!voiceCollapsed)
+                      for (final c in voiceChannels)
+                        _VoiceChannelGroup(
+                          channel: c,
+                          members: channelsState.voiceSessionsFor(c.id),
+                          isActive:
+                              voiceState.channelId == c.id &&
+                              voiceState.conversationId ==
+                                  widget.conversation.id,
+                          onJoin: () => _join(c),
+                          onOpenLounge: widget.onShowLounge,
+                        ),
+                  ],
                 ],
-                if (voiceChannels.isNotEmpty) ...[
-                  _CategoryHeader(
-                    label: 'Voice Channels',
-                    collapsed: voiceCollapsed,
-                    onToggle: () => ref
-                        .read(channelCategoryCollapsedProvider.notifier)
-                        .toggle(_kVoiceCategoryKey),
-                  ),
-                  if (!voiceCollapsed)
-                    for (final c in voiceChannels)
-                      _VoiceChannelGroup(
-                        channel: c,
-                        members: channelsState.voiceSessionsFor(c.id),
-                        isActive:
-                            voiceState.channelId == c.id &&
-                            voiceState.conversationId == conversation.id,
-                        onJoin: () => _join(ref, c),
-                        onOpenLounge: onShowLounge,
-                      ),
-                ],
-              ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    return Stack(
+      children: [
+        rail,
+        Positioned(
+          right: 0,
+          top: 0,
+          bottom: 0,
+          width: 6,
+          child: MouseRegion(
+            cursor: SystemMouseCursors.resizeColumn,
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onHorizontalDragUpdate: (details) {
+                setState(() {
+                  _dragWidth = ((_dragWidth ?? storedWidth) + details.delta.dx)
+                      .clamp(channelColumnMinWidth, channelColumnMaxWidth);
+                });
+              },
+              onHorizontalDragEnd: (_) {
+                final committed = _dragWidth;
+                _dragWidth = null;
+                if (committed != null) {
+                  ref
+                      .read(channelColumnWidthProvider.notifier)
+                      .setWidth(committed);
+                }
+              },
+              onHorizontalDragCancel: () =>
+                  setState(() => _dragWidth = null),
+              child: const SizedBox.expand(),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
-  Future<void> _join(WidgetRef ref, GroupChannel channel) async {
-    // Channels notifier owns the HTTP + LiveKit-join handshake; this
-    // matches what channel_bar.dart does so behaviour is identical
-    // regardless of which layout the user picked.
-    await ref
+  Future<void> _join(GroupChannel channel) async {
+    // Two-step join, mirroring channel_bar.dart's `_handleVoiceChipTap`:
+    //
+    //   1. POST to /api/groups/:id/voice/:chan/join — records membership
+    //      so the server's voice session reflects the new participant.
+    //   2. LiveKit join — opens the WebRTC connection that actually
+    //      streams audio and is what flips `livekitVoiceProvider.isActive`
+    //      to true.
+    //
+    // The old code only did step 1, so voiceActive stayed false, the
+    // home screen's `_resolveRightPanel` refused to render the lounge,
+    // and any `onShowLounge` callback flicker-dismissed almost
+    // immediately. Issue surfaced once Column mode shipped — bar mode
+    // never had this bug because it did both calls already.
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'VoiceLoungeUI',
+      'voice channel selected (column): ${channel.name} id=${channel.id}',
+    );
+    final success = await ref
         .read(channelsProvider.notifier)
-        .joinVoiceChannel(conversation.id, channel.id);
-    onShowLounge?.call();
+        .joinVoiceChannel(widget.conversation.id, channel.id);
+    if (!success) return;
+
+    final voiceSettings = ref.read(voiceSettingsProvider);
+    await ref
+        .read(livekitVoiceProvider.notifier)
+        .joinChannel(
+          conversationId: widget.conversation.id,
+          channelId: channel.id,
+          startMuted: voiceSettings.selfMuted || voiceSettings.selfDeafened,
+        );
+    widget.onShowLounge?.call();
+  }
+
+  Future<void> _showCreateMenu(Offset position) async {
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    if (overlay == null) return;
+    final choice = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        overlay.size.width - position.dx,
+        overlay.size.height - position.dy,
+      ),
+      items: const [
+        PopupMenuItem(
+          value: 'text',
+          child: ListTile(
+            leading: Icon(Icons.tag, size: 18),
+            title: Text('New text channel'),
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        PopupMenuItem(
+          value: 'voice',
+          child: ListTile(
+            leading: Icon(Icons.volume_up_outlined, size: 18),
+            title: Text('New voice channel'),
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
+    if (choice == null || !mounted) return;
+    await _createChannel(choice);
+  }
+
+  Future<void> _createChannel(String kind) async {
+    final name = await _promptChannelName(kind);
+    if (name == null || name.isEmpty || !mounted) return;
+    final success = await ref
+        .read(channelsProvider.notifier)
+        .createChannel(widget.conversation.id, name, kind);
+    if (!mounted) return;
+    if (success) {
+      ToastService.show(
+        context,
+        kind == 'voice'
+            ? 'Voice channel "$name" created'
+            : 'Channel #$name created',
+        type: ToastType.success,
+      );
+    } else {
+      ToastService.show(
+        context,
+        'Could not create channel',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  Future<String?> _promptChannelName(String kind) {
+    final controller = TextEditingController();
+    final title = kind == 'voice'
+        ? 'New voice channel'
+        : 'New text channel';
+    final hint = kind == 'voice' ? 'lounge' : 'general';
+    return showDialog<String>(
+      context: context,
+      builder: (dialogCtx) {
+        return AlertDialog(
+          backgroundColor: context.surface,
+          title: Text(title, style: TextStyle(color: context.textPrimary)),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            decoration: InputDecoration(
+              hintText: hint,
+              prefixIcon: Icon(
+                kind == 'voice' ? Icons.volume_up_outlined : Icons.tag,
+                size: 18,
+              ),
+            ),
+            onSubmitted: (v) => Navigator.of(dialogCtx).pop(v.trim()),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogCtx).pop(),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () =>
+                  Navigator.of(dialogCtx).pop(controller.text.trim()),
+              child: const Text('Create'),
+            ),
+          ],
+        );
+      },
+    );
   }
 }
 
@@ -190,10 +381,17 @@ class _CategoryHeader extends StatelessWidget {
   final String label;
   final bool collapsed;
   final VoidCallback onToggle;
+
+  /// Optional inline "+" button to create a channel in this category.
+  /// Mirrors the right-click menu surface so users who don't think to
+  /// right-click can still discover the action.
+  final VoidCallback? onCreate;
+
   const _CategoryHeader({
     required this.label,
     required this.collapsed,
     required this.onToggle,
+    this.onCreate,
   });
 
   @override
@@ -204,7 +402,7 @@ class _CategoryHeader extends StatelessWidget {
       child: InkWell(
         onTap: onToggle,
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(8, 4, 8, 6),
+          padding: const EdgeInsets.fromLTRB(8, 4, 6, 6),
           child: Row(
             children: [
               Icon(
@@ -224,6 +422,19 @@ class _CategoryHeader extends StatelessWidget {
                   ),
                 ),
               ),
+              if (onCreate != null)
+                InkWell(
+                  borderRadius: BorderRadius.circular(4),
+                  onTap: onCreate,
+                  child: Padding(
+                    padding: const EdgeInsets.all(2),
+                    child: Icon(
+                      Icons.add,
+                      size: 14,
+                      color: context.textMuted,
+                    ),
+                  ),
+                ),
             ],
           ),
         ),

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -36,6 +36,13 @@ class ChatHeaderBar extends ConsumerWidget {
   final VoidCallback? onMembersToggle;
   final VoidCallback? onGroupInfo;
 
+  /// When true, the group's avatar + name + status are NOT rendered.
+  /// Used by Column mode where the channel rail's own header already
+  /// shows the group identity (avatar + name + member count), so this
+  /// row would duplicate it. The action buttons on the right
+  /// (pin / search / shared media / members) still render.
+  final bool hideGroupIdentity;
+
   const ChatHeaderBar({
     super.key,
     required this.conversation,
@@ -46,6 +53,7 @@ class ChatHeaderBar extends ConsumerWidget {
     required this.onToggleSearch,
     this.onMembersToggle,
     this.onGroupInfo,
+    this.hideGroupIdentity = false,
   });
 
   @override
@@ -90,9 +98,14 @@ class ChatHeaderBar extends ConsumerWidget {
             ),
             const SizedBox(width: 4),
           ],
-          _buildHeaderAvatar(conv, displayName),
-          const SizedBox(width: 12),
-          Expanded(child: _buildNameAndStatus(context, ref, conv, displayName)),
+          if (!hideGroupIdentity) ...[
+            _buildHeaderAvatar(conv, displayName),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _buildNameAndStatus(context, ref, conv, displayName),
+            ),
+          ] else
+            const Spacer(),
           ..._buildActionButtons(context, ref, conv),
         ],
       ),
@@ -518,6 +531,37 @@ class ChatHeaderBar extends ConsumerWidget {
   }
 
   void _openSharedMedia(BuildContext context, Conversation conv) {
+    // Two surfaces share this gallery:
+    //   • Wide viewports (>= 900 px) → a centred dialog sized so the
+    //     grid has enough breathing room to render 4-5 thumbnails per
+    //     row instead of the cramped 2-per-row a phone-shaped sheet
+    //     forced on desktop.
+    //   • Narrow viewports → the existing bottom-sheet treatment,
+    //     which feels native on phones.
+    final screen = MediaQuery.of(context).size;
+    if (screen.width >= 900) {
+      showDialog<void>(
+        context: context,
+        builder: (dialogCtx) {
+          final size = MediaQuery.of(dialogCtx).size;
+          final width = size.width.clamp(720.0, 1200.0).toDouble();
+          final height = (size.height * 0.85).clamp(520.0, 900.0).toDouble();
+          return Dialog(
+            backgroundColor: Colors.transparent,
+            insetPadding: const EdgeInsets.all(24),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: SizedBox(
+                width: width,
+                height: height,
+                child: SharedMediaGallery(conversationId: conv.id),
+              ),
+            ),
+          );
+        },
+      );
+      return;
+    }
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -193,6 +193,10 @@ Widget buildChatContentBox(
               onToggleSearch: () => p.onSetShowSearch(!p.showSearch),
               onMembersToggle: p.onMembersToggle,
               onGroupInfo: p.onGroupInfo,
+              // Column mode's left rail already shows the group avatar +
+              // name + member count in its own header; rendering them
+              // here too produced the duplicate label the user reported.
+              hideGroupIdentity: useColumn,
             ),
             if (p.conv.isGroup && !useColumn && !useColumnDrawer)
               ChannelBar(

--- a/apps/client/lib/src/widgets/shared_media_gallery.dart
+++ b/apps/client/lib/src/widgets/shared_media_gallery.dart
@@ -175,12 +175,15 @@ class _MediaGrid extends StatelessWidget {
         : resolvedThumbUrls;
     final headers = mediaHeaders(authToken: authToken);
 
+    // Use a max-extent delegate so the grid scales: 3 columns on a phone,
+    // 5-6 on a wide desktop dialog. A fixed `crossAxisCount: 3` looked
+    // sparse when the gallery opened on desktop.
     return GridView.builder(
       padding: const EdgeInsets.all(4),
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 3,
-        crossAxisSpacing: 3,
-        mainAxisSpacing: 3,
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 180,
+        crossAxisSpacing: 4,
+        mainAxisSpacing: 4,
       ),
       itemCount: items.length,
       itemBuilder: (context, index) => _buildGridTile(


### PR DESCRIPTION
Rolls up PR #1025: four fixes against the Slack/Discord channel rail.

## Improved
- **Drag-to-resize.** The rail's right edge is now a drag handle
  (180-420 px range). Width persists across launches.
- **Inline channel creation.** Right-click the rail or tap a category
  header's `+` to create a new text or voice channel without leaving
  the chat.

## Fixed
- **No duplicate group header.** With Column mode on, the chat
  header bar no longer re-renders the group avatar + name + member
  count that the rail's own header already shows.
- **Lounge tap actually joins.** Tapping a voice channel in the rail
  used to mount the lounge for a fraction of a second then dispose —
  the rail recorded server membership but never started the LiveKit
  session. It now does both, matching bar mode.
- **Shared Media on desktop.** Opens as a centred 720-1200-wide
  dialog with a responsive grid (5-6 thumbnails per row) instead of
  the phone-shaped bottom sheet's cramped 2-per-row.