### PR TITLE
UI audit batches C + D: responsive overhaul + desktop power-user

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -148,6 +148,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   // the drag ends without crossing the threshold.  Initialized in initState.
   late final AnimationController _swipeSnapController;
 
+  /// Layout-tier picker with hysteresis. Lives on the State so the previous
+  /// decision survives across rebuilds. Without this, dragging the window
+  /// across 600 px or 900 px would swap top-level scaffolds every frame,
+  /// dropping scroll positions, open popovers and in-flight overlays.
+  final StableLayoutDecision _layoutDecision = StableLayoutDecision();
+
   @override
   void initState() {
     super.initState();
@@ -205,20 +211,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   @override
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    final isNarrow = width < 600;
-    final isDesktop = width >= 900;
+    final tier = _layoutDecision.next(width);
 
     _listenForErrors();
     _syncSelectedConversation();
 
-    Widget layout;
-    if (isNarrow) {
-      layout = _buildNarrowLayout();
-    } else if (isDesktop) {
-      layout = _buildDesktopLayout();
-    } else {
-      layout = _buildWideLayout();
-    }
+    final Widget layout = switch (tier) {
+      LayoutTier.narrow => _buildNarrowLayout(),
+      LayoutTier.desktop => _buildDesktopLayout(),
+      LayoutTier.wide => _buildWideLayout(),
+    };
 
     return EchoSystemChrome(
       child: CallbackShortcuts(

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -236,10 +236,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           const SingleActivator(LogicalKeyboardKey.slash, control: true): () {
             _showKeyboardShortcuts();
           },
+          // Power-user shortcuts: open settings (matches the Discord /
+          // browser convention) and close settings with Esc so the panel
+          // never strands the user without a mouse.
+          const SingleActivator(LogicalKeyboardKey.comma, control: true): () {
+            _openSettings();
+          },
+          const SingleActivator(LogicalKeyboardKey.escape): _onEscape,
         },
         child: Focus(autofocus: true, child: layout),
       ),
     );
+  }
+
+  /// Esc closes the inline settings panel on desktop. On narrow viewports
+  /// the settings screen is a real route and its own back button handles
+  /// dismissal, so we only intercept Esc when the inline panel is open.
+  void _onEscape() {
+    if (_showSettings) {
+      setState(() => _showSettings = false);
+    }
   }
 
   bool get _isDesktop => Responsive.isDesktop(context);

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -116,7 +116,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   bool _sidebarCollapsed = false;
   double _sidebarWidth = 350;
   static const _sidebarMinWidth = 200.0;
-  static const _sidebarMaxWidth = 500.0;
+
+  /// Base sidebar ceiling on a typical 1280-1600 px laptop. The actual max
+  /// used by the drag handle scales with viewport width via
+  /// [_sidebarMaxWidthFor] so that ultrawide users (3440 px etc.) can grow
+  /// the sidebar past 500 px instead of being squeezed.
+  static const _sidebarMaxWidthBase = 500.0;
+  static const _sidebarMaxWidthCeiling = 720.0;
+
+  /// Computes the sidebar's drag-resize ceiling for a given viewport width.
+  /// 28% of the viewport, clamped to `[500, 720]`. On a 1280 px screen this
+  /// returns 500 (base); on a 3440 px ultrawide it returns 720 (ceiling).
+  static double _sidebarMaxWidthFor(double viewportWidth) {
+    final scaled = viewportWidth * 0.28;
+    if (scaled < _sidebarMaxWidthBase) return _sidebarMaxWidthBase;
+    if (scaled > _sidebarMaxWidthCeiling) return _sidebarMaxWidthCeiling;
+    return scaled;
+  }
 
   /// Lower clamp during a resize drag — below `_sidebarMinWidth` so the
   /// drag-end handler can detect a pull-through and snap into compact mode

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -116,7 +116,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   bool _sidebarCollapsed = false;
   double _sidebarWidth = 350;
   static const _sidebarMinWidth = 200.0;
-  static const _sidebarMaxWidth = 500.0;
+  // 640 px gives users on 2560x1440+ displays room to surface long
+  // conversation titles, group names, and last-message previews without
+  // truncation. The previous 500 px cap felt cramped on wide monitors.
+  static const _sidebarMaxWidth = 640.0;
 
   /// Lower clamp during a resize drag — below `_sidebarMinWidth` so the
   /// drag-end handler can detect a pull-through and snap into compact mode

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -112,6 +112,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   /// 0 = Chats, 1 = Discover, 2 = Contacts, 3 = Settings.
   int _mobileTabIndex = 0;
 
+  // Members panel resize state. Mirrors the sidebar's drag-resize handle so
+  // ultrawide users can grow the right rail without code changes.
+  double _membersPanelWidth = MembersPanel.defaultWidth;
+
   // Collapsible sidebar state
   bool _sidebarCollapsed = false;
   double _sidebarWidth = 350;

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -200,8 +200,13 @@ mixin _HomeScreenDesktopLayoutMixin
                         Positioned(
                           top: 10,
                           right: 10,
+                          // Ring needs to contrast with the surrounding chip,
+                          // not blend into it. The footer chip uses `mainBg`,
+                          // so a `mainBg` ring is invisible. `sidebarBg`
+                          // matches the surrounding rail and keeps the dot
+                          // legible regardless of theme.
                           child: _DotBadge(
-                            ringColor: context.mainBg,
+                            ringColor: context.sidebarBg,
                             bgColor: context.accent,
                           ),
                         ),

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -409,53 +409,48 @@ mixin _HomeScreenDesktopLayoutMixin
   }
 
   /// Draggable resize handle between sidebar and content area.
+  ///
+  /// The hit area stays at 12 px (forgiving for the mouse) but the visible
+  /// seam was previously a 1 px border with no hover state — users would
+  /// hunt-and-peck for the handle. Hovering now brightens the seam to the
+  /// accent colour so the affordance is obvious, while the underlying drag /
+  /// double-click / pull-through behaviour is unchanged.
   Widget _buildResizeHandle() {
-    return MouseRegion(
-      cursor: SystemMouseCursors.resizeColumn,
-      child: Semantics(
-        label: 'Resize sidebar',
-        child: GestureDetector(
-          onHorizontalDragUpdate: (details) {
-            if (_self._sidebarCollapsed) return;
-            // Allow dragging below `_sidebarMinWidth` so users can pull the
-            // handle through to compact mode and the drag-end handler can
-            // snap to collapsed. The lower clamp keeps the sidebar from
-            // disappearing entirely mid-drag (#739).
-            setState(() {
-              _self._sidebarWidth = (_self._sidebarWidth + details.delta.dx)
-                  .clamp(
-                    _HomeScreenState._sidebarPullThroughWidth,
-                    _HomeScreenState._sidebarMaxWidth,
-                  );
-            });
-          },
-          onHorizontalDragEnd: (details) {
-            setState(() {
-              if (_self._sidebarWidth < _HomeScreenState._sidebarMinWidth) {
-                // User pulled past the min — snap to compact and restore the
-                // expanded default for the next expand-from-compact toggle.
-                _self._sidebarCollapsed = true;
-                _self._sidebarWidth = _HomeScreenState._sidebarDefaultWidth;
-              }
-            });
-          },
-          onDoubleTap: () {
-            setState(() {
-              if (_self._sidebarCollapsed) {
-                _self._sidebarCollapsed = false;
-                _self._sidebarWidth = _HomeScreenState._sidebarDefaultWidth;
-              } else {
-                _self._sidebarCollapsed = true;
-              }
-            });
-          },
-          child: Container(
-            width: 12,
-            color: Colors.transparent,
-            child: Center(child: Container(width: 1, color: context.border)),
-          ),
-        ),
-      ),
+    return _ResizeHandle(
+      isCollapsed: _self._sidebarCollapsed,
+      onHorizontalDragUpdate: (details) {
+        if (_self._sidebarCollapsed) return;
+        // Allow dragging below `_sidebarMinWidth` so users can pull the
+        // handle through to compact mode and the drag-end handler can
+        // snap to collapsed. The lower clamp keeps the sidebar from
+        // disappearing entirely mid-drag (#739).
+        setState(() {
+          _self._sidebarWidth = (_self._sidebarWidth + details.delta.dx).clamp(
+            _HomeScreenState._sidebarPullThroughWidth,
+            _HomeScreenState._sidebarMaxWidth,
+          );
+        });
+      },
+      onHorizontalDragEnd: (details) {
+        setState(() {
+          if (_self._sidebarWidth < _HomeScreenState._sidebarMinWidth) {
+            // User pulled past the min — snap to compact and restore the
+            // expanded default for the next expand-from-compact toggle.
+            _self._sidebarCollapsed = true;
+            _self._sidebarWidth = _HomeScreenState._sidebarDefaultWidth;
+          }
+        });
+      },
+      onDoubleTap: () {
+        setState(() {
+          if (_self._sidebarCollapsed) {
+            _self._sidebarCollapsed = false;
+            _self._sidebarWidth = _HomeScreenState._sidebarDefaultWidth;
+          } else {
+            _self._sidebarCollapsed = true;
+          }
+        });
+      },
     );
   }
 
@@ -480,5 +475,72 @@ mixin _HomeScreenDesktopLayoutMixin
         },
       ),
     ];
+  }
+}
+
+/// Sidebar resize handle. Stateful so the seam can highlight on hover and
+/// while a drag is in flight, without forcing a rebuild of the whole
+/// HomeScreen on every pointer enter/exit.
+class _ResizeHandle extends StatefulWidget {
+  final bool isCollapsed;
+  final GestureDragUpdateCallback onHorizontalDragUpdate;
+  final GestureDragEndCallback onHorizontalDragEnd;
+  final VoidCallback onDoubleTap;
+
+  const _ResizeHandle({
+    required this.isCollapsed,
+    required this.onHorizontalDragUpdate,
+    required this.onHorizontalDragEnd,
+    required this.onDoubleTap,
+  });
+
+  @override
+  State<_ResizeHandle> createState() => _ResizeHandleState();
+}
+
+class _ResizeHandleState extends State<_ResizeHandle> {
+  bool _hovering = false;
+  bool _dragging = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final highlighted = _hovering || _dragging;
+    final seamColor = highlighted ? context.accent : context.border;
+    final seamWidth = highlighted ? 2.0 : 1.0;
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeColumn,
+      onEnter: (_) => setState(() => _hovering = true),
+      onExit: (_) => setState(() => _hovering = false),
+      child: Tooltip(
+        message: 'Drag to resize, double-click to collapse',
+        waitDuration: const Duration(milliseconds: 500),
+        child: Semantics(
+          label: 'Resize sidebar',
+          child: GestureDetector(
+            onHorizontalDragStart: (_) => setState(() => _dragging = true),
+            onHorizontalDragUpdate: widget.onHorizontalDragUpdate,
+            onHorizontalDragEnd: (details) {
+              setState(() => _dragging = false);
+              widget.onHorizontalDragEnd(details);
+            },
+            onHorizontalDragCancel: () => setState(() => _dragging = false),
+            onDoubleTap: widget.onDoubleTap,
+            // Container is `double.infinity` tall via Row's cross-axis
+            // stretch, transparent fill keeps the full 12 px as hit area.
+            child: Container(
+              width: 12,
+              color: Colors.transparent,
+              alignment: Alignment.center,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                curve: Curves.easeOut,
+                width: seamWidth,
+                color: seamColor,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -421,12 +421,15 @@ mixin _HomeScreenDesktopLayoutMixin
             // handle through to compact mode and the drag-end handler can
             // snap to collapsed. The lower clamp keeps the sidebar from
             // disappearing entirely mid-drag (#739).
+            //
+            // The upper clamp scales with viewport width so ultrawide users
+            // can grow the sidebar past 500 px (up to 720 px).
+            final maxWidth = _HomeScreenState._sidebarMaxWidthFor(
+              MediaQuery.of(context).size.width,
+            );
             setState(() {
               _self._sidebarWidth = (_self._sidebarWidth + details.delta.dx)
-                  .clamp(
-                    _HomeScreenState._sidebarPullThroughWidth,
-                    _HomeScreenState._sidebarMaxWidth,
-                  );
+                  .clamp(_HomeScreenState._sidebarPullThroughWidth, maxWidth);
             });
           },
           onHorizontalDragEnd: (details) {

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -462,7 +462,9 @@ mixin _HomeScreenDesktopLayoutMixin
     );
   }
 
-  /// Optional 280px members panel on the right side.
+  /// Members panel on the right side. Width is user-resizable via a drag
+  /// handle (mirrors the left sidebar) and persisted in
+  /// `_HomeScreenState._membersPanelWidth` for the lifetime of the screen.
   List<Widget> _buildMembersPanel() {
     if (_self._showSettings ||
         !_self._showMembers ||
@@ -471,9 +473,10 @@ mixin _HomeScreenDesktopLayoutMixin
       return const [];
     }
     return [
-      Container(width: 1, color: context.border),
+      _buildMembersResizeHandle(),
       MembersPanel(
         conversation: _self._selectedConversation,
+        width: _self._membersPanelWidth,
         onGroupLeft: () {
           setState(() {
             _self._selectedConversation = null;
@@ -483,5 +486,40 @@ mixin _HomeScreenDesktopLayoutMixin
         },
       ),
     ];
+  }
+
+  /// Drag handle that lets the user resize the members panel. Visually
+  /// identical to [_buildResizeHandle] (the sidebar's handle); horizontal
+  /// drag updates clamp to [MembersPanel.minWidth] .. [MembersPanel.maxWidth].
+  Widget _buildMembersResizeHandle() {
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeColumn,
+      child: Semantics(
+        label: 'Resize members panel',
+        child: GestureDetector(
+          onHorizontalDragUpdate: (details) {
+            // Dragging the handle LEFT widens the panel (the handle sits on
+            // its left edge), so subtract the delta.
+            setState(() {
+              _self._membersPanelWidth =
+                  (_self._membersPanelWidth - details.delta.dx).clamp(
+                    MembersPanel.minWidth,
+                    MembersPanel.maxWidth,
+                  );
+            });
+          },
+          onDoubleTap: () {
+            setState(() {
+              _self._membersPanelWidth = MembersPanel.defaultWidth;
+            });
+          },
+          child: Container(
+            width: 12,
+            color: Colors.transparent,
+            child: Center(child: Container(width: 1, color: context.border)),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
+++ b/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
@@ -61,7 +61,11 @@ class FloatingDock extends ConsumerWidget {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             decoration: BoxDecoration(
-              color: const Color(0xE01C1C1E),
+              // Was hard-coded `Color(0xE01C1C1E)` — the same RGB as
+              // `EchoTheme.surface` with an 0xE0 (≈88%) alpha for the
+              // backdrop-blurred glass effect. Pull from the token so light
+              // theme and any future surface re-skin pick this up.
+              color: context.surface.withValues(alpha: 0.88),
               borderRadius: BorderRadius.circular(32),
               border: Border.all(color: context.border),
               boxShadow: [

--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -223,9 +223,17 @@ class ParticipantGrid extends StatelessWidget {
         ),
       );
     }
-    return OrientationBuilder(
-      builder: (context, orientation) {
-        final crossAxisCount = orientation == Orientation.portrait ? 2 : 3;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Aim for a tile that's a comfortable ~220 px wide on desktop; the
+        // grid then naturally widens to fill ultrawide viewports rather than
+        // capping at 3 columns the way the old portrait/landscape heuristic
+        // did. Clamped to [2, 6] so tiny widths still get a 2-up layout and
+        // we never shrink avatars into illegibility on 4K monitors.
+        const targetTileWidth = 220.0;
+        final crossAxisCount = (constraints.maxWidth / targetTileWidth)
+            .floor()
+            .clamp(2, 6);
         return Center(
           child: GridView.count(
             crossAxisCount: crossAxisCount,

--- a/apps/client/lib/src/theme/responsive.dart
+++ b/apps/client/lib/src/theme/responsive.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/widgets.dart';
 
+/// Three discrete layout tiers used across the app.
+enum LayoutTier { narrow, wide, desktop }
+
 /// Centralized responsive breakpoints for consistent layout behavior.
 ///
 /// Use these instead of ad-hoc `MediaQuery.of(context).size.width < 600`
@@ -13,6 +16,11 @@ class Responsive {
   /// Screens at or wider than this get the full desktop layout.
   static const double desktopBreakpoint = 900;
 
+  /// Hysteresis window applied around the breakpoints to prevent state loss
+  /// when the user drags the window across the seam. See
+  /// [StableLayoutDecision].
+  static const double hysteresis = 20;
+
   static double width(BuildContext context) =>
       MediaQuery.of(context).size.width;
 
@@ -24,4 +32,57 @@ class Responsive {
 
   static bool isDesktop(BuildContext context) =>
       width(context) >= desktopBreakpoint;
+
+  /// Classifies a raw pixel width into a [LayoutTier] using the standard
+  /// breakpoints — no hysteresis. Use [StableLayoutDecision.next] when you
+  /// need seam stability.
+  static LayoutTier layoutTier(double width) {
+    if (width < mobileBreakpoint) return LayoutTier.narrow;
+    if (width < desktopBreakpoint) return LayoutTier.wide;
+    return LayoutTier.desktop;
+  }
+}
+
+/// Picks a [LayoutTier] with a small hysteresis band so that dragging a
+/// window across the 600 px or 900 px seam doesn't tear down scaffolds (which
+/// would drop scroll positions, overlays, in-flight reactions, etc.).
+///
+/// Hold an instance in the State of any widget that switches scaffolds on
+/// width — call [next] from `build`, remember the result, and only rebuild
+/// the chosen scaffold when [next] returns a different tier.
+class StableLayoutDecision {
+  /// The currently active tier, or null until [next] is called once.
+  LayoutTier? current;
+
+  StableLayoutDecision();
+
+  /// Resolves the tier to use given the current raw [width]. The first call
+  /// returns the natural breakpoint result; subsequent calls only flip tier
+  /// when [width] crosses the *outer* edge of the hysteresis window.
+  LayoutTier next(double width) {
+    final raw = Responsive.layoutTier(width);
+    final prev = current;
+    if (prev == null) {
+      current = raw;
+      return raw;
+    }
+    // Already in the desired tier — done.
+    if (prev == raw) return prev;
+
+    // Otherwise only flip if `width` has cleared the OUT edge of `prev`.
+    const h = Responsive.hysteresis;
+    final stayInPrev = switch (prev) {
+      LayoutTier.narrow =>
+        width < Responsive.mobileBreakpoint + h, // need > 620 to leave narrow
+      LayoutTier.desktop =>
+        width >=
+            Responsive.desktopBreakpoint - h, // need < 880 to leave desktop
+      LayoutTier.wide =>
+        width >= Responsive.mobileBreakpoint - h &&
+            width < Responsive.desktopBreakpoint + h,
+    };
+    if (stayInPrev) return prev;
+    current = raw;
+    return raw;
+  }
 }

--- a/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
+++ b/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
@@ -28,9 +28,14 @@ class _KeyboardShortcutsOverlayState extends State<KeyboardShortcutsOverlay> {
     super.dispose();
   }
 
+  // Keep this list in sync with the actual `CallbackShortcuts` bindings in
+  // `home_screen.dart` and the message-composer key handlers. Listing keys
+  // here that aren't really bound is worse than listing fewer — users try
+  // them, nothing happens, and the whole overlay loses trust.
   static const _sections = <_ShortcutSection>[
     _ShortcutSection('Navigation', [
       _Shortcut('Ctrl+K', 'Quick-switch conversations'),
+      _Shortcut('Ctrl+Shift+F', 'Search across all conversations'),
       _Shortcut('Ctrl+/', 'Show keyboard shortcuts'),
       _Shortcut('Esc', 'Close overlay / cancel action'),
     ]),
@@ -38,18 +43,12 @@ class _KeyboardShortcutsOverlayState extends State<KeyboardShortcutsOverlay> {
       _Shortcut('Enter', 'Send message'),
       _Shortcut('Shift+Enter', 'New line in message'),
       _Shortcut('↑', 'Edit last sent message (when input is empty)'),
-      _Shortcut('Ctrl+V', 'Paste text or image'),
+      _Shortcut('Esc', 'Cancel message edit (while editing)'),
     ]),
     _ShortcutSection('Messages', [
-      _Shortcut('Long press', 'React to message (mobile)'),
-      _Shortcut('Hover + ❤', 'React to message (desktop)'),
+      _Shortcut('Long press', 'React or open actions (mobile)'),
       _Shortcut('Swipe →', 'Reply to message (mobile)'),
-      _Shortcut('Hover + ↩', 'Reply to message (desktop)'),
-    ]),
-    _ShortcutSection('Editing', [
-      _Shortcut('Ctrl+C', 'Copy selected text'),
-      _Shortcut('Ctrl+X', 'Cut selected text'),
-      _Shortcut('Esc', 'Cancel message edit (while editing)'),
+      _Shortcut('Right-click', 'Open message actions (desktop)'),
     ]),
   ];
 

--- a/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
+++ b/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
@@ -36,8 +36,9 @@ class _KeyboardShortcutsOverlayState extends State<KeyboardShortcutsOverlay> {
     _ShortcutSection('Navigation', [
       _Shortcut('Ctrl+K', 'Quick-switch conversations'),
       _Shortcut('Ctrl+Shift+F', 'Search across all conversations'),
+      _Shortcut('Ctrl+,', 'Open settings'),
       _Shortcut('Ctrl+/', 'Show keyboard shortcuts'),
-      _Shortcut('Esc', 'Close overlay / cancel action'),
+      _Shortcut('Esc', 'Close overlay or settings'),
     ]),
     _ShortcutSection('Messaging', [
       _Shortcut('Enter', 'Send message'),

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -21,7 +21,23 @@ class MembersPanel extends ConsumerWidget {
   /// Called after a leave or delete operation to clear the selected conversation.
   final VoidCallback? onGroupLeft;
 
-  const MembersPanel({super.key, this.conversation, this.onGroupLeft});
+  /// Panel width in logical pixels. Defaults to [defaultWidth] (280) to match
+  /// the pre-resize behaviour; the home-screen scaffold passes the value the
+  /// user has dragged the resize handle to.
+  final double width;
+
+  /// Default and bound constants used by the home-screen resize handle so
+  /// the width state and the panel render stay in sync.
+  static const double defaultWidth = 280;
+  static const double minWidth = 220;
+  static const double maxWidth = 480;
+
+  const MembersPanel({
+    super.key,
+    this.conversation,
+    this.onGroupLeft,
+    this.width = defaultWidth,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -69,7 +85,7 @@ class MembersPanel extends ConsumerWidget {
     addGroup('Members · ${regulars.length}', regulars);
 
     return Container(
-      width: 280,
+      width: width,
       color: context.sidebarBg,
       child: Column(
         children: [

--- a/apps/client/lib/src/widgets/window_chrome.dart
+++ b/apps/client/lib/src/widgets/window_chrome.dart
@@ -141,45 +141,52 @@ class AppTitleBar extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    return Container(
-      height: 36,
-      decoration: BoxDecoration(
-        color: context.sidebarBg,
-        border: Border(bottom: BorderSide(color: context.border, width: 1)),
-      ),
-      child: Stack(
-        children: [
-          // Full-width drag area underneath everything.
-          const Positioned.fill(child: AppDragArea(child: SizedBox.expand())),
-          // Centered name — IgnorePointer so clicks fall through to drag area.
-          // Reserve room on macOS so the title can't slide under the
-          // red/yellow/green traffic-light cluster anchored to the left.
-          if (title != null && title!.isNotEmpty)
-            Padding(
-              padding: EdgeInsets.only(left: Platform.isMacOS ? 72.0 : 0.0),
-              child: Center(
-                child: IgnorePointer(
-                  child: Text(
-                    title!,
-                    style: TextStyle(
-                      color: context.textSecondary,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w500,
+    // Clamp the OS text scaler inside the 36-px title bar. At 1.5x system
+    // scaling the title would overflow the fixed-height bar and clip into the
+    // window controls; clamping to 1.2x keeps a11y while preserving the
+    // chrome's geometry. Buttons are icon-only so they're unaffected.
+    return MediaQuery.withClampedTextScaling(
+      maxScaleFactor: 1.2,
+      child: Container(
+        height: 36,
+        decoration: BoxDecoration(
+          color: context.sidebarBg,
+          border: Border(bottom: BorderSide(color: context.border, width: 1)),
+        ),
+        child: Stack(
+          children: [
+            // Full-width drag area underneath everything.
+            const Positioned.fill(child: AppDragArea(child: SizedBox.expand())),
+            // Centered name — IgnorePointer so clicks fall through to drag
+            // area. Reserve room on macOS so the title can't slide under the
+            // red/yellow/green traffic-light cluster anchored to the left.
+            if (title != null && title!.isNotEmpty)
+              Padding(
+                padding: EdgeInsets.only(left: Platform.isMacOS ? 72.0 : 0.0),
+                child: Center(
+                  child: IgnorePointer(
+                    child: Text(
+                      title!,
+                      style: TextStyle(
+                        color: context.textSecondary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ),
+            // Window controls on top — rendered above drag area so they
+            // receive pointer events before the GestureDetector beneath.
+            const Positioned(
+              right: 0,
+              top: 0,
+              bottom: 0,
+              child: AppWindowButtons(),
             ),
-          // Window controls on top — rendered above drag area so they
-          // receive pointer events before the GestureDetector beneath.
-          const Positioned(
-            right: 0,
-            top: 0,
-            bottom: 0,
-            child: AppWindowButtons(),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/client/test/theme/responsive_test.dart
+++ b/apps/client/test/theme/responsive_test.dart
@@ -1,0 +1,69 @@
+import 'package:echo_app/src/theme/responsive.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Responsive.layoutTier', () {
+    test('classifies widths into the three tiers', () {
+      expect(Responsive.layoutTier(320), LayoutTier.narrow);
+      expect(Responsive.layoutTier(599.9), LayoutTier.narrow);
+      expect(Responsive.layoutTier(600), LayoutTier.wide);
+      expect(Responsive.layoutTier(899.9), LayoutTier.wide);
+      expect(Responsive.layoutTier(900), LayoutTier.desktop);
+      expect(Responsive.layoutTier(1920), LayoutTier.desktop);
+    });
+  });
+
+  group('StableLayoutDecision', () {
+    test('first call seeds from raw breakpoints', () {
+      expect(StableLayoutDecision().next(500), LayoutTier.narrow);
+      expect(StableLayoutDecision().next(700), LayoutTier.wide);
+      expect(StableLayoutDecision().next(1100), LayoutTier.desktop);
+    });
+
+    test('stays in narrow until width clears 600 + hysteresis', () {
+      final d = StableLayoutDecision()..next(500);
+      // Within the hysteresis band just past 600 -- should stay narrow.
+      expect(d.next(610), LayoutTier.narrow);
+      expect(d.next(619), LayoutTier.narrow);
+      // Past the OUT edge -- flips to wide.
+      expect(d.next(621), LayoutTier.wide);
+    });
+
+    test('stays in desktop until width drops below 900 - hysteresis', () {
+      final d = StableLayoutDecision()..next(1100);
+      // Just under 900 but inside the hysteresis band -- stay desktop.
+      expect(d.next(890), LayoutTier.desktop);
+      expect(d.next(881), LayoutTier.desktop);
+      // Past the OUT edge -- flips to wide.
+      expect(d.next(879), LayoutTier.wide);
+    });
+
+    test('wide tier is sticky around both seams', () {
+      final d = StableLayoutDecision()..next(750);
+      // Crossing 600 downward inside the band -- stay wide.
+      expect(d.next(590), LayoutTier.wide);
+      expect(d.next(581), LayoutTier.wide);
+      expect(d.next(579), LayoutTier.narrow);
+      // Reset to wide.
+      d.next(750);
+      // Crossing 900 upward inside the band -- stay wide.
+      expect(d.next(910), LayoutTier.wide);
+      expect(d.next(919), LayoutTier.wide);
+      expect(d.next(921), LayoutTier.desktop);
+    });
+
+    test('does not flicker when oscillating near a breakpoint', () {
+      // Simulate a user dragging the window edge back and forth across 600
+      // by a few pixels. Without hysteresis this oscillates wildly; with
+      // hysteresis we should stick in narrow the whole time.
+      final d = StableLayoutDecision()..next(595);
+      for (final w in [599.0, 601.0, 604.0, 599.0, 610.0, 605.0]) {
+        expect(
+          d.next(w),
+          LayoutTier.narrow,
+          reason: 'should stay narrow at width=$w (inside hysteresis band)',
+        );
+      }
+    });
+  });
+}

--- a/apps/client/test/widgets/members_panel_test.dart
+++ b/apps/client/test/widgets/members_panel_test.dart
@@ -63,4 +63,48 @@ void main() {
       expect(find.text('Delete Group'), findsNothing);
     });
   });
+
+  group('MembersPanel width', () {
+    const conv = Conversation(
+      id: 'g',
+      name: 'G',
+      isGroup: true,
+      members: [
+        ConversationMember(
+          userId: 'test-user-id',
+          username: 'testuser',
+          role: 'owner',
+        ),
+      ],
+    );
+
+    testWidgets('honors the explicit width parameter', (tester) async {
+      await tester.pumpApp(
+        const MembersPanel(conversation: conv, width: 360),
+        overrides: standardOverrides(),
+      );
+      await tester.pumpAndSettle();
+
+      final size = tester.getSize(find.byType(MembersPanel));
+      expect(size.width, 360);
+    });
+
+    testWidgets('falls back to defaultWidth when no width is passed', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const MembersPanel(conversation: conv),
+        overrides: standardOverrides(),
+      );
+      await tester.pumpAndSettle();
+
+      final size = tester.getSize(find.byType(MembersPanel));
+      expect(size.width, MembersPanel.defaultWidth);
+    });
+
+    test('width bounds are sane', () {
+      expect(MembersPanel.minWidth, lessThan(MembersPanel.defaultWidth));
+      expect(MembersPanel.defaultWidth, lessThan(MembersPanel.maxWidth));
+    });
+  });
 }


### PR DESCRIPTION
Two of the four still-deferred UI batches from the audit.

## Batch C — responsive overhaul

- **20 px hysteresis** at the 600/900 px layout seams stops the scroll/overlay/state drop when dragging the window across the breakpoint (root cause: `home_screen.dart` swapped top-level scaffolds on every pixel).
- **Sidebar scales on ultrawide** via `_sidebarMaxWidthFor` (28% of viewport, clamped 500-720 px).
- **Voice lounge participant grid** now computes `crossAxisCount` from `LayoutBuilder.constraints.maxWidth` (was hardcoded 2/3).
- **Title bar text-scaler clamp** at 1.2x so 1.5x OS scaling no longer overflows.
- **Members panel resizable** (mirrors sidebar's drag handle).

## Batch D — desktop power-user

- **Shortcuts overlay reconciled** with actual bindings; removed the fake Ctrl+V/C/X + hover-reaction lines.
- **Ctrl+, opens settings, Esc closes them** (CallbackShortcuts).
- **Resize handle hover state** — seam brightens to accent on hover/drag; tooltip 'Drag to resize, double-click to collapse'.
- **Settings update-dot ring** now contrasts (was `mainBg` on `mainBg`).
- **Tokenised voice-dock hard-coded `Color(0xE01C1C1E)`** so light theme picks it up.

## Tests / gates

- Both batches: cargo + flutter clean.
- New: 6 responsive_test cases covering hysteresis tier classification + stickiness; 3 members_panel width tests.