### PR TITLE
Log iOS uncaught exceptions to Console for symbolication

### DIFF
--- a/apps/client/ios/Runner/AppDelegate.swift
+++ b/apps/client/ios/Runner/AppDelegate.swift
@@ -15,6 +15,27 @@ import UserNotifications
   ) -> Bool {
     NSLog("[Echo] didFinishLaunching start")
 
+    // Install a global handler so any Objective-C exception that
+    // escapes Swift (e.g. unrecognized-selector crashes inside a
+    // dispatched block, like the iOS 26 voice/video crash we saw on
+    // TestFlight build 546) logs its selector, receiver class, and
+    // symbolicated call stack to Console.app before the process
+    // aborts. Stripped binary offsets in the .ips crash report aren't
+    // actionable without the dSYM; the human-readable lines this
+    // writes are.
+    NSSetUncaughtExceptionHandler { exception in
+      let name = exception.name.rawValue
+      let reason = exception.reason ?? "(no reason)"
+      NSLog("[Echo] UNCAUGHT EXCEPTION: %@ — %@", name, reason)
+      let userInfo = exception.userInfo ?? [:]
+      if !userInfo.isEmpty {
+        NSLog("[Echo] EXCEPTION userInfo: %@", userInfo as NSDictionary)
+      }
+      for line in exception.callStackSymbols {
+        NSLog("[Echo] EXCEPTION stack: %@", line)
+      }
+    }
+
     // Set up push notification delegate
     UNUserNotificationCenter.current().delegate = self
 


### PR DESCRIPTION
The iOS voice/video crash report from TestFlight build 546 tripped
\`NSException\` + \`abort()\` with this signature:

\`\`\`
-[__NSDictionaryM isEqualToString:]: unrecognized selector
  sent to instance 0x123fd7d60
\`\`\`

Some code expected an \`NSString\` and got an \`NSMutableDictionary\`.
The .ips report only carries stripped binary offsets
(\`imageOffset:1426676 in image 0\`), and without the dSYM I can't
pinpoint the exact symbol.

## What this PR does
Installs \`NSSetUncaughtExceptionHandler\` in \`AppDelegate.didFinishLaunching\`.
Before \`abort()\` fires, the closure writes the exception name,
reason, userInfo, and symbolicated \`callStackSymbols\` to NSLog —
which surfaces in Console.app / the device log.

## What this PR does NOT do
It does **not** fix the underlying crash. It only ensures the next
repro produces an actionable diagnostic. Once the user hits the
crash again with this build installed, the device log will tell us
which framework symbol is calling \`isEqualToString:\` on a dict, and
the real fix can land in a follow-up PR.

## Why this approach
Without symbolicating the current \`.ips\` (which would need the
TestFlight dSYM that Apple holds), every line of code that does
dispatch + dict access is a plausible suspect — the Runner Swift is
short and type-safe (\`as?\` casts everywhere, no \`isEqualToString\`),
which means the bad cast lives in statically-linked third-party
code inside the main binary. Pre-emptively rewriting half the iOS
host on a guess would be churn without certainty. Diagnostic-first,
then targeted fix.