### PR TITLE
fix(client): parse server-shaped invite response in TokenJoinScreen

### DIFF
--- a/apps/client/lib/src/screens/token_join_screen.dart
+++ b/apps/client/lib/src/screens/token_join_screen.dart
@@ -35,13 +35,19 @@ class _InvitePreview {
   });
 
   factory _InvitePreview.fromJson(Map<String, dynamic> json) {
+    // Server returns `{token, group: {id, title, description, icon_url,
+    // member_count, is_member, members}}`. Read the nested object — the
+    // earlier flat-key read produced "Unknown Group" + 0 members in the UI
+    // because none of the top-level keys existed.
+    final group =
+        (json['group'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
     return _InvitePreview(
-      conversationId: json['conversation_id'] as String,
-      name: json['name'] as String? ?? 'Unknown Group',
-      description: json['description'] as String?,
-      iconUrl: json['icon_url'] as String?,
-      memberCount: (json['member_count'] as num?)?.toInt() ?? 0,
-      isMember: json['is_member'] as bool? ?? false,
+      conversationId: group['id'] as String? ?? '',
+      name: group['title'] as String? ?? 'Unknown Group',
+      description: group['description'] as String?,
+      iconUrl: group['icon_url'] as String?,
+      memberCount: (group['member_count'] as num?)?.toInt() ?? 0,
+      isMember: group['is_member'] as bool? ?? false,
     );
   }
 
@@ -195,7 +201,11 @@ class _TokenJoinScreenState extends ConsumerState<TokenJoinScreen>
 
   Future<void> _handleAcceptInviteSuccess(http.Response response) async {
     final data = jsonDecode(response.body) as Map<String, dynamic>;
-    final alreadyMember = data['already_member'] as bool? ?? false;
+    // Server returns `{status: "already_member"|"joined", conversation_id}`.
+    // The earlier read of `data['already_member']` was a phantom — that key
+    // never appears in the response, so the toast always said "joined" even
+    // when the user was already a member.
+    final alreadyMember = (data['status'] as String?) == 'already_member';
     await ref.read(conversationsProvider.notifier).loadConversations();
     if (mounted) {
       final toastMsg = _buildSuccessToastMessage(alreadyMember);

--- a/apps/client/test/widgets/token_join_screen_test.dart
+++ b/apps/client/test/widgets/token_join_screen_test.dart
@@ -1,15 +1,23 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
 
 import 'package:echo_app/src/providers/auth_provider.dart';
 import 'package:echo_app/src/screens/token_join_screen.dart';
 import 'package:echo_app/src/theme/echo_theme.dart';
 
+import '../helpers/mock_http_client.dart';
 import '../helpers/mock_providers.dart';
 
-GoRouter _buildRouter({String token = 'test-invite-token'}) {
+const _kToken = 'test-invite-token';
+const _kConversationId = 'conv-abc-123';
+
+GoRouter _buildRouter({String token = _kToken}) {
   return GoRouter(
     initialLocation: '/invite/t/$token',
     routes: [
@@ -32,7 +40,78 @@ GoRouter _buildRouter({String token = 'test-invite-token'}) {
   );
 }
 
+Widget _wrap(GoRouter router, List<Override> overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp.router(
+      theme: EchoTheme.darkTheme,
+      darkTheme: EchoTheme.darkTheme,
+      themeMode: ThemeMode.dark,
+      routerConfig: router,
+    ),
+  );
+}
+
+/// Build the GET /api/invites/:token preview body in the shape the SERVER
+/// actually returns — `{token, group: {id, title, ...}}`. Keeping this in
+/// one place so tests assert against the real contract; if the server shape
+/// ever changes the test stubs change with it.
+Map<String, dynamic> _previewJson({
+  String token = _kToken,
+  String groupId = _kConversationId,
+  String title = 'Echo Hackers',
+  String? description = 'Build messengers in their spare time.',
+  String? iconUrl,
+  int memberCount = 42,
+  bool isMember = false,
+}) => {
+  'token': token,
+  'group': {
+    'id': groupId,
+    'title': title,
+    'description': description,
+    'icon_url': iconUrl,
+    'member_count': memberCount,
+    'is_member': isMember,
+    'members': const <Map<String, dynamic>>[],
+  },
+};
+
+void _stubPreview(
+  MockHttpClient mockClient, {
+  required Map<String, dynamic> body,
+  int statusCode = 200,
+}) {
+  when(
+    () => mockClient.get(
+      any(that: predicate<Uri>((u) => u.path == '/api/invites/$_kToken')),
+      headers: any(named: 'headers'),
+    ),
+  ).thenAnswer((_) async => http.Response(jsonEncode(body), statusCode));
+}
+
+void _stubAccept(
+  MockHttpClient mockClient, {
+  int statusCode = 200,
+  Map<String, dynamic>? body,
+}) {
+  when(
+    () => mockClient.post(
+      any(
+        that: predicate<Uri>((u) => u.path == '/api/invites/$_kToken/accept'),
+      ),
+      headers: any(named: 'headers'),
+      body: any(named: 'body'),
+      encoding: any(named: 'encoding'),
+    ),
+  ).thenAnswer(
+    (_) async => http.Response(jsonEncode(body ?? const {}), statusCode),
+  );
+}
+
 void main() {
+  setUpAll(registerHttpFallbackValues);
+
   group('TokenJoinScreen', () {
     testWidgets('shows loading skeleton initially', (tester) async {
       final router = _buildRouter();
@@ -49,8 +128,6 @@ void main() {
         ),
       );
 
-      // The screen starts loading — skeleton containers should be visible
-      // before the network call resolves.
       expect(find.byType(TokenJoinScreen), findsOneWidget);
     });
 
@@ -62,9 +139,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            ...standardOverrides(
-              authState: const AuthState(), // logged out
-            ),
+            ...standardOverrides(authState: const AuthState()), // logged out
           ],
           child: MaterialApp.router(
             theme: EchoTheme.darkTheme,
@@ -75,11 +150,9 @@ void main() {
         ),
       );
 
-      // Pump once for initState callback + once for setState after it runs
       await tester.pump();
       await tester.pump();
 
-      // Logged-out user sees a "Log in to join" button (no preview call is made)
       expect(find.text('Log in to join'), findsOneWidget);
     });
 
@@ -106,5 +179,145 @@ void main() {
 
       expect(find.text('LOGIN_SCREEN'), findsOneWidget);
     });
+
+    // -------------------------------------------------------------------
+    // Happy path: preview parsing exercises the nested `group:` object.
+    // Regression guard for the bug where the client read top-level keys
+    // (`name`, `description`, `member_count`) and rendered "Unknown Group"
+    // + 0 members + no description for every real invite.
+    // -------------------------------------------------------------------
+    testWidgets(
+      'preview renders group title, description, and member count from the '
+      'nested `group` object',
+      (tester) async {
+        final mockClient = MockHttpClient();
+        _stubPreview(
+          mockClient,
+          body: _previewJson(
+            title: 'Echo Hackers',
+            description: 'Folks who build messengers.',
+            memberCount: 17,
+          ),
+        );
+
+        await http.runWithClient(() async {
+          await tester.pumpWidget(_wrap(_buildRouter(), standardOverrides()));
+          // initState post-frame callback + preview resolve.
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('Echo Hackers'), findsOneWidget);
+          expect(find.text('Folks who build messengers.'), findsOneWidget);
+          // The preview scaffold renders "17 members" (plural).
+          expect(find.textContaining('17 members'), findsOneWidget);
+          // "Unknown Group" never appears once the nested parse works.
+          expect(find.text('Unknown Group'), findsNothing);
+        }, () => mockClient);
+      },
+    );
+
+    testWidgets(
+      'preview falls back to "Unknown Group" when `group` is absent',
+      (tester) async {
+        final mockClient = MockHttpClient();
+        // Malformed server response with no `group` key — defensive fallback
+        // should still render the screen instead of crashing.
+        _stubPreview(mockClient, body: const {'token': _kToken});
+
+        await http.runWithClient(() async {
+          await tester.pumpWidget(_wrap(_buildRouter(), standardOverrides()));
+          await tester.pump();
+          await tester.pump();
+
+          expect(find.text('Unknown Group'), findsOneWidget);
+        }, () => mockClient);
+      },
+    );
+
+    // -------------------------------------------------------------------
+    // Happy path: accept response detects `status: "already_member"`.
+    // Regression guard for the bug where the client read a non-existent
+    // `already_member: bool` field and always toasted "Joined!" even when
+    // the user was already a member.
+    // -------------------------------------------------------------------
+    testWidgets(
+      'accept response with status=already_member toasts the right copy',
+      (tester) async {
+        // Preview says non-member so the Join button is rendered. The race
+        // we're testing: user taps Join, but a concurrent path has already
+        // added them — server returns 200 with status=already_member.
+        final mockClient = MockHttpClient();
+        _stubPreview(
+          mockClient,
+          body: _previewJson(title: 'Echo Hackers', isMember: false),
+        );
+        _stubAccept(
+          mockClient,
+          statusCode: 200,
+          body: const {
+            'status': 'already_member',
+            'conversation_id': _kConversationId,
+          },
+        );
+
+        await http.runWithClient(() async {
+          await tester.pumpWidget(_wrap(_buildRouter(), standardOverrides()));
+          await tester.pump();
+          await tester.pump();
+
+          await tester.tap(find.text('Join Group'));
+          // Drive past the toast's 3-second auto-dismiss timer so it doesn't
+          // leak past teardown. The toast text is still findable while
+          // visible — assert before draining.
+          await tester.pump();
+          await tester.pump();
+
+          // The bug used to show "Joined Echo Hackers successfully!" because
+          // the client read a non-existent `already_member: bool` field. With
+          // the fix it correctly reads `status == "already_member"` and
+          // surfaces the alternate copy.
+          expect(
+            find.textContaining('already a member of Echo Hackers'),
+            findsOneWidget,
+          );
+
+          // Drain the toast's 3s auto-dismiss + 2.5s animation timers.
+          await tester.pump(const Duration(seconds: 4));
+        }, () => mockClient);
+      },
+    );
+
+    testWidgets(
+      'accept response with status=joined toasts joined-successfully',
+      (tester) async {
+        final mockClient = MockHttpClient();
+        _stubPreview(
+          mockClient,
+          body: _previewJson(title: 'Echo Hackers', isMember: false),
+        );
+        _stubAccept(
+          mockClient,
+          statusCode: 200,
+          body: const {'status': 'joined', 'conversation_id': _kConversationId},
+        );
+
+        await http.runWithClient(() async {
+          await tester.pumpWidget(_wrap(_buildRouter(), standardOverrides()));
+          await tester.pump();
+          await tester.pump();
+
+          await tester.tap(find.text('Join Group'));
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            find.textContaining('Joined Echo Hackers successfully'),
+            findsOneWidget,
+          );
+
+          await tester.pump(const Duration(seconds: 4));
+        }, () => mockClient);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
Found two contract mismatches between the Flutter client and the Rust server while validating the invite-link flow on prod today. Both bugs broke the token-based group-invite UI in real-world use — the unit tests passed because they didn't exercise the actual JSON shapes the server returns.

## Bugs fixed
1. \`GET /api/invites/:token\` returns \`{token, group: {id, title, description, icon_url, member_count, is_member, members}}\` but \`TokenJoinScreen._InvitePreview.fromJson\` read those keys at top level. Every invite link showed *Unknown Group* + 0 members + no description + no icon, and the conversation_id used for post-join navigation was an empty string.
2. \`POST /api/invites/:token/accept\` returns \`{status, conversation_id}\` where status is the string \"already_member\" or \"joined\". The client read a non-existent \`already_member: bool\` field, so it always toasted \"Joined X successfully!\" even when the user was already a member.

## Tests
- 4 new widget tests that exercise the real server JSON shape — preview happy path, preview falling back when \`group\` key is missing, accept-with-\`status: already_member\`, accept-with-\`status: joined\`. Both bugs would have been caught immediately by these.
- Existing 3 tests (loading skeleton + logged-out + login redirect) preserved.

## Validation
- \`flutter analyze --fatal-infos\` clean.
- \`flutter test\` — **2249 / 2249 pass** (up from 2245; +4 new from this fix).
- Live prod verification against a freshly-created invite for \`mdtest_a\`'s group — confirmed the preview JSON shape and the \`status: already_member\` accept response that the fix targets.

## Test plan
- [ ] CI: lint / Flutter test / Linux smoke green.
- [ ] Android dev-build APK failure expected (pre-existing #1111).

Reviewers: this also documents the server's \`/api/invites/:token\` shape for the next contract change.