### PR TITLE
Show DMs in the mobile drawer rail, not just groups

### DIFF
--- a/apps/client/lib/src/widgets/mobile_channel_drawer.dart
+++ b/apps/client/lib/src/widgets/mobile_channel_drawer.dart
@@ -7,17 +7,21 @@
 /// the channel list in over the chat, and tapping a channel closes the
 /// drawer and switches the chat focus to that channel.
 ///
-/// A 56-wide group rail on the far left mirrors Discord's "server bar"
-/// so users can also hop to another group without leaving the drawer.
+/// The 56-wide rail on the far left mirrors the Chats tab — every
+/// conversation (groups *and* 1:1 DMs) gets a circular avatar so
+/// users can hop sideways without leaving the drawer. Groups show a
+/// group-colour avatar; DMs show the peer's avatar.
 library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/conversation.dart';
-import '../providers/conversations_provider.dart';
+import '../providers/auth_provider.dart';
+import '../providers/conversation_filter_provider.dart';
+import '../providers/server_url_provider.dart';
 import '../theme/echo_theme.dart';
-import 'avatar_utils.dart' show buildAvatar, groupAvatarColor;
+import 'avatar_utils.dart' show buildAvatar, groupAvatarColor, resolveAvatarUrl;
 import 'channel_column.dart';
 
 class MobileChannelDrawer extends ConsumerWidget {
@@ -27,10 +31,10 @@ class MobileChannelDrawer extends ConsumerWidget {
   final ValueChanged<String> onConversationSelected;
   final VoidCallback? onShowLounge;
 
-  /// Total drawer width on a phone: 56-wide group rail + 232-wide
-  /// channel column = 288. Stays under the 304 default that Flutter's
-  /// `Drawer` uses, so the swipe behaviour and Material defaults
-  /// continue to work without overrides.
+  /// Total drawer width on a phone: 56-wide rail + 232-wide channel
+  /// column = 288. Stays under the 304 default that Flutter's `Drawer`
+  /// uses, so the swipe behaviour and Material defaults continue to
+  /// work without overrides.
   static const double railWidth = 56;
   static const double drawerWidth = railWidth + ChannelColumn.width - 28;
 
@@ -45,20 +49,22 @@ class MobileChannelDrawer extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final convs = ref
-        .watch(conversationsProvider)
-        .conversations
-        .where((c) => c.isGroup)
-        .toList();
+    // Same sort/filter the home Chats tab uses, so the rail visibly
+    // matches what the user just saw before opening this conversation.
+    final convs = ref.watch(sortedConversationsProvider);
+    final myUserId = ref.watch(authProvider.select((s) => s.userId)) ?? '';
+    final serverUrl = ref.watch(serverUrlProvider);
     return Drawer(
       width: drawerWidth,
       backgroundColor: context.sidebarBg,
       child: SafeArea(
         child: Row(
           children: [
-            _GroupRail(
-              groups: convs,
+            _ConversationRail(
+              conversations: convs,
               activeId: conversation.id,
+              myUserId: myUserId,
+              serverUrl: serverUrl,
               onSelect: (id) {
                 onConversationSelected(id);
                 Navigator.of(context).maybePop();
@@ -85,14 +91,18 @@ class MobileChannelDrawer extends ConsumerWidget {
   }
 }
 
-class _GroupRail extends StatelessWidget {
-  final List<Conversation> groups;
+class _ConversationRail extends StatelessWidget {
+  final List<Conversation> conversations;
   final String activeId;
+  final String myUserId;
+  final String serverUrl;
   final ValueChanged<String> onSelect;
 
-  const _GroupRail({
-    required this.groups,
+  const _ConversationRail({
+    required this.conversations,
     required this.activeId,
+    required this.myUserId,
+    required this.serverUrl,
     required this.onSelect,
   });
 
@@ -106,11 +116,13 @@ class _GroupRail extends StatelessWidget {
       ),
       child: ListView.builder(
         padding: const EdgeInsets.symmetric(vertical: 8),
-        itemCount: groups.length,
+        itemCount: conversations.length,
         itemBuilder: (_, i) {
-          final g = groups[i];
-          final active = g.id == activeId;
-          final name = g.displayName('');
+          final c = conversations[i];
+          final active = c.id == activeId;
+          final name = c.displayName(myUserId);
+          final avatar = _avatarFor(c, name);
+          final semanticsPrefix = c.isGroup ? 'group' : 'chat with';
           return Padding(
             padding: const EdgeInsets.symmetric(vertical: 4),
             child: Stack(
@@ -133,22 +145,19 @@ class _GroupRail extends StatelessWidget {
                   ),
                 Center(
                   child: Semantics(
-                    label: 'group ${name.isEmpty ? "unnamed" : name}',
+                    container: true,
+                    label:
+                        '$semanticsPrefix ${name.isEmpty ? "unnamed" : name}',
                     button: true,
                     selected: active,
                     child: InkResponse(
-                      onTap: () => onSelect(g.id),
+                      onTap: () => onSelect(c.id),
                       radius: 24,
-                      child: buildAvatar(
-                        name: name,
-                        radius: 20,
-                        bgColor: groupAvatarColor(g.id),
-                        fallbackIcon: const Icon(
-                          Icons.group,
-                          size: 18,
-                          color: Colors.white,
-                        ),
-                      ),
+                      // Avatars without an image fall back to a single
+                      // initial letter; without this exclude, that letter
+                      // gets merged into the row's accessibility label
+                      // (e.g. "chat with jake J").
+                      child: ExcludeSemantics(child: avatar),
                     ),
                   ),
                 ),
@@ -157,6 +166,24 @@ class _GroupRail extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+
+  Widget _avatarFor(Conversation c, String displayName) {
+    if (c.isGroup) {
+      return buildAvatar(
+        name: displayName,
+        radius: 20,
+        imageUrl: resolveAvatarUrl(c.iconUrl, serverUrl),
+        bgColor: groupAvatarColor(c.id),
+        fallbackIcon: const Icon(Icons.group, size: 18, color: Colors.white),
+      );
+    }
+    final peer = c.members.where((m) => m.userId != myUserId).firstOrNull;
+    return buildAvatar(
+      name: displayName,
+      radius: 20,
+      imageUrl: resolveAvatarUrl(peer?.avatarUrl, serverUrl),
     );
   }
 }

--- a/apps/client/test/widgets/mobile_channel_drawer_test.dart
+++ b/apps/client/test/widgets/mobile_channel_drawer_test.dart
@@ -1,5 +1,6 @@
 import 'package:echo_app/src/models/channel.dart';
 import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/providers/auth_provider.dart';
 import 'package:echo_app/src/providers/channels_provider.dart';
 import 'package:echo_app/src/providers/conversations_provider.dart';
 import 'package:echo_app/src/widgets/mobile_channel_drawer.dart';
@@ -22,6 +23,16 @@ void main() {
     isGroup: true,
     name: name,
     members: const [ConversationMember(userId: 'me', username: 'me')],
+  );
+
+  Conversation dm(String id, String peerName) => Conversation(
+    id: id,
+    isGroup: false,
+    name: peerName,
+    members: [
+      const ConversationMember(userId: 'me', username: 'me'),
+      ConversationMember(userId: '${id}-peer', username: peerName),
+    ],
   );
 
   GroupChannel text(String id, String name, {int pos = 0}) => GroupChannel(
@@ -47,6 +58,13 @@ void main() {
       conversationsProvider.overrideWith(
         () => _StubConversations(ConversationsState(conversations: convs)),
       );
+
+  // Pins authProvider.userId so `Conversation.displayName(myUserId)`
+  // can identify the peer in 1:1 DMs (otherwise an empty userId picks
+  // the wrong member and the rail labels render as the self user).
+  Override authOverride = authProvider.overrideWith(
+    () => _StubAuth(const AuthState(userId: 'me', username: 'me')),
+  );
 
   Future<void> openDrawer(WidgetTester tester) async {
     // `pumpApp` already wraps in an outer Scaffold(body: widget); the
@@ -82,6 +100,7 @@ void main() {
           onDrawerChanged: (open) => drawerOpen = open,
         ),
         overrides: [
+          authOverride,
           channelsOverride({
             'c1': [text('t1', 'general'), text('t2', 'releases', pos: 1)],
           }),
@@ -111,6 +130,7 @@ void main() {
           ),
         ),
         overrides: [
+          authOverride,
           channelsOverride({
             'c1': [text('t1', 'general')],
           }),
@@ -127,6 +147,33 @@ void main() {
       await tester.tap(find.bySemanticsLabel('group Taco Lovers'));
       await tester.pumpAndSettle();
       expect(switched, 'c2');
+    });
+
+    testWidgets('rail lists 1:1 DMs alongside groups', (tester) async {
+      String? switched;
+      await tester.pumpApp(
+        Scaffold(
+          drawer: MobileChannelDrawer(
+            conversation: conv('c1', 'Echo Devs'),
+            selectedTextChannelId: null,
+            onTextChannelChanged: (_) {},
+            onConversationSelected: (id) => switched = id,
+          ),
+        ),
+        overrides: [
+          authOverride,
+          channelsOverride({
+            'c1': [text('t1', 'general')],
+          }),
+          conversationsOverride([conv('c1', 'Echo Devs'), dm('d1', 'jake')]),
+        ],
+      );
+      await openDrawer(tester);
+      expect(find.bySemanticsLabel('group Echo Devs'), findsOneWidget);
+      expect(find.bySemanticsLabel('chat with jake'), findsOneWidget);
+      await tester.tap(find.bySemanticsLabel('chat with jake'));
+      await tester.pumpAndSettle();
+      expect(switched, 'd1');
     });
   });
 }
@@ -145,4 +192,12 @@ class _StubConversations extends ConversationsNotifier {
 
   @override
   ConversationsState build() => _initial;
+}
+
+class _StubAuth extends AuthNotifier {
+  _StubAuth(this._initial);
+  final AuthState _initial;
+
+  @override
+  AuthState build() => _initial;
 }


### PR DESCRIPTION
The Discord-style drawer the channel rail opens on mobile filtered
its left-side conversation rail by \`isGroup\`. If you had a single
group and a single DM on the home screen, the rail only showed the
group — the DM disappeared from the drawer entirely. The rail is
supposed to mirror the Chats tab.

## Fixed
- Rail now reads from \`sortedConversationsProvider\` (the same data
  the Chats tab uses, with the same sort: pinned first, then by
  last-message timestamp).
- Groups still get a group-colour avatar; DMs get the peer's avatar
  with an initials fallback when there's no image.
- Tapping either kind switches the active conversation and closes
  the drawer — unchanged behaviour, now reachable for DMs too.

## Behind the scenes
- Wrapped the rail avatars in \`ExcludeSemantics\` so the initial
  letter inside an initials-only avatar doesn't get merged into the
  row's accessibility label (was leaking as 'chat with jake J').
- New widget test covers the DM-in-rail path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)