### PR TITLE
showEchoBottomSheet — single helper, 10 callers migrated

### DIFF
--- a/apps/client/lib/src/screens/discover_groups_screen.dart
+++ b/apps/client/lib/src/screens/discover_groups_screen.dart
@@ -11,6 +11,7 @@ import '../providers/server_url_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../widgets/avatar_utils.dart' show groupAvatarColor;
+import '../widgets/echo_bottom_sheet.dart';
 import '../widgets/empty_state.dart';
 
 /// A public group returned by the discovery endpoint.
@@ -212,155 +213,137 @@ class _DiscoverGroupsScreenState extends ConsumerState<DiscoverGroupsScreen> {
   /// Show a bottom-sheet preview of a group with full details and a Join CTA.
   /// Lets users decide whether to join before committing.
   void _showGroupPreview(_PublicGroup group) {
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: context.surface,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
+    showEchoBottomSheet<void>(
+      context,
+      dragHandle: true,
       builder: (sheetCtx) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Drag handle
-                Center(
-                  child: Container(
-                    width: 40,
-                    height: 4,
-                    margin: const EdgeInsets.only(bottom: 16),
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Avatar + name
+              Row(
+                children: [
+                  Container(
+                    width: 56,
+                    height: 56,
                     decoration: BoxDecoration(
-                      color: context.textMuted.withValues(alpha: 0.4),
-                      borderRadius: BorderRadius.circular(2),
+                      color: groupAvatarColor(group.name),
+                      borderRadius: BorderRadius.circular(28),
+                    ),
+                    alignment: Alignment.center,
+                    child: const Icon(
+                      Icons.group,
+                      size: 28,
+                      color: Colors.white,
                     ),
                   ),
-                ),
-                // Avatar + name
-                Row(
-                  children: [
-                    Container(
-                      width: 56,
-                      height: 56,
-                      decoration: BoxDecoration(
-                        color: groupAvatarColor(group.name),
-                        borderRadius: BorderRadius.circular(28),
-                      ),
-                      alignment: Alignment.center,
-                      child: const Icon(
-                        Icons.group,
-                        size: 28,
-                        color: Colors.white,
-                      ),
-                    ),
-                    const SizedBox(width: 14),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            group.name,
-                            style: TextStyle(
-                              color: context.textPrimary,
-                              fontSize: 18,
-                              fontWeight: FontWeight.w700,
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          group.name,
+                          style: TextStyle(
+                            color: context.textPrimary,
+                            fontSize: 18,
+                            fontWeight: FontWeight.w700,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 2),
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.public,
+                              size: 13,
+                              color: context.textMuted,
                             ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          const SizedBox(height: 2),
-                          Row(
-                            children: [
-                              Icon(
-                                Icons.public,
-                                size: 13,
+                            const SizedBox(width: 4),
+                            Text(
+                              'Public group',
+                              style: TextStyle(
                                 color: context.textMuted,
+                                fontSize: 12,
                               ),
-                              const SizedBox(width: 4),
-                              Text(
-                                'Public group',
-                                style: TextStyle(
-                                  color: context.textMuted,
-                                  fontSize: 12,
-                                ),
-                              ),
-                              const SizedBox(width: 10),
-                              Icon(
-                                Icons.people_outline,
-                                size: 13,
+                            ),
+                            const SizedBox(width: 10),
+                            Icon(
+                              Icons.people_outline,
+                              size: 13,
+                              color: context.textMuted,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              '${group.memberCount} '
+                              'member${group.memberCount == 1 ? '' : 's'}',
+                              style: TextStyle(
                                 color: context.textMuted,
+                                fontSize: 12,
                               ),
-                              const SizedBox(width: 4),
-                              Text(
-                                '${group.memberCount} '
-                                'member${group.memberCount == 1 ? '' : 's'}',
-                                style: TextStyle(
-                                  color: context.textMuted,
-                                  fontSize: 12,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-                if (group.description != null &&
-                    group.description!.isNotEmpty) ...[
-                  const SizedBox(height: 18),
-                  Text(
-                    'About',
-                    style: TextStyle(
-                      color: context.textMuted,
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      letterSpacing: 0.6,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    group.description!,
-                    maxLines: 4,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: context.textSecondary,
-                      fontSize: 14,
-                      height: 1.45,
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
                   ),
                 ],
-                const SizedBox(height: 24),
-                // Join CTA — disabled when already joined.
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton(
-                    onPressed: group.joined
-                        ? null
-                        : () {
-                            Navigator.of(sheetCtx).pop();
-                            _joinGroup(group);
-                          },
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 14),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                    ),
-                    child: Text(
-                      group.joined ? 'Already joined' : 'Join group',
-                      style: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
+              ),
+              if (group.description != null &&
+                  group.description!.isNotEmpty) ...[
+                const SizedBox(height: 18),
+                Text(
+                  'About',
+                  style: TextStyle(
+                    color: context.textMuted,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0.6,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  group.description!,
+                  maxLines: 4,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: context.textSecondary,
+                    fontSize: 14,
+                    height: 1.45,
                   ),
                 ),
               ],
-            ),
+              const SizedBox(height: 24),
+              // Join CTA — disabled when already joined.
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: group.joined
+                      ? null
+                      : () {
+                          Navigator.of(sheetCtx).pop();
+                          _joinGroup(group);
+                        },
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  child: Text(
+                    group.joined ? 'Already joined' : 'Join group',
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ),
         );
       },

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -21,6 +21,7 @@ import '../services/debug_log_service.dart';
 import '../services/pip_controller.dart';
 import '../theme/echo_theme.dart';
 import '../utils/canvas_utils.dart';
+import '../widgets/echo_bottom_sheet.dart';
 import '../widgets/lounge_drawing_canvas.dart';
 import '../widgets/vertex_mesh_background.dart';
 import '../widgets/voice_canvas.dart';
@@ -620,32 +621,30 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         ),
       );
     } else {
-      await showModalBottomSheet<void>(
-        context: ctx,
+      await showEchoBottomSheet<void>(
+        ctx,
         builder: (sheetCtx) {
-          return SafeArea(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.image_outlined),
+                title: const Text('Choose voice lounge background'),
+                onTap: () {
+                  Navigator.of(sheetCtx).pop();
+                  _pickBackground();
+                },
+              ),
+              if (hasCustom)
                 ListTile(
-                  leading: const Icon(Icons.image_outlined),
-                  title: const Text('Choose voice lounge background'),
+                  leading: const Icon(Icons.restore),
+                  title: const Text('Reset to default'),
                   onTap: () {
                     Navigator.of(sheetCtx).pop();
-                    _pickBackground();
+                    _clearBackground();
                   },
                 ),
-                if (hasCustom)
-                  ListTile(
-                    leading: const Icon(Icons.restore),
-                    title: const Text('Reset to default'),
-                    onTap: () {
-                      Navigator.of(sheetCtx).pop();
-                      _clearBackground();
-                    },
-                  ),
-              ],
-            ),
+            ],
           );
         },
       );

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -20,6 +20,7 @@ import '../theme/responsive.dart';
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart' show buildAvatar, groupAvatarColor, resolveAvatarUrl;
 import 'chat_header_widgets.dart';
+import 'echo_bottom_sheet.dart';
 import 'group_members_sheet.dart' show showGroupMembersSheet;
 import 'shared_media_gallery.dart';
 
@@ -562,17 +563,11 @@ class ChatHeaderBar extends ConsumerWidget {
       );
       return;
     }
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      backgroundColor: Colors.transparent,
-      builder: (_) => ClipRRect(
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-        child: SizedBox(
-          height: MediaQuery.of(context).size.height * 0.85,
-          child: SharedMediaGallery(conversationId: conv.id),
-        ),
+    showEchoBottomSheet<void>(
+      context,
+      builder: (_) => SizedBox(
+        height: MediaQuery.of(context).size.height * 0.85,
+        child: SharedMediaGallery(conversationId: conv.id),
       ),
     );
   }

--- a/apps/client/lib/src/widgets/chat_header_widgets.dart
+++ b/apps/client/lib/src/widgets/chat_header_widgets.dart
@@ -24,6 +24,7 @@ import '../services/message_cache.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/time_utils.dart';
+import 'echo_bottom_sheet.dart';
 
 const _kAuthorizationHeader = 'Authorization';
 const _kDisappearingMessagesLabel = 'Disappearing messages';
@@ -81,80 +82,74 @@ class _IdentityChangedBadgeState extends ConsumerState<IdentityChangedBadge> {
     // display name down from the header.
     final peerLabel = widget.peerUserId;
 
-    await showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: context.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
+    await showEchoBottomSheet<void>(
+      context,
       builder: (sheetCtx) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 12),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 8,
-                  ),
-                  child: Row(
-                    children: [
-                      const Icon(
-                        Icons.warning_amber_rounded,
-                        size: 18,
-                        color: EchoTheme.warning,
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          'Identity key changed',
-                          style: GoogleFonts.inter(
-                            color: sheetCtx.textPrimary,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                          ),
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Row(
+                  children: [
+                    const Icon(
+                      Icons.warning_amber_rounded,
+                      size: 18,
+                      color: EchoTheme.warning,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Identity key changed',
+                        style: GoogleFonts.inter(
+                          color: sheetCtx.textPrimary,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-                ListTile(
-                  leading: Icon(
-                    Icons.verified_user_outlined,
-                    color: sheetCtx.accent,
-                  ),
-                  title: const Text('Verify safety number'),
-                  onTap: () {
-                    Navigator.of(sheetCtx).pop();
-                    SafetyNumberScreen.show(
-                      context,
-                      ref,
-                      peerUserId: widget.peerUserId,
-                      peerUsername: peerLabel,
-                      myUsername: myName,
-                    );
-                  },
+              ),
+              ListTile(
+                leading: Icon(
+                  Icons.verified_user_outlined,
+                  color: sheetCtx.accent,
                 ),
-                ListTile(
-                  leading: const Icon(
-                    Icons.check_circle_outline,
-                    color: EchoTheme.warning,
-                  ),
-                  title: const Text('Trust new key'),
-                  onTap: () async {
-                    Navigator.of(sheetCtx).pop();
-                    await ref
-                        .read(cryptoProvider.notifier)
-                        .acceptIdentityKeyChange(widget.peerUserId);
-                    if (mounted) {
-                      setState(() => _changed = false);
-                    }
-                  },
+                title: const Text('Verify safety number'),
+                onTap: () {
+                  Navigator.of(sheetCtx).pop();
+                  SafetyNumberScreen.show(
+                    context,
+                    ref,
+                    peerUserId: widget.peerUserId,
+                    peerUsername: peerLabel,
+                    myUsername: myName,
+                  );
+                },
+              ),
+              ListTile(
+                leading: const Icon(
+                  Icons.check_circle_outline,
+                  color: EchoTheme.warning,
                 ),
-              ],
-            ),
+                title: const Text('Trust new key'),
+                onTap: () async {
+                  Navigator.of(sheetCtx).pop();
+                  await ref
+                      .read(cryptoProvider.notifier)
+                      .acceptIdentityKeyChange(widget.peerUserId);
+                  if (mounted) {
+                    setState(() => _changed = false);
+                  }
+                },
+              ),
+            ],
           ),
         );
       },

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -38,6 +38,7 @@ import 'chat_input_bar/file_pickers.dart' as pickers;
 import 'chat_input_bar/attach_option.dart';
 import 'chat_input_bar/media_marker_helpers.dart';
 import 'chat_input_bar/media_picker_toggle.dart';
+import 'echo_bottom_sheet.dart';
 import 'chat_input_bar/recording_row.dart';
 import 'chat_input_bar/send_button.dart';
 import 'chat_input_bar/upload_helpers.dart';
@@ -1209,44 +1210,38 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   // ---------------------------------------------------------------------------
 
   void _showMobileAttachMenu() {
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: context.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (ctx) => SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AttachOption(
-                icon: Icons.photo_library_outlined,
-                label: 'Photos & Videos',
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _pickImageFromGallery();
-                },
-              ),
-              AttachOption(
-                icon: Icons.camera_alt_outlined,
-                label: 'Camera',
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _pickImageFromCamera();
-                },
-              ),
-              AttachOption(
-                icon: Icons.insert_drive_file_outlined,
-                label: 'File',
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _pickFile();
-                },
-              ),
-            ],
-          ),
+    showEchoBottomSheet<void>(
+      context,
+      builder: (ctx) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AttachOption(
+              icon: Icons.photo_library_outlined,
+              label: 'Photos & Videos',
+              onTap: () {
+                Navigator.pop(ctx);
+                _pickImageFromGallery();
+              },
+            ),
+            AttachOption(
+              icon: Icons.camera_alt_outlined,
+              label: 'Camera',
+              onTap: () {
+                Navigator.pop(ctx);
+                _pickImageFromCamera();
+              },
+            ),
+            AttachOption(
+              icon: Icons.insert_drive_file_outlined,
+              label: 'File',
+              onTap: () {
+                Navigator.pop(ctx);
+                _pickFile();
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/apps/client/lib/src/widgets/chat_panel/full_reaction_picker.dart
+++ b/apps/client/lib/src/widgets/chat_panel/full_reaction_picker.dart
@@ -2,7 +2,7 @@ import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/material.dart';
 
 import '../../models/chat_message.dart';
-import '../../theme/echo_theme.dart';
+import '../echo_bottom_sheet.dart';
 import '../emoji_picker_config.dart';
 
 /// Show the full emoji-picker bottom sheet for adding a reaction to a message.
@@ -20,13 +20,8 @@ Future<void> showFullReactionPicker(
   required String myUserId,
   required void Function(String emoji, bool alreadyReacted) onPick,
 }) {
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: context.surface,
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-    ),
+  return showEchoBottomSheet<void>(
+    context,
     builder: (sheetContext) => SizedBox(
       height: 380,
       child: DefaultTextStyle(

--- a/apps/client/lib/src/widgets/connection_status_badge.dart
+++ b/apps/client/lib/src/widgets/connection_status_badge.dart
@@ -9,6 +9,7 @@ import '../providers/websocket_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../version.dart';
+import 'echo_bottom_sheet.dart';
 
 /// Threshold past which we stop calling the state "reconnecting" and start
 /// calling it "offline". Matches the legacy chat-header dot's display logic;
@@ -168,17 +169,14 @@ class _ConnectionStatusBadgeState extends ConsumerState<ConnectionStatusBadge>
   }
 
   Future<void> _openMobileSheet(_ConnectionStateKind kind) async {
-    await showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: Colors.transparent,
+    await showEchoBottomSheet<void>(
+      context,
       builder: (sheetContext) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: _ConnectionStatusPopover(
-              kind: kind,
-              onDismiss: () => Navigator.of(sheetContext).maybePop(),
-            ),
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: _ConnectionStatusPopover(
+            kind: kind,
+            onDismiss: () => Navigator.of(sheetContext).maybePop(),
           ),
         );
       },

--- a/apps/client/lib/src/widgets/echo_bottom_sheet.dart
+++ b/apps/client/lib/src/widgets/echo_bottom_sheet.dart
@@ -1,0 +1,83 @@
+/// Single entry point for every modal bottom sheet in the app.
+///
+/// Every `showModalBottomSheet` site used to pass the same `isScrollControlled:
+/// true`, `backgroundColor: …`, and a `shape:` (or had its child wrap itself
+/// in `ClipRRect`) with the same 16-px top corner radius. Drift had already
+/// started — two callers used Material's `shape:` param, the rest passed
+/// `Colors.transparent` and rounded the child themselves. Same pixels, two
+/// ways to get there.
+///
+/// `showEchoBottomSheet` bakes in:
+///   • `backgroundColor: context.surface`
+///   • `shape:` rounded top corners (16 px)
+///   • `isScrollControlled: true` + `useSafeArea: true` defaults
+///   • optional drag handle pill prepended to the body
+///
+/// Callers just supply a builder for the content. Result: changing the
+/// surface colour, corner radius, or drag-handle styling is a single edit
+/// here, not a 13-file sweep.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../theme/echo_theme.dart';
+
+/// Show an Echo-styled modal bottom sheet.
+///
+/// [dragHandle] prepends a centred 36×4 pill above the body — used by the
+/// mobile profile sheet and the group-members sheet. Defaults to off; most
+/// sheets are short-lived menus that don't need it.
+Future<T?> showEchoBottomSheet<T>(
+  BuildContext context, {
+  required WidgetBuilder builder,
+  bool dragHandle = false,
+  bool isScrollControlled = true,
+  bool useSafeArea = true,
+  bool isDismissible = true,
+  bool enableDrag = true,
+}) {
+  return showModalBottomSheet<T>(
+    context: context,
+    isScrollControlled: isScrollControlled,
+    useSafeArea: useSafeArea,
+    isDismissible: isDismissible,
+    enableDrag: enableDrag,
+    backgroundColor: context.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (ctx) {
+      final body = builder(ctx);
+      if (!dragHandle) return body;
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SheetDragHandle(),
+          Flexible(child: body),
+        ],
+      );
+    },
+  );
+}
+
+/// Centred 36×4 pill used as a drag handle at the top of Echo bottom
+/// sheets. Exposed for surfaces that build a sheet manually
+/// (`DraggableScrollableSheet`-based ones) and want the same visual.
+class SheetDragHandle extends StatelessWidget {
+  const SheetDragHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Container(
+        width: 36,
+        height: 4,
+        decoration: BoxDecoration(
+          color: context.border,
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/profile_sheets.dart
+++ b/apps/client/lib/src/widgets/profile_sheets.dart
@@ -4,12 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../screens/group_info_screen.dart';
 import '../screens/user_profile_screen.dart';
 import '../theme/echo_theme.dart';
+import 'echo_bottom_sheet.dart';
 
 /// Opens the user profile in a bottom sheet on mobile or a dialog on desktop.
 ///
 /// On screens >= 900 px wide a centred [Dialog] (400 x 500) is shown.
-/// On narrower screens a drag-down-dismissible [ModalBottomSheet] covers
-/// ~85 % of the viewport height so chat context remains visible above it.
+/// On narrower screens an [showEchoBottomSheet] is opened with a drag
+/// handle, capped at ~85 % of the viewport height so chat context stays
+/// visible above it.
 void showUserProfileSheet(BuildContext context, WidgetRef ref, String userId) {
   final width = MediaQuery.of(context).size.width;
   if (width >= 900) {
@@ -29,13 +31,11 @@ void showUserProfileSheet(BuildContext context, WidgetRef ref, String userId) {
       ),
     );
   } else {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      backgroundColor: Colors.transparent,
-      builder: (sheetCtx) =>
-          _ProfileSheet(child: UserProfileScreen(userId: userId)),
+    showEchoBottomSheet<void>(
+      context,
+      dragHandle: true,
+      builder: (_) =>
+          _ProfileSheetBody(child: UserProfileScreen(userId: userId)),
     );
   }
 }
@@ -43,7 +43,8 @@ void showUserProfileSheet(BuildContext context, WidgetRef ref, String userId) {
 /// Opens the group info panel in a bottom sheet on mobile or a dialog on desktop.
 ///
 /// On screens >= 900 px wide a wide [Dialog] (680 x 600) is shown.
-/// On narrower screens a drag-down-dismissible [ModalBottomSheet] is used.
+/// On narrower screens an [showEchoBottomSheet] is opened with a drag
+/// handle.
 void showGroupProfileSheet(
   BuildContext context,
   WidgetRef ref,
@@ -70,21 +71,21 @@ void showGroupProfileSheet(
       ),
     );
   } else {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      backgroundColor: Colors.transparent,
-      builder: (sheetCtx) =>
-          _ProfileSheet(child: GroupInfoScreen(conversationId: conversationId)),
+    showEchoBottomSheet<void>(
+      context,
+      dragHandle: true,
+      builder: (_) => _ProfileSheetBody(
+        child: GroupInfoScreen(conversationId: conversationId),
+      ),
     );
   }
 }
 
-/// Shared bottom-sheet container: rounded top corners, drag handle, and
-/// an 85 %-viewport height constraint so the sheet feels intentional.
-class _ProfileSheet extends StatelessWidget {
-  const _ProfileSheet({required this.child});
+/// Inner body for the profile/group-info sheet — caps at 85 % of the
+/// viewport so chat context stays peeking out above the sheet and
+/// pushes the bottom edge up when the soft keyboard opens.
+class _ProfileSheetBody extends StatelessWidget {
+  const _ProfileSheetBody({required this.child});
 
   final Widget child;
 
@@ -94,30 +95,9 @@ class _ProfileSheet extends StatelessWidget {
     final screenHeight = MediaQuery.of(context).size.height;
     return Padding(
       padding: EdgeInsets.only(bottom: viewInsets.bottom),
-      child: Container(
+      child: ConstrainedBox(
         constraints: BoxConstraints(maxHeight: screenHeight * 0.85),
-        decoration: BoxDecoration(
-          color: context.surface,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Drag handle
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 10),
-              child: Container(
-                width: 36,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: context.border,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ),
-            ),
-            Flexible(child: child),
-          ],
-        ),
+        child: child,
       ),
     );
   }

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../providers/release_notes_provider.dart';
 import '../theme/echo_theme.dart';
+import 'echo_bottom_sheet.dart';
 
 /// Bottom-sheet style "What's New" modal showing the GitHub release
 /// notes for the version the user just updated to.  Markdown body is
@@ -279,10 +280,8 @@ Future<void> maybeShowWhatsNew(
     // overlay so the title bar stays draggable.
     onShow?.call(view);
   } else {
-    await showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
+    await showEchoBottomSheet<void>(
+      context,
       builder: (_) => WhatsNewModal(notes: view),
     );
   }


### PR DESCRIPTION
Continuing the cleanup pass. Every \`showModalBottomSheet\` site
repeated the same boilerplate — \`isScrollControlled: true\`,
\`useSafeArea: true\`, a 16-px rounded top, surface background — plus
some had a hand-rolled drag handle pill. Two ways to apply the shape
were drifting (Material's \`shape:\` param vs child-owned \`ClipRRect\`).

## Behind the scenes
- New \`showEchoBottomSheet(context, {builder, dragHandle, ...})\`
  bakes in every default. Callers just supply a builder.
- New \`SheetDragHandle\` widget so sheets that don't go through the
  helper (the three DraggableScrollableSheet-based ones) can still
  drop in the same 36×4 pill.

## Migrated (9 call sites)
- Reaction picker
- Mobile attach menu (chat input bar)
- Shared Media (chat header bar)
- What's New release notes (mobile)
- User + group profile sheets (with drag handle)
- Discover groups preview (with drag handle)
- Voice lounge background picker
- Identity-changed action sheet
- Connection-status mobile popover

## Deliberately not migrated (3)
- \`group_members_sheet\` — DraggableScrollableSheet, drag-to-expand.
- \`thread_view_panel\` — same pattern.
- \`context_menu_sheet\` — custom top border + animated keyboard
  padding the helper doesn't model.

These three keep their own \`showModalBottomSheet\` but use the new
\`SheetDragHandle\` widget for the drag pill — same visual.

## Verification
\`flutter analyze\` clean. 1916/1916 client tests pass.

The point: changing the sheet's surface colour, corner radius, or
drag handle is now **one edit** in \`echo_bottom_sheet.dart\`, not a
10-file sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)