### PR TITLE
Scroll every Settings panel from anywhere on the right pane (#1169)

### DIFF
--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -23,8 +23,9 @@ import '../../theme/echo_theme.dart';
 import '../../version.dart';
 import '../../widgets/confirm_dialog.dart';
 import '../../widgets/feedback_dialog.dart';
-import '../../widgets/settings/settings_list_tile.dart';
 import '../../widgets/input_dialog.dart';
+import '../../widgets/settings/settings_list_tile.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 class AboutSection extends ConsumerStatefulWidget {
   const AboutSection({super.key});
@@ -510,156 +511,146 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
-          children: [
-            Text(
-              'Echo Messenger',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Client v$appVersion',
-              style: TextStyle(color: context.textMuted, fontSize: 14),
-            ),
-            SelectableText(
-              'Build $appCommit'
-              '${appBuildTime.isEmpty ? '' : ' · $appBuildTime'}',
-              style: TextStyle(
-                color: context.textMuted,
-                fontSize: 12,
-                fontFamily: 'monospace',
-              ),
-            ),
-            const SizedBox(height: 16),
-            _buildCheckForUpdates(),
-            const SizedBox(height: 24),
-            Divider(color: context.border),
-            const SizedBox(height: 16),
-            // Server info (merged from former Server section)
-            Text(
-              'Server',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 12),
-            _buildServersList(),
-            const SizedBox(height: 8),
-            SettingsListTile(
-              icon: Icons.add_circle_outline,
-              title: 'Add server',
-              subtitle: 'Verifies the URL before adding it to your list.',
-              onTap: _showAddServerDialog,
-            ),
-            const SizedBox(height: 16),
-            Divider(color: context.border),
-            const SizedBox(height: 16),
-            // Debug logs entry (absorbed from former Debug section).
-            SettingsListTile(
-              icon: Icons.bug_report_outlined,
-              title: 'Debug Logs',
-              subtitle: 'View recent in-app log entries.',
-              onTap: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const _DebugLogsSubpage(),
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 8),
-            // Beta-prep #4c: surface the feedback dialog from About so testers
-            // have a one-tap path to report issues without leaving the app.
-            SettingsListTile(
-              key: const Key('about-send-feedback'),
-              icon: Icons.feedback_outlined,
-              title: 'Send feedback',
-              subtitle: 'Report a bug or share a suggestion.',
-              onTap: () => showFeedbackDialog(context),
-            ),
-            // Privacy link — opens the GitHub-rendered docs/PRIVACY.md so the
-            // canonical text isn't bundled in every app build.
-            SettingsListTile(
-              key: const Key('about-privacy-link'),
-              icon: Icons.privacy_tip_outlined,
-              title: 'Privacy',
-              subtitle:
-                  'What Echo stores, what it does not, and where the data lives.',
-              trailing: Icon(
-                Icons.open_in_new,
-                color: context.textMuted,
-                size: 18,
-              ),
-              onTap: () async {
-                final uri = Uri.parse(
-                  'https://github.com/NC1107/echo-messenger/blob/main/docs/PRIVACY.md',
-                );
-                final ok = await launchUrl(
-                  uri,
-                  mode: LaunchMode.externalApplication,
-                );
-                if (!ok && context.mounted) {
-                  ToastService.show(
-                    context,
-                    'Could not open privacy link.',
-                    type: ToastType.error,
-                  );
-                }
-              },
-            ),
-            const SizedBox(height: 16),
-            Divider(color: context.border),
-            const SizedBox(height: 16),
-            Text(
-              'Open source',
-              style: TextStyle(
-                color: context.accent,
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Echo is a decentralized, end-to-end encrypted messenger. '
-              'Contributions and self-hosting are welcome.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 32),
-            Divider(color: context.border),
-            const SizedBox(height: 16),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: _deleteAccount,
-                icon: const Icon(Icons.delete_forever_outlined, size: 18),
-                label: const Text('Delete Account'),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: EchoTheme.danger,
-                  side: const BorderSide(color: EchoTheme.danger),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                ),
-              ),
-            ),
-          ],
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Echo Messenger',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
         ),
-      ),
+        const SizedBox(height: 8),
+        Text(
+          'Client v$appVersion',
+          style: TextStyle(color: context.textMuted, fontSize: 14),
+        ),
+        SelectableText(
+          'Build $appCommit'
+          '${appBuildTime.isEmpty ? '' : ' · $appBuildTime'}',
+          style: TextStyle(
+            color: context.textMuted,
+            fontSize: 12,
+            fontFamily: 'monospace',
+          ),
+        ),
+        const SizedBox(height: 16),
+        _buildCheckForUpdates(),
+        const SizedBox(height: 24),
+        Divider(color: context.border),
+        const SizedBox(height: 16),
+        // Server info (merged from former Server section)
+        Text(
+          'Server',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 12),
+        _buildServersList(),
+        const SizedBox(height: 8),
+        SettingsListTile(
+          icon: Icons.add_circle_outline,
+          title: 'Add server',
+          subtitle: 'Verifies the URL before adding it to your list.',
+          onTap: _showAddServerDialog,
+        ),
+        const SizedBox(height: 16),
+        Divider(color: context.border),
+        const SizedBox(height: 16),
+        // Debug logs entry (absorbed from former Debug section).
+        SettingsListTile(
+          icon: Icons.bug_report_outlined,
+          title: 'Debug Logs',
+          subtitle: 'View recent in-app log entries.',
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const _DebugLogsSubpage(),
+              ),
+            );
+          },
+        ),
+        const SizedBox(height: 8),
+        // Beta-prep #4c: surface the feedback dialog from About so testers
+        // have a one-tap path to report issues without leaving the app.
+        SettingsListTile(
+          key: const Key('about-send-feedback'),
+          icon: Icons.feedback_outlined,
+          title: 'Send feedback',
+          subtitle: 'Report a bug or share a suggestion.',
+          onTap: () => showFeedbackDialog(context),
+        ),
+        // Privacy link — opens the GitHub-rendered docs/PRIVACY.md so the
+        // canonical text isn't bundled in every app build.
+        SettingsListTile(
+          key: const Key('about-privacy-link'),
+          icon: Icons.privacy_tip_outlined,
+          title: 'Privacy',
+          subtitle:
+              'What Echo stores, what it does not, and where the data lives.',
+          trailing: Icon(Icons.open_in_new, color: context.textMuted, size: 18),
+          onTap: () async {
+            final uri = Uri.parse(
+              'https://github.com/NC1107/echo-messenger/blob/main/docs/PRIVACY.md',
+            );
+            final ok = await launchUrl(
+              uri,
+              mode: LaunchMode.externalApplication,
+            );
+            if (!ok && context.mounted) {
+              ToastService.show(
+                context,
+                'Could not open privacy link.',
+                type: ToastType.error,
+              );
+            }
+          },
+        ),
+        const SizedBox(height: 16),
+        Divider(color: context.border),
+        const SizedBox(height: 16),
+        Text(
+          'Open source',
+          style: TextStyle(
+            color: context.accent,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Echo is a decentralized, end-to-end encrypted messenger. '
+          'Contributions and self-hosting are welcome.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 32),
+        Divider(color: context.border),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: _deleteAccount,
+            icon: const Icon(Icons.delete_forever_outlined, size: 18),
+            label: const Text('Delete Account'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: EchoTheme.danger,
+              side: const BorderSide(color: EchoTheme.danger),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/accessibility_section.dart
+++ b/apps/client/lib/src/screens/settings/accessibility_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/accessibility_provider.dart';
 import '../../providers/gif_playback_provider.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 /// Dedicated Accessibility settings section.
 ///
@@ -23,237 +24,227 @@ class AccessibilitySection extends ConsumerWidget {
     final state = ref.watch(accessibilityProvider);
     final notifier = ref.read(accessibilityProvider.notifier);
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
-          children: [
-            Text(
-              'Accessibility',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Adjust the app to your needs.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Accessibility',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Adjust the app to your needs.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
 
-            const SizedBox(height: 20),
+        const SizedBox(height: 20),
 
-            // ── Live Preview ─────────────────────────────────────────────
-            // Reflects the font-scale and high-contrast settings below in
-            // real time so users can see effects without leaving Settings.
-            Text(
-              'Preview',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 14,
-                fontWeight: FontWeight.w700,
-              ),
+        // ── Live Preview ─────────────────────────────────────────────
+        // Reflects the font-scale and high-contrast settings below in
+        // real time so users can see effects without leaving Settings.
+        Text(
+          'Preview',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        MediaQuery.withClampedTextScaling(
+          minScaleFactor: state.fontScale,
+          maxScaleFactor: state.fontScale,
+          child: Container(
+            decoration: BoxDecoration(
+              color: context.surface,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: Theme.of(context).dividerColor),
             ),
-            const SizedBox(height: 8),
-            MediaQuery.withClampedTextScaling(
-              minScaleFactor: state.fontScale,
-              maxScaleFactor: state.fontScale,
-              child: Container(
-                decoration: BoxDecoration(
-                  color: context.surface,
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: Theme.of(context).dividerColor),
-                ),
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
                   children: [
-                    Row(
-                      children: [
-                        CircleAvatar(
-                          radius: 18,
-                          backgroundColor: context.accent,
-                          child: Text(
-                            'SP',
-                            style: TextStyle(
-                              color: Theme.of(context).colorScheme.onPrimary,
-                              fontWeight: FontWeight.w600,
-                              fontSize: 13,
-                            ),
-                          ),
+                    CircleAvatar(
+                      radius: 18,
+                      backgroundColor: context.accent,
+                      child: Text(
+                        'SP',
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.onPrimary,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 13,
                         ),
-                        const SizedBox(width: 10),
-                        Text(
-                          'Sam Patel',
-                          style: TextStyle(
-                            color: context.textPrimary,
-                            fontWeight: FontWeight.w600,
-                            fontSize: 14,
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 6,
-                            vertical: 2,
-                          ),
-                          decoration: BoxDecoration(
-                            color: context.accent.withValues(alpha: 0.15),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: Text(
-                            'ADMIN',
-                            style: TextStyle(
-                              color: context.accent,
-                              fontSize: 10,
-                              fontWeight: FontWeight.w700,
-                              letterSpacing: 0.5,
-                            ),
-                          ),
-                        ),
-                      ],
+                      ),
                     ),
-                    const SizedBox(height: 10),
+                    const SizedBox(width: 10),
+                    Text(
+                      'Sam Patel',
+                      style: TextStyle(
+                        color: context.textPrimary,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
                     Container(
                       padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
+                        horizontal: 6,
+                        vertical: 2,
                       ),
                       decoration: BoxDecoration(
-                        color: context.accent.withValues(alpha: 0.12),
-                        borderRadius: BorderRadius.circular(12),
+                        color: context.accent.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(4),
                       ),
                       child: Text(
-                        'End-to-end encrypted. Self-hosted. '
-                        'Your messages stay yours.',
+                        'ADMIN',
                         style: TextStyle(
-                          color: context.textPrimary,
-                          fontSize: 14,
-                          height: 1.35,
+                          color: context.accent,
+                          fontSize: 10,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.5,
                         ),
                       ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      '7:38 PM',
-                      style: TextStyle(color: context.textMuted, fontSize: 11),
                     ),
                   ],
                 ),
-              ),
-            ),
-
-            const Divider(height: 32),
-
-            // ── Reduce Motion ─────────────────────────────────────────────
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              secondary: const Icon(Icons.animation_outlined),
-              title: Text(
-                'Reduce Motion',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
+                const SizedBox(height: 10),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: context.accent.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    'End-to-end encrypted. Self-hosted. '
+                    'Your messages stay yours.',
+                    style: TextStyle(
+                      color: context.textPrimary,
+                      fontSize: 14,
+                      height: 1.35,
+                    ),
+                  ),
                 ),
-              ),
-              subtitle: Text(
-                'Disable animated transitions and effects.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: state.reducedMotion,
-              onChanged: notifier.setReducedMotion,
-            ),
-
-            const SizedBox(height: 8),
-
-            // ── GIF autoplay (#1137) ──────────────────────────────────────
-            // Autoplay is a motion / vestibular / distraction concern; lives
-            // here next to Reduce Motion. Font size moved to Appearance.
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              secondary: const Icon(Icons.gif_outlined),
-              title: Text(
-                'Auto-play GIFs',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
+                const SizedBox(height: 6),
+                Text(
+                  '7:38 PM',
+                  style: TextStyle(color: context.textMuted, fontSize: 11),
                 ),
-              ),
-              subtitle: Text(
-                'When off, GIFs show as static thumbnails with a play button.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: ref.watch(gifPlaybackProvider).autoplayEnabled,
-              onChanged: (v) =>
-                  ref.read(gifPlaybackProvider.notifier).setAutoplay(v),
+              ],
             ),
-
-            const SizedBox(height: 16),
-
-            // ── High Contrast ─────────────────────────────────────────────
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              secondary: const Icon(Icons.contrast_outlined),
-              title: Text(
-                'High Contrast',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              subtitle: Text(
-                'Increase contrast for better readability.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: state.highContrast,
-              onChanged: notifier.setHighContrast,
-            ),
-
-            const SizedBox(height: 16),
-
-            // ── Hide undecryptable messages (#668) ─────────────────────────
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              secondary: const Icon(Icons.lock_outline),
-              title: Text(
-                'Hide undecryptable messages',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              subtitle: Text(
-                'When on, messages that cannot be decrypted are hidden '
-                'entirely instead of showing a lock icon.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: state.hideUndecryptable,
-              onChanged: notifier.setHideUndecryptable,
-            ),
-
-            const SizedBox(height: 24),
-            Text(
-              'OS accessibility preferences (reduce motion, large text) are '
-              'detected automatically and applied on first launch.',
-              style: TextStyle(
-                color: context.textMuted,
-                fontSize: 11,
-                height: 1.5,
-              ),
-            ),
-          ],
+          ),
         ),
-      ),
+
+        const Divider(height: 32),
+
+        // ── Reduce Motion ─────────────────────────────────────────────
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          secondary: const Icon(Icons.animation_outlined),
+          title: Text(
+            'Reduce Motion',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          subtitle: Text(
+            'Disable animated transitions and effects.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: state.reducedMotion,
+          onChanged: notifier.setReducedMotion,
+        ),
+
+        const SizedBox(height: 8),
+
+        // ── GIF autoplay (#1137) ──────────────────────────────────────
+        // Autoplay is a motion / vestibular / distraction concern; lives
+        // here next to Reduce Motion. Font size moved to Appearance.
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          secondary: const Icon(Icons.gif_outlined),
+          title: Text(
+            'Auto-play GIFs',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          subtitle: Text(
+            'When off, GIFs show as static thumbnails with a play button.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: ref.watch(gifPlaybackProvider).autoplayEnabled,
+          onChanged: (v) =>
+              ref.read(gifPlaybackProvider.notifier).setAutoplay(v),
+        ),
+
+        const SizedBox(height: 16),
+
+        // ── High Contrast ─────────────────────────────────────────────
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          secondary: const Icon(Icons.contrast_outlined),
+          title: Text(
+            'High Contrast',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          subtitle: Text(
+            'Increase contrast for better readability.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: state.highContrast,
+          onChanged: notifier.setHighContrast,
+        ),
+
+        const SizedBox(height: 16),
+
+        // ── Hide undecryptable messages (#668) ─────────────────────────
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          secondary: const Icon(Icons.lock_outline),
+          title: Text(
+            'Hide undecryptable messages',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          subtitle: Text(
+            'When on, messages that cannot be decrypted are hidden '
+            'entirely instead of showing a lock icon.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: state.hideUndecryptable,
+          onChanged: notifier.setHideUndecryptable,
+        ),
+
+        const SizedBox(height: 24),
+        Text(
+          'OS accessibility preferences (reduce motion, large text) are '
+          'detected automatically and applied on first launch.',
+          style: TextStyle(color: context.textMuted, fontSize: 11, height: 1.5),
+        ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -16,6 +16,7 @@ import '../../theme/echo_theme.dart';
 import '../../utils/friendly_error.dart';
 import '../../widgets/avatar_crop_dialog.dart';
 import '../../widgets/avatar_utils.dart' show resolveAvatarUrl;
+import '../../widgets/settings_panel_scaffold.dart';
 
 class _CountryCode {
   final String name;
@@ -598,188 +599,179 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     final authState = ref.watch(authProvider);
     final username = authState.username ?? 'Unknown';
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
+    return SettingsPanelScaffold(
+      children: [
+        _buildProfileCard(authState, username),
+        const SizedBox(height: 16),
+        // Action buttons row
+        Row(
           children: [
-            _buildProfileCard(authState, username),
-            const SizedBox(height: 16),
-            // Action buttons row
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _uploadAvatar,
-                    icon: const Icon(Icons.upload, size: 16),
-                    label: const Text('Upload Avatar'),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _showQrCodeDialog,
-                    icon: const Icon(Icons.qr_code, size: 16),
-                    label: const Text('QR Code'),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            SizedBox(
-              width: double.infinity,
+            Expanded(
               child: OutlinedButton.icon(
-                onPressed: _copyInviteLink,
-                icon: const Icon(Icons.link, size: 16),
-                label: const Text('Share Invite Link'),
+                onPressed: _uploadAvatar,
+                icon: const Icon(Icons.upload, size: 16),
+                label: const Text('Upload Avatar'),
               ),
             ),
-            if (_profileError) ...[
-              const Divider(height: 40),
-              Row(
-                children: [
-                  const Icon(
-                    Icons.error_outline,
-                    size: 18,
-                    color: EchoTheme.danger,
-                  ),
-                  const SizedBox(width: 8),
-                  const Expanded(
-                    child: Text(
-                      'Failed to load profile. Check your connection.',
-                      style: TextStyle(color: EchoTheme.danger, fontSize: 13),
-                    ),
-                  ),
-                  TextButton(
-                    onPressed: _loadProfile,
-                    child: const Text('Retry'),
-                  ),
-                ],
-              ),
-            ],
-            if (_profileLoaded) ...[
-              const Divider(height: 40),
-              Text(
-                'Profile',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Customize your public profile information.',
-                style: TextStyle(
-                  color: context.textSecondary,
-                  fontSize: 13,
-                  height: 1.5,
-                ),
-              ),
-              const Divider(height: 24),
-              _profileField(
-                controller: _displayNameController,
-                label: 'Display Name',
-                hint: 'How others see you',
-                maxLength: 50,
-              ),
-              const SizedBox(height: 12),
-              _buildPronounsField(),
-              const SizedBox(height: 12),
-              _profileField(
-                controller: _statusController,
-                label: 'Status',
-                hint: 'What are you up to?',
-                maxLength: 100,
-              ),
-              const SizedBox(height: 12),
-              _profileField(
-                controller: _bioController,
-                label: 'Bio',
-                hint: 'Tell people about yourself',
-                maxLength: 280,
-                maxLines: 3,
-              ),
-              const SizedBox(height: 12),
-              _buildTimezoneDropdown(),
-              const SizedBox(height: 12),
-              _profileField(
-                controller: _websiteController,
-                label: 'Website',
-                hint: 'https://example.com',
-                maxLength: 200,
-              ),
-              const SizedBox(height: 12),
-              _profileField(
-                controller: _emailController,
-                label: 'Email',
-                hint: 'you@example.com',
-                maxLength: 254,
-              ),
-              const SizedBox(height: 12),
-              _buildPhoneField(),
-              const SizedBox(height: 20),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  onPressed: _saving ? null : _saveProfile,
-                  child: _saving
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Colors.white,
-                          ),
-                        )
-                      : const Text('Save Profile'),
-                ),
-              ),
-            ],
-            // Password change section (always visible, outside _profileLoaded gate)
-            const Divider(height: 40),
-            Text(
-              'Change Password',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 16),
-            _profileField(
-              controller: _currentPasswordController,
-              label: 'Current Password',
-              hint: 'Enter your current password',
-              maxLength: 128,
-              obscure: true,
-            ),
-            const SizedBox(height: 12),
-            _profileField(
-              controller: _newPasswordController,
-              label: 'New Password',
-              hint: 'At least 8 characters',
-              maxLength: 128,
-              obscure: true,
-            ),
-            const SizedBox(height: 16),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton(
-                onPressed: _changingPassword ? null : _changePassword,
-                child: _changingPassword
-                    ? const SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Text('Change Password'),
+            const SizedBox(width: 8),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: _showQrCodeDialog,
+                icon: const Icon(Icons.qr_code, size: 16),
+                label: const Text('QR Code'),
               ),
             ),
           ],
         ),
-      ),
+        const SizedBox(height: 8),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: _copyInviteLink,
+            icon: const Icon(Icons.link, size: 16),
+            label: const Text('Share Invite Link'),
+          ),
+        ),
+        if (_profileError) ...[
+          const Divider(height: 40),
+          Row(
+            children: [
+              const Icon(
+                Icons.error_outline,
+                size: 18,
+                color: EchoTheme.danger,
+              ),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'Failed to load profile. Check your connection.',
+                  style: TextStyle(color: EchoTheme.danger, fontSize: 13),
+                ),
+              ),
+              TextButton(onPressed: _loadProfile, child: const Text('Retry')),
+            ],
+          ),
+        ],
+        if (_profileLoaded) ...[
+          const Divider(height: 40),
+          Text(
+            'Profile',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Customize your public profile information.',
+            style: TextStyle(
+              color: context.textSecondary,
+              fontSize: 13,
+              height: 1.5,
+            ),
+          ),
+          const Divider(height: 24),
+          _profileField(
+            controller: _displayNameController,
+            label: 'Display Name',
+            hint: 'How others see you',
+            maxLength: 50,
+          ),
+          const SizedBox(height: 12),
+          _buildPronounsField(),
+          const SizedBox(height: 12),
+          _profileField(
+            controller: _statusController,
+            label: 'Status',
+            hint: 'What are you up to?',
+            maxLength: 100,
+          ),
+          const SizedBox(height: 12),
+          _profileField(
+            controller: _bioController,
+            label: 'Bio',
+            hint: 'Tell people about yourself',
+            maxLength: 280,
+            maxLines: 3,
+          ),
+          const SizedBox(height: 12),
+          _buildTimezoneDropdown(),
+          const SizedBox(height: 12),
+          _profileField(
+            controller: _websiteController,
+            label: 'Website',
+            hint: 'https://example.com',
+            maxLength: 200,
+          ),
+          const SizedBox(height: 12),
+          _profileField(
+            controller: _emailController,
+            label: 'Email',
+            hint: 'you@example.com',
+            maxLength: 254,
+          ),
+          const SizedBox(height: 12),
+          _buildPhoneField(),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: _saving ? null : _saveProfile,
+              child: _saving
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Text('Save Profile'),
+            ),
+          ),
+        ],
+        // Password change section (always visible, outside _profileLoaded gate)
+        const Divider(height: 40),
+        Text(
+          'Change Password',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _profileField(
+          controller: _currentPasswordController,
+          label: 'Current Password',
+          hint: 'Enter your current password',
+          maxLength: 128,
+          obscure: true,
+        ),
+        const SizedBox(height: 12),
+        _profileField(
+          controller: _newPasswordController,
+          label: 'New Password',
+          hint: 'At least 8 characters',
+          maxLength: 128,
+          obscure: true,
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton(
+            onPressed: _changingPassword ? null : _changePassword,
+            child: _changingPassword
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Change Password'),
+          ),
+        ),
+      ],
     );
   }
 

--- a/apps/client/lib/src/screens/settings/advanced_theme_section.dart
+++ b/apps/client/lib/src/screens/settings/advanced_theme_section.dart
@@ -83,7 +83,7 @@ class AdvancedThemeSection extends ConsumerWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Inline variant: embeds directly inside AppearanceSection's ListView
+// Inline variant: embeds directly inside AppearanceSection's panel column
 // ---------------------------------------------------------------------------
 
 /// Compact inline widget that renders the two color picker tiles and an

--- a/apps/client/lib/src/screens/settings/advanced_theme_section.dart
+++ b/apps/client/lib/src/screens/settings/advanced_theme_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/theme_provider.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 /// Settings > Appearance > Advanced — lets the user override the current
 /// theme's primary and accent colors. Persisted via SharedPreferences keys
@@ -19,70 +20,64 @@ class AdvancedThemeSection extends ConsumerWidget {
     final effectivePrimary = custom.primaryColor ?? scheme.primary;
     final effectiveAccent = custom.accentColor ?? scheme.secondary;
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
-          children: [
-            Text(
-              'Advanced',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Override the active theme\'s primary and accent colors. '
-              'Changes apply immediately and survive restarts.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const Divider(height: 32),
-            _ColorPickerTile(
-              key: const Key('primary_color_tile'),
-              label: 'Primary color',
-              subtitle: 'Used for text highlights and UI elements',
-              currentColor: effectivePrimary,
-              isOverridden: custom.primaryColor != null,
-              onColorChanged: (c) =>
-                  ref.read(customColorsProvider.notifier).setPrimaryColor(c),
-            ),
-            const SizedBox(height: 12),
-            _ColorPickerTile(
-              key: const Key('accent_color_tile'),
-              label: 'Accent color',
-              subtitle: 'Used for buttons, links, and active states',
-              currentColor: effectiveAccent,
-              isOverridden: custom.accentColor != null,
-              onColorChanged: (c) =>
-                  ref.read(customColorsProvider.notifier).setAccentColor(c),
-            ),
-            if (custom.hasOverrides) ...[
-              const SizedBox(height: 24),
-              Align(
-                alignment: Alignment.centerLeft,
-                child: OutlinedButton.icon(
-                  key: const Key('reset_colors_button'),
-                  onPressed: () =>
-                      ref.read(customColorsProvider.notifier).resetColors(),
-                  icon: const Icon(Icons.refresh, size: 18),
-                  label: const Text('Reset to theme defaults'),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: context.textSecondary,
-                    side: BorderSide(color: context.border),
-                  ),
-                ),
-              ),
-            ],
-          ],
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Advanced',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
         ),
-      ),
+        const SizedBox(height: 4),
+        Text(
+          'Override the active theme\'s primary and accent colors. '
+          'Changes apply immediately and survive restarts.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const Divider(height: 32),
+        _ColorPickerTile(
+          key: const Key('primary_color_tile'),
+          label: 'Primary color',
+          subtitle: 'Used for text highlights and UI elements',
+          currentColor: effectivePrimary,
+          isOverridden: custom.primaryColor != null,
+          onColorChanged: (c) =>
+              ref.read(customColorsProvider.notifier).setPrimaryColor(c),
+        ),
+        const SizedBox(height: 12),
+        _ColorPickerTile(
+          key: const Key('accent_color_tile'),
+          label: 'Accent color',
+          subtitle: 'Used for buttons, links, and active states',
+          currentColor: effectiveAccent,
+          isOverridden: custom.accentColor != null,
+          onColorChanged: (c) =>
+              ref.read(customColorsProvider.notifier).setAccentColor(c),
+        ),
+        if (custom.hasOverrides) ...[
+          const SizedBox(height: 24),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: OutlinedButton.icon(
+              key: const Key('reset_colors_button'),
+              onPressed: () =>
+                  ref.read(customColorsProvider.notifier).resetColors(),
+              icon: const Icon(Icons.refresh, size: 18),
+              label: const Text('Reset to theme defaults'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: context.textSecondary,
+                side: BorderSide(color: context.border),
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -5,6 +5,7 @@ import '../../providers/accessibility_provider.dart';
 import '../../providers/channel_layout_provider.dart';
 import '../../providers/theme_provider.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 import 'advanced_theme_section.dart';
 
 /// SharedPreferences key for GIF autoplay setting.
@@ -162,204 +163,181 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
       ),
     ];
 
-    // SingleChildScrollView fills the full pane so mouse-wheel events in
-    // the side margins (outside the 900 px content column) still drive the
-    // scroll — the previous Center > ConstrainedBox > ListView only caught
-    // wheel events directly over a child (#1157).
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(24),
-      child: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 900),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                'Theme',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Choose a theme. All themes are tuned for WCAG AA contrast.',
-                style: TextStyle(
-                  color: context.textSecondary,
-                  fontSize: 13,
-                  height: 1.5,
-                ),
-              ),
-              const Divider(height: 24),
-              Wrap(
-                spacing: 12,
-                runSpacing: 12,
-                alignment: WrapAlignment.center,
-                children: themeOptions
-                    .map(
-                      (data) => _ThemeCard(
-                        data: data,
-                        isSelected: currentTheme == data.selection,
-                        onTap: () => ref
-                            .read(themeProvider.notifier)
-                            .setTheme(data.selection),
-                      ),
-                    )
-                    .toList(),
-              ),
-              const SizedBox(height: 32),
-              Text(
-                'Message layout',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 16),
-              _LayoutOption(
-                label: 'Default',
-                subtitle:
-                    'Bubbles aligned by sender, like iMessage or WhatsApp',
-                icon: Icons.chat_bubble_outline,
-                isSelected:
-                    ref.watch(messageLayoutProvider) == MessageLayout.bubbles,
-                onTap: () => ref
-                    .read(messageLayoutProvider.notifier)
-                    .setLayout(MessageLayout.bubbles),
-              ),
-              const SizedBox(height: 8),
-              _LayoutOption(
-                label: 'Discord',
-                subtitle:
-                    'Left-aligned with avatars and usernames, grouped by sender',
-                icon: Icons.format_align_left_outlined,
-                isSelected:
-                    ref.watch(messageLayoutProvider) == MessageLayout.compact,
-                onTap: () => ref
-                    .read(messageLayoutProvider.notifier)
-                    .setLayout(MessageLayout.compact),
-              ),
-              const SizedBox(height: 8),
-              _LayoutOption(
-                label: 'Slack',
-                subtitle:
-                    'Left-aligned, no bubbles — clean document-style feed',
-                icon: Icons.notes_outlined,
-                isSelected:
-                    ref.watch(messageLayoutProvider) == MessageLayout.plain,
-                onTap: () => ref
-                    .read(messageLayoutProvider.notifier)
-                    .setLayout(MessageLayout.plain),
-              ),
-              const SizedBox(height: 32),
-              // Density tier — UX roadmap Phase 2.  Independent of message
-              // layout: density tunes sidebar row spacing without changing
-              // bubble style.
-              Text(
-                'Density',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 16),
-              _LayoutOption(
-                label: 'Cozy',
-                subtitle: 'More breathing room',
-                icon: Icons.density_large,
-                isSelected: ref.watch(uiDensityProvider) == UIDensity.cozy,
-                onTap: () => ref
-                    .read(uiDensityProvider.notifier)
-                    .setDensity(UIDensity.cozy),
-              ),
-              const SizedBox(height: 8),
-              _LayoutOption(
-                label: 'Normal',
-                subtitle: 'Balanced default',
-                icon: Icons.density_medium,
-                isSelected: ref.watch(uiDensityProvider) == UIDensity.normal,
-                onTap: () => ref
-                    .read(uiDensityProvider.notifier)
-                    .setDensity(UIDensity.normal),
-              ),
-              const SizedBox(height: 8),
-              _LayoutOption(
-                label: 'Compact',
-                subtitle: 'Power-user dense, Discord-style',
-                icon: Icons.density_small,
-                isSelected: ref.watch(uiDensityProvider) == UIDensity.compact,
-                onTap: () => ref
-                    .read(uiDensityProvider.notifier)
-                    .setDensity(UIDensity.compact),
-              ),
-              const SizedBox(height: 32),
-              // Channel layout — top chip bar vs Slack/Discord vertical column.
-              // The toggle only affects desktop wide layouts; narrow viewports
-              // always render the bar because a column doesn't fit on phones.
-              Text(
-                'Channels',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 16),
-              _LayoutOption(
-                label: 'Bar',
-                subtitle: 'Chip row above the chat (current default)',
-                icon: Icons.view_stream_outlined,
-                isSelected:
-                    ref.watch(channelLayoutProvider) == ChannelLayout.bar,
-                onTap: () => ref
-                    .read(channelLayoutProvider.notifier)
-                    .setLayout(ChannelLayout.bar),
-              ),
-              const SizedBox(height: 8),
-              _LayoutOption(
-                label: 'Column',
-                subtitle: 'Slack/Discord-style vertical channel list',
-                icon: Icons.view_sidebar_outlined,
-                isSelected:
-                    ref.watch(channelLayoutProvider) == ChannelLayout.column,
-                onTap: () => ref
-                    .read(channelLayoutProvider.notifier)
-                    .setLayout(ChannelLayout.column),
-              ),
-              const SizedBox(height: 24),
-              // Font size (#1137 — moved from Accessibility). Pure visual
-              // preference, so it lives in Appearance alongside the theme
-              // picker. State still backs to accessibilityProvider so the
-              // setting roams between sections without a migration.
-              _FontSizeRow(),
-              const SizedBox(height: 32),
-              // Advanced color overrides (issue #613)
-              Text(
-                'Advanced',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                'Override the active theme\'s primary and accent colors.',
-                style: TextStyle(
-                  color: context.textSecondary,
-                  fontSize: 13,
-                  height: 1.5,
-                ),
-              ),
-              const SizedBox(height: 12),
-              const AdvancedThemeInline(),
-            ],
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Theme',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
           ),
         ),
-      ),
+        const SizedBox(height: 4),
+        Text(
+          'Choose a theme. All themes are tuned for WCAG AA contrast.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const Divider(height: 24),
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          alignment: WrapAlignment.center,
+          children: themeOptions
+              .map(
+                (data) => _ThemeCard(
+                  data: data,
+                  isSelected: currentTheme == data.selection,
+                  onTap: () =>
+                      ref.read(themeProvider.notifier).setTheme(data.selection),
+                ),
+              )
+              .toList(),
+        ),
+        const SizedBox(height: 32),
+        Text(
+          'Message layout',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _LayoutOption(
+          label: 'Default',
+          subtitle: 'Bubbles aligned by sender, like iMessage or WhatsApp',
+          icon: Icons.chat_bubble_outline,
+          isSelected: ref.watch(messageLayoutProvider) == MessageLayout.bubbles,
+          onTap: () => ref
+              .read(messageLayoutProvider.notifier)
+              .setLayout(MessageLayout.bubbles),
+        ),
+        const SizedBox(height: 8),
+        _LayoutOption(
+          label: 'Discord',
+          subtitle:
+              'Left-aligned with avatars and usernames, grouped by sender',
+          icon: Icons.format_align_left_outlined,
+          isSelected: ref.watch(messageLayoutProvider) == MessageLayout.compact,
+          onTap: () => ref
+              .read(messageLayoutProvider.notifier)
+              .setLayout(MessageLayout.compact),
+        ),
+        const SizedBox(height: 8),
+        _LayoutOption(
+          label: 'Slack',
+          subtitle: 'Left-aligned, no bubbles — clean document-style feed',
+          icon: Icons.notes_outlined,
+          isSelected: ref.watch(messageLayoutProvider) == MessageLayout.plain,
+          onTap: () => ref
+              .read(messageLayoutProvider.notifier)
+              .setLayout(MessageLayout.plain),
+        ),
+        const SizedBox(height: 32),
+        // Density tier — UX roadmap Phase 2.  Independent of message
+        // layout: density tunes sidebar row spacing without changing
+        // bubble style.
+        Text(
+          'Density',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _LayoutOption(
+          label: 'Cozy',
+          subtitle: 'More breathing room',
+          icon: Icons.density_large,
+          isSelected: ref.watch(uiDensityProvider) == UIDensity.cozy,
+          onTap: () =>
+              ref.read(uiDensityProvider.notifier).setDensity(UIDensity.cozy),
+        ),
+        const SizedBox(height: 8),
+        _LayoutOption(
+          label: 'Normal',
+          subtitle: 'Balanced default',
+          icon: Icons.density_medium,
+          isSelected: ref.watch(uiDensityProvider) == UIDensity.normal,
+          onTap: () =>
+              ref.read(uiDensityProvider.notifier).setDensity(UIDensity.normal),
+        ),
+        const SizedBox(height: 8),
+        _LayoutOption(
+          label: 'Compact',
+          subtitle: 'Power-user dense, Discord-style',
+          icon: Icons.density_small,
+          isSelected: ref.watch(uiDensityProvider) == UIDensity.compact,
+          onTap: () => ref
+              .read(uiDensityProvider.notifier)
+              .setDensity(UIDensity.compact),
+        ),
+        const SizedBox(height: 32),
+        // Channel layout — top chip bar vs Slack/Discord vertical column.
+        // The toggle only affects desktop wide layouts; narrow viewports
+        // always render the bar because a column doesn't fit on phones.
+        Text(
+          'Channels',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _LayoutOption(
+          label: 'Bar',
+          subtitle: 'Chip row above the chat (current default)',
+          icon: Icons.view_stream_outlined,
+          isSelected: ref.watch(channelLayoutProvider) == ChannelLayout.bar,
+          onTap: () => ref
+              .read(channelLayoutProvider.notifier)
+              .setLayout(ChannelLayout.bar),
+        ),
+        const SizedBox(height: 8),
+        _LayoutOption(
+          label: 'Column',
+          subtitle: 'Slack/Discord-style vertical channel list',
+          icon: Icons.view_sidebar_outlined,
+          isSelected: ref.watch(channelLayoutProvider) == ChannelLayout.column,
+          onTap: () => ref
+              .read(channelLayoutProvider.notifier)
+              .setLayout(ChannelLayout.column),
+        ),
+        const SizedBox(height: 24),
+        // Font size (#1137 — moved from Accessibility). Pure visual
+        // preference, so it lives in Appearance alongside the theme
+        // picker. State still backs to accessibilityProvider so the
+        // setting roams between sections without a migration.
+        _FontSizeRow(),
+        const SizedBox(height: 32),
+        // Advanced color overrides (issue #613)
+        Text(
+          'Advanced',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Override the active theme\'s primary and accent colors.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 12),
+        const AdvancedThemeInline(),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/data_storage_section.dart
+++ b/apps/client/lib/src/screens/settings/data_storage_section.dart
@@ -11,6 +11,7 @@ import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../widgets/confirm_dialog.dart';
 import '../../widgets/settings/settings_list_tile.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 class DataStorageSection extends ConsumerStatefulWidget {
   const DataStorageSection({super.key});
@@ -131,89 +132,80 @@ class _DataStorageSectionState extends ConsumerState<DataStorageSection> {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Data & Storage',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Manage cached data and storage usage.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const Divider(height: 24),
+        // Cache size
+        SettingsListTile(
+          icon: Icons.storage,
+          title: 'Message Cache',
+          subtitle: 'Estimated size: $_cacheSize',
+          trailing: OutlinedButton(
+            onPressed: _clearMessageCache,
+            child: const Text('Clear'),
+          ),
+        ),
+        const SizedBox(height: 24),
+        // Export section
+        ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: Icon(Icons.download_outlined, color: context.textSecondary),
+          title: Text(
+            'Export My Data',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Save your locally cached messages as a JSON file. '
+            'Only decrypted message content is included — private keys are never exported.',
+            style: TextStyle(
+              color: context.textSecondary,
+              fontSize: 12,
+              height: 1.4,
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
           children: [
-            Text(
-              'Data & Storage',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
+            OutlinedButton.icon(
+              onPressed: _isExporting ? null : _exportChats,
+              icon: _isExporting
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.download_outlined, size: 16),
+              label: Text(
+                _isExporting ? 'Exporting...' : 'Export chats (JSON)',
               ),
             ),
-            const SizedBox(height: 4),
-            Text(
-              'Manage cached data and storage usage.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const Divider(height: 24),
-            // Cache size
-            SettingsListTile(
-              icon: Icons.storage,
-              title: 'Message Cache',
-              subtitle: 'Estimated size: $_cacheSize',
-              trailing: OutlinedButton(
-                onPressed: _clearMessageCache,
-                child: const Text('Clear'),
-              ),
-            ),
-            const SizedBox(height: 24),
-            // Export section
-            ListTile(
-              contentPadding: EdgeInsets.zero,
-              leading: Icon(
-                Icons.download_outlined,
-                color: context.textSecondary,
-              ),
-              title: Text(
-                'Export My Data',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Save your locally cached messages as a JSON file. '
-                'Only decrypted message content is included — private keys are never exported.',
-                style: TextStyle(
-                  color: context.textSecondary,
-                  fontSize: 12,
-                  height: 1.4,
-                ),
-              ),
-            ),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 8,
-              children: [
-                OutlinedButton.icon(
-                  onPressed: _isExporting ? null : _exportChats,
-                  icon: _isExporting
-                      ? const SizedBox(
-                          width: 14,
-                          height: 14,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.download_outlined, size: 16),
-                  label: Text(
-                    _isExporting ? 'Exporting...' : 'Export chats (JSON)',
-                  ),
-                ),
-                OutlinedButton.icon(
-                  onPressed: _copyAccountInfo,
-                  icon: const Icon(Icons.copy, size: 16),
-                  label: const Text('Copy Account Info'),
-                ),
-              ],
+            OutlinedButton.icon(
+              onPressed: _copyAccountInfo,
+              icon: const Icon(Icons.copy, size: 16),
+              label: const Text('Copy Account Info'),
             ),
           ],
         ),
-      ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/devices_section.dart
+++ b/apps/client/lib/src/screens/settings/devices_section.dart
@@ -14,6 +14,7 @@ import '../../providers/websocket_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../widgets/confirm_dialog.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 class DevicesSection extends ConsumerStatefulWidget {
   const DevicesSection({super.key});
@@ -359,73 +360,60 @@ class _DevicesSectionState extends ConsumerState<DevicesSection> {
         ? ref.watch(cryptoServiceProvider).deviceId
         : null;
 
-    // Layout mirrors the other settings sections (notifications, privacy,
-    // appearance, ...): Center > ConstrainedBox(maxWidth: 900) > ListView
-    // with `padding: EdgeInsets.all(24)` and an 18px header. The previous
-    // mix of `shrinkWrap: true` + child-side LTRB padding caused the column
-    // to read as left-aligned relative to the settings top bar (#916).
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
+    return SettingsPanelScaffold(
+      children: [
+        Row(
           children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'My Devices',
-                        style: TextStyle(
-                          color: context.textPrimary,
-                          fontSize: 18,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        'Manage devices that have access to your account.',
-                        style: TextStyle(
-                          color: context.textSecondary,
-                          fontSize: 13,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                IconButton(
-                  icon: Icon(Icons.refresh, color: context.textSecondary),
-                  tooltip: 'Refresh',
-                  onPressed: _loading ? null : _loadDevices,
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            const Divider(height: 1),
-            _buildDeviceListBody(context, myDeviceId),
-            if (!_loading &&
-                _error == null &&
-                myDeviceId != null &&
-                _devices.any((d) => d.deviceId != myDeviceId))
-              Padding(
-                padding: const EdgeInsets.only(top: 16),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: TextButton.icon(
-                    onPressed: () => _revokeOtherDevices(myDeviceId),
-                    icon: const Icon(Icons.devices_other, size: 18),
-                    label: const Text('Log out all other devices'),
-                    style: TextButton.styleFrom(
-                      foregroundColor: EchoTheme.danger,
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'My Devices',
+                    style: TextStyle(
+                      color: context.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
                     ),
                   ),
-                ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Manage devices that have access to your account.',
+                    style: TextStyle(
+                      color: context.textSecondary,
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
               ),
+            ),
+            IconButton(
+              icon: Icon(Icons.refresh, color: context.textSecondary),
+              tooltip: 'Refresh',
+              onPressed: _loading ? null : _loadDevices,
+            ),
           ],
         ),
-      ),
+        const SizedBox(height: 12),
+        const Divider(height: 1),
+        _buildDeviceListBody(context, myDeviceId),
+        if (!_loading &&
+            _error == null &&
+            myDeviceId != null &&
+            _devices.any((d) => d.deviceId != myDeviceId))
+          Padding(
+            padding: const EdgeInsets.only(top: 16),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: () => _revokeOtherDevices(myDeviceId),
+                icon: const Icon(Icons.devices_other, size: 18),
+                label: const Text('Log out all other devices'),
+                style: TextButton.styleFrom(foregroundColor: EchoTheme.danger),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/language_section.dart
+++ b/apps/client/lib/src/screens/settings/language_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/locale_provider.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 /// Settings section that lets the user pick an app language.
 ///
@@ -15,59 +16,48 @@ class LanguageSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final currentLocale = ref.watch(localeProvider);
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
-          children: [
-            Text(
-              'Language',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Choose the language used throughout the app. '
-              'Takes effect immediately.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 16),
-            // Beta banner — translations beyond English are scaffolded but
-            // most labels still fall through to English.  Surfacing this
-            // here (#791) saves testers the "is my install broken?" loop.
-            _ComingSoonBanner(),
-            const Divider(height: 24),
-            ...kSupportedLocales.map(
-              (entry) => _LocaleOption(
-                entry: entry,
-                isSelected: currentLocale.languageCode == entry.tag,
-                isFullyTranslated: entry.tag == 'en',
-                onTap: () => ref
-                    .read(localeProvider.notifier)
-                    .setLocale(Locale(entry.tag)),
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'RTL languages (Arabic, Hebrew, etc.) will be added once '
-              'right-to-left layout testing is complete.',
-              style: TextStyle(
-                color: context.textMuted,
-                fontSize: 12,
-                height: 1.5,
-              ),
-            ),
-          ],
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Language',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
         ),
-      ),
+        const SizedBox(height: 4),
+        Text(
+          'Choose the language used throughout the app. '
+          'Takes effect immediately.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 16),
+        // Beta banner — translations beyond English are scaffolded but
+        // most labels still fall through to English.  Surfacing this
+        // here (#791) saves testers the "is my install broken?" loop.
+        _ComingSoonBanner(),
+        const Divider(height: 24),
+        ...kSupportedLocales.map(
+          (entry) => _LocaleOption(
+            entry: entry,
+            isSelected: currentLocale.languageCode == entry.tag,
+            isFullyTranslated: entry.tag == 'en',
+            onTap: () =>
+                ref.read(localeProvider.notifier).setLocale(Locale(entry.tag)),
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          'RTL languages (Arabic, Hebrew, etc.) will be added once '
+          'right-to-left layout testing is complete.',
+          style: TextStyle(color: context.textMuted, fontSize: 12, height: 1.5),
+        ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/notification_section.dart
+++ b/apps/client/lib/src/screens/settings/notification_section.dart
@@ -6,6 +6,7 @@ import '../../services/notification_service.dart';
 import '../../services/sound_service.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 part 'notification_section/parts/time_tile.dart';
 part 'notification_section/parts/sound_picker.dart';
@@ -183,245 +184,225 @@ class _NotificationSectionState extends State<NotificationSection> {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
-          children: [
-            Text(
-              'Notifications',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Configure how you receive notifications and alerts.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 12),
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Notifications',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Configure how you receive notifications and alerts.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 12),
 
-            // ---- DND active banner -------------------------------------------
-            if (_dndEnabled) ...[
-              Container(
-                margin: const EdgeInsets.only(bottom: 8),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 10,
-                ),
-                decoration: BoxDecoration(
-                  color: context.accent.withValues(alpha: 0.12),
-                  border: Border.all(
-                    color: context.accent.withValues(alpha: 0.31),
+        // ---- DND active banner -------------------------------------------
+        if (_dndEnabled) ...[
+          Container(
+            margin: const EdgeInsets.only(bottom: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: context.accent.withValues(alpha: 0.12),
+              border: Border.all(color: context.accent.withValues(alpha: 0.31)),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.do_not_disturb_on, color: context.accent, size: 18),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    'Do Not Disturb is on — all notifications are muted.',
+                    style: TextStyle(
+                      color: context.accent,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
+                ),
+              ],
+            ),
+          ),
+        ],
+
+        // ---- Do Not Disturb toggle ----------------------------------------
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          secondary: Icon(
+            Icons.do_not_disturb_on_outlined,
+            color: _dndEnabled ? context.accent : context.textSecondary,
+            size: 22,
+          ),
+          title: Text(
+            'Do Not Disturb',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Mute all notifications until manually disabled.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: _dndEnabled,
+          onChanged: _setDndEnabled,
+        ),
+
+        // ---- Quiet Hours --------------------------------------------------
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          secondary: Icon(
+            Icons.bedtime_outlined,
+            color: _quietHoursEnabled ? context.accent : context.textSecondary,
+            size: 22,
+          ),
+          title: Text(
+            'Quiet Hours',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Silence notifications during a scheduled time window.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: _quietHoursEnabled,
+          onChanged: _setQuietHoursEnabled,
+        ),
+        if (_quietHoursEnabled) ...[
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 16, right: 4, bottom: 4),
+            child: Row(
+              children: [
+                Expanded(
+                  child: _TimeTile(
+                    label: 'Start time',
+                    time: _quietStart,
+                    onTap: _pickQuietStart,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _TimeTile(
+                    label: 'End time',
+                    time: _quietEnd,
+                    onTap: _pickQuietEnd,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+
+        const Divider(height: 32),
+
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          title: Text(
+            'Enable Notifications',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Show desktop/mobile notifications for new messages.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: _notificationsEnabled,
+          onChanged: _setNotificationsEnabled,
+        ),
+        if (_notificationsEnabled) ...[
+          SwitchListTile.adaptive(
+            contentPadding: const EdgeInsets.only(left: 16),
+            title: Text(
+              'Direct Messages',
+              style: TextStyle(color: context.textPrimary, fontSize: 14),
+            ),
+            subtitle: Text(
+              'Notify for incoming DMs.',
+              style: TextStyle(color: context.textMuted, fontSize: 12),
+            ),
+            value: _dmNotifications,
+            onChanged: _setDmNotifications,
+          ),
+          SwitchListTile.adaptive(
+            contentPadding: const EdgeInsets.only(left: 16),
+            title: Text(
+              'Group Messages',
+              style: TextStyle(color: context.textPrimary, fontSize: 14),
+            ),
+            subtitle: Text(
+              'Notify for messages in group conversations.',
+              style: TextStyle(color: context.textMuted, fontSize: 12),
+            ),
+            value: _groupNotifications,
+            onChanged: _setGroupNotifications,
+          ),
+        ],
+        const Divider(height: 32),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          secondary: Icon(
+            Icons.volume_up_outlined,
+            color: _soundEnabled ? context.accent : context.textSecondary,
+            size: 22,
+          ),
+          title: Text(
+            'Enable Sound Effects',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Play sounds for messages, voice, and other app events.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: _soundEnabled,
+          onChanged: _setSoundEnabled,
+        ),
+        _SoundPickerRow(
+          selected: _notificationSound,
+          onChanged: _setNotificationSound,
+        ),
+        if (_notificationsEnabled) ...[
+          const SizedBox(height: 24),
+          Text(
+            'Test',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Send a test notification to verify your settings.',
+            style: TextStyle(
+              color: context.textSecondary,
+              fontSize: 13,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: _sendTestNotification,
+              icon: const Icon(Icons.notifications_active_outlined, size: 18),
+              label: const Text('Send Test Notification'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: context.accent,
+                side: BorderSide(color: context.accent),
+                shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.do_not_disturb_on,
-                      color: context.accent,
-                      size: 18,
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        'Do Not Disturb is on — all notifications are muted.',
-                        style: TextStyle(
-                          color: context.accent,
-                          fontSize: 13,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+                padding: const EdgeInsets.symmetric(vertical: 12),
               ),
-            ],
-
-            // ---- Do Not Disturb toggle ----------------------------------------
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              secondary: Icon(
-                Icons.do_not_disturb_on_outlined,
-                color: _dndEnabled ? context.accent : context.textSecondary,
-                size: 22,
-              ),
-              title: Text(
-                'Do Not Disturb',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Mute all notifications until manually disabled.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: _dndEnabled,
-              onChanged: _setDndEnabled,
             ),
-
-            // ---- Quiet Hours --------------------------------------------------
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              secondary: Icon(
-                Icons.bedtime_outlined,
-                color: _quietHoursEnabled
-                    ? context.accent
-                    : context.textSecondary,
-                size: 22,
-              ),
-              title: Text(
-                'Quiet Hours',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Silence notifications during a scheduled time window.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: _quietHoursEnabled,
-              onChanged: _setQuietHoursEnabled,
-            ),
-            if (_quietHoursEnabled) ...[
-              const SizedBox(height: 4),
-              Padding(
-                padding: const EdgeInsets.only(left: 16, right: 4, bottom: 4),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: _TimeTile(
-                        label: 'Start time',
-                        time: _quietStart,
-                        onTap: _pickQuietStart,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: _TimeTile(
-                        label: 'End time',
-                        time: _quietEnd,
-                        onTap: _pickQuietEnd,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-
-            const Divider(height: 32),
-
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Enable Notifications',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Show desktop/mobile notifications for new messages.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: _notificationsEnabled,
-              onChanged: _setNotificationsEnabled,
-            ),
-            if (_notificationsEnabled) ...[
-              SwitchListTile.adaptive(
-                contentPadding: const EdgeInsets.only(left: 16),
-                title: Text(
-                  'Direct Messages',
-                  style: TextStyle(color: context.textPrimary, fontSize: 14),
-                ),
-                subtitle: Text(
-                  'Notify for incoming DMs.',
-                  style: TextStyle(color: context.textMuted, fontSize: 12),
-                ),
-                value: _dmNotifications,
-                onChanged: _setDmNotifications,
-              ),
-              SwitchListTile.adaptive(
-                contentPadding: const EdgeInsets.only(left: 16),
-                title: Text(
-                  'Group Messages',
-                  style: TextStyle(color: context.textPrimary, fontSize: 14),
-                ),
-                subtitle: Text(
-                  'Notify for messages in group conversations.',
-                  style: TextStyle(color: context.textMuted, fontSize: 12),
-                ),
-                value: _groupNotifications,
-                onChanged: _setGroupNotifications,
-              ),
-            ],
-            const Divider(height: 32),
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              secondary: Icon(
-                Icons.volume_up_outlined,
-                color: _soundEnabled ? context.accent : context.textSecondary,
-                size: 22,
-              ),
-              title: Text(
-                'Enable Sound Effects',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Play sounds for messages, voice, and other app events.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: _soundEnabled,
-              onChanged: _setSoundEnabled,
-            ),
-            _SoundPickerRow(
-              selected: _notificationSound,
-              onChanged: _setNotificationSound,
-            ),
-            if (_notificationsEnabled) ...[
-              const SizedBox(height: 24),
-              Text(
-                'Test',
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'Send a test notification to verify your settings.',
-                style: TextStyle(
-                  color: context.textSecondary,
-                  fontSize: 13,
-                  height: 1.5,
-                ),
-              ),
-              const SizedBox(height: 16),
-              SizedBox(
-                width: double.infinity,
-                child: OutlinedButton.icon(
-                  onPressed: _sendTestNotification,
-                  icon: const Icon(
-                    Icons.notifications_active_outlined,
-                    size: 18,
-                  ),
-                  label: const Text('Send Test Notification'),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: context.accent,
-                    side: BorderSide(color: context.accent),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                  ),
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
+          ),
+        ],
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/privacy_section.dart
+++ b/apps/client/lib/src/screens/settings/privacy_section.dart
@@ -9,6 +9,7 @@ import '../../providers/privacy_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../widgets/confirm_dialog.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 import '../../widgets/user_avatar.dart';
 
 /// SharedPreferences key + reader for the "preserve original filenames"
@@ -630,161 +631,155 @@ class _PrivacySectionState extends ConsumerState<PrivacySection> {
     final biometric = ref.watch(biometricProvider);
     final contacts = ref.watch(contactsProvider);
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
+    return SettingsPanelScaffold(
+      children: [
+        if (privacy.error != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Text(
+              privacy.error!,
+              style: const TextStyle(color: EchoTheme.danger, fontSize: 12),
+            ),
+          ),
+        ..._buildAppLockSection(context, biometric),
+        const SizedBox(height: 24),
+        const Divider(),
+        const SizedBox(height: 8),
+        ..._buildMessagingPrivacySection(context, privacy),
+        const SizedBox(height: 24),
+        ..._buildContactInfoSection(context, privacy),
+        ..._buildDiscoverabilitySection(context, privacy),
+        ..._buildSearchVisibilitySection(context, privacy),
+        const SizedBox(height: 24),
+        Text(
+          'Encryption',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Echo uses end-to-end encryption for encrypted direct messages. '
+          'Your encryption keys are stored locally on this device.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (privacy.error != null)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: Text(
-                  privacy.error!,
-                  style: const TextStyle(color: EchoTheme.danger, fontSize: 12),
-                ),
-              ),
-            ..._buildAppLockSection(context, biometric),
-            const SizedBox(height: 24),
-            const Divider(),
-            const SizedBox(height: 8),
-            ..._buildMessagingPrivacySection(context, privacy),
-            const SizedBox(height: 24),
-            ..._buildContactInfoSection(context, privacy),
-            ..._buildDiscoverabilitySection(context, privacy),
-            ..._buildSearchVisibilitySection(context, privacy),
-            const SizedBox(height: 24),
-            Text(
-              'Encryption',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
+            Icon(
+              Icons.verified_user_outlined,
+              size: 16,
+              color: context.textMuted,
             ),
-            const SizedBox(height: 8),
-            Text(
-              'Echo uses end-to-end encryption for encrypted direct messages. '
-              'Your encryption keys are stored locally on this device.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 10),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Icon(
-                  Icons.verified_user_outlined,
-                  size: 16,
-                  color: context.textMuted,
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    'You can verify encryption with each contact by comparing '
-                    'safety numbers. Open any DM and tap the shield icon in the '
-                    'header to check.',
-                    style: TextStyle(
-                      color: context.textMuted,
-                      fontSize: 12,
-                      height: 1.5,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            if (crypto.isInitialized && !crypto.keysUploadFailed) ...[
-              const SizedBox(height: 12),
-              const Row(
-                children: [
-                  Icon(Icons.verified_user, color: EchoTheme.online, size: 18),
-                  SizedBox(width: 8),
-                  Text(
-                    'Encryption keys active',
-                    style: TextStyle(
-                      color: EchoTheme.online,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-            if (crypto.keysUploadFailed) ...[
-              const SizedBox(height: 12),
-              const Text(
-                'Encryption key upload failed. New conversations will not be '
-                'encrypted until keys are uploaded.',
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'You can verify encryption with each contact by comparing '
+                'safety numbers. Open any DM and tap the shield icon in the '
+                'header to check.',
                 style: TextStyle(
-                  color: EchoTheme.danger,
+                  color: context.textMuted,
                   fontSize: 12,
                   height: 1.5,
-                ),
-              ),
-              const SizedBox(height: 8),
-              SizedBox(
-                width: double.infinity,
-                child: OutlinedButton.icon(
-                  onPressed: crypto.isUploading ? null : _retryKeyUpload,
-                  icon: crypto.isUploading
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.upload_outlined, size: 18),
-                  label: Text(
-                    crypto.isUploading
-                        ? 'Uploading...'
-                        : 'Re-upload Encryption Keys',
-                  ),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: context.textPrimary,
-                    side: BorderSide(color: context.border),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                  ),
-                ),
-              ),
-            ],
-            ..._buildBlockedUsersSection(context, contacts),
-            const SizedBox(height: 24),
-            const Divider(),
-            const SizedBox(height: 8),
-            const Text(
-              'Danger Zone',
-              style: TextStyle(
-                color: EchoTheme.danger,
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0.5,
-              ),
-            ),
-            const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: _resetEncryptionKeys,
-                icon: const Icon(Icons.warning_amber_outlined, size: 18),
-                label: const Text('Reset Encryption Keys'),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: EchoTheme.danger,
-                  side: const BorderSide(color: EchoTheme.danger),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  padding: const EdgeInsets.symmetric(vertical: 12),
                 ),
               ),
             ),
           ],
         ),
-      ),
+        if (crypto.isInitialized && !crypto.keysUploadFailed) ...[
+          const SizedBox(height: 12),
+          const Row(
+            children: [
+              Icon(Icons.verified_user, color: EchoTheme.online, size: 18),
+              SizedBox(width: 8),
+              Text(
+                'Encryption keys active',
+                style: TextStyle(
+                  color: EchoTheme.online,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ],
+        if (crypto.keysUploadFailed) ...[
+          const SizedBox(height: 12),
+          const Text(
+            'Encryption key upload failed. New conversations will not be '
+            'encrypted until keys are uploaded.',
+            style: TextStyle(
+              color: EchoTheme.danger,
+              fontSize: 12,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: crypto.isUploading ? null : _retryKeyUpload,
+              icon: crypto.isUploading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.upload_outlined, size: 18),
+              label: Text(
+                crypto.isUploading
+                    ? 'Uploading...'
+                    : 'Re-upload Encryption Keys',
+              ),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: context.textPrimary,
+                side: BorderSide(color: context.border),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
+          ),
+        ],
+        ..._buildBlockedUsersSection(context, contacts),
+        const SizedBox(height: 24),
+        const Divider(),
+        const SizedBox(height: 8),
+        const Text(
+          'Danger Zone',
+          style: TextStyle(
+            color: EchoTheme.danger,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.5,
+          ),
+        ),
+        const SizedBox(height: 12),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: _resetEncryptionKeys,
+            icon: const Icon(Icons.warning_amber_outlined, size: 18),
+            label: const Text('Reset Encryption Keys'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: EchoTheme.danger,
+              side: const BorderSide(color: EchoTheme.danger),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/status_section.dart
+++ b/apps/client/lib/src/screens/settings/status_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/auth_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 /// Maximum characters accepted by `PUT /api/users/me/status-text`.
 /// The server caps at 64; we enforce 80 in the field but show a counter so
@@ -103,146 +104,137 @@ class _StatusSectionState extends ConsumerState<StatusSection> {
     final charCount = _controller.text.length;
     final overLimit = charCount > _kMaxStatusLength;
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
+    return SettingsPanelScaffold(
+      children: [
+        // Section header
+        Text(
+          'Status',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Your status appears next to your name in conversations.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 24),
+
+        // Text field
+        TextField(
+          controller: _controller,
+          maxLength: null, // manual counter below
+          maxLines: 1,
+          inputFormatters: [
+            // Hard-cap at 2× the limit so the user can see the counter
+            // turn red before being forcibly cut off.
+            LengthLimitingTextInputFormatter(_kMaxStatusLength * 2),
+          ],
+          style: TextStyle(color: context.textPrimary, fontSize: 14),
+          decoration: InputDecoration(
+            hintText: "What's on your mind?",
+            hintStyle: TextStyle(color: context.textMuted, fontSize: 14),
+            filled: true,
+            fillColor: context.surface,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 14,
+              vertical: 12,
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: context.border),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: context.border),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: BorderSide(color: context.accent, width: 1.5),
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: const BorderSide(color: EchoTheme.danger),
+            ),
+            focusedErrorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+              borderSide: const BorderSide(color: EchoTheme.danger, width: 1.5),
+            ),
+            errorText: overLimit
+                ? 'Status must be $_kMaxStatusLength characters or fewer'
+                : null,
+          ),
+        ),
+
+        // Character counter
+        const SizedBox(height: 4),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Text(
+            '$charCount / $_kMaxStatusLength',
+            style: TextStyle(
+              color: overLimit ? EchoTheme.danger : context.textMuted,
+              fontSize: 11,
+            ),
+          ),
+        ),
+
+        const SizedBox(height: 20),
+
+        // Action buttons
+        Row(
           children: [
-            // Section header
-            Text(
-              'Status',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Your status appears next to your name in conversations.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 24),
-
-            // Text field
-            TextField(
-              controller: _controller,
-              maxLength: null, // manual counter below
-              maxLines: 1,
-              inputFormatters: [
-                // Hard-cap at 2× the limit so the user can see the counter
-                // turn red before being forcibly cut off.
-                LengthLimitingTextInputFormatter(_kMaxStatusLength * 2),
-              ],
-              style: TextStyle(color: context.textPrimary, fontSize: 14),
-              decoration: InputDecoration(
-                hintText: "What's on your mind?",
-                hintStyle: TextStyle(color: context.textMuted, fontSize: 14),
-                filled: true,
-                fillColor: context.surface,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 12,
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: context.border),
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: context.border),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: BorderSide(color: context.accent, width: 1.5),
-                ),
-                errorBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: EchoTheme.danger),
-                ),
-                focusedErrorBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(
-                    color: EchoTheme.danger,
-                    width: 1.5,
-                  ),
-                ),
-                errorText: overLimit
-                    ? 'Status must be $_kMaxStatusLength characters or fewer'
+            Expanded(
+              child: FilledButton(
+                onPressed: (_isDirty && !overLimit && !_isSaving)
+                    ? _save
                     : null,
+                style: FilledButton.styleFrom(
+                  backgroundColor: context.accent,
+                  disabledBackgroundColor: context.accent.withValues(
+                    alpha: 0.4,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                ),
+                child: _isSaving
+                    ? SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: context.textPrimary,
+                        ),
+                      )
+                    : const Text('Save'),
               ),
             ),
-
-            // Character counter
-            const SizedBox(height: 4),
-            Align(
-              alignment: Alignment.centerRight,
-              child: Text(
-                '$charCount / $_kMaxStatusLength',
-                style: TextStyle(
-                  color: overLimit ? EchoTheme.danger : context.textMuted,
-                  fontSize: 11,
+            const SizedBox(width: 12),
+            Expanded(
+              child: OutlinedButton(
+                onPressed: _isSaving ? null : _clear,
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: context.textSecondary,
+                  side: BorderSide(color: context.border),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  padding: const EdgeInsets.symmetric(vertical: 12),
                 ),
+                child: const Text('Clear'),
               ),
-            ),
-
-            const SizedBox(height: 20),
-
-            // Action buttons
-            Row(
-              children: [
-                Expanded(
-                  child: FilledButton(
-                    onPressed: (_isDirty && !overLimit && !_isSaving)
-                        ? _save
-                        : null,
-                    style: FilledButton.styleFrom(
-                      backgroundColor: context.accent,
-                      disabledBackgroundColor: context.accent.withValues(
-                        alpha: 0.4,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                    ),
-                    child: _isSaving
-                        ? SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: context.textPrimary,
-                            ),
-                          )
-                        : const Text('Save'),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: _isSaving ? null : _clear,
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: context.textSecondary,
-                      side: BorderSide(color: context.border),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                    ),
-                    child: const Text('Clear'),
-                  ),
-                ),
-              ],
             ),
           ],
         ),
-      ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/screens/settings/voice_section.dart
+++ b/apps/client/lib/src/screens/settings/voice_section.dart
@@ -12,6 +12,7 @@ import '../../services/debug_log_service.dart';
 import '../../services/sound_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../utils/audio_level_analyzer.dart';
+import '../../widgets/settings_panel_scaffold.dart';
 
 /// Voice & Video settings.
 ///
@@ -371,262 +372,249 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
     final outputDevices = _audioOutputDevices;
     final cameraDevices = _videoInputDevices;
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 900),
-        child: ListView(
-          padding: const EdgeInsets.all(24),
+    return SettingsPanelScaffold(
+      children: [
+        Text(
+          'Voice & Video',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Configure voice device preferences and push-to-talk behavior.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 13,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 18),
+        _buildDevicePicker(
+          label: 'Input Device',
+          devices: inputDevices,
+          currentId: voice.inputDeviceId,
+          onChanged: notifier.setInputDevice,
+        ),
+        const SizedBox(height: 12),
+        _buildDevicePicker(
+          label: 'Output Device',
+          devices: outputDevices,
+          currentId: voice.outputDeviceId,
+          onChanged: notifier.setOutputDevice,
+        ),
+        const SizedBox(height: 12),
+        _buildDevicePicker(
+          label: 'Camera',
+          devices: cameraDevices,
+          currentId: voice.cameraDeviceId,
+          onChanged: notifier.setCameraDevice,
+        ),
+        const SizedBox(height: 12),
+        _CameraPreview(deviceId: voice.cameraDeviceId),
+        const SizedBox(height: 16),
+        Text(
+          'Microphone Gain',
+          style: TextStyle(color: context.textPrimary, fontSize: 13),
+        ),
+        Semantics(
+          label: 'Microphone gain',
+          slider: true,
+          value: '${(voice.inputGain * 100).toInt()}%',
+          child: Slider(
+            value: voice.inputGain,
+            min: 0,
+            max: 2,
+            divisions: 20,
+            label: voice.inputGain.toStringAsFixed(1),
+            onChanged: notifier.setInputGain,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Output Volume',
+          style: TextStyle(color: context.textPrimary, fontSize: 13),
+        ),
+        Semantics(
+          label: 'Output volume',
+          slider: true,
+          value: '${(voice.outputVolume * 100).toInt()}%',
+          child: Slider(
+            value: voice.outputVolume,
+            min: 0,
+            max: 1,
+            divisions: 20,
+            label: (voice.outputVolume * 100).round().toString(),
+            onChanged: notifier.setOutputVolume,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Row(
           children: [
-            Text(
-              'Voice & Video',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
+            OutlinedButton.icon(
+              onPressed: _isPlayingTestSound ? null : _playTestSound,
+              icon: Icon(
+                _isPlayingTestSound ? Icons.volume_up : Icons.play_arrow,
+                size: 18,
               ),
+              label: Text(_isPlayingTestSound ? 'Playing...' : 'Test Sound'),
             ),
-            const SizedBox(height: 8),
-            Text(
-              'Configure voice device preferences and push-to-talk behavior.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 13,
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 18),
-            _buildDevicePicker(
-              label: 'Input Device',
-              devices: inputDevices,
-              currentId: voice.inputDeviceId,
-              onChanged: notifier.setInputDevice,
-            ),
-            const SizedBox(height: 12),
-            _buildDevicePicker(
-              label: 'Output Device',
-              devices: outputDevices,
-              currentId: voice.outputDeviceId,
-              onChanged: notifier.setOutputDevice,
-            ),
-            const SizedBox(height: 12),
-            _buildDevicePicker(
-              label: 'Camera',
-              devices: cameraDevices,
-              currentId: voice.cameraDeviceId,
-              onChanged: notifier.setCameraDevice,
-            ),
-            const SizedBox(height: 12),
-            _CameraPreview(deviceId: voice.cameraDeviceId),
-            const SizedBox(height: 16),
-            Text(
-              'Microphone Gain',
-              style: TextStyle(color: context.textPrimary, fontSize: 13),
-            ),
-            Semantics(
-              label: 'Microphone gain',
-              slider: true,
-              value: '${(voice.inputGain * 100).toInt()}%',
-              child: Slider(
-                value: voice.inputGain,
-                min: 0,
-                max: 2,
-                divisions: 20,
-                label: voice.inputGain.toStringAsFixed(1),
-                onChanged: notifier.setInputGain,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Output Volume',
-              style: TextStyle(color: context.textPrimary, fontSize: 13),
-            ),
-            Semantics(
-              label: 'Output volume',
-              slider: true,
-              value: '${(voice.outputVolume * 100).toInt()}%',
-              child: Slider(
-                value: voice.outputVolume,
-                min: 0,
-                max: 1,
-                divisions: 20,
-                label: (voice.outputVolume * 100).round().toString(),
-                onChanged: notifier.setOutputVolume,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                OutlinedButton.icon(
-                  onPressed: _isPlayingTestSound ? null : _playTestSound,
-                  icon: Icon(
-                    _isPlayingTestSound ? Icons.volume_up : Icons.play_arrow,
-                    size: 18,
-                  ),
-                  label: Text(
-                    _isPlayingTestSound ? 'Playing...' : 'Test Sound',
-                  ),
-                ),
-                const SizedBox(width: 12),
-                OutlinedButton.icon(
-                  onPressed: _isMicTesting ? _stopMicTest : _startMicTest,
-                  icon: Icon(_isMicTesting ? Icons.stop : Icons.mic, size: 18),
-                  label: Text(_isMicTesting ? 'Stop' : 'Test Microphone'),
-                ),
-              ],
-            ),
-            if (_isMicTesting) ...[
-              const SizedBox(height: 10),
-              Row(
-                children: [
-                  Icon(Icons.mic, size: 16, color: context.textSecondary),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(4),
-                      child: LinearProgressIndicator(
-                        value: _micLevel,
-                        minHeight: 8,
-                        backgroundColor: context.surface,
-                        valueColor: AlwaysStoppedAnimation<Color>(
-                          _micLevelColor(),
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    '${(_micLevel * 100).round()}%',
-                    style: TextStyle(
-                      color: context.textSecondary,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-            const SizedBox(height: 10),
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Push-to-Talk',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'When enabled, your mic transmits only while push-to-talk is active.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: voice.pushToTalkEnabled,
-              onChanged: notifier.setPushToTalkEnabled,
-            ),
-            AnimatedOpacity(
-              opacity: voice.pushToTalkEnabled ? 1.0 : 0.4,
-              duration: const Duration(milliseconds: 200),
-              child: IgnorePointer(
-                ignoring: !voice.pushToTalkEnabled,
-                child: ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  title: Text(
-                    'Push-to-Talk Key',
-                    style: TextStyle(color: context.textPrimary, fontSize: 14),
-                  ),
-                  subtitle: Text(
-                    voice.pushToTalkKeyLabel,
-                    style: TextStyle(color: context.textMuted, fontSize: 12),
-                  ),
-                  trailing: OutlinedButton(
-                    onPressed: () => _capturePushToTalkKey(notifier),
-                    child: const Text('Set Key'),
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-            Divider(color: context.border),
-            const SizedBox(height: 16),
-            Text(
-              'Audio Processing',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'These settings apply the next time you join a voice channel.',
-              style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 12,
-                height: 1.5,
-              ),
-            ),
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Noise Suppression',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Reduce background noise like fans, typing, and ambient sounds.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: voice.noiseSuppression,
-              onChanged: (v) => notifier.setNoiseSuppression(v),
-            ),
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Echo Cancellation',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Prevent your speakers from feeding back into your microphone.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: voice.echoCancellation,
-              onChanged: (v) => notifier.setEchoCancellation(v),
-            ),
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Auto Gain Control',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Automatically adjust microphone volume for consistent levels.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: voice.autoGainControl,
-              onChanged: (v) => notifier.setAutoGainControl(v),
-            ),
-            const SizedBox(height: 16),
-            Divider(color: context.border),
-            const SizedBox(height: 16),
-            Text(
-              'Channel Behaviour',
-              style: TextStyle(
-                color: context.textPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 4),
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: Text(
-                'Confirm before joining voice channel',
-                style: TextStyle(color: context.textPrimary, fontSize: 14),
-              ),
-              subtitle: Text(
-                'Show a confirmation dialog before connecting to a voice channel.',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              value: voice.confirmBeforeJoinVoice,
-              onChanged: notifier.setConfirmBeforeJoinVoice,
+            const SizedBox(width: 12),
+            OutlinedButton.icon(
+              onPressed: _isMicTesting ? _stopMicTest : _startMicTest,
+              icon: Icon(_isMicTesting ? Icons.stop : Icons.mic, size: 18),
+              label: Text(_isMicTesting ? 'Stop' : 'Test Microphone'),
             ),
           ],
         ),
-      ),
+        if (_isMicTesting) ...[
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Icon(Icons.mic, size: 16, color: context.textSecondary),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: _micLevel,
+                    minHeight: 8,
+                    backgroundColor: context.surface,
+                    valueColor: AlwaysStoppedAnimation<Color>(_micLevelColor()),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${(_micLevel * 100).round()}%',
+                style: TextStyle(color: context.textSecondary, fontSize: 12),
+              ),
+            ],
+          ),
+        ],
+        const SizedBox(height: 10),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          title: Text(
+            'Push-to-Talk',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'When enabled, your mic transmits only while push-to-talk is active.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: voice.pushToTalkEnabled,
+          onChanged: notifier.setPushToTalkEnabled,
+        ),
+        AnimatedOpacity(
+          opacity: voice.pushToTalkEnabled ? 1.0 : 0.4,
+          duration: const Duration(milliseconds: 200),
+          child: IgnorePointer(
+            ignoring: !voice.pushToTalkEnabled,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(
+                'Push-to-Talk Key',
+                style: TextStyle(color: context.textPrimary, fontSize: 14),
+              ),
+              subtitle: Text(
+                voice.pushToTalkKeyLabel,
+                style: TextStyle(color: context.textMuted, fontSize: 12),
+              ),
+              trailing: OutlinedButton(
+                onPressed: () => _capturePushToTalkKey(notifier),
+                child: const Text('Set Key'),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Divider(color: context.border),
+        const SizedBox(height: 16),
+        Text(
+          'Audio Processing',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'These settings apply the next time you join a voice channel.',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 12,
+            height: 1.5,
+          ),
+        ),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          title: Text(
+            'Noise Suppression',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Reduce background noise like fans, typing, and ambient sounds.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: voice.noiseSuppression,
+          onChanged: (v) => notifier.setNoiseSuppression(v),
+        ),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          title: Text(
+            'Echo Cancellation',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Prevent your speakers from feeding back into your microphone.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: voice.echoCancellation,
+          onChanged: (v) => notifier.setEchoCancellation(v),
+        ),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          title: Text(
+            'Auto Gain Control',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Automatically adjust microphone volume for consistent levels.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: voice.autoGainControl,
+          onChanged: (v) => notifier.setAutoGainControl(v),
+        ),
+        const SizedBox(height: 16),
+        Divider(color: context.border),
+        const SizedBox(height: 16),
+        Text(
+          'Channel Behaviour',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 4),
+        SwitchListTile.adaptive(
+          contentPadding: EdgeInsets.zero,
+          title: Text(
+            'Confirm before joining voice channel',
+            style: TextStyle(color: context.textPrimary, fontSize: 14),
+          ),
+          subtitle: Text(
+            'Show a confirmation dialog before connecting to a voice channel.',
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+          value: voice.confirmBeforeJoinVoice,
+          onChanged: notifier.setConfirmBeforeJoinVoice,
+        ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/widgets/settings_panel_scaffold.dart
+++ b/apps/client/lib/src/widgets/settings_panel_scaffold.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+/// Shared layout shell for Settings sub-panels.
+///
+/// All Settings sub-panels share the same outer layout: a scrollable that
+/// fills the right pane with the visible content centered and capped at
+/// `maxWidth` pixels. The non-obvious bit is the wrap order — the scrollable
+/// must be the *outer* widget, not the inner one. If the layout were
+/// `Center > ConstrainedBox > ListView` (the old shape, fixed in #1157 and
+/// extracted here in #1169), wheel events outside the content column would
+/// fall through to no scroll surface and the user could only scroll while
+/// hovering directly over a widget.
+class SettingsPanelScaffold extends StatelessWidget {
+  const SettingsPanelScaffold({
+    super.key,
+    required this.children,
+    this.padding = const EdgeInsets.all(24),
+    this.maxWidth = 900,
+  });
+
+  final List<Widget> children;
+  final EdgeInsetsGeometry padding;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: padding,
+      child: Center(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: children,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/test/widgets/settings_panel_scaffold_test.dart
+++ b/apps/client/test/widgets/settings_panel_scaffold_test.dart
@@ -1,0 +1,69 @@
+// Regression test for #1169 (and originally #1157): the shared
+// SettingsPanelScaffold must catch mouse-wheel events anywhere in the right
+// pane, including the side margins outside the centered 900 px content
+// column. The whole point of the shared scaffold is that this contract
+// lives in one place — if a future refactor breaks it here, every settings
+// sub-panel regresses simultaneously, so we lock it down with a focused
+// scaffold-only test.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/settings_panel_scaffold.dart';
+
+void main() {
+  group('SettingsPanelScaffold', () {
+    Future<ScrollPosition> pumpAndFindScroll(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1600, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SettingsPanelScaffold(
+              children: List.generate(
+                50,
+                (i) =>
+                    SizedBox(height: 40, child: Center(child: Text('row $i'))),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final finder = find.byType(Scrollable);
+      expect(finder, findsOneWidget);
+      return tester.state<ScrollableState>(finder).position;
+    }
+
+    Future<void> scrollAt(WidgetTester tester, Offset position) async {
+      final pointer = TestPointer(1, PointerDeviceKind.mouse);
+      await tester.sendEventToBinding(pointer.hover(position));
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 200)));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('right-margin scroll drives the panel (#1157, #1169)', (
+      tester,
+    ) async {
+      final scroll = await pumpAndFindScroll(tester);
+      expect(scroll.pixels, 0.0);
+
+      await scrollAt(tester, const Offset(1550, 450));
+      expect(scroll.pixels, greaterThan(0.0));
+    });
+
+    testWidgets('left-margin scroll drives the panel (#1157, #1169)', (
+      tester,
+    ) async {
+      final scroll = await pumpAndFindScroll(tester);
+      expect(scroll.pixels, 0.0);
+
+      await scrollAt(tester, const Offset(50, 450));
+      expect(scroll.pixels, greaterThan(0.0));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

#1157 fixed the mouse-wheel scroll-region bug on the **Appearance** settings panel. Every other settings sub-panel had the same bug. This PR sweeps the fix across all of them and extracts a shared scaffold so the bug can't sneak back into a future panel.

Fixes #1169.

## Fixed

- **Wheel scroll now works across the full pane in every Settings sub-panel.** Notifications, Voice & Video, Privacy, Accessibility, Status, Data & Storage, Language, Devices, About, Account, and Advanced Theme all now match Appearance — hover the cursor anywhere in the right pane and scroll, the panel scrolls.

## New

- \`apps/client/lib/src/widgets/settings_panel_scaffold.dart\` (40 lines) — single shared shell that owns the \`SingleChildScrollView > Center > ConstrainedBox(900) > Column\` layout. Every settings panel now reaches for this; the old \`Center > ConstrainedBox > ListView\` pattern is gone.

## Behind the scenes

- 12 panel files migrated. Net **-87 lines** across the diff (each panel sheds a few lines of outer boilerplate).
- \`appearance_section.dart\` migrated to the scaffold too (drops its ad-hoc post-#1157 shell + comment) so every panel lives on the same surface.
- \`devices_section.dart\`'s stale \`// (other panels like appearance, ...): Center > ConstrainedBox(maxWidth: 900) > ListView\` comment is removed — that pattern is now an implementation detail of the scaffold, not a convention worth pointing at.
- Stale \`AppearanceSection's ListView\` comment in \`advanced_theme_section.dart\` updated to \`AppearanceSection's panel column\`.

## Tests

- New \`apps/client/test/widgets/settings_panel_scaffold_test.dart\` — focused widget test that pumps the scaffold with 50 trivial children at 1600 px width and fires \`PointerScrollEvent\` at **x=1550 (right margin)** and **x=50 (left margin)**, asserting the scroll offset advances in both cases. Locks the load-bearing invariant in one place; every panel inherits.
- Existing \`appearance_section_scroll_test.dart\` kept as defense-in-depth (verifies AppearanceSection actually wires through the scaffold rather than nesting a ListView directly).

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2274 passed**, 9 skipped (pre-existing), 0 failed (was 2272 → +2 net for the new scaffold tests).

## Manual smoke

- [ ] Open Settings → walk each section (Appearance, Notifications, Voice & Video, Privacy, Accessibility, Status, Data & Storage, Language, Devices, About, Account, Advanced Theme).
- [ ] In each, hover the cursor in the empty area at the right edge of the pane and scroll wheel.
- [ ] Confirm the panel scrolls.