### PR TITLE
refactor(client): debug-logs row-click copy + compact rows + drop Lifecycle spam (#1128)

### DIFF
--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -866,76 +866,72 @@ class _DebugLogEntryTileState extends State<_DebugLogEntryTile> {
 
   @override
   Widget build(BuildContext context) {
-    // Hovering a log entry tints the row so users can track which line
-    // they're pointing at when scanning a dense list. Cursor reverts to
-    // basic so it doesn't read as clickable beyond the Copy button.
-    // RepaintBoundary so hover state on this row doesn't invalidate the
-    // entire log list's paint layer (debug log can hold up to 5000
-    // entries). Plain Container instead of AnimatedContainer — the 80ms
-    // fade is imperceptible and AnimatedContainer allocates an implicit
-    // animation controller per row.
+    // Whole row is clickable; tap copies the formatted entry to the
+    // clipboard. The dedicated trailing IconButton was retired in #1128
+    // because Copy All already lives in the header and the per-row icon
+    // wasted ~44px of vertical reserve, cutting visible rows in half.
+    // RepaintBoundary so hover state on one row doesn't invalidate the
+    // whole list's paint layer (the buffer can hold up to 5000 entries).
     return RepaintBoundary(
       child: MouseRegion(
         onEnter: (_) => setState(() => _hovered = true),
         onExit: (_) => setState(() => _hovered = false),
-        child: Container(
-          decoration: BoxDecoration(
-            color: _hovered ? context.surfaceHover : Colors.transparent,
-            borderRadius: BorderRadius.circular(4),
-          ),
-          padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SizedBox(
-                width: 72,
-                child: Text(
-                  _formatTime(entry.timestamp),
-                  style: GoogleFonts.jetBrainsMono(
-                    color: context.textMuted,
-                    fontSize: 11,
+        child: InkWell(
+          onTap: () => _copySingleEntry(context),
+          borderRadius: BorderRadius.circular(4),
+          child: Container(
+            decoration: BoxDecoration(
+              color: _hovered ? context.surfaceHover : Colors.transparent,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            padding: const EdgeInsets.symmetric(vertical: 1, horizontal: 4),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: 72,
+                  child: Text(
+                    _formatTime(entry.timestamp),
+                    style: GoogleFonts.jetBrainsMono(
+                      color: context.textMuted,
+                      fontSize: 11,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 6),
-              _DebugLevelBadge(level: entry.level),
-              const SizedBox(width: 8),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-                decoration: BoxDecoration(
-                  color: context.surfaceHover,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                child: Text(
-                  entry.source,
-                  style: GoogleFonts.jetBrainsMono(
-                    color: context.textSecondary,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w500,
+                const SizedBox(width: 6),
+                _DebugLevelBadge(level: entry.level),
+                const SizedBox(width: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 1,
+                  ),
+                  decoration: BoxDecoration(
+                    color: context.surfaceHover,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    entry.source,
+                    style: GoogleFonts.jetBrainsMono(
+                      color: context.textSecondary,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  entry.message,
-                  style: GoogleFonts.jetBrainsMono(
-                    color: context.textPrimary,
-                    fontSize: 12,
-                    height: 1.4,
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    entry.message,
+                    style: GoogleFonts.jetBrainsMono(
+                      color: context.textPrimary,
+                      fontSize: 12,
+                      height: 1.3,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              IconButton(
-                icon: const Icon(Icons.copy_outlined, size: 14),
-                color: context.textMuted,
-                tooltip: 'Copy entry',
-                onPressed: () => _copySingleEntry(context),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/apps/client/lib/src/services/app_lifecycle_logger.dart
+++ b/apps/client/lib/src/services/app_lifecycle_logger.dart
@@ -25,25 +25,24 @@ class AppLifecycleLogger with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    DebugLogService.instance.log(
-      LogLevel.info,
-      'Lifecycle',
-      'state=${state.name}',
-    );
-
-    // Force an immediate disk flush on states that are close to the process
-    // going away: paused (backgrounded on iOS), detached (terminating), and
-    // hidden (multitasking switcher on iOS 17+).  This guarantees the
-    // breadcrumb is on disk even if the OS kills the process in the same
-    // run-loop tick.
+    // Skip resumed/inactive — they fire every time the window loses or
+    // regains focus (clicking outside the app and back), drowning out the
+    // useful entries. Paused / detached / hidden are the breadcrumbs that
+    // actually matter for triage because they mean the OS is about to kill
+    // the process. (#1128)
     final needsImmediateFlush =
         state == AppLifecycleState.paused ||
         state == AppLifecycleState.detached ||
         state == AppLifecycleState.hidden;
 
-    if (needsImmediateFlush) {
-      DebugLogService.instance.forceFlush().ignore();
-    }
+    if (!needsImmediateFlush) return;
+
+    DebugLogService.instance.log(
+      LogLevel.info,
+      'Lifecycle',
+      'state=${state.name}',
+    );
+    DebugLogService.instance.forceFlush().ignore();
   }
 
   /// Called by the framework when the platform requests the app to exit


### PR DESCRIPTION
## Summary
Three changes to the Debug Logs panel (Settings → About → Debug Logs):

1. **Per-row Copy icon retired** — the whole row is now an \`InkWell\` so tapping anywhere on it copies the formatted entry. Copy All still lives in the header for bulk grabs.
2. **Compact rows** — vertical padding 3 → 1 and line-height 1.4 → 1.3, plus the 44 px IconButton min-height that was forcing every row tall is gone. Roughly doubles visible row density on a desktop viewport.
3. **Lifecycle spam dropped** — \`state=resumed\` / \`state=inactive\` fired every time the window lost / regained focus and dominated the feed for real triage. Now only \`paused\` / \`detached\` / \`hidden\` (the states that mean the OS is about to kill the process) are logged.

## Code
- \`apps/client/lib/src/screens/settings/about_section.dart\` — \`_DebugLogEntryTile\` rewritten: \`InkWell\` wrapper + \`onTap = _copySingleEntry\`, no trailing \`IconButton\`, tighter padding.
- \`apps/client/lib/src/services/app_lifecycle_logger.dart\` — early-return on resumed/inactive; paused/detached/hidden still get logged + force-flushed.

## Validation
- \`flutter analyze --fatal-infos\` clean.
- \`flutter test\` — **2251 / 2251 pass.**

Closes #1128.