### PR TITLE
style: apply dart format + fix one pre-existing lint

### DIFF
--- a/apps/client/lib/src/providers/user_presence_provider.dart
+++ b/apps/client/lib/src/providers/user_presence_provider.dart
@@ -25,7 +25,5 @@ part 'user_presence_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 UserPresence userPresence(Ref ref, String userId) {
-  return ref.watch(
-    websocketProvider.select((s) => s.presenceFor(userId)),
-  );
+  return ref.watch(websocketProvider.select((s) => s.presenceFor(userId)));
 }

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -115,7 +115,9 @@ class WebSocketState {
   /// pattern with a single method call.
   UserPresence presenceFor(String userId) {
     final isOnline = onlineUsers.contains(userId);
-    final status = isOnline ? (presenceStatuses[userId] ?? 'online') : 'offline';
+    final status = isOnline
+        ? (presenceStatuses[userId] ?? 'online')
+        : 'offline';
     return UserPresence(status: status, isOnline: isOnline);
   }
 

--- a/apps/client/test/widgets/confirm_dialog_test.dart
+++ b/apps/client/test/widgets/confirm_dialog_test.dart
@@ -72,11 +72,7 @@ void main() {
     });
 
     testWidgets('custom labels appear on the buttons', (tester) async {
-      await pumpOpenDialog(
-        tester,
-        confirmLabel: 'Delete',
-        cancelLabel: 'Keep',
-      );
+      await pumpOpenDialog(tester, confirmLabel: 'Delete', cancelLabel: 'Keep');
       expect(find.text('Delete'), findsOneWidget);
       expect(find.text('Keep'), findsOneWidget);
       await tester.tap(find.text('Keep'));

--- a/apps/client/test/widgets/mobile_channel_drawer_test.dart
+++ b/apps/client/test/widgets/mobile_channel_drawer_test.dart
@@ -31,7 +31,7 @@ void main() {
     name: peerName,
     members: [
       const ConversationMember(userId: 'me', username: 'me'),
-      ConversationMember(userId: '${id}-peer', username: peerName),
+      ConversationMember(userId: '$id-peer', username: peerName),
     ],
   );
 


### PR DESCRIPTION
CI's `dart format --set-exit-if-changed` gate failed on the recent sonar-cleanup merges because lefthook wasn't on PATH in the agent worktrees. Same root cause as #1029. Also fixes one pre-existing `unnecessary_brace_in_string_interps` lint in the mobile-drawer test so the analyze gate runs clean too.