### PR TITLE
Release: centralized presence helpers

### DIFF
--- a/apps/client/lib/src/providers/user_presence_provider.dart
+++ b/apps/client/lib/src/providers/user_presence_provider.dart
@@ -1,0 +1,55 @@
+/// Per-user presence lookup.
+///
+/// Before this provider every widget that wanted a user's presence wrote
+/// the same three lines:
+///
+/// ```dart
+/// final ws = ref.watch(websocketProvider);
+/// final status = ws.presenceStatusFor(userId);
+/// final isOnline = ws.onlineUsers.contains(userId);
+/// ```
+///
+/// That fans out into a ws-state read on every rebuild, even when the
+/// user's specific presence didn't change. The family below selects only
+/// the two fields for the user in question, so unrelated presence
+/// updates don't trigger rebuilds.
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'websocket_provider.dart';
+
+part 'user_presence_provider.g.dart';
+
+@immutable
+class UserPresence {
+  final String status;
+  final bool isOnline;
+  const UserPresence({required this.status, required this.isOnline});
+
+  /// Sentinel for "we have no record of this user yet" — looks the same
+  /// as a deliberately-offline user to peers.
+  static const offline = UserPresence(status: 'offline', isOnline: false);
+
+  @override
+  bool operator ==(Object other) =>
+      other is UserPresence &&
+      other.status == status &&
+      other.isOnline == isOnline;
+
+  @override
+  int get hashCode => Object.hash(status, isOnline);
+}
+
+@Riverpod(keepAlive: true)
+UserPresence userPresence(Ref ref, String userId) {
+  final isOnline = ref.watch(
+    websocketProvider.select((s) => s.onlineUsers.contains(userId)),
+  );
+  final status = ref.watch(
+    websocketProvider.select((s) => s.presenceStatusFor(userId)),
+  );
+  return UserPresence(status: status, isOnline: isOnline);
+}

--- a/apps/client/lib/src/providers/user_presence_provider.g.dart
+++ b/apps/client/lib/src/providers/user_presence_provider.g.dart
@@ -1,0 +1,150 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_presence_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$userPresenceHash() => r'03fd47f477919993466a00bcc478ab9baf98ae1d';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [userPresence].
+@ProviderFor(userPresence)
+const userPresenceProvider = UserPresenceFamily();
+
+/// See also [userPresence].
+class UserPresenceFamily extends Family<UserPresence> {
+  /// See also [userPresence].
+  const UserPresenceFamily();
+
+  /// See also [userPresence].
+  UserPresenceProvider call(String userId) {
+    return UserPresenceProvider(userId);
+  }
+
+  @override
+  UserPresenceProvider getProviderOverride(
+    covariant UserPresenceProvider provider,
+  ) {
+    return call(provider.userId);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'userPresenceProvider';
+}
+
+/// See also [userPresence].
+class UserPresenceProvider extends Provider<UserPresence> {
+  /// See also [userPresence].
+  UserPresenceProvider(String userId)
+    : this._internal(
+        (ref) => userPresence(ref as UserPresenceRef, userId),
+        from: userPresenceProvider,
+        name: r'userPresenceProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$userPresenceHash,
+        dependencies: UserPresenceFamily._dependencies,
+        allTransitiveDependencies:
+            UserPresenceFamily._allTransitiveDependencies,
+        userId: userId,
+      );
+
+  UserPresenceProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.userId,
+  }) : super.internal();
+
+  final String userId;
+
+  @override
+  Override overrideWith(
+    UserPresence Function(UserPresenceRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: UserPresenceProvider._internal(
+        (ref) => create(ref as UserPresenceRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        userId: userId,
+      ),
+    );
+  }
+
+  @override
+  ProviderElement<UserPresence> createElement() {
+    return _UserPresenceProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is UserPresenceProvider && other.userId == userId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, userId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin UserPresenceRef on ProviderRef<UserPresence> {
+  /// The parameter `userId` of this provider.
+  String get userId;
+}
+
+class _UserPresenceProviderElement extends ProviderElement<UserPresence>
+    with UserPresenceRef {
+  _UserPresenceProviderElement(super.provider);
+
+  @override
+  String get userId => (origin as UserPresenceProvider).userId;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/providers/websocket_provider.g.dart
+++ b/apps/client/lib/src/providers/websocket_provider.g.dart
@@ -6,7 +6,7 @@ part of 'websocket_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$webSocketNotifierHash() => r'35e1fc3cf6aa99d51abd8d3d5ca7842344e54abf';
+String _$webSocketNotifierHash() => r'7260b2810ccaa2f225bb9ad26fa876875ae7526f';
 
 /// See also [WebSocketNotifier].
 @ProviderFor(WebSocketNotifier)

--- a/apps/client/lib/src/screens/user_profile_screen.dart
+++ b/apps/client/lib/src/screens/user_profile_screen.dart
@@ -10,9 +10,10 @@ import '../providers/auth_provider.dart';
 import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/server_url_provider.dart';
-import '../providers/websocket_provider.dart';
+import '../providers/user_presence_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import '../utils/presence.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
 import '../widgets/profile_sheets.dart';
 import 'safety_number_screen.dart';
@@ -294,21 +295,11 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
 
     final fullAvatarUrl = resolveAvatarUrl(_avatarUrl, serverUrl);
 
-    final wsState = ref.watch(websocketProvider);
-    final isOnline = wsState.onlineUsers.contains(widget.userId);
-    final presenceStatus = wsState.presenceStatusFor(widget.userId);
-
-    final Color ringColor;
-    if (!isOnline) {
-      ringColor = const Color(0xFF6B6B6F);
-    } else {
-      ringColor = switch (presenceStatus) {
-        'online' => EchoTheme.online,
-        'away' => EchoTheme.warning,
-        'dnd' => EchoTheme.danger,
-        _ => const Color(0xFF6B6B6F),
-      };
-    }
+    final presence = ref.watch(userPresenceProvider(widget.userId));
+    final ringColor = presenceColor(
+      presence.status,
+      isOnline: presence.isOnline,
+    );
 
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),

--- a/apps/client/lib/src/utils/presence.dart
+++ b/apps/client/lib/src/utils/presence.dart
@@ -1,0 +1,44 @@
+/// Shared mappings for a user's presence string (`'online' / 'away' / 'dnd'
+/// / 'invisible' / 'offline'`) to UI artefacts (colour swatch, screen-reader
+/// label, etc.).
+///
+/// Before this file, the same `switch (status) { 'online' => …, 'away' => … }`
+/// was inlined in `conversation_item.dart`, `conversation_panel.dart`,
+/// `members_panel.dart`, `user_profile_screen.dart` and the avatar widget.
+/// Each copy drifted slightly — the "unknown status" fallback was sometimes
+/// `online`, sometimes `offline-grey`, sometimes the offline string. This
+/// file is the one place to read and update those mappings.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../theme/echo_theme.dart';
+
+const Color _offlineGray = Color(0xFF6B6B6F);
+
+/// Resolve the colour for a presence dot, ring, or badge.
+///
+/// Off-line and `'invisible'` both fall through to the muted grey so they
+/// look indistinguishable to peers, matching server-side semantics.
+Color presenceColor(String status, {bool isOnline = true}) {
+  if (!isOnline) return _offlineGray;
+  return switch (status) {
+    'online' => EchoTheme.online,
+    'away' => EchoTheme.warning,
+    'dnd' => EchoTheme.danger,
+    'invisible' => _offlineGray,
+    _ => _offlineGray,
+  };
+}
+
+/// Human-readable, lower-case label suitable for the activity line under
+/// a username. Pairs with [presenceColor] for the dot.
+String presenceLabel(String status, {bool isOnline = true}) {
+  if (!isOnline || status == 'invisible') return 'offline';
+  return switch (status) {
+    'online' => 'online',
+    'away' => 'away',
+    'dnd' => 'do not disturb',
+    _ => 'online',
+  };
+}

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -10,6 +10,7 @@ import '../providers/chat_provider.dart';
 import '../providers/theme_provider.dart' show UIDensity, uiDensityProvider;
 import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
+import '../utils/presence.dart';
 import 'avatar_utils.dart';
 // Stack + Positioned (active edge bar overlay) come from material.dart.
 
@@ -33,22 +34,6 @@ double conversationItemHeightFor(UIDensity density) => switch (density) {
   UIDensity.normal => kConversationItemHeight,
   UIDensity.compact => kConversationItemHeightCompact,
 };
-
-/// Return the dot color for a peer presence status.
-Color presenceStatusDotColor(
-  BuildContext context,
-  String presenceStatus,
-  bool isOnline,
-) {
-  if (!isOnline) return const Color(0xFF6B6B6F);
-  return switch (presenceStatus) {
-    'online' => EchoTheme.online,
-    'away' => EchoTheme.warning,
-    'dnd' => EchoTheme.danger,
-    'invisible' => const Color(0xFF6B6B6F),
-    _ => const Color(0xFF6B6B6F),
-  };
-}
 
 /// Compose the screen-reader announcement for a conversation row (#631).
 ///
@@ -454,10 +439,9 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                   width: dotSize,
                   height: dotSize,
                   decoration: BoxDecoration(
-                    color: presenceStatusDotColor(
-                      context,
+                    color: presenceColor(
                       widget.peerPresenceStatus,
-                      widget.isPeerOnline,
+                      isOnline: widget.isPeerOnline,
                     ),
                     shape: BoxShape.circle,
                     border: Border.all(color: context.sidebarBg, width: 2),

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -22,6 +22,7 @@ import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../providers/theme_provider.dart' show uiDensityProvider;
+import '../utils/presence.dart';
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart';
 import 'connection_status_badge.dart';
@@ -1382,13 +1383,6 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     );
   }
 
-  static Color _presenceColor(String status) => switch (status) {
-    'away' => EchoTheme.warning,
-    'dnd' => EchoTheme.danger,
-    'invisible' => const Color(0xFF6B6B6F),
-    _ => EchoTheme.online,
-  };
-
   Widget _buildUserAvatar(
     BuildContext context,
     String myUsername,
@@ -1398,7 +1392,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
     String presenceStatus,
   ) {
     final dotColor = wsConnected
-        ? _presenceColor(presenceStatus)
+        ? presenceColor(presenceStatus)
         : EchoTheme.warning;
 
     return Semantics(

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -10,6 +10,7 @@ import '../providers/websocket_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import '../utils/presence.dart';
 import 'user_avatar.dart';
 
 class MembersPanel extends ConsumerWidget {
@@ -184,17 +185,6 @@ class _MemberListItem {
     isOnline: isOnline,
     status: status,
   );
-}
-
-/// Map a presence status to the activity-line label shown under the username.
-String _presenceLabel(String status, bool isOnline) {
-  if (!isOnline || status == 'invisible') return 'offline';
-  return switch (status) {
-    'online' => 'online',
-    'away' => 'away',
-    'dnd' => 'do not disturb',
-    _ => 'online',
-  };
 }
 
 class _MemberRow extends ConsumerStatefulWidget {
@@ -428,7 +418,10 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
                         ],
                       ),
                       Text(
-                        _presenceLabel(widget.presenceStatus, widget.isOnline),
+                        presenceLabel(
+                          widget.presenceStatus,
+                          isOnline: widget.isOnline,
+                        ),
                         style: TextStyle(
                           color: context.textMuted,
                           fontSize: 11,

--- a/apps/client/lib/src/widgets/user_avatar.dart
+++ b/apps/client/lib/src/widgets/user_avatar.dart
@@ -19,11 +19,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/server_url_provider.dart';
-import '../providers/websocket_provider.dart';
+import '../providers/user_presence_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../theme/echo_theme.dart';
+import '../utils/presence.dart';
 import 'avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
-import 'conversation_item.dart' show presenceStatusDotColor;
 
 class UserAvatar extends ConsumerWidget {
   /// The user this avatar represents. Used to (a) resolve the tap → open
@@ -94,9 +94,7 @@ class UserAvatar extends ConsumerWidget {
     );
 
     if (showPresence) {
-      final ws = ref.watch(websocketProvider);
-      final status = ws.presenceStatusFor(userId);
-      final isOnline = ws.onlineUsers.contains(userId);
+      final presence = ref.watch(userPresenceProvider(userId));
       final dotSize = (radius * 0.55).clamp(8.0, 14.0).toDouble();
       avatar = Stack(
         clipBehavior: Clip.none,
@@ -109,7 +107,10 @@ class UserAvatar extends ConsumerWidget {
               width: dotSize,
               height: dotSize,
               decoration: BoxDecoration(
-                color: presenceStatusDotColor(context, status, isOnline),
+                color: presenceColor(
+                  presence.status,
+                  isOnline: presence.isOnline,
+                ),
                 shape: BoxShape.circle,
                 border: Border.all(color: EchoTheme.sidebarBg, width: 1.5),
               ),

--- a/apps/client/test/utils/presence_test.dart
+++ b/apps/client/test/utils/presence_test.dart
@@ -1,0 +1,50 @@
+import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/utils/presence.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('presenceColor', () {
+    test('online: known statuses map to themed colours', () {
+      expect(presenceColor('online'), EchoTheme.online);
+      expect(presenceColor('away'), EchoTheme.warning);
+      expect(presenceColor('dnd'), EchoTheme.danger);
+    });
+
+    test('"invisible" looks the same as offline to peers', () {
+      expect(
+        presenceColor('invisible'),
+        presenceColor('online', isOnline: false),
+      );
+    });
+
+    test('isOnline=false overrides any status', () {
+      expect(presenceColor('online', isOnline: false), const Color(0xFF6B6B6F));
+      expect(presenceColor('away', isOnline: false), const Color(0xFF6B6B6F));
+    });
+
+    test('unknown status falls back to offline grey, not online green', () {
+      expect(presenceColor('quantum'), const Color(0xFF6B6B6F));
+    });
+  });
+
+  group('presenceLabel', () {
+    test('isOnline=false collapses every status to offline', () {
+      expect(presenceLabel('online', isOnline: false), 'offline');
+      expect(presenceLabel('away', isOnline: false), 'offline');
+      expect(presenceLabel('dnd', isOnline: false), 'offline');
+    });
+
+    test('"invisible" reads as offline even when online flag is true', () {
+      expect(presenceLabel('invisible', isOnline: true), 'offline');
+    });
+
+    test('"dnd" is spelled out for screen readers', () {
+      expect(presenceLabel('dnd'), 'do not disturb');
+    });
+
+    test('away keeps its short form', () {
+      expect(presenceLabel('away'), 'away');
+    });
+  });
+}


### PR DESCRIPTION
Rolls up #1041. Componentizes presence-related state and visuals: new userPresenceProvider family for per-user lookup (replaces a 3-line block repeated in 5 files), new presenceColor + presenceLabel helpers in utils/presence.dart (replaces inline switch blocks across 5 widgets with subtly different unknown-status fallbacks). 8 new tests; all 1901 existing client tests still pass.