### PR TITLE
fix(client): the update prompt now fills the chromeless window

### DIFF
--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -496,7 +496,13 @@ class _UpdatePromptBody extends ConsumerWidget {
     // card at every window size.
     return FadeTransition(
       opacity: fade,
+      // StackFit.expand forces the rounded card chain to fill the whole
+      // chromeless window. Without it the non-positioned Center wraps
+      // tightly around its content, the ClipRRect shrinks to that size,
+      // and the transparent window corners show through as black on
+      // compositors that don't paint window translucency.
       child: Stack(
+        fit: StackFit.expand,
         children: [
           _buildHaloBackdrop(accent),
           Center(


### PR DESCRIPTION
Follow-up to #1068. The centring change left the rounded card sized to its content, so on compositors without window-translucency the un-filled window corners painted as a black frame around the modal. `StackFit.expand` forces the card to fill the 320×440 window again.