### PR TITLE
release: fix Wayland window-restore lands off-screen (#1138, PR #1139 bundled)

### DIFF
--- a/apps/client/lib/src/services/window_state_service.dart
+++ b/apps/client/lib/src/services/window_state_service.dart
@@ -1,7 +1,7 @@
 import 'dart:io' show Platform;
 import 'dart:ui' show Color, Offset, Size;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:screen_retriever/screen_retriever.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:window_manager/window_manager.dart';
@@ -30,10 +30,53 @@ class WindowStateService {
   /// (no visible jump when the window grows).
   static const Offset _kTopLeftAnchor = Offset(40, 40);
 
+  /// Maximum allowed drift (in logical pixels) between the position we
+  /// requested via [setPosition] and the position the compositor actually
+  /// applied. When the drift exceeds this value we fall back to [center()].
+  ///
+  /// Wayland compositors that run with an XWayland fallback sometimes honour
+  /// `setPosition` on the first call but then silently undo it; compositors
+  /// without X11 support always ignore it. 200 px is large enough that a
+  /// compositor applying DPI scaling won't false-positive, but small enough to
+  /// catch the typical "window stayed at (0,0)" failure mode.
+  static const double _kPositionDriftTolerance = 200.0;
+
   /// True on a desktop platform where `window_manager` is supported.
   static bool get _isDesktop {
     if (kIsWeb) return false;
     return Platform.isLinux || Platform.isWindows || Platform.isMacOS;
+  }
+
+  /// Override for tests — set to [true] to simulate a Wayland session, [false]
+  /// to simulate X11/non-Wayland, or leave [null] to use env-var detection.
+  @visibleForTesting
+  static bool? debugOverrideIsWayland;
+
+  /// True when the current Linux session is running under a Wayland compositor.
+  ///
+  /// On Wayland, `windowManager.setPosition` is a no-op: the Wayland protocol
+  /// does not allow clients to dictate their own position — that is the
+  /// compositor's exclusive responsibility. Similarly, `getPosition` returns
+  /// compositor-local surface coordinates (often (0, 0)) that do not reflect
+  /// the window's real on-screen position. Saving and restoring those values
+  /// would therefore produce broken results.
+  ///
+  /// The fix: skip position save/restore on Wayland entirely; restore SIZE
+  /// only and let the compositor place the window (as Discord, Slack, and
+  /// Chromium all do on Wayland).
+  ///
+  /// Detection: `WAYLAND_DISPLAY` being set is the canonical signal.
+  /// `XDG_SESSION_TYPE=wayland` covers setups where the display variable is
+  /// absent but the session type is still declared (some minimal compositors).
+  ///
+  /// Exposed via [debugOverrideIsWayland] so unit tests can exercise both
+  /// branches without touching real environment variables.
+  static bool get isWaylandSession {
+    if (debugOverrideIsWayland != null) return debugOverrideIsWayland!;
+    if (!Platform.isLinux) return false;
+    final env = Platform.environment;
+    return env.containsKey('WAYLAND_DISPLAY') ||
+        env['XDG_SESSION_TYPE']?.toLowerCase() == 'wayland';
   }
 
   /// Save the current window size + position to SharedPreferences.
@@ -47,6 +90,11 @@ class WindowStateService {
   /// — which sits near the center of the monitor — and on the next launch
   /// [restore] would apply those center-screen coordinates to the full-size
   /// window, pushing it off the bottom-right edge.
+  ///
+  /// Position is also skipped on Wayland because [windowManager.getPosition]
+  /// returns compositor-local surface coordinates (typically (0, 0)) that do
+  /// not reflect the true on-screen position and would produce invalid saved
+  /// values.
   static Future<void> save() async {
     if (!_isDesktop) return;
     try {
@@ -59,12 +107,17 @@ class WindowStateService {
       if (size.width < 720.0 || size.height < 480.0) return;
       await prefs.setDouble(_kWidthKey, size.width);
       await prefs.setDouble(_kHeightKey, size.height);
-      try {
-        final pos = await windowManager.getPosition();
-        await prefs.setDouble(_kXKey, pos.dx);
-        await prefs.setDouble(_kYKey, pos.dy);
-      } catch (_) {
-        // getPosition isn't reliable on all platforms; size alone is fine.
+      // On Wayland, getPosition() returns compositor-local coordinates that
+      // don't map to global screen position. Skip saving x/y to prevent bogus
+      // values from corrupting the next restore.
+      if (!isWaylandSession) {
+        try {
+          final pos = await windowManager.getPosition();
+          await prefs.setDouble(_kXKey, pos.dx);
+          await prefs.setDouble(_kYKey, pos.dy);
+        } catch (_) {
+          // getPosition isn't reliable on all platforms; size alone is fine.
+        }
       }
     } catch (_) {
       // Never block app shutdown on a failed window-state save.
@@ -74,6 +127,13 @@ class WindowStateService {
   /// Restore the previously-saved window size + position AND re-attach the
   /// native title bar that [enterSplash] removed. Falls back to [defaultSize]
   /// centered on the primary display when no prior state is recorded.
+  ///
+  /// On Wayland the position restore is skipped entirely — the compositor owns
+  /// placement and [windowManager.setPosition] is a no-op. Size is still
+  /// restored. On X11/Windows/macOS the full save/restore cycle applies, but
+  /// a post-restore drift-check verifies that the compositor actually honoured
+  /// the requested position; if it drifted by more than
+  /// [_kPositionDriftTolerance] pixels the window is centered as a safety net.
   static Future<void> restore() async {
     if (!_isDesktop) return;
     try {
@@ -93,49 +153,97 @@ class WindowStateService {
         height.clamp(480.0, 10000.0),
       );
       await windowManager.setSize(size);
-      // Restore saved (x, y) only when both axes land inside the current
-      // primary display.  A multi-monitor disconnect or resolution change
-      // can park a previously valid coordinate halfway off-screen, leaving
-      // the user with a window they can barely grab (#whats-new-titlebar).
-      final savedX = prefs.getDouble(_kXKey);
-      final savedY = prefs.getDouble(_kYKey);
-      if (savedX != null &&
-          savedY != null &&
-          await _isOnScreen(savedX, savedY, size)) {
-        await windowManager.setPosition(Offset(savedX, savedY));
-      } else {
-        // First-launch default: centre the full-size window on the primary
-        // display. Earlier this snapped to the same top-left anchor as the
-        // splash, which made the post-splash window appear to "grow" out of
-        // the splash's exact corner instead of being a separate window
-        // landing in a natural place. center() handles multi-monitor and
-        // window-manager work-area quirks better than us math'ing it.
-        try {
-          await windowManager.center();
-        } catch (_) {
-          // Fall back to the safe inset if center() is unsupported on
-          // this compositor.
-          await windowManager.setPosition(_kTopLeftAnchor);
+
+      // On Wayland, setPosition is a compositor no-op. Skip position restore
+      // and let the compositor decide where to place the window.
+      if (!isWaylandSession) {
+        // Restore saved (x, y) only when both axes land inside at least one
+        // connected display. A multi-monitor disconnect or resolution change
+        // can park a previously valid coordinate off-screen.
+        final savedX = prefs.getDouble(_kXKey);
+        final savedY = prefs.getDouble(_kYKey);
+        if (savedX != null &&
+            savedY != null &&
+            await _isOnScreen(savedX, savedY, size)) {
+          await windowManager.setPosition(Offset(savedX, savedY));
+          // Safety-net drift check: verify the compositor actually applied the
+          // position. If the window drifted by more than the tolerance (e.g.
+          // XWayland or a non-standard compositor silently ignored the hint),
+          // fall back to center() so the window is always visible.
+          await _centerIfDrifted(savedX, savedY);
+          return;
         }
+      }
+
+      // Wayland, first-launch, or no valid saved position: let the compositor
+      // decide placement. center() handles multi-monitor work-area quirks
+      // better than hand-computing the offset.
+      try {
+        await windowManager.center();
+      } catch (_) {
+        // Fall back to the safe inset if center() is unsupported on
+        // this compositor.
+        await windowManager.setPosition(_kTopLeftAnchor);
       }
     } catch (_) {
       // Falling back to whatever size the splash set is acceptable.
     }
   }
 
-  /// True when at least 200 px of the window's top-left corner stays inside
-  /// the primary display's work area, so the user can always grab the
+  /// Checks whether the actual window position has drifted more than
+  /// [_kPositionDriftTolerance] pixels from the requested [expectedX]/
+  /// [expectedY]. If so — meaning the compositor silently ignored our
+  /// `setPosition` call — falls back to [center()] so the user always sees
+  /// the window within the visible work area.
+  static Future<void> _centerIfDrifted(
+    double expectedX,
+    double expectedY,
+  ) async {
+    try {
+      final actual = await windowManager.getPosition();
+      final dx = (actual.dx - expectedX).abs();
+      final dy = (actual.dy - expectedY).abs();
+      if (dx > _kPositionDriftTolerance || dy > _kPositionDriftTolerance) {
+        await windowManager.center();
+      }
+    } catch (_) {
+      // If we can't read back the position, try centering as a safety net.
+      try {
+        await windowManager.center();
+      } catch (_) {}
+    }
+  }
+
+  /// True when at least 100 px of the window's top-left corner stays inside
+  /// ANY connected display's work area, so the user can always grab the
   /// integrated title bar to drag the window back into view.
+  ///
+  /// Previously this checked only the PRIMARY display, which caused false
+  /// positives (or negatives) when:
+  ///   - the window was on a secondary monitor,
+  ///   - a monitor was unplugged between sessions (saved coord from the
+  ///     now-gone display would fail the primary-only check and fall back to
+  ///     center — correct, but the inverse was also possible: a coord that was
+  ///     off the primary but within the secondary was wrongly rejected).
+  ///
+  /// Now we iterate all displays and accept the coordinate if it falls inside
+  /// any one of them.
   static Future<bool> _isOnScreen(double x, double y, Size size) async {
     try {
-      final display = await screenRetriever.getPrimaryDisplay();
-      final screenSize = display.size;
-      const minVisible = 200.0;
-      final maxX = screenSize.width - minVisible;
-      final maxY = screenSize.height - minVisible;
-      // Allow slight negative for stacked-window managers that report the
-      // titlebar above the work area, but never more than 50 px.
-      return x > -50.0 && y > -50.0 && x < maxX && y < maxY;
+      final displays = await screenRetriever.getAllDisplays();
+      const minVisible = 100.0;
+      for (final display in displays) {
+        final origin = display.visiblePosition ?? Offset.zero;
+        final screenSize = display.size;
+        final minX = origin.dx - 50.0;
+        final minY = origin.dy - 50.0;
+        final maxX = origin.dx + screenSize.width - minVisible;
+        final maxY = origin.dy + screenSize.height - minVisible;
+        if (x >= minX && y >= minY && x < maxX && y < maxY) {
+          return true;
+        }
+      }
+      return false;
     } catch (_) {
       // If we can't introspect the display, prefer center() over a stale
       // saved coordinate.

--- a/apps/client/test/services/window_state_service_test.dart
+++ b/apps/client/test/services/window_state_service_test.dart
@@ -1,0 +1,430 @@
+/// Unit tests for [WindowStateService] — Wayland position skip + multi-monitor
+/// validation.
+///
+/// These tests verify the three new behaviours introduced to fix the Linux
+/// off-screen restore regression (#linux-wayland-window):
+///
+///   1. On Wayland, [WindowStateService.save] must NOT persist x/y
+///      (`window.x` / `window.y`) because [windowManager.getPosition] returns
+///      compositor-local coordinates that are meaningless on the next launch.
+///
+///   2. On Wayland, [WindowStateService.restore] must NOT call
+///      `windowManager.setPosition` (i.e. no `setBounds` call with the saved
+///      x/y coordinates).
+///
+///   3. After a `setPosition` call on X11/Windows, if the actual window
+///      position drifted more than 200 px from the requested position, the
+///      service falls back to `center()`. We detect `center()` being invoked
+///      by watching for a `getCursorScreenPoint` call on the screen_retriever
+///      channel (that call is only made by `calcWindowPosition`, which is only
+///      called from `windowManager.center()`).
+///
+/// Channel notes:
+/// - window_manager uses `MethodChannel('window_manager')`. getSize/getPosition
+///   go through `getBounds`; setSize/setPosition go through `setBounds`.
+/// - screen_retriever uses
+///   `MethodChannel('dev.leanflutter.plugins/screen_retriever')`.
+///   `getAllDisplays` result wraps the list under a `'displays'` key.
+library;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/services/window_state_service.dart';
+
+// ---------------------------------------------------------------------------
+// Channel references
+// ---------------------------------------------------------------------------
+
+const _wmChannel = MethodChannel('window_manager');
+const _srChannel =
+    MethodChannel('dev.leanflutter.plugins/screen_retriever');
+
+// ---------------------------------------------------------------------------
+// Call-tracking lists (reset in setUp)
+// ---------------------------------------------------------------------------
+
+final List<MethodCall> _wmCalls = [];
+final List<MethodCall> _srCalls = [];
+
+// ---------------------------------------------------------------------------
+// Default fake display maps (match Display.fromJson expectations)
+// ---------------------------------------------------------------------------
+
+const Map<String, Object?> _fakeDisplayMap = {
+  'id': 'display-0',
+  'name': 'DP-1',
+  'scaleFactor': 1.0,
+  'size': {'width': 1920.0, 'height': 1080.0},
+  'visiblePosition': {'dx': 0.0, 'dy': 0.0},
+  'visibleSize': {'width': 1920.0, 'height': 1040.0},
+};
+
+const Map<String, Object?> _fakeSecondaryDisplayMap = {
+  'id': 'display-1',
+  'name': 'DP-2',
+  'scaleFactor': 1.0,
+  'size': {'width': 1920.0, 'height': 1080.0},
+  'visiblePosition': {'dx': 1920.0, 'dy': 0.0},
+  'visibleSize': {'width': 1920.0, 'height': 1040.0},
+};
+
+// ---------------------------------------------------------------------------
+// Mock installers
+// ---------------------------------------------------------------------------
+
+/// Install a fake handler on the `window_manager` channel.
+///
+/// [boundsResult] is returned for every `getBounds` call (used by both
+/// `getSize` and `getPosition`). Override to simulate compositor drift.
+void _installWmMock({
+  Map<String, Object?> boundsResult = const {
+    'x': 0.0,
+    'y': 0.0,
+    'width': 1280.0,
+    'height': 720.0,
+  },
+}) {
+  _wmCalls.clear();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_wmChannel, (call) async {
+        _wmCalls.add(call);
+        if (call.method == 'getBounds') return boundsResult;
+        return null;
+      });
+}
+
+/// Install a fake handler on the `screen_retriever` channel.
+///
+/// [displays] is used for `getAllDisplays` (wrapped under `'displays'` key)
+/// and for `getPrimaryDisplay` (first element). A cursor point well inside
+/// the primary display is returned for `getCursorScreenPoint`.
+void _installSrMock({
+  List<Map<String, Object?>> displays = const [_fakeDisplayMap],
+}) {
+  _srCalls.clear();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_srChannel, (call) async {
+        _srCalls.add(call);
+        switch (call.method) {
+          case 'getAllDisplays':
+            return {'displays': displays};
+          case 'getPrimaryDisplay':
+            return displays.isNotEmpty ? displays.first : _fakeDisplayMap;
+          case 'getCursorScreenPoint':
+            return {'dx': 960.0, 'dy': 540.0};
+          default:
+            return null;
+        }
+      });
+}
+
+void _removeMocks() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_wmChannel, null);
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(_srChannel, null);
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
+
+/// True when a `setBounds` call was made with position exactly (x, y).
+///
+/// `setPosition(Offset(x, y))` → `setBounds` arguments contain 'x' == x
+/// AND 'y' == y. `setSize` calls contain 'width'/'height' but no 'x'/'y'.
+bool _setPositionWasCalledWith(double x, double y) {
+  return _wmCalls.any((c) {
+    if (c.method != 'setBounds') return false;
+    final args = c.arguments as Map?;
+    if (args == null) return false;
+    return args['x'] == x && args['y'] == y;
+  });
+}
+
+/// True when `center()` was invoked.
+///
+/// `center()` → `calcWindowPosition()` → `screenRetriever.getCursorScreenPoint()`
+/// That is the only call path that hits `getCursorScreenPoint`, so it serves
+/// as a reliable marker for center() being called.
+bool get _centerWasCalled =>
+    _srCalls.any((c) => c.method == 'getCursorScreenPoint');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    _installWmMock();
+    _installSrMock();
+  });
+
+  tearDown(() {
+    WindowStateService.debugOverrideIsWayland = null;
+    _removeMocks();
+  });
+
+  // ── 1. Wayland detection ────────────────────────────────────────────────────
+
+  group('isWaylandSession via debugOverrideIsWayland', () {
+    test('returns true when override is set to true', () {
+      WindowStateService.debugOverrideIsWayland = true;
+      expect(WindowStateService.isWaylandSession, isTrue);
+    });
+
+    test('returns false when override is set to false', () {
+      WindowStateService.debugOverrideIsWayland = false;
+      expect(WindowStateService.isWaylandSession, isFalse);
+    });
+  });
+
+  // ── 2. save() on Wayland ────────────────────────────────────────────────────
+
+  group('save() on Wayland', () {
+    setUp(() => WindowStateService.debugOverrideIsWayland = true);
+
+    test('does NOT persist window.x or window.y', () async {
+      await WindowStateService.save();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('window.x'), isNull,
+          reason: 'window.x must not be saved on Wayland');
+      expect(prefs.getDouble('window.y'), isNull,
+          reason: 'window.y must not be saved on Wayland');
+    });
+
+    test('still persists window.width and window.height', () async {
+      await WindowStateService.save();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('window.width'), isNotNull,
+          reason: 'window.width must still be saved on Wayland');
+      expect(prefs.getDouble('window.height'), isNotNull,
+          reason: 'window.height must still be saved on Wayland');
+    });
+  });
+
+  // ── 3. save() on X11 ────────────────────────────────────────────────────────
+
+  group('save() on X11 / non-Wayland', () {
+    setUp(() => WindowStateService.debugOverrideIsWayland = false);
+
+    test('persists window.x and window.y from getBounds', () async {
+      _installWmMock(
+        boundsResult: {
+          'x': 150.0,
+          'y': 200.0,
+          'width': 1280.0,
+          'height': 720.0,
+        },
+      );
+
+      await WindowStateService.save();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('window.x'), 150.0);
+      expect(prefs.getDouble('window.y'), 200.0);
+    });
+  });
+
+  // ── 4. restore() on Wayland ─────────────────────────────────────────────────
+
+  group('restore() on Wayland', () {
+    setUp(() {
+      WindowStateService.debugOverrideIsWayland = true;
+      SharedPreferences.setMockInitialValues({
+        'window.width': 1280.0,
+        'window.height': 720.0,
+        'window.x': 200.0,
+        'window.y': 200.0,
+      });
+    });
+
+    test('does NOT call setPosition with the saved coordinates', () async {
+      await WindowStateService.restore();
+
+      expect(
+        _setPositionWasCalledWith(200.0, 200.0),
+        isFalse,
+        reason: 'setPosition must not be called with saved coords on Wayland',
+      );
+    });
+
+    test('calls center() instead of restoring the saved position', () async {
+      await WindowStateService.restore();
+
+      expect(
+        _centerWasCalled,
+        isTrue,
+        reason:
+            'center() must be called on Wayland since setPosition is a no-op',
+      );
+    });
+  });
+
+  // ── 5. restore() on X11 with valid coords ───────────────────────────────────
+
+  group('restore() on X11 / non-Wayland, valid saved position', () {
+    setUp(() {
+      WindowStateService.debugOverrideIsWayland = false;
+      SharedPreferences.setMockInitialValues({
+        'window.width': 1280.0,
+        'window.height': 720.0,
+        'window.x': 300.0,
+        'window.y': 300.0,
+      });
+      // Compositor honours the position — no drift.
+      _installWmMock(
+        boundsResult: {
+          'x': 300.0,
+          'y': 300.0,
+          'width': 1280.0,
+          'height': 720.0,
+        },
+      );
+    });
+
+    test('calls setPosition with the saved coordinates', () async {
+      await WindowStateService.restore();
+
+      expect(
+        _setPositionWasCalledWith(300.0, 300.0),
+        isTrue,
+        reason: 'setPosition must be called with saved coords when on-screen',
+      );
+    });
+
+    test('does not call center() on X11 when position was honoured', () async {
+      await WindowStateService.restore();
+
+      expect(
+        _centerWasCalled,
+        isFalse,
+        reason:
+            'center() must not be called when compositor honoured position',
+      );
+    });
+  });
+
+  // ── 6. restore() drift-check ────────────────────────────────────────────────
+
+  group('restore() drift-check fallback on X11', () {
+    setUp(() {
+      WindowStateService.debugOverrideIsWayland = false;
+      SharedPreferences.setMockInitialValues({
+        'window.width': 1280.0,
+        'window.height': 720.0,
+        'window.x': 300.0,
+        'window.y': 300.0,
+      });
+    });
+
+    test('calls center() when compositor drifted > 200 px', () async {
+      // Simulate: compositor ignored setPosition and left window at (5, 5).
+      _installWmMock(
+        boundsResult: {'x': 5.0, 'y': 5.0, 'width': 1280.0, 'height': 720.0},
+      );
+
+      await WindowStateService.restore();
+
+      // setPosition(300, 300) must have been attempted.
+      expect(_setPositionWasCalledWith(300.0, 300.0), isTrue);
+      // After detecting the > 200 px drift, center() must be called.
+      expect(
+        _centerWasCalled,
+        isTrue,
+        reason: 'center() must be called when the compositor drifted > 200 px',
+      );
+    });
+
+    test('does NOT call center() when drift is within tolerance', () async {
+      // Compositor placed the window at (310, 305) — within 200 px of (300, 300).
+      _installWmMock(
+        boundsResult: {
+          'x': 310.0,
+          'y': 305.0,
+          'width': 1280.0,
+          'height': 720.0,
+        },
+      );
+
+      await WindowStateService.restore();
+
+      expect(_setPositionWasCalledWith(300.0, 300.0), isTrue);
+      expect(
+        _centerWasCalled,
+        isFalse,
+        reason: 'center() must NOT be called when drift is within tolerance',
+      );
+    });
+  });
+
+  // ── 7. multi-monitor _isOnScreen awareness ──────────────────────────────────
+
+  group('restore() multi-monitor position validation', () {
+    setUp(() => WindowStateService.debugOverrideIsWayland = false);
+
+    test('restores position when coord is on secondary monitor', () async {
+      // Saved position is on the second monitor (right of 1920-wide primary).
+      SharedPreferences.setMockInitialValues({
+        'window.width': 1280.0,
+        'window.height': 720.0,
+        'window.x': 2000.0,
+        'window.y': 100.0,
+      });
+      // Compositor places the window exactly where requested.
+      _installWmMock(
+        boundsResult: {
+          'x': 2000.0,
+          'y': 100.0,
+          'width': 1280.0,
+          'height': 720.0,
+        },
+      );
+      // Two monitors: primary 0..1920, secondary 1920..3840.
+      _installSrMock(displays: [_fakeDisplayMap, _fakeSecondaryDisplayMap]);
+
+      await WindowStateService.restore();
+
+      expect(
+        _setPositionWasCalledWith(2000.0, 100.0),
+        isTrue,
+        reason: 'setPosition must be called for a coord valid on the secondary',
+      );
+      expect(_centerWasCalled, isFalse);
+    });
+
+    test('falls back to center() when coords are off all screens', () async {
+      // Saved position is clearly off all monitors.
+      SharedPreferences.setMockInitialValues({
+        'window.width': 1280.0,
+        'window.height': 720.0,
+        'window.x': 5000.0,
+        'window.y': 5000.0,
+      });
+      _installWmMock();
+      // Only the 1920×1080 primary display — (5000, 5000) is off-screen.
+      _installSrMock(displays: [_fakeDisplayMap]);
+
+      await WindowStateService.restore();
+
+      expect(
+        _setPositionWasCalledWith(5000.0, 5000.0),
+        isFalse,
+        reason: 'setPosition must not be called for off-screen coords',
+      );
+      expect(
+        _centerWasCalled,
+        isTrue,
+        reason:
+            'center() must be called when saved coords are off all displays',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Bundles **#1139** (\`copilot/fix-linux-window-restore-issue\`) into a dev → main release.

## Why bundle through dev

PR #1139's source branch (\`copilot/...\`) didn't match the \`feature/**\`/\`fix/**\` pattern that triggers the path-gated dev-build CI, so the Smoke Linux Desktop / Maintained Suite jobs never fired against it directly. Re-running through dev exercises the full pipeline before main.

## What this ships

Fixes #1138 — Linux client always restoring at the same off-screen coordinates regardless of where the window was last closed. Root cause: \`windowManager.setPosition\` is a no-op on Wayland (compositor owns placement) and \`getPosition\` returns surface-local coords, so saved bounds were both written wrong AND ignored on restore.

**Behaviour changes:**
- On Wayland (\`WAYLAND_DISPLAY\` set OR \`XDG_SESSION_TYPE=wayland\`): skip the position save entirely; on restore, restore size only and let the compositor place the window. Same approach Discord / Slack / Chromium take on Wayland.
- On X11/Windows/macOS: full save/restore unchanged, with a new post-restore drift check — if the compositor's actual position is more than 200 px from what we requested, fall back to \`center()\` so the user never sees an off-screen window.
- Multi-monitor: \`_isOnScreen\` now iterates ALL connected displays via \`getAllDisplays()\` instead of only the primary, with proper \`visiblePosition\` offset. Correctly handles "secondary monitor disconnected between sessions" cases.

**Code:**
- \`apps/client/lib/src/services/window_state_service.dart\` — adds \`isWaylandSession\` detection, \`_centerIfDrifted\` safety net, multi-display \`_isOnScreen\`.
- \`apps/client/test/services/window_state_service_test.dart\` — 13 new tests covering: Wayland override, position save/skip per session, center vs setPosition, drift-check threshold, multi-monitor secondary acceptance, off-all-screens fallback.

## Local validation
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` — **2238 / 2238 pass** (up from 2225 baseline; +13 new tests from this PR).

## Test plan
- [ ] Watch CI on this PR — lint / Flutter test / Linux smoke must be green.
- [ ] Android dev-build APK failure expected (pre-existing #1111).
- [ ] On merge, release pipeline publishes a new patch version; watchtower picks it up on prod.

Once green, PR #1139 will be closed in favor of this bundle.