### PR TITLE
refactor(client): adopt copyToClipboard helper at raw Clipboard.setData sites

### DIFF
--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;

--- a/apps/client/lib/src/screens/group_info_screen/parts/invite_section.dart
+++ b/apps/client/lib/src/screens/group_info_screen/parts/invite_section.dart
@@ -28,12 +28,11 @@ extension _InviteSection on _GroupInfoScreenState {
       if (response.statusCode == 201) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
         final url = data['url'] as String? ?? '';
-        await Clipboard.setData(ClipboardData(text: url));
         if (mounted) {
-          ToastService.show(
+          await copyToClipboard(
             context,
-            'Invite link copied to clipboard',
-            type: ToastType.success,
+            url,
+            successMessage: 'Invite link copied to clipboard',
           );
         }
       } else {

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -15,6 +14,7 @@ import '../../providers/crypto_provider.dart';
 import '../../providers/server_url_provider.dart';
 import '../../providers/update_provider.dart';
 import '../../providers/websocket_provider.dart';
+import '../../services/clipboard_service.dart';
 import '../../services/debug_log_service.dart';
 import '../../services/message_cache.dart';
 import '../../services/secure_key_store.dart';
@@ -765,14 +765,12 @@ class _DebugLogsSubpageState extends State<_DebugLogsSubpage> {
       };
       buffer.writeln('$h:$m:$s [$level] ${e.source}: ${e.message}');
     }
-    Clipboard.setData(ClipboardData(text: buffer.toString()));
-    if (mounted) {
-      ToastService.show(
-        context,
-        '${entries.length} log entries copied to clipboard',
-        type: ToastType.success,
-      );
-    }
+    if (!mounted) return;
+    copyToClipboard(
+      context,
+      buffer.toString(),
+      successMessage: '${entries.length} log entries copied to clipboard',
+    );
   }
 
   void _onLogsChanged() {
@@ -916,11 +914,10 @@ class _DebugLogEntryTileState extends State<_DebugLogEntryTile> {
       LogLevel.fatal => 'FTL',
     };
     final text = '$h:$m:$s [$level] ${entry.source}: ${entry.message}';
-    Clipboard.setData(ClipboardData(text: text));
-    ToastService.show(
+    copyToClipboard(
       context,
-      'Log entry copied to clipboard',
-      type: ToastType.success,
+      text,
+      successMessage: 'Log entry copied to clipboard',
     );
   }
 

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -9,6 +9,7 @@ import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../providers/auth_provider.dart';
 import '../../providers/server_url_provider.dart';
+import '../../services/clipboard_service.dart';
 import '../../services/toast_service.dart';
 import '../../services/upload_client.dart';
 import '../../theme/echo_theme.dart';
@@ -340,11 +341,10 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     if (username.isEmpty) return;
     final link =
         'https://echo-messenger.us/#/u/${Uri.encodeComponent(username)}';
-    Clipboard.setData(ClipboardData(text: link));
-    ToastService.show(
+    copyToClipboard(
       context,
-      'Invite link copied to clipboard',
-      type: ToastType.success,
+      link,
+      successMessage: 'Invite link copied to clipboard',
     );
   }
 
@@ -409,11 +409,10 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
             const SizedBox(height: 12),
             OutlinedButton.icon(
               onPressed: () {
-                Clipboard.setData(ClipboardData(text: inviteLink));
-                ToastService.show(
+                copyToClipboard(
                   dialogContext,
-                  'Invite link copied to clipboard',
-                  type: ToastType.success,
+                  inviteLink,
+                  successMessage: 'Invite link copied to clipboard',
                 );
               },
               icon: const Icon(Icons.copy, size: 16),

--- a/apps/client/lib/src/widgets/connection_status_badge.dart
+++ b/apps/client/lib/src/widgets/connection_status_badge.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/server_url_provider.dart';
 import '../providers/websocket_provider.dart';
-import '../services/toast_service.dart';
+import '../services/clipboard_service.dart';
 import '../theme/echo_theme.dart';
 import '../version.dart';
 import 'echo_bottom_sheet.dart';
@@ -461,12 +460,10 @@ class _ConnectionStatusPopoverState
                           serverUrl: serverUrl,
                           platform: Theme.of(context).platform,
                         );
-                        await Clipboard.setData(ClipboardData(text: text));
-                        if (!context.mounted) return;
-                        ToastService.show(
+                        await copyToClipboard(
                           context,
-                          'Diagnostics copied',
-                          type: ToastType.success,
+                          text,
+                          successMessage: 'Diagnostics copied',
                         );
                       },
                     )

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -12,6 +12,7 @@ import 'package:photo_manager/photo_manager.dart' show PhotoManager;
 
 import '../models/chat_message.dart';
 import '../providers/theme_provider.dart' show MessageLayout, UIDensity;
+import '../services/clipboard_service.dart';
 import '../services/message_cache.dart' show MessageCache;
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
@@ -1438,19 +1439,15 @@ class _MessageItemState extends State<MessageItem>
 
   void _copyMessageText(ChatMessage msg, String? mediaUrl) {
     final copyText = mediaUrl != null ? _resolveUrl(mediaUrl) : msg.content;
-    Clipboard.setData(ClipboardData(text: copyText));
-    if (!mounted) return;
-    ToastService.show(
+    copyToClipboard(
       context,
-      mediaUrl != null ? 'Link copied' : 'Copied to clipboard',
-      type: ToastType.success,
+      copyText,
+      successMessage: mediaUrl != null ? 'Link copied' : 'Copied to clipboard',
     );
   }
 
   void _copyMessageId(ChatMessage msg) {
-    Clipboard.setData(ClipboardData(text: msg.id));
-    if (!mounted) return;
-    ToastService.show(context, 'Message ID copied', type: ToastType.success);
+    copyToClipboard(context, msg.id, successMessage: 'Message ID copied');
   }
 
   /// Compose a single composite semantic label for the message bubble so


### PR DESCRIPTION
## Summary

Migrates 8 raw `Clipboard.setData(...) + ToastService.show(..., type: ToastType.success)` pairs to the existing `copyToClipboard(context, text, successMessage: ...)` helper in `services/clipboard_service.dart`. Toast wording is preserved verbatim; the helper API is unchanged.

## Migrated sites

- `screens/settings/account_section.dart:343` — `_copyInviteLink` (invite URL).
- `screens/settings/account_section.dart:412` — QR-code dialog "Copy invite link" button (uses `dialogContext`).
- `screens/settings/about_section.dart:768` — bulk copy of debug-log entries.
- `screens/settings/about_section.dart:919` — copy a single debug-log entry.
- `screens/group_info_screen/parts/invite_section.dart:31` — copy freshly-minted group invite URL.
- `widgets/connection_status_badge.dart:464` — diagnostics popover copy.
- `widgets/message_item.dart:1441` — `_copyMessageText` (message body or media URL).
- `widgets/message_item.dart:1451` — `_copyMessageId`.

## Skipped sites and why

- `screens/settings/data_storage_section.dart:84` — the surrounding `ToastService.show` omits the `type:` arg, so it defaults to `ToastType.info`. The helper hard-codes `success`, so migrating would change the toast type.
- `widgets/image_gallery_viewer.dart:145` — fallback path uses `ToastType.info` ("Save not supported here. Link copied.").
- `widgets/message_item.dart:313, 356` — both are fallback paths that surface `ToastType.info` ("Save not supported here yet. Link copied.", "Image copy not supported, link copied").
- `widgets/message/media_content.dart:307` — fallback path uses `ToastType.info`.
- `widgets/chat_input_bar/parts/keyboard_handling.dart:77` — Ctrl+C / Ctrl+X keyboard handler; intentionally has no toast and isn't a "copy" UX surface.

## Behind the scenes

- Drops now-unused `flutter/services.dart` and `toast_service.dart` imports from files that no longer reference them.
- `flutter analyze --fatal-infos` is clean; `dart format` is a no-op on the touched files.
- Affected widget tests pass (`account_section_test`, `about_section_test`, `connection_status_badge_test`, `message_item_test` — 51/51).

## Test plan

- [ ] Settings → Account → "Copy invite link" still shows the existing toast.
- [ ] Settings → About → Debug logs → copy all + copy single still show their toasts.
- [ ] Group info → generate invite link still shows the existing toast.
- [ ] Connection status popover → diagnostics copy still shows the existing toast.
- [ ] Message context menu → copy message + copy ID still show their toasts.