### PR TITLE
perf(client): decode avatars at display size, not source size

### DIFF
--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -41,6 +41,11 @@ Widget buildAvatar({
   );
 
   if (imageUrl != null && imageUrl.isNotEmpty) {
+    // Decode at ~3x the display size so the image cache holds a small
+    // bitmap instead of the source resolution. A 1024×1024 source decoded
+    // at 64dp display becomes a ~192×192 bitmap — roughly 28× less memory.
+    // 3× covers retina DPR; oversized sources never decode larger than this.
+    final memCacheWidth = (radius * 2 * 3).ceil();
     return ClipOval(
       key: ValueKey(imageUrl),
       child: SizedBox(
@@ -50,6 +55,7 @@ Widget buildAvatar({
           imageUrl: imageUrl,
           cacheKey: stableMediaCacheKey(imageUrl),
           cacheManager: chatMediaCacheManager,
+          memCacheWidth: memCacheWidth,
           fit: BoxFit.cover,
           fadeInDuration: Duration.zero,
           fadeOutDuration: Duration.zero,


### PR DESCRIPTION
## Summary
\`buildAvatar\` was leaving \`CachedNetworkImage.memCacheWidth\` unset, so a 1024×1024 source PNG shown at 64dp held a 4 MB bitmap in the image cache instead of the ~192×192 the screen actually needs. Setting \`memCacheWidth\` to 3× the display diameter (covers retina DPR) reduces per-avatar memory ~28×.

## Where this helps
- Long member lists / group rosters (20+ avatars in view)
- Busy chat histories where each row repeats the sender avatar at small radii
- Web in particular, where the 100 MB image cache cap is held in the JS heap

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test test/widgets/conversation_panel_test.dart\` — 40/40 pass (resolveAvatarUrl + buildAvatar coverage)
- [x] \`dart format\` clean

## Behind the scenes
Single-line addition: \`memCacheWidth: (radius * 2 * 3).ceil()\`. Source on disk is untouched; the cache manager still pulls full-resolution images. References #1117.