### PR TITLE
refactor(client): adopt EmptyState at inline empty-state sites

### DIFF
--- a/apps/client/lib/src/screens/create_group_screen.dart
+++ b/apps/client/lib/src/screens/create_group_screen.dart
@@ -9,6 +9,7 @@ import '../providers/server_url_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
+import '../widgets/empty_state.dart';
 
 class CreateGroupScreen extends ConsumerStatefulWidget {
   const CreateGroupScreen({super.key});
@@ -270,12 +271,10 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
       return const Center(child: CircularProgressIndicator());
     }
     if (contactsState.contacts.isEmpty) {
-      return Center(
-        child: Text(
-          'No contacts available.\nAdd contacts first.',
-          textAlign: TextAlign.center,
-          style: TextStyle(color: context.textMuted),
-        ),
+      return const EmptyState(
+        icon: Icons.person_outline,
+        title: 'No contacts available.',
+        body: 'Add contacts first.',
       );
     }
     return ListView.builder(

--- a/apps/client/lib/src/screens/new_message_screen.dart
+++ b/apps/client/lib/src/screens/new_message_screen.dart
@@ -8,6 +8,7 @@ import '../providers/conversations_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/fuzzy_score.dart';
+import '../widgets/empty_state.dart';
 import '../widgets/settings/section_header.dart';
 import '../widgets/user_avatar.dart';
 
@@ -561,28 +562,9 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
         child: CircularProgressIndicator(color: context.accent, strokeWidth: 2),
       );
     }
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.person_search_outlined,
-              size: 48,
-              color: context.textMuted.withValues(alpha: 0.5),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              _query.isEmpty
-                  ? 'No contacts yet'
-                  : 'No contacts match "$_query"',
-              style: TextStyle(color: context.textSecondary, fontSize: 14),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
-      ),
+    return EmptyState(
+      icon: Icons.person_search_outlined,
+      title: _query.isEmpty ? 'No contacts yet' : 'No contacts match "$_query"',
     );
   }
 }

--- a/apps/client/lib/src/widgets/empty_state.dart
+++ b/apps/client/lib/src/widgets/empty_state.dart
@@ -17,8 +17,11 @@ class EmptyState extends StatelessWidget {
   /// Primary headline above the body copy.
   final String title;
 
-  /// Supporting copy describing what the user can do next.
-  final String body;
+  /// Supporting copy describing what the user can do next. When null the
+  /// body line and its 8 px gap are dropped so the title sits closer to the
+  /// badge — useful for compact contexts (autocomplete dropdowns, etc.)
+  /// where the title alone is enough.
+  final String? body;
 
   /// Optional CTA button label. When null, no button is rendered.
   final String? ctaLabel;
@@ -42,7 +45,7 @@ class EmptyState extends StatelessWidget {
     super.key,
     required this.icon,
     required this.title,
-    required this.body,
+    this.body,
     this.ctaLabel,
     this.onCta,
     this.secondaryCtaLabel,
@@ -78,18 +81,20 @@ class EmptyState extends StatelessWidget {
                 color: context.textPrimary,
               ),
             ),
-            const SizedBox(height: 8),
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 320),
-              child: Text(
-                body,
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: context.textSecondary,
-                  height: 1.4,
+            if (body != null) ...[
+              const SizedBox(height: 8),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 320),
+                child: Text(
+                  body!,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: context.textSecondary,
+                    height: 1.4,
+                  ),
                 ),
               ),
-            ),
+            ],
             if (ctaLabel != null) ...[
               const SizedBox(height: 16),
               // Wrap so the secondary CTA tucks under the primary on narrow


### PR DESCRIPTION
## Summary

The componentization audit (2026-05-22) listed 11+ sites where inline `Center > Column > Icon + Text` empty-state trees should be migrated to the canonical `EmptyState` widget in `apps/client/lib/src/widgets/empty_state.dart`. After auditing each site, two needed migration; the rest were already migrated or are intentionally compact placeholders that wouldn't fit the illustrated EmptyState's 64 px badge.

Refs #1100.

## Migrated

- `apps/client/lib/src/screens/new_message_screen.dart:558` — the autocomplete empty-state in the chip-based new-message composer. Title varies by query (`No contacts yet` vs `No contacts match "$_query"`), no body. Replaced the bespoke `Center > Padding > Column > Icon + Text` with `EmptyState(icon: Icons.person_search_outlined, title: ...)`.
- `apps/client/lib/src/screens/create_group_screen.dart:272` — the contacts-list empty-state in the create-group member picker. Previous text was `'No contacts available.\nAdd contacts first.'` split across two visual lines; now title = `No contacts available.`, body = `Add contacts first.`, icon = `Icons.person_outline` to match the contacts-screen empty-state. (The original pattern had no icon — adding one is unavoidable because `EmptyState` requires it. Picked the icon already used on the sibling contacts screen for consistency.)

## EmptyState API tweak

`EmptyState.body` is now optional (`String?` instead of `required String`). The new-message composer empty-state has only a title in its dropdown, and forcing callers to invent body copy just to satisfy the signature would be worse than allowing the title-only layout. When `body` is null the body text and its 8 px gap are skipped; all existing call sites pass a body and render unchanged.

## Skipped (with reasons)

- `apps/client/lib/src/screens/contacts_screen.dart:538` — already uses `EmptyState` (no migration needed).
- `apps/client/lib/src/screens/admin/admin_dashboard_screen.dart:101` — already uses `EmptyState`.
- `apps/client/lib/src/screens/discover_groups_screen.dart:486` — already uses `EmptyState`.
- `apps/client/lib/src/screens/home_screen/parts/listeners.dart:110` — already uses `EmptyState`.
- `apps/client/lib/src/screens/saved_messages_screen.dart:72` — already uses `EmptyState`.
- `apps/client/lib/src/widgets/quick_switcher_overlay.dart:244` — single `Text('No results')` inside the cmd-K overlay's result-list area. The overlay is intentionally tight (~480 px wide, list flexes to remaining space); a 64 px illustrated badge would dominate the surface and feel like a different component. Kept as a compact inline placeholder.
- `apps/client/lib/src/widgets/emoji_picker_config.dart:32` — the `noRecents` slot of the third-party `emoji_picker_flutter` `Config`. Plugin expects a small inline widget for the recents tab; an illustrated `EmptyState` would be out of scale and visually break the tab. Kept as a small `Text`.
- `apps/client/lib/src/screens/voice_lounge/participant_grid.dart:76` — `_buildPlaceholder` is a shared helper also used for the transient `'Connecting to voice...'` message and for narrow compact-grid layouts. Migrating only the empty case would fork the helper, and `EmptyState`'s badge is the wrong scale for the compact voice-grid tile. Kept as a compact centered text.
- `apps/client/lib/src/widgets/channel_bar.dart:190` — `_channelStatusLabel` returns a `String` for the channel-bar status row (loading vs empty); it isn't a widget tree at all. Not an empty-state surface in the widget sense.
- `apps/client/lib/src/widgets/channel_bar.dart:1141` — a single italicised `Text('No one in voice yet')` inside the voice-channel peek popover (small floating panel anchored to a channel row). An illustrated `EmptyState` would balloon the popover. Kept as inline copy.

## Test plan

- [x] `dart format` on the three changed files
- [x] `flutter analyze --fatal-infos` on the three changed files — no issues
- [x] `flutter test test/screens/new_message_screen_test.dart test/widgets/create_group_screen_test.dart` — 9/9 pass
- [x] `flutter test test/screens/home_screen_test.dart test/screens/admin/admin_dashboard_screen_test.dart` — 23/23 pass (verifies the `body`-optional change doesn't break existing `EmptyState` callers)
- [ ] CI: lint, dev-build (web + linux) on push