### PR TITLE
refactor(client): drop chat-header search icon, surface search on Ctrl+F (#1135)

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -249,6 +249,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           const SingleActivator(LogicalKeyboardKey.keyK, control: true): () {
             _showQuickSwitcher();
           },
+          // Ctrl+F and Ctrl+Shift+F both open the global search overlay.
+          // Ctrl+F matches the OS-native "find" muscle memory; the older
+          // Ctrl+Shift+F stays bound so existing users don't have to relearn.
+          // The per-chat magnifying glass was retired in #1135.
+          const SingleActivator(LogicalKeyboardKey.keyF, control: true): () {
+            _showGlobalSearch();
+          },
           const SingleActivator(
             LogicalKeyboardKey.keyF,
             control: true,

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -33,8 +33,6 @@ class ChatHeaderBar extends ConsumerWidget {
   final String myUserId;
   final String serverUrl;
   final VoidCallback? onBack;
-  final bool showSearch;
-  final VoidCallback onToggleSearch;
   final VoidCallback? onMembersToggle;
   final VoidCallback? onGroupInfo;
 
@@ -42,7 +40,8 @@ class ChatHeaderBar extends ConsumerWidget {
   /// Used by Column mode where the channel rail's own header already
   /// shows the group identity (avatar + name + member count), so this
   /// row would duplicate it. The action buttons on the right
-  /// (pin / search / shared media / members) still render.
+  /// (pin / shared media / members) still render. Search lives on
+  /// Ctrl+F (#1135).
   final bool hideGroupIdentity;
 
   const ChatHeaderBar({
@@ -51,8 +50,6 @@ class ChatHeaderBar extends ConsumerWidget {
     required this.myUserId,
     required this.serverUrl,
     this.onBack,
-    required this.showSearch,
-    required this.onToggleSearch,
     this.onMembersToggle,
     this.onGroupInfo,
     this.hideGroupIdentity = false,
@@ -340,14 +337,6 @@ class ChatHeaderBar extends ConsumerWidget {
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
         ),
-      IconButton(
-        icon: Icon(showSearch ? Icons.search_off : Icons.search, size: 20),
-        color: showSearch ? context.accent : context.textSecondary,
-        tooltip: showSearch ? 'Close search' : 'Search messages',
-        onPressed: onToggleSearch,
-        padding: EdgeInsets.zero,
-        constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
-      ),
       _buildOverflowMenu(context, ref, conv, pinnedCount, isWide: false),
     ];
   }
@@ -472,14 +461,6 @@ class ChatHeaderBar extends ConsumerWidget {
       _PinnedMessagesIconButton(
         pinnedCount: pinnedCount,
         onPressed: () => _showPinnedMessagesDialog(context, ref, conv),
-      ),
-      IconButton(
-        icon: Icon(showSearch ? Icons.search_off : Icons.search, size: 20),
-        color: showSearch ? context.accent : context.textSecondary,
-        tooltip: showSearch ? 'Close search' : 'Search messages',
-        onPressed: onToggleSearch,
-        padding: EdgeInsets.zero,
-        constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
       ),
       IconButton(
         icon: const Icon(Icons.photo_library_outlined, size: 20),

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -130,7 +130,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   // `_updateFloatingDate` to detect the topmost visible message.
   final _messageKeys = <String, GlobalKey>{};
 
-  bool _showSearch = false;
   ChatMessage? _threadParent;
   String? _highlightedMessageId;
   String? _pendingInitialMessageId;
@@ -230,7 +229,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     _activeVoiceChannelId = null;
     _loadedHistoryKey = null;
     _controller.autoScrollConversationKey = null;
-    _showSearch = false;
     _threadParent = null;
     _highlightedMessageId = null;
     _pendingInitialMessageId = widget.initialMessageId;
@@ -973,7 +971,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         hasNewMessagesBelow: _hasNewMessagesBelow,
         newMessagesBannerText: _newMessagesBannerText(),
         liveRegionAnnouncement: _liveRegionAnnouncement,
-        showSearch: _showSearch,
         hideVoiceDock: widget.hideVoiceDock,
         typingUsers: input.typingUsers,
         isDragOver: _isDragOver,
@@ -987,7 +984,6 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         onVoiceChannelChanged: (channelId) {
           if (mounted) setState(() => _activeVoiceChannelId = channelId);
         },
-        onSetShowSearch: (v) => setState(() => _showSearch = v),
         onHighlightMessage: _highlightMessage,
         onShowReactionPicker: _showReactionPicker,
         onToggleReaction: _toggleReaction,

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -15,7 +15,6 @@ import '../channel_column.dart';
 import '../chat_header_bar.dart';
 import '../chat_input_bar.dart';
 import '../encryption_status_banner.dart';
-import '../message_search_overlay.dart';
 import '../mobile_channel_drawer.dart';
 import 'chat_message_list.dart';
 import 'drop_overlay.dart';
@@ -52,7 +51,6 @@ class ChatPanelBodyParams {
     required this.hasNewMessagesBelow,
     required this.newMessagesBannerText,
     required this.liveRegionAnnouncement,
-    required this.showSearch,
     required this.hideVoiceDock,
     required this.typingUsers,
     required this.isDragOver,
@@ -63,7 +61,6 @@ class ChatPanelBodyParams {
     required this.onShowLounge,
     required this.onTextChannelChanged,
     required this.onVoiceChannelChanged,
-    required this.onSetShowSearch,
     required this.onHighlightMessage,
     required this.onShowReactionPicker,
     required this.onToggleReaction,
@@ -109,7 +106,6 @@ class ChatPanelBodyParams {
   final bool hasNewMessagesBelow;
   final String newMessagesBannerText;
   final String liveRegionAnnouncement;
-  final bool showSearch;
   final bool hideVoiceDock;
   final List<String> typingUsers;
   final bool isDragOver;
@@ -120,7 +116,6 @@ class ChatPanelBodyParams {
   final VoidCallback? onShowLounge;
   final ValueChanged<String?> onTextChannelChanged;
   final ValueChanged<String?> onVoiceChannelChanged;
-  final ValueChanged<bool> onSetShowSearch;
   final ValueChanged<String> onHighlightMessage;
   final void Function(ChatMessage, Offset) onShowReactionPicker;
   final void Function(ChatMessage, String, bool) onToggleReaction;
@@ -246,8 +241,6 @@ Widget buildChatContentBox(
               myUserId: p.myUserId,
               serverUrl: p.serverUrl,
               onBack: p.onBack,
-              showSearch: p.showSearch,
-              onToggleSearch: () => p.onSetShowSearch(!p.showSearch),
               onMembersToggle: p.onMembersToggle,
               onGroupInfo: p.onGroupInfo,
               // Column mode's left rail already shows the group avatar +
@@ -270,15 +263,6 @@ Widget buildChatContentBox(
             // action button where applicable. Renders a SizedBox.shrink()
             // when no flag is active.
             EncryptionStatusBanner(conversation: p.conv),
-            if (p.showSearch)
-              MessageSearchOverlay(
-                conversationId: p.conv.id,
-                onMessageSelected: (messageId) {
-                  p.onSetShowSearch(false);
-                  p.onHighlightMessage(messageId);
-                },
-                onClose: () => p.onSetShowSearch(false),
-              ),
             if (p.isLoadingHistory)
               LinearProgressIndicator(
                 minHeight: 2,

--- a/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
+++ b/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
@@ -35,7 +35,11 @@ class _KeyboardShortcutsOverlayState extends State<KeyboardShortcutsOverlay> {
   static const _sections = <_ShortcutSection>[
     _ShortcutSection('Navigation', [
       _Shortcut('Ctrl+K', 'Quick-switch conversations'),
-      _Shortcut('Ctrl+Shift+F', 'Search across all conversations'),
+      _Shortcut('Ctrl+F', 'Search across all conversations'),
+      _Shortcut(
+        'Ctrl+Shift+F',
+        'Search across all conversations (legacy alias)',
+      ),
       _Shortcut('Ctrl+,', 'Open settings'),
       _Shortcut('Ctrl+/', 'Show keyboard shortcuts'),
       _Shortcut('Esc', 'Close overlay or settings'),


### PR DESCRIPTION
## Summary
Removes the magnifying-glass icon from the chat header (both layouts) and binds **Ctrl+F** to the global search overlay so users get the OS-native search combo. Ctrl+Shift+F stays bound as a legacy alias.

## What changed
- \`widgets/chat_header_bar.dart\` — search IconButton dropped from both narrow + wide action rows; \`showSearch\` / \`onToggleSearch\` params removed.
- \`widgets/chat_panel/chat_panel_body.dart\` + \`widgets/chat_panel.dart\` — pruned \`showSearch\` state + \`onSetShowSearch\` callback + the conditional \`MessageSearchOverlay\` rendering hook + the now-unused import.
- \`screens/home_screen.dart\` — added \`SingleActivator(LogicalKeyboardKey.keyF, control: true) → _showGlobalSearch\`. Existing \`Ctrl+Shift+F\` binding kept verbatim.
- \`widgets/keyboard_shortcuts_overlay.dart\` — Navigation section now lists \`Ctrl+F\` first; \`Ctrl+Shift+F\` annotated as legacy alias.

## Why MessageSearchOverlay stays in the codebase
It got fresh coverage in #1124 (15 widget tests). Future slash-command revival is cheap; removing the widget would just throw away tested code.

## Validation
- \`flutter analyze --fatal-infos\` clean across the whole client tree.
- \`flutter test\` — **2251 / 2251 pass.**

Closes #1135.