### PR TITLE
build: exclude platform-conditional files from sonar coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,11 @@ sonar.test.inclusions=**/*_test.dart,**/*_test.rs,**/tests/**
 # Exclusions
 sonar.exclusions=**/build/**,**/target/**,**/.dart_tool/**,**/generated/**,**/*.g.dart,**/*.freezed.dart
 
+# Coverage exclusions — files that aren't reasonably unit-testable. Headline
+# coverage % should reflect testable surface area, not platform-conditional
+# stubs or process-entry orchestration. Tracked in #1103.
+sonar.coverage.exclusions=**/*_io.dart,**/*_web.dart,**/*_stub.dart,**/main.dart,apps/server/src/main.rs
+
 # Coverage (imported from CI artifacts)
 sonar.dart.lcov.reportPaths=apps/client/coverage/lcov.info
 sonar.rust.lcov.reportPaths=coverage/rust/lcov.info


### PR DESCRIPTION
## Summary
Adds \`sonar.coverage.exclusions\` so the project's coverage % reflects testable surface area, not platform-conditional stubs and process-entry orchestration.

Excluded patterns:
- \`**/*_io.dart\` (dart:io variants)
- \`**/*_web.dart\` (web variants)
- \`**/*_stub.dart\` (no-op stubs)
- \`**/main.dart\` (Flutter entry point)
- \`apps/server/src/main.rs\` (server startup orchestration)

## Test plan
- No code change — only Sonar configuration. Verify the next CI run on this PR uploads coverage and the dashboard reflects the new exclusions.

Resolves #1103.