### PR TITLE
Release: dart format hotfix

### DIFF
--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -734,9 +734,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       'No usable group key for $conversationId — owner self-heal',
       'WebSocket',
     );
-    await ref
-        .read(cryptoProvider.notifier)
-        .seedInitialGroupKey(conversationId);
+    await ref.read(cryptoProvider.notifier).seedInitialGroupKey(conversationId);
     keyResult = await groupCrypto.getGroupKey(conversationId);
     // TD-5: if seedInitialGroupKey lost a 409 race the local
     // cache may still be empty even though the server now has

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -1167,8 +1167,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     required bool isMe,
   }) {
     final isBlocked = _isMemberBlocked(member.userId);
-    final canModerate =
-        viewerIsAdminOrOwner && !isMe && role != 'owner';
+    final canModerate = viewerIsAdminOrOwner && !isMe && role != 'owner';
 
     final target = MemberTarget(
       userId: member.userId,
@@ -1181,14 +1180,10 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
       onUnblock: (isMe || !isBlocked)
           ? null
           : () => _unblockMember(member.userId),
-      onCopyUsername: () => _copyToClipboardWithToast(
-        member.username,
-        'Username copied',
-      ),
-      onCopyUserId: () => _copyToClipboardWithToast(
-        member.userId,
-        'User ID copied',
-      ),
+      onCopyUsername: () =>
+          _copyToClipboardWithToast(member.username, 'Username copied'),
+      onCopyUserId: () =>
+          _copyToClipboardWithToast(member.userId, 'User ID copied'),
       onKick: canModerate ? () => _kickMember(member) : null,
       onBan: canModerate ? () => _banMember(member) : null,
     );

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -669,8 +669,7 @@ class _UpdatePromptBody extends ConsumerWidget {
     return SizedBox(
       width: compact ? 220 : 280,
       child: FilledButton(
-        onPressed: () =>
-            ref.read(updateProvider.notifier).downloadUpdate(),
+        onPressed: () => ref.read(updateProvider.notifier).downloadUpdate(),
         style: FilledButton.styleFrom(
           backgroundColor: accent,
           minimumSize: const Size(double.infinity, 40),

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -86,8 +86,7 @@ class _ChannelColumnState extends ConsumerState<ChannelColumn> {
       ),
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onSecondaryTapUp: (details) =>
-            _showCreateMenu(details.globalPosition),
+        onSecondaryTapUp: (details) => _showCreateMenu(details.globalPosition),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -172,8 +171,7 @@ class _ChannelColumnState extends ConsumerState<ChannelColumn> {
                       .setWidth(committed);
                 }
               },
-              onHorizontalDragCancel: () =>
-                  setState(() => _dragWidth = null),
+              onHorizontalDragCancel: () => setState(() => _dragWidth = null),
               child: const SizedBox.expand(),
             ),
           ),
@@ -280,9 +278,7 @@ class _ChannelColumnState extends ConsumerState<ChannelColumn> {
 
   Future<String?> _promptChannelName(String kind) {
     final controller = TextEditingController();
-    final title = kind == 'voice'
-        ? 'New voice channel'
-        : 'New text channel';
+    final title = kind == 'voice' ? 'New voice channel' : 'New text channel';
     final hint = kind == 'voice' ? 'lounge' : 'general';
     return showDialog<String>(
       context: context,
@@ -428,11 +424,7 @@ class _CategoryHeader extends StatelessWidget {
                   onTap: onCreate,
                   child: Padding(
                     padding: const EdgeInsets.all(2),
-                    child: Icon(
-                      Icons.add,
-                      size: 14,
-                      color: context.textMuted,
-                    ),
+                    child: Icon(Icons.add, size: 14, color: context.textMuted),
                   ),
                 ),
             ],

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -213,8 +213,9 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       onMarkAsUnread: null,
       onToggleMute: () => _toggleMute(conv.id),
       onTogglePin: () => _togglePin(conv.id),
-      onOpenInfo:
-          conv.isGroup ? () => context.go('/group-info/${conv.id}') : null,
+      onOpenInfo: conv.isGroup
+          ? () => context.go('/group-info/${conv.id}')
+          : null,
       // Invite-people / encryption-activity link out to existing
       // routes today; centralising the entry points is enough for v1.
       onInvitePeople: canInviteOrManage
@@ -223,7 +224,11 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
       onOpenEncryptionActivity: canInviteOrManage
           ? () => context.go('/group-info/${conv.id}')
           : null,
-      onViewSafetyNumber: _resolveSafetyNumberCallback(conv, myMember, myUserId),
+      onViewSafetyNumber: _resolveSafetyNumberCallback(
+        conv,
+        myMember,
+        myUserId,
+      ),
       onCopyId: () => _copyConversationId(conv.id),
       onLeave: canLeave ? () => _leaveGroup(conv) : null,
       onDelete: _resolveDeleteCallback(conv, canDeleteGroup),
@@ -235,7 +240,8 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   // entirely rather than render it disabled.
   bool _resolveCanLeave(Conversation conv, String myRole, String myUserId) {
     if (!conv.isGroup) return false;
-    final ownerWithMembers = myRole == 'owner' &&
+    final ownerWithMembers =
+        myRole == 'owner' &&
         conv.members.where((m) => m.userId != myUserId).isNotEmpty;
     return !ownerWithMembers;
   }
@@ -266,9 +272,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   ) {
     if (conv.isGroup || myMember == null) return null;
     return () {
-      final peer = conv.members
-          .where((m) => m.userId != myUserId)
-          .firstOrNull;
+      final peer = conv.members.where((m) => m.userId != myUserId).firstOrNull;
       if (peer != null) {
         context.go('/safety-number/${peer.userId}');
       }

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -838,8 +838,7 @@ class _MessageItemState extends State<MessageItem>
       return OwnDecryptFailedBubble(
         originalText: msg.failedContent!,
         onResend: widget.onRetry == null ? null : () => widget.onRetry!(msg),
-        onDelete:
-            widget.onDelete == null ? null : () => widget.onDelete!(msg),
+        onDelete: widget.onDelete == null ? null : () => widget.onDelete!(msg),
       );
     }
     return const DecryptFailurePill();
@@ -1451,11 +1450,7 @@ class _MessageItemState extends State<MessageItem>
   void _copyMessageId(ChatMessage msg) {
     Clipboard.setData(ClipboardData(text: msg.id));
     if (!mounted) return;
-    ToastService.show(
-      context,
-      'Message ID copied',
-      type: ToastType.success,
-    );
+    ToastService.show(context, 'Message ID copied', type: ToastType.success);
   }
 
   /// Compose a single composite semantic label for the message bubble so

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -103,11 +103,7 @@ class WhatsNewModal extends ConsumerWidget {
     );
   }
 
-  Widget _buildTitleRow(
-    BuildContext context,
-    ThemeData theme,
-    WidgetRef ref,
-  ) {
+  Widget _buildTitleRow(BuildContext context, ThemeData theme, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Row(
@@ -153,10 +149,7 @@ class WhatsNewModal extends ConsumerWidget {
       styleSheet: _buildMarkdownStyleSheet(context, theme),
       onTapLink: (text, href, title) {
         if (href != null) {
-          launchUrl(
-            Uri.parse(href),
-            mode: LaunchMode.externalApplication,
-          );
+          launchUrl(Uri.parse(href), mode: LaunchMode.externalApplication);
         }
       },
     );


### PR DESCRIPTION
Restores the format check broken by #1028 (lefthook didn't run inside the agent worktrees, so seven files made it through without `dart format`). No logic changes.