### PR TITLE
Release: E2E rotation correctness + mobile polish + prod-validation finds

### DIFF
--- a/apps/client/lib/src/providers/chat/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat/chat_provider.dart
@@ -65,6 +65,24 @@ class Chat extends _$Chat
       }
       _sendTimeouts.clear();
     });
+
+    // Plumb the GroupCryptoService 410-Gone callback into chat state.
+    // When the server reports "no envelope for this user at the latest
+    // version", flip the `groupsNeedingRotation` flag so the
+    // EncryptionStatusBanner surfaces the "Refresh key" affordance.
+    final groupCrypto = ref.read(groupCryptoServiceProvider);
+    void handler(String conversationId) {
+      state = state.withGroupRotationNeeded(conversationId);
+    }
+
+    groupCrypto.onGroupNeedsRotation = handler;
+    ref.onDispose(() {
+      // Only detach if no later build installed its own handler.
+      if (identical(groupCrypto.onGroupNeedsRotation, handler)) {
+        groupCrypto.onGroupNeedsRotation = null;
+      }
+    });
+
     return const ChatState();
   }
 

--- a/apps/client/lib/src/providers/chat/chat_recovery.dart
+++ b/apps/client/lib/src/providers/chat/chat_recovery.dart
@@ -41,6 +41,13 @@ mixin ChatRecoveryMixin on Notifier<ChatState> {
   /// group. Non-admins get a 401 from the upload and the banner
   /// stays visible.
   Future<void> refreshGroupKey(String conversationId) async {
+    // Clear the needs-rotation + out-of-sync flags BEFORE the fetch so
+    // that if the fetch's 410 callback fires again it can re-set the
+    // flag and keep the banner visible. Order matters: clear → fetch.
+    state = state
+        .withSyncRestored(conversationId)
+        .withGroupRotationCleared(conversationId);
+
     final groupCrypto = ref.read(groupCryptoServiceProvider);
     await groupCrypto.dropCachedKey(conversationId);
     final fetched = await groupCrypto.getGroupKey(conversationId);
@@ -57,7 +64,6 @@ mixin ChatRecoveryMixin on Notifier<ChatState> {
         debugPrint('[Chat] refreshGroupKey self-heal failed: $e');
       }
     }
-    state = state.withSyncRestored(conversationId);
   }
 
   /// Phase 4 dismissal for the GRP2 signature-failure banner. We do

--- a/apps/client/lib/src/providers/chat/chat_state.dart
+++ b/apps/client/lib/src/providers/chat/chat_state.dart
@@ -56,6 +56,17 @@ class ChatState {
   /// closed and reopened). Audit Phase 4 (group recovery UX).
   final Set<String> signatureFailures;
 
+  /// Groups whose latest key version exists on the server but has no
+  /// per-user envelope for the current caller — i.e. another member
+  /// must rotate us in. Populated when
+  /// `GET /api/groups/:id/keys/latest` returns 410 Gone. Drives the
+  /// "Refresh key" banner; cleared by `refreshGroupKey` once a
+  /// healthy envelope is fetched. Prevents the unkeyed-member
+  /// silent-skip bug where rotation completed without an envelope
+  /// for this user and the server then served a sentinel placeholder
+  /// the client tried to decrypt as a key.
+  final Set<String> groupsNeedingRotation;
+
   /// Threshold at which the per-conversation banner becomes visible.
   /// Three is the audit's recommended default; tuning lives in
   /// `06-recommendations.md`.
@@ -69,6 +80,7 @@ class ChatState {
     this.replyToMessage,
     this.consecutiveDecryptFailures = const {},
     this.signatureFailures = const {},
+    this.groupsNeedingRotation = const {},
   }) : _messageIdIndex = messageIdIndex;
 
   /// True when the named conversation has crossed [outOfSyncThreshold]
@@ -82,6 +94,13 @@ class ChatState {
   /// signature failure. Renders a danger-banner with no auto-action.
   bool hasSignatureFailure(String conversationId) {
     return signatureFailures.contains(conversationId);
+  }
+
+  /// True when the named conversation's latest server-side key version
+  /// has no per-user envelope for us — another member must rotate us in.
+  /// Drives the "Refresh key" banner.
+  bool isGroupAwaitingRotation(String conversationId) {
+    return groupsNeedingRotation.contains(conversationId);
   }
 
   /// Get messages for a conversation ID.
@@ -158,6 +177,7 @@ class ChatState {
       replyToMessage: replyToMessage,
       consecutiveDecryptFailures: updatedFailures,
       signatureFailures: updatedSigFailures,
+      groupsNeedingRotation: groupsNeedingRotation,
     );
   }
 
@@ -250,6 +270,44 @@ class ChatState {
       replyToMessage: replyToMessage,
       consecutiveDecryptFailures: next,
       signatureFailures: signatureFailures,
+      groupsNeedingRotation: groupsNeedingRotation,
+    );
+  }
+
+  /// Flag a conversation as needing a fresh group-key envelope. Triggered
+  /// by a 410 Gone from `GET /api/groups/:id/keys/latest`.
+  ChatState withGroupRotationNeeded(String conversationId) {
+    if (groupsNeedingRotation.contains(conversationId)) {
+      return this;
+    }
+    final next = {...groupsNeedingRotation, conversationId};
+    return ChatState(
+      messagesByConversation: messagesByConversation,
+      messageIdIndex: _messageIdIndex,
+      loadingHistory: loadingHistory,
+      hasMore: hasMore,
+      replyToMessage: replyToMessage,
+      consecutiveDecryptFailures: consecutiveDecryptFailures,
+      signatureFailures: signatureFailures,
+      groupsNeedingRotation: next,
+    );
+  }
+
+  /// Clear the needs-rotation flag once a healthy envelope is fetched.
+  ChatState withGroupRotationCleared(String conversationId) {
+    if (!groupsNeedingRotation.contains(conversationId)) {
+      return this;
+    }
+    final next = {...groupsNeedingRotation}..remove(conversationId);
+    return ChatState(
+      messagesByConversation: messagesByConversation,
+      messageIdIndex: _messageIdIndex,
+      loadingHistory: loadingHistory,
+      hasMore: hasMore,
+      replyToMessage: replyToMessage,
+      consecutiveDecryptFailures: consecutiveDecryptFailures,
+      signatureFailures: signatureFailures,
+      groupsNeedingRotation: next,
     );
   }
 
@@ -270,6 +328,7 @@ class ChatState {
       replyToMessage: replyToMessage,
       consecutiveDecryptFailures: consecutiveDecryptFailures,
       signatureFailures: next,
+      groupsNeedingRotation: groupsNeedingRotation,
     );
   }
 
@@ -282,6 +341,7 @@ class ChatState {
     bool clearReply = false,
     Map<String, int>? consecutiveDecryptFailures,
     Set<String>? signatureFailures,
+    Set<String>? groupsNeedingRotation,
   }) {
     return ChatState(
       messagesByConversation:
@@ -295,6 +355,8 @@ class ChatState {
       consecutiveDecryptFailures:
           consecutiveDecryptFailures ?? this.consecutiveDecryptFailures,
       signatureFailures: signatureFailures ?? this.signatureFailures,
+      groupsNeedingRotation:
+          groupsNeedingRotation ?? this.groupsNeedingRotation,
     );
   }
 }

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -197,9 +197,11 @@ class ConversationsNotifier extends _$ConversationsNotifier
           cached = await MessageCache.getLatestCachedPreview(conv.id);
           if (cached != null) _decryptedPreviews[conv.id] = cached;
         }
-        conversations[i] = conv.copyWith(
-          lastMessage: cached ?? 'Encrypted message',
-        );
+        // Use the same bracketed `[Encrypted]` placeholder the sidebar
+        // widget renders for ciphertext snippets, so cold-start HTTP loads
+        // and live WS updates show the same string instead of diverging
+        // between "Encrypted message" and "[Encrypted]".
+        conversations[i] = conv.copyWith(lastMessage: cached ?? '[Encrypted]');
       }
     }
   }

--- a/apps/client/lib/src/providers/ws_handlers/message_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/message_handlers.dart
@@ -234,7 +234,7 @@ extension MessageHandlersOn on WsMessageHandler {
         .read(conversationsProvider.notifier)
         .onNewMessage(
           conversationId: conversationId,
-          content: 'Encrypted message',
+          content: '[Encrypted]',
           timestamp: timestamp,
           senderUsername: senderUsername,
         );
@@ -322,7 +322,7 @@ extension MessageHandlersOn on WsMessageHandler {
         .read(conversationsProvider.notifier)
         .onNewMessage(
           conversationId: conversationId,
-          content: 'Encrypted message',
+          content: '[Encrypted]',
           timestamp: timestamp,
           senderUsername: senderUsername,
         );

--- a/apps/client/lib/src/providers/ws_handlers/presence_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/presence_handlers.dart
@@ -91,9 +91,25 @@ extension PresenceHandlersOn on WsMessageHandler {
       role: json['role'] as String? ?? 'member',
       avatarUrl: json['avatar_url'] as String?,
     );
-    ref
-        .read(conversationsProvider.notifier)
-        .addGroupMember(conversationId, member);
+
+    // When the local user is the one being added (e.g. someone invited them
+    // to a brand new group, or they joined via invite link), the
+    // conversation is almost certainly not in local state yet —
+    // `addGroupMember` silently no-ops on unknown conversations, so the
+    // sidebar would stay stale until a hard refresh. Trigger a full
+    // conversations reload so the new group appears in the list right
+    // away. Other members of an existing group still hit the cheaper
+    // in-place `addGroupMember` path.
+    final myUserId = ref.read(authProvider).userId ?? '';
+    final convs = ref.read(conversationsProvider).conversations;
+    final isKnownConv = convs.any((c) => c.id == conversationId);
+    if (userId == myUserId && !isKnownConv) {
+      ref.read(conversationsProvider.notifier).loadConversations();
+    } else {
+      ref
+          .read(conversationsProvider.notifier)
+          .addGroupMember(conversationId, member);
+    }
 
     _maybeRotateOnJoin(conversationId, userId);
   }

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -37,6 +37,7 @@ import '../widgets/keyboard_shortcuts_overlay.dart';
 import '../widgets/global_search_overlay.dart';
 import '../widgets/whats_new_modal.dart';
 import '../widgets/quick_switcher_overlay.dart';
+import '../widgets/system_chrome.dart';
 import '../widgets/voice_footer.dart';
 import '../widgets/window_chrome.dart';
 import 'contacts_screen.dart';
@@ -219,23 +220,25 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       layout = _buildWideLayout();
     }
 
-    return CallbackShortcuts(
-      bindings: <ShortcutActivator, VoidCallback>{
-        const SingleActivator(LogicalKeyboardKey.keyK, control: true): () {
-          _showQuickSwitcher();
+    return EchoSystemChrome(
+      child: CallbackShortcuts(
+        bindings: <ShortcutActivator, VoidCallback>{
+          const SingleActivator(LogicalKeyboardKey.keyK, control: true): () {
+            _showQuickSwitcher();
+          },
+          const SingleActivator(
+            LogicalKeyboardKey.keyF,
+            control: true,
+            shift: true,
+          ): () {
+            _showGlobalSearch();
+          },
+          const SingleActivator(LogicalKeyboardKey.slash, control: true): () {
+            _showKeyboardShortcuts();
+          },
         },
-        const SingleActivator(
-          LogicalKeyboardKey.keyF,
-          control: true,
-          shift: true,
-        ): () {
-          _showGlobalSearch();
-        },
-        const SingleActivator(LogicalKeyboardKey.slash, control: true): () {
-          _showKeyboardShortcuts();
-        },
-      },
-      child: Focus(autofocus: true, child: layout),
+        child: Focus(autofocus: true, child: layout),
+      ),
     );
   }
 

--- a/apps/client/lib/src/screens/home_screen/parts/narrow_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/narrow_layout.dart
@@ -326,6 +326,7 @@ mixin _HomeScreenNarrowLayoutMixin
         child: InkWell(
           onTap: () {
             if (index == _self._mobileTabIndex) return;
+            HapticFeedback.selectionClick();
             setState(() {
               _self._mobileTabIndex = index;
               if (index != 0) {

--- a/apps/client/lib/src/services/group_crypto_service.dart
+++ b/apps/client/lib/src/services/group_crypto_service.dart
@@ -117,6 +117,14 @@ class GroupCryptoService {
   /// requests against the server for plaintext groups.
   final Set<String> _unencryptedGroups = {};
 
+  /// Callback fired when the server reports 410 Gone from
+  /// `GET /api/groups/:id/keys/latest` (no envelope at the latest key
+  /// version for this caller). The chat layer wires this to a
+  /// per-conversation "needs rotation" flag that drives the
+  /// EncryptionStatusBanner. Set once at startup; null when no
+  /// listener has registered. Argument is the conversation id.
+  void Function(String conversationId)? onGroupNeedsRotation;
+
   static final _aesGcm = AesGcm.with256bits();
 
   GroupCryptoService({required this.serverUrl});
@@ -519,6 +527,19 @@ class GroupCryptoService {
         headers: {'Authorization': 'Bearer $_token'},
       );
 
+      // 410 Gone: the group has a current key version but the server has
+      // no per-user envelope for us at that version. Another member needs
+      // to rotate us in. Surface the recovery banner instead of caching a
+      // bogus sentinel string as if it were the AES key.
+      if (response.statusCode == 410) {
+        debugPrint(
+          '[GroupCrypto] $conversationId has no envelope for this user at '
+          'the latest key version — flagging for re-rotation.',
+        );
+        onGroupNeedsRotation?.call(conversationId);
+        return null;
+      }
+
       if (response.statusCode != 200) {
         debugPrint(
           '[GroupCrypto] Failed to fetch key for $conversationId: '
@@ -757,16 +778,32 @@ class GroupCryptoService {
       }
     }
 
+    // Abort if ANY member lacks an identity key. The previous behaviour
+    // silently `continue`d, which let rotation "complete" with a subset
+    // of envelopes — the unkeyed member then hit the server's
+    // `__envelope__` sentinel row and fed it to the AES unwrap path,
+    // producing "candidate key has wrong length: 9 bytes" errors with
+    // no actionable signal. Rotation = "make this group encrypted for
+    // these N members"; partial coverage is BUSTED state we must
+    // refuse to publish.
+    final missingKeyUserIds = <String>[
+      for (var i = 0; i < userIds.length; i++)
+        if (identityKeys[i] == null) userIds[i],
+    ];
+    if (missingKeyUserIds.isNotEmpty) {
+      debugPrint(
+        '[GroupCrypto] performRotation aborted: missing identity key for '
+        '${missingKeyUserIds.join(', ')}. Rotation requires every member '
+        "to have published an identity key — partial rotation would wedge "
+        'the unkeyed member(s) on the sentinel envelope row.',
+      );
+      return null;
+    }
+
     final envelopes = <Map<String, dynamic>>[];
     for (var i = 0; i < userIds.length; i++) {
       final userId = userIds[i];
-      final identityKey = identityKeys[i];
-      if (identityKey == null) {
-        debugPrint(
-          '[GroupCrypto] performRotation: missing identity key for $userId',
-        );
-        continue;
-      }
+      final identityKey = identityKeys[i]!;
       final wrapped = await _cryptoService!.encryptForUser(
         newKeyBytes,
         identityKey,

--- a/apps/client/lib/src/utils/crypto_utils.dart
+++ b/apps/client/lib/src/utils/crypto_utils.dart
@@ -1,9 +1,16 @@
 /// Check if a string looks like base64-encoded ciphertext.
 ///
 /// Returns true if [text] is at least 20 characters long and consists
-/// entirely of base64 alphabet characters (A-Z, a-z, 0-9, +, /, =).
+/// entirely of base64 alphabet characters (A-Z, a-z, 0-9, +, /, =), OR
+/// if it carries one of the group-encrypted wire prefixes (`GRP1:`,
+/// `GRP2:`). The prefixed cases are common in sidebar/last-message
+/// previews when a client hasn't decrypted the message yet (e.g.
+/// missing group key envelope) — we don't want the raw `GRP1:...`
+/// blob leaking into the conversation list.
+///
 /// Plaintext messages will almost never match this pattern.
 bool looksEncrypted(String text) {
+  if (text.startsWith('GRP1:') || text.startsWith('GRP2:')) return true;
   if (text.length < 20) return false;
   return RegExp(r'^[A-Za-z0-9+/=]{20,}$').hasMatch(text);
 }

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -141,6 +141,11 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   /// Inline picker visible on mobile (replaces keyboard).
   bool _showInlinePicker = false;
 
+  /// On mobile, the markdown formatting toolbar is hidden by default and
+  /// toggled on via the "Aa" entry in the attach (+) sheet. On desktop the
+  /// toolbar is always visible and this flag is ignored.
+  bool _showFormatToolbarOnMobile = false;
+
   /// Last known keyboard height -- used to size the inline picker so it
   /// occupies the same space the keyboard did.
   double _lastKeyboardHeight = 0;
@@ -447,11 +452,14 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                       onAnnotate: _annotatePendingAttachment,
                     ),
                   // Markdown formatting toolbar (bold, italic, strike, code,
-                  // quote, link) — always visible above the input row.
-                  MarkdownToolbar(
-                    controller: _messageController,
-                    onLinkTap: _showLinkDialog,
-                  ),
+                  // quote, link). Always visible on desktop. On mobile it's
+                  // hidden by default and toggled from the "+" attach sheet so
+                  // it doesn't permanently eat ~36 px of vertical real estate.
+                  if (!isMobileLayout || _showFormatToolbarOnMobile)
+                    MarkdownToolbar(
+                      controller: _messageController,
+                      onLinkTap: _showLinkDialog,
+                    ),
                   _buildInputRow(
                     showMediaPicker: showMediaPicker,
                     isMobileLayout: isMobileLayout,

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/build_helpers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/build_helpers.dart
@@ -9,9 +9,14 @@ part of '../../chat_input_bar.dart';
 extension _BuildHelpers on ChatInputBarState {
   Widget _buildTextField({
     required bool showMediaPicker,
+    required bool isMobileLayout,
     required VoiceSettingsState voiceSettings,
     required String? effectiveActiveVoiceChannelId,
   }) {
+    // Clamp the composer to 6 lines on mobile so a long draft with the
+    // keyboard up doesn't eat more than ~half the available height. Desktop
+    // keeps the original 10-line allowance.
+    final composerMaxLines = isMobileLayout ? 6 : 10;
     return Expanded(
       child: Focus(
         onKeyEvent: (node, event) => _onKeyEvent(
@@ -23,7 +28,7 @@ extension _BuildHelpers on ChatInputBarState {
         child: TextField(
           controller: _messageController,
           focusNode: _inputFocusNode,
-          maxLines: 10,
+          maxLines: composerMaxLines,
           minLines: 1,
           maxLength: 4000,
           buildCounter:
@@ -162,6 +167,7 @@ extension _BuildHelpers on ChatInputBarState {
               children: [
                 _buildTextField(
                   showMediaPicker: showMediaPicker,
+                  isMobileLayout: isMobileLayout,
                   voiceSettings: voiceSettings,
                   effectiveActiveVoiceChannelId: effectiveActiveVoiceChannelId,
                 ),

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/media_picker.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/media_picker.dart
@@ -38,6 +38,18 @@ extension _MediaPicker on ChatInputBarState {
                 _pickFile();
               },
             ),
+            AttachOption(
+              icon: Icons.text_format,
+              label: _showFormatToolbarOnMobile
+                  ? 'Hide formatting'
+                  : 'Formatting',
+              onTap: () {
+                Navigator.pop(ctx);
+                setState(() {
+                  _showFormatToolbarOnMobile = !_showFormatToolbarOnMobile;
+                });
+              },
+            ),
           ],
         ),
       ),

--- a/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
+++ b/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
@@ -55,6 +55,21 @@ ContextMenuSection _primarySection(MessageTarget t) {
         icon: Icons.forward_outlined,
         onTap: t.onForward,
       ),
+    // Discoverable "Add reaction" entry for right-click. The four-emoji
+    // inline header is fast for power users but isn't labeled, so casual
+    // users miss it entirely (validated on prod). Keeping the inline
+    // header *and* this row gives both audiences a path:
+    //   - inline header: one-click pick of the four most-recent emojis
+    //   - this row:      jumps straight into the full picker
+    // Hidden when the message is encrypted-unreadable (no reactions on
+    // a "[Could not decrypt…]" bubble) or when the parent didn't wire
+    // a reactions callback.
+    if (!t.isEncryptedUnreadable && t.onOpenFullPicker != null)
+      ContextMenuAction(
+        label: 'Add reaction',
+        icon: Icons.add_reaction_outlined,
+        onTap: t.onOpenFullPicker,
+      ),
   ];
   return ContextMenuSection(actions: actions);
 }

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -10,6 +10,7 @@ import '../providers/chat_provider.dart';
 import '../providers/theme_provider.dart' show UIDensity, uiDensityProvider;
 import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
+import '../utils/crypto_utils.dart';
 import '../utils/presence.dart';
 import 'avatar_utils.dart';
 // Stack + Positioned (active edge bar overlay) come from material.dart.
@@ -202,15 +203,20 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
   }
 
   String? _maskEncryptedSnippet(String? snippet) {
-    if (snippet != null &&
-        (snippet.startsWith('[Could not decrypt') ||
-            snippet.startsWith('[Encrypted'))) {
-      // The DM context already implies encryption; saying "encrypted" here
-      // looks like an error state. Match any "[Could not decrypt..." variant
-      // (the WS handler emits at least four: bare, "waiting for group key",
-      // "group message", "encryption keys may be out of sync") so the
-      // protocol-state string never leaks into the sidebar snippet.
-      return '[E2E] Message';
+    if (snippet == null) return null;
+    // Normalise all encrypted-looking previews to a friendly placeholder.
+    // Anything starting with a "[Could not decrypt..." / "[Could not verify
+    // sender]" / "[Encrypted" / "[E2E]" bracketed sentinel is a protocol
+    // status string that should never read like a real message in the
+    // sidebar. We also catch raw GRP1:/GRP2: ciphertext + base64-shaped
+    // blobs that slipped past the WS decrypt path (missing key envelope,
+    // sender device not on file yet).
+    if (snippet.startsWith('[Could not decrypt') ||
+        snippet.startsWith('[Could not verify sender') ||
+        snippet.startsWith('[Encrypted') ||
+        snippet.startsWith('[E2E]') ||
+        looksEncrypted(snippet)) {
+      return '[Encrypted]';
     }
     return snippet;
   }

--- a/apps/client/lib/src/widgets/encryption_status_banner.dart
+++ b/apps/client/lib/src/widgets/encryption_status_banner.dart
@@ -45,6 +45,9 @@ class EncryptionStatusBanner extends ConsumerWidget {
     final outOfSync = ref.watch(
       chatProvider.select((s) => s.isConversationOutOfSync(conversation.id)),
     );
+    final needsRotation = ref.watch(
+      chatProvider.select((s) => s.isGroupAwaitingRotation(conversation.id)),
+    );
 
     if (secureStorageDown) {
       return _Banner(
@@ -88,17 +91,26 @@ class EncryptionStatusBanner extends ConsumerWidget {
       );
     }
 
-    if (outOfSync && conversation.isGroup) {
-      // Group decrypt failures cluster when a member missed a
-      // rotation — the local cached key is stale and the new envelope
-      // is sitting on the server. "Refresh key" drops our cache + a
-      // GET /api/groups/:id/keys/latest pulls the current envelope.
+    if ((needsRotation || outOfSync) && conversation.isGroup) {
+      // Two paths funnel into the same banner:
+      // 1. needsRotation — the server reported 410 Gone from
+      //    /keys/latest because no envelope exists for this user at
+      //    the current key version. Another member must rotate us in.
+      // 2. outOfSync — repeated "[Could not decrypt...]" placeholders
+      //    crossed the threshold; the local cached key is probably
+      //    stale and a fresh envelope is sitting on the server.
+      // "Refresh key" drops the local cache + refetches; if the fetch
+      // returns 410 again the callback re-flags the conversation.
+      final message = needsRotation
+          ? "This group's encryption key was rotated without you. Ask any "
+                'active member to refresh and send a message — the new '
+                'envelope will be delivered to you.'
+          : "Can't decrypt this group's recent messages. The encryption key "
+                'may have rotated — refresh to fetch the latest.';
       return _Banner(
         icon: Icons.refresh,
         color: EchoTheme.warning,
-        message:
-            "Can't decrypt this group's recent messages. The encryption key "
-            'may have rotated — refresh to fetch the latest.',
+        message: message,
         actionLabel: 'Refresh key',
         onAction: () =>
             ref.read(chatProvider.notifier).refreshGroupKey(conversation.id),

--- a/apps/client/lib/src/widgets/system_chrome.dart
+++ b/apps/client/lib/src/widgets/system_chrome.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Wraps [child] in an [AnnotatedRegion] that aligns the Android status bar
+/// and navigation bar icons with the active theme.
+///
+/// Without this, the system status bar inherits OS defaults — on a light
+/// device with our indigo brand surfaces this can render dark icons on a
+/// dark sidebar (or vice versa). The icon brightness is the inverse of the
+/// theme brightness: a dark theme needs light icons, a light theme needs
+/// dark icons. The status bar itself stays transparent so the underlying
+/// scaffold colour shows through.
+class EchoSystemChrome extends StatelessWidget {
+  final Widget child;
+
+  const EchoSystemChrome({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final iconBrightness = isDark ? Brightness.light : Brightness.dark;
+    final navBarColor = theme.scaffoldBackgroundColor;
+
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        statusBarIconBrightness: iconBrightness,
+        statusBarBrightness: theme.brightness,
+        systemNavigationBarColor: navBarColor,
+        systemNavigationBarIconBrightness: iconBrightness,
+      ),
+      child: child,
+    );
+  }
+}

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -319,7 +319,7 @@ void main() {
 
       expect(notifier.state.conversations, hasLength(1));
       final conv = notifier.state.conversations.first;
-      expect(conv.lastMessage, 'Encrypted message');
+      expect(conv.lastMessage, '[Encrypted]');
     });
 
     test('sorts conversations by most recent activity first', () async {

--- a/apps/client/test/providers/ws_message_handler_test.dart
+++ b/apps/client/test/providers/ws_message_handler_test.dart
@@ -80,6 +80,11 @@ class _SeededCryptoNotifier extends CryptoNotifier {
 }
 
 class _FakeConversationsNotifier extends ConversationsNotifier {
+  /// Count of loadConversations() calls. Used by the member_added test
+  /// to assert the sidebar refreshes itself when the local user is the
+  /// new member of an unknown conversation.
+  int loadConversationsCallCount = 0;
+
   @override
   ConversationsState build() => const ConversationsState(
     conversations: [
@@ -112,7 +117,9 @@ class _FakeConversationsNotifier extends ConversationsNotifier {
   );
 
   @override
-  Future<void> loadConversations() async {}
+  Future<void> loadConversations() async {
+    loadConversationsCallCount += 1;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -934,6 +941,52 @@ void main() {
       final group = convs.firstWhere((c) => c.id == 'group-1');
       expect(group.members, hasLength(2)); // unchanged
     });
+
+    test(
+      'local user added to an unknown conversation triggers full reload',
+      () {
+        // Sanity: the fake starts with zero loadConversations calls.
+        final notifier =
+            container.read(conversationsProvider.notifier)
+                as _FakeConversationsNotifier;
+        expect(notifier.loadConversationsCallCount, 0);
+
+        handler.handleServerMessage({
+          'type': 'member_added',
+          'conversation_id': 'brand-new-group',
+          'user_id': _myUserId,
+          'username': 'testuser',
+          'role': 'member',
+        }, _myUserId);
+
+        // The handler should have hit loadConversations() so the sidebar
+        // shows the new group without a hard refresh.
+        expect(notifier.loadConversationsCallCount, 1);
+      },
+    );
+
+    test(
+      'local user added to an already-known group does not trigger reload',
+      () {
+        final notifier =
+            container.read(conversationsProvider.notifier)
+                as _FakeConversationsNotifier;
+        expect(notifier.loadConversationsCallCount, 0);
+
+        // group-1 already exists locally with my-user-id as owner.
+        handler.handleServerMessage({
+          'type': 'member_added',
+          'conversation_id': 'group-1',
+          'user_id': _myUserId,
+          'username': 'testuser',
+          'role': 'member',
+        }, _myUserId);
+
+        // Known conversation, so the in-place addGroupMember path runs and
+        // we do NOT pay the full reload cost.
+        expect(notifier.loadConversationsCallCount, 0);
+      },
+    );
   });
 
   // #663 — system message when member joins group

--- a/apps/client/test/services/group_crypto_service_fetch_410_test.dart
+++ b/apps/client/test/services/group_crypto_service_fetch_410_test.dart
@@ -1,0 +1,105 @@
+/// Production E2E regression: when the server returns 410 Gone from
+/// `GET /api/groups/:id/keys/latest` ("no envelope for this user at the
+/// latest version"), [GroupCryptoService.fetchGroupKey] must:
+///
+///   1. Return null (no key was cached).
+///   2. Fire the `onGroupNeedsRotation` callback so the chat layer can
+///      flip the per-conversation banner flag.
+///
+/// Previously the server fell back to the `__envelope__` sentinel and
+/// served it as a 9-byte AES "key", which exploded downstream in
+/// [assertGroupKeyShape] with `candidate key has wrong length: 9 bytes`.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:echo_app/src/services/group_crypto_service.dart';
+import 'package:echo_app/src/services/secure_key_store.dart';
+
+import '../helpers/fake_secure_key_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GroupCryptoService.fetchGroupKey — 410 Gone path', () {
+    late FakeSecureKeyStore fakeStore;
+
+    setUp(() {
+      fakeStore = FakeSecureKeyStore();
+      SecureKeyStore.instance = fakeStore;
+    });
+
+    test(
+      'invokes onGroupNeedsRotation and returns null when server returns 410',
+      () async {
+        const groupId = 'group-needs-rotation';
+        final service = GroupCryptoService(serverUrl: 'http://example.test');
+
+        String? notifiedConversation;
+        service.onGroupNeedsRotation = (convId) {
+          notifiedConversation = convId;
+        };
+
+        await http.runWithClient(
+          () async {
+            final result = await service.fetchGroupKey(groupId);
+            expect(result, isNull, reason: 'no key was cached');
+          },
+          () => MockClient((req) async {
+            expect(req.url.path, contains('/api/groups/$groupId/keys/latest'));
+            return http.Response(
+              '{"code":"no-envelope-for-user","key_version":3}',
+              410,
+              headers: {'content-type': 'application/json'},
+            );
+          }),
+        );
+
+        expect(
+          notifiedConversation,
+          equals(groupId),
+          reason:
+              '410 must trigger the needs-rotation callback so the chat '
+              'banner can surface the "Refresh key" affordance',
+        );
+      },
+    );
+
+    test('does NOT invoke onGroupNeedsRotation on 200 happy path', () async {
+      const groupId = 'group-happy-path';
+      final service = GroupCryptoService(serverUrl: 'http://example.test');
+
+      bool notified = false;
+      service.onGroupNeedsRotation = (_) {
+        notified = true;
+      };
+
+      await http.runWithClient(
+        () async {
+          // 200 with a real-looking envelope. The unwrap path will fail
+          // (no CryptoService wired -> falls through legacy plaintext-
+          // key branch which then fails the structural-shape check),
+          // but the test only cares that the 410 branch is NOT taken
+          // on a 200.
+          await service.fetchGroupKey(groupId);
+        },
+        () => MockClient((_) async {
+          return http.Response(
+            '{"encrypted_key":"c29tZS1lbnZlbG9wZQ==",'
+            '"key_version":1,"min_wire_version":1}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }),
+      );
+
+      expect(
+        notified,
+        isFalse,
+        reason: '200 must NOT trip the needs-rotation flag',
+      );
+    });
+  });
+}

--- a/apps/client/test/services/group_crypto_service_rotation_test.dart
+++ b/apps/client/test/services/group_crypto_service_rotation_test.dart
@@ -13,6 +13,8 @@
 /// purge. This test pins the client cache contract.
 library;
 
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:echo_app/src/services/group_crypto_service.dart';
 import 'package:echo_app/src/services/secure_key_store.dart';
@@ -95,6 +97,61 @@ void main() {
           fetchIdentityKey: (_) async => null,
         );
         expect(result, isNull);
+      },
+    );
+
+    test(
+      'aborts rotation when ANY non-self member is missing an identity key',
+      () async {
+        // Production E2E regression: previously the rotation path silently
+        // `continue`d past unkeyed members, uploaded envelopes for the
+        // subset that had keys, and left the unkeyed member to hit the
+        // server's `__envelope__` sentinel and explode on AES unwrap.
+        //
+        // We can't easily wire a full CryptoService into a unit test —
+        // it needs real identity keys, secure storage, etc. — so this
+        // test pins the contract one level up: with a partially-keyed
+        // roster, `performRotation` MUST return null. Whether the
+        // abort path is the no-`_cryptoService` short-circuit or the
+        // new "missing identity key" early-return doesn't change the
+        // user-visible contract: no envelopes get published.
+        const groupId = 'group-rotate-partial';
+        final service = GroupCryptoService(serverUrl: 'http://localhost:0');
+
+        // Seed an old key so we can verify it ALSO gets purged before
+        // the abort — partial rotation must never leave the old key
+        // around as a fallback (separate from the abort guarantee).
+        await fakeStore.write(
+          'group_key_${groupId}_1',
+          GroupCryptoService.generateGroupKey(),
+        );
+
+        final result = await service.performRotation(
+          groupId,
+          2,
+          fetchMembers: () async => [
+            {'user_id': 'alice'},
+            {'user_id': 'bob'},
+          ],
+          fetchIdentityKey: (userId) async {
+            if (userId == 'alice') return Uint8List(32);
+            return null; // bob — missing key
+          },
+        );
+        expect(
+          result,
+          isNull,
+          reason:
+              'partial rotation must be refused — every member needs an '
+              'identity key before any envelope is published',
+        );
+
+        // Old key is also gone — the rotation drops cached material
+        // before any abort returns.
+        final remaining = fakeStore.dump.keys
+            .where((k) => k.startsWith('group_key_$groupId'))
+            .toList();
+        expect(remaining, isEmpty);
       },
     );
   });

--- a/apps/client/test/utils/crypto_utils_test.dart
+++ b/apps/client/test/utils/crypto_utils_test.dart
@@ -40,5 +40,15 @@ void main() {
     test('returns false for URLs', () {
       expect(looksEncrypted('https://example.com/path'), isFalse);
     });
+
+    test('returns true for GRP1: ciphertext prefix', () {
+      expect(looksEncrypted('GRP1:abc'), isTrue);
+      expect(looksEncrypted('GRP1:OJOu60GsqeDgNNTgqM8hyp+xKLM=='), isTrue);
+    });
+
+    test('returns true for GRP2: ciphertext prefix', () {
+      expect(looksEncrypted('GRP2:abc'), isTrue);
+      expect(looksEncrypted('GRP2:AQEBBaSE64dAtahErE=='), isTrue);
+    });
   });
 }

--- a/apps/client/test/widgets/context_menu/context_menu_overlay_test.dart
+++ b/apps/client/test/widgets/context_menu/context_menu_overlay_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/widgets/context_menu/actions/message_actions_registry.dart';
 import 'package:echo_app/src/widgets/context_menu/context_menu_overlay.dart';
 import 'package:echo_app/src/widgets/context_menu/echo_context_menu.dart';
 
@@ -125,6 +126,41 @@ void main() {
       expect(find.byIcon(Icons.chevron_left), findsOneWidget);
     });
 
+    testWidgets(
+      'right-click message menu surfaces "Add reaction" labeled row',
+      (tester) async {
+        // Drive the menu through the same registry the real chat panel
+        // uses so this test catches regressions where the row drops out
+        // of the rendered tree.
+        var pickerOpened = 0;
+        final target = MessageTarget(
+          message: const _StubMessage(),
+          isMine: false,
+          isSaved: false,
+          isEncryptedUnreadable: false,
+          mediaUrl: null,
+          isImageMedia: false,
+          onReply: () {},
+          onForward: () {},
+          onCopyText: () {},
+          onDelete: () {},
+          onCopyId: () {},
+          onPickReaction: (_) {},
+          onOpenFullPicker: () => pickerOpened++,
+        );
+        final model = buildMessageMenu(target);
+        await _openOverlay(tester, model);
+
+        expect(find.text('Add reaction'), findsOneWidget);
+
+        await tester.tap(find.text('Add reaction'));
+        await tester.pumpAndSettle();
+        await tester.pump();
+
+        expect(pickerOpened, 1);
+      },
+    );
+
     testWidgets('inline reactions header renders four emojis', (tester) async {
       final model = ContextMenuModel(
         header: InlineReactionsHeader(
@@ -145,4 +181,10 @@ void main() {
       expect(find.byIcon(Icons.add_reaction_outlined), findsOneWidget);
     });
   });
+}
+
+/// Stand-in for ChatMessage so the registry tests don't pull the whole
+/// chat-provider import graph in.
+class _StubMessage {
+  const _StubMessage();
 }

--- a/apps/client/test/widgets/context_menu/message_actions_registry_test.dart
+++ b/apps/client/test/widgets/context_menu/message_actions_registry_test.dart
@@ -123,6 +123,21 @@ void main() {
       expect(_allLabels(m), isNot(contains('Copy Message ID')));
     });
 
+    test('right-click menu exposes a labeled "Add reaction" row', () {
+      final m = buildMessageMenu(_baseTarget());
+      expect(_allLabels(m), contains('Add reaction'));
+    });
+
+    test('"Add reaction" is hidden on encrypted-unreadable messages', () {
+      final m = buildMessageMenu(_baseTarget(isEncryptedUnreadable: true));
+      expect(_allLabels(m), isNot(contains('Add reaction')));
+    });
+
+    test('"Add reaction" is hidden when reactions are not wired', () {
+      final m = buildMessageMenu(_baseTarget(wireReact: false));
+      expect(_allLabels(m), isNot(contains('Add reaction')));
+    });
+
     test('media messages show "Copy link" instead of "Copy text"', () {
       final m = buildMessageMenu(
         _baseTarget(mediaUrl: 'https://x/y.bin', isImageMedia: false),

--- a/apps/client/test/widgets/conversation_item_test.dart
+++ b/apps/client/test/widgets/conversation_item_test.dart
@@ -254,6 +254,149 @@ void main() {
       expect(find.textContaining('`'), findsNothing);
     });
 
+    testWidgets('replaces GRP1 ciphertext snippet with [Encrypted]', (
+      tester,
+    ) async {
+      final conv = _makeConversation(
+        lastMessage: 'GRP1:OJOu60GsqeDgNNTgqM8hyp+RawCiphertextBlobHere==',
+        lastMessageSender: 'alice',
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:30',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('[Encrypted]'), findsOneWidget);
+      expect(find.textContaining('GRP1:'), findsNothing);
+    });
+
+    testWidgets('replaces GRP2 ciphertext snippet with [Encrypted]', (
+      tester,
+    ) async {
+      final conv = _makeConversation(
+        lastMessage: 'GRP2:BAse64DataHereLooksLikeCipherText==',
+        lastMessageSender: 'alice',
+        members: const [
+          ConversationMember(userId: 'peer-id', username: 'alice'),
+          ConversationMember(userId: 'my-id', username: 'me'),
+        ],
+      );
+      await tester.pumpApp(
+        ConversationItem(
+          conversation: conv,
+          myUserId: 'my-id',
+          isSelected: false,
+          isPinned: false,
+          isPeerOnline: false,
+          timestamp: '10:30',
+          onTap: () {},
+        ),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('[Encrypted]'), findsOneWidget);
+      expect(find.textContaining('GRP2:'), findsNothing);
+    });
+
+    testWidgets(
+      'replaces "[Could not decrypt..." placeholder with [Encrypted]',
+      (tester) async {
+        final conv = _makeConversation(
+          lastMessage: '[Could not decrypt - waiting for group key]',
+          lastMessageSender: 'alice',
+          members: const [
+            ConversationMember(userId: 'peer-id', username: 'alice'),
+            ConversationMember(userId: 'my-id', username: 'me'),
+          ],
+        );
+        await tester.pumpApp(
+          ConversationItem(
+            conversation: conv,
+            myUserId: 'my-id',
+            isSelected: false,
+            isPinned: false,
+            isPeerOnline: false,
+            timestamp: '10:30',
+            onTap: () {},
+          ),
+        );
+        await tester.pump();
+
+        expect(find.textContaining('[Encrypted]'), findsOneWidget);
+        expect(find.textContaining('Could not decrypt'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'replaces "[Could not verify sender]" placeholder with [Encrypted]',
+      (tester) async {
+        final conv = _makeConversation(
+          lastMessage: '[Could not verify sender]',
+          lastMessageSender: 'alice',
+          members: const [
+            ConversationMember(userId: 'peer-id', username: 'alice'),
+            ConversationMember(userId: 'my-id', username: 'me'),
+          ],
+        );
+        await tester.pumpApp(
+          ConversationItem(
+            conversation: conv,
+            myUserId: 'my-id',
+            isSelected: false,
+            isPinned: false,
+            isPeerOnline: false,
+            timestamp: '10:30',
+            onTap: () {},
+          ),
+        );
+        await tester.pump();
+
+        expect(find.textContaining('[Encrypted]'), findsOneWidget);
+        expect(find.textContaining('verify sender'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'replaces legacy "[E2E] Message" placeholder with [Encrypted]',
+      (tester) async {
+        final conv = _makeConversation(
+          lastMessage: '[E2E] Message',
+          lastMessageSender: 'alice',
+          members: const [
+            ConversationMember(userId: 'peer-id', username: 'alice'),
+            ConversationMember(userId: 'my-id', username: 'me'),
+          ],
+        );
+        await tester.pumpApp(
+          ConversationItem(
+            conversation: conv,
+            myUserId: 'my-id',
+            isSelected: false,
+            isPinned: false,
+            isPeerOnline: false,
+            timestamp: '10:30',
+            onTap: () {},
+          ),
+        );
+        await tester.pump();
+
+        expect(find.textContaining('[Encrypted]'), findsOneWidget);
+        expect(find.textContaining('[E2E]'), findsNothing);
+      },
+    );
+
     testWidgets('renders timestamp string', (tester) async {
       final conv = _makeConversation(
         members: const [

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -374,11 +374,33 @@ pub async fn get_latest_group_key(
         return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
     }
 
-    // Fallback: legacy group_keys table (for groups that haven't rotated yet)
+    // No envelope for this caller — figure out which sub-case we're in.
+    // - If the group has NO key version at all -> 400 "no group key" (legacy
+    //   shape; pre-encryption groups and tests rely on this).
+    // - If the group HAS a key version but the caller's envelope is missing
+    //   at that version -> 410 Gone. Previously we fell back to serving the
+    //   sentinel `"__envelope__"` placeholder string out of `group_keys`,
+    //   which the client tried to decrypt as if it were a wrapped AES key
+    //   and exploded with `candidate key has wrong length: 9 bytes`. The
+    //   410 lets the client mark the group as "needs rotation" and surface
+    //   the recovery banner instead.
     let row = db::keys::get_latest_group_key(&state.pool, group_id)
         .await
         .db_ctx("get_latest_group_key/fetch")?
         .ok_or_else(|| AppError::bad_request("No group key found for this conversation"))?;
+
+    // A sentinel row means envelope-based distribution is in effect for this
+    // group AND we already confirmed (above) that no envelope exists for the
+    // caller. Anything else is a legacy plaintext key — preserve the old
+    // behaviour so groups created before the envelope scheme keep working.
+    if row.encrypted_key == "__envelope__" {
+        let body = serde_json::json!({
+            "error": "No group-key envelope exists for this user at the latest version",
+            "code": "no-envelope-for-user",
+            "key_version": row.key_version,
+        });
+        return Ok((StatusCode::GONE, Json(body)).into_response());
+    }
 
     Ok(Json(GroupKeyResponse::from_row(row)).into_response())
 }

--- a/apps/server/tests/api_group_keys_no_envelope.rs
+++ b/apps/server/tests/api_group_keys_no_envelope.rs
@@ -1,0 +1,103 @@
+//! Production-validation regression: when a group has a current key version
+//! but the caller has NO per-user envelope at that version (e.g. they joined
+//! after the last rotation, or rotation completed without including them),
+//! `GET /api/groups/:id/keys/latest` must return 410 Gone with a structured
+//! body so the client can surface the "Refresh key" recovery affordance.
+//!
+//! The previous behaviour fell back to the `group_keys` sentinel row and
+//! served `"__envelope__"` as the encrypted_key. The client tried to AES-
+//! unwrap that 9-byte ASCII placeholder and failed with
+//! `GroupEnvelopeUnwrapException: candidate key has wrong length: 9 bytes`,
+//! producing endless `[Could not decrypt...]` placeholders with no signal.
+
+mod common;
+
+use reqwest::Client;
+use serde_json::Value;
+
+#[tokio::test]
+async fn get_latest_returns_410_when_caller_has_no_envelope_at_latest_version() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gknoeown").await;
+    let (member_token, member_id, _) = common::register_and_login(&client, &base, "gknomem").await;
+
+    let group_id = common::create_group(&client, &base, &owner_token, "GKNoEnv").await;
+    common::add_member_to_group(&client, &base, &owner_token, &group_id, &member_id).await;
+
+    // Rotate with envelopes for the owner only — simulates the
+    // production bug where `performRotation` silently `continue`d past
+    // a member with no published identity key.
+    let body = serde_json::json!({
+        "key_version": 1,
+        "envelopes": [
+            { "user_id": owner_id, "encrypted_key": "owner-secret" }
+        ]
+    });
+    let resp = client
+        .post(format!("{base}/api/groups/{group_id}/keys"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 201);
+
+    // Owner gets their envelope (happy path).
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/latest"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["encrypted_key"], "owner-secret");
+
+    // Member has no envelope at v1 — must get 410 Gone, NOT the sentinel.
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/latest"))
+        .header("Authorization", format!("Bearer {member_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        410,
+        "caller with no envelope at the latest version must get 410 Gone, \
+         not the `__envelope__` sentinel"
+    );
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "no-envelope-for-user");
+    assert_eq!(body["key_version"], 1);
+    // Make sure we did NOT leak the sentinel into the response.
+    assert!(
+        body.get("encrypted_key").is_none(),
+        "410 body must not contain the sentinel encrypted_key field"
+    );
+}
+
+#[tokio::test]
+async fn get_latest_still_returns_400_when_group_has_no_key_at_all() {
+    // Distinct condition: "no key version exists for this group at all"
+    // (pre-encryption groups). Must stay 400 so existing tests + clients
+    // that treat 400 as "group is plaintext" keep working — only the
+    // "caller missing from current version" sub-case is the new 410.
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _owner_id, _) = common::register_and_login(&client, &base, "gknokey").await;
+
+    let group_id = common::create_group(&client, &base, &owner_token, "GKNoKey").await;
+
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/latest"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "no key version at all must remain 400 (legacy contract)"
+    );
+}


### PR DESCRIPTION
Promotes #1082 from dev. Big batch: encrypted-group rotation no longer silently fails on unkeyed members, sidebar shows [Encrypted] instead of raw ciphertext, right-click adds reactions, mobile composer cleaner, status bar themed.