### PR TITLE
refactor(client): font scale to Appearance, GIF autoplay to Accessibility (#1137)

### DIFF
--- a/apps/client/lib/src/screens/settings/accessibility_section.dart
+++ b/apps/client/lib/src/screens/settings/accessibility_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/accessibility_provider.dart';
+import '../../providers/gif_playback_provider.dart';
 import '../../theme/echo_theme.dart';
 
 /// Dedicated Accessibility settings section.
@@ -172,52 +173,27 @@ class AccessibilitySection extends ConsumerWidget {
 
             const SizedBox(height: 8),
 
-            // ── Font Scale ────────────────────────────────────────────────
-            Text(
-              'Font Size',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
+            // ── GIF autoplay (#1137) ──────────────────────────────────────
+            // Autoplay is a motion / vestibular / distraction concern; lives
+            // here next to Reduce Motion. Font size moved to Appearance.
+            SwitchListTile.adaptive(
+              contentPadding: EdgeInsets.zero,
+              secondary: const Icon(Icons.gif_outlined),
+              title: Text(
+                'Auto-play GIFs',
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Scale text across the app. Default is 100%.',
-              style: TextStyle(color: context.textMuted, fontSize: 12),
-            ),
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                Text(
-                  '85%',
-                  style: TextStyle(color: context.textMuted, fontSize: 12),
-                ),
-                Expanded(
-                  child: Semantics(
-                    label: 'font size',
-                    slider: true,
-                    value: '${(state.fontScale * 100).round()}%',
-                    child: Slider(
-                      value: state.fontScale,
-                      min: 0.85,
-                      max: 1.5,
-                      divisions: 13,
-                      label: '${(state.fontScale * 100).round()}%',
-                      onChanged: notifier.setFontScale,
-                    ),
-                  ),
-                ),
-                Text(
-                  '150%',
-                  style: TextStyle(color: context.textMuted, fontSize: 12),
-                ),
-              ],
-            ),
-            Text(
-              'Current: ${(state.fontScale * 100).round()}%',
-              style: TextStyle(color: context.textSecondary, fontSize: 12),
-              textAlign: TextAlign.center,
+              subtitle: Text(
+                'When off, GIFs show as static thumbnails with a play button.',
+                style: TextStyle(color: context.textMuted, fontSize: 12),
+              ),
+              value: ref.watch(gifPlaybackProvider).autoplayEnabled,
+              onChanged: (v) =>
+                  ref.read(gifPlaybackProvider.notifier).setAutoplay(v),
             ),
 
             const SizedBox(height: 16),

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../providers/accessibility_provider.dart';
 import '../../providers/channel_layout_provider.dart';
-import '../../providers/gif_playback_provider.dart';
 import '../../providers/theme_provider.dart';
 import '../../theme/echo_theme.dart';
 import 'advanced_theme_section.dart';
 
 /// SharedPreferences key for GIF autoplay setting.
+///
+/// The toggle UI moved to Accessibility in #1137, but the storage key
+/// is canonical and used by `gif_playback_provider`. Keep the constant
+/// exported here so the key stays a single source of truth.
 const kGifAutoplayKey = 'gif_autoplay_enabled';
 
 /// Preview color data for rendering a miniature theme thumbnail.
@@ -107,10 +111,6 @@ class AppearanceSection extends ConsumerStatefulWidget {
 }
 
 class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
-  Future<void> _setGifAutoplay(bool value) async {
-    await ref.read(gifPlaybackProvider.notifier).setAutoplay(value);
-  }
-
   @override
   Widget build(BuildContext context) {
     final currentTheme = ref.watch(themeProvider);
@@ -321,20 +321,11 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
                   .setLayout(ChannelLayout.column),
             ),
             const SizedBox(height: 24),
-            // GIF autoplay
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Auto-play GIFs',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'When off, GIFs show as static thumbnails with a play button.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: ref.watch(gifPlaybackProvider).autoplayEnabled,
-              onChanged: _setGifAutoplay,
-            ),
+            // Font size (#1137 — moved from Accessibility). Pure visual
+            // preference, so it lives in Appearance alongside the theme
+            // picker. State still backs to accessibilityProvider so the
+            // setting roams between sections without a migration.
+            _FontSizeRow(),
             const SizedBox(height: 32),
             // Advanced color overrides (issue #613)
             Text(
@@ -359,6 +350,69 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
           ],
         ),
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Font size slider (#1137 — moved from Accessibility)
+// ---------------------------------------------------------------------------
+
+class _FontSizeRow extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(accessibilityProvider);
+    final notifier = ref.read(accessibilityProvider.notifier);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Font Size',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Scale text across the app. Default is 100%.',
+          style: TextStyle(color: context.textMuted, fontSize: 12),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Text(
+              '85%',
+              style: TextStyle(color: context.textMuted, fontSize: 12),
+            ),
+            Expanded(
+              child: Semantics(
+                label: 'font size',
+                slider: true,
+                value: '${(state.fontScale * 100).round()}%',
+                child: Slider(
+                  value: state.fontScale,
+                  min: 0.85,
+                  max: 1.5,
+                  divisions: 13,
+                  label: '${(state.fontScale * 100).round()}%',
+                  onChanged: notifier.setFontScale,
+                ),
+              ),
+            ),
+            Text(
+              '150%',
+              style: TextStyle(color: context.textMuted, fontSize: 12),
+            ),
+          ],
+        ),
+        Text(
+          'Current: ${(state.fontScale * 100).round()}%',
+          style: TextStyle(color: context.textSecondary, fontSize: 12),
+          textAlign: TextAlign.center,
+        ),
+      ],
     );
   }
 }

--- a/apps/client/test/widgets/settings/accessibility_section_test.dart
+++ b/apps/client/test/widgets/settings/accessibility_section_test.dart
@@ -30,10 +30,11 @@ void main() {
       expect(find.text('Reduce Motion'), findsOneWidget);
     });
 
-    testWidgets('renders Font Size slider', (tester) async {
+    testWidgets('renders GIF autoplay toggle (#1137)', (tester) async {
       await _pump(tester);
-      expect(find.text('Font Size'), findsOneWidget);
-      expect(find.byType(Slider), findsOneWidget);
+      // GIF autoplay moved from Appearance → Accessibility in #1137 because
+      // autoplay is a motion / vestibular / distraction concern.
+      expect(find.text('Auto-play GIFs'), findsOneWidget);
     });
 
     testWidgets('renders High Contrast switch', (tester) async {
@@ -41,12 +42,22 @@ void main() {
       expect(find.text('High Contrast'), findsOneWidget);
     });
 
-    testWidgets('all three controls are present', (tester) async {
+    testWidgets('Font Size slider is NOT here — moved to Appearance (#1137)', (
+      tester,
+    ) async {
       await _pump(tester);
-      // Two SwitchListTile.adaptive widgets (reduce motion + high contrast)
-      expect(find.byType(Slider), findsOneWidget);
+      // Font size is a visual preference; it lives in Appearance now.
+      expect(find.text('Font Size'), findsNothing);
+      expect(find.byType(Slider), findsNothing);
+    });
+
+    testWidgets('Reduce Motion + High Contrast + GIF autoplay all present', (
+      tester,
+    ) async {
+      await _pump(tester);
       expect(find.text('Reduce Motion'), findsOneWidget);
       expect(find.text('High Contrast'), findsOneWidget);
+      expect(find.text('Auto-play GIFs'), findsOneWidget);
     });
   });
 }

--- a/apps/client/test/widgets/settings/appearance_section_test.dart
+++ b/apps/client/test/widgets/settings/appearance_section_test.dart
@@ -100,5 +100,21 @@ void main() {
       expect(find.text('Normal'), findsOneWidget);
       expect(find.text('Compact'), findsOneWidget);
     });
+
+    testWidgets('renders Font Size slider — moved from Accessibility (#1137)', (
+      tester,
+    ) async {
+      await _pumpWide(tester);
+      expect(find.text('Font Size'), findsOneWidget);
+      expect(find.byType(Slider), findsOneWidget);
+    });
+
+    testWidgets('no longer renders the GIF autoplay toggle (#1137)', (
+      tester,
+    ) async {
+      await _pumpWide(tester);
+      // GIF autoplay moved to Accessibility because it's a motion concern.
+      expect(find.text('Auto-play GIFs'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary
Two settings moved between panels to match what each panel is actually for. State backing is unchanged so existing user preferences roam between sections without a migration.

### Moves
- **Font size slider** → from Accessibility to **Appearance**. Visual preference; belongs next to theme and density.
- **GIF autoplay toggle** → from Appearance to **Accessibility**. Motion / vestibular / distraction concern; belongs next to Reduce Motion.

### What stays in this PR
- New \`_FontSizeRow\` extracted as a private \`ConsumerWidget\` in \`appearance_section.dart\`. Reads \`accessibilityProvider\` directly so the underlying state stays put.
- GIF autoplay control inlined into the Accessibility \`ConsumerWidget\` build method.
- Old test assertions updated; new \"should not be here anymore\" guards added on the old placements so a future move-back fails CI.

### What's deferred (still part of #1137)
- **Theme-preview redraw** — \`_darkPreview\` / \`_graphitePreview\` etc. drifted from current chat rendering. That's a focused design task; deserves a separate PR with screenshot diffs.
- **Show-encrypted-previews toggle** — needs a new SharedPreferences key + provider notifier + conditionals in \`conversations_provider\` and the WS message handler. Separate PR for clean review.

## Validation
- \`flutter analyze --fatal-infos\` clean.
- \`flutter test\` — **2254 / 2254 pass** (+3 net from the new placement-guard tests).

Refs #1137.