### PR TITLE
fix(uploads): chunked path as default, retry legacy 413, 1 GB cap (#1134)

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -12,6 +12,7 @@ import '../../models/canvas_models.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/canvas_provider.dart';
 import '../../providers/server_url_provider.dart';
+import '../../services/chunked_upload_client.dart';
 import '../../services/toast_service.dart';
 import '../../services/upload_client.dart';
 import '../../theme/echo_theme.dart';
@@ -333,15 +334,41 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   }) async {
     final ext = file.extension?.toLowerCase() ?? 'png';
     final mimeType = _mimeForExtension(ext);
-    final uploader = UploadClient(ref.read(authProvider.notifier));
-    final uploadResult = await uploader.uploadFile(
-      serverUrl: serverUrl,
-      path: '/api/media/upload',
-      bytes: file.bytes!,
-      fileName: file.name,
-      mimeType: mimeType,
-      extraFields: {'conversation_id': conversationId},
-    );
+    final bytes = file.bytes!;
+
+    Future<UploadResult> uploadChunked() async {
+      final auth = ref.read(authProvider.notifier);
+      final chunked = ChunkedUploadClient(
+        tokenGetter: () => auth.currentToken,
+        refresher: auth.refreshAccessToken,
+      );
+      final result = await chunked.uploadBytes(
+        bytes: bytes,
+        serverUrl: serverUrl,
+        mimeType: mimeType,
+        filename: file.name,
+        conversationId: conversationId,
+      );
+      return result.toUploadResult();
+    }
+
+    final UploadResult uploadResult;
+    if (shouldUseChunkedUpload(bytes.length)) {
+      uploadResult = await uploadChunked();
+    } else {
+      final uploader = UploadClient(ref.read(authProvider.notifier));
+      final singleShot = await uploader.uploadFile(
+        serverUrl: serverUrl,
+        path: '/api/media/upload',
+        bytes: bytes,
+        fileName: file.name,
+        mimeType: mimeType,
+        extraFields: {'conversation_id': conversationId},
+      );
+      uploadResult = (!singleShot.ok && singleShot.statusCode == 413)
+          ? await uploadChunked()
+          : singleShot;
+    }
     if (!mounted) return null;
 
     if (uploadResult.ok) {

--- a/apps/client/lib/src/services/chunked_upload_client.dart
+++ b/apps/client/lib/src/services/chunked_upload_client.dart
@@ -35,10 +35,13 @@ const List<Duration> _kRetryBackoffs = [
 ];
 
 /// Threshold (in bytes) at which a caller should prefer the chunked path
-/// over the legacy single-shot multipart endpoint.  Kept 5 MB below
-/// Cloudflare's 100 MB edge cap so a borderline file never reaches the
-/// edge limit even after multipart framing overhead.
-const int kChunkedUploadThresholdBytes = 95 * 1024 * 1024;
+/// over the legacy single-shot multipart endpoint.
+///
+/// Keep this low so most attachments use the resumable pipeline by default.
+const int kChunkedUploadThresholdBytes = 5 * 1024 * 1024;
+
+bool shouldUseChunkedUpload(int byteLength) =>
+    byteLength >= kChunkedUploadThresholdBytes;
 
 const String _kOctetStream = 'application/octet-stream';
 const String _kJsonMime = 'application/json';

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/attachments.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/attachments.dart
@@ -171,8 +171,7 @@ extension _Attachments on ChatInputBarState {
     // PATCH pipeline (#556).  Cloudflare's edge cap is 100 MB; the chunked
     // path streams 5 MB chunks server-side so it can ferry files multiples
     // of that without ever pinning the whole payload in server RAM.
-    final UploadResult result;
-    if (bytes.length > kChunkedUploadThresholdBytes) {
+    Future<UploadResult> uploadChunked() async {
       final auth = ref.read(authProvider.notifier);
       final chunked = ChunkedUploadClient(
         tokenGetter: () => auth.currentToken,
@@ -186,10 +185,15 @@ extension _Attachments on ChatInputBarState {
         conversationId: widget.conversation.id,
         onProgress: onProgress,
       );
-      result = chunkedResult.toUploadResult();
+      return chunkedResult.toUploadResult();
+    }
+
+    final UploadResult result;
+    if (shouldUseChunkedUpload(bytes.length)) {
+      result = await uploadChunked();
     } else {
       final uploader = UploadClient(ref.read(authProvider.notifier));
-      result = await uploader.uploadFile(
+      final singleShotResult = await uploader.uploadFile(
         serverUrl: serverUrl,
         path: '/api/media/upload',
         bytes: bytes,
@@ -198,6 +202,11 @@ extension _Attachments on ChatInputBarState {
         extraFields: {'conversation_id': widget.conversation.id},
         onProgress: onProgress,
       );
+      if (!singleShotResult.ok && singleShotResult.statusCode == 413) {
+        result = await uploadChunked();
+      } else {
+        result = singleShotResult;
+      }
     }
 
     if (result.ok) {
@@ -213,9 +222,12 @@ extension _Attachments on ChatInputBarState {
     }
 
     if (mounted && !result.ok) {
+      final error = result.errorMessage?.trim();
       ToastService.show(
         context,
-        'Upload failed (${result.statusCode})',
+        (error != null && error.isNotEmpty)
+            ? 'Upload failed: $error'
+            : 'Upload failed (${result.statusCode})',
         type: ToastType.error,
       );
     }

--- a/apps/client/test/services/chunked_upload_client_test.dart
+++ b/apps/client/test/services/chunked_upload_client_test.dart
@@ -32,6 +32,15 @@ ChunkedUploadClient _client({
 
 void main() {
   group('ChunkedUploadClient.uploadBytes', () {
+    test('chunked threshold defaults to 5 MB', () {
+      expect(kChunkedUploadThresholdBytes, 5 * 1024 * 1024);
+    });
+
+    test('shouldUseChunkedUpload includes exact threshold boundary', () {
+      expect(shouldUseChunkedUpload(kChunkedUploadThresholdBytes - 1), isFalse);
+      expect(shouldUseChunkedUpload(kChunkedUploadThresholdBytes), isTrue);
+    });
+
     test(
       'happy path issues init + chunk(s) + finalize and returns url',
       () async {

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -41,6 +41,15 @@ use super::AppState;
 /// in `routes/mod.rs` cap the multipart payload at this value.
 pub const MAX_FILE_SIZE: usize = 100 * 1024 * 1024;
 
+fn legacy_upload_too_large_message(actual_bytes: usize) -> String {
+    let actual_mb = actual_bytes as f64 / (1024.0 * 1024.0);
+    let max_mb = MAX_FILE_SIZE as f64 / (1024.0 * 1024.0);
+    format!(
+        "This file is {actual_mb:.1} MB. Legacy /api/media/upload is limited to \
+         {max_mb:.0} MB. Please retry with chunked upload via /api/media/upload/init."
+    )
+}
+
 /// Allowed MIME types for upload.
 const ALLOWED_MIME_TYPES: &[&str] = &[
     // Images
@@ -123,8 +132,8 @@ pub(super) fn extension_for_mime(mime: &str) -> &str {
 #[cfg(test)]
 fn validate_bytes(data: &[u8], declared_mime: &str) -> Result<String, AppError> {
     if data.len() > MAX_FILE_SIZE {
-        return Err(AppError::bad_request(format!(
-            "File too large. Maximum size is {MAX_FILE_SIZE} bytes"
+        return Err(AppError::bad_request(legacy_upload_too_large_message(
+            data.len(),
         )));
     }
 
@@ -211,8 +220,8 @@ async fn stream_field_to_temp(
             // Clean up the partial temp file before returning.
             drop(tmp_file);
             let _ = fs::remove_file(&temp_name).await;
-            return Err(AppError::bad_request(format!(
-                "File too large. Maximum size is {MAX_FILE_SIZE} bytes"
+            return Err(AppError::bad_request(legacy_upload_too_large_message(
+                total_bytes,
             )));
         }
 
@@ -978,7 +987,8 @@ mod tests {
         let data = vec![0u8; MAX_FILE_SIZE + 1];
         let err =
             validate_bytes(&data, "application/pdf").expect_err("oversize file should be rejected");
-        assert!(err.message.contains("too large"));
+        assert!(err.message.contains("Legacy /api/media/upload is limited"));
+        assert!(err.message.contains("/api/media/upload/init"));
     }
 
     #[test]

--- a/apps/server/src/routes/media_chunked.rs
+++ b/apps/server/src/routes/media_chunked.rs
@@ -4,7 +4,7 @@
 //! single-shot multipart upload capped at 100 MB.  This module adds a
 //! parallel pipeline -- init / PATCH chunks / finalize -- that streams
 //! every chunk to disk without buffering the body in RAM, so files up to
-//! `MAX_CHUNKED_UPLOAD_BYTES` (2 GB by default) can be uploaded over
+//! `MAX_CHUNKED_UPLOAD_BYTES` (1 GB by default) can be uploaded over
 //! flaky cellular links with per-chunk retries.
 //!
 //! ## Why chunked instead of bumping the single-shot cap
@@ -72,9 +72,9 @@ const MAX_CHUNK_BYTES: i64 = 16 * 1024 * 1024;
 const TMP_DIR: &str = "./uploads/.tmp";
 
 /// Default ceiling on the total size of a chunked upload, when the
-/// `MAX_CHUNKED_UPLOAD_BYTES` env var is unset.  2 GB is enough for
-/// modern phone video and well below typical disk-quota concerns.
-pub const DEFAULT_MAX_CHUNKED_UPLOAD_BYTES: i64 = 2 * 1024 * 1024 * 1024;
+/// `MAX_CHUNKED_UPLOAD_BYTES` env var is unset.  1 GB covers long
+/// phone videos while staying conservative on disk quotas.
+pub const DEFAULT_MAX_CHUNKED_UPLOAD_BYTES: i64 = 1024 * 1024 * 1024;
 
 /// Read the configured upper bound on a chunked upload.  Re-read each
 /// time so operators can rotate the value at runtime without a restart.
@@ -685,5 +685,10 @@ mod tests {
     fn sanitize_filename_falls_back_on_empty() {
         assert_eq!(sanitize_filename(""), "upload");
         assert_eq!(sanitize_filename("\n\r/\""), "upload");
+    }
+
+    #[test]
+    fn default_max_chunked_upload_bytes_is_one_gib() {
+        assert_eq!(DEFAULT_MAX_CHUNKED_UPLOAD_BYTES, 1024 * 1024 * 1024);
     }
 }


### PR DESCRIPTION
Bundle of PR #1145 (\`copilot/fix-100mb-upload-limit-error\`) into a dev → main release.

## What ships

Fixes #1134. Two related problems were keeping the 100 MB upload error on screen even after #556 shipped chunked uploads:

1. Some entry points were landing on the legacy \`/api/media/upload\` for files between 5 MB and 95 MB, where Cloudflare's 100 MB edge cap rejected the request.
2. The legacy 413 said *\"File too large. Maximum size is N bytes\"* without telling the user (or the client code) that the chunked endpoint exists.

**Client changes:**
- \`kChunkedUploadThresholdBytes\` dropped **95 MB → 5 MB**. Anything above ~5 MB takes the resumable pipeline by default.
- New \`shouldUseChunkedUpload()\` helper with explicit \`>=\` boundary; tested.
- If the legacy path returns 413 anyway, **automatically retries via chunked**. Wired into the chat-attach path AND the voice-lounge drawing path.
- Failure toast surfaces the server's actual error message instead of \`Upload failed (413)\`.

**Server changes:**
- 413 error string rewritten to name the actual file size and direct callers at \`/api/media/upload/init\`.
- \`DEFAULT_MAX_CHUNKED_UPLOAD_BYTES\` reduced **2 GB → 1 GB** (the user's \"make it a gig\" ask).

## Chunk math (answering the obvious question)
- Server advertises \`DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024\` (5 MB).
- A 10 MB file → exactly 2 PATCH chunks. Round-trip: \`POST /init → PATCH (0-5MB) → PATCH (5-10MB) → POST /finalize\`.
- A 4.9 MB file → still legacy single-shot path (below threshold).

## Local validation
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` — **2251 / 2251 pass** (up from 2249; +2 boundary tests).

## Coverage gap (follow-up needed)
Three more \`UploadClient.uploadFile\` call sites still don't have the 413 fallback:
- \`screens/onboarding_wizard.dart\` (onboarding avatar)
- \`screens/settings/account_section.dart\` (own avatar upload)
- \`screens/group_info_screen/parts/header_section.dart\` (group icon)

These are usually small enough to slip under 100 MB, but a follow-up extracting \`uploadWithChunkedFallback()\` and using it everywhere is worth doing.

## Test plan
- [ ] CI: lint / Flutter test / Linux smoke green.
- [ ] Android dev-build APK failure expected (pre-existing #1111).