### PR TITLE
fix(client): profile and group-info dialogs fit narrow viewports

### DIFF
--- a/apps/client/lib/src/widgets/profile_sheets.dart
+++ b/apps/client/lib/src/widgets/profile_sheets.dart
@@ -8,13 +8,16 @@ import 'echo_bottom_sheet.dart';
 
 /// Opens the user profile in a bottom sheet on mobile or a dialog on desktop.
 ///
-/// On screens >= 900 px wide a centred [Dialog] (400 x 500) is shown.
+/// On screens >= 700 px wide a centred [Dialog] is shown, sized to fit the
+/// viewport (clamped to 360-480 wide, 400-600 tall, ≤90 % of viewport height).
 /// On narrower screens an [showEchoBottomSheet] is opened with a drag
 /// handle, capped at ~85 % of the viewport height so chat context stays
 /// visible above it.
 void showUserProfileSheet(BuildContext context, WidgetRef ref, String userId) {
-  final width = MediaQuery.of(context).size.width;
-  if (width >= 900) {
+  final mq = MediaQuery.of(context).size;
+  if (mq.width >= 700) {
+    final dialogWidth = mq.width.clamp(360.0, 480.0);
+    final dialogHeight = (mq.height * 0.9).clamp(400.0, 600.0);
     showDialog<void>(
       context: context,
       builder: (_) => Dialog(
@@ -24,8 +27,8 @@ void showUserProfileSheet(BuildContext context, WidgetRef ref, String userId) {
           side: BorderSide(color: context.border),
         ),
         child: SizedBox(
-          width: 400,
-          height: 500,
+          width: dialogWidth,
+          height: dialogHeight,
           child: UserProfileScreen(userId: userId),
         ),
       ),
@@ -42,16 +45,18 @@ void showUserProfileSheet(BuildContext context, WidgetRef ref, String userId) {
 
 /// Opens the group info panel in a bottom sheet on mobile or a dialog on desktop.
 ///
-/// On screens >= 900 px wide a wide [Dialog] (680 x 600) is shown.
-/// On narrower screens an [showEchoBottomSheet] is opened with a drag
-/// handle.
+/// On screens >= 800 px wide a wide [Dialog] is shown, sized to fit the
+/// viewport (clamped to 480-760 wide, 480-720 tall, ≤90 % of viewport height).
+/// On narrower screens an [showEchoBottomSheet] is opened with a drag handle.
 void showGroupProfileSheet(
   BuildContext context,
   WidgetRef ref,
   String conversationId,
 ) {
-  final width = MediaQuery.of(context).size.width;
-  if (width >= 900) {
+  final mq = MediaQuery.of(context).size;
+  if (mq.width >= 800) {
+    final dialogWidth = mq.width.clamp(480.0, 760.0);
+    final dialogHeight = (mq.height * 0.9).clamp(480.0, 720.0);
     showDialog<void>(
       context: context,
       builder: (_) => Dialog(
@@ -61,8 +66,8 @@ void showGroupProfileSheet(
           side: BorderSide(color: context.border),
         ),
         child: SizedBox(
-          width: 680,
-          height: 600,
+          width: dialogWidth,
+          height: dialogHeight,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(16),
             child: GroupInfoScreen(conversationId: conversationId),


### PR DESCRIPTION
## Summary
Both \`showUserProfileSheet\` and \`showGroupProfileSheet\` had hard-coded dialog sizes (400x500 and 680x600) and opened only above 900px width. On shorter laptops in landscape (e.g. 1280x720) and on 700-900px tablets they overflowed or refused to open as a dialog. Both now clamp width and height to the viewport with sensible min/max bounds.

## Fixed
- \`showUserProfileSheet\` — 360-480 wide, 400-600 tall, ≤90% viewport height. Breakpoint lowered to 700px.
- \`showGroupProfileSheet\` — 480-760 wide, 480-720 tall, ≤90% viewport height. Breakpoint lowered to 800px.

Below those breakpoints the bottom-sheet path is unchanged.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`dart format\` clean

Part of the 2026-05-22 responsive audit (#1101).