### PR TITLE
fix(client): centre the update prompt and hide the threads sidebar row

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -41,7 +41,6 @@ import '../widgets/window_chrome.dart';
 import 'contacts_screen.dart';
 import 'new_message_screen.dart';
 import 'saved_messages_screen.dart';
-import 'threads_screen.dart';
 import 'voice_lounge_screen.dart';
 import 'create_group_screen.dart';
 import 'discover_groups_screen.dart';

--- a/apps/client/lib/src/screens/home_screen/parts/actions.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/actions.dart
@@ -300,56 +300,6 @@ mixin _HomeScreenActionsMixin on ConsumerState<HomeScreen> {
     );
   }
 
-  void _openThreads() {
-    final isMobile = MediaQuery.sizeOf(context).width < 600;
-    if (isMobile) {
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => ThreadsScreen(onOpenThread: _navigateToThread),
-        ),
-      );
-      return;
-    }
-    showDialog(
-      context: context,
-      builder: (dialogContext) {
-        final size = MediaQuery.of(dialogContext).size;
-        return Dialog(
-          backgroundColor: context.surface,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-            side: BorderSide(color: context.border),
-          ),
-          child: SizedBox(
-            width: (size.width * 0.45).clamp(340.0, 600.0),
-            height: (size.height * 0.7).clamp(400.0, 720.0),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(12),
-              child: ThreadsScreen(
-                onOpenThread: (convId, parentId) {
-                  Navigator.pop(dialogContext);
-                  _navigateToThread(convId, parentId);
-                },
-              ),
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  /// Open the conversation containing [parentMessageId] and pass the
-  /// parent id through as `initialMessageId`. The chat panel scrolls to
-  /// that message; opening the thread panel itself is a follow-up the
-  /// chat panel handles via its existing `_openThread` flow when the
-  /// user taps the reply count badge.
-  void _navigateToThread(String conversationId, String parentMessageId) {
-    final conversations = ref.read(conversationsProvider).conversations;
-    final conv = conversations.where((c) => c.id == conversationId).firstOrNull;
-    if (conv == null) return;
-    _selectConversation(conv, messageId: parentMessageId);
-  }
-
   void _openSettings() {
     if (_self._isDesktop || !Responsive.isMobile(context)) {
       setState(() {

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -23,7 +23,6 @@ mixin _HomeScreenDesktopLayoutMixin
       onNewGroup: _openCreateGroup,
       onDiscover: _openDiscoverGroups,
       onSavedMessages: _openSavedMessages,
-      onOpenThreads: _openThreads,
       onCollapseSidebar: onCollapseSidebar,
       onSettings: _openSettings,
       onShowContacts: _openContacts,

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -488,22 +488,36 @@ class _UpdatePromptBody extends ConsumerWidget {
         ? const EdgeInsets.fromLTRB(28, 44, 28, 22)
         : const EdgeInsets.fromLTRB(36, 24, 36, 38);
 
+    // The previous layout used MainAxisAlignment.spaceBetween across the
+    // full viewport, which on anything larger than the 320×440 desktop
+    // splash window left huge empty gaps above and below the action block.
+    // Centring the brand + action as one tight stack and pinning the
+    // version label to the bottom keeps the prompt feeling like a focused
+    // card at every window size.
     return FadeTransition(
       opacity: fade,
       child: Stack(
         children: [
           _buildHaloBackdrop(accent),
-          Padding(
-            padding: outerPadding,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                _buildBrandBlock(context),
-                _buildActionBlock(context, ref, update, accent),
-                if (compact) _buildVersionLabel(context),
-              ],
+          Center(
+            child: Padding(
+              padding: outerPadding,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  _buildBrandBlock(context),
+                  const SizedBox(height: 28),
+                  _buildActionBlock(context, ref, update, accent),
+                ],
+              ),
             ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 16,
+            child: Center(child: _buildVersionLabel(context)),
           ),
         ],
       ),
@@ -540,34 +554,28 @@ class _UpdatePromptBody extends ConsumerWidget {
     final logoSize = compact ? 64.0 : 84.0;
     final wordmarkSize = compact ? 22.0 : 28.0;
     final taglineSize = compact ? 12.0 : 13.0;
-    return Padding(
-      padding: EdgeInsets.only(top: compact ? 12 : 60),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          EchoLogoIcon(size: logoSize),
-          SizedBox(height: compact ? 18 : 24),
-          Text(
-            'Echo',
-            style: TextStyle(
-              fontSize: wordmarkSize,
-              fontWeight: FontWeight.w700,
-              letterSpacing: -0.5,
-              height: 1.0,
-              color: context.textPrimary,
-            ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        EchoLogoIcon(size: logoSize),
+        SizedBox(height: compact ? 18 : 24),
+        Text(
+          'Echo',
+          style: TextStyle(
+            fontSize: wordmarkSize,
+            fontWeight: FontWeight.w700,
+            letterSpacing: -0.5,
+            height: 1.0,
+            color: context.textPrimary,
           ),
-          SizedBox(height: compact ? 8 : 10),
-          Text(
-            'Update available',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: taglineSize,
-              color: context.textSecondary,
-            ),
-          ),
-        ],
-      ),
+        ),
+        SizedBox(height: compact ? 8 : 10),
+        Text(
+          'Update available',
+          textAlign: TextAlign.center,
+          style: TextStyle(fontSize: taglineSize, color: context.textSecondary),
+        ),
+      ],
     );
   }
 
@@ -606,10 +614,6 @@ class _UpdatePromptBody extends ConsumerWidget {
         ),
         if (isError) _buildErrorMessage(update),
         if (!isReady && !isInstalling) _buildSkipButton(context, isBusy),
-        if (!compact) ...[
-          const SizedBox(height: 18),
-          _buildVersionLabel(context),
-        ],
       ],
     );
   }

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -34,7 +34,6 @@ import 'echo_logo_icon.dart';
 import 'empty_state.dart';
 import 'feedback_dialog.dart';
 import 'skeleton_loader.dart';
-import 'threads_sidebar_entry.dart';
 import 'voice_dock.dart';
 import 'voice_footer.dart';
 
@@ -59,12 +58,6 @@ class ConversationPanel extends ConsumerStatefulWidget {
   final VoidCallback? onShowContacts;
   final VoidCallback? onGlobalSearch;
   final VoidCallback? onSavedMessages;
-
-  /// Opens the aggregate Threads screen (#449). When null, the sidebar
-  /// "Threads" row is hidden — used by tests / shells that don't need
-  /// the entry. Production wires this to the home screen's threads
-  /// route.
-  final VoidCallback? onOpenThreads;
 
   /// Opens the keyboard-shortcuts overlay (also bindable to Ctrl+/).
   /// When null, the help icon in the header is hidden.
@@ -96,7 +89,6 @@ class ConversationPanel extends ConsumerStatefulWidget {
     this.onShowContacts,
     this.onGlobalSearch,
     this.onSavedMessages,
-    this.onOpenThreads,
     this.onShowKeyboardShortcuts,
     this.onScanQr,
     this.onMessageContact,
@@ -190,8 +182,6 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel>
               _buildFilterChips(),
               _buildReplacedBanner(context, wsReplaced),
               if (pendingCount > 0) _buildPendingBanner(pendingCount),
-              if (widget.onOpenThreads != null)
-                ThreadsSidebarEntry(onTap: widget.onOpenThreads),
               Expanded(
                 child: _buildChatsTab(
                   convState,


### PR DESCRIPTION
Two small fixes from user testing.

## Fixed

- **Update-available prompt looked stretched out** on larger desktop windows — three slots distributed across the full viewport via spaceBetween. Now the brand + action stack sits centred and the version label is pinned to the bottom of the Stack, so the prompt reads as one focused card at every size.

## Removed

- **'Threads' sidebar row** above the conversation list is gone (and its now-unused home_screen plumbing with it). The aggregate Threads screen + provider stay in tree for the next, Slack-style thread UX which surfaces threads inline at their parent message instead of as a top-level destination.

## Test plan

- [x] dart format + flutter analyze clean
- [x] flutter test --concurrency=1 — 2108 passed, 8 skipped, 0 failed