### PR TITLE
perf(client): smoother chat scrolling with wider list cache

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -252,6 +252,12 @@ class ChatMessageList extends ConsumerWidget {
       child: ListView.builder(
         controller: scrollController,
         padding: const EdgeInsets.only(bottom: 16),
+        // Pre-build ~one viewport of off-screen messages on each side so that
+        // momentum scrolling doesn't flash blank space while items mount. The
+        // Flutter default of 250 is too tight for chat where rows include
+        // images, reactions, and reply quotes that each take a frame to lay
+        // out. Tuned conservatively to keep memory in check on long histories.
+        cacheExtent: 600,
         itemCount: messages.length + 1,
         itemBuilder: (context, index) {
           if (index == 0) {


### PR DESCRIPTION
## Summary
The chat \`ListView.builder\` had no explicit \`cacheExtent\`, defaulting to 250px. For messages that include images, reactions, and reply quotes — each requiring a frame to lay out — momentum scrolling occasionally flashed blank space before items mounted. Bump to 600px (about one viewport) so the visible window stays warm during fast scrolling.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test test/widgets/chat_panel/\` — 4/4 pass

## Behind the scenes
Single-line change in \`chat_message_list.dart\`. No behaviour change, only smoother scrolling.