### PR TITLE
Release: showEchoConfirmDialog helper

### DIFF
--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -24,6 +24,7 @@ import '../utils/fuzzy_score.dart';
 import '../utils/presence.dart';
 import '../widgets/avatar_crop_dialog.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import '../widgets/confirm_dialog.dart';
 import '../widgets/member_role.dart';
 import '../widgets/user_avatar.dart';
 import '../widgets/context_menu/actions/member_actions_registry.dart';
@@ -356,31 +357,17 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
 
   Future<void> _deleteGroup() async {
     final groupName = _conversation?.name ?? 'this group';
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete Group'),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Delete Group',
+      content:
           'Are you sure you want to delete "$groupName"? '
           'This will permanently remove all messages and members. '
           'This action cannot be undone.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Delete',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final token = ref.read(authProvider).token;
     if (token == null) return;
@@ -417,28 +404,15 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   }
 
   Future<void> _leaveGroup() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: const Text('Leave Group'),
-        content: const Text('Are you sure you want to leave this group?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: const Text('Leave'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Leave Group',
+      content: 'Are you sure you want to leave this group?',
+      confirmLabel: 'Leave',
+      destructive: true,
     );
 
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final token = ref.read(authProvider).token;
     if (token == null) return;
@@ -468,27 +442,14 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   }
 
   Future<void> _kickMember(ConversationMember member) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Remove Member'),
-        content: Text('Remove ${member.username} from this group?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: const Text('Remove'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Remove Member',
+      content: 'Remove ${member.username} from this group?',
+      confirmLabel: 'Remove',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final token = ref.read(authProvider).token;
     if (token == null) return;
@@ -526,30 +487,16 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   }
 
   Future<void> _banMember(ConversationMember member) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Ban Member'),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Ban Member',
+      content:
           'Ban ${member.username} from this group? '
           'They will not be able to rejoin.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: const Text('Ban'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Ban',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final token = ref.read(authProvider).token;
     if (token == null) return;
@@ -788,27 +735,14 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   }
 
   Future<void> _deleteChannel(String channelId, String channelName) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete Channel'),
-        content: Text('Delete channel "$channelName"? This cannot be undone.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Delete Channel',
+      content: 'Delete channel "$channelName"? This cannot be undone.',
+      confirmLabel: 'Delete',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final success = await ref
         .read(channelsProvider.notifier)

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -26,6 +26,7 @@ import '../services/tray_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
 import '../widgets/chat_panel.dart';
+import '../widgets/confirm_dialog.dart';
 import '../widgets/conversation_panel.dart'
     show ConversationPanel, buildAvatar, groupAvatarColor, resolveAvatarUrl;
 import '../widgets/members_panel.dart';
@@ -657,45 +658,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   }
 
   Future<void> _logout() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Log Out',
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
-          'Are you sure you want to log out?',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Log Out'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Log Out',
+      content: 'Are you sure you want to log out?',
+      confirmLabel: 'Log Out',
+      destructive: true,
     );
 
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     ref.read(websocketProvider.notifier).disconnect();
     ref.read(chatProvider.notifier).clear();

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -21,6 +21,7 @@ import '../../services/secure_key_store.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../version.dart';
+import '../../widgets/confirm_dialog.dart';
 import '../../widgets/feedback_dialog.dart';
 
 class AboutSection extends ConsumerStatefulWidget {
@@ -198,44 +199,15 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
         Uri.tryParse(ref.read(serverUrlProvider))?.host ??
         ref.read(serverUrlProvider);
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Switch server?',
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Switch server?',
+      content:
           "You'll be logged out of $oldHost; messages and keys for both "
           'servers stay on this device.',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 13,
-            height: 1.4,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            child: const Text('Switch'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Switch',
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     await ref.read(serverUrlProvider.notifier).switchTo(target.url);
     if (!mounted) return;
@@ -247,46 +219,17 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
   /// Forget a known server: drop it from the list and best-effort wipe its
   /// scoped state on this device. The active server cannot be forgotten.
   Future<void> _confirmAndForget(KnownServer target) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Forget server?',
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Forget server?',
+      content:
           'This deletes locally-stored keys and message cache for '
           '${Uri.tryParse(target.url)?.host ?? target.url}. '
           'The remote account is not affected.',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 13,
-            height: 1.4,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Forget'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Forget',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     // Wipe scoped state. SecureKeyStore.deleteAllForUser only operates on
     // the currently-set scope, so we briefly set it for the user we have

--- a/apps/client/lib/src/screens/settings/data_storage_section.dart
+++ b/apps/client/lib/src/screens/settings/data_storage_section.dart
@@ -9,6 +9,7 @@ import '../../services/export_service.dart';
 import '../../services/message_cache.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/confirm_dialog.dart';
 
 class DataStorageSection extends ConsumerStatefulWidget {
   const DataStorageSection({super.key});
@@ -49,36 +50,15 @@ class _DataStorageSectionState extends ConsumerState<DataStorageSection> {
   }
 
   Future<void> _clearMessageCache() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Clear Message Cache',
-          style: TextStyle(color: context.textPrimary, fontSize: 18),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Clear Message Cache',
+      content:
           'Cached messages will be reloaded from the server. '
           'No data will be lost.',
-          style: TextStyle(color: context.textSecondary, fontSize: 14),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Clear'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Clear',
     );
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     await MessageCache.clearAll();
     await _calculateCacheSize();
@@ -109,36 +89,15 @@ class _DataStorageSectionState extends ConsumerState<DataStorageSection> {
   }
 
   Future<void> _exportChats() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Export chats',
-          style: TextStyle(color: context.textPrimary, fontSize: 18),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Export chats',
+      content:
           'Your locally cached messages will be saved as a JSON file. '
           'Private keys and Signal session state are not included.',
-          style: TextStyle(color: context.textSecondary, fontSize: 14),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Export'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Export',
     );
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     setState(() => _isExporting = true);
     try {

--- a/apps/client/lib/src/screens/settings/devices_section.dart
+++ b/apps/client/lib/src/screens/settings/devices_section.dart
@@ -13,6 +13,7 @@ import '../../providers/server_url_provider.dart';
 import '../../providers/websocket_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/confirm_dialog.dart';
 
 class DevicesSection extends ConsumerStatefulWidget {
   const DevicesSection({super.key});
@@ -125,46 +126,17 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
   }
 
   Future<void> _revokeDevice(_Device device) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Revoke ${device.displayLabel}',
-          style: const TextStyle(
-            color: EchoTheme.danger,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Revoke ${device.displayLabel}',
+      content:
           'This will remove ${device.displayLabel} from your account. '
           'Any active session on that device will be signed out immediately.',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Revoke'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Revoke',
+      destructive: true,
     );
 
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final serverUrl = ref.read(serverUrlProvider);
     try {
@@ -200,45 +172,15 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
 
   /// Revoke every device except the current one after confirming with the user.
   Future<void> _revokeOtherDevices(int currentDeviceId) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Log out all other devices',
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
-          'This will log out every device except this one. Continue?',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Log out others'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Log out all other devices',
+      content: 'This will log out every device except this one. Continue?',
+      confirmLabel: 'Log out others',
+      destructive: true,
     );
 
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final serverUrl = ref.read(serverUrlProvider);
     try {

--- a/apps/client/lib/src/screens/settings/privacy_section.dart
+++ b/apps/client/lib/src/screens/settings/privacy_section.dart
@@ -8,6 +8,7 @@ import '../../providers/crypto_provider.dart';
 import '../../providers/privacy_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/confirm_dialog.dart';
 
 /// SharedPreferences key + reader for the "preserve original filenames"
 /// toggle. Default `true` (preserve). When `false`, uploads are sent with a
@@ -216,47 +217,14 @@ class _PrivacySectionState extends ConsumerState<PrivacySection> {
   }
 
   Future<void> _confirmUnblock(String userId, String username) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Unblock @$username?',
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
-          'They will be able to message you again.',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(
-              'Cancel',
-              style: TextStyle(color: context.textSecondary),
-            ),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Unblock'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Unblock @$username?',
+      content: 'They will be able to message you again.',
+      confirmLabel: 'Unblock',
     );
 
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final success = await ref
         .read(contactsProvider.notifier)

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -11,6 +11,7 @@ import '../providers/websocket_provider.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
 import '../version.dart';
+import '../widgets/confirm_dialog.dart';
 import '../widgets/settings/card_row.dart';
 import '../widgets/settings/section_header.dart';
 import '../widgets/settings/user_header_card.dart';
@@ -366,61 +367,38 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   SettingsSection? _mobileDetailSection;
 
   Future<void> _logout() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          _logOutLabel,
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Are you sure you want to log out?',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 14,
-                height: 1.5,
-              ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: _logOutLabel,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Are you sure you want to log out?',
+            style: TextStyle(
+              color: context.textSecondary,
+              fontSize: 14,
+              height: 1.5,
             ),
-            const SizedBox(height: 12),
-            const Text(
-              'Your local encryption keys will be cleared. '
-              'Old encrypted messages on this device may become unreadable.',
-              style: TextStyle(
-                color: EchoTheme.danger,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
           ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text(_logOutLabel),
+          const SizedBox(height: 12),
+          const Text(
+            'Your local encryption keys will be cleared. '
+            'Old encrypted messages on this device may become unreadable.',
+            style: TextStyle(
+              color: EchoTheme.danger,
+              fontSize: 13,
+              height: 1.5,
+            ),
           ),
         ],
       ),
+      confirmLabel: _logOutLabel,
+      destructive: true,
     );
 
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     ref.read(websocketProvider.notifier).disconnect();
     ref.read(chatProvider.notifier).clear();

--- a/apps/client/lib/src/screens/user_profile_screen.dart
+++ b/apps/client/lib/src/screens/user_profile_screen.dart
@@ -15,6 +15,7 @@ import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/presence.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import '../widgets/confirm_dialog.dart';
 import '../widgets/profile_sheets.dart';
 import 'safety_number_screen.dart';
 
@@ -640,36 +641,16 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
   }
 
   Future<void> _blockContact() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: const Text('Block user'),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Block user',
+      content:
           'Are you sure you want to block @$_username? '
           'They will not be able to message you.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(
-              'Cancel',
-              style: TextStyle(color: context.textSecondary),
-            ),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Block'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Block',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     final serverUrl = ref.read(serverUrlProvider);
     try {

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -13,6 +13,7 @@ import '../providers/voice_settings_provider.dart';
 import '../services/debug_log_service.dart';
 import '../theme/echo_theme.dart';
 import '../theme/responsive.dart';
+import 'confirm_dialog.dart';
 
 class ChannelBar extends ConsumerStatefulWidget {
   final String conversationId;
@@ -113,41 +114,15 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
         );
   }
 
-  Future<bool> _confirmVoiceJoin(String channelName) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Join Voice Channel?',
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
-          'Join $channelName now? Your microphone will be enabled based on your voice settings.',
-          style: TextStyle(color: context.textSecondary, fontSize: 14),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            child: const Text('Join'),
-          ),
-        ],
-      ),
+  Future<bool> _confirmVoiceJoin(String channelName) {
+    return showEchoConfirmDialog(
+      context,
+      title: 'Join Voice Channel?',
+      content:
+          'Join $channelName now? Your microphone will be enabled '
+          'based on your voice settings.',
+      confirmLabel: 'Join',
     );
-
-    return confirmed ?? false;
   }
 
   Future<void> _leaveVoiceChannel(String channelId) async {

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -20,6 +20,7 @@ import '../theme/responsive.dart';
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart' show buildAvatar, groupAvatarColor, resolveAvatarUrl;
 import 'chat_header_widgets.dart';
+import 'confirm_dialog.dart';
 import 'echo_bottom_sheet.dart';
 import 'group_members_sheet.dart' show showGroupMembersSheet;
 import 'shared_media_gallery.dart';
@@ -729,42 +730,17 @@ class ChatHeaderBar extends ConsumerWidget {
         ?.userId;
     if (peerId == null) return;
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Reset encryption keys?',
-          style: GoogleFonts.inter(
-            color: context.textPrimary,
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Reset encryption keys?',
+      content:
           'This will establish a fresh encrypted session. '
           'Messages encrypted with the old keys may become unreadable.',
-          style: GoogleFonts.inter(color: context.textSecondary, fontSize: 14),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Reset Keys'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Reset Keys',
+      destructive: true,
     );
 
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     try {
       final crypto = ref.read(cryptoServiceProvider);

--- a/apps/client/lib/src/widgets/confirm_dialog.dart
+++ b/apps/client/lib/src/widgets/confirm_dialog.dart
@@ -1,0 +1,85 @@
+/// Single entry point for every "Are you sure?" dialog in the app.
+///
+/// Before this helper, the same `showDialog<bool>` + `AlertDialog`
+/// with surface background, 12-px rounded corners, border, title text,
+/// content text, and a Cancel + Confirm button pair was hand-rolled in
+/// 23 places. Drift had already started:
+///   • Title size landed at 16 px in some places and 18 px in others.
+///   • Some destructive confirms used `EchoTheme.danger` for the
+///     button background; others used the default accent and just
+///     changed the label to "Delete".
+///   • A couple of sites had the dialog mounted-check, most didn't.
+///
+/// `showEchoConfirmDialog` bakes in the dialog chrome and forces a
+/// single `destructive` flag for the red-confirm variant. Changing the
+/// dialog's corner radius, border, or destructive treatment is a
+/// one-line edit here instead of a 23-file sweep.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../theme/echo_theme.dart';
+
+/// Show a confirm-or-cancel dialog. Returns `true` when the user taps
+/// the confirm button, `false` on cancel or barrier dismiss.
+///
+/// [destructive] swaps the confirm button to `EchoTheme.danger` and is
+/// the visual cue that the action is irreversible (delete, remove,
+/// leave, etc.). Default false.
+///
+/// [content] is the prompt body. Accepts either a [String] (rendered
+/// with the standard styling) or a [Widget] for richer bodies (e.g. a
+/// list of consequences). When you only need text, pass a String.
+Future<bool> showEchoConfirmDialog(
+  BuildContext context, {
+  required String title,
+  required Object content,
+  String confirmLabel = 'Confirm',
+  String cancelLabel = 'Cancel',
+  bool destructive = false,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (dialogCtx) {
+      final body = content is Widget
+          ? content
+          : Text(
+              content.toString(),
+              style: TextStyle(
+                color: dialogCtx.textSecondary,
+                fontSize: 14,
+              ),
+            );
+      return AlertDialog(
+        backgroundColor: dialogCtx.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: dialogCtx.border),
+        ),
+        title: Text(
+          title,
+          style: TextStyle(
+            color: dialogCtx.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        content: body,
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogCtx, false),
+            child: Text(cancelLabel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogCtx, true),
+            style: destructive
+                ? FilledButton.styleFrom(backgroundColor: EchoTheme.danger)
+                : null,
+            child: Text(confirmLabel),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? false;
+}

--- a/apps/client/lib/src/widgets/confirm_dialog.dart
+++ b/apps/client/lib/src/widgets/confirm_dialog.dart
@@ -45,10 +45,7 @@ Future<bool> showEchoConfirmDialog(
           ? content
           : Text(
               content.toString(),
-              style: TextStyle(
-                color: dialogCtx.textSecondary,
-                fontSize: 14,
-              ),
+              style: TextStyle(color: dialogCtx.textSecondary, fontSize: 14),
             );
       return AlertDialog(
         backgroundColor: dialogCtx.surface,
@@ -59,7 +56,11 @@ Future<bool> showEchoConfirmDialog(
         title: Text(
           title,
           style: TextStyle(
-            color: dialogCtx.textPrimary,
+            // Destructive confirms colour the title red as an extra
+            // signal beyond the red confirm button — matches the
+            // pattern conversation_panel and chat_header_bar already
+            // used by hand.
+            color: destructive ? EchoTheme.danger : dialogCtx.textPrimary,
             fontSize: 16,
             fontWeight: FontWeight.w600,
           ),

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -25,6 +25,7 @@ import '../providers/theme_provider.dart' show uiDensityProvider;
 import '../utils/presence.dart';
 import '../utils/time_utils.dart';
 import 'avatar_utils.dart';
+import 'confirm_dialog.dart';
 import 'connection_status_badge.dart';
 import 'context_menu/actions/conversation_actions_registry.dart';
 import 'context_menu/echo_context_menu.dart';
@@ -308,45 +309,15 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   }
 
   Future<void> _leaveGroup(Conversation conv) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: const Text(
-          'Leave Group',
-          style: TextStyle(
-            color: EchoTheme.danger,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
-          'Are you sure you want to leave "${conv.name ?? "this group"}"?',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Leave'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Leave Group',
+      content: 'Are you sure you want to leave "${conv.name ?? "this group"}"?',
+      confirmLabel: 'Leave',
+      destructive: true,
     );
 
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     try {
       final success = await ref
@@ -380,46 +351,17 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   }
 
   Future<void> _deleteGroup(Conversation conv) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: const Text(
-          'Delete Group',
-          style: TextStyle(
-            color: EchoTheme.danger,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Delete Group',
+      content:
           'This will permanently delete "${conv.name ?? "this group"}" '
           'and all its messages for everyone. This cannot be undone.',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Delete',
+      destructive: true,
     );
 
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     try {
       final success = await ref
@@ -449,46 +391,17 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel> {
   }
 
   Future<void> _deleteDm(Conversation conv) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: const Text(
-          'Delete Conversation',
-          style: TextStyle(
-            color: EchoTheme.danger,
-            fontSize: 18,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Delete Conversation',
+      content:
           'This will remove the conversation from your list. '
           'You can start a new conversation anytime.',
-          style: TextStyle(
-            color: context.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Delete',
+      destructive: true,
     );
 
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     final success = await ref
         .read(conversationsProvider.notifier)

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -11,6 +11,7 @@ import '../screens/user_profile_screen.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/presence.dart';
+import 'confirm_dialog.dart';
 import 'member_role.dart';
 import 'user_avatar.dart';
 
@@ -175,41 +176,15 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
   bool _isRemoving = false;
 
   Future<void> _removeMember() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: context.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-          side: BorderSide(color: context.border),
-        ),
-        title: Text(
-          'Remove member',
-          style: TextStyle(
-            color: context.textPrimary,
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        content: Text(
-          'Remove ${widget.member.username} from this group?',
-          style: TextStyle(color: context.textSecondary, fontSize: 14),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(backgroundColor: EchoTheme.danger),
-            child: const Text('Remove'),
-          ),
-        ],
-      ),
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Remove member',
+      content: 'Remove ${widget.member.username} from this group?',
+      confirmLabel: 'Remove',
+      destructive: true,
     );
 
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     setState(() => _isRemoving = true);
 

--- a/apps/client/test/widgets/confirm_dialog_test.dart
+++ b/apps/client/test/widgets/confirm_dialog_test.dart
@@ -1,0 +1,87 @@
+import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/widgets/confirm_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/pump_app.dart';
+
+void main() {
+  Future<bool>? lastFuture;
+
+  Future<void> pumpOpenDialog(
+    WidgetTester tester, {
+    bool destructive = false,
+    String confirmLabel = 'Confirm',
+    String cancelLabel = 'Cancel',
+    String content = 'Are you sure?',
+  }) async {
+    await tester.pumpApp(
+      Builder(
+        builder: (ctx) => TextButton(
+          onPressed: () {
+            lastFuture = showEchoConfirmDialog(
+              ctx,
+              title: 'Confirm action',
+              content: content,
+              confirmLabel: confirmLabel,
+              cancelLabel: cancelLabel,
+              destructive: destructive,
+            );
+          },
+          child: const Text('open'),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('showEchoConfirmDialog', () {
+    testWidgets('renders the title and content', (tester) async {
+      await pumpOpenDialog(tester);
+      expect(find.text('Confirm action'), findsOneWidget);
+      expect(find.text('Are you sure?'), findsOneWidget);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      await lastFuture;
+    });
+
+    testWidgets('confirm tap resolves the future to true', (tester) async {
+      await pumpOpenDialog(tester);
+      await tester.tap(find.text('Confirm'));
+      await tester.pumpAndSettle();
+      expect(await lastFuture, isTrue);
+    });
+
+    testWidgets('cancel tap resolves the future to false', (tester) async {
+      await pumpOpenDialog(tester);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(await lastFuture, isFalse);
+    });
+
+    testWidgets('destructive: true paints the title in the danger colour', (
+      tester,
+    ) async {
+      await pumpOpenDialog(tester, destructive: true);
+      final titleWidget = tester.widget<Text>(find.text('Confirm action'));
+      expect(titleWidget.style?.color, EchoTheme.danger);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      await lastFuture;
+    });
+
+    testWidgets('custom labels appear on the buttons', (tester) async {
+      await pumpOpenDialog(
+        tester,
+        confirmLabel: 'Delete',
+        cancelLabel: 'Keep',
+      );
+      expect(find.text('Delete'), findsOneWidget);
+      expect(find.text('Keep'), findsOneWidget);
+      await tester.tap(find.text('Keep'));
+      await tester.pumpAndSettle();
+      await lastFuture;
+    });
+  });
+}


### PR DESCRIPTION
Rolls up #1049. Single helper replaces 20 hand-rolled confirm dialogs across 11 files; destructive: true auto-colours both title and button red, making destructive actions read consistently across the app for the first time. -462 LOC net.