### PR TITLE
fix(client): stop the voice lounge from melting browser tabs + screenshare overlap

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -919,10 +919,17 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
 
   void _startAudioLevelPolling() {
     _audioLevelTimer?.cancel();
-    _audioLevelTimer = Timer.periodic(
-      const Duration(milliseconds: 100),
-      (_) => _pollAudioLevels(),
-    );
+    // Web on CanvasKit is far more expensive per repaint than native, and
+    // every audio-level publish (currently observed by `ref.watch(
+    // livekitVoiceProvider)` callers in the lounge) triggers a wholesale
+    // rebuild of the participant grid. The 100 ms cadence that was fine
+    // on desktop/mobile crashed Chrome tabs in voice calls; throttle to
+    // 250 ms there and let `_pollAudioLevels` skip publishes when the
+    // numbers haven't meaningfully changed.
+    final interval = kIsWeb
+        ? const Duration(milliseconds: 250)
+        : const Duration(milliseconds: 100);
+    _audioLevelTimer = Timer.periodic(interval, (_) => _pollAudioLevels());
   }
 
   void _stopAudioLevelPolling() {
@@ -970,12 +977,40 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       peerLevels[key] = p.audioLevel;
     }
 
-    if (!_disposed) {
+    // Dedup: when nobody is talking, the values are all near-zero on every
+    // tick — republishing identical state burns CanvasKit on web for no
+    // visual change. Compare to 0.01 because LiveKit returns floating
+    // noise around the silence floor that's not perceptible in the UI.
+    if (!_disposed && _audioLevelsChanged(localLevel, peerLevels)) {
       state = state.copyWith(
         localAudioLevel: localLevel,
         peerAudioLevels: peerLevels,
       );
     }
+  }
+
+  /// Returns true when the new audio-level snapshot is meaningfully
+  /// different from the one currently published. Treats values below
+  /// 0.01 as silence and ignores fluctuations between two silence
+  /// readings so the participant grid doesn't rebuild ten times per
+  /// second when nothing is happening.
+  bool _audioLevelsChanged(double newLocal, Map<String, double> newPeers) {
+    const epsilon = 0.01;
+    final prev = state;
+    bool changed(double a, double b) {
+      final aQuiet = a < epsilon;
+      final bQuiet = b < epsilon;
+      if (aQuiet && bQuiet) return false;
+      return (a - b).abs() >= epsilon;
+    }
+
+    if (changed(prev.localAudioLevel, newLocal)) return true;
+    if (prev.peerAudioLevels.length != newPeers.length) return true;
+    for (final entry in newPeers.entries) {
+      final prevLevel = prev.peerAudioLevels[entry.key] ?? 0.0;
+      if (changed(prevLevel, entry.value)) return true;
+    }
+    return false;
   }
 
   // -------------------------------------------------------------------------

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -755,7 +755,17 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   ) {
     return _buildLoungeScaffold(context, [
       Positioned.fill(child: _buildBackground(context)),
-      Column(children: [Expanded(child: contentArea)]),
+      // Reserve the top strip for the floating header badge + the
+      // background-picker button so a remote screen share (or any other
+      // edge-to-edge contentArea like a video tile) doesn't sit under
+      // them. 64 px = badge/button top:16 + their ~32 px height + a
+      // little breathing room before the share frame begins.
+      Column(
+        children: [
+          const SizedBox(height: 64),
+          Expanded(child: contentArea),
+        ],
+      ),
       if (!_spotlightMode) Positioned.fill(child: drawingOverlay),
       ..._buildSubmenuFollowers(conversationId),
       Positioned(bottom: 16, left: 0, right: 0, child: dock),


### PR DESCRIPTION
Two bugs from production testing right after Phase 1 of the domain migration went live.

**1. Web tab crash when joining a voice lounge.** The audio-level poller fired every 100 ms and published a fresh LiveKitVoiceState every tick. The lounge screen watches that provider wholesale, so the participant grid rebuilt 10×/sec — fine on native but it accumulated GL texture pressure on CanvasKit until Chrome killed the tab. Throttled to 250 ms on web, and the publish is now skipped entirely when the level deltas are below the audible threshold (no rebuild storm while nobody is talking).

**2. Landscape lounge: `← lounge · N` badge + the background-picker icon overlap an active screen share.** The contentArea sat directly under the floating header. Reserved a 64 px top strip in the landscape layout so the share frame begins below both floaters.

Test plan:
- [x] dart format + flutter analyze clean
- [x] voice + lounge widget tests pass
- [ ] User to confirm web lounge no longer crashes the tab after merge