### PR TITLE
fix(client): voice lounge background-picker fits narrow viewports

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -580,7 +580,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
             ],
           ),
           content: SizedBox(
-            width: 400,
+            width: MediaQuery.sizeOf(dialogCtx).width.clamp(320.0, 440.0),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [


### PR DESCRIPTION
## Summary
The background-picker dialog had a hard-coded width of 400px, but it opens at 600px+ viewports — there is no safety net for 360-400px phones. Clamp to \`viewport.clamp(320, 440)\` so the dialog stays inside any screen that can trigger it.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`dart format\` clean

Part of the 2026-05-22 responsive audit (#1101).