### PR TITLE
Scroll the Appearance panel from anywhere on the right pane (#1157)

### DIFF
--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -162,192 +162,202 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
       ),
     ];
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
-          children: [
-            Text(
-              'Theme',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
+    // SingleChildScrollView fills the full pane so mouse-wheel events in
+    // the side margins (outside the 900 px content column) still drive the
+    // scroll — the previous Center > ConstrainedBox > ListView only caught
+    // wheel events directly over a child (#1157).
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 900),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Theme',
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                ),
               ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Choose a theme. All themes are tuned for WCAG AA contrast.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
+              const SizedBox(height: 4),
+              Text(
+                'Choose a theme. All themes are tuned for WCAG AA contrast.',
+                style: TextStyle(
+                  color: context.textSecondary,
+                  fontSize: 13,
+                  height: 1.5,
+                ),
               ),
-            ),
-            const Divider(height: 24),
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              alignment: WrapAlignment.center,
-              children: themeOptions
-                  .map(
-                    (data) => _ThemeCard(
-                      data: data,
-                      isSelected: currentTheme == data.selection,
-                      onTap: () => ref
-                          .read(themeProvider.notifier)
-                          .setTheme(data.selection),
-                    ),
-                  )
-                  .toList(),
-            ),
-            const SizedBox(height: 32),
-            Text(
-              'Message layout',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
+              const Divider(height: 24),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                alignment: WrapAlignment.center,
+                children: themeOptions
+                    .map(
+                      (data) => _ThemeCard(
+                        data: data,
+                        isSelected: currentTheme == data.selection,
+                        onTap: () => ref
+                            .read(themeProvider.notifier)
+                            .setTheme(data.selection),
+                      ),
+                    )
+                    .toList(),
               ),
-            ),
-            const SizedBox(height: 16),
-            _LayoutOption(
-              label: 'Default',
-              subtitle: 'Bubbles aligned by sender, like iMessage or WhatsApp',
-              icon: Icons.chat_bubble_outline,
-              isSelected:
-                  ref.watch(messageLayoutProvider) == MessageLayout.bubbles,
-              onTap: () => ref
-                  .read(messageLayoutProvider.notifier)
-                  .setLayout(MessageLayout.bubbles),
-            ),
-            const SizedBox(height: 8),
-            _LayoutOption(
-              label: 'Discord',
-              subtitle:
-                  'Left-aligned with avatars and usernames, grouped by sender',
-              icon: Icons.format_align_left_outlined,
-              isSelected:
-                  ref.watch(messageLayoutProvider) == MessageLayout.compact,
-              onTap: () => ref
-                  .read(messageLayoutProvider.notifier)
-                  .setLayout(MessageLayout.compact),
-            ),
-            const SizedBox(height: 8),
-            _LayoutOption(
-              label: 'Slack',
-              subtitle: 'Left-aligned, no bubbles — clean document-style feed',
-              icon: Icons.notes_outlined,
-              isSelected:
-                  ref.watch(messageLayoutProvider) == MessageLayout.plain,
-              onTap: () => ref
-                  .read(messageLayoutProvider.notifier)
-                  .setLayout(MessageLayout.plain),
-            ),
-            const SizedBox(height: 32),
-            // Density tier — UX roadmap Phase 2.  Independent of message
-            // layout: density tunes sidebar row spacing without changing
-            // bubble style.
-            Text(
-              'Density',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
+              const SizedBox(height: 32),
+              Text(
+                'Message layout',
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
-            ),
-            const SizedBox(height: 16),
-            _LayoutOption(
-              label: 'Cozy',
-              subtitle: 'More breathing room',
-              icon: Icons.density_large,
-              isSelected: ref.watch(uiDensityProvider) == UIDensity.cozy,
-              onTap: () => ref
-                  .read(uiDensityProvider.notifier)
-                  .setDensity(UIDensity.cozy),
-            ),
-            const SizedBox(height: 8),
-            _LayoutOption(
-              label: 'Normal',
-              subtitle: 'Balanced default',
-              icon: Icons.density_medium,
-              isSelected: ref.watch(uiDensityProvider) == UIDensity.normal,
-              onTap: () => ref
-                  .read(uiDensityProvider.notifier)
-                  .setDensity(UIDensity.normal),
-            ),
-            const SizedBox(height: 8),
-            _LayoutOption(
-              label: 'Compact',
-              subtitle: 'Power-user dense, Discord-style',
-              icon: Icons.density_small,
-              isSelected: ref.watch(uiDensityProvider) == UIDensity.compact,
-              onTap: () => ref
-                  .read(uiDensityProvider.notifier)
-                  .setDensity(UIDensity.compact),
-            ),
-            const SizedBox(height: 32),
-            // Channel layout — top chip bar vs Slack/Discord vertical column.
-            // The toggle only affects desktop wide layouts; narrow viewports
-            // always render the bar because a column doesn't fit on phones.
-            Text(
-              'Channels',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
+              const SizedBox(height: 16),
+              _LayoutOption(
+                label: 'Default',
+                subtitle:
+                    'Bubbles aligned by sender, like iMessage or WhatsApp',
+                icon: Icons.chat_bubble_outline,
+                isSelected:
+                    ref.watch(messageLayoutProvider) == MessageLayout.bubbles,
+                onTap: () => ref
+                    .read(messageLayoutProvider.notifier)
+                    .setLayout(MessageLayout.bubbles),
               ),
-            ),
-            const SizedBox(height: 16),
-            _LayoutOption(
-              label: 'Bar',
-              subtitle: 'Chip row above the chat (current default)',
-              icon: Icons.view_stream_outlined,
-              isSelected: ref.watch(channelLayoutProvider) == ChannelLayout.bar,
-              onTap: () => ref
-                  .read(channelLayoutProvider.notifier)
-                  .setLayout(ChannelLayout.bar),
-            ),
-            const SizedBox(height: 8),
-            _LayoutOption(
-              label: 'Column',
-              subtitle: 'Slack/Discord-style vertical channel list',
-              icon: Icons.view_sidebar_outlined,
-              isSelected:
-                  ref.watch(channelLayoutProvider) == ChannelLayout.column,
-              onTap: () => ref
-                  .read(channelLayoutProvider.notifier)
-                  .setLayout(ChannelLayout.column),
-            ),
-            const SizedBox(height: 24),
-            // Font size (#1137 — moved from Accessibility). Pure visual
-            // preference, so it lives in Appearance alongside the theme
-            // picker. State still backs to accessibilityProvider so the
-            // setting roams between sections without a migration.
-            _FontSizeRow(),
-            const SizedBox(height: 32),
-            // Advanced color overrides (issue #613)
-            Text(
-              'Advanced',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
+              const SizedBox(height: 8),
+              _LayoutOption(
+                label: 'Discord',
+                subtitle:
+                    'Left-aligned with avatars and usernames, grouped by sender',
+                icon: Icons.format_align_left_outlined,
+                isSelected:
+                    ref.watch(messageLayoutProvider) == MessageLayout.compact,
+                onTap: () => ref
+                    .read(messageLayoutProvider.notifier)
+                    .setLayout(MessageLayout.compact),
               ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Override the active theme\'s primary and accent colors.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
+              const SizedBox(height: 8),
+              _LayoutOption(
+                label: 'Slack',
+                subtitle:
+                    'Left-aligned, no bubbles — clean document-style feed',
+                icon: Icons.notes_outlined,
+                isSelected:
+                    ref.watch(messageLayoutProvider) == MessageLayout.plain,
+                onTap: () => ref
+                    .read(messageLayoutProvider.notifier)
+                    .setLayout(MessageLayout.plain),
               ),
-            ),
-            const SizedBox(height: 12),
-            const AdvancedThemeInline(),
-          ],
+              const SizedBox(height: 32),
+              // Density tier — UX roadmap Phase 2.  Independent of message
+              // layout: density tunes sidebar row spacing without changing
+              // bubble style.
+              Text(
+                'Density',
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 16),
+              _LayoutOption(
+                label: 'Cozy',
+                subtitle: 'More breathing room',
+                icon: Icons.density_large,
+                isSelected: ref.watch(uiDensityProvider) == UIDensity.cozy,
+                onTap: () => ref
+                    .read(uiDensityProvider.notifier)
+                    .setDensity(UIDensity.cozy),
+              ),
+              const SizedBox(height: 8),
+              _LayoutOption(
+                label: 'Normal',
+                subtitle: 'Balanced default',
+                icon: Icons.density_medium,
+                isSelected: ref.watch(uiDensityProvider) == UIDensity.normal,
+                onTap: () => ref
+                    .read(uiDensityProvider.notifier)
+                    .setDensity(UIDensity.normal),
+              ),
+              const SizedBox(height: 8),
+              _LayoutOption(
+                label: 'Compact',
+                subtitle: 'Power-user dense, Discord-style',
+                icon: Icons.density_small,
+                isSelected: ref.watch(uiDensityProvider) == UIDensity.compact,
+                onTap: () => ref
+                    .read(uiDensityProvider.notifier)
+                    .setDensity(UIDensity.compact),
+              ),
+              const SizedBox(height: 32),
+              // Channel layout — top chip bar vs Slack/Discord vertical column.
+              // The toggle only affects desktop wide layouts; narrow viewports
+              // always render the bar because a column doesn't fit on phones.
+              Text(
+                'Channels',
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 16),
+              _LayoutOption(
+                label: 'Bar',
+                subtitle: 'Chip row above the chat (current default)',
+                icon: Icons.view_stream_outlined,
+                isSelected:
+                    ref.watch(channelLayoutProvider) == ChannelLayout.bar,
+                onTap: () => ref
+                    .read(channelLayoutProvider.notifier)
+                    .setLayout(ChannelLayout.bar),
+              ),
+              const SizedBox(height: 8),
+              _LayoutOption(
+                label: 'Column',
+                subtitle: 'Slack/Discord-style vertical channel list',
+                icon: Icons.view_sidebar_outlined,
+                isSelected:
+                    ref.watch(channelLayoutProvider) == ChannelLayout.column,
+                onTap: () => ref
+                    .read(channelLayoutProvider.notifier)
+                    .setLayout(ChannelLayout.column),
+              ),
+              const SizedBox(height: 24),
+              // Font size (#1137 — moved from Accessibility). Pure visual
+              // preference, so it lives in Appearance alongside the theme
+              // picker. State still backs to accessibilityProvider so the
+              // setting roams between sections without a migration.
+              _FontSizeRow(),
+              const SizedBox(height: 32),
+              // Advanced color overrides (issue #613)
+              Text(
+                'Advanced',
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Override the active theme\'s primary and accent colors.',
+                style: TextStyle(
+                  color: context.textSecondary,
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 12),
+              const AdvancedThemeInline(),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/client/test/screens/settings/appearance_section_scroll_test.dart
+++ b/apps/client/test/screens/settings/appearance_section_scroll_test.dart
@@ -1,0 +1,66 @@
+// Regression test for #1157: scroll-wheel events in the side margins of the
+// Appearance settings pane must drive the panel's scroll. Previously the pane
+// nested a max-900px ListView inside Center + ConstrainedBox, so anything
+// outside the 900 px content column received no scroll surface and the wheel
+// did nothing.
+//
+// Pump the section in a 1600 px window, fire a PointerScrollEvent 50 px from
+// the right edge (guaranteed to be outside the 900 px column), and assert the
+// SingleChildScrollView's offset increased.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/screens/settings/appearance_section.dart';
+import 'package:echo_app/src/theme/echo_theme.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('side-margin scroll drives the appearance panel (#1157)', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1600, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: EchoTheme.darkTheme,
+          home: const Scaffold(body: AppearanceSection()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final scrollableFinder = find.byType(Scrollable);
+    expect(scrollableFinder, findsOneWidget);
+    final scrollPosition = tester
+        .state<ScrollableState>(scrollableFinder)
+        .position;
+    expect(scrollPosition.pixels, 0.0);
+
+    // Pointer 50 px from the right edge — well outside the 900 px content
+    // column on a 1600 px window. Before the fix this position received no
+    // scroll surface and the event did nothing.
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    const sidePosition = Offset(1550, 450);
+    await tester.sendEventToBinding(pointer.hover(sidePosition));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, 200)));
+    await tester.pumpAndSettle();
+
+    expect(
+      scrollPosition.pixels,
+      greaterThan(0.0),
+      reason:
+          'Scrolling at the right margin (1550 px on a 1600 px window) must '
+          'drive the Appearance panel — fix for #1157.',
+    );
+  });
+}

--- a/apps/client/test/screens/settings/appearance_section_scroll_test.dart
+++ b/apps/client/test/screens/settings/appearance_section_scroll_test.dart
@@ -4,9 +4,10 @@
 // outside the 900 px content column received no scroll surface and the wheel
 // did nothing.
 //
-// Pump the section in a 1600 px window, fire a PointerScrollEvent 50 px from
-// the right edge (guaranteed to be outside the 900 px column), and assert the
-// SingleChildScrollView's offset increased.
+// On a 1600 px window the centered 900 px column sits at x≈350..1250, so
+// fire a PointerScrollEvent at x=1550 (right margin) AND x=50 (left margin),
+// asserting both drive the scroll — symmetric coverage so a future regression
+// that only re-narrows one side still fails.
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -22,9 +23,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testWidgets('side-margin scroll drives the appearance panel (#1157)', (
-    tester,
-  ) async {
+  Future<ScrollPosition> pumpAndFindScroll(WidgetTester tester) async {
     tester.view.physicalSize = const Size(1600, 900);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -39,28 +38,35 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final scrollableFinder = find.byType(Scrollable);
-    expect(scrollableFinder, findsOneWidget);
-    final scrollPosition = tester
-        .state<ScrollableState>(scrollableFinder)
-        .position;
-    expect(scrollPosition.pixels, 0.0);
+    final finder = find.byType(Scrollable);
+    expect(finder, findsOneWidget);
+    return tester.state<ScrollableState>(finder).position;
+  }
 
-    // Pointer 50 px from the right edge — well outside the 900 px content
-    // column on a 1600 px window. Before the fix this position received no
-    // scroll surface and the event did nothing.
+  Future<void> scrollAt(WidgetTester tester, Offset position) async {
     final pointer = TestPointer(1, PointerDeviceKind.mouse);
-    const sidePosition = Offset(1550, 450);
-    await tester.sendEventToBinding(pointer.hover(sidePosition));
+    await tester.sendEventToBinding(pointer.hover(position));
     await tester.sendEventToBinding(pointer.scroll(const Offset(0, 200)));
     await tester.pumpAndSettle();
+  }
 
-    expect(
-      scrollPosition.pixels,
-      greaterThan(0.0),
-      reason:
-          'Scrolling at the right margin (1550 px on a 1600 px window) must '
-          'drive the Appearance panel — fix for #1157.',
-    );
+  testWidgets('right-margin scroll drives the appearance panel (#1157)', (
+    tester,
+  ) async {
+    final scroll = await pumpAndFindScroll(tester);
+    expect(scroll.pixels, 0.0);
+
+    await scrollAt(tester, const Offset(1550, 450));
+    expect(scroll.pixels, greaterThan(0.0));
+  });
+
+  testWidgets('left-margin scroll drives the appearance panel (#1157)', (
+    tester,
+  ) async {
+    final scroll = await pumpAndFindScroll(tester);
+    expect(scroll.pixels, 0.0);
+
+    await scrollAt(tester, const Offset(50, 450));
+    expect(scroll.pixels, greaterThan(0.0));
   });
 }


### PR DESCRIPTION
## Summary

Mouse-wheel scrolling in Settings → Appearance only worked when the cursor was directly over a UI element. Hovering in the empty side margins of the right pane did nothing. Now the wheel scrolls the panel from anywhere in the pane.

Fixes #1157.

## Fixed

- **Wheel scroll now works across the full pane.** Restructured the layout: \`SingleChildScrollView\` fills the pane (catches wheel events anywhere), and the centered + 900 px-capped content lives inside as a \`Column\`. Visible content is identical to before — only the scroll-surface size changed.

## Behind the scenes

- New widget test \`apps/client/test/screens/settings/appearance_section_scroll_test.dart\` pumps the section in a 1600 px window and fires \`PointerScrollEvent\` at both the **right margin (x=1550)** and the **left margin (x=50)** — guaranteed outside the 900 px content column. Asserts the scrollable's offset moves in both cases. Regression-proof against any future re-narrowing of the scroll surface.

## Follow-up

The same broken pattern (\`Center > ConstrainedBox(900) > ListView\`) exists in every other settings sub-panel — Notifications, Voice & Video, Privacy, Accessibility, etc. Tracked as **#1169** for a sweep or extract-shared-shell pass. Out of scope here.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2271 passed**, 9 skipped (pre-existing), 0 failed (was 2269 → +2 net for the symmetric scroll tests).