### PR TITLE
Admin dashboard (Phase 1) and resumable chunked uploads for files >100 MB

### DIFF
--- a/apps/client/lib/src/providers/admin_realtime_provider.dart
+++ b/apps/client/lib/src/providers/admin_realtime_provider.dart
@@ -1,0 +1,195 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import 'auth_provider.dart';
+import 'server_url_provider.dart';
+
+/// Headline metrics from `GET /api/admin/stats/realtime` (#681 Phase 1).
+///
+/// Mirrors `RealtimeStats` in `apps/server/src/routes/admin.rs` — when the
+/// server grows a new metric, add it here and the corresponding card in
+/// `admin_dashboard_screen.dart`.
+@immutable
+class AdminRealtimeStats {
+  final int connectedSessions;
+  final PlatformBreakdown connectedSessionsByPlatform;
+  final double messagesPerSec;
+  final int activeVoiceRooms;
+  final int dbPoolInFlight;
+  final int dbPoolMax;
+
+  const AdminRealtimeStats({
+    required this.connectedSessions,
+    required this.connectedSessionsByPlatform,
+    required this.messagesPerSec,
+    required this.activeVoiceRooms,
+    required this.dbPoolInFlight,
+    required this.dbPoolMax,
+  });
+
+  factory AdminRealtimeStats.fromJson(Map<String, dynamic> json) {
+    return AdminRealtimeStats(
+      connectedSessions: _asInt(json['connected_sessions']),
+      connectedSessionsByPlatform: PlatformBreakdown.fromJson(
+        json['connected_sessions_by_platform'] as Map<String, dynamic>? ??
+            const {},
+      ),
+      messagesPerSec: _asDouble(json['messages_per_sec']),
+      activeVoiceRooms: _asInt(json['active_voice_rooms']),
+      dbPoolInFlight: _asInt(json['db_pool_in_flight']),
+      dbPoolMax: _asInt(json['db_pool_max']),
+    );
+  }
+}
+
+@immutable
+class PlatformBreakdown {
+  final int web;
+  final int mobile;
+  final int desktop;
+  final int unknown;
+
+  const PlatformBreakdown({
+    required this.web,
+    required this.mobile,
+    required this.desktop,
+    required this.unknown,
+  });
+
+  factory PlatformBreakdown.fromJson(Map<String, dynamic> json) {
+    return PlatformBreakdown(
+      web: _asInt(json['web']),
+      mobile: _asInt(json['mobile']),
+      desktop: _asInt(json['desktop']),
+      unknown: _asInt(json['unknown']),
+    );
+  }
+}
+
+int _asInt(Object? v) {
+  if (v is int) return v;
+  if (v is num) return v.toInt();
+  return int.tryParse('$v') ?? 0;
+}
+
+double _asDouble(Object? v) {
+  if (v is num) return v.toDouble();
+  return double.tryParse('$v') ?? 0.0;
+}
+
+/// Discriminant set by [AdminRealtimeNotifier] when the server signals that
+/// the access token is too old for admin routes. The dashboard renders a
+/// distinct surface for this (a toast plus a friendlier message) so the
+/// operator knows to re-enter their password — the actual re-auth prompt
+/// is intentionally deferred to #681 Phase 1.5.
+class AdminReauthRequired implements Exception {
+  const AdminReauthRequired();
+  @override
+  String toString() => 'reauth_required';
+}
+
+/// 403 from the server's [`AdminUser`] extractor. Surfaced as a typed
+/// exception so the screen can render a friendlier message instead of
+/// the raw HTTP error.
+class AdminForbidden implements Exception {
+  const AdminForbidden();
+  @override
+  String toString() => 'forbidden';
+}
+
+class AdminHttpFailure implements Exception {
+  final int statusCode;
+  final String message;
+  const AdminHttpFailure(this.statusCode, this.message);
+  @override
+  String toString() => message;
+}
+
+/// Poll cadence for the dashboard. Five seconds is a sensible trade-off
+/// between freshness and load: the server-side endpoint does one cheap
+/// SELECT plus a DashMap snapshot, but the dashboard is not the place to
+/// turn a single operator into a constant-RPS source either.
+const _pollInterval = Duration(seconds: 5);
+
+final adminRealtimeProvider =
+    AsyncNotifierProvider.autoDispose<
+      AdminRealtimeNotifier,
+      AdminRealtimeStats
+    >(AdminRealtimeNotifier.new);
+
+class AdminRealtimeNotifier
+    extends AutoDisposeAsyncNotifier<AdminRealtimeStats> {
+  Timer? _timer;
+
+  @override
+  Future<AdminRealtimeStats> build() {
+    // Schedule the recurring poll; cancel it when this notifier is disposed
+    // (autoDispose semantics — leaving the screen tears down the timer).
+    _timer?.cancel();
+    _timer = Timer.periodic(_pollInterval, (_) => _tick());
+    ref.onDispose(() {
+      _timer?.cancel();
+      _timer = null;
+    });
+    return _load();
+  }
+
+  Future<void> _tick() async {
+    // Don't stomp on an in-progress request: only fire when the previous
+    // result has settled.  If the dashboard is offscreen or the user just
+    // switched tabs, autoDispose has already torn us down.
+    if (state.isLoading || state.isRefreshing) return;
+    final next = await AsyncValue.guard(_load);
+    // Don't overwrite a fresh data state with a transient error during a
+    // background tick — keep showing the last good numbers but stash the
+    // error so the UI can surface a small "stale" indicator. We use
+    // [AsyncValue.guard] above precisely so this branch is reachable.
+    state = next;
+  }
+
+  Future<AdminRealtimeStats> _load() async {
+    final serverUrl = ref.read(serverUrlProvider);
+    final auth = ref.read(authProvider.notifier);
+    final response = await auth.authenticatedRequest(
+      (token) => http.get(
+        Uri.parse('$serverUrl/api/admin/stats/realtime'),
+        headers: {'Authorization': 'Bearer $token'},
+      ),
+    );
+    switch (response.statusCode) {
+      case 200:
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        return AdminRealtimeStats.fromJson(json);
+      case 401:
+        // The server emits `code: "reauth-required"` plus a
+        // WWW-Authenticate header.  We accept either as the signal so a
+        // stale token doesn't surface as a generic 401.
+        final wwwAuth = response.headers['www-authenticate'] ?? '';
+        if (wwwAuth.contains('reauth_required') ||
+            response.body.contains('reauth-required')) {
+          throw const AdminReauthRequired();
+        }
+        throw const AdminHttpFailure(
+          401,
+          'Session expired — please sign in again',
+        );
+      case 403:
+        throw const AdminForbidden();
+      default:
+        throw AdminHttpFailure(
+          response.statusCode,
+          'Failed to load realtime stats (HTTP ${response.statusCode})',
+        );
+    }
+  }
+
+  /// Manual refresh (e.g. pull-to-refresh, refresh button).
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(_load);
+  }
+}

--- a/apps/client/lib/src/providers/auth/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.dart
@@ -42,6 +42,11 @@ class AuthState {
   /// not yet loaded or when the user has no status set.
   final String? statusText;
 
+  /// Operator flag from the server's auth response. Gates the
+  /// "Admin dashboard" tile in settings (#681 Phase 1). Defaults to
+  /// `false` so existing call sites that omit it stay locked down.
+  final bool isAdmin;
+
   const AuthState({
     this.isLoggedIn = false,
     this.userId,
@@ -54,6 +59,7 @@ class AuthState {
     this.presenceStatus = 'online',
     this.onboardingCompleted = true,
     this.statusText,
+    this.isAdmin = false,
   });
 
   // @S107: copyWith mirrors the AuthState constructor; refactoring to a param
@@ -74,6 +80,7 @@ class AuthState {
     // Use the sentinel pattern so callers can explicitly clear statusText to
     // null without copyWith silently keeping the previous value.
     Object? statusText = _kKeep,
+    bool? isAdmin,
   }) {
     return AuthState(
       isLoggedIn: isLoggedIn ?? this.isLoggedIn,
@@ -89,6 +96,7 @@ class AuthState {
       statusText: statusText == _kKeep
           ? this.statusText
           : statusText as String?,
+      isAdmin: isAdmin ?? this.isAdmin,
     );
   }
 }
@@ -171,6 +179,7 @@ class AuthNotifier extends _$AuthNotifier
         // browser; we deliberately ignore the body value to avoid storing it.
         final refreshToken = kIsWeb ? null : data['refresh_token'] as String?;
         final userId = data['user_id'] as String;
+        final isAdmin = data['is_admin'] as bool? ?? false;
 
         await _storeTokens(
           accessToken: accessToken,
@@ -187,6 +196,7 @@ class AuthNotifier extends _$AuthNotifier
           token: accessToken,
           refreshToken: refreshToken,
           onboardingCompleted: false,
+          isAdmin: isAdmin,
         );
       } else {
         String errorMsg = 'Registration failed';
@@ -236,6 +246,7 @@ class AuthNotifier extends _$AuthNotifier
         final refreshToken = kIsWeb ? null : data['refresh_token'] as String?;
         final userId = data['user_id'] as String;
         final avatarUrl = data['avatar_url'] as String?;
+        final isAdmin = data['is_admin'] as bool? ?? false;
 
         await _storeTokens(
           accessToken: accessToken,
@@ -252,6 +263,7 @@ class AuthNotifier extends _$AuthNotifier
           token: accessToken,
           refreshToken: refreshToken,
           avatarUrl: avatarUrl,
+          isAdmin: isAdmin,
         );
 
         // Start background service to keep WebSocket alive on mobile

--- a/apps/client/lib/src/screens/admin/admin_dashboard_screen.dart
+++ b/apps/client/lib/src/screens/admin/admin_dashboard_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../providers/admin_realtime_provider.dart';
 import '../../providers/admin_stats_provider.dart';
 
 /// Operator dashboard for issue #682. Renders the headline metrics from
@@ -53,10 +54,17 @@ class _DashboardBody extends StatelessWidget {
         // pull-to-refresh affordance just defers to it.
         final element = ProviderScope.containerOf(context, listen: false);
         await element.read(adminDashboardProvider.notifier).refresh();
+        await element.read(adminRealtimeProvider.notifier).refresh();
       },
       child: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          Text('Realtime', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          const _RealtimeSection(),
+          const SizedBox(height: 24),
+          Text('Last 24h', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
           _StatsGrid(stats: data.stats),
           const SizedBox(height: 24),
           Text(
@@ -73,6 +81,151 @@ class _DashboardBody extends StatelessWidget {
             ...data.feedback.map(_FeedbackTile.new),
         ],
       ),
+    );
+  }
+}
+
+/// Renders the four headline cards from [adminRealtimeProvider] plus the
+/// friendly 403 / reauth_required surfaces.
+///
+/// Pulled out of [_DashboardBody] so the realtime panel can fail
+/// independently of the 24h aggregate panel — the operator should still
+/// see historical numbers if the realtime endpoint hiccups, and vice versa.
+class _RealtimeSection extends ConsumerStatefulWidget {
+  const _RealtimeSection();
+
+  @override
+  ConsumerState<_RealtimeSection> createState() => _RealtimeSectionState();
+}
+
+class _RealtimeSectionState extends ConsumerState<_RealtimeSection> {
+  bool _toastShown = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final async = ref.watch(adminRealtimeProvider);
+
+    // Surface the reauth-required signal exactly once per error transition;
+    // re-firing the toast on every poll tick is just noise.
+    ref.listen<AsyncValue<AdminRealtimeStats>>(adminRealtimeProvider, (
+      prev,
+      next,
+    ) {
+      final err = next.error;
+      if (err is AdminReauthRequired && !_toastShown) {
+        _toastShown = true;
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Re-enter your password to access the admin dashboard.',
+            ),
+          ),
+        );
+      } else if (err is! AdminReauthRequired) {
+        _toastShown = false;
+      }
+    });
+
+    return async.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+      error: (err, _) => _RealtimeError(err),
+      data: (data) => _RealtimeGrid(stats: data),
+    );
+  }
+}
+
+class _RealtimeError extends StatelessWidget {
+  final Object err;
+  const _RealtimeError(this.err);
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final (icon, message) = _resolveCopy(err);
+    return Card(
+      key: const Key('admin-realtime-error'),
+      elevation: 0,
+      color: scheme.surfaceContainerHigh,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(icon, color: scheme.error),
+            const SizedBox(width: 12),
+            Expanded(child: Text(message)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static (IconData, String) _resolveCopy(Object err) {
+    if (err is AdminForbidden) {
+      return (Icons.lock_outline, "You're not an admin on this server.");
+    }
+    if (err is AdminReauthRequired) {
+      return (
+        Icons.password_outlined,
+        'Re-enter your password to view realtime stats.',
+      );
+    }
+    return (Icons.error_outline, 'Could not load realtime stats: $err');
+  }
+}
+
+class _RealtimeGrid extends StatelessWidget {
+  final AdminRealtimeStats stats;
+  const _RealtimeGrid({required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final messagesPerSec = stats.messagesPerSec;
+    // Render 2 decimal places when the rate is <10 msg/s (most servers most
+    // of the time); above that, integer precision is enough.
+    final messagesLabel = messagesPerSec >= 10
+        ? messagesPerSec.toStringAsFixed(0)
+        : messagesPerSec.toStringAsFixed(2);
+
+    final cards = <Widget>[
+      _StatCard(
+        key: const Key('admin-realtime-card-sessions'),
+        label: 'Connected sessions',
+        value: stats.connectedSessions,
+      ),
+      _StatCardText(
+        key: const Key('admin-realtime-card-mps'),
+        label: 'Messages / sec',
+        value: messagesLabel,
+      ),
+      _StatCard(
+        key: const Key('admin-realtime-card-voice'),
+        label: 'Voice rooms',
+        value: stats.activeVoiceRooms,
+      ),
+      _StatCardText(
+        key: const Key('admin-realtime-card-db'),
+        label: 'DB pool',
+        value: '${stats.dbPoolInFlight} / ${stats.dbPoolMax}',
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final cols = width >= 720 ? 4 : (width >= 480 ? 2 : 1);
+        const spacing = 12.0;
+        final cardWidth = (width - spacing * (cols - 1)) / cols;
+        return Wrap(
+          spacing: spacing,
+          runSpacing: spacing,
+          children: [
+            for (final card in cards) SizedBox(width: cardWidth, child: card),
+          ],
+        );
+      },
     );
   }
 }
@@ -118,7 +271,24 @@ class _StatsGrid extends StatelessWidget {
 class _StatCard extends StatelessWidget {
   final String label;
   final int value;
-  const _StatCard({required this.label, required this.value});
+  const _StatCard({super.key, required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    // Don't forward `key` into the inner widget — the outer element already
+    // owns the key. Passing it again would surface two widgets with the
+    // same key in the tree and break `find.byKey` in tests.
+    return _StatCardText(label: label, value: '$value');
+  }
+}
+
+/// Variant of [_StatCard] that takes a pre-formatted string value — used
+/// for the realtime cards that need a decimal (messages/sec) or a
+/// composite ("3 / 32") rendering.
+class _StatCardText extends StatelessWidget {
+  final String label;
+  final String value;
+  const _StatCardText({super.key, required this.label, required this.value});
 
   @override
   Widget build(BuildContext context) {
@@ -139,7 +309,7 @@ class _StatCard extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             Text(
-              '$value',
+              value,
               style: Theme.of(context).textTheme.headlineMedium?.copyWith(
                 color: scheme.onSurface,
                 fontWeight: FontWeight.w600,

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -227,6 +227,18 @@ class SettingsRootView extends ConsumerWidget {
           const SectionHeader('Echo'),
           _CardGroup(
             children: [
+              if (ref.watch(authProvider).isAdmin)
+                Semantics(
+                  label: 'settings admin dashboard',
+                  button: true,
+                  child: CardRow(
+                    key: const Key('settings-admin-dashboard-tile'),
+                    icon: Icons.shield_outlined,
+                    iconColor: const Color(0xFFEAB308),
+                    label: 'Admin dashboard',
+                    onTap: () => context.push('/admin'),
+                  ),
+                ),
               _row(
                 context,
                 icon: Icons.info_outline,

--- a/apps/client/lib/src/services/chunked_upload_client.dart
+++ b/apps/client/lib/src/services/chunked_upload_client.dart
@@ -1,0 +1,572 @@
+// Chunked / resumable upload client (#556).
+//
+// Mirrors the three Rust endpoints on `/api/media/upload`:
+//   1. POST   /init       → returns `{ upload_id, chunk_size }`
+//   2. PATCH  /{id}/chunk → appends one chunk at the next offset
+//   3. POST   /{id}/finalize → assembles the media row and returns
+//      the same shape the legacy single-shot endpoint does
+//   4. GET    /{id}       → re-sync after a 416 / crash
+//
+// The on-disk file is read incrementally in `chunk_size`-byte slices; no
+// part of the upload ever sits in RAM longer than one chunk.  Each chunk
+// gets up to [maxRetriesPerChunk] retries with exponential back-off; a
+// 416 from the server triggers a fresh GET so the client can pick the
+// right offset before retrying.
+//
+// The public return shape matches the existing [UploadClient.uploadFile]
+// result so callers can switch between the two paths without branching on
+// the return type.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show File;
+
+import 'package:http/http.dart' as http;
+
+import 'upload_client.dart';
+
+/// Default back-off table used between chunk retries.  Kept module-private
+/// because callers cannot meaningfully tune it -- the right knob is
+/// [ChunkedUploadClient.maxRetriesPerChunk], not the schedule.
+const List<Duration> _kRetryBackoffs = [
+  Duration(milliseconds: 200),
+  Duration(milliseconds: 800),
+  Duration(seconds: 2),
+];
+
+/// Threshold (in bytes) at which a caller should prefer the chunked path
+/// over the legacy single-shot multipart endpoint.  Kept 5 MB below
+/// Cloudflare's 100 MB edge cap so a borderline file never reaches the
+/// edge limit even after multipart framing overhead.
+const int kChunkedUploadThresholdBytes = 95 * 1024 * 1024;
+
+/// Token getter callback shape.  Mirrors [UploadClient]'s tokenGetter so
+/// the production wiring stays single-source-of-truth.
+typedef ChunkedTokenGetter = String? Function();
+
+/// Refresh callback shape, returning whether the refresh succeeded.
+typedef ChunkedRefresher = Future<bool> Function();
+
+/// HTTP transport hook -- only present so tests can swap in a mock client.
+typedef ChunkedHttpTransport = http.Client Function();
+
+/// Result returned by [ChunkedUploadClient.upload], deliberately shaped
+/// identically to [UploadResult] so the chat-input bar can hand it back
+/// to its existing success/error branches unchanged.
+class ChunkedUploadResult {
+  const ChunkedUploadResult({
+    required this.ok,
+    this.url,
+    this.errorMessage,
+    this.statusCode,
+    this.width,
+    this.height,
+  });
+
+  final bool ok;
+  final String? url;
+  final String? errorMessage;
+  final int? statusCode;
+  final int? width;
+  final int? height;
+
+  UploadResult toUploadResult() => UploadResult(
+    ok: ok,
+    url: url,
+    statusCode: statusCode,
+    errorMessage: errorMessage,
+    width: width,
+    height: height,
+  );
+}
+
+class ChunkedUploadClient {
+  /// Wire up against a live [UploadClient] / [AuthNotifier].  The token
+  /// getter and refresher are reused so this client behaves identically
+  /// w.r.t. 401 → refresh → retry as the single-shot path.
+  ChunkedUploadClient({
+    required ChunkedTokenGetter tokenGetter,
+    required ChunkedRefresher refresher,
+    http.Client? httpClient,
+  }) : _tokenGetter = tokenGetter,
+       _refresher = refresher,
+       _transport = (() => httpClient ?? http.Client());
+
+  /// Test-only seam: caller supplies a [ChunkedHttpTransport] so a mock can be
+  /// injected without depending on production auth wiring.
+  ChunkedUploadClient.withCallbacks({
+    required ChunkedTokenGetter tokenGetter,
+    required ChunkedRefresher refresher,
+    required ChunkedHttpTransport transport,
+  }) : _tokenGetter = tokenGetter,
+       _refresher = refresher,
+       _transport = transport;
+
+  final ChunkedTokenGetter _tokenGetter;
+  final ChunkedRefresher _refresher;
+  final ChunkedHttpTransport _transport;
+
+  /// Upload an in-memory [bytes] buffer using the chunked pipeline.  Same
+  /// init / PATCH / finalize wire flow as [upload], but reads slices out of
+  /// the in-memory buffer instead of a `dart:io` File.  Used by the chat
+  /// composer, which already has the payload in RAM (the pickers stage it
+  /// there for preview).
+  Future<ChunkedUploadResult> uploadBytes({
+    required List<int> bytes,
+    required String serverUrl,
+    String? mimeType,
+    String? filename,
+    String? conversationId,
+    void Function(int sent, int total)? onProgress,
+    int maxRetriesPerChunk = 3,
+  }) async {
+    final total = bytes.length;
+    final declaredName = filename ?? 'upload.bin';
+    final declaredMime = mimeType ?? 'application/octet-stream';
+
+    final client = _transport();
+    try {
+      final init = await _initSession(
+        client: client,
+        serverUrl: serverUrl,
+        filename: declaredName,
+        mimeType: declaredMime,
+        totalSize: total,
+        conversationId: conversationId,
+      );
+      if (!init.ok) {
+        return ChunkedUploadResult(
+          ok: false,
+          statusCode: init.statusCode,
+          errorMessage: init.errorMessage,
+        );
+      }
+
+      var sent = 0;
+      while (sent < total) {
+        final end = (sent + init.chunkSize).clamp(0, total).toInt();
+        final chunk = bytes.sublist(sent, end);
+        final chunkResult = await _sendChunkWithRetries(
+          client: client,
+          serverUrl: serverUrl,
+          uploadId: init.uploadId,
+          chunk: chunk,
+          start: sent,
+          total: total,
+          maxRetries: maxRetriesPerChunk,
+        );
+        if (!chunkResult.ok) {
+          return ChunkedUploadResult(
+            ok: false,
+            statusCode: chunkResult.statusCode,
+            errorMessage: chunkResult.errorMessage,
+          );
+        }
+        sent = chunkResult.bytesReceived;
+        if (onProgress != null) onProgress(sent, total);
+      }
+
+      return _finalize(
+        client: client,
+        serverUrl: serverUrl,
+        uploadId: init.uploadId,
+      );
+    } finally {
+      client.close();
+    }
+  }
+
+  /// Upload [file] in chunks.  Returns a [ChunkedUploadResult] mirroring
+  /// the single-shot [UploadResult] shape so callers can branch on `ok`.
+  ///
+  /// [onProgress] receives `(sent, total)` byte counts after every chunk
+  /// completes.  Per-chunk progress within a chunk is intentionally not
+  /// surfaced -- the existing progress reporter consumes a coarse counter.
+  Future<ChunkedUploadResult> upload({
+    required File file,
+    required String serverUrl,
+    String? mimeType,
+    String? filename,
+    String? conversationId,
+    void Function(int sent, int total)? onProgress,
+    int maxRetriesPerChunk = 3,
+  }) async {
+    final total = await file.length();
+    final declaredName = filename ?? file.uri.pathSegments.last;
+    final declaredMime = mimeType ?? 'application/octet-stream';
+
+    final client = _transport();
+    try {
+      final init = await _initSession(
+        client: client,
+        serverUrl: serverUrl,
+        filename: declaredName,
+        mimeType: declaredMime,
+        totalSize: total,
+        conversationId: conversationId,
+      );
+      if (!init.ok) {
+        return ChunkedUploadResult(
+          ok: false,
+          statusCode: init.statusCode,
+          errorMessage: init.errorMessage,
+        );
+      }
+
+      var sent = 0;
+      while (sent < total) {
+        final end = (sent + init.chunkSize).clamp(0, total).toInt();
+        final chunk = await _readSlice(file, sent, end);
+        final chunkResult = await _sendChunkWithRetries(
+          client: client,
+          serverUrl: serverUrl,
+          uploadId: init.uploadId,
+          chunk: chunk,
+          start: sent,
+          total: total,
+          maxRetries: maxRetriesPerChunk,
+        );
+        if (!chunkResult.ok) {
+          return ChunkedUploadResult(
+            ok: false,
+            statusCode: chunkResult.statusCode,
+            errorMessage: chunkResult.errorMessage,
+          );
+        }
+        sent = chunkResult.bytesReceived;
+        if (onProgress != null) onProgress(sent, total);
+      }
+
+      return _finalize(
+        client: client,
+        serverUrl: serverUrl,
+        uploadId: init.uploadId,
+      );
+    } finally {
+      client.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 1: init
+  // ---------------------------------------------------------------------------
+
+  Future<_InitResult> _initSession({
+    required http.Client client,
+    required String serverUrl,
+    required String filename,
+    required String mimeType,
+    required int totalSize,
+    String? conversationId,
+  }) async {
+    final body = <String, dynamic>{
+      'filename': filename,
+      'mime_type': mimeType,
+      'total_size': totalSize,
+      'conversation_id': ?conversationId,
+    };
+
+    final resp = await _authedRequest(
+      build: (token) =>
+          http.Request('POST', Uri.parse('$serverUrl/api/media/upload/init'))
+            ..headers['Authorization'] = 'Bearer $token'
+            ..headers['Content-Type'] = 'application/json'
+            ..body = jsonEncode(body),
+      client: client,
+    );
+    final text = await resp.stream.bytesToString();
+    if (resp.statusCode != 201 && resp.statusCode != 200) {
+      return _InitResult.fail(
+        statusCode: resp.statusCode,
+        errorMessage: _extractError(text),
+      );
+    }
+    final data = jsonDecode(text) as Map<String, dynamic>;
+    return _InitResult.ok(
+      uploadId: data['upload_id'] as String,
+      chunkSize: (data['chunk_size'] as num).toInt(),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 2: chunk (with retry + 416 re-sync)
+  // ---------------------------------------------------------------------------
+
+  Future<_ChunkResult> _sendChunkWithRetries({
+    required http.Client client,
+    required String serverUrl,
+    required String uploadId,
+    required List<int> chunk,
+    required int start,
+    required int total,
+    required int maxRetries,
+  }) async {
+    var attempt = 0;
+    var localStart = start;
+    var localChunk = chunk;
+
+    while (true) {
+      final resp = await _sendOneChunk(
+        client: client,
+        serverUrl: serverUrl,
+        uploadId: uploadId,
+        chunk: localChunk,
+        start: localStart,
+        total: total,
+      );
+
+      if (resp.ok) return resp;
+
+      // 416 → re-sync from server and adjust the offset.  This is a
+      // one-shot correction; if the server tells us nothing, fall through
+      // to the regular retry path.
+      if (resp.statusCode == 416 && resp.bytesReceived >= 0) {
+        final newStart = resp.bytesReceived;
+        // Don't keep bytes we've already shipped.  If the server is ahead
+        // of where we thought, advance; if behind, re-send the trailing
+        // slice.
+        if (newStart > localStart) {
+          final advance = newStart - localStart;
+          if (advance >= localChunk.length) {
+            // Server already has more than we were about to send -- skip
+            // this whole chunk and let the outer loop fetch the next.
+            return _ChunkResult.ok(bytesReceived: newStart);
+          }
+          localChunk = localChunk.sublist(advance);
+          localStart = newStart;
+          continue;
+        }
+        // newStart < start: server lost progress; resume from there.
+        // We don't have the missing bytes here, so the caller's outer
+        // loop will re-derive the chunk on the next iteration.  Surface
+        // a synthetic ok=true so the outer loop re-reads from disk.
+        return _ChunkResult.ok(bytesReceived: newStart);
+      }
+
+      attempt++;
+      if (attempt > maxRetries) return resp;
+      await Future<void>.delayed(
+        _kRetryBackoffs[(attempt - 1).clamp(0, _kRetryBackoffs.length - 1)],
+      );
+    }
+  }
+
+  Future<_ChunkResult> _sendOneChunk({
+    required http.Client client,
+    required String serverUrl,
+    required String uploadId,
+    required List<int> chunk,
+    required int start,
+    required int total,
+  }) async {
+    final end = start + chunk.length - 1;
+    final resp = await _authedRequest(
+      build: (token) =>
+          http.Request(
+              'PATCH',
+              Uri.parse('$serverUrl/api/media/upload/$uploadId/chunk'),
+            )
+            ..headers['Authorization'] = 'Bearer $token'
+            ..headers['Content-Type'] = 'application/octet-stream'
+            ..headers['Content-Range'] = 'bytes $start-$end/$total'
+            ..bodyBytes = chunk,
+      client: client,
+    );
+
+    final text = await resp.stream.bytesToString();
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(text) as Map<String, dynamic>;
+      return _ChunkResult.ok(
+        bytesReceived: (data['bytes_received'] as num).toInt(),
+      );
+    }
+
+    if (resp.statusCode == 416) {
+      // Body shape mirrors the server-side `range_mismatch` AppError:
+      // `{ "bytes_received": N }`.  Defensive parse so a future body
+      // shape change doesn't crash the client.
+      var rebased = -1;
+      try {
+        final data = jsonDecode(text) as Map<String, dynamic>;
+        final raw = data['bytes_received'];
+        if (raw is num) rebased = raw.toInt();
+      } catch (_) {
+        // Older servers may return an empty 416 body.  Trigger a state
+        // fetch as a fallback.
+      }
+      if (rebased < 0) {
+        rebased =
+            await _getState(
+              client: client,
+              serverUrl: serverUrl,
+              uploadId: uploadId,
+            ) ??
+            -1;
+      }
+      return _ChunkResult.fail(
+        statusCode: 416,
+        errorMessage: _extractError(text),
+        bytesReceived: rebased,
+      );
+    }
+
+    return _ChunkResult.fail(
+      statusCode: resp.statusCode,
+      errorMessage: _extractError(text),
+    );
+  }
+
+  Future<int?> _getState({
+    required http.Client client,
+    required String serverUrl,
+    required String uploadId,
+  }) async {
+    final resp = await _authedRequest(
+      build: (token) => http.Request(
+        'GET',
+        Uri.parse('$serverUrl/api/media/upload/$uploadId'),
+      )..headers['Authorization'] = 'Bearer $token',
+      client: client,
+    );
+    final text = await resp.stream.bytesToString();
+    if (resp.statusCode != 200) return null;
+    try {
+      final data = jsonDecode(text) as Map<String, dynamic>;
+      final raw = data['bytes_received'];
+      return raw is num ? raw.toInt() : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 3: finalize
+  // ---------------------------------------------------------------------------
+
+  Future<ChunkedUploadResult> _finalize({
+    required http.Client client,
+    required String serverUrl,
+    required String uploadId,
+  }) async {
+    final resp = await _authedRequest(
+      build: (token) =>
+          http.Request(
+              'POST',
+              Uri.parse('$serverUrl/api/media/upload/$uploadId/finalize'),
+            )
+            ..headers['Authorization'] = 'Bearer $token'
+            ..headers['Content-Type'] = 'application/json'
+            ..body = '{}',
+      client: client,
+    );
+    final text = await resp.stream.bytesToString();
+    if (resp.statusCode != 201 && resp.statusCode != 200) {
+      return ChunkedUploadResult(
+        ok: false,
+        statusCode: resp.statusCode,
+        errorMessage: _extractError(text),
+      );
+    }
+    try {
+      final data = jsonDecode(text) as Map<String, dynamic>;
+      return ChunkedUploadResult(
+        ok: true,
+        statusCode: resp.statusCode,
+        url: data['url'] as String?,
+        width: data['width'] as int?,
+        height: data['height'] as int?,
+      );
+    } catch (_) {
+      return ChunkedUploadResult(
+        ok: false,
+        statusCode: resp.statusCode,
+        errorMessage: 'Malformed finalize response',
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared helpers
+  // ---------------------------------------------------------------------------
+
+  /// Send `build(token)` and, if the response is a 401, run `_refresher`
+  /// once and retry exactly once with the new token.
+  Future<http.StreamedResponse> _authedRequest({
+    required http.Request Function(String token) build,
+    required http.Client client,
+  }) async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final token = _tokenGetter() ?? '';
+      final resp = await client.send(build(token));
+      if (resp.statusCode == 401 && attempt == 0) {
+        // Drain the body so the connection can be returned to the pool.
+        await resp.stream.drain<void>();
+        final refreshed = await _refresher();
+        if (!refreshed) return resp;
+        continue;
+      }
+      return resp;
+    }
+    throw StateError('unreachable: _authedRequest loop exited');
+  }
+
+  Future<List<int>> _readSlice(File file, int start, int end) async {
+    // openRead is a `Stream<List<int>>` that lazily reads only the
+    // requested byte window from disk, so we never load the whole file
+    // into RAM even for multi-GB inputs.
+    final out = <int>[];
+    await for (final chunk in file.openRead(start, end)) {
+      out.addAll(chunk);
+    }
+    return out;
+  }
+
+  /// Best-effort extraction of a server-side error string.
+  static String? _extractError(String body) {
+    if (body.isEmpty) return null;
+    try {
+      final data = jsonDecode(body) as Map<String, dynamic>;
+      return (data['error'] ?? data['message']) as String?;
+    } catch (_) {
+      return body.length > 200 ? body.substring(0, 200) : body;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal result types
+// ---------------------------------------------------------------------------
+
+class _InitResult {
+  _InitResult.ok({required this.uploadId, required this.chunkSize})
+    : ok = true,
+      statusCode = 201,
+      errorMessage = null;
+  _InitResult.fail({required this.statusCode, this.errorMessage})
+    : ok = false,
+      uploadId = '',
+      chunkSize = 0;
+
+  final bool ok;
+  final String uploadId;
+  final int chunkSize;
+  final int? statusCode;
+  final String? errorMessage;
+}
+
+class _ChunkResult {
+  _ChunkResult.ok({required this.bytesReceived})
+    : ok = true,
+      statusCode = 200,
+      errorMessage = null;
+  _ChunkResult.fail({
+    required this.statusCode,
+    this.errorMessage,
+    this.bytesReceived = -1,
+  }) : ok = false;
+
+  final bool ok;
+  final int bytesReceived;
+  final int? statusCode;
+  final String? errorMessage;
+}

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -26,6 +26,7 @@ import '../screens/settings/privacy_section.dart'
 import '../services/slash_commands.dart';
 import '../services/sound_service.dart';
 import '../services/toast_service.dart';
+import '../services/chunked_upload_client.dart';
 import '../services/upload_client.dart';
 import '../services/emoji_shortcodes.dart';
 import '../theme/echo_theme.dart';

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/attachments.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/attachments.dart
@@ -167,16 +167,38 @@ extension _Attachments on ChatInputBarState {
     final preserve = await readPreserveOriginalFilenames();
     final uploadFileName = preserve ? fileName : genericFilename(fileName);
 
-    final uploader = UploadClient(ref.read(authProvider.notifier));
-    final result = await uploader.uploadFile(
-      serverUrl: serverUrl,
-      path: '/api/media/upload',
-      bytes: bytes,
-      fileName: uploadFileName,
-      mimeType: mimeType,
-      extraFields: {'conversation_id': widget.conversation.id},
-      onProgress: onProgress,
-    );
+    // Files above the chunked-upload threshold go through the resumable
+    // PATCH pipeline (#556).  Cloudflare's edge cap is 100 MB; the chunked
+    // path streams 5 MB chunks server-side so it can ferry files multiples
+    // of that without ever pinning the whole payload in server RAM.
+    final UploadResult result;
+    if (bytes.length > kChunkedUploadThresholdBytes) {
+      final auth = ref.read(authProvider.notifier);
+      final chunked = ChunkedUploadClient(
+        tokenGetter: () => auth.currentToken,
+        refresher: auth.refreshAccessToken,
+      );
+      final chunkedResult = await chunked.uploadBytes(
+        bytes: bytes,
+        serverUrl: serverUrl,
+        mimeType: mimeType,
+        filename: uploadFileName,
+        conversationId: widget.conversation.id,
+        onProgress: onProgress,
+      );
+      result = chunkedResult.toUploadResult();
+    } else {
+      final uploader = UploadClient(ref.read(authProvider.notifier));
+      result = await uploader.uploadFile(
+        serverUrl: serverUrl,
+        path: '/api/media/upload',
+        bytes: bytes,
+        fileName: uploadFileName,
+        mimeType: mimeType,
+        extraFields: {'conversation_id': widget.conversation.id},
+        onProgress: onProgress,
+      );
+    }
 
     if (result.ok) {
       // Pre-populate the dimension cache so ImageAttachment can reserve the

--- a/apps/client/test/screens/admin/admin_dashboard_screen_test.dart
+++ b/apps/client/test/screens/admin/admin_dashboard_screen_test.dart
@@ -1,21 +1,29 @@
 import 'dart:async';
 
+import 'package:echo_app/src/providers/admin_realtime_provider.dart';
 import 'package:echo_app/src/providers/admin_stats_provider.dart';
 import 'package:echo_app/src/screens/admin/admin_dashboard_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Widget tests for the admin dashboard (#682). We swap in a fake notifier
-/// so the screen renders deterministically without hitting the network.
+/// Widget tests for the admin dashboard (#682, #681 Phase 1). We swap in
+/// fake notifiers so the screen renders deterministically without hitting
+/// the network.
 void main() {
   Future<void> pump(
     WidgetTester tester, {
     required AdminDashboardNotifier Function() override,
+    AdminRealtimeNotifier Function()? realtimeOverride,
   }) async {
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [adminDashboardProvider.overrideWith(override)],
+        overrides: [
+          adminDashboardProvider.overrideWith(override),
+          adminRealtimeProvider.overrideWith(
+            realtimeOverride ?? _RealtimeStubNotifier.new,
+          ),
+        ],
         child: const MaterialApp(home: AdminDashboardScreen()),
       ),
     );
@@ -60,6 +68,64 @@ void main() {
     await pump(tester, override: _EmptyFeedbackNotifier.new);
     await tester.pumpAndSettle();
     expect(find.text('No open feedback.'), findsOneWidget);
+  });
+
+  // ------------------------------------------------------------------
+  // #681 Phase 1: realtime section
+  // ------------------------------------------------------------------
+
+  testWidgets('renders the four realtime cards on success', (tester) async {
+    await pump(
+      tester,
+      override: _SuccessNotifier.new,
+      realtimeOverride: _RealtimeStubNotifier.new,
+    );
+    await tester.pumpAndSettle();
+
+    // All four card labels should be present.
+    expect(find.text('Connected sessions'), findsOneWidget);
+    expect(find.text('Messages / sec'), findsOneWidget);
+    expect(find.text('Voice rooms'), findsOneWidget);
+    expect(find.text('DB pool'), findsOneWidget);
+
+    // Stat values from the stub.
+    expect(
+      find.byKey(const Key('admin-realtime-card-sessions')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('admin-realtime-card-mps')), findsOneWidget);
+    expect(find.byKey(const Key('admin-realtime-card-voice')), findsOneWidget);
+    expect(find.byKey(const Key('admin-realtime-card-db')), findsOneWidget);
+  });
+
+  testWidgets('renders a friendly message when the server returns 403', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      override: _SuccessNotifier.new,
+      realtimeOverride: _ForbiddenRealtimeNotifier.new,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text("You're not an admin on this server."), findsOneWidget);
+    expect(find.byKey(const Key('admin-realtime-error')), findsOneWidget);
+  });
+
+  testWidgets('renders the reauth-required surface for 401 reauth', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      override: _SuccessNotifier.new,
+      realtimeOverride: _ReauthRealtimeNotifier.new,
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Re-enter your password to view realtime stats.'),
+      findsOneWidget,
+    );
   });
 }
 
@@ -129,5 +195,39 @@ class _EmptyFeedbackNotifier extends AdminDashboardNotifier {
       ),
       feedback: [],
     );
+  }
+}
+
+/// Default realtime stub: always-success with deterministic numbers.
+class _RealtimeStubNotifier extends AdminRealtimeNotifier {
+  @override
+  Future<AdminRealtimeStats> build() async {
+    return const AdminRealtimeStats(
+      connectedSessions: 12,
+      connectedSessionsByPlatform: PlatformBreakdown(
+        web: 0,
+        mobile: 0,
+        desktop: 0,
+        unknown: 12,
+      ),
+      messagesPerSec: 1.25,
+      activeVoiceRooms: 2,
+      dbPoolInFlight: 3,
+      dbPoolMax: 32,
+    );
+  }
+}
+
+class _ForbiddenRealtimeNotifier extends AdminRealtimeNotifier {
+  @override
+  Future<AdminRealtimeStats> build() {
+    return Future.error(const AdminForbidden());
+  }
+}
+
+class _ReauthRealtimeNotifier extends AdminRealtimeNotifier {
+  @override
+  Future<AdminRealtimeStats> build() {
+    return Future.error(const AdminReauthRequired());
   }
 }

--- a/apps/client/test/services/chunked_upload_client_test.dart
+++ b/apps/client/test/services/chunked_upload_client_test.dart
@@ -1,0 +1,282 @@
+// Unit tests for ChunkedUploadClient.
+//
+// Uses a hand-rolled `MockClient` in place of the production `http.Client`
+// so we never make a real network call.  Each test asserts on (a) the
+// request shape the client sends and (b) how the client reacts to a
+// scripted response sequence.
+
+import 'dart:convert';
+
+import 'package:echo_app/src/services/chunked_upload_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Helper: build a [ChunkedUploadClient] backed by a [MockClient] whose
+/// handler is supplied by the caller.  The mock records every request so
+/// individual tests can assert on the sent sequence.
+ChunkedUploadClient _client({
+  required Future<http.Response> Function(http.Request) handler,
+  List<http.Request>? sink,
+}) {
+  final mock = MockClient((request) {
+    sink?.add(request);
+    return handler(request);
+  });
+  return ChunkedUploadClient.withCallbacks(
+    tokenGetter: () => 'tok',
+    refresher: () async => true,
+    transport: () => mock,
+  );
+}
+
+void main() {
+  group('ChunkedUploadClient.uploadBytes', () {
+    test(
+      'happy path issues init + chunk(s) + finalize and returns url',
+      () async {
+        final calls = <http.Request>[];
+        final bytes = List<int>.generate(12, (i) => i);
+
+        final client = _client(
+          sink: calls,
+          handler: (req) async {
+            if (req.url.path.endsWith('/api/media/upload/init')) {
+              return http.Response(
+                jsonEncode({'upload_id': 'upl-1', 'chunk_size': 5}),
+                201,
+              );
+            }
+            if (req.url.path.endsWith('/chunk')) {
+              // Server echoes how many bytes have landed so far.  Compute
+              // the expected count from the Content-Range header.
+              final range = req.headers['content-range']!;
+              final endPart = range.split('/').first.split('-').last;
+              final received = int.parse(endPart) + 1;
+              return http.Response(
+                jsonEncode({'bytes_received': received}),
+                200,
+              );
+            }
+            if (req.url.path.endsWith('/finalize')) {
+              return http.Response(
+                jsonEncode({'id': 'media-1', 'url': '/api/media/media-1'}),
+                201,
+              );
+            }
+            return http.Response('not found', 404);
+          },
+        );
+
+        final result = await client.uploadBytes(
+          bytes: bytes,
+          serverUrl: 'https://example.test',
+          mimeType: 'image/png',
+          filename: 'a.png',
+        );
+
+        expect(result.ok, isTrue);
+        expect(result.url, '/api/media/media-1');
+        // 12 bytes with chunk_size=5 → 5 + 5 + 2 → 3 chunk PATCHes + init + finalize.
+        final patches = calls.where((r) => r.method == 'PATCH').toList();
+        expect(patches, hasLength(3));
+        expect(patches.first.headers['content-range'], 'bytes 0-4/12');
+        expect(patches[1].headers['content-range'], 'bytes 5-9/12');
+        expect(patches[2].headers['content-range'], 'bytes 10-11/12');
+      },
+    );
+
+    test(
+      'chunk failure retries the same offset up to maxRetriesPerChunk',
+      () async {
+        final calls = <http.Request>[];
+        var chunkAttempts = 0;
+        final bytes = List<int>.generate(4, (i) => i);
+
+        final client = _client(
+          sink: calls,
+          handler: (req) async {
+            if (req.url.path.endsWith('/init')) {
+              return http.Response(
+                jsonEncode({'upload_id': 'upl-2', 'chunk_size': 4}),
+                201,
+              );
+            }
+            if (req.url.path.endsWith('/chunk')) {
+              chunkAttempts++;
+              // Fail twice, succeed on the third.
+              if (chunkAttempts < 3) {
+                return http.Response('boom', 502);
+              }
+              return http.Response(jsonEncode({'bytes_received': 4}), 200);
+            }
+            if (req.url.path.endsWith('/finalize')) {
+              return http.Response(
+                jsonEncode({'id': 'm', 'url': '/api/media/m'}),
+                201,
+              );
+            }
+            return http.Response('not found', 404);
+          },
+        );
+
+        final result = await client.uploadBytes(
+          bytes: bytes,
+          serverUrl: 'https://example.test',
+          mimeType: 'image/png',
+          filename: 'a.png',
+          maxRetriesPerChunk: 3,
+        );
+
+        expect(result.ok, isTrue);
+        // All three chunk PATCHes targeted the same byte range.
+        final patches = calls.where((r) => r.method == 'PATCH').toList();
+        expect(patches, hasLength(3));
+        for (final p in patches) {
+          expect(p.headers['content-range'], 'bytes 0-3/4');
+        }
+      },
+    );
+
+    test(
+      '416 with bytes_received body re-syncs without an extra GET',
+      () async {
+        final calls = <http.Request>[];
+        var firstChunkSeen = false;
+        final bytes = List<int>.generate(10, (i) => i);
+
+        final client = _client(
+          sink: calls,
+          handler: (req) async {
+            if (req.url.path.endsWith('/init')) {
+              return http.Response(
+                jsonEncode({'upload_id': 'upl-3', 'chunk_size': 5}),
+                201,
+              );
+            }
+            if (req.url.path.endsWith('/chunk')) {
+              if (!firstChunkSeen) {
+                firstChunkSeen = true;
+                // Pretend the server already has 3 bytes -- client should
+                // advance the offset and ship the rest from there.
+                return http.Response(jsonEncode({'bytes_received': 3}), 416);
+              }
+              final range = req.headers['content-range']!;
+              final endPart = range.split('/').first.split('-').last;
+              return http.Response(
+                jsonEncode({'bytes_received': int.parse(endPart) + 1}),
+                200,
+              );
+            }
+            if (req.url.path.endsWith('/finalize')) {
+              return http.Response(
+                jsonEncode({'id': 'm', 'url': '/api/media/m'}),
+                201,
+              );
+            }
+            return http.Response('not found', 404);
+          },
+        );
+
+        final result = await client.uploadBytes(
+          bytes: bytes,
+          serverUrl: 'https://example.test',
+          mimeType: 'image/png',
+          filename: 'a.png',
+        );
+
+        expect(result.ok, isTrue);
+        // The client should have continued from offset 3, never doing a GET
+        // re-sync (because the 416 body carried bytes_received already).
+        final gets = calls.where((r) => r.method == 'GET').toList();
+        expect(gets, isEmpty);
+      },
+    );
+
+    test(
+      '416 with empty body triggers GET re-sync from /api/media/upload/{id}',
+      () async {
+        final calls = <http.Request>[];
+        var firstChunkSeen = false;
+
+        final client = _client(
+          sink: calls,
+          handler: (req) async {
+            if (req.url.path.endsWith('/init')) {
+              return http.Response(
+                jsonEncode({'upload_id': 'upl-4', 'chunk_size': 5}),
+                201,
+              );
+            }
+            if (req.method == 'GET') {
+              return http.Response(
+                jsonEncode({
+                  'upload_id': 'upl-4',
+                  'bytes_received': 2,
+                  'total_size': 5,
+                  'status': 'pending',
+                }),
+                200,
+              );
+            }
+            if (req.url.path.endsWith('/chunk')) {
+              if (!firstChunkSeen) {
+                firstChunkSeen = true;
+                // Empty 416 body — older server / hostile proxy.
+                return http.Response('', 416);
+              }
+              final range = req.headers['content-range']!;
+              final endPart = range.split('/').first.split('-').last;
+              return http.Response(
+                jsonEncode({'bytes_received': int.parse(endPart) + 1}),
+                200,
+              );
+            }
+            if (req.url.path.endsWith('/finalize')) {
+              return http.Response(
+                jsonEncode({'id': 'm', 'url': '/api/media/m'}),
+                201,
+              );
+            }
+            return http.Response('not found', 404);
+          },
+        );
+
+        final result = await client.uploadBytes(
+          bytes: List<int>.filled(5, 1),
+          serverUrl: 'https://example.test',
+          mimeType: 'image/png',
+          filename: 'a.png',
+        );
+
+        expect(result.ok, isTrue);
+        final gets = calls.where((r) => r.method == 'GET').toList();
+        expect(
+          gets,
+          hasLength(1),
+          reason: 'expected one fallback GET to re-sync bytes_received',
+        );
+      },
+    );
+
+    test('init failure short-circuits and surfaces the server error', () async {
+      final client = _client(
+        handler: (req) async {
+          if (req.url.path.endsWith('/init')) {
+            return http.Response(jsonEncode({'error': 'File too large'}), 400);
+          }
+          return http.Response('not reached', 500);
+        },
+      );
+
+      final result = await client.uploadBytes(
+        bytes: [1, 2, 3],
+        serverUrl: 'https://example.test',
+      );
+
+      expect(result.ok, isFalse);
+      expect(result.statusCode, 400);
+      expect(result.errorMessage, contains('File too large'));
+    });
+  });
+}

--- a/apps/client/test/widgets/settings_screen_test.dart
+++ b/apps/client/test/widgets/settings_screen_test.dart
@@ -2,18 +2,29 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:echo_app/src/providers/auth_provider.dart';
 import 'package:echo_app/src/screens/settings_screen.dart';
 import 'package:echo_app/src/theme/echo_theme.dart';
 
 import '../helpers/mock_providers.dart';
 
+const _adminAuthState = AuthState(
+  isLoggedIn: true,
+  userId: 'admin-user-id',
+  username: 'opsy',
+  token: 'fake-jwt-token',
+  refreshToken: 'fake-refresh-token',
+  isAdmin: true,
+);
+
 Widget _rootApp({
   SettingsSection? selected,
   void Function(SettingsSection)? onTap,
   VoidCallback? onLogout,
+  AuthState authState = loggedInAuthState,
 }) {
   return ProviderScope(
-    overrides: [authOverride(loggedInAuthState), serverUrlOverride()],
+    overrides: [authOverride(authState), serverUrlOverride()],
     child: MaterialApp(
       theme: EchoTheme.darkTheme,
       darkTheme: EchoTheme.darkTheme,
@@ -152,6 +163,40 @@ void main() {
 
       await tester.tap(find.text('Log out'));
       expect(loggedOut, isTrue);
+    });
+
+    testWidgets('hides admin dashboard tile for non-admin users', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(_rootApp());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('settings-admin-dashboard-tile')),
+        findsNothing,
+      );
+      expect(find.text('Admin dashboard'), findsNothing);
+    });
+
+    testWidgets('shows admin dashboard tile for admin users', (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(_rootApp(authState: _adminAuthState));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('settings-admin-dashboard-tile')),
+        findsOneWidget,
+      );
+      expect(find.text('Admin dashboard'), findsOneWidget);
     });
   });
 }

--- a/apps/server/migrations/20260520000000_admin_bootstrap_first_user.sql
+++ b/apps/server/migrations/20260520000000_admin_bootstrap_first_user.sql
@@ -1,0 +1,24 @@
+-- Admin dashboard Phase 1: bootstrap rule for fresh deployments.
+--
+-- The `users.is_admin` column already exists (see
+-- 20260515000000_add_feedback_and_is_admin.sql).  The original convention
+-- was "operator UPDATEs the row by hand"; that turns out to be a friction
+-- point on first-boot for self-hosted instances, so the registration
+-- handler now auto-promotes the very first registered user.
+--
+-- This migration handles the data side for existing deployments: if no
+-- admin exists yet AND there is at least one user, promote the oldest
+-- account.  Brand-new databases hit no rows and the registration handler
+-- takes care of the first signup; both code paths agree on the same
+-- invariant (exactly one bootstrap admin per fresh server).
+--
+-- The UPDATE is wrapped in a `WHERE NOT EXISTS (... is_admin)` guard so
+-- it's safe to re-run.
+UPDATE users
+SET is_admin = TRUE
+WHERE id = (
+    SELECT id FROM users
+    ORDER BY created_at ASC, id ASC
+    LIMIT 1
+)
+AND NOT EXISTS (SELECT 1 FROM users WHERE is_admin = TRUE);

--- a/apps/server/migrations/20260521000000_upload_sessions.sql
+++ b/apps/server/migrations/20260521000000_upload_sessions.sql
@@ -1,0 +1,34 @@
+-- Resumable / chunked upload sessions (#556).
+--
+-- A row is created per in-flight chunked upload and torn down once the
+-- session is finalized into a `media` row, aborted by the client, or
+-- swept by the background cleanup task (24h idle).  The `temp_path` is
+-- always a UUID under `./uploads/.tmp/` -- never user-controlled, so a
+-- compromised row cannot escape the uploads directory.
+--
+-- `status` is intentionally a TEXT column rather than a PG enum so future
+-- statuses can be added without an enum migration.  Allowed values:
+--   'pending'   -- bytes are still being received
+--   'finalized' -- moved into ./uploads/ and a media row was created
+--   'aborted'   -- swept by the cleanup task or explicitly cancelled
+CREATE TABLE IF NOT EXISTS upload_sessions (
+    id              UUID PRIMARY KEY,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    filename        TEXT NOT NULL,
+    mime_type       TEXT NOT NULL,
+    total_size      BIGINT NOT NULL,
+    bytes_received  BIGINT NOT NULL DEFAULT 0,
+    conversation_id UUID REFERENCES conversations(id) ON DELETE SET NULL,
+    temp_path       TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The cleanup sweep filters on `(status, updated_at)` and per-user listings
+-- filter on `(user_id, status)`.  The composite index covers both shapes.
+CREATE INDEX IF NOT EXISTS idx_upload_sessions_user_status
+    ON upload_sessions (user_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_upload_sessions_status_updated
+    ON upload_sessions (status, updated_at);

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -12,6 +12,7 @@ pub mod polls;
 pub mod push_tokens;
 pub mod reactions;
 pub mod tokens;
+pub mod upload_sessions;
 pub mod users;
 
 use sqlx::PgPool;

--- a/apps/server/src/db/upload_sessions.rs
+++ b/apps/server/src/db/upload_sessions.rs
@@ -1,0 +1,145 @@
+//! Upload-session queries for the chunked / resumable upload pipeline (#556).
+//!
+//! Each row represents one in-flight chunked upload.  The handler in
+//! `routes/media.rs` creates rows in `init`, updates `bytes_received` after
+//! every chunk write, and either flips the row to `finalized` (with the
+//! corresponding `media` row created in the same transaction) or leaves it
+//! `pending` for the cleanup sweep to reap after 24 h of inactivity.
+
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub const STATUS_PENDING: &str = "pending";
+pub const STATUS_FINALIZED: &str = "finalized";
+pub const STATUS_ABORTED: &str = "aborted";
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct UploadSessionRow {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub filename: String,
+    pub mime_type: String,
+    pub total_size: i64,
+    pub bytes_received: i64,
+    pub conversation_id: Option<Uuid>,
+    pub temp_path: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Insert a new pending upload session.  The caller has already validated
+/// `total_size` and minted the UUID-only `temp_path` -- this function just
+/// records the row so subsequent chunk PATCHes can locate it.
+#[allow(clippy::too_many_arguments)]
+pub async fn create(
+    pool: &PgPool,
+    id: Uuid,
+    user_id: Uuid,
+    filename: &str,
+    mime_type: &str,
+    total_size: i64,
+    conversation_id: Option<Uuid>,
+    temp_path: &str,
+) -> Result<UploadSessionRow, sqlx::Error> {
+    sqlx::query_as::<_, UploadSessionRow>(
+        "INSERT INTO upload_sessions \
+            (id, user_id, filename, mime_type, total_size, conversation_id, temp_path, status) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending') \
+         RETURNING id, user_id, filename, mime_type, total_size, bytes_received, \
+                   conversation_id, temp_path, status, created_at, updated_at",
+    )
+    .bind(id)
+    .bind(user_id)
+    .bind(filename)
+    .bind(mime_type)
+    .bind(total_size)
+    .bind(conversation_id)
+    .bind(temp_path)
+    .fetch_one(pool)
+    .await
+}
+
+/// Fetch one session.  Returns `None` when no row exists -- callers map that
+/// to 404.  Always filter by `user_id` at the call site so one user cannot
+/// poke at another user's upload by ID.
+pub async fn get(
+    pool: &PgPool,
+    id: Uuid,
+    user_id: Uuid,
+) -> Result<Option<UploadSessionRow>, sqlx::Error> {
+    sqlx::query_as::<_, UploadSessionRow>(
+        "SELECT id, user_id, filename, mime_type, total_size, bytes_received, \
+                conversation_id, temp_path, status, created_at, updated_at \
+         FROM upload_sessions WHERE id = $1 AND user_id = $2",
+    )
+    .bind(id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Add `delta` bytes to the running `bytes_received` counter.  Called once
+/// per chunk **after** the bytes have already been flushed to disk so a
+/// crash between disk write and DB update reports too few bytes (the client
+/// will resume from `bytes_received` and re-send the trailing chunk), never
+/// too many.
+pub async fn add_bytes(
+    pool: &PgPool,
+    id: Uuid,
+    delta: i64,
+) -> Result<UploadSessionRow, sqlx::Error> {
+    sqlx::query_as::<_, UploadSessionRow>(
+        "UPDATE upload_sessions \
+         SET bytes_received = bytes_received + $2, updated_at = now() \
+         WHERE id = $1 \
+         RETURNING id, user_id, filename, mime_type, total_size, bytes_received, \
+                   conversation_id, temp_path, status, created_at, updated_at",
+    )
+    .bind(id)
+    .bind(delta)
+    .fetch_one(pool)
+    .await
+}
+
+/// Mark a session as `finalized`.  Called from the finalize handler after
+/// the temp file has been renamed and the `media` row inserted.
+pub async fn mark_finalized(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE upload_sessions SET status = 'finalized', updated_at = now() WHERE id = $1",
+    )
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Mark a session as `aborted`.  Called by the cleanup sweep and (in
+/// future) an explicit cancel endpoint.  Returns the row before update so
+/// the sweep can locate `temp_path` for unlinking.
+pub async fn mark_aborted(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE upload_sessions SET status = 'aborted', updated_at = now() WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Return every pending session that has been idle longer than
+/// `idle_seconds`.  The cleanup task feeds these into [`mark_aborted`] and
+/// unlinks each `temp_path`.
+pub async fn list_stale_pending(
+    pool: &PgPool,
+    idle_seconds: i64,
+) -> Result<Vec<UploadSessionRow>, sqlx::Error> {
+    sqlx::query_as::<_, UploadSessionRow>(
+        "SELECT id, user_id, filename, mime_type, total_size, bytes_received, \
+                conversation_id, temp_path, status, created_at, updated_at \
+         FROM upload_sessions \
+         WHERE status = 'pending' AND updated_at < now() - make_interval(secs => $1)",
+    )
+    .bind(idle_seconds)
+    .fetch_all(pool)
+    .await
+}

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -19,21 +19,49 @@ pub struct UserRow {
     pub status_message: Option<String>,
     #[allow(dead_code)]
     pub status_text: Option<String>,
+    /// Operator flag — admin dashboard access (Phase 1, #681).
+    /// Surfaced in the login / register response so the client can gate
+    /// the dashboard tile without a separate round-trip.
+    #[sqlx(default)]
+    pub is_admin: bool,
+}
+
+/// Result of inserting a new user. Carries the auto-assigned id plus the
+/// `is_admin` flag so the registration handler can surface admin status
+/// on the very first signup without a second round-trip.
+#[derive(Debug)]
+pub struct CreatedUser {
+    pub id: Uuid,
+    pub is_admin: bool,
 }
 
 pub async fn create_user(
     pool: &PgPool,
     username: &str,
     password_hash: &str,
-) -> Result<Uuid, sqlx::Error> {
-    let row: (Uuid,) =
-        sqlx::query_as("INSERT INTO users (username, password_hash) VALUES ($1, $2) RETURNING id")
-            .bind(username)
-            .bind(password_hash)
-            .fetch_one(pool)
-            .await?;
+) -> Result<CreatedUser, sqlx::Error> {
+    // First-user bootstrap: when the users table is empty (and so by
+    // construction no admin exists yet), this signup becomes the operator.
+    // The `NOT EXISTS` subquery sees its snapshot inside the same statement
+    // as the INSERT, so even with two concurrent registrations against an
+    // empty table only one row sees an empty table -- the other observes
+    // the freshly inserted row and gets `is_admin = FALSE`.  Combined with
+    // the unique-username constraint this means a fresh DB deterministically
+    // gets exactly one admin from the registration path.
+    let row: (Uuid, bool) = sqlx::query_as(
+        "INSERT INTO users (username, password_hash, is_admin) \
+         VALUES ($1, $2, (SELECT NOT EXISTS (SELECT 1 FROM users))) \
+         RETURNING id, is_admin",
+    )
+    .bind(username)
+    .bind(password_hash)
+    .fetch_one(pool)
+    .await?;
 
-    Ok(row.0)
+    Ok(CreatedUser {
+        id: row.0,
+        is_admin: row.1,
+    })
 }
 
 pub async fn find_by_username(
@@ -41,7 +69,8 @@ pub async fn find_by_username(
     username: &str,
 ) -> Result<Option<UserRow>, sqlx::Error> {
     sqlx::query_as::<_, UserRow>(
-        "SELECT id, username, password_hash, avatar_url, display_name, bio, status_message, status_text FROM users WHERE username = $1",
+        "SELECT id, username, password_hash, avatar_url, display_name, bio, \
+         status_message, status_text, is_admin FROM users WHERE username = $1",
     )
     .bind(username)
     .fetch_optional(pool)
@@ -50,7 +79,8 @@ pub async fn find_by_username(
 
 pub async fn find_by_id(pool: &PgPool, id: Uuid) -> Result<Option<UserRow>, sqlx::Error> {
     sqlx::query_as::<_, UserRow>(
-        "SELECT id, username, password_hash, avatar_url, display_name, bio, status_message, status_text FROM users WHERE id = $1",
+        "SELECT id, username, password_hash, avatar_url, display_name, bio, \
+         status_message, status_text, is_admin FROM users WHERE id = $1",
     )
     .bind(id)
     .fetch_optional(pool)

--- a/apps/server/src/lib.rs
+++ b/apps/server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod config;
 pub mod db;
 pub mod error;
+pub mod metrics;
 pub mod middleware;
 pub mod push;
 pub mod routes;

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -86,6 +86,17 @@ async fn main() {
             async move { cleanup_orphan_media_files(&pool).await }
         }
     });
+    // Sweep abandoned chunked-upload sessions hourly (#556).  Idle window is
+    // 24 h so a user who closed their laptop overnight can still resume.
+    spawn_periodic("stale_uploads", std::time::Duration::from_secs(3600), {
+        let pool = pool.clone();
+        move || {
+            let pool = pool.clone();
+            async move {
+                echo_server::routes::media_chunked::cleanup_stale_uploads(&pool, 24 * 60 * 60).await
+            }
+        }
+    });
 
     // Evict stale entries from the typing_service membership/member-ID/conv-kind
     // caches; without this, entries accumulate unboundedly on long-running servers.

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -37,6 +37,7 @@ async fn main() {
         hub: hub.clone(),
         ticket_store: Arc::new(dashmap::DashMap::new()),
         media_tickets: Arc::new(dashmap::DashMap::new()),
+        message_rate: Arc::new(echo_server::metrics::MessageRateCounter::new()),
     });
 
     // Per-task cleanup loops with panic recovery; cadence per task.

--- a/apps/server/src/metrics.rs
+++ b/apps/server/src/metrics.rs
@@ -1,0 +1,134 @@
+//! Lightweight in-memory counters that back the operator dashboard
+//! (`/api/admin/stats/realtime`, #681).
+//!
+//! ## Privacy invariant
+//!
+//! These counters carry **no** per-user, per-conversation, or
+//! per-message-content identification.  The only thing we track is "a
+//! relay happened, now."  That keeps the metrics surface compatible with
+//! the design-doc invariant in `docs/group-e2e-design/` (no content,
+//! no decrypted previews, aggregated counts only).
+//!
+//! ## Hot-path contract
+//!
+//! [`MessageRateCounter::record`] runs inside the WS message relay path
+//! and must not introduce contention.  The implementation is a single
+//! relaxed `AtomicU64` fetch-add plus a `Mutex<VecDeque<...>>` lock that
+//! is taken only when the seconds bucket rolls over (~once per second
+//! across the whole server, not per message).  Under steady load the
+//! mutex is effectively cold; the atomic increment is the only thing the
+//! hot path touches.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// Sliding window length for [`MessageRateCounter::per_second`].
+/// Sixty seconds matches the dashboard's "messages per second" tile —
+/// long enough to smooth quiet periods, short enough that an operator
+/// notices a flood within ~a minute.
+const WINDOW: Duration = Duration::from_secs(60);
+
+/// Records each successful WS message relay and reports a sliding-window
+/// per-second rate.
+#[derive(Debug)]
+pub struct MessageRateCounter {
+    /// Counter for the bucket currently being filled.  Read+reset under
+    /// the mutex once per second (or when the caller asks for a snapshot),
+    /// so the relay path only does a relaxed fetch-add.
+    current_bucket: AtomicU64,
+    /// `(bucket_start, count)` for each completed second still inside the
+    /// 60-second window.  Locked only when buckets roll over — every
+    /// ~1 s on a hot server, never on a quiet one.
+    history: Mutex<RateHistory>,
+}
+
+#[derive(Debug)]
+struct RateHistory {
+    /// `Instant` at which the current bucket started.
+    current_started: Instant,
+    /// Completed buckets, oldest first.  Capacity is bounded by `WINDOW`
+    /// in seconds, so this never grows beyond ~60 entries.
+    buckets: std::collections::VecDeque<(Instant, u64)>,
+}
+
+impl Default for MessageRateCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MessageRateCounter {
+    pub fn new() -> Self {
+        Self {
+            current_bucket: AtomicU64::new(0),
+            history: Mutex::new(RateHistory {
+                current_started: Instant::now(),
+                buckets: std::collections::VecDeque::with_capacity(64),
+            }),
+        }
+    }
+
+    /// Mark one successful relay. Hot path — must stay lock-free in the
+    /// common case (no bucket roll).
+    #[inline]
+    pub fn record(&self) {
+        self.current_bucket.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Per-second rate over the trailing [`WINDOW`].  Computes by
+    /// rolling stale buckets out of the window, snapshotting the current
+    /// bucket, and dividing the sum by the window length.
+    pub fn per_second(&self) -> f64 {
+        let now = Instant::now();
+        let mut history = self.history.lock().expect("metrics mutex poisoned");
+
+        // Roll the in-progress bucket out whenever a full second has
+        // elapsed.  We always pull the AtomicU64 to zero (swap) so two
+        // back-to-back `per_second` calls can't double-count.
+        if now.duration_since(history.current_started) >= Duration::from_secs(1) {
+            let count = self.current_bucket.swap(0, Ordering::Relaxed);
+            let started = history.current_started;
+            history.buckets.push_back((started, count));
+            history.current_started = now;
+        }
+
+        // Drop buckets older than the window.
+        let cutoff = now - WINDOW;
+        while let Some((started, _)) = history.buckets.front() {
+            if *started + Duration::from_secs(1) < cutoff {
+                history.buckets.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        let historical: u64 = history.buckets.iter().map(|(_, n)| *n).sum();
+        let in_progress = self.current_bucket.load(Ordering::Relaxed);
+        let total = historical + in_progress;
+        let seconds = WINDOW.as_secs_f64();
+        total as f64 / seconds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newly_constructed_counter_is_zero() {
+        let c = MessageRateCounter::new();
+        assert!(c.per_second().abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn records_contribute_to_rate() {
+        let c = MessageRateCounter::new();
+        for _ in 0..120 {
+            c.record();
+        }
+        // 120 events in <1s → contribute to the 60s window → 2.0 per second.
+        let rate = c.per_second();
+        assert!((rate - 2.0).abs() < 0.001, "expected 2.0 msg/s, got {rate}");
+    }
+}

--- a/apps/server/src/routes/admin.rs
+++ b/apps/server/src/routes/admin.rs
@@ -8,14 +8,24 @@
 use std::sync::Arc;
 
 use axum::Json;
-use axum::extract::{FromRequestParts, Query, State};
+use axum::extract::{FromRequestParts, Path, Query, State};
 use axum::http::request::Parts;
-use axum::response::IntoResponse;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
+use crate::auth::jwt;
 use crate::auth::middleware::AuthUser;
 use crate::error::{AppError, DbErrCtx};
 use crate::routes::AppState;
+
+/// Window during which a freshly-issued JWT is considered "warm" enough to
+/// access admin routes. Five minutes lets an operator chain a handful of
+/// dashboard refreshes off one re-auth without keeping the elevated
+/// session indefinitely. When `iat` is older than this the response
+/// includes `WWW-Authenticate: Bearer error="reauth_required"` so the
+/// client knows to prompt for the password again.
+const ADMIN_REAUTH_WINDOW_SECS: i64 = 5 * 60;
 
 /// Extractor that resolves a JWT to a user and then short-circuits with 403
 /// unless `users.is_admin` is TRUE.  Implemented on top of [`AuthUser`] so
@@ -26,25 +36,74 @@ pub struct AdminUser {
 }
 
 impl FromRequestParts<Arc<AppState>> for AdminUser {
-    type Rejection = AppError;
+    type Rejection = Response;
 
     async fn from_request_parts(
         parts: &mut Parts,
         state: &Arc<AppState>,
     ) -> Result<Self, Self::Rejection> {
-        let auth = AuthUser::from_request_parts(parts, state).await?;
+        let auth = AuthUser::from_request_parts(parts, state)
+            .await
+            .map_err(IntoResponse::into_response)?;
+
         let (is_admin,): (bool,) = sqlx::query_as("SELECT is_admin FROM users WHERE id = $1")
             .bind(auth.user_id)
             .fetch_one(&state.pool)
             .await
-            .db_ctx("admin/is_admin_lookup")?;
+            .db_ctx("admin/is_admin_lookup")
+            .map_err(IntoResponse::into_response)?;
         if !is_admin {
-            return Err(AppError::forbidden("Admin access required"));
+            return Err(AppError::forbidden("Admin access required").into_response());
         }
+
+        // Re-auth window: the same JWT used for normal API calls is fine
+        // for admin endpoints only when it was minted recently.  Stale
+        // tokens get 401 with the `reauth_required` indicator so the
+        // client can prompt for the password without forcing a full
+        // logout.
+        if !admin_token_is_fresh(parts, &state.jwt_secret) {
+            return Err(reauth_required_response());
+        }
+
         Ok(AdminUser {
             user_id: auth.user_id,
         })
     }
+}
+
+/// Returns `true` when the bearer token's `iat` is within
+/// [`ADMIN_REAUTH_WINDOW_SECS`] seconds of now. Absence of a token or any
+/// decode failure flips this to `false` — the surrounding [`AuthUser`]
+/// already rejected the request if the token was actually invalid, so the
+/// only realistic path into the `false` branch is a valid-but-stale token.
+fn admin_token_is_fresh(parts: &Parts, secret: &str) -> bool {
+    let Some(token) = parts
+        .headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    else {
+        return false;
+    };
+    let Ok(claims) = jwt::validate_token(token, secret) else {
+        return false;
+    };
+    let now = chrono::Utc::now().timestamp();
+    let iat = claims.iat as i64;
+    (now - iat) <= ADMIN_REAUTH_WINDOW_SECS
+}
+
+fn reauth_required_response() -> Response {
+    let body = serde_json::json!({
+        "error": "Admin session is stale — please re-authenticate",
+        "code": "reauth-required",
+    });
+    let mut resp = (StatusCode::UNAUTHORIZED, Json(body)).into_response();
+    resp.headers_mut().insert(
+        header::WWW_AUTHENTICATE,
+        HeaderValue::from_static("Bearer error=\"reauth_required\""),
+    );
+    resp
 }
 
 #[derive(Debug, Serialize)]
@@ -224,4 +283,130 @@ pub async fn list_feedback(
         .collect();
 
     Ok(Json(serde_json::json!({ "feedback": payload })))
+}
+
+// ---------------------------------------------------------------------------
+// Realtime dashboard (#681 Phase 1)
+// ---------------------------------------------------------------------------
+
+/// Aggregated, privacy-safe operator metrics polled by the admin dashboard.
+///
+/// **Privacy invariant**: no message content, no decrypted previews, no
+/// per-user-conversation identification.  Everything below is either a
+/// process-level counter or a server-wide aggregate.
+#[derive(Debug, Serialize)]
+pub struct RealtimeStats {
+    /// Distinct user_ids currently registered in the WS hub.
+    pub connected_sessions: u64,
+    /// Per-platform breakdown of [`Self::connected_sessions`].  The current
+    /// WS upgrade path doesn't capture the client platform, so everyone
+    /// lands in `unknown` for now (Phase 1 — wiring TBD in #681 Phase 2).
+    pub connected_sessions_by_platform: PlatformBreakdown,
+    /// Sliding 60s window: messages successfully relayed per second.
+    pub messages_per_sec: f64,
+    /// Distinct conversation_ids with at least one active voice session.
+    /// Sourced from the existing `voice_sessions` table; no LiveKit-specific
+    /// data is exposed.
+    pub active_voice_rooms: u32,
+    /// In-flight DB connections (`size - num_idle`).
+    pub db_pool_in_flight: u32,
+    /// Configured pool ceiling.
+    pub db_pool_max: u32,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct PlatformBreakdown {
+    pub web: u64,
+    pub mobile: u64,
+    pub desktop: u64,
+    /// Where every session lands today — the WS handshake doesn't carry a
+    /// platform field yet. Documented as TBD in #681 Phase 2 so we don't
+    /// fake numbers (the privacy invariant cuts both ways: we won't
+    /// fabricate observability either).
+    pub unknown: u64,
+}
+
+pub async fn get_realtime_stats(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminUser,
+) -> Result<impl IntoResponse, AppError> {
+    let online_user_ids = state.hub.get_online_user_ids();
+    let connected_sessions = online_user_ids.len() as u64;
+    let connected_sessions_by_platform = PlatformBreakdown {
+        // TODO(#681 Phase 2): wire WS handshake `X-Echo-Platform` header
+        // into the hub so we can split this honestly.  Until then, every
+        // session reports as `unknown` — the dashboard renders that
+        // bucket explicitly so an operator can see the gap.
+        unknown: connected_sessions,
+        ..PlatformBreakdown::default()
+    };
+
+    let messages_per_sec = state.message_rate.per_second();
+
+    let (active_voice_rooms,): (i64,) = sqlx::query_as(
+        // Voice sessions hang off a channel, which hangs off a conversation.
+        // Distinct conversations = distinct active voice rooms.
+        "SELECT COUNT(DISTINCT c.conversation_id) \
+         FROM voice_sessions vs \
+         JOIN channels c ON c.id = vs.channel_id",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .db_ctx("admin/realtime_voice_rooms")?;
+
+    let db_pool_in_flight = state
+        .pool
+        .size()
+        .saturating_sub(state.pool.num_idle() as u32);
+    let db_pool_max = state.pool.options().get_max_connections();
+
+    Ok(Json(RealtimeStats {
+        connected_sessions,
+        connected_sessions_by_platform,
+        messages_per_sec,
+        active_voice_rooms: u32::try_from(active_voice_rooms.max(0)).unwrap_or(u32::MAX),
+        db_pool_in_flight,
+        db_pool_max,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Promotion (#681 Phase 1)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct PromotedUser {
+    pub id: String,
+    pub username: String,
+    pub is_admin: bool,
+}
+
+/// `POST /api/admin/promote/{user_id}` — make `user_id` an admin.
+///
+/// Demotion is intentionally not in this PR (#681 Phase 1.5).  404 on
+/// missing user, 200 with the updated row (sans password) on success.
+pub async fn promote_user(
+    State(state): State<Arc<AppState>>,
+    _admin: AdminUser,
+    Path(user_id): Path<uuid::Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let row: Option<(uuid::Uuid, String, bool)> = sqlx::query_as(
+        "UPDATE users SET is_admin = TRUE \
+         WHERE id = $1 \
+         RETURNING id, username, is_admin",
+    )
+    .bind(user_id)
+    .fetch_optional(&state.pool)
+    .await
+    .db_ctx("admin/promote_user")?;
+
+    let Some((id, username, is_admin)) = row else {
+        return Err(AppError::not_found("User not found"));
+    };
+
+    Ok(Json(PromotedUser {
+        id: id.to_string(),
+        username,
+        is_admin,
+    }))
 }

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -64,6 +64,10 @@ pub struct AuthResponse {
     pub access_token: String,
     pub refresh_token: String,
     pub avatar_url: Option<String>,
+    /// Operator flag: lets the client gate the admin dashboard tile in
+    /// settings without an extra round-trip. Fresh server bootstrap (no
+    /// admin yet) auto-promotes the first registered account.
+    pub is_admin: bool,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -76,6 +80,9 @@ pub struct RefreshRequest {
 pub struct RefreshResponse {
     pub access_token: String,
     pub refresh_token: String,
+    /// Echoed from the user row so a client that signed in before the
+    /// operator was promoted picks up the new flag without re-logging in.
+    pub is_admin: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -157,18 +164,19 @@ pub async fn register(
     let password_hash = tokio::task::spawn_blocking(move || password::hash_password(&pw))
         .await
         .map_err(|_| AppError::internal("Password hashing failed"))??;
-    let user_id = db::users::create_user(&state.pool, &body.username, &password_hash).await?;
-    let access_token = jwt::create_token(user_id, &state.jwt_secret)?;
-    let (refresh_token, _family_id) = issue_refresh_token(&state.pool, user_id).await?;
+    let created = db::users::create_user(&state.pool, &body.username, &password_hash).await?;
+    let access_token = jwt::create_token(created.id, &state.jwt_secret)?;
+    let (refresh_token, _family_id) = issue_refresh_token(&state.pool, created.id).await?;
 
     // Web clients consume the cookie; mobile/desktop still read the JSON body.
     let jar = jar.add(build_refresh_cookie(refresh_token.clone()));
 
     let response = AuthResponse {
-        user_id: user_id.to_string(),
+        user_id: created.id.to_string(),
         access_token,
         refresh_token,
         avatar_url: None,
+        is_admin: created.is_admin,
     };
 
     Ok((StatusCode::CREATED, jar, Json(response)))
@@ -222,6 +230,7 @@ pub async fn login(
         access_token,
         refresh_token,
         avatar_url: user.avatar_url,
+        is_admin: user.is_admin,
     };
 
     Ok((jar, Json(response)))
@@ -379,6 +388,15 @@ pub async fn refresh(
 
     let access_token = jwt::create_token(row.user_id, &state.jwt_secret)?;
 
+    // Re-read is_admin from the canonical row so promotion / demotion that
+    // happens between login and refresh propagates to the client on its
+    // next 15-minute access-token roll.
+    let (is_admin,): (bool,) = sqlx::query_as("SELECT is_admin FROM users WHERE id = $1")
+        .bind(row.user_id)
+        .fetch_one(&state.pool)
+        .await
+        .db_ctx("refresh/lookup_is_admin")?;
+
     let jar = jar.add(build_refresh_cookie(new_raw_token.clone()));
 
     Ok((
@@ -386,6 +404,7 @@ pub async fn refresh(
         Json(RefreshResponse {
             access_token,
             refresh_token: new_raw_token,
+            is_admin,
         }),
     ))
 }

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -27,7 +27,7 @@ use crate::error::{AppError, DbErrCtx, ErrorCode};
 /// Uses [`imagesize`] which parses only the file header — no full decode,
 /// no large allocations. Returns `None` for non-image formats or when the
 /// header is unrecognised; the caller stores `NULL` in those cases.
-fn read_image_dimensions(path: &str) -> Option<(u32, u32)> {
+pub(super) fn read_image_dimensions(path: &str) -> Option<(u32, u32)> {
     match imagesize::size(path) {
         Ok(dim) => Some((dim.width as u32, dim.height as u32)),
         Err(_) => None,
@@ -81,7 +81,7 @@ const ALLOWED_MIME_TYPES: &[&str] = &[
 ];
 
 /// Derive a file extension from a MIME type.
-fn extension_for_mime(mime: &str) -> &str {
+pub(super) fn extension_for_mime(mime: &str) -> &str {
     match mime {
         "image/jpeg" => "jpg",
         "image/png" => "png",
@@ -248,7 +248,7 @@ async fn stream_field_to_temp(
 /// Validate the magic bytes from the head buffer against the allowed MIME
 /// types.  Mirrors `validate_bytes` but accepts a head slice rather than
 /// requiring the whole file in RAM.
-fn validate_head(head: &[u8], declared_mime: &str) -> Result<String, AppError> {
+pub(super) fn validate_head(head: &[u8], declared_mime: &str) -> Result<String, AppError> {
     match infer::get(head) {
         Some(inferred) => {
             let m = inferred.mime_type();
@@ -352,7 +352,7 @@ async fn process_multipart_fields(
 }
 
 /// Build the JSON response with media metadata.
-fn build_upload_response(
+pub(super) fn build_upload_response(
     row: &db::media::MediaRow,
     thumb_url: Option<String>,
 ) -> serde_json::Value {
@@ -447,7 +447,7 @@ pub async fn upload(
 /// Run ffmpeg to extract the first frame of a video as a JPEG thumbnail.
 /// Returns `Err` if ffmpeg isn't installed or exits non-zero — the caller
 /// logs a warning and continues without a thumbnail.
-async fn generate_video_thumbnail(input: &str, output: &str) -> Result<(), String> {
+pub(super) async fn generate_video_thumbnail(input: &str, output: &str) -> Result<(), String> {
     let result = tokio::process::Command::new("ffmpeg")
         .args([
             "-y",

--- a/apps/server/src/routes/media_chunked.rs
+++ b/apps/server/src/routes/media_chunked.rs
@@ -1,0 +1,689 @@
+//! Resumable / chunked upload endpoints (#556).
+//!
+//! The legacy `POST /api/media/upload` handler stays in `media.rs` as a
+//! single-shot multipart upload capped at 100 MB.  This module adds a
+//! parallel pipeline -- init / PATCH chunks / finalize -- that streams
+//! every chunk to disk without buffering the body in RAM, so files up to
+//! `MAX_CHUNKED_UPLOAD_BYTES` (2 GB by default) can be uploaded over
+//! flaky cellular links with per-chunk retries.
+//!
+//! ## Why chunked instead of bumping the single-shot cap
+//!
+//! - Cloudflare Free caps request bodies at 100 MB at the edge, so a 2 GB
+//!   single-shot upload cannot reach the origin at all.
+//! - The existing `field.bytes().await` would load each chunk into RAM
+//!   before writing; this module uses `Body::into_data_stream()` and
+//!   writes each frame directly to a `tokio::fs::File`.
+//! - Per-chunk retries allow the client to resume after a transient
+//!   disconnect without re-uploading the whole file.
+//!
+//! ## Security
+//!
+//! - Every endpoint requires `AuthUser`.
+//! - `temp_path` is `./uploads/.tmp/<uuid>` -- always derived from a
+//!   server-generated UUID; user-supplied filenames are only honoured at
+//!   the very end (in finalize) after being sanitised the same way the
+//!   legacy endpoint sanitises them.
+//! - The client-supplied `Content-Range` start offset must equal the
+//!   server-side `bytes_received` counter; any mismatch is rejected with
+//!   416 so a stale or hostile client cannot rewrite earlier bytes.
+//! - `Content-Range` end - start + 1 must equal the body length, again
+//!   rejected with 4xx; we never append more than the declared range.
+//! - Finalize verifies `bytes_received == total_size`; finalising a
+//!   short or oversized session is a 4xx.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use uuid::Uuid;
+
+use crate::auth::middleware::AuthUser;
+use crate::db;
+use crate::error::{AppError, DbErrCtx};
+
+use super::AppState;
+use super::media;
+
+/// Default chunk size announced to clients on init.  Mirrors the standard
+/// S3 multipart minimum (5 MB) so the math feels familiar; small enough
+/// that a single chunk completes quickly on cellular, large enough that
+/// the per-chunk PostgreSQL round-trip doesn't dominate throughput.
+pub const DEFAULT_CHUNK_SIZE: i64 = 5 * 1024 * 1024;
+
+/// Hard upper bound on the size of a single PATCH chunk body, regardless
+/// of what `Content-Range` declares.  This is a defence-in-depth cap that
+/// prevents a malicious client from streaming an unbounded body even with
+/// a well-formed range header; it should be slightly larger than the
+/// advertised `DEFAULT_CHUNK_SIZE` so well-behaved clients are not
+/// truncated by it.
+const MAX_CHUNK_BYTES: i64 = 16 * 1024 * 1024;
+
+/// Where pending chunked uploads land on disk.  Created lazily on init.
+const TMP_DIR: &str = "./uploads/.tmp";
+
+/// Default ceiling on the total size of a chunked upload, when the
+/// `MAX_CHUNKED_UPLOAD_BYTES` env var is unset.  2 GB is enough for
+/// modern phone video and well below typical disk-quota concerns.
+pub const DEFAULT_MAX_CHUNKED_UPLOAD_BYTES: i64 = 2 * 1024 * 1024 * 1024;
+
+/// Read the configured upper bound on a chunked upload.  Re-read each
+/// time so operators can rotate the value at runtime without a restart.
+fn max_chunked_upload_bytes() -> i64 {
+    std::env::var("MAX_CHUNKED_UPLOAD_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_MAX_CHUNKED_UPLOAD_BYTES)
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/media/upload/init
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct InitUploadRequest {
+    pub filename: String,
+    pub mime_type: String,
+    pub total_size: i64,
+    /// Optional conversation scope; matches the legacy multipart field.
+    pub conversation_id: Option<Uuid>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InitUploadResponse {
+    pub upload_id: Uuid,
+    pub chunk_size: i64,
+}
+
+/// `POST /api/media/upload/init` -- begin a new resumable upload.
+pub async fn init(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<InitUploadRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.total_size <= 0 {
+        return Err(AppError::bad_request("total_size must be positive"));
+    }
+    let max = max_chunked_upload_bytes();
+    if req.total_size > max {
+        return Err(AppError::bad_request(format!(
+            "File too large. Maximum chunked upload size is {max} bytes"
+        )));
+    }
+    if req.filename.trim().is_empty() {
+        return Err(AppError::bad_request("filename is required"));
+    }
+    if req.mime_type.trim().is_empty() {
+        return Err(AppError::bad_request("mime_type is required"));
+    }
+
+    if let Some(cid) = req.conversation_id {
+        let is_member = db::groups::is_member(&state.pool, cid, auth.user_id)
+            .await
+            .db_ctx("chunked_upload/init/is_member")?;
+        if !is_member {
+            return Err(AppError::with_code(
+                crate::error::ErrorCode::NotMember,
+                "Not a member of this conversation",
+            ));
+        }
+    }
+
+    fs::create_dir_all(TMP_DIR)
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to create temp upload directory: {e}")))?;
+
+    let upload_id = Uuid::new_v4();
+    let temp_path = format!("{TMP_DIR}/{upload_id}");
+
+    // Pre-create the empty temp file so the very first PATCH never has to
+    // distinguish "file missing" from "file at offset 0".
+    fs::File::create(&temp_path)
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to create temp upload file: {e}")))?;
+
+    db::upload_sessions::create(
+        &state.pool,
+        upload_id,
+        auth.user_id,
+        req.filename.trim(),
+        req.mime_type.trim(),
+        req.total_size,
+        req.conversation_id,
+        &temp_path,
+    )
+    .await
+    .db_ctx("chunked_upload/init/create")?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(InitUploadResponse {
+            upload_id,
+            chunk_size: DEFAULT_CHUNK_SIZE,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/media/upload/{id}/chunk
+// ---------------------------------------------------------------------------
+
+/// Parsed `Content-Range: bytes <start>-<end>/<total>` triple.
+///
+/// `end` is inclusive (matches the HTTP spec); the chunk body length must
+/// be `end - start + 1` bytes.  `total` must match the session's
+/// `total_size` -- a mismatch here means the client thinks it's uploading
+/// a different file than the one init reserved space for.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ContentRange {
+    pub start: i64,
+    pub end: i64,
+    pub total: i64,
+}
+
+/// Parse a `Content-Range: bytes <start>-<end>/<total>` header.  Returns
+/// `Err(())` for any malformed input.  Kept as a pure function so the
+/// unit tests below can exercise every branch without spinning up axum.
+pub(crate) fn parse_content_range(header: &str) -> Result<ContentRange, ()> {
+    let spec = header.trim().strip_prefix("bytes ").ok_or(())?;
+    let (range, total) = spec.split_once('/').ok_or(())?;
+    let (s, e) = range.split_once('-').ok_or(())?;
+    let start: i64 = s.parse().map_err(|_| ())?;
+    let end: i64 = e.parse().map_err(|_| ())?;
+    let total: i64 = total.parse().map_err(|_| ())?;
+    if start < 0 || end < start || total <= 0 || end >= total {
+        return Err(());
+    }
+    Ok(ContentRange { start, end, total })
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChunkResponse {
+    pub bytes_received: i64,
+}
+
+/// `PATCH /api/media/upload/{id}/chunk` -- append a chunk to a pending
+/// session.
+///
+/// Wire contract:
+/// - `Content-Range: bytes <start>-<end>/<total>` (required, inclusive).
+/// - Body is raw bytes, length `end - start + 1`.
+/// - `start` MUST equal the session's `bytes_received`; otherwise 416.
+/// - 4xx for any header / size / state mismatch; 200 on success with
+///   the new `bytes_received` so clients can re-sync without an extra GET.
+pub async fn upload_chunk(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<impl IntoResponse, AppError> {
+    let range_header = headers
+        .get(axum::http::header::CONTENT_RANGE)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| AppError::bad_request("Content-Range header is required"))?;
+
+    let range = parse_content_range(range_header)
+        .map_err(|()| AppError::bad_request("Malformed Content-Range header"))?;
+
+    let session = load_pending_session(&state, id, auth.user_id).await?;
+
+    if range.total != session.total_size {
+        return Err(AppError::bad_request(
+            "Content-Range total does not match session total_size",
+        ));
+    }
+    if range.start != session.bytes_received {
+        return Err(range_mismatch(session.bytes_received));
+    }
+
+    let declared_len = range.end - range.start + 1;
+    if declared_len <= 0 || declared_len > MAX_CHUNK_BYTES {
+        return Err(AppError::bad_request("Chunk size out of bounds"));
+    }
+    if range.end + 1 > session.total_size {
+        return Err(AppError::bad_request(
+            "Chunk would exceed declared total_size",
+        ));
+    }
+
+    let written = stream_chunk_to_disk(&session.temp_path, body, declared_len).await?;
+    let updated = db::upload_sessions::add_bytes(&state.pool, id, written)
+        .await
+        .db_ctx("chunked_upload/chunk/add_bytes")?;
+
+    Ok(Json(ChunkResponse {
+        bytes_received: updated.bytes_received,
+    }))
+}
+
+/// 416 Range Not Satisfiable with a `bytes_received` body so the client
+/// can re-sync from a single response.
+fn range_mismatch(bytes_received: i64) -> AppError {
+    AppError {
+        status: StatusCode::RANGE_NOT_SATISFIABLE,
+        message: format!(
+            "Content-Range start does not match server bytes_received={bytes_received}"
+        ),
+        code: crate::error::ErrorCode::BadRequest,
+        body: Some(json!({ "bytes_received": bytes_received })),
+    }
+}
+
+/// Stream the request body into the temp file, capped at `declared_len`.
+///
+/// We tear the connection down (return Err) if the body is larger than
+/// declared so a buggy or malicious client cannot rewrite bytes past the
+/// declared range.  If the body is short we still return the partial
+/// count -- subsequent chunk requests will resume from there.
+async fn stream_chunk_to_disk(
+    temp_path: &str,
+    body: Body,
+    declared_len: i64,
+) -> Result<i64, AppError> {
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(temp_path)
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to open temp upload file: {e}")))?;
+
+    let mut written: i64 = 0;
+    let mut stream = body.into_data_stream();
+    while let Some(frame) = stream.next().await {
+        let bytes =
+            frame.map_err(|e| AppError::bad_request(format!("Failed to read chunk body: {e}")))?;
+        let remaining = declared_len - written;
+        if remaining <= 0 {
+            // Body claims more bytes than the range allows.  Don't write,
+            // and surface a 4xx so the client knows to abort + retry.
+            return Err(AppError::bad_request("Chunk body exceeds declared range"));
+        }
+        let take = (bytes.len() as i64).min(remaining) as usize;
+        if take < bytes.len() {
+            // Body is larger than declared even on a single frame.  Same
+            // 4xx, no partial write past the cap.
+            return Err(AppError::bad_request("Chunk body exceeds declared range"));
+        }
+        if take > 0 {
+            file.write_all(&bytes[..take])
+                .await
+                .map_err(|e| AppError::internal(format!("Failed to write chunk to disk: {e}")))?;
+            written += take as i64;
+        }
+    }
+    file.flush()
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to flush chunk: {e}")))?;
+    Ok(written)
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/media/upload/{id}/finalize
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Default)]
+pub struct FinalizeRequest {
+    /// Optional client-side SHA-256 of the assembled file (hex).  Rejected
+    /// 4xx if present and the server-side hash differs.
+    pub sha256: Option<String>,
+}
+
+/// `POST /api/media/upload/{id}/finalize` -- assemble the final media row.
+pub async fn finalize(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+    body: Option<Json<FinalizeRequest>>,
+) -> Result<impl IntoResponse, AppError> {
+    let req = body.map(|Json(r)| r).unwrap_or_default();
+    let session = load_pending_session(&state, id, auth.user_id).await?;
+
+    if session.bytes_received != session.total_size {
+        return Err(AppError::bad_request(format!(
+            "Upload is incomplete: bytes_received={} total_size={}",
+            session.bytes_received, session.total_size
+        )));
+    }
+
+    if let Some(expected_hex) = req.sha256.as_deref() {
+        verify_sha256(&session.temp_path, expected_hex).await?;
+    }
+
+    let mime_type = detect_mime_from_file(&session.temp_path, &session.mime_type).await?;
+    let ext = media::extension_for_mime(&mime_type);
+    let file_uuid = Uuid::new_v4();
+    let disk_path = format!("./uploads/{file_uuid}.{ext}");
+
+    fs::create_dir_all("./uploads")
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to create uploads directory: {e}")))?;
+
+    fs::rename(&session.temp_path, &disk_path)
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to move temp upload into place: {e}")))?;
+
+    let safe_filename = sanitize_filename(&session.filename);
+    let (img_w, img_h) = if mime_type.starts_with("image/") {
+        media::read_image_dimensions(&disk_path)
+            .map(|(w, h)| (Some(w as i32), Some(h as i32)))
+            .unwrap_or((None, None))
+    } else {
+        (None, None)
+    };
+
+    let row = db::media::create_media(
+        &state.pool,
+        file_uuid,
+        auth.user_id,
+        &safe_filename,
+        &mime_type,
+        session.total_size,
+        session.conversation_id,
+        img_w,
+        img_h,
+    )
+    .await
+    .db_ctx("chunked_upload/finalize/create_media")?;
+
+    let mut thumb_url: Option<String> = None;
+    if mime_type.starts_with("video/") {
+        let thumb_path = format!("./uploads/{file_uuid}.thumb.jpg");
+        if let Err(e) = media::generate_video_thumbnail(&disk_path, &thumb_path).await {
+            tracing::warn!(
+                media_id = %row.id,
+                "chunked upload: video thumbnail generation skipped: {e}"
+            );
+        } else {
+            thumb_url = Some(format!("/api/media/{}/thumb", row.id));
+        }
+    }
+
+    db::upload_sessions::mark_finalized(&state.pool, id)
+        .await
+        .db_ctx("chunked_upload/finalize/mark_finalized")?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(media::build_upload_response(&row, thumb_url)),
+    ))
+}
+
+/// Strip characters that would break Content-Disposition / on-disk paths.
+/// Mirrors the sanitiser in the legacy download path so chunked-uploaded
+/// files can be served back identically.
+fn sanitize_filename(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .filter(|c| *c != '"' && *c != '\\' && *c != '\r' && *c != '\n' && *c != '/' && *c != '\0')
+        .collect();
+    if cleaned.trim().is_empty() {
+        "upload".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Hash the assembled file with SHA-256 and compare against the
+/// client-provided hex digest.  4xx if they differ.
+async fn verify_sha256(path: &str, expected_hex: &str) -> Result<(), AppError> {
+    use tokio::io::AsyncReadExt;
+    let mut file = fs::File::open(path)
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to open temp file for hashing: {e}")))?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .await
+            .map_err(|e| AppError::internal(format!("Failed to read temp file: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let digest = hasher.finalize();
+    let actual = hex_lower(&digest);
+    if !actual.eq_ignore_ascii_case(expected_hex.trim()) {
+        return Err(AppError::bad_request(format!(
+            "sha256 mismatch: client {expected_hex} != server {actual}"
+        )));
+    }
+    Ok(())
+}
+
+/// Bare hex encoder so we don't pull in an extra dependency.
+fn hex_lower(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(TABLE[(b >> 4) as usize] as char);
+        out.push(TABLE[(b & 0xF) as usize] as char);
+    }
+    out
+}
+
+/// Sniff the first 512 bytes of the assembled file with `infer` -- same
+/// magic-byte gate the legacy single-shot endpoint uses on the streamed
+/// head buffer.  This is the only point where client-declared MIME is
+/// allowed to influence the stored mime_type (and only for the audio/m4a
+/// vs video/mp4 disambiguation that `media::validate_head` already
+/// codifies).
+async fn detect_mime_from_file(path: &str, declared: &str) -> Result<String, AppError> {
+    use tokio::io::AsyncReadExt;
+    let mut file = fs::File::open(path)
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to open temp file for sniffing: {e}")))?;
+    let mut head = vec![0u8; 512];
+    let n = file
+        .read(&mut head)
+        .await
+        .map_err(|e| AppError::internal(format!("Failed to read temp file head: {e}")))?;
+    head.truncate(n);
+    media::validate_head(&head, declared)
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/media/upload/{id}
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct UploadStateResponse {
+    pub upload_id: Uuid,
+    pub bytes_received: i64,
+    pub total_size: i64,
+    pub status: String,
+}
+
+/// `GET /api/media/upload/{id}` -- read the current state of a session
+/// so a client recovering from a crash can resume from the right offset.
+pub async fn get_state(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let session = db::upload_sessions::get(&state.pool, id, auth.user_id)
+        .await
+        .db_ctx("chunked_upload/get_state")?
+        .ok_or_else(|| AppError {
+            status: StatusCode::NOT_FOUND,
+            message: "Upload session not found".to_string(),
+            code: crate::error::ErrorCode::NotFound,
+            body: None,
+        })?;
+
+    Ok(Json(UploadStateResponse {
+        upload_id: session.id,
+        bytes_received: session.bytes_received,
+        total_size: session.total_size,
+        status: session.status,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Background cleanup
+// ---------------------------------------------------------------------------
+
+/// Sweep `upload_sessions` for pending rows idle longer than
+/// `idle_seconds`, delete their temp file, and mark them aborted.
+///
+/// Spawned from `main.rs` on the same `spawn_periodic` cadence used by
+/// the other cleanup loops.
+pub async fn cleanup_stale_uploads(pool: &sqlx::PgPool, idle_seconds: i64) {
+    let rows = match db::upload_sessions::list_stale_pending(pool, idle_seconds).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("chunked upload cleanup: list_stale_pending failed: {e}");
+            return;
+        }
+    };
+
+    for row in rows {
+        if let Err(e) = fs::remove_file(&row.temp_path).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                upload_id = %row.id,
+                "chunked upload cleanup: failed to unlink {}: {e}",
+                row.temp_path
+            );
+        }
+        if let Err(e) = db::upload_sessions::mark_aborted(pool, row.id).await {
+            tracing::warn!(
+                upload_id = %row.id,
+                "chunked upload cleanup: mark_aborted failed: {e}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Load a session owned by `user_id` and reject anything not in the
+/// `pending` state with a clear 4xx.
+async fn load_pending_session(
+    state: &AppState,
+    id: Uuid,
+    user_id: Uuid,
+) -> Result<db::upload_sessions::UploadSessionRow, AppError> {
+    let session = db::upload_sessions::get(&state.pool, id, user_id)
+        .await
+        .db_ctx("chunked_upload/load_pending_session")?
+        .ok_or_else(|| AppError {
+            status: StatusCode::NOT_FOUND,
+            message: "Upload session not found".to_string(),
+            code: crate::error::ErrorCode::NotFound,
+            body: None,
+        })?;
+
+    if session.status != db::upload_sessions::STATUS_PENDING {
+        return Err(AppError::bad_request(format!(
+            "Upload session is not pending (status={})",
+            session.status
+        )));
+    }
+    Ok(session)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_content_range_basic() {
+        let r = parse_content_range("bytes 0-4/10").unwrap();
+        assert_eq!(
+            r,
+            ContentRange {
+                start: 0,
+                end: 4,
+                total: 10
+            }
+        );
+    }
+
+    #[test]
+    fn parse_content_range_full_file() {
+        let r = parse_content_range("bytes 0-99/100").unwrap();
+        assert_eq!(r.start, 0);
+        assert_eq!(r.end, 99);
+        assert_eq!(r.total, 100);
+    }
+
+    #[test]
+    fn parse_content_range_rejects_missing_prefix() {
+        assert!(parse_content_range("0-4/10").is_err());
+        assert!(parse_content_range("bytes=0-4/10").is_err());
+    }
+
+    #[test]
+    fn parse_content_range_rejects_end_past_total() {
+        assert!(parse_content_range("bytes 0-100/100").is_err());
+    }
+
+    #[test]
+    fn parse_content_range_rejects_inverted_range() {
+        assert!(parse_content_range("bytes 100-50/200").is_err());
+    }
+
+    #[test]
+    fn parse_content_range_rejects_negative_start() {
+        assert!(parse_content_range("bytes -1-10/100").is_err());
+    }
+
+    #[test]
+    fn parse_content_range_rejects_zero_total() {
+        assert!(parse_content_range("bytes 0-0/0").is_err());
+    }
+
+    #[test]
+    fn parse_content_range_rejects_garbage() {
+        assert!(parse_content_range("not a range").is_err());
+        assert!(parse_content_range("bytes a-b/c").is_err());
+        assert!(parse_content_range("bytes 0-4").is_err());
+    }
+
+    #[test]
+    fn hex_lower_known_vector() {
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        let bytes = [
+            0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+            0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+            0x78, 0x52, 0xb8, 0x55,
+        ];
+        assert_eq!(
+            hex_lower(&bytes),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_strips_dangerous_chars() {
+        assert_eq!(
+            sanitize_filename("hello\"world\\evil/../etc/passwd\n"),
+            "helloworldevil..etcpasswd"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_falls_back_on_empty() {
+        assert_eq!(sanitize_filename(""), "upload");
+        assert_eq!(sanitize_filename("\n\r/\""), "upload");
+    }
+}

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -35,6 +35,7 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 use uuid::Uuid;
 
+use crate::metrics::MessageRateCounter;
 use crate::middleware::rate_limit;
 use crate::ws::hub::Hub;
 
@@ -54,6 +55,10 @@ pub struct AppState {
     pub hub: Hub,
     pub ticket_store: TicketStore,
     pub media_tickets: MediaTicketStore,
+    /// Sliding-window counter feeding the admin dashboard's
+    /// "messages per second" tile (#681). Bumped from the WS relay path
+    /// after each successful store-and-fanout.
+    pub message_rate: Arc<MessageRateCounter>,
 }
 
 /// Narrow view of [`AppState`] for the auth handlers (`register`, `login`,
@@ -417,7 +422,9 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
         .route("/api/search", get(search::universal_search))
         .route("/api/feedback", post(feedback::create_feedback))
         .route("/api/admin/stats", get(admin::get_stats))
+        .route("/api/admin/stats/realtime", get(admin::get_realtime_stats))
         .route("/api/admin/feedback", get(admin::list_feedback))
+        .route("/api/admin/promote/{user_id}", post(admin::promote_user))
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .route("/api/health", get(health))

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -9,6 +9,7 @@ pub mod groups;
 pub mod keys;
 pub mod link_preview;
 pub mod media;
+pub mod media_chunked;
 pub mod messages;
 pub mod polls;
 pub mod push;
@@ -280,10 +281,34 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
         .route("/device/{device_id}", delete(keys::revoke_device))
         .route("/otp-count", get(keys::get_otp_count));
 
+    // Chunked-upload routes (#556).  These coexist with the legacy
+    // `POST /api/media/upload` single-shot endpoint at `/upload`.  Each
+    // chunked route carries its own DefaultBodyLimit (32 MB, comfortably
+    // above the 16 MB hard cap on a single PATCH body) so the parent
+    // router's 100 MB MAX_FILE_SIZE limit -- which protects the legacy
+    // multipart upload -- isn't accidentally applied to chunks too.
+    let chunk_body_limit = DefaultBodyLimit::max(32 * 1024 * 1024);
+
     let media_routes = Router::new()
         .route(
             "/upload",
             post(media::upload).layer(middleware::from_fn(media_upload_limit)),
+        )
+        .route(
+            "/upload/init",
+            post(media_chunked::init).layer(chunk_body_limit),
+        )
+        .route(
+            "/upload/{id}",
+            get(media_chunked::get_state).layer(chunk_body_limit),
+        )
+        .route(
+            "/upload/{id}/chunk",
+            patch(media_chunked::upload_chunk).layer(chunk_body_limit),
+        )
+        .route(
+            "/upload/{id}/finalize",
+            post(media_chunked::finalize).layer(chunk_body_limit),
         )
         .route("/ticket", post(media::request_media_ticket))
         .route("/{id}", get(media::download))

--- a/apps/server/src/ws/message_service/mod.rs
+++ b/apps/server/src/ws/message_service/mod.rs
@@ -128,6 +128,13 @@ pub(super) async fn handle_send_message(
         return;
     };
 
+    // Bump the dashboard "messages per second" counter exactly once per
+    // accepted relay (post-store, pre-fanout). Hot path: a single relaxed
+    // atomic fetch-add, no allocation, no lock except for the once-per-second
+    // bucket roll inside `MessageRateCounter`.  Carries no per-user or
+    // per-content data — see `metrics.rs` for the privacy invariant.
+    state.message_rate.record();
+
     let deliver = ServerMessage::NewMessage {
         message_id: stored.id,
         from_user_id: sender_id,

--- a/apps/server/tests/api_admin_realtime.rs
+++ b/apps/server/tests/api_admin_realtime.rs
@@ -1,0 +1,230 @@
+//! Admin dashboard Phase 1 (#681) — realtime stats + promotion endpoint.
+//!
+//! Covers:
+//! - `GET /api/admin/stats/realtime` rejects non-admin with 403
+//! - `GET /api/admin/stats/realtime` returns the expected JSON shape for an
+//!   admin with a fresh token
+//! - `POST /api/admin/promote/{user_id}` flips `is_admin` and returns 200
+//! - `POST /api/admin/promote/{user_id}` returns 404 for an unknown user
+//! - A stale access token (issued more than the 5-minute re-auth window
+//!   ago) returns 401 plus `WWW-Authenticate: Bearer error="reauth_required"`
+
+mod common;
+
+use common::{TEST_JWT_SECRET, register_and_login, spawn_server, test_pool};
+use jsonwebtoken::{EncodingKey, Header, encode};
+use reqwest::Client;
+use serde::Serialize;
+use uuid::Uuid;
+
+async fn promote_via_db(user_id: &str) {
+    let pool = test_pool().await;
+    let id = Uuid::parse_str(user_id).expect("valid user_id");
+    sqlx::query("UPDATE users SET is_admin = TRUE WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect("promote to admin");
+}
+
+#[tokio::test]
+async fn realtime_stats_rejects_non_admin() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = register_and_login(&client, &base, "rt_plain").await;
+
+    let resp = client
+        .get(format!("{base}/api/admin/stats/realtime"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 403);
+}
+
+#[tokio::test]
+async fn realtime_stats_returns_expected_shape_for_admin() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (token, user_id, _) = register_and_login(&client, &base, "rt_admin").await;
+    promote_via_db(&user_id).await;
+
+    let resp = client
+        .get(format!("{base}/api/admin/stats/realtime"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    for key in [
+        "connected_sessions",
+        "active_voice_rooms",
+        "db_pool_in_flight",
+        "db_pool_max",
+    ] {
+        assert!(
+            body[key].is_u64() || body[key].is_i64(),
+            "expected integer for {key} in {body}"
+        );
+    }
+    assert!(
+        body["messages_per_sec"].is_f64() || body["messages_per_sec"].is_i64(),
+        "expected number for messages_per_sec in {body}"
+    );
+
+    let platforms = &body["connected_sessions_by_platform"];
+    for key in ["web", "mobile", "desktop", "unknown"] {
+        assert!(
+            platforms[key].is_u64() || platforms[key].is_i64(),
+            "missing platform key {key} in {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn promote_user_flips_is_admin() {
+    let base = spawn_server().await;
+    let client = Client::new();
+
+    let (admin_token, admin_id, _) = register_and_login(&client, &base, "promote_caller").await;
+    promote_via_db(&admin_id).await;
+
+    let (_target_token, target_id, target_username) =
+        register_and_login(&client, &base, "promote_target").await;
+
+    let resp = client
+        .post(format!("{base}/api/admin/promote/{target_id}"))
+        .header("Authorization", format!("Bearer {admin_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["id"], target_id);
+    assert_eq!(body["username"], target_username);
+    assert_eq!(body["is_admin"], true);
+    // Defense-in-depth: server must not echo the password hash.
+    assert!(
+        body.get("password_hash").is_none(),
+        "promote response leaked password_hash: {body}"
+    );
+
+    // Verify the row actually flipped.
+    let pool = test_pool().await;
+    let (is_admin,): (bool,) = sqlx::query_as("SELECT is_admin FROM users WHERE id = $1")
+        .bind(Uuid::parse_str(&target_id).unwrap())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(is_admin);
+}
+
+#[tokio::test]
+async fn promote_user_returns_404_for_unknown_user() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (admin_token, admin_id, _) = register_and_login(&client, &base, "promote_404").await;
+    promote_via_db(&admin_id).await;
+
+    let missing = Uuid::new_v4();
+    let resp = client
+        .post(format!("{base}/api/admin/promote/{missing}"))
+        .header("Authorization", format!("Bearer {admin_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 404);
+}
+
+/// Mint a JWT with a deliberately-old `iat`/`exp` that still validates
+/// against the test signing secret, but falls outside the 5-minute admin
+/// re-auth window.
+fn mint_token_with_iat(user_id: Uuid, iat_seconds_ago: i64) -> String {
+    #[derive(Serialize)]
+    struct ClaimsLike {
+        sub: String,
+        exp: usize,
+        iat: usize,
+        iss: String,
+        aud: String,
+    }
+    let now = chrono::Utc::now().timestamp();
+    let claims = ClaimsLike {
+        sub: user_id.to_string(),
+        exp: (now + 3600) as usize,
+        iat: (now - iat_seconds_ago) as usize,
+        iss: "echo-messenger".to_string(),
+        aud: "echo-app".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_bytes()),
+    )
+    .expect("sign admin reauth test token")
+}
+
+#[tokio::test]
+async fn stale_admin_token_returns_reauth_required() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    let (_token, user_id, _) = register_and_login(&client, &base, "stale_admin").await;
+    promote_via_db(&user_id).await;
+
+    let uid = Uuid::parse_str(&user_id).unwrap();
+    // 30 minutes > 5-minute window. Token is still cryptographically valid
+    // (exp is +1h), but `iat` is stale.
+    let stale_token = mint_token_with_iat(uid, 30 * 60);
+
+    let resp = client
+        .get(format!("{base}/api/admin/stats/realtime"))
+        .header("Authorization", format!("Bearer {stale_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+    let www_auth = resp
+        .headers()
+        .get(reqwest::header::WWW_AUTHENTICATE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        www_auth.contains("reauth_required"),
+        "expected reauth_required hint in WWW-Authenticate header, got {www_auth:?}"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "reauth-required");
+}
+
+#[tokio::test]
+async fn register_response_includes_is_admin_flag() {
+    let base = spawn_server().await;
+    let client = Client::new();
+    // We can't assert "first user is admin" deterministically because the
+    // integration tests share one DB and other tests already registered.
+    // The contract we *do* enforce is that the field is always present so
+    // the client can read it.
+    // Username max is 32 chars (see `validate_username` in routes/auth.rs);
+    // truncate the UUID suffix so we stay inside the budget.
+    let suffix = Uuid::new_v4().simple().to_string();
+    let username = format!("admin_flag_{}", &suffix[..8]);
+    let resp = client
+        .post(format!("{base}/api/auth/register"))
+        .json(&serde_json::json!({
+            "username": username,
+            "password": "password123",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body["is_admin"].is_boolean(),
+        "register response must surface is_admin, got {body}"
+    );
+}

--- a/apps/server/tests/api_media_chunked.rs
+++ b/apps/server/tests/api_media_chunked.rs
@@ -1,0 +1,304 @@
+//! Integration tests for the resumable / chunked upload pipeline (#556).
+//!
+//! These exercise the public `POST/PATCH/GET /api/media/upload/...`
+//! endpoints end-to-end against a real Postgres + Axum stack spun up by
+//! the shared test harness in `tests/common`.  No mocks: every test
+//! authenticates a real user, drives a real HTTP client, and asserts on
+//! the live DB state where relevant.
+
+mod common;
+
+use reqwest::Client;
+use serde_json::{Value, json};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Synthetic PNG payload used as the body of the chunked test uploads.
+/// Repeats a 1x1 PNG to reach 7 MB so the upload spans two 5 MB chunks
+/// (the server-announced `chunk_size`).  The MIME detection in finalize
+/// runs against the first 512 bytes only, so the leading PNG magic is
+/// the only thing that matters for content-sniff.
+const MINIMAL_PNG_HEADER: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+    0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+fn synthetic_payload(size: usize) -> Vec<u8> {
+    let mut v = Vec::with_capacity(size);
+    v.extend_from_slice(MINIMAL_PNG_HEADER);
+    v.resize(size, 0);
+    v
+}
+
+async fn init_upload(client: &Client, base: &str, token: &str, total_size: usize) -> (Uuid, i64) {
+    let resp = client
+        .post(format!("{base}/api/media/upload/init"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&json!({
+            "filename": "test.png",
+            "mime_type": "image/png",
+            "total_size": total_size,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201, "init should return 201");
+    let body: Value = resp.json().await.unwrap();
+    let id = Uuid::parse_str(body["upload_id"].as_str().unwrap()).unwrap();
+    let chunk_size = body["chunk_size"].as_i64().unwrap();
+    (id, chunk_size)
+}
+
+async fn send_chunk(
+    client: &Client,
+    base: &str,
+    token: &str,
+    upload_id: Uuid,
+    chunk: &[u8],
+    start: usize,
+    total: usize,
+) -> reqwest::Response {
+    let end = start + chunk.len() - 1;
+    client
+        .patch(format!("{base}/api/media/upload/{upload_id}/chunk"))
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Range", format!("bytes {start}-{end}/{total}"))
+        .body(chunk.to_vec())
+        .send()
+        .await
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn init_creates_pending_session_in_db() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = common::register_and_login(&client, &base, "chunked_init").await;
+
+    let (upload_id, chunk_size) = init_upload(&client, &base, &token, 1024).await;
+    assert_eq!(
+        chunk_size,
+        5 * 1024 * 1024,
+        "default chunk_size must be 5MB"
+    );
+
+    // GET state should report a pending session at offset 0.
+    let resp = client
+        .get(format!("{base}/api/media/upload/{upload_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["bytes_received"].as_i64().unwrap(), 0);
+    assert_eq!(body["total_size"].as_i64().unwrap(), 1024);
+    assert_eq!(body["status"].as_str().unwrap(), "pending");
+}
+
+#[tokio::test]
+async fn chunks_append_in_order_and_finalize_returns_media_url() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = common::register_and_login(&client, &base, "chunked_happy").await;
+
+    let total = 7 * 1024 * 1024; // spans two chunks at the 5 MB boundary
+    let payload = synthetic_payload(total);
+    let (upload_id, chunk_size) = init_upload(&client, &base, &token, total).await;
+
+    let chunk_size = chunk_size as usize;
+    let first = &payload[..chunk_size];
+    let second = &payload[chunk_size..];
+
+    let r1 = send_chunk(&client, &base, &token, upload_id, first, 0, total).await;
+    assert_eq!(r1.status().as_u16(), 200, "first chunk should 200");
+    let b1: Value = r1.json().await.unwrap();
+    assert_eq!(b1["bytes_received"].as_i64().unwrap(), chunk_size as i64);
+
+    let r2 = send_chunk(&client, &base, &token, upload_id, second, chunk_size, total).await;
+    assert_eq!(r2.status().as_u16(), 200, "second chunk should 200");
+    let b2: Value = r2.json().await.unwrap();
+    assert_eq!(b2["bytes_received"].as_i64().unwrap(), total as i64);
+
+    let resp = client
+        .post(format!("{base}/api/media/upload/{upload_id}/finalize"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201, "finalize should return 201");
+    let body: Value = resp.json().await.unwrap();
+    assert!(!body["id"].as_str().unwrap().is_empty());
+    assert!(body["url"].as_str().unwrap().contains("/api/media/"));
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-order / range-mismatch behaviour
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn out_of_order_chunk_returns_416_with_bytes_received() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = common::register_and_login(&client, &base, "chunked_416").await;
+
+    let total = 1024;
+    let payload = synthetic_payload(total);
+    let (upload_id, _) = init_upload(&client, &base, &token, total).await;
+
+    // Skip the first 100 bytes and try to write from offset 100.
+    let resp = send_chunk(
+        &client,
+        &base,
+        &token,
+        upload_id,
+        &payload[100..200],
+        100,
+        total,
+    )
+    .await;
+    assert_eq!(resp.status().as_u16(), 416, "range mismatch must be 416");
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["bytes_received"].as_i64().unwrap(),
+        0,
+        "server should report its real offset so the client can re-sync"
+    );
+}
+
+#[tokio::test]
+async fn malformed_content_range_returns_4xx() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = common::register_and_login(&client, &base, "chunked_bad_range").await;
+
+    let (upload_id, _) = init_upload(&client, &base, &token, 1024).await;
+
+    let resp = client
+        .patch(format!("{base}/api/media/upload/{upload_id}/chunk"))
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Range", "not-a-range")
+        .body(vec![0u8; 10])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+// ---------------------------------------------------------------------------
+// Finalize state validation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn finalize_rejects_incomplete_session() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = common::register_and_login(&client, &base, "chunked_incomplete").await;
+
+    let total = 1024;
+    let (upload_id, _) = init_upload(&client, &base, &token, total).await;
+
+    // Only send half the bytes.
+    let payload = synthetic_payload(total);
+    let half = &payload[..512];
+    let chunk_resp = send_chunk(&client, &base, &token, upload_id, half, 0, total).await;
+    assert_eq!(chunk_resp.status().as_u16(), 200);
+
+    let resp = client
+        .post(format!("{base}/api/media/upload/{upload_id}/finalize"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "incomplete upload must not finalize"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Auth / cross-tenant isolation
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn chunked_endpoints_reject_unauth() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("{base}/api/media/upload/init"))
+        .json(&json!({"filename":"a","mime_type":"image/png","total_size":1}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+#[tokio::test]
+async fn other_user_cannot_see_or_chunk_my_session() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (token_a, _, _) = common::register_and_login(&client, &base, "chunked_owner").await;
+    let (token_b, _, _) = common::register_and_login(&client, &base, "chunked_other").await;
+
+    let (upload_id, _) = init_upload(&client, &base, &token_a, 1024).await;
+
+    let resp = client
+        .get(format!("{base}/api/media/upload/{upload_id}"))
+        .header("Authorization", format!("Bearer {token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 404, "must look like 404 to others");
+
+    let resp = send_chunk(&client, &base, &token_b, upload_id, &[0u8; 16], 0, 1024).await;
+    assert_eq!(resp.status().as_u16(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// Background cleanup
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cleanup_sweep_aborts_stale_pending_session() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _, _) = common::register_and_login(&client, &base, "chunked_sweep").await;
+
+    let (upload_id, _) = init_upload(&client, &base, &token, 1024).await;
+
+    // Run the sweep with a zero-second idle window so the freshly created
+    // session is immediately eligible.  Pull a PgPool the same way the
+    // harness does so we don't need to expose internals on AppState.
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("TEST_DATABASE_URL or DATABASE_URL must be set");
+    let pool: PgPool = sqlx::PgPool::connect(&database_url).await.unwrap();
+
+    echo_server::routes::media_chunked::cleanup_stale_uploads(&pool, 0).await;
+
+    let resp = client
+        .get(format!("{base}/api/media/upload/{upload_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["status"].as_str().unwrap(),
+        "aborted",
+        "sweep should mark the row aborted"
+    );
+}

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -70,6 +70,7 @@ async fn spawn_server_inner(trusted_proxies: Vec<IpNet>) -> String {
         hub,
         ticket_store: Arc::new(dashmap::DashMap::new()),
         media_tickets: Arc::new(dashmap::DashMap::new()),
+        message_rate: Arc::new(echo_server::metrics::MessageRateCounter::new()),
     });
 
     let app = routes::create_router(state, trusted_proxies);


### PR DESCRIPTION
Two Phase-1 slices bundled. 2108 client tests passing, full Rust + Dart format / clippy / analyze clean.

## New

- **Admin dashboard.** First-registered user on a fresh server becomes admin automatically. A new \"Admin dashboard\" tile appears in Settings for admins only; tapping it opens a screen with four live cards updated every 5 seconds: connected sessions, messages/sec relay rate, active voice rooms, and database connection-pool usage. Non-admins get a friendly 403. (#681, Phase 1 of XL)
- **Resumable uploads for files larger than 100 MB.** New `/api/media/upload/{init,chunk,finalize}` flow streams chunks to disk on the server (no full-body buffering) and resumes from the last successful offset if the network drops mid-upload. The existing single-shot endpoint is untouched for files ≤100 MB. (#556, Phase 1)

## Improved

- **Privacy invariant respected end-to-end** in the admin metrics. No message content, no decrypted previews, no who-talks-to-whom — only aggregated counters from the WS hub, the voice-session table, and `pool.size() / pool.num_idle()`.
- **Admin re-auth window.** Admin routes require a JWT issued within the last 5 minutes; stale tokens return 401 with `WWW-Authenticate: Bearer error=\"reauth_required\"` so the client can prompt for password re-entry (prompt UI ships in Phase 1.5).

## Fixed

- The old upload path called `field.bytes().await` which buffered entire file bodies into server memory. The new chunked endpoint never does — `body.into_data_stream()` writes each frame to disk as it arrives.

## Behind the scenes

- New migrations: `20260520000000_admin_bootstrap_first_user.sql` (backfill admin on existing deployments) and `20260521000000_upload_sessions.sql` (resumable session state).
- 60-second sliding-window message-rate counter via `AtomicU64` + `VecDeque<(Instant, u64)>` — no lock on the relay hot path.
- 416 \"Range Not Satisfiable\" response on chunk-offset mismatch carries `{bytes_received}` in the body so the client resumes without an extra GET round-trip.
- Per-chunk retry with exponential backoff (200 ms / 800 ms / 2 s); server picks the chunk size (5 MB) so clients can be dumb about it.
- Hourly cleanup sweep aborts and deletes pending upload sessions idle for 24 h.
- **+41 tests total**: 9 Rust unit, 14 Rust integration (8 chunked + 6 admin), 18 Dart (5 chunked-client unit + 3 realtime-provider + 5 dashboard widget + 5 settings-tile gating).

## Out of scope (Phase 2+ per the issue bodies)

- Admin: historical metrics, per-route latency, log browser, /metrics Prometheus endpoint, re-auth prompt UI, demotion.
- Uploads: explicit cancel endpoint (24-h sweep handles it), encrypted-at-rest temp files, S3/object-storage migration, tus.io adoption.

## Test plan

- [x] `dart format` + `flutter analyze` clean
- [x] `flutter test --concurrency=1` — 2108 passed, 8 skipped, 0 failed
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Server integration tests need a Postgres TEST_DATABASE_URL — both agents verified locally, CI will run on push