### PR TITLE
Fix voice lounge on regional Echo servers like us-east (#1164)

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -735,7 +735,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
         final lkToken = data['token'] as String?;
         // Server may not return url — derive from serverUrl
-        final lkUrl = data['url'] as String? ?? _deriveLiveKitUrl(serverUrl);
+        final lkUrl = data['url'] as String? ?? deriveLiveKitUrl(serverUrl);
 
         if (lkToken != null) {
           debugPrint('[LiveKitVoice] token obtained, connecting to $lkUrl');
@@ -1106,11 +1106,20 @@ class _LiveKitTokenResult {
 }
 
 /// Derive LiveKit WebSocket URL from the Echo server URL.
-/// https://echo-messenger.us → wss://livekit.echo-messenger.us
-String _deriveLiveKitUrl(String serverUrl) {
+///
+/// Regional Echo subdomains (`us-east.echo-messenger.us`, `eu.echo-messenger.us`, ...)
+/// all share one LiveKit deployment at `livekit.echo-messenger.us`, so any
+/// `*.echo-messenger.us` host normalizes to the apex. Self-hosted (non-Echo)
+/// domains keep verbatim host prefixing so unknown deployments still work.
+@visibleForTesting
+String deriveLiveKitUrl(String serverUrl) {
   final uri = Uri.parse(serverUrl);
   final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
-  return '$scheme://livekit.${uri.host}';
+  final host = uri.host;
+  const echoApex = 'echo-messenger.us';
+  final isEchoHost = host == echoApex || host.endsWith('.$echoApex');
+  final livekitHost = isEchoHost ? 'livekit.$echoApex' : 'livekit.$host';
+  return '$scheme://$livekitHost';
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -1110,7 +1110,13 @@ class _LiveKitTokenResult {
 /// Regional Echo subdomains (`us-east.echo-messenger.us`, `eu.echo-messenger.us`, ...)
 /// all share one LiveKit deployment at `livekit.echo-messenger.us`, so any
 /// `*.echo-messenger.us` host normalizes to the apex. Self-hosted (non-Echo)
-/// domains keep verbatim host prefixing so unknown deployments still work.
+/// domains keep verbatim host prefixing — and preserve a non-standard port —
+/// so unknown deployments still work.
+///
+/// Examples:
+///   `https://echo-messenger.us`         → `wss://livekit.echo-messenger.us`
+///   `https://us-east.echo-messenger.us` → `wss://livekit.echo-messenger.us`
+///   `https://chat.example.com:8443`     → `wss://livekit.chat.example.com:8443`
 @visibleForTesting
 String deriveLiveKitUrl(String serverUrl) {
   final uri = Uri.parse(serverUrl);
@@ -1118,8 +1124,9 @@ String deriveLiveKitUrl(String serverUrl) {
   final host = uri.host;
   const echoApex = 'echo-messenger.us';
   final isEchoHost = host == echoApex || host.endsWith('.$echoApex');
-  final livekitHost = isEchoHost ? 'livekit.$echoApex' : 'livekit.$host';
-  return '$scheme://$livekitHost';
+  if (isEchoHost) return '$scheme://livekit.$echoApex';
+  final port = uri.hasPort ? ':${uri.port}' : '';
+  return '$scheme://livekit.$host$port';
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/test/providers/livekit_voice/derive_url_test.dart
+++ b/apps/client/test/providers/livekit_voice/derive_url_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/providers/livekit_voice/livekit_voice_provider.dart';
+
+void main() {
+  group('deriveLiveKitUrl', () {
+    test('apex echo-messenger.us derives livekit.echo-messenger.us', () {
+      expect(
+        deriveLiveKitUrl('https://echo-messenger.us'),
+        'wss://livekit.echo-messenger.us',
+      );
+    });
+
+    test('us-east regional API host normalizes to apex', () {
+      expect(
+        deriveLiveKitUrl('https://us-east.echo-messenger.us'),
+        'wss://livekit.echo-messenger.us',
+      );
+    });
+
+    test('arbitrary future region (eu) normalizes to apex', () {
+      expect(
+        deriveLiveKitUrl('https://eu.echo-messenger.us'),
+        'wss://livekit.echo-messenger.us',
+      );
+    });
+
+    test('self-host preserves verbatim host prefix', () {
+      expect(
+        deriveLiveKitUrl('https://chat.example.com'),
+        'wss://livekit.chat.example.com',
+      );
+    });
+
+    test('http schemes downgrade to ws', () {
+      expect(
+        deriveLiveKitUrl('http://localhost:8080'),
+        'ws://livekit.localhost',
+      );
+    });
+
+    test('echo lookalike domain is not normalized', () {
+      expect(
+        deriveLiveKitUrl('https://fakeecho-messenger.us'),
+        'wss://livekit.fakeecho-messenger.us',
+      );
+    });
+  });
+}

--- a/apps/client/test/providers/livekit_voice/derive_url_test.dart
+++ b/apps/client/test/providers/livekit_voice/derive_url_test.dart
@@ -32,10 +32,17 @@ void main() {
       );
     });
 
-    test('http schemes downgrade to ws', () {
+    test('http schemes downgrade to ws and preserve port', () {
       expect(
         deriveLiveKitUrl('http://localhost:8080'),
-        'ws://livekit.localhost',
+        'ws://livekit.localhost:8080',
+      );
+    });
+
+    test('self-host preserves a non-standard port', () {
+      expect(
+        deriveLiveKitUrl('https://chat.example.com:8443'),
+        'wss://livekit.chat.example.com:8443',
       );
     });
 
@@ -43,6 +50,20 @@ void main() {
       expect(
         deriveLiveKitUrl('https://fakeecho-messenger.us'),
         'wss://livekit.fakeecho-messenger.us',
+      );
+    });
+
+    test('uppercase echo host is normalized (Uri.parse lowercases)', () {
+      expect(
+        deriveLiveKitUrl('HTTPS://US-EAST.Echo-Messenger.US'),
+        'wss://livekit.echo-messenger.us',
+      );
+    });
+
+    test('trailing slash on regional host still normalizes to apex', () {
+      expect(
+        deriveLiveKitUrl('https://us-east.echo-messenger.us/'),
+        'wss://livekit.echo-messenger.us',
       );
     });
   });


### PR DESCRIPTION
## Summary

Riley (Windows, server picker set to `us-east.echo-messenger.us`) couldn't join the voice lounge — every attempt failed with:

```
[ERR] LiveKitVoice: joinChannel: room.connect threw: ClientException with SocketException:
  Failed host lookup: 'livekit.us-east.echo-messenger.us'
  (OS Error: No such host is known, errno = 11001)
```

The client derives the LiveKit URL by blindly prepending `livekit.` to whatever API host the user picked. With the Phase 1 domain migration (#1063), `us-east.echo-messenger.us` is now a valid API host alongside the apex, but only `livekit.echo-messenger.us` exists in DNS. Any regional Echo client hits NXDOMAIN.

Fixes #1164.

## Fixed

- **Voice lounge now connects from regional Echo servers.** Any `*.echo-messenger.us` API host (apex, `us-east.`, `eu.`, future regions) is normalized to `livekit.echo-messenger.us` before connecting. Self-hosted deployments keep verbatim host prefixing.
- **Self-hosted ports are now preserved.** Previously `deriveLiveKitUrl` silently dropped the port from the API URL, so a self-hoster running LiveKit on `:8443` would fail with no clear signal. `https://chat.example.com:8443` now derives `wss://livekit.chat.example.com:8443`. (This was a pre-existing latent bug surfaced during review.)

## Tested

`deriveLiveKitUrl` is renamed from private to `@visibleForTesting` and pinned by 9 unit tests covering:

- Apex (`echo-messenger.us` → `livekit.echo-messenger.us`).
- The **actual Riley regression** (`us-east.echo-messenger.us` → `livekit.echo-messenger.us`).
- Arbitrary future region (`eu.echo-messenger.us` → `livekit.echo-messenger.us`).
- Self-host verbatim (`chat.example.com` → `livekit.chat.example.com`).
- `http` schemes downgrade to `ws` and **preserve port** (`http://localhost:8080` → `ws://livekit.localhost:8080`).
- Self-host with a non-standard port (`chat.example.com:8443` → `livekit.chat.example.com:8443`).
- Lookalike domain is **not** normalized (`fakeecho-messenger.us` stays as `fakeecho-messenger.us`, defensive check on the suffix matcher).
- Uppercase hosts normalize (`HTTPS://US-EAST.Echo-Messenger.US` → `wss://livekit.echo-messenger.us`).
- Trailing slash on the API URL still normalizes (`us-east.echo-messenger.us/` → `livekit.echo-messenger.us`).

## Behind the scenes

- The server already has an `LIVEKIT_URL` env-var escape hatch (`apps/server/src/routes/voice.rs:159`) that pins the URL server-side. The hotfix has been applied to prod separately for an immediate Riley unblock. This PR is the durable client-side fix so new regional rollouts don't depend on operators remembering to set the env-var.

## Validation plan

- [ ] Wait for `dev-build.yml → build-windows` to finish.
- [ ] Hand the Windows artefact to Riley.
- [ ] In server picker, choose `us-east.echo-messenger.us`. Join the voice lounge.
- [ ] Expected: lounge connects without DNS error.
- [ ] Sanity on Linux: existing apex flow (`echo-messenger.us`) still works.

## Test results

- `dart format --set-exit-if-changed` — clean.
- `flutter analyze --fatal-infos` — clean.
- `flutter test` (full client suite) — **2265 passed**, 9 skipped (pre-existing), 0 failed (was 2256 baseline → +9 new).