### PR TITLE
Release: louder feedback (sounds + haptics) and a more obvious new-messages pill

### DIFF
--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -13,6 +13,8 @@ import '../services/crypto_service.dart';
 import '../services/debug_log_service.dart';
 import '../services/message_cache.dart';
 import '../services/group_crypto_service.dart';
+import '../screens/settings/notification_section.dart'
+    show shouldSuppressNotification;
 import '../services/notification_service.dart';
 import '../services/sound_service.dart';
 import '../utils/crypto_utils.dart';
@@ -414,7 +416,12 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
 
     // #26: don't re-notify for messages the user already saw.
     if (fromUserId != myUserId && !alreadySeen) {
-      _notifyIfAllowed(conversationId, senderUsername, decryptedContent);
+      _notifyIfAllowed(
+        conversationId,
+        senderUsername,
+        decryptedContent,
+        isMention: isMention,
+      );
     }
   }
 
@@ -602,34 +609,47 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
     return containsMention(decryptedContent, ref.read(authProvider).username);
   }
 
-  /// Show a notification + play sound if the conversation is not muted.
-  /// Shared between the live and queued decrypt paths.
+  /// Show a notification + play sound if the conversation is not muted and
+  /// the user isn't currently in DND or quiet hours.
+  ///
+  /// Mentions play a louder ping ([SoundService.playMention]) so the user
+  /// can hear the difference between a passing group message and one that
+  /// names them.
   void _notifyIfAllowed(
     String conversationId,
     String senderUsername,
-    String displayContent,
-  ) {
+    String displayContent, {
+    bool isMention = false,
+  }) {
     final conversations = ref.read(conversationsProvider).conversations;
     final conv = conversations.where((c) => c.id == conversationId).firstOrNull;
     final isMuted = conv?.isMuted ?? false;
     if (isMuted) return;
 
-    // Fire-and-forget: playMessageReceived is async but errors are
-    // caught inside it. Use .ignore() to prevent any unhandled-future
-    // warnings from the test runner when the audio plugin is unavailable.
-    SoundService().playMessageReceived().ignore();
-    final body = displayContent.length > 100
-        ? '${displayContent.substring(0, 100)}...'
-        : displayContent;
-    final myUserId = ref.read(authProvider).userId ?? '';
-    NotificationService().showMessageNotification(
-      senderUsername: senderUsername,
-      body: body,
-      conversationId: conversationId,
-      conversationName: conv?.displayName(myUserId),
-      isGroup: conv?.isGroup ?? false,
-      isMuted: isMuted,
-    );
+    // Gate everything below on DND/quiet-hours so the user gets full silence
+    // when they've asked for it. The desktop NotificationService also checks
+    // shouldSuppressNotification, but pre-checking here keeps the sound and
+    // the platform toast aligned and skips a wasted async call.
+    shouldSuppressNotification().then((suppress) {
+      if (suppress) return;
+      if (isMention) {
+        SoundService().playMention().ignore();
+      } else {
+        SoundService().playMessageReceived().ignore();
+      }
+      final body = displayContent.length > 100
+          ? '${displayContent.substring(0, 100)}...'
+          : displayContent;
+      final myUserId = ref.read(authProvider).userId ?? '';
+      NotificationService().showMessageNotification(
+        senderUsername: senderUsername,
+        body: body,
+        conversationId: conversationId,
+        conversationName: conv?.displayName(myUserId),
+        isGroup: conv?.isGroup ?? false,
+        isMuted: isMuted,
+      );
+    });
   }
 
   void _handleCanvasEvent(Map<String, dynamic> json) {

--- a/apps/client/lib/src/services/sound_service.dart
+++ b/apps/client/lib/src/services/sound_service.dart
@@ -50,6 +50,7 @@ class SoundService {
 
   final AudioPlayer _sentPlayer = AudioPlayer();
   final AudioPlayer _receivedPlayer = AudioPlayer();
+  final AudioPlayer _mentionPlayer = AudioPlayer();
   final AudioPlayer _voiceJoinPlayer = AudioPlayer();
   final AudioPlayer _voiceLeavePlayer = AudioPlayer();
 
@@ -180,6 +181,26 @@ class SoundService {
     }
   }
 
+  /// Play a louder ping when the local user is @-mentioned in a message.
+  ///
+  /// Bypasses the [enabled] global only when no template asset is bundled
+  /// for mentions yet — for now it reuses `received.mp3` at higher volume
+  /// so the user can distinguish a mention from a normal message even with
+  /// the same sample. Swap to `assets/sounds/mention.mp3` once a dedicated
+  /// chime ships.
+  Future<void> playMention() async {
+    if (!_enabled) return;
+    try {
+      await _mentionPlayer
+          .play(AssetSource('sounds/received.mp3'), volume: 0.6)
+          .catchError((Object e) {
+            debugPrint('[Sound] Failed to play mention sound (late): $e');
+          });
+    } catch (e) {
+      debugPrint('[Sound] Failed to play mention sound: $e');
+    }
+  }
+
   /// Play descending chime when leaving a voice channel.
   Future<void> playVoiceLeave() async {
     if (!_enabled) return;
@@ -196,6 +217,7 @@ class SoundService {
   void dispose() {
     _sentPlayer.dispose();
     _receivedPlayer.dispose();
+    _mentionPlayer.dispose();
     _voiceJoinPlayer.dispose();
     _voiceLeavePlayer.dispose();
   }

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -24,6 +24,7 @@ import '../providers/websocket_provider.dart';
 import '../screens/settings/privacy_section.dart'
     show readPreserveOriginalFilenames;
 import '../services/slash_commands.dart';
+import '../services/sound_service.dart';
 import '../services/toast_service.dart';
 import '../services/upload_client.dart';
 import '../services/emoji_shortcodes.dart';

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/send_handling.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/send_handling.dart
@@ -200,6 +200,12 @@ extension _SendHandling on ChatInputBarState {
           replyToUsername: replyTo?.fromUsername,
         );
 
+    // Soft tactile feedback + send chime once the message is committed
+    // locally. The platform haptic is a no-op on desktop and respects
+    // the OS-level system-haptics setting on iOS.
+    HapticFeedback.lightImpact();
+    SoundService().playMessageSent().ignore();
+
     // Clear reply state after capturing the reply info.
     if (replyTo != null) {
       ref.read(chatProvider.notifier).clearReplyTo();

--- a/apps/client/lib/src/widgets/chat_panel/new_messages_pill.dart
+++ b/apps/client/lib/src/widgets/chat_panel/new_messages_pill.dart
@@ -3,11 +3,42 @@ import 'package:flutter/material.dart';
 
 import '../../theme/echo_theme.dart';
 
-class NewMessagesPill extends StatelessWidget {
+class NewMessagesPill extends StatefulWidget {
   final String text;
   final VoidCallback onTap;
 
   const NewMessagesPill({super.key, required this.text, required this.onTap});
+
+  @override
+  State<NewMessagesPill> createState() => _NewMessagesPillState();
+}
+
+class _NewMessagesPillState extends State<NewMessagesPill>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _entrance = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 280),
+  );
+  late final Animation<double> _scale = CurvedAnimation(
+    parent: _entrance,
+    curve: Curves.elasticOut,
+  );
+  late final Animation<double> _fade = CurvedAnimation(
+    parent: _entrance,
+    curve: Curves.easeOut,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _entrance.forward();
+  }
+
+  @override
+  void dispose() {
+    _entrance.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -20,38 +51,47 @@ class NewMessagesPill extends StatelessWidget {
           label: 'scroll to new messages',
           button: true,
           child: GestureDetector(
-            onTap: onTap,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              decoration: BoxDecoration(
-                color: context.accent,
-                borderRadius: BorderRadius.circular(20),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.25),
-                    blurRadius: 8,
-                    offset: const Offset(0, 2),
+            onTap: widget.onTap,
+            child: FadeTransition(
+              opacity: _fade,
+              child: ScaleTransition(
+                scale: Tween<double>(begin: 0.7, end: 1.0).animate(_scale),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
                   ),
-                ],
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    text,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                    ),
+                  decoration: BoxDecoration(
+                    color: context.accent,
+                    borderRadius: BorderRadius.circular(20),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.25),
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 4),
-                  const Icon(
-                    Icons.arrow_downward,
-                    size: 14,
-                    color: Colors.white,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        widget.text,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      const Icon(
+                        Icons.arrow_downward,
+                        size: 14,
+                        color: Colors.white,
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
             ),
           ),

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -84,14 +84,19 @@ class ChatPanelController extends ChangeNotifier {
     _scrollController = controller;
   }
 
-  /// Returns true when the user is within 150px of the bottom of the list.
-  /// Defaults to true when the controller has no clients yet so the initial
-  /// auto-scroll path runs as if we're already pinned to the bottom.
+  /// Returns true when the user is within ~3 messages of the bottom of the
+  /// list. Defaults to true when the controller has no clients yet so the
+  /// initial auto-scroll path runs as if we're already pinned to the bottom.
+  ///
+  /// The 300px window was chosen so that being two-or-three messages
+  /// scrolled up (a normal reading position) still counts as "at the
+  /// bottom" — otherwise new messages stay hidden and the user has to
+  /// notice the corner pill to see them (#prod-2026-05-21).
   bool isNearBottom() {
     final c = _scrollController;
     if (c == null || !c.hasClients) return true;
     final pos = c.position;
-    return pos.maxScrollExtent - pos.pixels < 150;
+    return pos.maxScrollExtent - pos.pixels < 300;
   }
 
   /// Pick the oldest non-system message as the pagination cursor.

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:livekit_client/livekit_client.dart' show ConnectionQuality;
 
@@ -564,7 +565,10 @@ class _DockIconButton extends StatelessWidget {
     return Tooltip(
       message: tooltip,
       child: InkWell(
-        onTap: onPressed,
+        onTap: () {
+          HapticFeedback.lightImpact();
+          onPressed();
+        },
         borderRadius: BorderRadius.circular(8),
         // 44x44 hit target stays constant across density tiers (WCAG 2.5.5);
         // only the visual icon scales.


### PR DESCRIPTION
Promotes #1061 from dev. Tests-only PR #1060 was the previous main-bound release.

## What the user notices on next launch

- Sending a message gives a soft tap (mobile) and a quick chime.
- @-mentions in groups play a louder ping so they cut through normal chatter.
- Voice dock buttons (mic, deafen, camera, screen share, hangup) all tap back.
- New incoming messages scroll into view as long as you're roughly within 3 messages of the bottom; if you're further up, the floating "N new messages" pill bounces in instead of slipping in silently.
- DND and quiet hours now silence the sound too, not just the toast.

Mention sound currently reuses the existing notification sample at higher volume — your sound designer can drop in a dedicated mention chime later without code changes.