### PR TITLE
Hide Skip button while update is downloading (#1155)

### DIFF
--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -633,7 +633,8 @@ class _UpdatePromptBody extends ConsumerWidget {
           isReady: isReady,
         ),
         if (isError) _buildErrorMessage(update),
-        if (!isReady && !isInstalling) _buildSkipButton(context, isBusy),
+        if (!isReady && !isInstalling && !isDownloading)
+          _buildSkipButton(context, isBusy),
       ],
     );
   }


### PR DESCRIPTION
## Summary

While an update is downloading from the splash screen, the **Skip** button currently renders directly below the progress bar — disabled, but still visible and crowding the "update in progress" view. Hides Skip during downloading (it was already correctly hidden during installing / ready-to-install), so the splash shows just the progress bar and the existing **Cancel download** affordance.

Fixes #1155.

## Fixed

- **Cleaner splash during update download.** Skip is now hidden whenever the update is in flight (downloading, installing, or ready-to-install). It stays visible for the idle / available / error states where dismissing the prompt is a legitimate next action.

## Behind the scenes

- One-line predicate change in `apps/client/lib/src/screens/splash_screen.dart` (`!isReady && !isInstalling` → `!isReady && !isInstalling && !isDownloading`).
- No new tests — there's no splash-widget test scaffolding to extend, and the change is a literal visibility-state gate; full 2265-test suite still passes.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` — 2265 passed, 9 skipped (pre-existing), 0 failed.