### PR TITLE
perf(client): reapply chat-list cacheExtent (#1133)

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -252,6 +252,18 @@ class ChatMessageList extends ConsumerWidget {
       child: ListView.builder(
         controller: scrollController,
         padding: const EdgeInsets.only(bottom: 16),
+        // Pre-build ~one viewport of off-screen messages on each side so that
+        // momentum scrolling doesn't flash blank space while items mount. The
+        // Flutter default of 250 is too tight for chat where rows include
+        // images, reactions, and reply quotes that each take a frame to lay
+        // out. Tuned conservatively to keep memory in check on long histories.
+        //
+        // Flutter 3.41+ renames this to scrollCacheExtent. We keep the old
+        // name + ignore the deprecation so the build works against both the
+        // pinned SDK (3.41.x) and any local dev SDK that still predates the
+        // rename. Drop the ignore once .flutter-version moves above 3.41.9.
+        // ignore: deprecated_member_use
+        cacheExtent: 600,
         itemCount: messages.length + 1,
         itemBuilder: (context, index) {
           if (index == 0) {


### PR DESCRIPTION
## Summary
Re-adds the chat \`ListView.builder\` \`cacheExtent: 600\` perf change that was reverted during PR #1132 because CI's Flutter (3.41.9) flagged the param as deprecated while local Flutter (3.41.6) didn't recognise the new name yet.

Using \`cacheExtent\` (old name) + \`// ignore: deprecated_member_use\` works on every Flutter 3.41.x version without an SDK pin bump. When \`.flutter-version\` eventually moves past 3.41.9 across the team, drop the ignore and rename to \`scrollCacheExtent\`.

## Effect
Pre-builds ~one viewport of off-screen messages on each side so momentum scrolling stops flashing blank space while images / reactions / reply quotes mount.

## Validation
- \`flutter analyze --fatal-infos\` clean on the touched file.
- \`flutter test test/widgets/chat_panel/\` — 35/35 pass.

Closes #1133.