### PR TITLE
refactor(client): adopt UserAvatar at inline-CircleAvatar sites

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -286,10 +286,13 @@ class ChatMessageList extends ConsumerWidget {
         child: MessageListSkeleton(),
       );
     } else if (messages.isEmpty && !isLoadingHistory) {
+      final peer = conv.members.where((m) => m.userId != myUserId).firstOrNull;
       child = KeyedSubtree(
         key: const ValueKey('empty'),
         child: EmptyMessagePlaceholder(
+          userId: peer?.userId ?? '',
           displayName: displayName,
+          avatarUrl: peer == null ? null : memberAvatars[peer.userId],
           onSayHi: onSayHi,
         ),
       );

--- a/apps/client/lib/src/widgets/chat_panel/empty_message_placeholder.dart
+++ b/apps/client/lib/src/widgets/chat_panel/empty_message_placeholder.dart
@@ -2,15 +2,20 @@
 import 'package:flutter/material.dart';
 
 import '../../theme/echo_theme.dart';
+import '../user_avatar.dart';
 
 class EmptyMessagePlaceholder extends StatelessWidget {
+  final String userId;
   final String displayName;
+  final String? avatarUrl;
   final VoidCallback onSayHi;
 
   const EmptyMessagePlaceholder({
     super.key,
+    required this.userId,
     required this.displayName,
     required this.onSayHi,
+    this.avatarUrl,
   });
 
   @override
@@ -19,13 +24,13 @@ class EmptyMessagePlaceholder extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          CircleAvatar(
+          UserAvatar(
+            userId: userId,
+            username: displayName,
+            avatarUrl: avatarUrl,
             radius: 28,
-            backgroundColor: context.accent,
-            child: Text(
-              displayName.isNotEmpty ? displayName[0].toUpperCase() : '?',
-              style: TextStyle(fontSize: 22, color: context.onAccent),
-            ),
+            bgColor: context.accent,
+            openProfileOnTap: false,
           ),
           const SizedBox(height: 12),
           Text(


### PR DESCRIPTION
Componentization sweep from the 2026-05-22 audit (#1099). Reviewed 11 inline `CircleAvatar` / `Container(shape: circle)` sites flagged as candidates for the canonical `UserAvatar` widget. Only one of the 11 actually represented a real user — the rest are static decoration, the user's own profile-editor card (with bespoke camera-button + accent-border overlay), or group/channel avatars.

## Behind the scenes
- `widgets/chat_panel/empty_message_placeholder.dart:22` — migrated to `UserAvatar(openProfileOnTap: false, bgColor: context.accent)`. Threaded the peer's `userId` and `avatarUrl` through `ChatMessageList` (already had `conv` + `myUserId` + `memberAvatars` in scope), so the empty 1:1 placeholder now shows the peer's real avatar when one is set instead of always falling back to an initial circle.

## Skipped (with reason)
Each of these was flagged by the audit but is not a user-avatar surface or would lose features if force-fit through `UserAvatar`'s API:

- `screens/settings/accessibility_section.dart:78` — static "Sam Patel" font-scale preview card. No real user.
- `screens/settings/account_section.dart:452` — the local user's own profile-card avatar. Has a hand-built stack: accent-coloured border ring, camera-button upload overlay, hard-coded `EchoTheme.online` dot, and a `NetworkImage` with custom `Authorization` headers. Migrating would either widen `UserAvatar`'s API significantly (a one-off use case) or drop the upload/auth-header features.
- `screens/join/join_preview_scaffold.dart:286` — `Icons.link_off_rounded` error icon, not a user.
- `screens/join/join_preview_scaffold.dart:366, 373` — group/server preview avatar (uses `iconUrl` and group-name initials, not a user).
- `screens/onboarding_wizard.dart:543` — avatar picker during signup. Includes a camera/upload overlay, accent border, and the user has no profile to open yet.
- `widgets/global_search_overlay.dart:630` — group result tile (uses `r.title`, not a user).
- `screens/group_info_screen/parts/header_section.dart:151, 159` — group header avatar with upload affordance. Not a user.
- `widgets/channel_column.dart:329` — group column header (uses `groupAvatarColor(conversation.id)`). Not a user.

Per the task's guidance, I did not widen `UserAvatar`'s API to force-fit the "own-profile card with upload affordance" cases — they are deliberately bespoke. A future componentization pass could introduce a separate `EditableOwnAvatar` widget shared between `account_section`, `onboarding_wizard`, and `header_section` (group upload variant), but that is outside the scope of this PR.

Refs #1099.

## Test plan
- [x] `flutter analyze --fatal-infos` — clean.
- [x] `flutter test test/widgets/chat_panel_test.dart test/widgets/chat_panel/` — 19/19 pass (includes the "empty placeholder renders with no messages" coverage).
- [ ] Visual: open a 1:1 chat with no history and confirm the empty-state circle now shows the peer's avatar image when set (was always a one-letter circle before).