### PR TITLE
Componentize role badge, role icon, and copy-to-clipboard

### DIFF
--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
 
 import '../models/conversation.dart';
+import '../services/clipboard_service.dart';
 import '../services/toast_service.dart';
 import '../services/upload_client.dart';
 import '../theme/echo_theme.dart';
@@ -23,6 +24,7 @@ import '../utils/fuzzy_score.dart';
 import '../utils/presence.dart';
 import '../widgets/avatar_crop_dialog.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import '../widgets/member_role.dart';
 import '../widgets/user_avatar.dart';
 import '../widgets/context_menu/actions/member_actions_registry.dart';
 import '../widgets/context_menu/echo_context_menu.dart';
@@ -1072,51 +1074,6 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   /// Color mapping matches the desktop members panel (#769):
   ///   Owner -> warning amber (rare, high authority)
   ///   Admin -> accent blue
-  List<Widget> _buildRoleBadge(String role) {
-    if (role == 'owner') {
-      return [
-        const SizedBox(width: 6),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-          decoration: BoxDecoration(
-            color: EchoTheme.warning.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: const Text(
-            'Owner',
-            style: TextStyle(
-              fontSize: 10,
-              color: EchoTheme.warning,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.3,
-            ),
-          ),
-        ),
-      ];
-    }
-    if (role == 'admin') {
-      return [
-        const SizedBox(width: 6),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-          decoration: BoxDecoration(
-            color: context.accent.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: Text(
-            'Admin',
-            style: TextStyle(
-              fontSize: 10,
-              color: context.accentHover,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.3,
-            ),
-          ),
-        ),
-      ];
-    }
-    return [];
-  }
 
   /// Trailing "..." affordance on a member row. Routes through
   /// [EchoContextMenu] so the menu items match right-click and
@@ -1227,9 +1184,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   }
 
   void _copyToClipboardWithToast(String text, String successMessage) {
-    Clipboard.setData(ClipboardData(text: text));
-    if (!mounted) return;
-    ToastService.show(context, successMessage, type: ToastType.success);
+    copyToClipboard(context, text, successMessage: successMessage);
   }
 
   /// Single roster row. Matches the desktop members panel styling (#769):
@@ -1249,10 +1204,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
       activity = 'You';
     } else {
       final presence = ref.watch(userPresenceProvider(member.userId));
-      activity = presenceLabel(
-        presence.status,
-        isOnline: presence.isOnline,
-      );
+      activity = presenceLabel(presence.status, isOnline: presence.isOnline);
     }
 
     return InkWell(
@@ -1300,21 +1252,8 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
                 children: [
                   Row(
                     children: [
-                      if (role == 'owner') ...[
-                        const Icon(
-                          Icons.star_rounded,
-                          size: 14,
-                          color: Colors.amber,
-                          semanticLabel: 'owner',
-                        ),
-                        const SizedBox(width: 4),
-                      ] else if (role == 'admin') ...[
-                        const Icon(
-                          Icons.shield_rounded,
-                          size: 14,
-                          color: Colors.blue,
-                          semanticLabel: 'admin',
-                        ),
+                      if (role == 'owner' || role == 'admin') ...[
+                        MemberRoleIcon(role: role),
                         const SizedBox(width: 4),
                       ],
                       Flexible(
@@ -1328,7 +1267,10 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
                           ),
                         ),
                       ),
-                      ..._buildRoleBadge(role),
+                      MemberRoleBadge(
+                        role: role,
+                        margin: const EdgeInsets.only(left: 6),
+                      ),
                     ],
                   ),
                   const SizedBox(height: 2),

--- a/apps/client/lib/src/screens/safety_number_screen.dart
+++ b/apps/client/lib/src/screens/safety_number_screen.dart
@@ -14,6 +14,7 @@ import 'package:qr_flutter/qr_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../providers/crypto_provider.dart';
+import '../services/clipboard_service.dart';
 import '../services/crypto_service.dart';
 import '../services/safety_number_service.dart';
 import '../services/secure_key_store.dart';
@@ -233,12 +234,10 @@ class _SafetyNumberScreenState extends ConsumerState<SafetyNumberScreen> {
 
   Future<void> _copyInviteMessage() async {
     final text = 'Add me on Echo Messenger: $_inviteUrl';
-    await Clipboard.setData(ClipboardData(text: text));
-    if (!mounted) return;
-    ToastService.show(
+    await copyToClipboard(
       context,
-      'Invite message copied',
-      type: ToastType.success,
+      text,
+      successMessage: 'Invite message copied',
     );
   }
 
@@ -433,17 +432,11 @@ class _SafetyNumberScreenState extends ConsumerState<SafetyNumberScreen> {
                 children: [
                   Expanded(
                     child: OutlinedButton.icon(
-                      onPressed: () async {
-                        await Clipboard.setData(
-                          ClipboardData(text: _inviteUrl),
-                        );
-                        if (!mounted) return;
-                        ToastService.show(
-                          context,
-                          'Invite link copied',
-                          type: ToastType.success,
-                        );
-                      },
+                      onPressed: () => copyToClipboard(
+                        context,
+                        _inviteUrl,
+                        successMessage: 'Invite link copied',
+                      ),
                       icon: const Icon(Icons.copy, size: 16),
                       label: const Text('Copy Link'),
                     ),
@@ -481,14 +474,11 @@ class _SafetyNumberScreenState extends ConsumerState<SafetyNumberScreen> {
           label: 'copy safety number',
           button: true,
           child: GestureDetector(
-            onTap: () {
-              Clipboard.setData(ClipboardData(text: _safetyNumber!));
-              ToastService.show(
-                context,
-                'Safety number copied',
-                type: ToastType.success,
-              );
-            },
+            onTap: () => copyToClipboard(
+              context,
+              _safetyNumber!,
+              successMessage: 'Safety number copied',
+            ),
             child: Container(
               width: double.infinity,
               padding: const EdgeInsets.all(16),

--- a/apps/client/lib/src/services/clipboard_service.dart
+++ b/apps/client/lib/src/services/clipboard_service.dart
@@ -1,0 +1,30 @@
+/// Copy-text-and-toast helper.
+///
+/// `Clipboard.setData(ClipboardData(text: …))` + `ToastService.show(…)`
+/// was repeated in 10+ places — account section, profile sheet, safety
+/// number, message actions, group info, settings sections. Each call
+/// site picked its own toast wording and type. This helper standardises
+/// the success message and the toast type while still allowing per-call
+/// overrides for context-specific copy ("Username copied" vs "Invite
+/// link copied" vs "Message ID copied").
+library;
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'toast_service.dart';
+
+/// Copy [text] to the system clipboard and show a success toast.
+///
+/// [successMessage] defaults to `'Copied'`; pass a more specific label
+/// when the context is ambiguous (e.g. `'Invite link copied'`,
+/// `'Username copied'`). Pass `null` to skip the toast entirely.
+Future<void> copyToClipboard(
+  BuildContext context,
+  String text, {
+  String? successMessage = 'Copied',
+}) async {
+  await Clipboard.setData(ClipboardData(text: text));
+  if (!context.mounted || successMessage == null) return;
+  ToastService.show(context, successMessage, type: ToastType.success);
+}

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:go_router/go_router.dart';
@@ -17,6 +16,7 @@ import '../providers/conversations_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/websocket_provider.dart';
+import '../services/clipboard_service.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
@@ -281,12 +281,10 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   }
 
   void _copyConversationId(String conversationId) {
-    Clipboard.setData(ClipboardData(text: conversationId));
-    if (!mounted) return;
-    ToastService.show(
+    copyToClipboard(
       context,
-      'Conversation ID copied',
-      type: ToastType.success,
+      conversationId,
+      successMessage: 'Conversation ID copied',
     );
   }
 

--- a/apps/client/lib/src/widgets/group_members_sheet.dart
+++ b/apps/client/lib/src/widgets/group_members_sheet.dart
@@ -16,6 +16,7 @@ import '../providers/websocket_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../theme/echo_theme.dart';
 import '../utils/presence.dart';
+import 'member_role.dart';
 import 'user_avatar.dart';
 
 /// Shows the [GroupMembersSheet] as a modal bottom sheet.
@@ -243,21 +244,8 @@ class _MobilesMemberRow extends ConsumerWidget {
               Expanded(
                 child: Row(
                   children: [
-                    if (member.role == 'owner') ...[
-                      const Icon(
-                        Icons.star_rounded,
-                        size: 14,
-                        color: Colors.amber,
-                        semanticLabel: 'owner',
-                      ),
-                      const SizedBox(width: 4),
-                    ] else if (member.role == 'admin') ...[
-                      const Icon(
-                        Icons.shield_rounded,
-                        size: 14,
-                        color: Colors.blue,
-                        semanticLabel: 'admin',
-                      ),
+                    if (member.role == 'owner' || member.role == 'admin') ...[
+                      MemberRoleIcon(role: member.role),
                       const SizedBox(width: 4),
                     ],
                     Flexible(
@@ -285,44 +273,9 @@ class _MobilesMemberRow extends ConsumerWidget {
                 ),
               ),
               // Role badge chip
-              if (member.role == 'owner' || member.role == 'admin')
-                _roleBadge(context, member.role!),
+              MemberRoleBadge(role: member.role),
             ],
           ),
-        ),
-      ),
-    );
-  }
-
-  Widget _roleBadge(BuildContext context, String role) {
-    final Color bgColor;
-    final Color textColor;
-    final String label;
-
-    if (role == 'owner') {
-      bgColor = EchoTheme.warning.withValues(alpha: 0.15);
-      textColor = EchoTheme.warning;
-      label = 'Owner';
-    } else {
-      bgColor = context.accent.withValues(alpha: 0.15);
-      textColor = context.accentHover;
-      label = 'Admin';
-    }
-
-    return Container(
-      margin: const EdgeInsets.only(left: 8),
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
-      decoration: BoxDecoration(
-        color: bgColor,
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: Text(
-        label,
-        style: GoogleFonts.inter(
-          color: textColor,
-          fontSize: 10,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0.3,
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/member_role.dart
+++ b/apps/client/lib/src/widgets/member_role.dart
@@ -1,0 +1,90 @@
+/// Owner / admin role indicators reused across every member listing.
+///
+/// Before this file the same `Icons.star_rounded (amber)` /
+/// `Icons.shield_rounded (blue)` pattern and the same Owner / Admin
+/// pill ran inline in `members_panel.dart`, `group_members_sheet.dart`
+/// and `group_info_screen.dart`. Each copy chose its own padding,
+/// font-size and corner radius — close, but visibly off. These two
+/// widgets are the one place to render either treatment.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../theme/echo_theme.dart';
+
+/// A small inline icon used next to a member's username to indicate
+/// their role. Returns an empty box for ordinary members so callers
+/// can drop it into a Row unconditionally without a null check.
+class MemberRoleIcon extends StatelessWidget {
+  final String? role;
+  final double size;
+  const MemberRoleIcon({super.key, required this.role, this.size = 14});
+
+  @override
+  Widget build(BuildContext context) {
+    if (role == 'owner') {
+      return Icon(
+        Icons.star_rounded,
+        size: size,
+        color: Colors.amber,
+        semanticLabel: 'owner',
+      );
+    }
+    if (role == 'admin') {
+      return Icon(
+        Icons.shield_rounded,
+        size: size,
+        color: Colors.blue,
+        semanticLabel: 'admin',
+      );
+    }
+    return const SizedBox.shrink();
+  }
+}
+
+/// The Owner / Admin pill rendered to the right of a member's name.
+/// Renders nothing for ordinary members so callers can drop it into a
+/// Row unconditionally.
+class MemberRoleBadge extends StatelessWidget {
+  final String? role;
+  final EdgeInsetsGeometry margin;
+  const MemberRoleBadge({
+    super.key,
+    required this.role,
+    this.margin = const EdgeInsets.only(left: 8),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (role != 'owner' && role != 'admin') return const SizedBox.shrink();
+    final isOwner = role == 'owner';
+    // Reserve amber (EchoTheme.warning) for actual warnings — away
+    // presence, "Experimental" feature pills, etc. Owner gets the
+    // brighter `accentHover` accent variant so it still reads as
+    // distinct from Admin's `accent` at lower alpha.
+    final bgColor = isOwner
+        ? EchoTheme.accentHover.withValues(alpha: 0.22)
+        : context.accent.withValues(alpha: 0.15);
+    final textColor = isOwner ? EchoTheme.accentHover : context.accentHover;
+    final label = isOwner ? 'Owner' : 'Admin';
+
+    return Container(
+      margin: margin,
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.inter(
+          color: textColor,
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.3,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -11,6 +11,7 @@ import '../screens/user_profile_screen.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/presence.dart';
+import 'member_role.dart';
 import 'user_avatar.dart';
 
 class MembersPanel extends ConsumerWidget {
@@ -261,48 +262,6 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
     }
   }
 
-  Widget _buildRoleBadge(String role) {
-    final Color bgColor;
-    final Color textColor;
-    final String label;
-
-    switch (role) {
-      case 'owner':
-        // Reserve amber (EchoTheme.warning) for actual warnings —
-        // "Experimental" feature pill, away presence, etc. Owner is a
-        // positive role attribute, so use a brighter accent variant so
-        // it still distinguishes from Admin (same accent at lower alpha)
-        // without leaning on the warning palette.
-        bgColor = EchoTheme.accentHover.withValues(alpha: 0.22);
-        textColor = EchoTheme.accentHover;
-        label = 'Owner';
-      case 'admin':
-        bgColor = context.accent.withValues(alpha: 0.15);
-        textColor = context.accentHover;
-        label = 'Admin';
-      default:
-        return const SizedBox.shrink();
-    }
-
-    return Container(
-      margin: const EdgeInsets.only(left: 6),
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-      decoration: BoxDecoration(
-        color: bgColor,
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: textColor,
-          fontSize: 10,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0.3,
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final member = widget.member;
@@ -313,9 +272,7 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
     // Everyone else reads from the centralized provider.
     final UserPresence presence;
     if (widget.isMe) {
-      final myStatus = ref.watch(
-        authProvider.select((s) => s.presenceStatus),
-      );
+      final myStatus = ref.watch(authProvider.select((s) => s.presenceStatus));
       presence = UserPresence(status: myStatus, isOnline: true);
     } else {
       presence = ref.watch(userPresenceProvider(member.userId));
@@ -357,21 +314,9 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
                     children: [
                       Row(
                         children: [
-                          if (member.role == 'owner') ...[
-                            const Icon(
-                              Icons.star_rounded,
-                              size: 14,
-                              color: Colors.amber,
-                              semanticLabel: 'owner',
-                            ),
-                            const SizedBox(width: 4),
-                          ] else if (member.role == 'admin') ...[
-                            const Icon(
-                              Icons.shield_rounded,
-                              size: 14,
-                              color: Colors.blue,
-                              semanticLabel: 'admin',
-                            ),
+                          if (member.role == 'owner' ||
+                              member.role == 'admin') ...[
+                            MemberRoleIcon(role: member.role),
                             const SizedBox(width: 4),
                           ],
                           Flexible(
@@ -384,10 +329,10 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
                               ),
                             ),
                           ),
-                          if (member.role != null &&
-                              (member.role == 'owner' ||
-                                  member.role == 'admin'))
-                            _buildRoleBadge(member.role!),
+                          MemberRoleBadge(
+                            role: member.role,
+                            margin: const EdgeInsets.only(left: 6),
+                          ),
                         ],
                       ),
                       Text(

--- a/apps/client/test/widgets/member_role_test.dart
+++ b/apps/client/test/widgets/member_role_test.dart
@@ -1,0 +1,51 @@
+import 'package:echo_app/src/widgets/member_role.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/pump_app.dart';
+
+void main() {
+  group('MemberRoleIcon', () {
+    testWidgets('renders amber star for owner', (tester) async {
+      await tester.pumpApp(const MemberRoleIcon(role: 'owner'));
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.icon, Icons.star_rounded);
+      expect(icon.color, Colors.amber);
+    });
+
+    testWidgets('renders blue shield for admin', (tester) async {
+      await tester.pumpApp(const MemberRoleIcon(role: 'admin'));
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.icon, Icons.shield_rounded);
+      expect(icon.color, Colors.blue);
+    });
+
+    testWidgets('renders nothing for ordinary members', (tester) async {
+      await tester.pumpApp(const MemberRoleIcon(role: 'member'));
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('renders nothing for null role', (tester) async {
+      await tester.pumpApp(const MemberRoleIcon(role: null));
+      expect(find.byType(Icon), findsNothing);
+    });
+  });
+
+  group('MemberRoleBadge', () {
+    testWidgets('shows "Owner" label for owner role', (tester) async {
+      await tester.pumpApp(const MemberRoleBadge(role: 'owner'));
+      expect(find.text('Owner'), findsOneWidget);
+    });
+
+    testWidgets('shows "Admin" label for admin role', (tester) async {
+      await tester.pumpApp(const MemberRoleBadge(role: 'admin'));
+      expect(find.text('Admin'), findsOneWidget);
+    });
+
+    testWidgets('renders nothing for ordinary members', (tester) async {
+      await tester.pumpApp(const MemberRoleBadge(role: 'member'));
+      expect(find.text('Owner'), findsNothing);
+      expect(find.text('Admin'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Follow-up audit pass after the presence cleanup. Three more
inline-duplicated patterns I spotted and unified.

## New components
- **\`MemberRoleIcon\`** — the amber \`star_rounded\` (owner) and blue
  \`shield_rounded\` (admin) icons rendered next to a member's
  username. Was inlined identically in three files
  (\`members_panel\`, \`group_members_sheet\`, \`group_info_screen\`).
- **\`MemberRoleBadge\`** — the Owner / Admin pill rendered after the
  name. Three files had three colour treatments: \`group_members_sheet\`
  and \`group_info_screen\` used amber for Owner; \`members_panel\` used
  \`accentHover\` with an explicit *"Reserve amber for actual warnings"*
  comment. The members_panel choice wins — amber stays reserved for
  away presence and warning chrome.
- **\`copyToClipboard(context, text, successMessage)\`** — the
  \`Clipboard.setData(...) + ToastService.show(...)\` pair lived in
  10+ places. Helper handles the \`mounted\` check before showing the
  toast so callers stop forgetting it.

## Verification
\`\`\`
$ grep -rn 'Icons.star_rounded|Icons.shield_rounded' lib/src/ | grep -v member_role.dart
(no matches)

$ grep -rn \"label = 'Owner'|label = 'Admin'\" lib/src/ | grep -v member_role.dart
(no matches)
\`\`\`

\`flutter analyze\` clean. 1916/1916 client tests pass (+7 for the
new components).

## Tests
- 7 new tests cover owner-vs-admin-vs-member rendering for both the
  icon and the badge, plus the null-role no-render case.

## Decisions made along the way
The "owner = amber star" choice in the icon stayed (the icon
remains universal — a gold star looks like ownership across every
app); only the badge background colour changed to accent. The
\`copyToClipboard\` helper deliberately does not take a \`type\`
param — every call site uses \`ToastType.success\`. The one place
that wanted \`ToastType.info\` (image-gallery save fallback) was left
alone to keep the helper's API narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)