### PR TITLE
Release: finish presence migration

### DIFF
--- a/apps/client/lib/src/providers/user_presence_provider.dart
+++ b/apps/client/lib/src/providers/user_presence_provider.dart
@@ -15,41 +15,17 @@
 /// updates don't trigger rebuilds.
 library;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../utils/presence.dart';
 import 'websocket_provider.dart';
 
 part 'user_presence_provider.g.dart';
 
-@immutable
-class UserPresence {
-  final String status;
-  final bool isOnline;
-  const UserPresence({required this.status, required this.isOnline});
-
-  /// Sentinel for "we have no record of this user yet" — looks the same
-  /// as a deliberately-offline user to peers.
-  static const offline = UserPresence(status: 'offline', isOnline: false);
-
-  @override
-  bool operator ==(Object other) =>
-      other is UserPresence &&
-      other.status == status &&
-      other.isOnline == isOnline;
-
-  @override
-  int get hashCode => Object.hash(status, isOnline);
-}
-
 @Riverpod(keepAlive: true)
 UserPresence userPresence(Ref ref, String userId) {
-  final isOnline = ref.watch(
-    websocketProvider.select((s) => s.onlineUsers.contains(userId)),
+  return ref.watch(
+    websocketProvider.select((s) => s.presenceFor(userId)),
   );
-  final status = ref.watch(
-    websocketProvider.select((s) => s.presenceStatusFor(userId)),
-  );
-  return UserPresence(status: status, isOnline: isOnline);
 }

--- a/apps/client/lib/src/providers/user_presence_provider.g.dart
+++ b/apps/client/lib/src/providers/user_presence_provider.g.dart
@@ -6,7 +6,7 @@ part of 'user_presence_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userPresenceHash() => r'03fd47f477919993466a00bcc478ab9baf98ae1d';
+String _$userPresenceHash() => r'5663ea8853fc186266ebd02cd0e08914e58f969d';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -18,6 +18,7 @@ import '../services/sound_service.dart';
 import '../utils/crypto_utils.dart';
 import '../utils/debug_log.dart';
 import '../utils/mention_detection.dart';
+import '../utils/presence.dart';
 import '../utils/uuid_bytes.dart';
 import 'auth_provider.dart';
 import 'canvas_provider.dart';
@@ -106,6 +107,16 @@ class WebSocketState {
   String presenceStatusFor(String userId) {
     if (!onlineUsers.contains(userId)) return 'offline';
     return presenceStatuses[userId] ?? 'online';
+  }
+
+  /// Return a [UserPresence] snapshot — the structured pair that
+  /// downstream widgets actually want. Lets callers replace the inline
+  /// `onlineUsers.contains(...) + presenceStatuses[...] ?? 'online'`
+  /// pattern with a single method call.
+  UserPresence presenceFor(String userId) {
+    final isOnline = onlineUsers.contains(userId);
+    final status = isOnline ? (presenceStatuses[userId] ?? 'online') : 'offline';
+    return UserPresence(status: status, isOnline: isOnline);
   }
 
   String _typingKey(String conversationId, String? channelId) {

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -18,10 +18,12 @@ import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/media_ticket_provider.dart';
 import '../providers/server_url_provider.dart';
-import '../providers/websocket_provider.dart';
+import '../providers/user_presence_provider.dart';
 import '../utils/fuzzy_score.dart';
+import '../utils/presence.dart';
 import '../widgets/avatar_crop_dialog.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import '../widgets/user_avatar.dart';
 import '../widgets/context_menu/actions/member_actions_registry.dart';
 import '../widgets/context_menu/echo_context_menu.dart';
 import '../widgets/profile_sheets.dart';
@@ -1237,13 +1239,21 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     required ConversationMember member,
     required String myUserId,
     required bool isOwnerOrAdmin,
-    required bool isOnline,
   }) {
-    final serverUrl = ref.read(serverUrlProvider);
     final isMe = member.userId == myUserId;
     final role = member.role ?? 'member';
-    final onlineStatus = isOnline ? 'online' : 'away';
-    final activity = isMe ? 'You' : onlineStatus;
+    // "You" trumps the presence label on the row that represents the
+    // viewer themselves; everyone else gets the standard activity line.
+    final String activity;
+    if (isMe) {
+      activity = 'You';
+    } else {
+      final presence = ref.watch(userPresenceProvider(member.userId));
+      activity = presenceLabel(
+        presence.status,
+        isOnline: presence.isOnline,
+      );
+    }
 
     return InkWell(
       onTap: () {
@@ -1272,24 +1282,17 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         child: Row(
           children: [
-            buildAvatar(
-              name: member.username,
+            // The outer InkWell owns the tap; UserAvatar renders the
+            // avatar + presence dot in one go.
+            UserAvatar(
+              userId: member.userId,
+              username: member.username,
+              avatarUrl: member.avatarUrl,
               radius: 18,
-              imageUrl: resolveAvatarUrl(member.avatarUrl, serverUrl),
+              showPresence: true,
+              openProfileOnTap: false,
             ),
             const SizedBox(width: 10),
-            // Online presence dot, ringed in the surface color so it reads
-            // against any avatar background.
-            Container(
-              width: 8,
-              height: 8,
-              decoration: BoxDecoration(
-                color: isOnline ? EchoTheme.online : context.textMuted,
-                shape: BoxShape.circle,
-                border: Border.all(color: context.surface, width: 1.5),
-              ),
-            ),
-            const SizedBox(width: 8),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -1357,10 +1360,6 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     required String myUserId,
     required bool isOwnerOrAdmin,
   }) {
-    final onlineUsers = ref.watch(
-      websocketProvider.select((s) => s.onlineUsers),
-    );
-
     int sortByName(ConversationMember a, ConversationMember b) =>
         a.username.toLowerCase().compareTo(b.username.toLowerCase());
 
@@ -1398,7 +1397,6 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
           member: m,
           myUserId: myUserId,
           isOwnerOrAdmin: isOwnerOrAdmin,
-          isOnline: onlineUsers.contains(m.userId),
         );
       }
     }

--- a/apps/client/lib/src/screens/new_message_screen.dart
+++ b/apps/client/lib/src/screens/new_message_screen.dart
@@ -5,13 +5,11 @@ import '../models/contact.dart';
 import '../models/conversation.dart';
 import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
-import '../providers/server_url_provider.dart';
-import '../providers/websocket_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/fuzzy_score.dart';
-import '../widgets/avatar_utils.dart';
 import '../widgets/settings/section_header.dart';
+import '../widgets/user_avatar.dart';
 
 // ---------------------------------------------------------------------------
 // NewMessageScreen
@@ -122,10 +120,6 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
             borderRadius: BorderRadius.circular(10),
             child: _DropdownList(
               suggestions: suggestions,
-              serverUrl: ref.read(serverUrlProvider),
-              onlineUsers: ref.read(
-                websocketProvider.select((s) => s.onlineUsers),
-              ),
               selectedIds: _chips.map((c) => c.userId).toSet(),
               onSelect: _selectSuggestion,
             ),
@@ -293,10 +287,6 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
   @override
   Widget build(BuildContext context) {
     final contactsState = ref.watch(contactsProvider);
-    final serverUrl = ref.watch(serverUrlProvider);
-    final onlineUsers = ref.watch(
-      websocketProvider.select((s) => s.onlineUsers),
-    );
 
     final suggestions = _filterContacts(contactsState.contacts, _query);
 
@@ -330,8 +320,6 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
               Expanded(
                 child: _ContactList(
                   contacts: suggestions,
-                  serverUrl: serverUrl,
-                  onlineUsers: onlineUsers,
                   selectedIds: _chips.map((c) => c.userId).toSet(),
                   onSelect: _selectSuggestion,
                 ),
@@ -605,15 +593,11 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
 
 class _ContactList extends StatelessWidget {
   final List<Contact> contacts;
-  final String serverUrl;
-  final Set<String> onlineUsers;
   final Set<String> selectedIds;
   final ValueChanged<Contact> onSelect;
 
   const _ContactList({
     required this.contacts,
-    required this.serverUrl,
-    required this.onlineUsers,
     required this.selectedIds,
     required this.onSelect,
   });
@@ -625,8 +609,6 @@ class _ContactList extends StatelessWidget {
       itemCount: contacts.length,
       itemBuilder: (_, i) => _ContactRow(
         contact: contacts[i],
-        serverUrl: serverUrl,
-        isOnline: onlineUsers.contains(contacts[i].userId),
         isSelected: selectedIds.contains(contacts[i].userId),
         onTap: () => onSelect(contacts[i]),
       ),
@@ -640,15 +622,11 @@ class _ContactList extends StatelessWidget {
 
 class _DropdownList extends StatelessWidget {
   final List<Contact> suggestions;
-  final String serverUrl;
-  final Set<String> onlineUsers;
   final Set<String> selectedIds;
   final ValueChanged<Contact> onSelect;
 
   const _DropdownList({
     required this.suggestions,
-    required this.serverUrl,
-    required this.onlineUsers,
     required this.selectedIds,
     required this.onSelect,
   });
@@ -663,8 +641,6 @@ class _DropdownList extends StatelessWidget {
         itemCount: suggestions.length,
         itemBuilder: (_, i) => _ContactRow(
           contact: suggestions[i],
-          serverUrl: serverUrl,
-          isOnline: onlineUsers.contains(suggestions[i].userId),
           isSelected: selectedIds.contains(suggestions[i].userId),
           onTap: () => onSelect(suggestions[i]),
         ),
@@ -679,15 +655,11 @@ class _DropdownList extends StatelessWidget {
 
 class _ContactRow extends StatelessWidget {
   final Contact contact;
-  final String serverUrl;
-  final bool isOnline;
   final bool isSelected;
   final VoidCallback onTap;
 
   const _ContactRow({
     required this.contact,
-    required this.serverUrl,
-    required this.isOnline,
     required this.isSelected,
     required this.onTap,
   });
@@ -697,7 +669,6 @@ class _ContactRow extends StatelessWidget {
     final displayName = contact.displayName?.isNotEmpty == true
         ? contact.displayName!
         : contact.username;
-    final resolvedAvatar = resolveAvatarUrl(contact.avatarUrl, serverUrl);
 
     return Material(
       color: isSelected ? context.accentLight : Colors.transparent,
@@ -708,30 +679,13 @@ class _ContactRow extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
           child: Row(
             children: [
-              Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  buildAvatar(
-                    name: displayName,
-                    radius: 22,
-                    imageUrl: resolvedAvatar,
-                  ),
-                  Positioned(
-                    right: -1,
-                    bottom: -1,
-                    child: Container(
-                      width: 12,
-                      height: 12,
-                      decoration: BoxDecoration(
-                        color: isOnline
-                            ? EchoTheme.online
-                            : const Color(0xFF6B6B6F),
-                        shape: BoxShape.circle,
-                        border: Border.all(color: context.mainBg, width: 2),
-                      ),
-                    ),
-                  ),
-                ],
+              UserAvatar(
+                userId: contact.userId,
+                username: displayName,
+                avatarUrl: contact.avatarUrl,
+                radius: 22,
+                showPresence: true,
+                openProfileOnTap: false,
               ),
               const SizedBox(width: 12),
               Expanded(

--- a/apps/client/lib/src/utils/presence.dart
+++ b/apps/client/lib/src/utils/presence.dart
@@ -16,6 +16,30 @@ import '../theme/echo_theme.dart';
 
 const Color _offlineGray = Color(0xFF6B6B6F);
 
+/// Snapshot of a single user's presence: WebSocket-tracked online flag
+/// + last-seen status string. Constructed by `WebSocketState.presenceFor`
+/// and `userPresenceProvider`; consumed everywhere a widget needs to
+/// colour a dot, label an activity line, or sort by presence.
+@immutable
+class UserPresence {
+  final String status;
+  final bool isOnline;
+  const UserPresence({required this.status, required this.isOnline});
+
+  /// Sentinel for "we have no record of this user yet" — looks the same
+  /// as a deliberately-offline user to peers.
+  static const offline = UserPresence(status: 'offline', isOnline: false);
+
+  @override
+  bool operator ==(Object other) =>
+      other is UserPresence &&
+      other.status == status &&
+      other.isOnline == isOnline;
+
+  @override
+  int get hashCode => Object.hash(status, isOnline);
+}
+
 /// Resolve the colour for a presence dot, ring, or badge.
 ///
 /// Off-line and `'invisible'` both fall through to the muted grey so they

--- a/apps/client/lib/src/widgets/group_members_sheet.dart
+++ b/apps/client/lib/src/widgets/group_members_sheet.dart
@@ -15,6 +15,7 @@ import '../providers/auth_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../theme/echo_theme.dart';
+import '../utils/presence.dart';
 import 'user_avatar.dart';
 
 /// Shows the [GroupMembersSheet] as a modal bottom sheet.
@@ -83,23 +84,18 @@ class _GroupMembersSheetState extends ConsumerState<GroupMembersSheet> {
     final auth = ref.watch(authProvider);
     final myUserId = auth.userId ?? '';
     final myPresenceStatus = auth.presenceStatus;
-    final onlineUsers = ref.watch(
-      websocketProvider.select((s) => s.onlineUsers),
-    );
-    final presenceStatuses = ref.watch(
-      websocketProvider.select((s) => s.presenceStatuses),
-    );
+    final ws = ref.watch(websocketProvider);
 
     final members = conv.members;
 
-    // Resolve online/status for each member (mirrors MembersPanel logic).
-    ({bool isOnline, String status}) presenceFor(ConversationMember m) {
+    // Resolve online/status for each member: self is never broadcast by
+    // the WS, so substitute auth's local status. Everyone else uses the
+    // central presenceFor lookup.
+    UserPresence presenceFor(ConversationMember m) {
       if (m.userId == myUserId) {
-        return (isOnline: true, status: myPresenceStatus);
+        return UserPresence(status: myPresenceStatus, isOnline: true);
       }
-      final online = onlineUsers.contains(m.userId);
-      final status = presenceStatuses[m.userId] ?? 'online';
-      return (isOnline: online, status: status);
+      return ws.presenceFor(m.userId);
     }
 
     // Sort: online first, then alphabetical within each bucket.
@@ -197,11 +193,8 @@ class _GroupMembersSheetState extends ConsumerState<GroupMembersSheet> {
                         itemCount: sorted.length,
                         itemBuilder: (context, index) {
                           final member = sorted[index];
-                          final presence = presenceFor(member);
                           return _MobilesMemberRow(
                             member: member,
-                            isOnline: presence.isOnline,
-                            presenceStatus: presence.status,
                             isMe: member.userId == myUserId,
                           );
                         },
@@ -217,16 +210,9 @@ class _GroupMembersSheetState extends ConsumerState<GroupMembersSheet> {
 
 class _MobilesMemberRow extends ConsumerWidget {
   final ConversationMember member;
-  final bool isOnline;
-  final String presenceStatus;
   final bool isMe;
 
-  const _MobilesMemberRow({
-    required this.member,
-    required this.isOnline,
-    required this.presenceStatus,
-    required this.isMe,
-  });
+  const _MobilesMemberRow({required this.member, required this.isMe});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -6,7 +6,7 @@ import '../models/conversation.dart';
 import '../providers/auth_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/server_url_provider.dart';
-import '../providers/websocket_provider.dart';
+import '../providers/user_presence_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
@@ -32,24 +32,6 @@ class MembersPanel extends ConsumerWidget {
     final members = conv.members;
     final auth = ref.watch(authProvider);
     final myUserId = auth.userId ?? '';
-    final myPresenceStatus = auth.presenceStatus;
-    final onlineUsers = ref.watch(
-      websocketProvider.select((s) => s.onlineUsers),
-    );
-    final presenceStatuses = ref.watch(
-      websocketProvider.select((s) => s.presenceStatuses),
-    );
-
-    // Resolve presence for any member: self is always online (server doesn't
-    // broadcast presence to self); others come from the WS-tracked maps.
-    ({bool isOnline, String status}) presenceFor(ConversationMember m) {
-      if (m.userId == myUserId) {
-        return (isOnline: true, status: myPresenceStatus);
-      }
-      final online = onlineUsers.contains(m.userId);
-      final status = presenceStatuses[m.userId] ?? 'online';
-      return (isOnline: online, status: status);
-    }
 
     // Determine if current user is owner or admin
     final myMember = members.where((m) => m.userId == myUserId).firstOrNull;
@@ -76,10 +58,7 @@ class MembersPanel extends ConsumerWidget {
       if (roster.isEmpty) return;
       items.add(_MemberListItem.header(headerLabel));
       for (final m in roster) {
-        final p = presenceFor(m);
-        items.add(
-          _MemberListItem.member(m, isOnline: p.isOnline, status: p.status),
-        );
+        items.add(_MemberListItem.member(m));
       }
     }
 
@@ -144,8 +123,6 @@ class MembersPanel extends ConsumerWidget {
                   conversationId: conv.id,
                   canRemove: canRemove && member.role != 'owner',
                   isMe: member.userId == myUserId,
-                  isOnline: item.isOnline,
-                  presenceStatus: item.status,
                 );
               },
             ),
@@ -161,30 +138,18 @@ class _MemberListItem {
   final bool isHeader;
   final String? headerLabel;
   final ConversationMember? member;
-  final bool isOnline;
-  final String status;
 
   const _MemberListItem._({
     required this.isHeader,
     this.headerLabel,
     this.member,
-    this.isOnline = false,
-    this.status = 'offline',
   });
 
   factory _MemberListItem.header(String label) =>
       _MemberListItem._(isHeader: true, headerLabel: label);
 
-  factory _MemberListItem.member(
-    ConversationMember m, {
-    required bool isOnline,
-    required String status,
-  }) => _MemberListItem._(
-    isHeader: false,
-    member: m,
-    isOnline: isOnline,
-    status: status,
-  );
+  factory _MemberListItem.member(ConversationMember m) =>
+      _MemberListItem._(isHeader: false, member: m);
 }
 
 class _MemberRow extends ConsumerStatefulWidget {
@@ -192,16 +157,12 @@ class _MemberRow extends ConsumerStatefulWidget {
   final String conversationId;
   final bool canRemove;
   final bool isMe;
-  final bool isOnline;
-  final String presenceStatus;
 
   const _MemberRow({
     required this.member,
     required this.conversationId,
     required this.canRemove,
     required this.isMe,
-    required this.isOnline,
-    required this.presenceStatus,
   });
 
   @override
@@ -348,6 +309,18 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
     final showRemove =
         widget.canRemove && !widget.isMe && _isHovered && !_isRemoving;
 
+    // Self isn't broadcast by the WS, so use auth's local status.
+    // Everyone else reads from the centralized provider.
+    final UserPresence presence;
+    if (widget.isMe) {
+      final myStatus = ref.watch(
+        authProvider.select((s) => s.presenceStatus),
+      );
+      presence = UserPresence(status: myStatus, isOnline: true);
+    } else {
+      presence = ref.watch(userPresenceProvider(member.userId));
+    }
+
     return Semantics(
       label: 'member ${member.username} — open profile',
       button: true,
@@ -419,8 +392,8 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
                       ),
                       Text(
                         presenceLabel(
-                          widget.presenceStatus,
-                          isOnline: widget.isOnline,
+                          presence.status,
+                          isOnline: presence.isOnline,
                         ),
                         style: TextStyle(
                           color: context.textMuted,


### PR DESCRIPTION
Rolls up #1043. Completes the cleanup #1041 only half-finished: every inline 'onlineUsers.contains + presenceStatuses[...] ?? online' two-liner and every inline avatar+dot Stack across members_panel, group_members_sheet, new_message_screen, group_info_screen is now gone. grep returns zero hits. Net -78 LOC across the affected files.