### PR TITLE
Release: unified UserAvatar component

### DIFF
--- a/apps/client/lib/src/widgets/contact_item.dart
+++ b/apps/client/lib/src/widgets/contact_item.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../models/contact.dart';
 import '../theme/echo_theme.dart';
-import 'avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import 'user_avatar.dart';
 
 class ContactItem extends StatefulWidget {
   final Contact contact;
@@ -32,8 +32,6 @@ class _ContactItemState extends State<ContactItem> {
     final contact = widget.contact;
     final username = contact.username;
     final displayName = contact.displayName;
-    final fullAvatarUrl = resolveAvatarUrl(contact.avatarUrl, widget.serverUrl);
-    final isOnline = widget.onlineUsers.contains(contact.userId);
 
     return Material(
       type: MaterialType.transparency,
@@ -56,33 +54,14 @@ class _ContactItemState extends State<ContactItem> {
                   label: 'contact: $username',
                   child: Row(
                     children: [
-                      // Avatar with online dot
-                      Stack(
-                        children: [
-                          buildAvatar(
-                            name: username,
-                            radius: 18,
-                            imageUrl: fullAvatarUrl,
-                          ),
-                          Positioned(
-                            bottom: 0,
-                            right: 0,
-                            child: Container(
-                              width: 10,
-                              height: 10,
-                              decoration: BoxDecoration(
-                                color: isOnline
-                                    ? EchoTheme.online
-                                    : context.textMuted,
-                                shape: BoxShape.circle,
-                                border: Border.all(
-                                  color: context.sidebarBg,
-                                  width: 2,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
+                      // Row InkWell already calls onProfile on tap.
+                      UserAvatar(
+                        userId: contact.userId,
+                        username: username,
+                        avatarUrl: contact.avatarUrl,
+                        radius: 18,
+                        showPresence: true,
+                        openProfileOnTap: false,
                       ),
                       const SizedBox(width: 12),
                       // Name

--- a/apps/client/lib/src/widgets/group_members_sheet.dart
+++ b/apps/client/lib/src/widgets/group_members_sheet.dart
@@ -12,12 +12,10 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../models/conversation.dart';
 import '../providers/auth_provider.dart';
-import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../theme/echo_theme.dart';
-import 'avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
-import 'conversation_item.dart' show presenceStatusDotColor;
+import 'user_avatar.dart';
 
 /// Shows the [GroupMembersSheet] as a modal bottom sheet.
 ///
@@ -232,8 +230,6 @@ class _MobilesMemberRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final serverUrl = ref.watch(serverUrlProvider);
-
     return Semantics(
       label: 'member: ${member.username}',
       button: true,
@@ -246,32 +242,15 @@ class _MobilesMemberRow extends ConsumerWidget {
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
           child: Row(
             children: [
-              // Avatar with presence dot overlay
-              Stack(
-                children: [
-                  buildAvatar(
-                    name: member.username,
-                    radius: 18,
-                    imageUrl: resolveAvatarUrl(member.avatarUrl, serverUrl),
-                  ),
-                  Positioned(
-                    bottom: 0,
-                    right: 0,
-                    child: Container(
-                      width: 11,
-                      height: 11,
-                      decoration: BoxDecoration(
-                        color: presenceStatusDotColor(
-                          context,
-                          presenceStatus,
-                          isOnline,
-                        ),
-                        shape: BoxShape.circle,
-                        border: Border.all(color: context.surface, width: 2),
-                      ),
-                    ),
-                  ),
-                ],
+              // Outer InkWell already pops + opens profile, so the avatar
+              // itself shouldn't fight that tap target.
+              UserAvatar(
+                userId: member.userId,
+                username: member.username,
+                avatarUrl: member.avatarUrl,
+                radius: 18,
+                showPresence: true,
+                openProfileOnTap: false,
               ),
               const SizedBox(width: 14),
               // Name + role badge

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -10,8 +10,7 @@ import '../providers/websocket_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
-import 'avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
-import 'conversation_item.dart' show presenceStatusDotColor;
+import 'user_avatar.dart';
 
 class MembersPanel extends ConsumerWidget {
   final Conversation? conversation;
@@ -376,39 +375,15 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Row(
               children: [
-                // Avatar with presence dot overlaid (matches conversation list
-                // pattern in conversation_item.dart — #403).
-                Stack(
-                  children: [
-                    buildAvatar(
-                      name: member.username,
-                      radius: 14,
-                      imageUrl: resolveAvatarUrl(
-                        member.avatarUrl,
-                        ref.watch(serverUrlProvider),
-                      ),
-                    ),
-                    Positioned(
-                      bottom: 0,
-                      right: 0,
-                      child: Container(
-                        width: 10,
-                        height: 10,
-                        decoration: BoxDecoration(
-                          color: presenceStatusDotColor(
-                            context,
-                            widget.presenceStatus,
-                            widget.isOnline,
-                          ),
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: context.sidebarBg,
-                            width: 2,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
+                // The row-level GestureDetector handles the tap; the
+                // avatar widget renders chrome only.
+                UserAvatar(
+                  userId: member.userId,
+                  username: member.username,
+                  avatarUrl: member.avatarUrl,
+                  radius: 14,
+                  showPresence: true,
+                  openProfileOnTap: false,
                 ),
                 const SizedBox(width: 12),
                 // Username + role icon + activity line (slice 7).

--- a/apps/client/lib/src/widgets/user_avatar.dart
+++ b/apps/client/lib/src/widgets/user_avatar.dart
@@ -1,0 +1,143 @@
+/// One avatar, one tap behaviour, one place to render the presence dot.
+///
+/// Before this widget, the same `Stack(avatar, Positioned(dot))` pattern
+/// was inlined in `members_panel.dart`, `group_members_sheet.dart`,
+/// `message_item.dart` and a handful of other surfaces — each version
+/// drifted slightly (dot size, border colour, tap target, what tapping
+/// actually does). `UserAvatar` collapses those copies into one widget:
+///
+///   • Always resolves `avatarUrl` against `serverUrlProvider`.
+///   • Tapping the avatar opens [UserProfileScreen] by default — set
+///     `openProfileOnTap: false` to opt out, or pass `onTap` to override.
+///   • `showPresence: true` overlays a coloured status dot driven by
+///     `websocketProvider`. Dot colour comes from the same
+///     [presenceStatusDotColor] helper conversation rows already use, so
+///     the colour stays consistent across every surface.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/server_url_provider.dart';
+import '../providers/websocket_provider.dart';
+import '../screens/user_profile_screen.dart';
+import '../theme/echo_theme.dart';
+import 'avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import 'conversation_item.dart' show presenceStatusDotColor;
+
+class UserAvatar extends ConsumerWidget {
+  /// The user this avatar represents. Used to (a) resolve the tap → open
+  /// profile and (b) look up the presence status when [showPresence] is on.
+  final String userId;
+
+  /// Display name. Drives the initial-letter fallback and the screen-
+  /// reader label.
+  final String username;
+
+  /// Optional relative or absolute avatar path. Relative paths are
+  /// resolved against the current `serverUrlProvider`.
+  final String? avatarUrl;
+
+  /// Half-size of the avatar circle. Default 16 matches the in-chat
+  /// sender avatar; member panels typically use 18–20.
+  final double radius;
+
+  /// Overlay a coloured presence dot. Off by default — most surfaces in
+  /// chat hide the dot, member listings turn it on.
+  final bool showPresence;
+
+  /// Whether tapping opens [UserProfileScreen]. Default true. Pass false
+  /// for read-only contexts (mention picker hover thumbnails, etc.).
+  final bool openProfileOnTap;
+
+  /// Override the default tap. When non-null this fully replaces the
+  /// "open profile" behaviour. Use sparingly — the whole point of this
+  /// widget is to make taps consistent.
+  final VoidCallback? onTap;
+
+  /// Optional long-press handler. Surfaces that want a context menu
+  /// (right-click on desktop, long-press on mobile) wire this.
+  final VoidCallback? onLongPress;
+
+  /// Override the fallback background colour. Defaults to the
+  /// per-username colour from `avatarColor(name)`.
+  final Color? bgColor;
+
+  /// Override the initial-letter fallback (e.g. show a group icon).
+  final Widget? fallbackIcon;
+
+  const UserAvatar({
+    super.key,
+    required this.userId,
+    required this.username,
+    this.avatarUrl,
+    this.radius = 16,
+    this.showPresence = false,
+    this.openProfileOnTap = true,
+    this.onTap,
+    this.onLongPress,
+    this.bgColor,
+    this.fallbackIcon,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final serverUrl = ref.watch(serverUrlProvider);
+    final resolvedUrl = resolveAvatarUrl(avatarUrl, serverUrl);
+
+    Widget avatar = buildAvatar(
+      name: username,
+      radius: radius,
+      imageUrl: resolvedUrl,
+      bgColor: bgColor,
+      fallbackIcon: fallbackIcon,
+    );
+
+    if (showPresence) {
+      final ws = ref.watch(websocketProvider);
+      final status = ws.presenceStatusFor(userId);
+      final isOnline = ws.onlineUsers.contains(userId);
+      final dotSize = (radius * 0.55).clamp(8.0, 14.0).toDouble();
+      avatar = Stack(
+        clipBehavior: Clip.none,
+        children: [
+          avatar,
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: Container(
+              width: dotSize,
+              height: dotSize,
+              decoration: BoxDecoration(
+                color: presenceStatusDotColor(context, status, isOnline),
+                shape: BoxShape.circle,
+                border: Border.all(color: EchoTheme.sidebarBg, width: 1.5),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    final effectiveTap =
+        onTap ?? (openProfileOnTap ? () => _openProfile(context, ref) : null);
+
+    if (effectiveTap == null && onLongPress == null) return avatar;
+
+    return Semantics(
+      container: true,
+      label: 'open $username profile',
+      button: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: effectiveTap,
+        onLongPress: onLongPress,
+        child: avatar,
+      ),
+    );
+  }
+
+  void _openProfile(BuildContext context, WidgetRef ref) {
+    UserProfileScreen.show(context, ref, userId);
+  }
+}

--- a/apps/client/test/widgets/user_avatar_test.dart
+++ b/apps/client/test/widgets/user_avatar_test.dart
@@ -1,0 +1,59 @@
+import 'package:echo_app/src/widgets/user_avatar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/pump_app.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('UserAvatar', () {
+    testWidgets('renders fallback initial when no avatar URL', (tester) async {
+      await tester.pumpApp(
+        const UserAvatar(userId: 'u1', username: 'jane', radius: 18),
+      );
+      expect(find.text('J'), findsOneWidget);
+    });
+
+    testWidgets('wires a GestureDetector when openProfileOnTap is on', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const UserAvatar(userId: 'u1', username: 'jane', radius: 18),
+      );
+      expect(find.byType(GestureDetector), findsOneWidget);
+    });
+
+    testWidgets('skips the GestureDetector when openProfileOnTap is off', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const UserAvatar(
+          userId: 'u1',
+          username: 'jane',
+          radius: 18,
+          openProfileOnTap: false,
+        ),
+      );
+      expect(find.byType(GestureDetector), findsNothing);
+    });
+
+    testWidgets('custom onTap fires when the avatar is tapped', (tester) async {
+      var taps = 0;
+      await tester.pumpApp(
+        UserAvatar(
+          userId: 'u1',
+          username: 'jane',
+          radius: 18,
+          onTap: () => taps++,
+        ),
+      );
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pump();
+      expect(taps, 1);
+    });
+  });
+}


### PR DESCRIPTION
Rolls up #1039. Componentized the user-avatar + presence-dot pattern (it was inlined in six surfaces with drifting dot sizes, border colours, and tap targets). New `UserAvatar` widget centralizes the look and the tap-opens-profile behaviour; three callers migrated (group_members_sheet, members_panel, contact_item). 4 new widget tests. All 1897 existing tests still pass.