### PR TITLE
test(client): baseline coverage for quick-switcher and message-search overlays

### DIFF
--- a/apps/client/test/widgets/message_search_overlay_test.dart
+++ b/apps/client/test/widgets/message_search_overlay_test.dart
@@ -1,0 +1,433 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/widgets/message_search_overlay.dart';
+
+import '../helpers/mock_providers.dart';
+
+/// Build a server payload matching what /api/conversations/{id}/search returns.
+String _payload(List<Map<String, dynamic>> messages) => jsonEncode(messages);
+
+Map<String, dynamic> _msg({
+  required String id,
+  required String content,
+  String username = 'alice',
+  String? createdAt,
+}) => {
+  'message_id': id,
+  'conversation_id': 'conv-1',
+  'sender_id': 'user-alice',
+  'sender_username': username,
+  'content': content,
+  'created_at': createdAt ?? '2026-01-15T10:30:00Z',
+};
+
+Widget _wrap({
+  required ValueChanged<String> onMessageSelected,
+  required VoidCallback onClose,
+  String conversationId = 'conv-1',
+}) {
+  return ProviderScope(
+    overrides: [authOverride(loggedInAuthState), serverUrlOverride()],
+    child: MaterialApp(
+      theme: EchoTheme.darkTheme,
+      darkTheme: EchoTheme.darkTheme,
+      themeMode: ThemeMode.dark,
+      home: Scaffold(
+        body: MessageSearchOverlay(
+          conversationId: conversationId,
+          onMessageSelected: onMessageSelected,
+          onClose: onClose,
+        ),
+      ),
+    ),
+  );
+}
+
+/// Drive the search debounce: the overlay waits 400ms after the last
+/// keystroke before calling the server.
+Future<void> _flushDebounce(WidgetTester tester) async {
+  await tester.pump(const Duration(milliseconds: 450));
+  // Let the MockClient future resolve and the setState fire.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  testWidgets('empty initial state renders text field but no results or '
+      'empty-state copy', (tester) async {
+    await tester.pumpWidget(_wrap(onMessageSelected: (_) {}, onClose: () {}));
+    await tester.pump();
+
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.text('No results found'), findsNothing);
+    expect(find.byType(ListView), findsNothing);
+  });
+
+  testWidgets('typed query fetches results from the server', (tester) async {
+    String? capturedQuery;
+
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'hello');
+        await _flushDebounce(tester);
+
+        expect(find.textContaining('hello world'), findsOneWidget);
+        expect(find.textContaining('hello there'), findsOneWidget);
+      },
+      () => MockClient((request) async {
+        if (request.url.path.endsWith('/api/conversations/conv-1/search')) {
+          capturedQuery = request.url.queryParameters['q'];
+          return http.Response(
+            _payload([
+              _msg(id: 'm1', content: 'hello world'),
+              _msg(id: 'm2', content: 'hello there', username: 'bob'),
+            ]),
+            200,
+          );
+        }
+        return http.Response('not found', 404);
+      }),
+    );
+
+    expect(capturedQuery, 'hello');
+  });
+
+  testWidgets('whitespace-only query does NOT hit the server', (tester) async {
+    var requestCount = 0;
+
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), '   ');
+        await _flushDebounce(tester);
+
+        expect(find.text('No results found'), findsNothing);
+      },
+      () => MockClient((request) async {
+        requestCount++;
+        return http.Response(_payload(const []), 200);
+      }),
+    );
+
+    expect(requestCount, 0);
+  });
+
+  testWidgets('empty result set shows "No results found"', (tester) async {
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'nope');
+        await _flushDebounce(tester);
+
+        expect(find.text('No results found'), findsOneWidget);
+      },
+      () =>
+          MockClient((request) async => http.Response(_payload(const []), 200)),
+    );
+  });
+
+  testWidgets('server error shows the empty-state copy, not a crash', (
+    tester,
+  ) async {
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'boom');
+        await _flushDebounce(tester);
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('No results found'), findsOneWidget);
+      },
+      () => MockClient((request) async => http.Response('internal error', 500)),
+    );
+  });
+
+  testWidgets('network exception is swallowed and shows empty state', (
+    tester,
+  ) async {
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'crash');
+        await _flushDebounce(tester);
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('No results found'), findsOneWidget);
+      },
+      () => MockClient((request) {
+        throw Exception('network down');
+      }),
+    );
+  });
+
+  testWidgets('tapping a result row fires onMessageSelected with the id', (
+    tester,
+  ) async {
+    String? selectedId;
+
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (id) => selectedId = id, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'pick');
+        await _flushDebounce(tester);
+
+        await tester.tap(find.textContaining('second result'));
+        await tester.pump();
+      },
+      () => MockClient((request) async {
+        return http.Response(
+          _payload([
+            _msg(id: 'm-first', content: 'first result'),
+            _msg(id: 'm-second', content: 'second result', username: 'bob'),
+          ]),
+          200,
+        );
+      }),
+    );
+
+    expect(selectedId, 'm-second');
+  });
+
+  testWidgets('Escape key fires onClose', (tester) async {
+    var closeCount = 0;
+    await tester.pumpWidget(
+      _wrap(onMessageSelected: (_) {}, onClose: () => closeCount++),
+    );
+
+    // Give the KeyboardListener's FocusNode time to claim focus.
+    await tester.pump();
+    final focusNode = tester
+        .widgetList<KeyboardListener>(find.byType(KeyboardListener))
+        .first
+        .focusNode;
+    focusNode.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(closeCount, 1);
+  });
+
+  testWidgets('close button (X icon) fires onClose', (tester) async {
+    var closeCount = 0;
+    await tester.pumpWidget(
+      _wrap(onMessageSelected: (_) {}, onClose: () => closeCount++),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Close search'));
+    await tester.pump();
+
+    expect(closeCount, 1);
+  });
+
+  testWidgets('clear (X) button only appears once a query has results', (
+    tester,
+  ) async {
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        // Before any query: only the close button (tooltip "Close search").
+        expect(find.byIcon(Icons.clear), findsNothing);
+
+        await tester.enterText(find.byType(TextField), 'hello');
+        await _flushDebounce(tester);
+
+        // After the search resolves, the clear icon appears.
+        expect(find.byIcon(Icons.clear), findsOneWidget);
+      },
+      () => MockClient((request) async {
+        return http.Response(
+          _payload([_msg(id: 'm1', content: 'hello world')]),
+          200,
+        );
+      }),
+    );
+  });
+
+  testWidgets('clear button wipes results and the empty-state copy', (
+    tester,
+  ) async {
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'hello');
+        await _flushDebounce(tester);
+        expect(find.textContaining('hello world'), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.clear));
+        await tester.pump();
+
+        expect(find.textContaining('hello world'), findsNothing);
+        expect(find.text('No results found'), findsNothing);
+      },
+      () => MockClient((request) async {
+        return http.Response(
+          _payload([_msg(id: 'm1', content: 'hello world')]),
+          200,
+        );
+      }),
+    );
+  });
+
+  testWidgets('debounce coalesces rapid keystrokes into a single request', (
+    tester,
+  ) async {
+    var requestCount = 0;
+    final queries = <String>[];
+
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        // Three keystrokes within the 400ms window.
+        await tester.enterText(find.byType(TextField), 'h');
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.enterText(find.byType(TextField), 'he');
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.enterText(find.byType(TextField), 'hel');
+        await _flushDebounce(tester);
+      },
+      () => MockClient((request) async {
+        requestCount++;
+        queries.add(request.url.queryParameters['q'] ?? '');
+        return http.Response(_payload(const []), 200);
+      }),
+    );
+
+    expect(requestCount, 1);
+    expect(queries.single, 'hel');
+  });
+
+  testWidgets('results are sorted by fuzzy score (closer match wins)', (
+    tester,
+  ) async {
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'cat');
+        await _flushDebounce(tester);
+
+        // Both messages match in some way; the exact-substring "cat" should
+        // out-rank the scattered "c...a...t" match in "concatenate".
+        final exactFinder = find.textContaining('cat sat');
+        final scatteredFinder = find.textContaining('concatenate');
+        expect(exactFinder, findsOneWidget);
+        expect(scatteredFinder, findsOneWidget);
+
+        final exactY = tester.getTopLeft(exactFinder).dy;
+        final scatteredY = tester.getTopLeft(scatteredFinder).dy;
+        expect(
+          exactY,
+          lessThan(scatteredY),
+          reason: 'Exact substring match should sort above scattered match',
+        );
+      },
+      () => MockClient((request) async {
+        // Server is unsorted — overlay re-sorts client-side by fuzzy score.
+        return http.Response(
+          _payload([
+            _msg(id: 'm-scatter', content: 'concatenate later'),
+            _msg(id: 'm-exact', content: 'cat sat on a mat'),
+          ]),
+          200,
+        );
+      }),
+    );
+  });
+
+  testWidgets(
+    'long message content is truncated to 80 characters with ellipsis',
+    (tester) async {
+      final longContent = 'x' * 200; // way past the 80-char cap
+      await http.runWithClient(
+        () async {
+          await tester.pumpWidget(
+            _wrap(onMessageSelected: (_) {}, onClose: () {}),
+          );
+
+          await tester.enterText(find.byType(TextField), 'xxx');
+          await _flushDebounce(tester);
+
+          // The visible row should NOT contain the full 200-char string.
+          expect(find.text(longContent), findsNothing);
+          // It SHOULD contain the truncated form ending with '...'.
+          expect(find.textContaining('...'), findsWidgets);
+        },
+        () => MockClient((request) async {
+          return http.Response(
+            _payload([_msg(id: 'm-long', content: longContent)]),
+            200,
+          );
+        }),
+      );
+    },
+  );
+
+  testWidgets('sender username is rendered alongside the content preview', (
+    tester,
+  ) async {
+    await http.runWithClient(
+      () async {
+        await tester.pumpWidget(
+          _wrap(onMessageSelected: (_) {}, onClose: () {}),
+        );
+
+        await tester.enterText(find.byType(TextField), 'ping');
+        await _flushDebounce(tester);
+
+        expect(find.text('zelda'), findsOneWidget);
+        expect(find.textContaining('ping!'), findsOneWidget);
+      },
+      () => MockClient((request) async {
+        return http.Response(
+          _payload([_msg(id: 'm1', content: 'ping!', username: 'zelda')]),
+          200,
+        );
+      }),
+    );
+  });
+}

--- a/apps/client/test/widgets/quick_switcher_overlay_test.dart
+++ b/apps/client/test/widgets/quick_switcher_overlay_test.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/theme/echo_theme.dart';
+import 'package:echo_app/src/widgets/quick_switcher_overlay.dart';
+
+import '../helpers/mock_providers.dart';
+
+/// Sample conversations crafted so each one has a deterministic, unique
+/// display name. 1:1 conversations resolve to the peer's username via
+/// [Conversation.displayName], so we always include "test-user-id"
+/// alongside the peer to mirror real-world member lists.
+final _conversations = <Conversation>[
+  const Conversation(
+    id: 'conv-alice',
+    isGroup: false,
+    members: [
+      ConversationMember(userId: 'user-alice', username: 'alice'),
+      ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ],
+  ),
+  const Conversation(
+    id: 'conv-bob',
+    isGroup: false,
+    members: [
+      ConversationMember(userId: 'user-bob', username: 'bob'),
+      ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ],
+  ),
+  const Conversation(
+    id: 'conv-charlie',
+    isGroup: false,
+    members: [
+      ConversationMember(userId: 'user-charlie', username: 'charlie'),
+      ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ],
+  ),
+  const Conversation(
+    id: 'conv-dev-team',
+    name: 'Dev Team',
+    isGroup: true,
+    members: [
+      ConversationMember(userId: 'user-bob', username: 'bob'),
+      ConversationMember(userId: 'test-user-id', username: 'testuser'),
+    ],
+  ),
+];
+
+/// Push the overlay inside a real Navigator so `Navigator.of(context).pop()`
+/// works the same way it does in production (the overlay is opened via
+/// `showDialog` in `home_screen/parts/actions.dart`).
+Widget _harness({
+  required void Function(Conversation) onSelect,
+  List<Conversation>? conversations,
+}) {
+  return ProviderScope(
+    overrides: [
+      authOverride(loggedInAuthState),
+      serverUrlOverride(),
+      conversationsOverride(conversations ?? _conversations),
+    ],
+    child: MaterialApp(
+      theme: EchoTheme.darkTheme,
+      darkTheme: EchoTheme.darkTheme,
+      themeMode: ThemeMode.dark,
+      home: Builder(
+        builder: (ctx) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () {
+                showDialog<void>(
+                  context: ctx,
+                  builder: (_) => QuickSwitcherOverlay(onSelect: onSelect),
+                );
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _open(WidgetTester tester) async {
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+/// Focus the search input so that the TextField becomes the soft-keyboard
+/// input client. Arrow keys still bubble up to the surrounding
+/// [KeyboardListener]; Enter is dispatched via `onSubmitted` through
+/// [TestTextInput.receiveAction].
+Future<void> _focusSearchField(WidgetTester tester) async {
+  await tester.tap(find.byType(TextField));
+  await tester.pumpAndSettle();
+}
+
+/// Fire the TextField's "submit" action (the production Enter path).
+Future<void> _submit(WidgetTester tester) async {
+  await tester.testTextInput.receiveAction(TextInputAction.done);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  testWidgets('empty query shows all conversations (up to 8)', (tester) async {
+    await tester.pumpWidget(_harness(onSelect: (_) {}));
+    await _open(tester);
+
+    expect(find.text('alice'), findsOneWidget);
+    expect(find.text('bob'), findsAtLeastNWidgets(1));
+    expect(find.text('charlie'), findsOneWidget);
+    expect(find.text('Dev Team'), findsOneWidget);
+    expect(find.text('No results'), findsNothing);
+  });
+
+  testWidgets('empty conversations list shows the empty state', (tester) async {
+    await tester.pumpWidget(
+      _harness(onSelect: (_) {}, conversations: const []),
+    );
+    await _open(tester);
+
+    expect(find.text('No results'), findsOneWidget);
+  });
+
+  testWidgets('typing a unique query filters out non-matching conversations', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_harness(onSelect: (_) {}));
+    await _open(tester);
+
+    // 'alice' is unique: charlie has no 'c' after 'i', bob has no 'a',
+    // 'Dev Team' has no 'l'.
+    await tester.enterText(find.byType(TextField), 'alice');
+    await tester.pumpAndSettle();
+
+    // The TextField itself also renders the literal "alice" as its value,
+    // so we look for the result-row text outside of any EditableText.
+    Finder rowText(String label) =>
+        find.descendant(of: find.byType(InkWell), matching: find.text(label));
+
+    expect(rowText('alice'), findsOneWidget);
+    expect(rowText('bob'), findsNothing);
+    expect(rowText('charlie'), findsNothing);
+    expect(rowText('Dev Team'), findsNothing);
+  });
+
+  testWidgets('group conversations match against their group name', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_harness(onSelect: (_) {}));
+    await _open(tester);
+
+    await tester.enterText(find.byType(TextField), 'dev team');
+    await tester.pumpAndSettle();
+
+    Finder rowText(String label) =>
+        find.descendant(of: find.byType(InkWell), matching: find.text(label));
+
+    expect(rowText('Dev Team'), findsOneWidget);
+    // The "Group" trailing label appears next to group hits.
+    expect(find.text('Group'), findsOneWidget);
+    expect(rowText('alice'), findsNothing);
+  });
+
+  testWidgets('query with no matches shows the empty state', (tester) async {
+    await tester.pumpWidget(_harness(onSelect: (_) {}));
+    await _open(tester);
+
+    await tester.enterText(find.byType(TextField), 'zzznomatchzzz');
+    await tester.pumpAndSettle();
+
+    expect(find.text('No results'), findsOneWidget);
+    expect(find.text('alice'), findsNothing);
+  });
+
+  testWidgets('Enter on default selection fires onSelect with first result', (
+    tester,
+  ) async {
+    Conversation? picked;
+    await tester.pumpWidget(_harness(onSelect: (c) => picked = c));
+    await _open(tester);
+
+    await _focusSearchField(tester);
+    await _submit(tester);
+
+    expect(picked, isNotNull);
+    expect(picked!.id, _conversations.first.id);
+  });
+
+  testWidgets('ArrowDown moves selection forward; Enter picks 2nd item', (
+    tester,
+  ) async {
+    Conversation? picked;
+    await tester.pumpWidget(_harness(onSelect: (c) => picked = c));
+    await _open(tester);
+    await _focusSearchField(tester);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await _submit(tester);
+
+    expect(picked, isNotNull);
+    expect(picked!.id, _conversations[1].id);
+  });
+
+  testWidgets('ArrowUp cycles selection back up', (tester) async {
+    Conversation? picked;
+    await tester.pumpWidget(_harness(onSelect: (c) => picked = c));
+    await _open(tester);
+    await _focusSearchField(tester);
+
+    // Down twice -> index 2, then up once -> index 1.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    await _submit(tester);
+
+    expect(picked, isNotNull);
+    expect(picked!.id, _conversations[1].id);
+  });
+
+  testWidgets('ArrowDown clamps at the last result without crashing', (
+    tester,
+  ) async {
+    Conversation? picked;
+    await tester.pumpWidget(_harness(onSelect: (c) => picked = c));
+    await _open(tester);
+    await _focusSearchField(tester);
+
+    for (var i = 0; i < 20; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+    }
+    expect(tester.takeException(), isNull);
+
+    await _submit(tester);
+
+    expect(picked, isNotNull);
+    expect(picked!.id, _conversations.last.id);
+  });
+
+  testWidgets('ArrowUp clamps at the first result without crashing', (
+    tester,
+  ) async {
+    Conversation? picked;
+    await tester.pumpWidget(_harness(onSelect: (c) => picked = c));
+    await _open(tester);
+    await _focusSearchField(tester);
+
+    for (var i = 0; i < 20; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+    }
+    expect(tester.takeException(), isNull);
+
+    await _submit(tester);
+
+    expect(picked, isNotNull);
+    expect(picked!.id, _conversations.first.id);
+  });
+
+  testWidgets('Escape closes the overlay without firing onSelect', (
+    tester,
+  ) async {
+    var pickedCount = 0;
+    await tester.pumpWidget(_harness(onSelect: (_) => pickedCount++));
+    await _open(tester);
+
+    expect(find.byType(QuickSwitcherOverlay), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(QuickSwitcherOverlay), findsNothing);
+    expect(pickedCount, 0);
+  });
+
+  testWidgets('tapping a result row fires onSelect and pops the overlay', (
+    tester,
+  ) async {
+    Conversation? picked;
+    await tester.pumpWidget(_harness(onSelect: (c) => picked = c));
+    await _open(tester);
+
+    await tester.tap(find.text('charlie'));
+    await tester.pumpAndSettle();
+
+    expect(picked, isNotNull);
+    expect(picked!.id, 'conv-charlie');
+    expect(find.byType(QuickSwitcherOverlay), findsNothing);
+  });
+
+  testWidgets('typing a new query resets selection to the first match', (
+    tester,
+  ) async {
+    Conversation? picked;
+    await tester.pumpWidget(_harness(onSelect: (c) => picked = c));
+    await _open(tester);
+    await _focusSearchField(tester);
+
+    // Move selection off the first result first…
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+
+    // …then type a query that produces a single-result list. Selection
+    // must snap back to index 0 (otherwise Enter would dereference out
+    // of range, or pick the wrong conversation).
+    await tester.enterText(find.byType(TextField), 'charlie');
+    await tester.pumpAndSettle();
+
+    await _submit(tester);
+
+    expect(picked, isNotNull);
+    expect(picked!.id, 'conv-charlie');
+  });
+
+  testWidgets('Enter on empty results does NOT fire onSelect', (tester) async {
+    var pickedCount = 0;
+    await tester.pumpWidget(
+      _harness(onSelect: (_) => pickedCount++, conversations: const []),
+    );
+    await _open(tester);
+    await _focusSearchField(tester);
+
+    await _submit(tester);
+
+    expect(pickedCount, 0);
+    // Overlay should still be visible — _selectCurrent is a no-op on empty.
+    expect(find.byType(QuickSwitcherOverlay), findsOneWidget);
+  });
+
+  testWidgets('tapping the backdrop dismisses the overlay', (tester) async {
+    var pickedCount = 0;
+    await tester.pumpWidget(_harness(onSelect: (_) => pickedCount++));
+    await _open(tester);
+
+    expect(find.byType(QuickSwitcherOverlay), findsOneWidget);
+
+    // Tap top-left where the backdrop sits, away from the centered card.
+    await tester.tapAt(const Offset(20, 20));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(QuickSwitcherOverlay), findsNothing);
+    expect(pickedCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary

Adds widget-level test coverage for two keyboard-driven overlays that were at 0% on the SonarQube 2026-05-22 baseline. Both are user-facing surfaces where a silent regression would break discovery and in-chat search; this PR locks in the current behavior so future refactors fail loudly.

- `apps/client/test/widgets/quick_switcher_overlay_test.dart` — 15 tests
- `apps/client/test/widgets/message_search_overlay_test.dart` — 15 tests

## Behaviors covered — `QuickSwitcherOverlay`

- Empty query renders the full conversation list (up to 8); empty conversations list renders the `No results` empty state.
- Typed query filters via `fuzzyScore`; non-matching conversations disappear; group conversations match against their group name; gibberish query falls back to the empty state.
- `Enter` on the default selection fires `onSelect` with the first result.
- `ArrowDown` advances; `ArrowUp` walks back; clamping at both ends never throws.
- Typing a new query resets `_selectedIndex` so `Enter` always lands on the top match.
- `Enter` on empty results is a no-op (overlay stays mounted).
- `Escape` and backdrop tap both dismiss without firing `onSelect`.
- Tapping a result row fires `onSelect` and pops the dialog.

## Behaviors covered — `MessageSearchOverlay`

- Empty initial state shows the text field but neither a result list nor the empty-state copy.
- Typed query hits `GET /api/conversations/{id}/search?q=...` with the trimmed query string (verified via `MockClient`).
- Whitespace-only query does not hit the server.
- 200-with-empty-list, non-200 server error, and thrown network exception all surface the same `No results found` empty state without crashing.
- Tapping a result row fires `onMessageSelected` with the correct message id.
- `Escape` and the close (X) button both fire `onClose`.
- The clear (X) icon only appears once a query has results, and clears the result list when tapped.
- The 400 ms debounce coalesces three rapid keystrokes into a single server request with the final query.
- Results are re-sorted client-side by `fuzzyScore` (an exact-substring match outranks a scattered match even when the server returns them in the wrong order).
- Long content is truncated to 80 chars with an ellipsis; the sender username is rendered alongside the content preview.

## Test plan

- [x] `flutter test test/widgets/quick_switcher_overlay_test.dart test/widgets/message_search_overlay_test.dart` → 30/30 pass.
- [x] `flutter analyze --fatal-infos` on both new files → clean.
- [x] `dart format --set-exit-if-changed` on both new files → clean.
- [x] No production code touched.