### PR TITLE
Close out the remaining SonarCloud findings (HIGH + MEDIUM + LOW)

### DIFF
--- a/apps/client/lib/src/providers/auth/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.dart
@@ -56,6 +56,10 @@ class AuthState {
     this.statusText,
   });
 
+  // @S107: copyWith mirrors the AuthState constructor; refactoring to a param
+  // object would break the idiomatic `state = state.copyWith(field: value)`
+  // pattern used throughout the codebase. Each named param maps 1:1 to an
+  // immutable field on AuthState.
   AuthState copyWith({
     bool? isLoggedIn,
     String? userId,

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -114,6 +114,11 @@ class LiveKitVoiceState {
     this.rttMs = 0,
   });
 
+  // @S107: copyWith mirrors LiveKitVoiceState's 21 immutable fields one-to-one.
+  // Refactoring into grouped param objects would break the idiomatic
+  // `state = state.copyWith(field: value)` calls scattered across the LiveKit
+  // event handlers and would not reduce overall complexity — the fields are
+  // genuinely independent (capture, video, peers, quality, timing).
   LiveKitVoiceState copyWith({
     bool? isActive,
     bool? isJoining,

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -8,6 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../models/chat_message.dart';
+import '../models/conversation.dart';
 import '../services/crypto_service.dart' show IdentityKeyChangedException;
 import '../services/debug_log_service.dart';
 import '../services/group_crypto_service.dart';
@@ -589,109 +590,42 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     // GRP1 paths leave this null and the server keeps minting its own.
     String? clientMessageId;
     if (isEncrypted) {
-      try {
-        final groupCrypto = ref.read(groupCryptoServiceProvider);
-        final token = ref.read(authProvider).token ?? '';
-        groupCrypto.setToken(token);
-        var keyResult = await groupCrypto.getGroupKey(conversationId);
-
-        // Self-heal: if there's no usable key and the sender is the
-        // group's admin/owner, the wedged envelope is theirs to rotate.
-        // Run seedInitialGroupKey (which probes /keys/latest and bumps
-        // past the existing version) and retry the fetch. This rescues
-        // the most common stuck case — an owner whose group was wedged
-        // by an earlier client and who would otherwise see "Message
-        // may not have been delivered" forever, with no banner to tap
-        // because send-failures don't bump the receive-failure counter.
-        if (keyResult == null) {
-          final myUserId = ref.read(authProvider).userId ?? '';
-          final myMember = conversation?.members
-              .where((m) => m.userId == myUserId)
-              .firstOrNull;
-          final isAdminOrOwner =
-              myMember?.role == 'owner' || myMember?.role == 'admin';
-          if (isAdminOrOwner) {
-            debugLog(
-              'No usable group key for $conversationId — owner self-heal',
-              'WebSocket',
-            );
-            await ref
-                .read(cryptoProvider.notifier)
-                .seedInitialGroupKey(conversationId);
-            keyResult = await groupCrypto.getGroupKey(conversationId);
-            // TD-5: if seedInitialGroupKey lost a 409 race the local
-            // cache may still be empty even though the server now has
-            // a fresh key version. Force a network refetch before we
-            // give up, so a rotation won-elsewhere doesn't bounce the
-            // sender into the failed-message retry loop.
-            keyResult ??= await groupCrypto.fetchGroupKey(conversationId);
-          }
-        }
-
-        if (keyResult == null) {
-          // No group session yet -- hard fail rather than leak plaintext.
-          _addFailedMessage(
-            '',
-            _friendlyEncryptionError('No group session'),
-            conversationId: conversationId,
-            originalContent: content,
-          );
-          return;
-        }
-        final (_, keyBase64) = keyResult;
-
-        // Phase 2D dispatch: GRP2 if the cached envelope's
-        // min_wire_version pins us there, GRP1 otherwise. Old groups
-        // and groups whose rotator hasn't upgraded yet stay on GRP1
-        // until the next rotation bumps them.
-        final minWireVersion =
-            groupCrypto.cachedMinWireVersion(conversationId) ?? 1;
-        if (minWireVersion >= 2) {
-          final crypto = ref.read(cryptoServiceProvider);
-          final signingKey = crypto.signingKeyPair;
-          if (signingKey == null) {
-            // Identity signing key isn't loaded yet (mid-init). Refuse
-            // to fall back to GRP1 because the envelope is pinned to
-            // GRP2 — that would just bounce off the receiver's
-            // min_wire_version guard. Surface as a typed failure.
-            _addFailedMessage(
-              '',
-              _friendlyEncryptionError('Signing key unavailable for GRP2 send'),
-              conversationId: conversationId,
-              originalContent: content,
-            );
-            return;
-          }
-          final convIdBytes = uuidStringToBytes(conversationId);
-          final msgIdBytes = newUuidBytes();
-          clientMessageId = uuidBytesToString(msgIdBytes);
-          payload = await GroupCryptoService.encryptGroupMessageV2(
-            plaintext: content,
-            keyBase64: keyBase64,
-            conversationIdBytes: convIdBytes,
-            messageIdBytes: msgIdBytes,
-            senderSigningKey: signingKey,
-          );
-        } else {
-          payload = await GroupCryptoService.encryptGroupMessage(
-            content,
-            keyBase64,
-          );
-        }
-      } catch (e) {
-        debugLog('Group encryption failed: $e', 'WebSocket');
-        _addFailedMessage(
-          '',
-          _friendlyEncryptionError(e),
-          conversationId: conversationId,
-          originalContent: content,
-        );
+      final encrypted = await _encryptForGroupSend(
+        conversationId: conversationId,
+        content: content,
+        conversation: conversation,
+      );
+      if (encrypted == null) {
+        // Failure already enqueued via _addFailedMessage; do not send.
         return;
       }
+      payload = encrypted.payload;
+      clientMessageId = encrypted.clientMessageId;
     } else {
       payload = content;
     }
 
+    _channel?.sink.add(
+      jsonEncode(
+        _buildGroupSendFrame(
+          conversationId: conversationId,
+          payload: payload,
+          clientMessageId: clientMessageId,
+          channelId: channelId,
+          replyToId: replyToId,
+        ),
+      ),
+    );
+  }
+
+  /// Builds the JSON map sent over the wire for a group `send_message`.
+  Map<String, dynamic> _buildGroupSendFrame({
+    required String conversationId,
+    required String payload,
+    required String? clientMessageId,
+    required String? channelId,
+    required String? replyToId,
+  }) {
     final msg = <String, dynamic>{
       'type': 'send_message',
       'conversation_id': conversationId,
@@ -709,7 +643,155 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     if (replyToId != null && replyToId.isNotEmpty) {
       msg['reply_to_id'] = replyToId;
     }
-    _channel?.sink.add(jsonEncode(msg));
+    return msg;
+  }
+
+  /// Encrypts [content] for a group send. Returns `null` when encryption
+  /// fails (and enqueues a failed-message placeholder for retry); callers
+  /// must short-circuit in that case so plaintext never reaches the wire.
+  Future<({String payload, String? clientMessageId})?> _encryptForGroupSend({
+    required String conversationId,
+    required String content,
+    required Conversation? conversation,
+  }) async {
+    try {
+      final groupCrypto = ref.read(groupCryptoServiceProvider);
+      final token = ref.read(authProvider).token ?? '';
+      groupCrypto.setToken(token);
+
+      final keyResult = await _resolveGroupKeyWithSelfHeal(
+        conversationId: conversationId,
+        conversation: conversation,
+        groupCrypto: groupCrypto,
+      );
+      if (keyResult == null) {
+        // No group session yet -- hard fail rather than leak plaintext.
+        _addFailedMessage(
+          '',
+          _friendlyEncryptionError('No group session'),
+          conversationId: conversationId,
+          originalContent: content,
+        );
+        return null;
+      }
+      final (_, keyBase64) = keyResult;
+
+      // Phase 2D dispatch: GRP2 if the cached envelope's
+      // min_wire_version pins us there, GRP1 otherwise. Old groups
+      // and groups whose rotator hasn't upgraded yet stay on GRP1
+      // until the next rotation bumps them.
+      final minWireVersion =
+          groupCrypto.cachedMinWireVersion(conversationId) ?? 1;
+      if (minWireVersion >= 2) {
+        return await _encryptGroupGrp2(
+          conversationId: conversationId,
+          content: content,
+          keyBase64: keyBase64,
+        );
+      }
+      final payload = await GroupCryptoService.encryptGroupMessage(
+        content,
+        keyBase64,
+      );
+      return (payload: payload, clientMessageId: null);
+    } catch (e) {
+      debugLog('Group encryption failed: $e', 'WebSocket');
+      _addFailedMessage(
+        '',
+        _friendlyEncryptionError(e),
+        conversationId: conversationId,
+        originalContent: content,
+      );
+      return null;
+    }
+  }
+
+  /// Looks up the cached group key, and if missing tries an owner/admin
+  /// self-heal seed + refetch so a wedged envelope can recover without
+  /// the user needing to tap a banner.
+  Future<(int, String)?> _resolveGroupKeyWithSelfHeal({
+    required String conversationId,
+    required Conversation? conversation,
+    required GroupCryptoService groupCrypto,
+  }) async {
+    var keyResult = await groupCrypto.getGroupKey(conversationId);
+    if (keyResult != null) {
+      return keyResult;
+    }
+
+    // Self-heal: if there's no usable key and the sender is the
+    // group's admin/owner, the wedged envelope is theirs to rotate.
+    // Run seedInitialGroupKey (which probes /keys/latest and bumps
+    // past the existing version) and retry the fetch. This rescues
+    // the most common stuck case — an owner whose group was wedged
+    // by an earlier client and who would otherwise see "Message
+    // may not have been delivered" forever, with no banner to tap
+    // because send-failures don't bump the receive-failure counter.
+    if (!_isAdminOrOwnerOf(conversation)) {
+      return null;
+    }
+    debugLog(
+      'No usable group key for $conversationId — owner self-heal',
+      'WebSocket',
+    );
+    await ref
+        .read(cryptoProvider.notifier)
+        .seedInitialGroupKey(conversationId);
+    keyResult = await groupCrypto.getGroupKey(conversationId);
+    // TD-5: if seedInitialGroupKey lost a 409 race the local
+    // cache may still be empty even though the server now has
+    // a fresh key version. Force a network refetch before we
+    // give up, so a rotation won-elsewhere doesn't bounce the
+    // sender into the failed-message retry loop.
+    keyResult ??= await groupCrypto.fetchGroupKey(conversationId);
+    return keyResult;
+  }
+
+  /// True when the current user is an owner/admin of [conversation].
+  bool _isAdminOrOwnerOf(Conversation? conversation) {
+    final myUserId = ref.read(authProvider).userId ?? '';
+    final myMember = conversation?.members
+        .where((m) => m.userId == myUserId)
+        .firstOrNull;
+    final role = myMember?.role;
+    return role == 'owner' || role == 'admin';
+  }
+
+  /// Encrypts a GRP2 group send. Returns `null` (after enqueueing a
+  /// failed-message placeholder) when the identity signing key isn't
+  /// available — we refuse to silently downgrade to GRP1 because the
+  /// envelope's min_wire_version is pinned to 2.
+  Future<({String payload, String? clientMessageId})?> _encryptGroupGrp2({
+    required String conversationId,
+    required String content,
+    required String keyBase64,
+  }) async {
+    final crypto = ref.read(cryptoServiceProvider);
+    final signingKey = crypto.signingKeyPair;
+    if (signingKey == null) {
+      // Identity signing key isn't loaded yet (mid-init). Refuse
+      // to fall back to GRP1 because the envelope is pinned to
+      // GRP2 — that would just bounce off the receiver's
+      // min_wire_version guard. Surface as a typed failure.
+      _addFailedMessage(
+        '',
+        _friendlyEncryptionError('Signing key unavailable for GRP2 send'),
+        conversationId: conversationId,
+        originalContent: content,
+      );
+      return null;
+    }
+    final convIdBytes = uuidStringToBytes(conversationId);
+    final msgIdBytes = newUuidBytes();
+    final clientMessageId = uuidBytesToString(msgIdBytes);
+    final payload = await GroupCryptoService.encryptGroupMessageV2(
+      plaintext: content,
+      keyBase64: keyBase64,
+      conversationIdBytes: convIdBytes,
+      messageIdBytes: msgIdBytes,
+      senderSigningKey: signingKey,
+    );
+    return (payload: payload, clientMessageId: clientMessageId);
   }
 
   /// Send a typing indicator (throttled to max 1 per 3 seconds per conversation).

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -1166,12 +1166,9 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     required bool viewerIsAdminOrOwner,
     required bool isMe,
   }) {
-    final blockedIds = ref
-        .read(contactsProvider)
-        .blockedUsers
-        .map((u) => u.blockedId)
-        .toSet();
-    final isBlocked = blockedIds.contains(member.userId);
+    final isBlocked = _isMemberBlocked(member.userId);
+    final canModerate =
+        viewerIsAdminOrOwner && !isMe && role != 'owner';
 
     final target = MemberTarget(
       userId: member.userId,
@@ -1180,47 +1177,20 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
       targetIsOwner: role == 'owner',
       viewerIsAdminOrOwner: viewerIsAdminOrOwner,
       onViewProfile: () => showUserProfileSheet(context, ref, member.userId),
-      onSendMessage: isMe
-          ? null
-          : () async {
-              try {
-                final conv = await ref
-                    .read(conversationsProvider.notifier)
-                    .getOrCreateDm(member.userId, member.username);
-                if (!mounted) return;
-                context.go('/home?conversation=${conv.id}');
-              } catch (_) {
-                if (!mounted) return;
-                ToastService.show(
-                  context,
-                  'Failed to open conversation',
-                  type: ToastType.error,
-                );
-              }
-            },
+      onSendMessage: isMe ? null : () => _openDmWithMember(member),
       onUnblock: (isMe || !isBlocked)
           ? null
-          : () async {
-              await ref
-                  .read(contactsProvider.notifier)
-                  .unblockUser(member.userId);
-            },
-      onCopyUsername: () {
-        Clipboard.setData(ClipboardData(text: member.username));
-        if (!mounted) return;
-        ToastService.show(context, 'Username copied', type: ToastType.success);
-      },
-      onCopyUserId: () {
-        Clipboard.setData(ClipboardData(text: member.userId));
-        if (!mounted) return;
-        ToastService.show(context, 'User ID copied', type: ToastType.success);
-      },
-      onKick: (viewerIsAdminOrOwner && !isMe && role != 'owner')
-          ? () => _kickMember(member)
-          : null,
-      onBan: (viewerIsAdminOrOwner && !isMe && role != 'owner')
-          ? () => _banMember(member)
-          : null,
+          : () => _unblockMember(member.userId),
+      onCopyUsername: () => _copyToClipboardWithToast(
+        member.username,
+        'Username copied',
+      ),
+      onCopyUserId: () => _copyToClipboardWithToast(
+        member.userId,
+        'User ID copied',
+      ),
+      onKick: canModerate ? () => _kickMember(member) : null,
+      onBan: canModerate ? () => _banMember(member) : null,
     );
 
     EchoContextMenu.open(
@@ -1229,6 +1199,40 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
       anchor: anchor,
       model: buildMemberMenu(target),
     );
+  }
+
+  bool _isMemberBlocked(String userId) {
+    return ref
+        .read(contactsProvider)
+        .blockedUsers
+        .any((u) => u.blockedId == userId);
+  }
+
+  Future<void> _openDmWithMember(ConversationMember member) async {
+    try {
+      final conv = await ref
+          .read(conversationsProvider.notifier)
+          .getOrCreateDm(member.userId, member.username);
+      if (!mounted) return;
+      context.go('/home?conversation=${conv.id}');
+    } catch (_) {
+      if (!mounted) return;
+      ToastService.show(
+        context,
+        'Failed to open conversation',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  Future<void> _unblockMember(String userId) async {
+    await ref.read(contactsProvider.notifier).unblockUser(userId);
+  }
+
+  void _copyToClipboardWithToast(String text, String successMessage) {
+    Clipboard.setData(ClipboardData(text: text));
+    if (!mounted) return;
+    ToastService.show(context, successMessage, type: ToastType.success);
   }
 
   /// Single roster row. Matches the desktop members panel styling (#769):

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -483,16 +483,7 @@ class _UpdatePromptBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final update = ref.watch(updateProvider);
-    final isDownloading = update.status == UpdateStatus.downloading;
-    final isInstalling = update.status == UpdateStatus.installing;
-    final isReady = update.status == UpdateStatus.readyToInstall;
-    final isError = update.status == UpdateStatus.error;
-    final isBusy = isDownloading || isInstalling;
-
     final accent = context.accent;
-    final logoSize = compact ? 64.0 : 84.0;
-    final wordmarkSize = compact ? 22.0 : 28.0;
-    final taglineSize = compact ? 12.0 : 13.0;
     final outerPadding = compact
         ? const EdgeInsets.fromLTRB(28, 44, 28, 22)
         : const EdgeInsets.fromLTRB(36, 24, 36, 38);
@@ -501,192 +492,231 @@ class _UpdatePromptBody extends ConsumerWidget {
       opacity: fade,
       child: Stack(
         children: [
-          Positioned(
-            top: compact ? -120 : -40,
-            left: 0,
-            right: 0,
-            child: IgnorePointer(
-              child: Center(
-                child: Container(
-                  width: compact ? 360 : 420,
-                  height: compact ? 360 : 420,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    gradient: RadialGradient(
-                      colors: [
-                        accent.withValues(alpha: 0.13),
-                        accent.withValues(alpha: 0.0),
-                      ],
-                      stops: const [0.0, 0.6],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
+          _buildHaloBackdrop(accent),
           Padding(
             padding: outerPadding,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                // Brand block (logo + wordmark + tagline). Identical
-                // geometry to _SplashBody so the prompt slides into the
-                // same window without a visual jolt.
-                Padding(
-                  padding: EdgeInsets.only(top: compact ? 12 : 60),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      EchoLogoIcon(size: logoSize),
-                      SizedBox(height: compact ? 18 : 24),
-                      Text(
-                        'Echo',
-                        style: TextStyle(
-                          fontSize: wordmarkSize,
-                          fontWeight: FontWeight.w700,
-                          letterSpacing: -0.5,
-                          height: 1.0,
-                          color: context.textPrimary,
-                        ),
-                      ),
-                      SizedBox(height: compact ? 8 : 10),
-                      Text(
-                        'Update available',
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          fontSize: taglineSize,
-                          color: context.textSecondary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                // Action block. Mirrors _SplashBody's status-caption +
-                // progress-sweep position so the eye lands in the same
-                // place across both screens.
-                Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      'v$appVersion  →  v${update.latestVersion}',
-                      style: EchoTheme.mono(
-                        fontSize: 12,
-                        color: context.textMuted,
-                        letterSpacing: 0.4,
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    if (isDownloading) ...[
-                      SizedBox(
-                        width: compact ? 220 : 280,
-                        child: LinearProgressIndicator(
-                          value: update.downloadProgress,
-                          color: accent,
-                          backgroundColor: context.border,
-                          minHeight: 4,
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        'Downloading… ${(update.downloadProgress * 100).toInt()}%',
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: context.textMuted,
-                        ),
-                      ),
-                    ] else if (isInstalling) ...[
-                      Text(
-                        'Installing…',
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: context.textMuted,
-                        ),
-                      ),
-                    ] else if (isReady) ...[
-                      SizedBox(
-                        width: compact ? 220 : 280,
-                        child: FilledButton.icon(
-                          onPressed: () =>
-                              ref.read(updateProvider.notifier).applyUpdate(),
-                          icon: const Icon(Icons.restart_alt, size: 16),
-                          label: const Text('Restart to Update'),
-                          style: FilledButton.styleFrom(
-                            backgroundColor: accent,
-                            minimumSize: const Size(double.infinity, 40),
-                            shape: const StadiumBorder(),
-                          ),
-                        ),
-                      ),
-                    ] else ...[
-                      SizedBox(
-                        width: compact ? 220 : 280,
-                        child: FilledButton(
-                          onPressed: () => ref
-                              .read(updateProvider.notifier)
-                              .downloadUpdate(),
-                          style: FilledButton.styleFrom(
-                            backgroundColor: accent,
-                            minimumSize: const Size(double.infinity, 40),
-                            shape: const StadiumBorder(),
-                          ),
-                          child: const Text('Download Update'),
-                        ),
-                      ),
-                    ],
-                    if (isError) ...[
-                      const SizedBox(height: 10),
-                      Text(
-                        update.errorMessage ?? 'Download failed',
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          fontSize: 12,
-                          color: Colors.redAccent,
-                        ),
-                      ),
-                    ],
-                    if (!isReady && !isInstalling) ...[
-                      const SizedBox(height: 6),
-                      TextButton(
-                        onPressed: isBusy ? null : onSkip,
-                        child: Text(
-                          'Skip',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: isBusy
-                                ? context.textMuted.withValues(alpha: 0.4)
-                                : context.textMuted,
-                          ),
-                        ),
-                      ),
-                    ],
-                    if (!compact) ...[
-                      const SizedBox(height: 18),
-                      Text(
-                        'v$appVersion',
-                        style: EchoTheme.mono(
-                          fontSize: 10,
-                          color: context.textMuted,
-                          letterSpacing: 0.3,
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-                if (compact)
-                  Text(
-                    'v$appVersion',
-                    style: EchoTheme.mono(
-                      fontSize: 10,
-                      color: context.textMuted,
-                      letterSpacing: 0.3,
-                    ),
-                  ),
+                _buildBrandBlock(context),
+                _buildActionBlock(context, ref, update, accent),
+                if (compact) _buildVersionLabel(context),
               ],
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildHaloBackdrop(Color accent) {
+    return Positioned(
+      top: compact ? -120 : -40,
+      left: 0,
+      right: 0,
+      child: IgnorePointer(
+        child: Center(
+          child: Container(
+            width: compact ? 360 : 420,
+            height: compact ? 360 : 420,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: RadialGradient(
+                colors: [
+                  accent.withValues(alpha: 0.13),
+                  accent.withValues(alpha: 0.0),
+                ],
+                stops: const [0.0, 0.6],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBrandBlock(BuildContext context) {
+    final logoSize = compact ? 64.0 : 84.0;
+    final wordmarkSize = compact ? 22.0 : 28.0;
+    final taglineSize = compact ? 12.0 : 13.0;
+    return Padding(
+      padding: EdgeInsets.only(top: compact ? 12 : 60),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          EchoLogoIcon(size: logoSize),
+          SizedBox(height: compact ? 18 : 24),
+          Text(
+            'Echo',
+            style: TextStyle(
+              fontSize: wordmarkSize,
+              fontWeight: FontWeight.w700,
+              letterSpacing: -0.5,
+              height: 1.0,
+              color: context.textPrimary,
+            ),
+          ),
+          SizedBox(height: compact ? 8 : 10),
+          Text(
+            'Update available',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: taglineSize,
+              color: context.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionBlock(
+    BuildContext context,
+    WidgetRef ref,
+    dynamic update,
+    Color accent,
+  ) {
+    final isDownloading = update.status == UpdateStatus.downloading;
+    final isInstalling = update.status == UpdateStatus.installing;
+    final isReady = update.status == UpdateStatus.readyToInstall;
+    final isError = update.status == UpdateStatus.error;
+    final isBusy = isDownloading || isInstalling;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          'v$appVersion  →  v${update.latestVersion}',
+          style: EchoTheme.mono(
+            fontSize: 12,
+            color: context.textMuted,
+            letterSpacing: 0.4,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _buildPrimaryAction(
+          context,
+          ref,
+          update,
+          accent,
+          isDownloading: isDownloading,
+          isInstalling: isInstalling,
+          isReady: isReady,
+        ),
+        if (isError) _buildErrorMessage(update),
+        if (!isReady && !isInstalling) _buildSkipButton(context, isBusy),
+        if (!compact) ...[
+          const SizedBox(height: 18),
+          _buildVersionLabel(context),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildPrimaryAction(
+    BuildContext context,
+    WidgetRef ref,
+    dynamic update,
+    Color accent, {
+    required bool isDownloading,
+    required bool isInstalling,
+    required bool isReady,
+  }) {
+    if (isDownloading) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: compact ? 220 : 280,
+            child: LinearProgressIndicator(
+              value: update.downloadProgress,
+              color: accent,
+              backgroundColor: context.border,
+              minHeight: 4,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Downloading… ${(update.downloadProgress * 100).toInt()}%',
+            style: TextStyle(fontSize: 12, color: context.textMuted),
+          ),
+        ],
+      );
+    }
+    if (isInstalling) {
+      return Text(
+        'Installing…',
+        style: TextStyle(fontSize: 12, color: context.textMuted),
+      );
+    }
+    if (isReady) {
+      return SizedBox(
+        width: compact ? 220 : 280,
+        child: FilledButton.icon(
+          onPressed: () => ref.read(updateProvider.notifier).applyUpdate(),
+          icon: const Icon(Icons.restart_alt, size: 16),
+          label: const Text('Restart to Update'),
+          style: FilledButton.styleFrom(
+            backgroundColor: accent,
+            minimumSize: const Size(double.infinity, 40),
+            shape: const StadiumBorder(),
+          ),
+        ),
+      );
+    }
+    return SizedBox(
+      width: compact ? 220 : 280,
+      child: FilledButton(
+        onPressed: () =>
+            ref.read(updateProvider.notifier).downloadUpdate(),
+        style: FilledButton.styleFrom(
+          backgroundColor: accent,
+          minimumSize: const Size(double.infinity, 40),
+          shape: const StadiumBorder(),
+        ),
+        child: const Text('Download Update'),
+      ),
+    );
+  }
+
+  Widget _buildErrorMessage(dynamic update) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 10),
+      child: Text(
+        update.errorMessage ?? 'Download failed',
+        textAlign: TextAlign.center,
+        style: const TextStyle(fontSize: 12, color: Colors.redAccent),
+      ),
+    );
+  }
+
+  Widget _buildSkipButton(BuildContext context, bool isBusy) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: TextButton(
+        onPressed: isBusy ? null : onSkip,
+        child: Text(
+          'Skip',
+          style: TextStyle(
+            fontSize: 12,
+            color: isBusy
+                ? context.textMuted.withValues(alpha: 0.4)
+                : context.textMuted,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVersionLabel(BuildContext context) {
+    return Text(
+      'v$appVersion',
+      style: EchoTheme.mono(
+        fontSize: 10,
+        color: context.textMuted,
+        letterSpacing: 0.3,
       ),
     );
   }

--- a/apps/client/lib/src/services/upload_client.dart
+++ b/apps/client/lib/src/services/upload_client.dart
@@ -100,6 +100,10 @@ class UploadClient {
   /// [method] defaults to `POST`; pass `PUT` for avatar endpoints.
   /// [extraFields] are added as plain form fields before the file part.
   /// [onProgress] receives `(sent, total)` byte counts during streaming.
+  // @S107: 7 required + 2 optional named params model the HTTP upload contract
+  // directly. Grouping them into a param object would force every caller
+  // (avatar pickers, chat attachments, drawing exports) to construct a record
+  // for what is fundamentally a flat multipart-form request signature.
   Future<UploadResult> uploadFile({
     required String serverUrl,
     required String path,

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -1499,25 +1499,15 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
 
     if (event is! KeyDownEvent) return KeyEventResult.ignored;
 
-    // Mention picker keyboard nav takes precedence — Tab/Enter accept the
-    // selected row, arrows move it, Escape closes the picker (without
-    // also bubbling Escape through to message edit-cancel).
-    if (_mentionController.showPicker) {
-      final mentionResult = _handleMentionPickerKey(event);
-      if (mentionResult != KeyEventResult.ignored) return mentionResult;
-      // Space falls through — extractMentionQuery sees the space and
-      // closes the picker, leaving the literal "@" in the text.
-    }
+    final mentionResult = _handleMentionPickerIfActive(event);
+    if (mentionResult != KeyEventResult.ignored) return mentionResult;
 
     if (event.logicalKey == LogicalKeyboardKey.escape) {
       _handleEscapeKey();
     }
 
-    if (event.logicalKey == LogicalKeyboardKey.enter &&
-        !HardwareKeyboard.instance.isShiftPressed) {
-      _isEditing ? _submitEdit() : _sendMessage();
-      return KeyEventResult.handled;
-    }
+    final submitResult = _handleEnterSubmit(event);
+    if (submitResult != KeyEventResult.ignored) return submitResult;
 
     final modResult = _handleModifierShortcut(event);
     if (modResult != KeyEventResult.ignored) return modResult;
@@ -1526,6 +1516,25 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       return _handleArrowUpEditLast();
     }
 
+    return KeyEventResult.ignored;
+  }
+
+  // Mention picker keyboard nav takes precedence — Tab/Enter accept the
+  // selected row, arrows move it, Escape closes the picker (without
+  // also bubbling Escape through to message edit-cancel). Space falls
+  // through — extractMentionQuery sees the space and closes the picker,
+  // leaving the literal "@" in the text.
+  KeyEventResult _handleMentionPickerIfActive(KeyDownEvent event) {
+    if (!_mentionController.showPicker) return KeyEventResult.ignored;
+    return _handleMentionPickerKey(event);
+  }
+
+  KeyEventResult _handleEnterSubmit(KeyDownEvent event) {
+    if (event.logicalKey == LogicalKeyboardKey.enter &&
+        !HardwareKeyboard.instance.isShiftPressed) {
+      _isEditing ? _submitEdit() : _sendMessage();
+      return KeyEventResult.handled;
+    }
     return KeyEventResult.ignored;
   }
 

--- a/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
@@ -162,28 +162,32 @@ typedef _PickAndDispatchParams = ({
 });
 
 Future<void> _pickAndDispatch(_PickAndDispatchParams params) async {
-  final context = params.context;
   if (params.isPicking()) return;
   params.setIsPicking(true);
   try {
-    final result = await FilePicker.pickFiles(
-      type: params.type,
-      allowMultiple: true,
-      withData: true,
-    );
-    if (result == null || result.files.isEmpty) return;
-    if (!params.mounted() || !context.mounted) return;
-    await _dispatchPickedFiles(context, params, result.files);
+    await _runPickAndDispatch(params);
   } catch (e) {
-    if (!context.mounted) return;
-    ToastService.show(
-      context,
-      '${params.errorPrefix} error: $e',
-      type: ToastType.error,
-    );
+    _showPickError(params.context, '${params.errorPrefix} error: $e');
   } finally {
     params.setIsPicking(false);
   }
+}
+
+Future<void> _runPickAndDispatch(_PickAndDispatchParams params) async {
+  final context = params.context;
+  final result = await FilePicker.pickFiles(
+    type: params.type,
+    allowMultiple: true,
+    withData: true,
+  );
+  if (result == null || result.files.isEmpty) return;
+  if (!params.mounted() || !context.mounted) return;
+  await _dispatchPickedFiles(context, params, result.files);
+}
+
+void _showPickError(BuildContext context, String message) {
+  if (!context.mounted) return;
+  ToastService.show(context, message, type: ToastType.error);
 }
 
 /// Dispatches a previously-picked list of files, surfacing toast feedback

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -480,15 +480,17 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     final conv = widget.conversation;
     if (conv == null) return;
     await history.jumpToReplyQuote(
-      context: context,
-      ref: ref,
-      conv: conv,
-      selectedTextChannelId: _selectedTextChannelId,
-      controller: _controller,
-      replyToId: replyToId,
-      resolveMessages: _resolveMessages,
-      mounted: () => mounted,
-      onHighlight: () => _highlightMessage(replyToId),
+      history.JumpToReplyQuoteParams(
+        context: context,
+        ref: ref,
+        conv: conv,
+        selectedTextChannelId: _selectedTextChannelId,
+        controller: _controller,
+        replyToId: replyToId,
+        resolveMessages: _resolveMessages,
+        mounted: () => mounted,
+        onHighlight: () => _highlightMessage(replyToId),
+      ),
     );
   }
 

--- a/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
+++ b/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
@@ -224,18 +224,44 @@ Future<bool> _paginateOnceForReply(_PaginationParams params) async {
   );
 }
 
-Future<void> jumpToReplyQuote({
-  required BuildContext context,
-  required WidgetRef ref,
-  required Conversation conv,
-  required String? selectedTextChannelId,
-  required ChatPanelController controller,
-  required String replyToId,
-  required List<ChatMessage> Function(Conversation, ChatState, String?, bool)
-  resolveMessages,
-  required bool Function() mounted,
-  required VoidCallback onHighlight,
-}) async {
+/// Parameter bundle for [jumpToReplyQuote]. Grouped to keep the call signature
+/// flat and stay under the 7-param S107 limit.
+class JumpToReplyQuoteParams {
+  const JumpToReplyQuoteParams({
+    required this.context,
+    required this.ref,
+    required this.conv,
+    required this.selectedTextChannelId,
+    required this.controller,
+    required this.replyToId,
+    required this.resolveMessages,
+    required this.mounted,
+    required this.onHighlight,
+  });
+
+  final BuildContext context;
+  final WidgetRef ref;
+  final Conversation conv;
+  final String? selectedTextChannelId;
+  final ChatPanelController controller;
+  final String replyToId;
+  final List<ChatMessage> Function(Conversation, ChatState, String?, bool)
+  resolveMessages;
+  final bool Function() mounted;
+  final VoidCallback onHighlight;
+}
+
+Future<void> jumpToReplyQuote(JumpToReplyQuoteParams params) async {
+  final context = params.context;
+  final ref = params.ref;
+  final conv = params.conv;
+  final selectedTextChannelId = params.selectedTextChannelId;
+  final controller = params.controller;
+  final replyToId = params.replyToId;
+  final resolveMessages = params.resolveMessages;
+  final mounted = params.mounted;
+  final onHighlight = params.onHighlight;
+
   final selectedChannelId = conv.isGroup ? selectedTextChannelId : null;
   final includeUnchanneled = conv.isGroup && selectedTextChannelId == null;
 

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -196,15 +196,9 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     final pinnedIds = ref.read(pinnedConversationIdsProvider);
     final isPinned = pinnedIds.contains(conv.id) || conv.isPinned;
     final hasUnread = conv.unreadCount > 0 || conv.mentionCount > 0;
-
-    // The owner of a group with other members can't leave (the
-    // server enforces this); per the cross-cutting decision we hide
-    // the row entirely rather than render it disabled.
-    final canLeave =
-        conv.isGroup &&
-        !(myRole == 'owner' &&
-            conv.members.where((m) => m.userId != myUserId).isNotEmpty);
+    final canLeave = _resolveCanLeave(conv, myRole, myUserId);
     final canDeleteGroup = conv.isGroup && myRole == 'owner';
+    final canInviteOrManage = conv.isGroup && isAdminOrOwner;
 
     return ConversationTarget(
       conversationId: conv.id,
@@ -213,59 +207,81 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       isMuted: conv.isMuted,
       hasUnread: hasUnread,
       isAdminOrOwner: isAdminOrOwner,
-      onMarkAsRead: hasUnread
-          ? () => unawaited(
-              ref.read(conversationsProvider.notifier).sendReadReceipt(conv.id),
-            )
-          : null,
+      onMarkAsRead: hasUnread ? () => _markRead(conv.id) : null,
       // Mark-as-unread isn't wired to a real provider yet; defer to a
       // follow-up so we don't introduce dead UI here.
       onMarkAsUnread: null,
-      onToggleMute: () async {
-        final ok = await ref
-            .read(conversationsProvider.notifier)
-            .toggleMute(conv.id);
-        if (!ok && mounted) {
-          ToastService.show(
-            context,
-            'Failed to update mute settings',
-            type: ToastType.error,
-          );
-        }
-      },
+      onToggleMute: () => _toggleMute(conv.id),
       onTogglePin: () => _togglePin(conv.id),
-      onOpenInfo: conv.isGroup
-          ? () => context.go('/group-info/${conv.id}')
-          : null,
+      onOpenInfo:
+          conv.isGroup ? () => context.go('/group-info/${conv.id}') : null,
       // Invite-people / encryption-activity link out to existing
       // routes today; centralising the entry points is enough for v1.
-      onInvitePeople: (conv.isGroup && isAdminOrOwner)
+      onInvitePeople: canInviteOrManage
           ? () => context.go('/group-info/${conv.id}')
           : null,
-      onOpenEncryptionActivity: (conv.isGroup && isAdminOrOwner)
+      onOpenEncryptionActivity: canInviteOrManage
           ? () => context.go('/group-info/${conv.id}')
           : null,
-      onViewSafetyNumber: (!conv.isGroup && myMember != null)
-          ? () {
-              final peer = conv.members
-                  .where((m) => m.userId != myUserId)
-                  .firstOrNull;
-              if (peer != null) {
-                context.go('/safety-number/${peer.userId}');
-              }
-            }
-          : null,
-      onCopyId: () {
-        Clipboard.setData(ClipboardData(text: conv.id));
-        if (!mounted) return;
-        ToastService.show(
-          context,
-          'Conversation ID copied',
-          type: ToastType.success,
-        );
-      },
+      onViewSafetyNumber: _resolveSafetyNumberCallback(conv, myMember, myUserId),
+      onCopyId: () => _copyConversationId(conv.id),
       onLeave: canLeave ? () => _leaveGroup(conv) : null,
       onDelete: _resolveDeleteCallback(conv, canDeleteGroup),
+    );
+  }
+
+  // The owner of a group with other members can't leave (the server
+  // enforces this); per the cross-cutting decision we hide the row
+  // entirely rather than render it disabled.
+  bool _resolveCanLeave(Conversation conv, String myRole, String myUserId) {
+    if (!conv.isGroup) return false;
+    final ownerWithMembers = myRole == 'owner' &&
+        conv.members.where((m) => m.userId != myUserId).isNotEmpty;
+    return !ownerWithMembers;
+  }
+
+  void _markRead(String conversationId) {
+    unawaited(
+      ref.read(conversationsProvider.notifier).sendReadReceipt(conversationId),
+    );
+  }
+
+  Future<void> _toggleMute(String conversationId) async {
+    final ok = await ref
+        .read(conversationsProvider.notifier)
+        .toggleMute(conversationId);
+    if (!ok && mounted) {
+      ToastService.show(
+        context,
+        'Failed to update mute settings',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  VoidCallback? _resolveSafetyNumberCallback(
+    Conversation conv,
+    dynamic myMember,
+    String myUserId,
+  ) {
+    if (conv.isGroup || myMember == null) return null;
+    return () {
+      final peer = conv.members
+          .where((m) => m.userId != myUserId)
+          .firstOrNull;
+      if (peer != null) {
+        context.go('/safety-number/${peer.userId}');
+      }
+    };
+  }
+
+  void _copyConversationId(String conversationId) {
+    Clipboard.setData(ClipboardData(text: conversationId));
+    if (!mounted) return;
+    ToastService.show(
+      context,
+      'Conversation ID copied',
+      type: ToastType.success,
     );
   }
 

--- a/apps/client/lib/src/widgets/message/reply_count_badge.dart
+++ b/apps/client/lib/src/widgets/message/reply_count_badge.dart
@@ -60,44 +60,57 @@ class ReplyCountBadge extends StatelessWidget {
         : _buildPill(context, label);
   }
 
+  EdgeInsets _topPadding(double topInset) =>
+      EdgeInsets.only(top: topInset, left: isMine ? 0 : 36);
+
+  Alignment get _alignment =>
+      isMine ? Alignment.centerRight : Alignment.centerLeft;
+
+  VoidCallback? get _onTapCallback =>
+      onTap == null ? null : () => onTap!(message);
+
   Widget _buildInline(BuildContext context, String label) {
     return Padding(
-      padding: EdgeInsets.only(top: 2, left: isMine ? 0 : 36),
+      padding: _topPadding(2),
       child: Align(
-        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+        alignment: _alignment,
         child: Semantics(
           label: hasUnread ? 'View $label (new replies)' : 'View $label',
           button: true,
           child: InkWell(
             borderRadius: BorderRadius.circular(2),
-            onTap: onTap == null ? null : () => onTap!(message),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  label,
-                  style: GoogleFonts.inter(
-                    fontSize: 12,
-                    color: context.accent,
-                    fontWeight: FontWeight.w500,
-                    decoration: TextDecoration.underline,
-                    decorationColor: context.accent.withValues(alpha: 0.4),
-                  ),
-                ),
-                if (hasUnread) _unreadDot(context),
-              ],
-            ),
+            onTap: _onTapCallback,
+            child: _buildInlineRow(context, label),
           ),
         ),
       ),
     );
   }
 
+  Widget _buildInlineRow(BuildContext context, String label) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          label,
+          style: GoogleFonts.inter(
+            fontSize: 12,
+            color: context.accent,
+            fontWeight: FontWeight.w500,
+            decoration: TextDecoration.underline,
+            decorationColor: context.accent.withValues(alpha: 0.4),
+          ),
+        ),
+        if (hasUnread) _unreadDot(context),
+      ],
+    );
+  }
+
   Widget _buildPill(BuildContext context, String label) {
     return Padding(
-      padding: EdgeInsets.only(top: 4, left: isMine ? 0 : 36),
+      padding: _topPadding(4),
       child: Align(
-        alignment: isMine ? Alignment.centerRight : Alignment.centerLeft,
+        alignment: _alignment,
         child: Semantics(
           label: 'View $label',
           button: true,
@@ -105,33 +118,37 @@ class ReplyCountBadge extends StatelessWidget {
             color: Colors.transparent,
             child: InkWell(
               borderRadius: BorderRadius.circular(12),
-              onTap: onTap == null ? null : () => onTap!(message),
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: context.accent.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.forum_outlined, size: 12, color: context.accent),
-                    const SizedBox(width: 4),
-                    Text(
-                      label,
-                      style: GoogleFonts.inter(
-                        fontSize: 12,
-                        color: context.accent,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    if (hasUnread) _unreadDot(context),
-                  ],
-                ),
-              ),
+              onTap: _onTapCallback,
+              child: _buildPillContainer(context, label),
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildPillContainer(BuildContext context, String label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: context.accent.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.forum_outlined, size: 12, color: context.accent),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: context.accent,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (hasUnread) _unreadDot(context),
+        ],
       ),
     );
   }

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -759,78 +759,98 @@ class _MessageItemState extends State<MessageItem>
     required bool isFailed,
     required bool hasMedia,
   }) {
-    // Poll messages render as an interactive vote widget.
-    if (isPollContent(msg.content)) {
-      final parsed = parsePollTag(msg.content);
-      if (parsed != null &&
-          widget.serverUrl != null &&
-          widget.authToken != null) {
-        return PollWidget(
-          messageId: msg.id,
-          serverUrl: widget.serverUrl!,
-          authToken: widget.authToken!,
-          question: parsed.question,
-          options: parsed.options,
-        );
-      }
-    }
+    final poll = _tryBuildPoll(msg);
+    if (poll != null) return poll;
 
     if (hasMedia) {
-      // Forwarded messages: strip the `[Forwarded] ` prefix so the
-      // marker regex inside MediaContent can match. The "Forwarded"
-      // badge above the bubble still signals provenance.
-      final mediaContent = msg.content.startsWith(_forwardedPrefix)
-          ? msg.content.substring(_forwardedPrefix.length)
-          : msg.content;
-      final mediaWidget = MediaContent(
-        content: mediaContent,
-        isMine: isMine,
-        serverUrl: widget.serverUrl,
-        authToken: widget.authToken,
-        mediaTicket: widget.mediaTicket,
-        onImageTap: widget.onImageTap,
-      );
-      final caption = extractMediaCaption(mediaContent);
-      if (caption == null) return mediaWidget;
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          mediaWidget,
-          const SizedBox(height: 4),
-          RichTextContent(
-            text: caption,
-            textColor: _contentTextColor(isMine: isMine, isFailed: isFailed),
-            accentHoverColor: context.accentHover,
-            textSecondaryColor: context.textSecondary,
-            density: widget.density,
-          ),
-        ],
-      );
+      return _buildMediaBubble(msg: msg, isMine: isMine, isFailed: isFailed);
     }
     if (_isDecryptFailure(msg.content)) {
-      // Sender side: if WE drafted this message and the system preserved
-      // the original text in failedContent, show the user what they wrote
-      // (dimmed) with a Resend/Delete footer rather than the generic
-      // "couldn't decrypt" pill — the pill makes it look like the message
-      // was sent by someone else. F-006 / expert recommendation in the
-      // 2026-05-19 UI audit.
-      if (isMine && (msg.failedContent ?? '').isNotEmpty) {
-        return OwnDecryptFailedBubble(
-          originalText: msg.failedContent!,
-          onResend: widget.onRetry == null ? null : () => widget.onRetry!(msg),
-          onDelete: widget.onDelete == null
-              ? null
-              : () => widget.onDelete!(msg),
-        );
-      }
-      return const DecryptFailurePill();
+      return _buildDecryptFailureBubble(msg: msg, isMine: isMine);
     }
+    return _buildTextBubble(msg: msg, isMine: isMine, isFailed: isFailed);
+  }
 
-    final displayContent = msg.content.startsWith(_forwardedPrefix)
-        ? msg.content.substring(_forwardedPrefix.length)
-        : msg.content;
+  /// Poll messages render as an interactive vote widget.
+  Widget? _tryBuildPoll(ChatMessage msg) {
+    if (!isPollContent(msg.content)) return null;
+    final parsed = parsePollTag(msg.content);
+    if (parsed == null ||
+        widget.serverUrl == null ||
+        widget.authToken == null) {
+      return null;
+    }
+    return PollWidget(
+      messageId: msg.id,
+      serverUrl: widget.serverUrl!,
+      authToken: widget.authToken!,
+      question: parsed.question,
+      options: parsed.options,
+    );
+  }
 
+  // Forwarded messages: strip the `[Forwarded] ` prefix so the marker
+  // regex inside MediaContent can match. The "Forwarded" badge above the
+  // bubble still signals provenance.
+  Widget _buildMediaBubble({
+    required ChatMessage msg,
+    required bool isMine,
+    required bool isFailed,
+  }) {
+    final mediaContent = _stripForwardedPrefix(msg.content);
+    final mediaWidget = MediaContent(
+      content: mediaContent,
+      isMine: isMine,
+      serverUrl: widget.serverUrl,
+      authToken: widget.authToken,
+      mediaTicket: widget.mediaTicket,
+      onImageTap: widget.onImageTap,
+    );
+    final caption = extractMediaCaption(mediaContent);
+    if (caption == null) return mediaWidget;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        mediaWidget,
+        const SizedBox(height: 4),
+        RichTextContent(
+          text: caption,
+          textColor: _contentTextColor(isMine: isMine, isFailed: isFailed),
+          accentHoverColor: context.accentHover,
+          textSecondaryColor: context.textSecondary,
+          density: widget.density,
+        ),
+      ],
+    );
+  }
+
+  // Sender side: if WE drafted this message and the system preserved the
+  // original text in failedContent, show the user what they wrote (dimmed)
+  // with a Resend/Delete footer rather than the generic "couldn't decrypt"
+  // pill — the pill makes it look like the message was sent by someone
+  // else. F-006 / expert recommendation in the 2026-05-19 UI audit.
+  Widget _buildDecryptFailureBubble({
+    required ChatMessage msg,
+    required bool isMine,
+  }) {
+    if (isMine && (msg.failedContent ?? '').isNotEmpty) {
+      return OwnDecryptFailedBubble(
+        originalText: msg.failedContent!,
+        onResend: widget.onRetry == null ? null : () => widget.onRetry!(msg),
+        onDelete:
+            widget.onDelete == null ? null : () => widget.onDelete!(msg),
+      );
+    }
+    return const DecryptFailurePill();
+  }
+
+  Widget _buildTextBubble({
+    required ChatMessage msg,
+    required bool isMine,
+    required bool isFailed,
+  }) {
+    final displayContent = _stripForwardedPrefix(msg.content);
     final textColor = _contentTextColor(isMine: isMine, isFailed: isFailed);
     final textWidget = RichTextContent(
       text: displayContent,
@@ -867,6 +887,12 @@ class _MessageItemState extends State<MessageItem>
         ],
       ],
     );
+  }
+
+  String _stripForwardedPrefix(String content) {
+    return content.startsWith(_forwardedPrefix)
+        ? content.substring(_forwardedPrefix.length)
+        : content;
   }
 
   /// Assemble the children of the bubble Column.
@@ -1354,52 +1380,27 @@ class _MessageItemState extends State<MessageItem>
       isEncryptedUnreadable: unreadable,
       mediaUrl: mediaUrl,
       isImageMedia: isImage,
-      onReply: widget.onReply == null ? null : () => widget.onReply!(msg),
-      onForward: widget.onForward == null ? null : () => widget.onForward!(msg),
-      onRetry: (msg.status == MessageStatus.failed && widget.onRetry != null)
-          ? () => widget.onRetry!(msg)
-          : null,
-      onCopyText: () {
-        final copyText = mediaUrl != null ? _resolveUrl(mediaUrl) : msg.content;
-        Clipboard.setData(ClipboardData(text: copyText));
-        if (!mounted) return;
-        ToastService.show(
-          context,
-          mediaUrl != null ? 'Link copied' : 'Copied to clipboard',
-          type: ToastType.success,
-        );
-      },
+      onReply: _wrapMsgCallback(widget.onReply, msg),
+      onForward: _wrapMsgCallback(widget.onForward, msg),
+      onRetry: _resolveRetryCallback(msg),
+      onCopyText: () => _copyMessageText(msg, mediaUrl),
       // `isImage` only true when `mediaUrl` is non-null (the predicate
       // guards both), so the analyser promotes `mediaUrl` here.
       onViewGallery: isImage ? () => _handleImageAction(mediaUrl) : null,
-      onPin: (msg.pinnedAt == null && widget.onPin != null)
-          ? () => widget.onPin!(msg)
-          : null,
-      onUnpin: (msg.pinnedAt != null && widget.onUnpin != null)
-          ? () => widget.onUnpin!(msg)
-          : null,
-      onSave: widget.onSave == null ? null : () => widget.onSave!(msg),
-      onUnsave: widget.onUnsave == null ? null : () => widget.onUnsave!(msg),
-      onEdit: widget.onEdit == null ? null : () => widget.onEdit!(msg),
-      onDelete: widget.onDelete == null ? null : () => widget.onDelete!(msg),
-      onCopyId: () {
-        Clipboard.setData(ClipboardData(text: msg.id));
-        if (!mounted) return;
-        ToastService.show(
-          context,
-          'Message ID copied',
-          type: ToastType.success,
-        );
-      },
+      onPin: _resolvePinCallback(msg),
+      onUnpin: _resolveUnpinCallback(msg),
+      onSave: _wrapMsgCallback(widget.onSave, msg),
+      onUnsave: _wrapMsgCallback(widget.onUnsave, msg),
+      onEdit: _wrapMsgCallback(widget.onEdit, msg),
+      onDelete: _wrapMsgCallback(widget.onDelete, msg),
+      onCopyId: () => _copyMessageId(msg),
       // Inline reactions header is hidden by the registry when
       // isEncryptedUnreadable; we still wire the callbacks so the
       // registry can decide.
       onPickReaction: widget.onReactionSelect == null
           ? null
           : (emoji) => widget.onReactionSelect!(msg, emoji),
-      onOpenFullPicker: widget.onMoreReactions == null
-          ? null
-          : () => widget.onMoreReactions!(msg),
+      onOpenFullPicker: _wrapMsgCallback(widget.onMoreReactions, msg),
       recentReactions: reactionEmojis.take(4).toList(),
     );
 
@@ -1408,6 +1409,52 @@ class _MessageItemState extends State<MessageItem>
       target: target,
       anchor: anchor,
       model: buildMessageMenu(target),
+    );
+  }
+
+  VoidCallback? _wrapMsgCallback(
+    void Function(ChatMessage)? callback,
+    ChatMessage msg,
+  ) {
+    if (callback == null) return null;
+    return () => callback(msg);
+  }
+
+  VoidCallback? _resolveRetryCallback(ChatMessage msg) {
+    if (msg.status != MessageStatus.failed || widget.onRetry == null) {
+      return null;
+    }
+    return () => widget.onRetry!(msg);
+  }
+
+  VoidCallback? _resolvePinCallback(ChatMessage msg) {
+    if (msg.pinnedAt != null || widget.onPin == null) return null;
+    return () => widget.onPin!(msg);
+  }
+
+  VoidCallback? _resolveUnpinCallback(ChatMessage msg) {
+    if (msg.pinnedAt == null || widget.onUnpin == null) return null;
+    return () => widget.onUnpin!(msg);
+  }
+
+  void _copyMessageText(ChatMessage msg, String? mediaUrl) {
+    final copyText = mediaUrl != null ? _resolveUrl(mediaUrl) : msg.content;
+    Clipboard.setData(ClipboardData(text: copyText));
+    if (!mounted) return;
+    ToastService.show(
+      context,
+      mediaUrl != null ? 'Link copied' : 'Copied to clipboard',
+      type: ToastType.success,
+    );
+  }
+
+  void _copyMessageId(ChatMessage msg) {
+    Clipboard.setData(ClipboardData(text: msg.id));
+    if (!mounted) return;
+    ToastService.show(
+      context,
+      'Message ID copied',
+      type: ToastType.success,
     );
   }
 

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -122,19 +122,6 @@ class VoiceDock extends ConsumerWidget {
     final peerCount = voiceLk.peerConnectionStates.length;
     final statusColor = _statusColor(context, voiceLk.isJoining, peerCount);
 
-    if (collapsed) {
-      return _buildCollapsedDock(
-        context,
-        ref,
-        voiceLk,
-        voiceSettings,
-        screenShare,
-        conversationId,
-        channelId,
-        statusColor,
-      );
-    }
-
     final spec = (
       context: context,
       ref: ref,
@@ -145,6 +132,20 @@ class VoiceDock extends ConsumerWidget {
       channelId: channelId,
       m: m,
     );
+
+    if (collapsed) {
+      final compactSpec = (
+        context: context,
+        ref: ref,
+        voiceLk: voiceLk,
+        voiceSettings: voiceSettings,
+        screenShare: screenShare,
+        conversationId: conversationId,
+        channelId: channelId,
+        m: _DockMetrics.compact,
+      );
+      return _buildCollapsedDock(compactSpec, statusColor);
+    }
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onTap: onNavigateToLounge,
@@ -183,17 +184,15 @@ class VoiceDock extends ConsumerWidget {
   }
 
   /// Compact vertical dock for the 60px collapsed sidebar.
-  Widget _buildCollapsedDock(
-    BuildContext context,
-    WidgetRef ref,
-    LiveKitVoiceState voiceLk,
-    VoiceSettingsState voiceSettings,
-    ScreenShareState screenShare,
-    String conversationId,
-    String channelId,
-    Color statusColor,
-  ) {
-    const m = _DockMetrics.compact;
+  Widget _buildCollapsedDock(_DockButtonSpec spec, Color statusColor) {
+    final context = spec.context;
+    final ref = spec.ref;
+    final voiceLk = spec.voiceLk;
+    final voiceSettings = spec.voiceSettings;
+    final screenShare = spec.screenShare;
+    final conversationId = spec.conversationId;
+    final channelId = spec.channelId;
+    final m = spec.m;
     final callStartedAt = voiceLk.callStartedAt;
     return GestureDetector(
       behavior: HitTestBehavior.translucent,

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -72,116 +72,132 @@ class WhatsNewModal extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (!isDialog) ...[
-          // Drag-handle indicator for bottom sheet.
-          const SizedBox(height: 8),
-          Center(
-            child: Container(
-              width: 36,
-              height: 4,
-              decoration: BoxDecoration(
-                color: context.textMuted.withValues(alpha: 0.4),
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
-        ],
+        if (!isDialog) _buildDragHandle(context),
         const SizedBox(height: 16),
-
-        // Title row.
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: Row(
-            children: [
-              Icon(Icons.celebration_outlined, color: context.accent, size: 28),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      "What's New",
-                      style: theme.textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    Text(
-                      'Echo v${notes.version}',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: context.textMuted,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              if (isDialog)
-                IconButton(
-                  icon: const Icon(Icons.close),
-                  color: context.textMuted,
-                  onPressed: () => _dismiss(context, ref),
-                ),
-            ],
-          ),
-        ),
+        _buildTitleRow(context, theme, ref),
         const SizedBox(height: 16),
-
-        // Scrollable markdown body.
-        Flexible(
-          child: Markdown(
-            data: notes.body,
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            shrinkWrap: true,
-            selectable: true,
-            styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
-              p: theme.textTheme.bodyMedium?.copyWith(height: 1.45),
-              h1: theme.textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-              h2: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-              h3: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-              listBullet: theme.textTheme.bodyMedium,
-              code: theme.textTheme.bodySmall?.copyWith(
-                fontFamily: 'monospace',
-                backgroundColor: context.surfaceHover,
-              ),
-              codeblockDecoration: BoxDecoration(
-                color: context.surfaceHover,
-                borderRadius: BorderRadius.circular(6),
-              ),
-              a: theme.textTheme.bodyMedium?.copyWith(
-                color: context.accent,
-                decoration: TextDecoration.underline,
-              ),
-            ),
-            onTapLink: (text, href, title) {
-              if (href != null) {
-                launchUrl(
-                  Uri.parse(href),
-                  mode: LaunchMode.externalApplication,
-                );
-              }
-            },
-          ),
-        ),
+        Flexible(child: _buildMarkdownBody(context, theme)),
         const SizedBox(height: 16),
+        _buildDismissButton(context, ref),
+      ],
+    );
+  }
 
-        // Dismiss button.
-        Padding(
-          padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
-          child: FilledButton(
-            onPressed: () => _dismiss(context, ref),
-            style: FilledButton.styleFrom(
-              backgroundColor: context.accent,
-              minimumSize: const Size.fromHeight(48),
+  // Drag-handle indicator for bottom sheet.
+  Widget _buildDragHandle(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(height: 8),
+        Center(
+          child: Container(
+            width: 36,
+            height: 4,
+            decoration: BoxDecoration(
+              color: context.textMuted.withValues(alpha: 0.4),
+              borderRadius: BorderRadius.circular(2),
             ),
-            child: const Text('Got it'),
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildTitleRow(
+    BuildContext context,
+    ThemeData theme,
+    WidgetRef ref,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        children: [
+          Icon(Icons.celebration_outlined, color: context.accent, size: 28),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  "What's New",
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Text(
+                  'Echo v${notes.version}',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: context.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (isDialog)
+            IconButton(
+              icon: const Icon(Icons.close),
+              color: context.textMuted,
+              onPressed: () => _dismiss(context, ref),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMarkdownBody(BuildContext context, ThemeData theme) {
+    return Markdown(
+      data: notes.body,
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      shrinkWrap: true,
+      selectable: true,
+      styleSheet: _buildMarkdownStyleSheet(context, theme),
+      onTapLink: (text, href, title) {
+        if (href != null) {
+          launchUrl(
+            Uri.parse(href),
+            mode: LaunchMode.externalApplication,
+          );
+        }
+      },
+    );
+  }
+
+  MarkdownStyleSheet _buildMarkdownStyleSheet(
+    BuildContext context,
+    ThemeData theme,
+  ) {
+    return MarkdownStyleSheet.fromTheme(theme).copyWith(
+      p: theme.textTheme.bodyMedium?.copyWith(height: 1.45),
+      h1: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+      h2: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+      h3: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+      listBullet: theme.textTheme.bodyMedium,
+      code: theme.textTheme.bodySmall?.copyWith(
+        fontFamily: 'monospace',
+        backgroundColor: context.surfaceHover,
+      ),
+      codeblockDecoration: BoxDecoration(
+        color: context.surfaceHover,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      a: theme.textTheme.bodyMedium?.copyWith(
+        color: context.accent,
+        decoration: TextDecoration.underline,
+      ),
+    );
+  }
+
+  Widget _buildDismissButton(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
+      child: FilledButton(
+        onPressed: () => _dismiss(context, ref),
+        style: FilledButton.styleFrom(
+          backgroundColor: context.accent,
+          minimumSize: const Size.fromHeight(48),
+        ),
+        child: const Text('Got it'),
+      ),
     );
   }
 

--- a/apps/server/src/db/mentions.rs
+++ b/apps/server/src/db/mentions.rs
@@ -145,6 +145,92 @@ async fn resolve_username_mentions(
     Ok(rows.into_iter().map(|(uid,)| uid).collect())
 }
 
+/// Scan `content` for every mention signal: explicit `@<username>` tokens
+/// plus the two broadcast keywords.  Returns the lowercase username list
+/// and the broadcast flags as a single tuple so the caller can decide
+/// whether any further DB work is required.
+fn scan_mention_signals(content: &str) -> (Vec<String>, bool, bool) {
+    (
+        extract_at_usernames(content),
+        is_standalone_keyword(content, "everyone"),
+        is_standalone_keyword(content, "here"),
+    )
+}
+
+/// #829: defence-in-depth -- verify the sender is a non-removed member of
+/// the conversation before persisting any mention rows. The upstream
+/// `send_message` path already enforces membership, but a future caller
+/// that forgets to gate could otherwise turn `@everyone` into an
+/// unauthenticated broadcast against an arbitrary group.
+async fn sender_is_member(
+    pool: &PgPool,
+    conversation_id: Uuid,
+    sender_id: Uuid,
+) -> Result<bool, sqlx::Error> {
+    let row: (bool,) = sqlx::query_as(
+        "SELECT EXISTS ( \
+             SELECT 1 FROM conversation_members \
+             WHERE conversation_id = $1 \
+               AND user_id = $2 \
+               AND is_removed = false \
+         )",
+    )
+    .bind(conversation_id)
+    .bind(sender_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
+}
+
+/// Resolve the parsed signal set to the de-duplicated, sender-stripped
+/// list of `user_id`s to write to the `mentions` table.  For broadcast
+/// keywords we pull every member; for `@<username>` we pull only matching
+/// members.  Self-mentions are dropped so the sender doesn't bump their
+/// own badge.
+async fn resolve_mention_targets(
+    pool: &PgPool,
+    conversation_id: Uuid,
+    sender_id: Uuid,
+    usernames: &[String],
+    mentions_everyone: bool,
+    mentions_here: bool,
+) -> Result<Vec<Uuid>, sqlx::Error> {
+    let mut targets: Vec<Uuid> = Vec::new();
+
+    if mentions_everyone || mentions_here {
+        targets.extend(resolve_broadcast_members(pool, conversation_id).await?);
+    }
+
+    if !usernames.is_empty() {
+        targets.extend(resolve_username_mentions(pool, conversation_id, usernames).await?);
+    }
+
+    targets.retain(|uid| *uid != sender_id);
+    targets.sort_unstable();
+    targets.dedup();
+    Ok(targets)
+}
+
+/// Bulk-insert one row per target into `mentions` with `ON CONFLICT DO
+/// NOTHING` so a redelivery is a no-op.  Uses `UNNEST` to bind a single
+/// array parameter rather than building a variadic `VALUES` clause.
+async fn insert_mention_rows(
+    pool: &PgPool,
+    message_id: Uuid,
+    targets: &[Uuid],
+) -> Result<usize, sqlx::Error> {
+    let inserted = sqlx::query(
+        "INSERT INTO mentions (message_id, mentioned_user_id) \
+         SELECT $1, uid FROM UNNEST($2::uuid[]) AS t(uid) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(message_id)
+    .bind(targets)
+    .execute(pool)
+    .await?;
+    Ok(inserted.rows_affected() as usize)
+}
+
 /// Insert mention rows for `message_id` in conversation `conv_id`.
 ///
 /// Resolves `@<username>` tokens against the conversation's member list
@@ -162,71 +248,33 @@ pub async fn extract_and_persist(
     sender_id: Uuid,
     content: &str,
 ) -> Result<usize, sqlx::Error> {
-    let usernames = extract_at_usernames(content);
-    let mentions_everyone = is_standalone_keyword(content, "everyone");
-    let mentions_here = is_standalone_keyword(content, "here");
+    let (usernames, mentions_everyone, mentions_here) = scan_mention_signals(content);
 
     if usernames.is_empty() && !mentions_everyone && !mentions_here {
         return Ok(0);
     }
 
-    // #829: defence-in-depth -- verify the sender is a non-removed member of
-    // the conversation before persisting any mention rows. The upstream
-    // `send_message` path already enforces membership, but a future caller
-    // that forgets to gate could otherwise turn `@everyone` into an
-    // unauthenticated broadcast against an arbitrary group. Bail with an
-    // empty result so callers' logging stays quiet on legitimate misses.
-    let is_member: (bool,) = sqlx::query_as(
-        "SELECT EXISTS ( \
-             SELECT 1 FROM conversation_members \
-             WHERE conversation_id = $1 \
-               AND user_id = $2 \
-               AND is_removed = false \
-         )",
-    )
-    .bind(conversation_id)
-    .bind(sender_id)
-    .fetch_one(pool)
-    .await?;
-    if !is_member.0 {
+    // Bail with an empty result so callers' logging stays quiet on
+    // legitimate misses (non-member sender, e.g. removed mid-flight).
+    if !sender_is_member(pool, conversation_id, sender_id).await? {
         return Ok(0);
     }
 
-    // Resolve to user_ids.  For broadcast keywords we pull every member;
-    // for `@<username>` we pull only matching members.
-    let mut targets: Vec<Uuid> = Vec::new();
-
-    if mentions_everyone || mentions_here {
-        targets.extend(resolve_broadcast_members(pool, conversation_id).await?);
-    }
-
-    if !usernames.is_empty() {
-        targets.extend(resolve_username_mentions(pool, conversation_id, &usernames).await?);
-    }
-
-    // Drop the sender (a self-mention should not bump their own badge)
-    // and de-dupe across the broadcast / explicit paths.
-    targets.retain(|uid| *uid != sender_id);
-    targets.sort_unstable();
-    targets.dedup();
+    let targets = resolve_mention_targets(
+        pool,
+        conversation_id,
+        sender_id,
+        &usernames,
+        mentions_everyone,
+        mentions_here,
+    )
+    .await?;
 
     if targets.is_empty() {
         return Ok(0);
     }
 
-    // Build `INSERT ... VALUES (..), (..)` with ON CONFLICT DO NOTHING.
-    // Using UNNEST here lets us bind a single array parameter.
-    let inserted = sqlx::query(
-        "INSERT INTO mentions (message_id, mentioned_user_id) \
-         SELECT $1, uid FROM UNNEST($2::uuid[]) AS t(uid) \
-         ON CONFLICT DO NOTHING",
-    )
-    .bind(message_id)
-    .bind(&targets)
-    .execute(pool)
-    .await?;
-
-    Ok(inserted.rows_affected() as usize)
+    insert_mention_rows(pool, message_id, &targets).await
 }
 
 #[cfg(test)]

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -174,14 +174,15 @@ fn validate_upload_request(body: &UploadGroupKeyRequest) -> Result<(), AppError>
     Ok(())
 }
 
-pub async fn upload_group_key(
-    auth: AuthUser,
-    State(state): State<Arc<AppState>>,
-    Path(group_id): Path<Uuid>,
-    Json(body): Json<UploadGroupKeyRequest>,
-) -> Result<impl IntoResponse, AppError> {
-    // Verify membership and role
-    let role_str = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
+/// Authorise the caller as an admin (or above) of the group. Extracted
+/// from [`upload_group_key`] to keep the handler's cognitive complexity
+/// under the lint threshold.
+async fn require_admin_or_above(
+    state: &AppState,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<(), AppError> {
+    let role_str = db::groups::get_member_role(&state.pool, group_id, user_id)
         .await
         .db_ctx("upload_group_key/get_role")?
         .ok_or_else(|| AppError::unauthorized("Not a member of this group"))?;
@@ -192,21 +193,25 @@ pub async fn upload_group_key(
             "Only admins and owners can upload group keys",
         ));
     }
+    Ok(())
+}
 
-    validate_upload_request(&body)?;
-
-    // Sentinel row + envelopes commit atomically; member-set read inside
-    // the same tx so we see the committed view that matches the writes.
-    let mut tx = state.pool.begin().await.db_ctx("upload_group_key/begin")?;
-
+/// Confirm every envelope's `user_id` is a current member of the group.
+/// Reads the member set inside the caller's transaction so the view
+/// matches the writes that follow.
+async fn ensure_envelopes_target_members(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    group_id: Uuid,
+    envelopes: &[KeyEnvelope],
+) -> Result<(), AppError> {
     let member_ids: std::collections::HashSet<Uuid> =
-        db::groups::get_conversation_member_ids(&mut *tx, group_id)
+        db::groups::get_conversation_member_ids(&mut **tx, group_id)
             .await
             .db_ctx("upload_group_key/members")?
             .into_iter()
             .collect();
 
-    for envelope in &body.envelopes {
+    for envelope in envelopes {
         if !member_ids.contains(&envelope.user_id) {
             return Err(AppError::bad_request(format!(
                 "envelope user_id {} is not a member of this group",
@@ -214,6 +219,36 @@ pub async fn upload_group_key(
             )));
         }
     }
+    Ok(())
+}
+
+/// Map the `store_group_key` DB error to an [`AppError`]. A unique-violation
+/// (`23505`) on the sentinel row maps to 409 Conflict; everything else is
+/// an opaque 500 with the underlying error logged.
+fn map_store_group_key_error(e: sqlx::Error) -> AppError {
+    match &e {
+        sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("23505") => {
+            AppError::conflict("A group key with this version already exists")
+        }
+        _ => {
+            tracing::error!("DB error in upload_group_key/store: {e:?}");
+            AppError::internal("Failed to store group key")
+        }
+    }
+}
+
+/// Write the sentinel row, every per-member envelope, and the audit row
+/// in a single transaction so the rotation lands atomically. Returns the
+/// newly-stored sentinel row for the response payload.
+async fn persist_group_key_and_envelopes(
+    state: &AppState,
+    group_id: Uuid,
+    auth_user_id: Uuid,
+    body: &UploadGroupKeyRequest,
+) -> Result<db::keys::GroupKeyRow, AppError> {
+    let mut tx = state.pool.begin().await.db_ctx("upload_group_key/begin")?;
+
+    ensure_envelopes_target_members(&mut tx, group_id, &body.envelopes).await?;
 
     // Store a sentinel row in group_keys for version tracking (encrypted_key
     // is a placeholder -- the real per-member keys live in group_key_envelopes).
@@ -222,18 +257,10 @@ pub async fn upload_group_key(
         group_id,
         body.key_version,
         "__envelope__",
-        auth.user_id,
+        auth_user_id,
     )
     .await
-    .map_err(|e| match &e {
-        sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("23505") => {
-            AppError::conflict("A group key with this version already exists")
-        }
-        _ => {
-            tracing::error!("DB error in upload_group_key/store: {e:?}");
-            AppError::internal("Failed to store group key")
-        }
-    })?;
+    .map_err(map_store_group_key_error)?;
 
     // Store per-member envelopes inside the same tx. Every envelope at a
     // given key_version shares the same min_wire_version — the constraint
@@ -263,17 +290,26 @@ pub async fn upload_group_key(
     db::group_key_rotations::insert_completed_rotation(
         &mut *tx,
         group_id,
-        auth.user_id,
+        auth_user_id,
         &body.triggered_by_event,
         body.key_version,
-        auth.user_id,
+        auth_user_id,
     )
     .await
     .db_ctx("upload_group_key/audit")?;
 
     tx.commit().await.db_ctx("upload_group_key/commit")?;
+    Ok(row)
+}
 
-    // Broadcast key_rotated event to all group members
+/// Broadcast a `group_key_rotated` event to every member of the group and
+/// also echo it back to the uploader so their client caches the new version.
+async fn broadcast_key_rotated(
+    state: &AppState,
+    group_id: Uuid,
+    auth_user_id: Uuid,
+    key_version: i32,
+) {
     let member_ids = db::groups::get_conversation_member_ids(&state.pool, group_id)
         .await
         .unwrap_or_default();
@@ -281,19 +317,33 @@ pub async fn upload_group_key(
     let event = serde_json::json!({
         "type": "group_key_rotated",
         "conversation_id": group_id,
-        "key_version": row.key_version,
-        "created_by": auth.user_id,
+        "key_version": key_version,
+        "created_by": auth_user_id,
     });
     if let Ok(json) = serde_json::to_string(&event) {
         use axum::extract::ws::Message as WsMessage;
         state
             .hub
-            .broadcast_json(&member_ids, &json, Some(auth.user_id));
+            .broadcast_json(&member_ids, &json, Some(auth_user_id));
         // Also notify the uploader so their client caches the new version
         state
             .hub
-            .send_to(&auth.user_id, WsMessage::Text(json.into()));
+            .send_to(&auth_user_id, WsMessage::Text(json.into()));
     }
+}
+
+pub async fn upload_group_key(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(group_id): Path<Uuid>,
+    Json(body): Json<UploadGroupKeyRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    require_admin_or_above(&state, group_id, auth.user_id).await?;
+    validate_upload_request(&body)?;
+
+    let row = persist_group_key_and_envelopes(&state, group_id, auth.user_id, &body).await?;
+
+    broadcast_key_rotated(&state, group_id, auth.user_id, row.key_version).await;
 
     Ok((StatusCode::CREATED, Json(GroupKeyResponse::from_row(row))))
 }


### PR DESCRIPTION
Sweep of the 19 HIGH + 19 MEDIUM + 3 LOW open SonarCloud findings.
Split across four parallel agent worktrees by file ownership so they
didn't race on the same files, then merged into one branch.

## What changed

### High-complexity refactors (S3776, cognitive complexity ≤ 15)
Behaviour-preserving extraction of long methods into well-named
private helpers. No user-visible change, no behaviour change — just
each method now reads top-to-bottom instead of hiding logic five
levels deep.

- `splash_screen.dart` — `_UpdatePromptBody.build` (30→<15)
- `chat_input_bar.dart` — `_onKeyEvent` (19→<15)
- `chat_input_bar/file_pickers.dart` — `_pickAndDispatch` (16→<15)
- `message_item.dart` — `_buildBubbleContent` and `_openContextMenu`
  (24+24→<15)
- `conversation_panel.dart` — `_buildConversationTarget` (26→<15)
- `group_info_screen.dart` — `_openMemberContextMenu` (21→<15)
- `whats_new_modal.dart` — `_buildContent` (16→<15)
- `reply_count_badge.dart` — `build` (16→<15)
- `websocket_provider.dart` — `sendGroupMessage` (23→<15)
- **Server (Rust)**: `group_keys.rs::upload_group_key` (18→~4) and
  `mentions.rs::extract_and_persist` (20→~5)

### Too-many-parameters refactors (S107)
- `voice_dock.dart::_buildCollapsedDock` 8→2 params via existing
  `_DockButtonSpec` record.
- `chat_panel/history_loaders.dart::jumpToReplyQuote` 9→1 params via
  new `JumpToReplyQuoteParams` data class.

Three other S107 findings (`auth_provider.copyWith`,
`livekit_voice_provider.copyWith`, `upload_client.uploadFile`) are
kept with explanatory rationale comments — converting `copyWith` to
a param object would be a strict downgrade across dozens of call
sites, and `uploadFile`'s callers live in files owned by other
in-flight workstreams.

### Deferred (3)
- `crypto_provider.dart` and `group_crypto_service.dart` — these
  refactor through live encryption-orchestration code; we don't
  touch them without a dedicated crypto review.
- `chat_message.dart::fromJson` — wire-format deserializer; a
  misstep here corrupts every cached message on disk.

### Stale on SonarCloud (≈27)
The agents discovered that many findings were already fixed by
earlier commits (the medium/low sweep in #1020 and the channel-rail
PR in #1025) but SonarCloud hadn't re-scanned. Those will clear
automatically on the next scan; no code changes needed in this PR.

## Verification
- `flutter analyze .` from `apps/client` → No issues found
- `flutter test` → 1896/1896 passed
- `cargo clippy -p echo-server -- -D warnings` → clean
- `cargo test -p echo-server --lib` → 163/163 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)