### PR TITLE
feat(scripts): seed v2 helpers and realistic-day scenario

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ flutter build web --release --pwa-strategy=none --dart-define=APP_VERSION=X.Y.Z
 
 **run.sh** accepts optional `[username] [password]` args. Default is `dev/devpass123`, which also auto-creates demo contacts (alice, bob, charlie).
 
-**Other scripts**: `scripts/demo_two_apps.sh` (launch two client instances for testing), `scripts/seed_demo_data.sh` (populate test data).
+**Other scripts**: `scripts/demo_two_apps.sh` (launch two client instances for testing), `scripts/seed_demo_data.sh` (populate test data). For richer fixtures see `scripts/seed_v2_lib.sh` (sourceable helpers — `seed_user`, `seed_group`, `seed_dm_message`, etc.) and the two scenarios it powers: `scripts/seed_realistic_day.sh` (6 users, plaintext + encrypted groups, pairwise DMs, standup→EOD message rhythm with branching reply threads) and `scripts/seed_dms_only.sh` (DM-focused fixture, no groups). Usernames are timestamp-prefixed so reruns don't collide.
 
 ## Tests
 

--- a/scripts/seed_dms_only.sh
+++ b/scripts/seed_dms_only.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/seed_dms_only.sh — minimal pure-DM scenario.
+#
+# 4 users, all-to-all contacts, 6 pairwise DM threads of 8-15 messages each.
+# Useful for DM-focused UI testing (sidebar ordering, unread badges, last-
+# message preview, scroll behavior) without group noise.
+#
+# Usage:
+#   SEED_SERVER=http://localhost:8080 ./scripts/seed_dms_only.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./seed_v2_lib.sh
+source "$SCRIPT_DIR/seed_v2_lib.sh"
+
+SEED_SERVER="${SEED_SERVER:-http://localhost:8080}"
+PASSWORD="${PASSWORD:-seedv2pass}"
+STAMP="$(date +%s)"
+
+seed_log info "echo seed v2 — DMs only"
+seed_log dim "server: $SEED_SERVER  stamp: $STAMP"
+
+USERNAMES=(piper sage rowan nico)
+BIOS=(
+  "loves walking meetings"
+  "prefers async, will reply tomorrow"
+  "lives in a different timezone, sorry"
+  "fast typist, slow thinker"
+)
+STATUSES=(online away online dnd)
+
+declare -A USER_ID
+declare -A USER_TOKEN
+
+seed_log info "phase 1 — users"
+for i in "${!USERNAMES[@]}"; do
+  uname="${USERNAMES[$i]}_$STAMP"
+  seed_user "$uname" "$PASSWORD" "${BIOS[$i]}" "${STATUSES[$i]}"
+  USER_ID["${USERNAMES[$i]}"]="$SEED_USER_ID"
+  USER_TOKEN["${USERNAMES[$i]}"]="$SEED_USER_TOKEN"
+  printf "    %-10s %s  [%s]\n" "$uname" "$SEED_USER_ID" "${STATUSES[$i]}"
+done
+
+seed_log info "phase 2 — all-to-all contacts"
+for a in "${USERNAMES[@]}"; do
+  for b in "${USERNAMES[@]}"; do
+    [ "$a" = "$b" ] && continue
+    seed_contact_accept "${USER_TOKEN[$a]}" "${USER_TOKEN[$b]}" "${b}_$STAMP"
+  done
+done
+
+# 4 users -> 6 unordered pairs.
+PAIRS=(
+  "piper:sage"   "piper:rowan"  "piper:nico"
+  "sage:rowan"   "sage:nico"    "rowan:nico"
+)
+
+TOPICS=(generic tech music gaming generic tech)
+
+seed_log info "phase 3 — DMs"
+TOTAL=0
+for idx in "${!PAIRS[@]}"; do
+  pair="${PAIRS[$idx]}"
+  a="${pair%%:*}"
+  b="${pair##*:}"
+  topic="${TOPICS[$idx]}"
+  count=$((8 + RANDOM % 8))   # 8-15
+  seed_log dim "  $a <-> $b ($topic) — $count messages"
+  for ((j=0; j<count; j++)); do
+    if [ $((j % 2)) -eq 0 ]; then
+      sender="$a"; recipient="$b"
+    else
+      sender="$b"; recipient="$a"
+    fi
+    text="$(random_message_text "$topic")"
+    seed_dm_message "${USER_TOKEN[$sender]}" "${USER_ID[$recipient]}" "$text"
+    TOTAL=$((TOTAL + 1))
+  done
+done
+
+cat <<EOF
+
+==> seed v2 dms-only complete
+
+  users          : ${#USERNAMES[@]}  (prefix _$STAMP, password $PASSWORD)
+  pair threads   : ${#PAIRS[@]}
+  total messages : $TOTAL
+
+  login: any of ${USERNAMES[*]}_$STAMP / $PASSWORD
+EOF

--- a/scripts/seed_realistic_day.sh
+++ b/scripts/seed_realistic_day.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# scripts/seed_realistic_day.sh
+#
+# Exercises gaps the existing seeders miss:
+#   * a real rhythm to the day (standup, async chat, lunch lull, decision
+#     thread, EOD updates) instead of one big firehose
+#   * mixed plaintext + ENCRYPTED groups (is_encrypted=true), so the
+#     "[Encrypted]" placeholder + lock indicator code paths are populated
+#   * pairwise DMs alongside groups
+#   * varied presence states (online / away / dnd / invisible)
+#   * reply threads that actually branch — replies to several different
+#     parents, not all chained to the first message
+#
+# Usage:
+#   SEED_SERVER=http://localhost:8080 ./scripts/seed_realistic_day.sh
+#
+# Idempotency: usernames are prefixed with the current epoch second so
+# reruns create fresh accounts instead of colliding on the unique index.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./seed_v2_lib.sh
+source "$SCRIPT_DIR/seed_v2_lib.sh"
+
+SEED_SERVER="${SEED_SERVER:-http://localhost:8080}"
+PASSWORD="${PASSWORD:-seedv2pass}"
+STAMP="$(date +%s)"
+
+seed_log info "echo seed v2 — realistic day"
+seed_log dim  "server: $SEED_SERVER"
+seed_log dim  "stamp:  $STAMP (username prefix)"
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+# Six named personas with distinct bios + presence states so the seeded
+# sidebar lights up with the full range of status colours.
+USERNAMES=(riley morgan taylor jordan casey quinn)
+BIOS=(
+  "platform engineer · coffee enthusiast"
+  "designer · likes long ferries"
+  "qa lead · finds the bug you didn't write a test for"
+  "pm · still convinced standup could be a slack message"
+  "frontend · responsible for at least 30%% of the css"
+  "backend · postgres apologist"
+)
+STATUSES=(online online away dnd online invisible)
+TOPICS=(tech tech music gaming generic generic)
+
+declare -A USER_ID
+declare -A USER_TOKEN
+declare -A USER_TOPIC
+
+seed_log info "phase 1 — users"
+for i in "${!USERNAMES[@]}"; do
+  uname="${USERNAMES[$i]}_$STAMP"
+  bio="${BIOS[$i]}"
+  status="${STATUSES[$i]}"
+  topic="${TOPICS[$i]}"
+  seed_user "$uname" "$PASSWORD" "$bio" "$status"
+  USER_ID["${USERNAMES[$i]}"]="$SEED_USER_ID"
+  USER_TOKEN["${USERNAMES[$i]}"]="$SEED_USER_TOKEN"
+  USER_TOPIC["${USERNAMES[$i]}"]="$topic"
+  printf "    %-12s %s  [%s]\n" "$uname" "$SEED_USER_ID" "$status"
+done
+
+# ---------------------------------------------------------------------------
+# Contacts (all-to-all)
+# ---------------------------------------------------------------------------
+seed_log info "phase 2 — contacts (all-to-all)"
+for a in "${USERNAMES[@]}"; do
+  for b in "${USERNAMES[@]}"; do
+    [ "$a" = "$b" ] && continue
+    seed_contact_accept "${USER_TOKEN[$a]}" "${USER_TOKEN[$b]}" "${b}_$STAMP"
+  done
+done
+
+# ---------------------------------------------------------------------------
+# Groups (one plaintext, one encrypted)
+# ---------------------------------------------------------------------------
+seed_log info "phase 3 — groups"
+OWNER=riley
+seed_group "${USER_TOKEN[$OWNER]}" "Daily Standup ($STAMP)" \
+  "open team channel, plaintext" 0
+PLAINTEXT_GROUP="$SEED_GROUP_ID"
+seed_log ok "plaintext group: $PLAINTEXT_GROUP"
+
+seed_group "${USER_TOKEN[$OWNER]}" "Secure Room ($STAMP)" \
+  "encrypted team channel" 1
+ENCRYPTED_GROUP="$SEED_GROUP_ID"
+seed_log ok "encrypted group: $ENCRYPTED_GROUP"
+
+# Everyone else joins both groups.
+for u in "${USERNAMES[@]}"; do
+  [ "$u" = "$OWNER" ] && continue
+  seed_group_invite_accept "${USER_TOKEN[$OWNER]}" "${USER_TOKEN[$u]}" "$PLAINTEXT_GROUP"
+  seed_group_invite_accept "${USER_TOKEN[$OWNER]}" "${USER_TOKEN[$u]}" "$ENCRYPTED_GROUP"
+done
+
+# ---------------------------------------------------------------------------
+# Pairwise DMs
+# ---------------------------------------------------------------------------
+seed_log info "phase 4 — pairwise DMs"
+TOTAL_DMS=0
+# Pick a stable order of pairs.
+PAIRS=(
+  "riley:morgan"   "riley:taylor"   "morgan:jordan"
+  "taylor:casey"   "jordan:quinn"   "casey:quinn"
+)
+for pair in "${PAIRS[@]}"; do
+  a="${pair%%:*}"
+  b="${pair##*:}"
+  # 4-10 messages, alternating sender, distributed across the day.
+  count=$((4 + RANDOM % 7))
+  seed_log dim "  $a <-> $b — $count messages"
+  for ((j=0; j<count; j++)); do
+    if [ $((j % 2)) -eq 0 ]; then
+      sender="$a"; recipient="$b"
+    else
+      sender="$b"; recipient="$a"
+    fi
+    topic="${USER_TOPIC[$sender]}"
+    text="$(random_message_text "$topic")"
+    seed_dm_message "${USER_TOKEN[$sender]}" "${USER_ID[$recipient]}" "$text"
+    TOTAL_DMS=$((TOTAL_DMS + 1))
+  done
+done
+
+# ---------------------------------------------------------------------------
+# Group rhythm — plaintext group gets the realistic-day arc
+# ---------------------------------------------------------------------------
+seed_log info "phase 5 — plaintext group rhythm"
+TOTAL_GROUP_MSGS=0
+declare -a STANDUP_IDS=()
+declare -a ASYNC_IDS=()
+declare -a DECISION_IDS=()
+
+# 08:00 — standup (5 short messages, one per person who's "online" first).
+seed_log dim "  08:00 standup (5 msgs)"
+STANDUP_BLURBS=(
+  "morning, working on the auth refactor today"
+  "design review at 11 if anyone wants to weigh in"
+  "qa sweep on the new build, will post repros as i find them"
+  "stakeholder sync moved to 3, fyi"
+  "shipping the css token cleanup this morning"
+)
+for i in "${!STANDUP_BLURBS[@]}"; do
+  sender="${USERNAMES[$i]}"
+  seed_group_message "${USER_TOKEN[$sender]}" "$PLAINTEXT_GROUP" "${STANDUP_BLURBS[$i]}"
+  [ -n "$SEED_MESSAGE_ID" ] && STANDUP_IDS+=("$SEED_MESSAGE_ID")
+  TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+done
+
+# 09:30 — async chat (12 msgs, 2-3 reply threads).
+seed_log dim "  09:30 async chat (12 msgs + replies)"
+for ((i=0; i<12; i++)); do
+  sender="${USERNAMES[$((RANDOM % ${#USERNAMES[@]}))]}"
+  topic="${USER_TOPIC[$sender]}"
+  text="$(random_message_text "$topic")"
+  seed_group_message "${USER_TOKEN[$sender]}" "$PLAINTEXT_GROUP" "$text"
+  [ -n "$SEED_MESSAGE_ID" ] && ASYNC_IDS+=("$SEED_MESSAGE_ID")
+  TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+done
+
+# Branching: 3 reply threads, each replying to a different async parent.
+if [ "${#ASYNC_IDS[@]}" -ge 3 ]; then
+  parents=("${ASYNC_IDS[2]}" "${ASYNC_IDS[5]}" "${ASYNC_IDS[8]}")
+  for p in "${parents[@]}"; do
+    for r in 1 2; do
+      sender="${USERNAMES[$((RANDOM % ${#USERNAMES[@]}))]}"
+      text="$(random_message_text generic)"
+      seed_group_message "${USER_TOKEN[$sender]}" "$PLAINTEXT_GROUP" \
+        "$text" "$p"
+      TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+    done
+  done
+fi
+
+# 12:00 — lunch lull (1-2 msgs).
+seed_log dim "  12:00 lunch lull (2 msgs)"
+seed_group_message "${USER_TOKEN[casey]}" "$PLAINTEXT_GROUP" \
+  "anyone want anything from the cafe"
+TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+seed_group_message "${USER_TOKEN[quinn]}" "$PLAINTEXT_GROUP" \
+  "iced americano please, owe you one"
+TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+
+# 14:00 — decision thread (8 msgs, 4 replies).
+seed_log dim "  14:00 decision thread (8 msgs + 4 replies)"
+DECISIONS=(
+  "ok decision needed: do we ship the lounge fix in this patch or roll it forward?"
+  "personally i'd cut a patch — the perf regression hits the most-used screen"
+  "if we cut today we have to skip the icon update, that's the tradeoff"
+  "icon update can wait, lounge has more user impact"
+  "+1 to shipping today, qa already smoked the build"
+  "what's the rollback plan if it regresses live?"
+  "watchtower will pick up the previous tag in under 5 min, we've done it twice this month"
+  "ok consensus — patch today, icons next week. thanks all"
+)
+for i in "${!DECISIONS[@]}"; do
+  sender="${USERNAMES[$((i % ${#USERNAMES[@]}))]}"
+  seed_group_message "${USER_TOKEN[$sender]}" "$PLAINTEXT_GROUP" "${DECISIONS[$i]}"
+  [ -n "$SEED_MESSAGE_ID" ] && DECISION_IDS+=("$SEED_MESSAGE_ID")
+  TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+done
+
+# Branching: 4 replies to a mix of decision-thread parents.
+if [ "${#DECISION_IDS[@]}" -ge 6 ]; then
+  REPLY_TARGETS=("${DECISION_IDS[0]}" "${DECISION_IDS[2]}" "${DECISION_IDS[5]}" "${DECISION_IDS[6]}")
+  REPLY_TEXTS=(
+    "agree, let's call it"
+    "the icons can ride the next train"
+    "yeah rollback is well-rehearsed at this point"
+    "we should still write that runbook though"
+  )
+  for i in "${!REPLY_TARGETS[@]}"; do
+    sender="${USERNAMES[$(( (i + 1) % ${#USERNAMES[@]} ))]}"
+    seed_group_message "${USER_TOKEN[$sender]}" "$PLAINTEXT_GROUP" \
+      "${REPLY_TEXTS[$i]}" "${REPLY_TARGETS[$i]}"
+    TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+  done
+fi
+
+# 17:30 — EOD updates (5 msgs).
+seed_log dim "  17:30 EOD (5 msgs)"
+EOD_BLURBS=(
+  "shipped the auth refactor, no rollback"
+  "design system PR is up, would love eyes tomorrow"
+  "filed 3 bugs from the smoke pass, all p2 or below"
+  "calling it, see you all tomorrow"
+  "out till friday — coverage on the on-call rotation, thanks quinn"
+)
+for i in "${!EOD_BLURBS[@]}"; do
+  sender="${USERNAMES[$i]}"
+  seed_group_message "${USER_TOKEN[$sender]}" "$PLAINTEXT_GROUP" "${EOD_BLURBS[$i]}"
+  TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+done
+
+# ---------------------------------------------------------------------------
+# Encrypted group — populate with realistic ciphertext-shaped strings.
+# The server stores message.content verbatim; we can't drive the Signal
+# Protocol from bash, so the simplest faithful approximation is to post
+# strings that *look* like base64-wrapped ratchet wire so the client's
+# "[Encrypted]" placeholder and the lock indicator both render. NOT real
+# ciphertext — this is for UI exercise only.
+# ---------------------------------------------------------------------------
+seed_log info "phase 6 — encrypted group placeholders"
+random_b64() {
+  # Approx 120-char base64 string, no =, no newlines.
+  head -c 90 /dev/urandom | base64 | tr -d '=\n' | head -c 120
+}
+ENCRYPTED_MSG_COUNT=8
+for ((i=0; i<ENCRYPTED_MSG_COUNT; i++)); do
+  sender="${USERNAMES[$((i % ${#USERNAMES[@]}))]}"
+  fake_ct="$(random_b64)"
+  seed_group_message "${USER_TOKEN[$sender]}" "$ENCRYPTED_GROUP" "$fake_ct"
+  TOTAL_GROUP_MSGS=$((TOTAL_GROUP_MSGS + 1))
+done
+
+# ---------------------------------------------------------------------------
+# Reactions
+# ---------------------------------------------------------------------------
+seed_log info "phase 7 — reactions"
+REACTION_EMOJI=("👍" "🎉" "🚀" "❤" "👀" "🙌" "🔥" "✅" "🤔" "😂")
+ALL_IDS=("${STANDUP_IDS[@]}" "${ASYNC_IDS[@]}" "${DECISION_IDS[@]}")
+REACTION_COUNT=0
+TARGET_REACTIONS=15
+if [ "${#ALL_IDS[@]}" -gt 0 ]; then
+  for ((i=0; i<TARGET_REACTIONS; i++)); do
+    mid="${ALL_IDS[$((RANDOM % ${#ALL_IDS[@]}))]}"
+    emoji="${REACTION_EMOJI[$((RANDOM % ${#REACTION_EMOJI[@]}))]}"
+    reactor="${USERNAMES[$((RANDOM % ${#USERNAMES[@]}))]}"
+    seed_reaction "${USER_TOKEN[$reactor]}" "$mid" "$emoji"
+    REACTION_COUNT=$((REACTION_COUNT + 1))
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+cat <<EOF
+
+==> seed v2 realistic-day complete
+
+  users created       : ${#USERNAMES[@]}  (prefix _$STAMP, password $PASSWORD)
+  plaintext group     : Daily Standup ($STAMP) = $PLAINTEXT_GROUP
+  encrypted group     : Secure Room ($STAMP)  = $ENCRYPTED_GROUP
+  pairwise DM threads : ${#PAIRS[@]}
+  total DM messages   : $TOTAL_DMS
+  total group msgs    : $TOTAL_GROUP_MSGS
+  reactions seeded    : $REACTION_COUNT
+
+  login: any of ${USERNAMES[*]}_$STAMP / $PASSWORD
+EOF

--- a/scripts/seed_v2_lib.sh
+++ b/scripts/seed_v2_lib.sh
@@ -1,0 +1,417 @@
+#!/usr/bin/env bash
+# scripts/seed_v2_lib.sh — sourceable helper library for the Echo Messenger
+# seed-v2 scenario scripts.  Builds on the public REST + WS API only — no DB
+# access, no fixtures, no privileged endpoints — so it runs against localhost
+# or any reachable Echo server.
+#
+# Usage:
+#   source "$(dirname "$0")/seed_v2_lib.sh"
+#
+#   seed_user alice secret "bio" online
+#   echo "Created $SEED_USER_ID with token $SEED_USER_TOKEN"
+#
+# Conventions:
+#   - Bash 4+ (associative arrays, mapfile).
+#   - Functions that mint a user/group/message echo nothing; results are
+#     returned via the SEED_* globals listed beside each helper.
+#   - All HTTP requests go through `_seed_curl` so they share the same
+#     User-Agent (Cloudflare blocks no-UA) and timeout.
+#   - The base URL is `${SEED_SERVER:-http://localhost:8080}`.
+#
+# Required tools: curl, jq.  websocat is NOT required — seed_v2 sticks to REST
+# endpoints so it can run from minimal CI containers.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Error trap: print the failing line + command on any non-zero exit.
+# ---------------------------------------------------------------------------
+_seed_on_err() {
+  local line="$1" cmd="$2"
+  printf '\033[31mseed_v2_lib: failed at line %s: %s\033[0m\n' \
+    "$line" "$cmd" >&2
+}
+trap '_seed_on_err "$LINENO" "$BASH_COMMAND"' ERR
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+SEED_SERVER="${SEED_SERVER:-http://localhost:8080}"
+SEED_USER_AGENT="Mozilla/5.0 echo-seed"
+SEED_TIMEOUT="${SEED_TIMEOUT:-15}"
+
+# Last-call outputs.  Functions document which globals they populate.
+SEED_USER_ID=""
+SEED_USER_TOKEN=""
+SEED_GROUP_ID=""
+SEED_MESSAGE_ID=""
+SEED_DM_CONVERSATION_ID=""
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+# seed_log <level> <msg>    level in {info, warn, error, ok, dim}
+seed_log() {
+  local level="$1"; shift
+  local msg="$*"
+  local color reset='\033[0m'
+  case "$level" in
+    info)  color='\033[36m' ;;  # cyan
+    ok)    color='\033[32m' ;;  # green
+    warn)  color='\033[33m' ;;  # yellow
+    error) color='\033[31m' ;;  # red
+    dim)   color='\033[2m'  ;;  # dim
+    *)     color=''         ;;
+  esac
+  printf '%b[%s]%b %s\n' "$color" "$level" "$reset" "$msg" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Low-level HTTP
+# ---------------------------------------------------------------------------
+# _seed_curl <method> <path> [token] [json_body]
+# Echoes the response body. Non-2xx still echoes body so callers can inspect.
+_seed_curl() {
+  local method="$1" path="$2" token="${3:-}" body="${4:-}"
+  local args=(
+    -sS -m "$SEED_TIMEOUT"
+    -X "$method"
+    "$SEED_SERVER$path"
+    -H "Content-Type: application/json"
+    -H "User-Agent: $SEED_USER_AGENT"
+  )
+  [ -n "$token" ] && args+=(-H "Authorization: Bearer $token")
+  [ -n "$body" ]  && args+=(-d "$body")
+  curl "${args[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+# seed_user <username> <password> [bio] [status]
+#   Registers (or logs in if taken) and optionally sets profile + presence.
+#   Populates: SEED_USER_ID, SEED_USER_TOKEN
+seed_user() {
+  local username="$1" password="$2" bio="${3:-}" status="${4:-}"
+  local body resp
+  body=$(jq -nc --arg u "$username" --arg p "$password" \
+    '{username:$u, password:$p}')
+  resp=$(_seed_curl POST /api/auth/register "" "$body" || true)
+  if [ -z "$(jq -r '.access_token // empty' <<<"$resp" 2>/dev/null)" ]; then
+    # Username already exists (or registration rate-limited): fall back to login.
+    resp=$(_seed_curl POST /api/auth/login "" "$body")
+  fi
+  SEED_USER_ID=$(jq -r '.user_id // empty' <<<"$resp")
+  SEED_USER_TOKEN=$(jq -r '.access_token // empty' <<<"$resp")
+  if [ -z "$SEED_USER_ID" ] || [ -z "$SEED_USER_TOKEN" ]; then
+    seed_log error "register/login failed for $username: $resp"
+    return 1
+  fi
+  if [ -n "$bio" ]; then
+    local pbody
+    pbody=$(jq -nc --arg b "$bio" '{bio:$b}')
+    _seed_curl PATCH /api/users/me/profile "$SEED_USER_TOKEN" "$pbody" >/dev/null || true
+  fi
+  if [ -n "$status" ]; then
+    seed_set_presence "$SEED_USER_TOKEN" "$status" || true
+  fi
+}
+
+# seed_login <username> <password>
+#   Login-only; populates SEED_USER_ID + SEED_USER_TOKEN.
+seed_login() {
+  local username="$1" password="$2"
+  local body resp
+  body=$(jq -nc --arg u "$username" --arg p "$password" \
+    '{username:$u, password:$p}')
+  resp=$(_seed_curl POST /api/auth/login "" "$body")
+  SEED_USER_ID=$(jq -r '.user_id // empty' <<<"$resp")
+  SEED_USER_TOKEN=$(jq -r '.access_token // empty' <<<"$resp")
+  if [ -z "$SEED_USER_ID" ] || [ -z "$SEED_USER_TOKEN" ]; then
+    seed_log error "login failed for $username: $resp"
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Contacts
+# ---------------------------------------------------------------------------
+# seed_contact_accept <user_a_token> <user_b_token> <user_b_username>
+#   A sends request to B's username, B accepts.  Idempotent: already-contacts
+#   responses are silently ignored.
+seed_contact_accept() {
+  local a_token="$1" b_token="$2" b_username="$3"
+  local body resp contact_id
+  body=$(jq -nc --arg u "$b_username" '{username:$u}')
+  resp=$(_seed_curl POST /api/contacts/request "$a_token" "$body" || true)
+  contact_id=$(jq -r '.contact_id // empty' <<<"$resp" 2>/dev/null || true)
+  if [ -z "$contact_id" ]; then
+    return 0  # already contacts, or request rejected — fine
+  fi
+  local abody
+  abody=$(jq -nc --arg c "$contact_id" '{contact_id:$c}')
+  _seed_curl POST /api/contacts/accept "$b_token" "$abody" >/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Groups
+# ---------------------------------------------------------------------------
+# seed_group <owner_token> <name> [description] [is_encrypted=0]
+#   Creates a public group, optionally end-to-end encrypted.
+#   Populates: SEED_GROUP_ID
+seed_group() {
+  local owner_token="$1" name="$2" description="${3:-}" is_encrypted="${4:-0}"
+  local enc_bool=false
+  [ "$is_encrypted" = "1" ] || [ "$is_encrypted" = "true" ] && enc_bool=true
+  local body resp
+  body=$(jq -nc \
+    --arg n "$name" \
+    --arg d "$description" \
+    --argjson e "$enc_bool" \
+    '{name:$n, description:$d, is_public:true, is_encrypted:$e, member_ids:[]}')
+  resp=$(_seed_curl POST /api/groups "$owner_token" "$body")
+  SEED_GROUP_ID=$(jq -r '.id // empty' <<<"$resp")
+  if [ -z "$SEED_GROUP_ID" ]; then
+    seed_log error "group create failed: $resp"
+    return 1
+  fi
+}
+
+# seed_group_invite_accept <owner_token> <member_token> <group_id>
+#   Owner mints an invite, member accepts it.  Uses the public-invite flow so
+#   we don't need each member's user_id upfront.
+seed_group_invite_accept() {
+  local owner_token="$1" member_token="$2" group_id="$3"
+  local resp token abody
+  # Create a single-use invite (default expiry / max_uses left to server).
+  resp=$(_seed_curl POST "/api/groups/$group_id/invites" "$owner_token" '{}')
+  token=$(jq -r '.token // empty' <<<"$resp")
+  if [ -z "$token" ]; then
+    # Fallback: direct join via member token (works for public groups).
+    _seed_curl POST "/api/groups/$group_id/join" "$member_token" '{}' >/dev/null || true
+    return 0
+  fi
+  _seed_curl POST "/api/invites/$token/accept" "$member_token" '{}' >/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Messaging
+# ---------------------------------------------------------------------------
+# seed_dm_message <sender_token> <recipient_user_id> <plaintext>
+#   1:1 message via REST: POST /api/conversations/dm to ensure the conversation
+#   exists (idempotent — server returns the existing conversation_id), then
+#   the WS protocol's storage layer is NOT used here; we rely on the same
+#   POST-then-fetch shape the client uses today.  The actual send goes
+#   through the WS /ws endpoint via ws-ticket, mirroring what seed_full_demo
+#   does.  Confirmed the only server-side message-write paths are:
+#     - WS `send_message` frame (apps/server/src/ws/message_service/mod.rs)
+#     - There is NO REST POST /api/messages — get/list/edit/delete only.
+#   So we use a transient WS connection per send.
+#   Populates: SEED_DM_CONVERSATION_ID, SEED_MESSAGE_ID (best-effort)
+seed_dm_message() {
+  local sender_token="$1" recipient_user_id="$2" plaintext="$3"
+  # Find-or-create the DM conversation.
+  local body resp cid
+  body=$(jq -nc --arg p "$recipient_user_id" '{peer_user_id:$p}')
+  resp=$(_seed_curl POST /api/conversations/dm "$sender_token" "$body")
+  cid=$(jq -r '.conversation_id // empty' <<<"$resp")
+  if [ -z "$cid" ]; then
+    seed_log error "create_dm failed: $resp"
+    return 1
+  fi
+  SEED_DM_CONVERSATION_ID="$cid"
+  seed_group_message "$sender_token" "$cid" "$plaintext"
+}
+
+# seed_group_message <sender_token> <conversation_id> <plaintext> [reply_to_id]
+#   Sends a message into a group (or DM) conversation via WS.  Returns the
+#   most recent message id for that conversation in SEED_MESSAGE_ID (best
+#   effort; server message IDs aren't echoed back on the open frame, so we
+#   refetch /api/messages/<cid>?limit=1 after the send).
+seed_group_message() {
+  local sender_token="$1" cid="$2" plaintext="$3" reply_to_id="${4:-}"
+  local payload
+  if [ -n "$reply_to_id" ]; then
+    payload=$(jq -nc --arg cid "$cid" --arg t "$plaintext" --arg r "$reply_to_id" \
+      '{type:"send_message", conversation_id:$cid, content:$t, reply_to_id:$r}')
+  else
+    payload=$(jq -nc --arg cid "$cid" --arg t "$plaintext" \
+      '{type:"send_message", conversation_id:$cid, content:$t}')
+  fi
+  _seed_ws_send "$sender_token" "$payload"
+  # Best-effort: refetch the latest message id so callers can chain reactions
+  # / replies.  Only one round-trip per message — heavy seeders that don't
+  # need IDs should pass an empty $4 and ignore SEED_MESSAGE_ID.
+  local resp
+  resp=$(_seed_curl GET "/api/messages/$cid?limit=1" "$sender_token" || true)
+  SEED_MESSAGE_ID=$(jq -r '.[0].id // empty' <<<"$resp" 2>/dev/null || echo "")
+}
+
+# Internal: send one WS frame and tear the socket down.  Requires websocat.
+_seed_ws_send() {
+  local token="$1" payload="$2"
+  if ! command -v websocat >/dev/null 2>&1; then
+    seed_log error "websocat is required for WS sends (cargo install websocat)"
+    return 1
+  fi
+  local ticket_resp ticket ws_base
+  ticket_resp=$(_seed_curl POST /api/auth/ws-ticket "$token" '{}')
+  ticket=$(jq -r '.ticket // empty' <<<"$ticket_resp")
+  if [ -z "$ticket" ]; then
+    seed_log warn "ws-ticket failed (rate limit?); skipping send"
+    return 1
+  fi
+  ws_base="$(printf '%s' "$SEED_SERVER" \
+    | sed -e 's|^http://|ws://|' -e 's|^https://|wss://|')"
+  printf '%s' "$payload" \
+    | websocat --no-close -E "$ws_base/ws?ticket=$ticket" \
+        >/dev/null 2>&1 &
+  local pid=$!
+  sleep 0.6
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Reactions / Presence
+# ---------------------------------------------------------------------------
+# seed_reaction <sender_token> <message_id> <emoji>
+seed_reaction() {
+  local sender_token="$1" message_id="$2" emoji="$3"
+  local body
+  body=$(jq -nc --arg e "$emoji" '{emoji:$e}')
+  _seed_curl POST "/api/messages/$message_id/reactions" "$sender_token" "$body" \
+    >/dev/null || true
+}
+
+# seed_set_presence <token> <state>
+#   state in {online, away, dnd, invisible}.  The server-side enum does not
+#   include a literal "offline" — clients map offline → invisible — so this
+#   helper does the same.
+seed_set_presence() {
+  local token="$1" state="$2"
+  case "$state" in
+    offline) state="invisible" ;;
+    online|away|dnd|invisible) ;;
+    *)
+      seed_log warn "unknown presence '$state', falling back to online"
+      state="online" ;;
+  esac
+  local body
+  body=$(jq -nc --arg s "$state" '{status:$s}')
+  _seed_curl PATCH /api/users/me/status "$token" "$body" >/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Random / time helpers
+# ---------------------------------------------------------------------------
+# weighted_choice "70:20:10" "common:rare:epic"
+#   Echoes one of the colon-separated values according to the weights.
+weighted_choice() {
+  local weights_str="$1" values_str="$2"
+  IFS=':' read -ra weights <<<"$weights_str"
+  IFS=':' read -ra values  <<<"$values_str"
+  if [ "${#weights[@]}" -ne "${#values[@]}" ]; then
+    seed_log error "weighted_choice: weights/values length mismatch"
+    return 1
+  fi
+  local total=0 w
+  for w in "${weights[@]}"; do total=$((total + w)); done
+  local r=$((RANDOM % total))
+  local cum=0 i
+  for i in "${!weights[@]}"; do
+    cum=$((cum + weights[i]))
+    if [ "$r" -lt "$cum" ]; then
+      printf '%s' "${values[$i]}"
+      return 0
+    fi
+  done
+  printf '%s' "${values[-1]}"
+}
+
+# random_message_text [topic]    topic in {tech, gaming, music, generic}
+random_message_text() {
+  local topic="${1:-generic}"
+  local -a pool
+  case "$topic" in
+    tech)
+      pool=(
+        "Anyone else seeing flaky CI on the rust job today?"
+        "Just upgraded to flutter 3.41 and analyze is way faster."
+        "TIL postgres' DISTINCT ON beats GROUP BY for last-per-key."
+        "Push notifications on iOS background still mostly a mystery to me."
+        "Riverpod 3 migration is mostly fine if you avoid family providers."
+        "Anyone got a clean pattern for retrying websocket reconnects with jitter?"
+        "Docker BuildKit cache mounts saved me 10 min per build."
+        "End-to-end tests caught the bug, unit tests missed it. Again."
+        "Cargo audit flagged a transitive dep — checking if it's actually reachable."
+        "Cloudflare blocking curl with no UA cost me an hour today."
+      )
+      ;;
+    gaming)
+      pool=(
+        "anyone up for a few rounds tonight?"
+        "the new patch made the early game way more interesting"
+        "lol that lobby was rough, 3 disconnects"
+        "lfg ranked, need one more"
+        "honestly the soundtrack is doing all the heavy lifting"
+        "rng was not on our side that match"
+        "stream's up in 10 if anyone wants to watch"
+        "finally beat the boss after like 40 tries"
+        "loadout question: smg or rifle for objective?"
+        "vc on discord, mic check"
+      )
+      ;;
+    music)
+      pool=(
+        "new album dropped, listening on loop"
+        "anyone got recs in the same vibe as the latest Khruangbin?"
+        "found a sick lofi playlist for late night coding"
+        "saw them live last month — opener was actually better"
+        "the bass on this track is unreal with headphones"
+        "vinyl pressing finally arrived, no scratches"
+        "mixing my first track this weekend, wish me luck"
+        "spotify wrapped is gonna be embarrassing this year"
+        "midnights deluxe or just regular, which version"
+        "concert tickets next month, hype"
+      )
+      ;;
+    *)
+      pool=(
+        "morning everyone"
+        "lunch break, brb in 30"
+        "how's everyone's week going"
+        "rough day, going to log off early"
+        "did you see the news today"
+        "weekend plans?"
+        "coffee number 3 and still tired"
+        "anyone else completely swamped right now"
+        "sun finally came out, going for a walk"
+        "calling it a day, see you all tomorrow"
+      )
+      ;;
+  esac
+  printf '%s' "${pool[$((RANDOM % ${#pool[@]}))]}"
+}
+
+# backdate_seconds <offset_seconds>
+#   Echoes a UTC ISO-8601 timestamp `offset` seconds before now.  Used for
+#   building human-readable scenario summaries; note that the server stamps
+#   `messages.created_at` itself on insert — we can't backdate the row via
+#   the public API, only annotate the log output.
+backdate_seconds() {
+  local offset="$1"
+  date -u -d "@$(( $(date -u +%s) - offset ))" \
+    +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# ---------------------------------------------------------------------------
+# Sanity check on source: tools.
+# ---------------------------------------------------------------------------
+for _t in curl jq; do
+  if ! command -v "$_t" >/dev/null 2>&1; then
+    printf 'seed_v2_lib: missing required tool: %s\n' "$_t" >&2
+    return 1 2>/dev/null || exit 1
+  fi
+done
+unset _t


### PR DESCRIPTION
## Summary

Adds a seed-v2 library and two scenario scripts that exercise gaps the existing seeders miss. The existing `seed_demo_data.sh`, `seed_full_demo.sh`, and `seed_stress_data.sh` are unchanged.

## What ships

- **`scripts/seed_v2_lib.sh`** — sourceable helpers, REST + WS only (no DB access). Functions: `seed_user`, `seed_login`, `seed_contact_accept`, `seed_group` (with `is_encrypted` toggle), `seed_group_invite_accept`, `seed_dm_message`, `seed_group_message` (with `reply_to_id`), `seed_reaction`, `seed_set_presence`, `weighted_choice`, `random_message_text`, `backdate_seconds`, `seed_log`. Cloudflare-safe UA, `set -euo pipefail`, error trap that prints the failing line.
- **`scripts/seed_realistic_day.sh`** — 6 users with varied bios/presence, all-to-all contacts, one **plaintext** + one **encrypted** group (`is_encrypted=true`), all members join both, pairwise DMs (4-10 msgs each), and a realistic-day group rhythm: 08:00 standup, 09:30 async chat with **branching** reply threads (replies hit several different parents instead of all chaining to the first message), 12:00 lunch lull, 14:00 decision thread with 4 replies, 17:30 EOD. Plus ~15 reactions sprinkled across group messages.
- **`scripts/seed_dms_only.sh`** — minimal pure-DM fixture: 4 users, 6 pairwise DM threads of 8-15 messages each. No groups.
- One-paragraph mention in `CLAUDE.md`'s Build & Run section so the scripts are discoverable.

## Scenarios covered

- **DMs** (gap: existing seeders only do groups)
- **Encrypted groups** with `is_encrypted=true` so the `[Encrypted]` placeholder + lock indicator render. Posts ~120-char random-base64 strings as ciphertext placeholders since the Signal Protocol can't be driven from bash (file comment explains this).
- **Conversation branching** — replies hit multiple parents, not just one root.
- **Presence variety** — `online`, `away`, `dnd`, `invisible` (the server enum has no literal `offline`; the lib maps `offline → invisible`).
- **Realistic message rhythm** across the simulated day instead of one firehose burst.
- **Idempotency-ish reruns** via timestamp-prefixed usernames (`riley_1716345678`).

## Gaps remaining

- **Multi-device** — no programmatic way to provision a second device key bundle from bash. Future work.
- **Voice / video calls** — LiveKit signaling is interactive and not covered.
- **Push tokens** — no APNs/FCM seeding (requires real device tokens).
- **Backdated `created_at`** — the server stamps `messages.created_at` itself; the lib's `backdate_seconds` is annotation-only. Truly historical history needs DB access.
- **Disappearing-message TTL variants** — endpoint exists (`PUT /api/conversations/:id/disappearing`) but no scenario uses it yet. Easy follow-up.
- **@mentions / @here / @everyone** — server stores them as message text + extracts via the parsing pass; the new scripts don't drive that yet. Easy follow-up.

The motivator was an audit of what the current seeders don't exercise — the gaps above are documented inline in the lib so the next pass knows where to extend.

## Test plan

- [ ] Local: `cargo run -p echo-server` then `SEED_SERVER=http://localhost:8080 ./scripts/seed_realistic_day.sh` — verify 6 users land in the sidebar with varied presence dots, plaintext group has the standup/async/decision/EOD rhythm, encrypted group shows the lock indicator + `[Encrypted]` placeholders.
- [ ] Local: `./scripts/seed_dms_only.sh` — verify 4 users, 6 DM threads, no groups.
- [ ] `bash -n` on all three scripts passes (verified pre-merge).
- [ ] Existing seeders still work: spot-check `./scripts/seed_demo_data.sh`.