### PR TITLE
Show the real reason when creating a conversation fails (#1161)

### DIFF
--- a/apps/client/lib/src/providers/conversations_http_actions.dart
+++ b/apps/client/lib/src/providers/conversations_http_actions.dart
@@ -366,11 +366,16 @@ mixin _ConversationsHttpActionsMixin on Notifier<ConversationsState> {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
         final conversationId =
             data['conversation_id'] as String? ?? data['id'] as String? ?? '';
+        if (conversationId.isEmpty) {
+          // Server returned 2xx but no id — treat as failure so the
+          // Future<String> contract holds for every caller.
+          throw const GroupException('Server response missing conversation id');
+        }
         await loadConversations();
         // Only seed the initial group-key envelope when the creator
         // actually opted into encryption. A plaintext group skips this
         // entirely; sends go through the unencrypted path.
-        if (isEncrypted && conversationId.isNotEmpty) {
+        if (isEncrypted) {
           try {
             await ref
                 .read(cryptoProvider.notifier)

--- a/apps/client/lib/src/providers/conversations_http_actions.dart
+++ b/apps/client/lib/src/providers/conversations_http_actions.dart
@@ -337,7 +337,7 @@ mixin _ConversationsHttpActionsMixin on Notifier<ConversationsState> {
   /// server's `is_encrypted` column stays false and no first-key seed
   /// runs. When true, the creator's client uploads the initial per-
   /// member envelope inline so the very first message can encrypt.
-  Future<String?> createGroup(
+  Future<String> createGroup(
     String name,
     List<String> memberIds, {
     String? description,
@@ -388,15 +388,24 @@ mixin _ConversationsHttpActionsMixin on Notifier<ConversationsState> {
         }
         return conversationId;
       } else {
-        final data = jsonDecode(response.body) as Map<String, dynamic>;
-        state = state.copyWith(
-          error: data['error'] as String? ?? 'Failed to create group',
+        final msg = _parseServerError(response.body, 'Failed to create group');
+        DebugLogService.instance.log(
+          LogLevel.error,
+          'Conversations',
+          'createGroup failed (HTTP ${response.statusCode}): $msg',
         );
-        return null;
+        throw GroupException(msg);
       }
+    } on GroupException {
+      rethrow;
     } catch (e) {
-      state = state.copyWith(error: _friendlyError(e));
-      return null;
+      debugPrint('[Conversations] createGroup failed: $e');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'Conversations',
+        'createGroup error: $e',
+      );
+      throw GroupException(_friendlyError(e));
     }
   }
 }

--- a/apps/client/lib/src/providers/conversations_provider.dart
+++ b/apps/client/lib/src/providers/conversations_provider.dart
@@ -297,3 +297,14 @@ class DmException implements Exception {
   @override
   String toString() => message;
 }
+
+/// Thrown by [ConversationsNotifier.createGroup] when the server rejects
+/// the request or a network error occurs. [message] is safe to display to
+/// the user.
+class GroupException implements Exception {
+  final String message;
+  const GroupException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/apps/client/lib/src/screens/create_group_screen.dart
+++ b/apps/client/lib/src/screens/create_group_screen.dart
@@ -76,13 +76,11 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
     if (!mounted) return;
     setState(() => _isCreating = false);
 
-    if (conversationId.isNotEmpty) {
-      ToastService.show(context, 'Group created', type: ToastType.success);
-      if (Navigator.canPop(context)) {
-        Navigator.pop(context);
-      }
-      context.go('/home?conversation=$conversationId');
+    ToastService.show(context, 'Group created', type: ToastType.success);
+    if (Navigator.canPop(context)) {
+      Navigator.pop(context);
     }
+    context.go('/home?conversation=$conversationId');
   }
 
   @override

--- a/apps/client/lib/src/screens/create_group_screen.dart
+++ b/apps/client/lib/src/screens/create_group_screen.dart
@@ -55,20 +55,28 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
 
     final description = _descriptionController.text.trim();
 
-    final conversationId = await ref
-        .read(conversationsProvider.notifier)
-        .createGroup(
-          name,
-          _selectedUserIds.toList(),
-          description: description.isNotEmpty ? description : null,
-          isPublic: _isPublic,
-          isEncrypted: _isEncrypted,
-        );
+    final String conversationId;
+    try {
+      conversationId = await ref
+          .read(conversationsProvider.notifier)
+          .createGroup(
+            name,
+            _selectedUserIds.toList(),
+            description: description.isNotEmpty ? description : null,
+            isPublic: _isPublic,
+            isEncrypted: _isEncrypted,
+          );
+    } on GroupException catch (e) {
+      if (!mounted) return;
+      setState(() => _isCreating = false);
+      ToastService.show(context, e.message, type: ToastType.error);
+      return;
+    }
 
     if (!mounted) return;
     setState(() => _isCreating = false);
 
-    if (conversationId != null && conversationId.isNotEmpty) {
+    if (conversationId.isNotEmpty) {
       ToastService.show(context, 'Group created', type: ToastType.success);
       if (Navigator.canPop(context)) {
         Navigator.pop(context);

--- a/apps/client/lib/src/screens/new_message_screen.dart
+++ b/apps/client/lib/src/screens/new_message_screen.dart
@@ -236,11 +236,18 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
     setState(() => _isBusy = true);
     try {
       final memberIds = _chips.map((c) => c.userId).toList();
-      final convId = await ref
-          .read(conversationsProvider.notifier)
-          .createGroup(name, memberIds);
+      final String convId;
+      try {
+        convId = await ref
+            .read(conversationsProvider.notifier)
+            .createGroup(name, memberIds);
+      } on GroupException catch (e) {
+        if (!mounted) return;
+        ToastService.show(context, e.message, type: ToastType.error);
+        return;
+      }
       if (!mounted) return;
-      if (convId == null || convId.isEmpty) {
+      if (convId.isEmpty) {
         ToastService.show(
           context,
           'Failed to create group',

--- a/apps/client/lib/src/screens/new_message_screen.dart
+++ b/apps/client/lib/src/screens/new_message_screen.dart
@@ -247,14 +247,6 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
         return;
       }
       if (!mounted) return;
-      if (convId.isEmpty) {
-        ToastService.show(
-          context,
-          'Failed to create group',
-          type: ToastType.error,
-        );
-        return;
-      }
       // Find the newly created conversation in state.
       final conv = ref
           .read(conversationsProvider)

--- a/apps/client/test/providers/conversations_http_test.dart
+++ b/apps/client/test/providers/conversations_http_test.dart
@@ -87,7 +87,7 @@ void main() {
       expect(result, 'new-group-id');
     });
 
-    test('returns null on failure', () async {
+    test('throws GroupException on failure', () async {
       when(
         () => mockClient.post(
           any(that: predicate<Uri>((u) => u.path == '/api/groups')),
@@ -98,12 +98,19 @@ void main() {
       ).thenAnswer((_) async => http.Response('{"error": "forbidden"}', 403));
 
       final notifier = container.read(conversationsProvider.notifier);
-      final result = await http.runWithClient(
-        () => notifier.createGroup('Test', []),
-        () => mockClient,
+      await expectLater(
+        http.runWithClient(
+          () => notifier.createGroup('Test', []),
+          () => mockClient,
+        ),
+        throwsA(
+          isA<GroupException>().having(
+            (e) => e.message,
+            'message',
+            'forbidden',
+          ),
+        ),
       );
-
-      expect(result, isNull);
     });
 
     test('sends correct JSON body', () async {

--- a/apps/client/test/providers/create_group_error_test.dart
+++ b/apps/client/test/providers/create_group_error_test.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/conversations_provider.dart';
+import 'package:echo_app/src/providers/privacy_provider.dart';
+import 'package:echo_app/src/providers/server_url_provider.dart';
+
+import '../helpers/mock_http_client.dart';
+import '../helpers/mock_providers.dart';
+
+// ---------------------------------------------------------------------------
+// #1161: surface the real server-side reason when group creation fails.
+//
+// createGroup must throw a [GroupException] whose message is safe to display
+// to the user (the toast in new_message_screen.dart reads e.message verbatim).
+// ---------------------------------------------------------------------------
+
+void main() {
+  late MockHttpClient mockClient;
+  late ProviderContainer container;
+
+  setUpAll(() {
+    registerHttpFallbackValues();
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    mockClient = MockHttpClient();
+    when(() => mockClient.close()).thenReturn(null);
+
+    container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(
+          () => FakeLoggedInAuthNotifier(
+            const AuthState(
+              isLoggedIn: true,
+              userId: 'me',
+              username: 'testuser',
+              token: 'fake-token',
+              refreshToken: 'fake-refresh',
+            ),
+          ),
+        ),
+        serverUrlProvider.overrideWith(
+          () => FakeServerUrlNotifier('http://localhost:8080'),
+        ),
+        privacyProvider.overrideWith(Privacy.new),
+      ],
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  group('ConversationsNotifier.createGroup error surfacing', () {
+    test(
+      '409 with server message throws GroupException carrying that message',
+      () async {
+        when(
+          () => mockClient.post(
+            any(that: predicate<Uri>((u) => u.path == '/api/groups')),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response('{"error": "Group name taken"}', 409),
+        );
+
+        final notifier = container.read(conversationsProvider.notifier);
+        await expectLater(
+          http.runWithClient(
+            () => notifier.createGroup('Dupes', ['u1', 'u2']),
+            () => mockClient,
+          ),
+          throwsA(
+            isA<GroupException>().having(
+              (e) => e.message,
+              'message',
+              'Group name taken',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'network failure throws GroupException with _friendlyError translation',
+      () async {
+        when(
+          () => mockClient.post(
+            any(that: predicate<Uri>((u) => u.path == '/api/groups')),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenThrow(const SocketException('Connection refused'));
+
+        final notifier = container.read(conversationsProvider.notifier);
+        await expectLater(
+          http.runWithClient(
+            () => notifier.createGroup('Whatever', ['u1', 'u2']),
+            () => mockClient,
+          ),
+          throwsA(
+            isA<GroupException>().having(
+              (e) => e.message,
+              'message',
+              predicate<String>(
+                (m) => m.isNotEmpty && m != 'Failed to create group',
+                'is a friendly non-empty message, not the generic fallback',
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/apps/client/test/providers/create_group_error_test.dart
+++ b/apps/client/test/providers/create_group_error_test.dart
@@ -89,6 +89,67 @@ void main() {
       },
     );
 
+    test('non-2xx with empty body falls back to the generic message', () async {
+      // Server returns 500 with no JSON body (or a body missing the
+      // `error` field) — the user-facing message should be the
+      // fallback, not an empty string.
+      when(
+        () => mockClient.post(
+          any(that: predicate<Uri>((u) => u.path == '/api/groups')),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+          encoding: any(named: 'encoding'),
+        ),
+      ).thenAnswer((_) async => http.Response('{}', 500));
+
+      final notifier = container.read(conversationsProvider.notifier);
+      await expectLater(
+        http.runWithClient(
+          () => notifier.createGroup('Whatever', ['u1', 'u2']),
+          () => mockClient,
+        ),
+        throwsA(
+          isA<GroupException>().having(
+            (e) => e.message,
+            'message',
+            'Failed to create group',
+          ),
+        ),
+      );
+    });
+
+    test(
+      '2xx response missing conversation id throws GroupException',
+      () async {
+        // The Future<String> contract: a 2xx body with no id field is a
+        // server bug, not a success. Treat as failure so callers don't
+        // navigate into a non-existent conversation.
+        when(
+          () => mockClient.post(
+            any(that: predicate<Uri>((u) => u.path == '/api/groups')),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer((_) async => http.Response('{}', 201));
+
+        final notifier = container.read(conversationsProvider.notifier);
+        await expectLater(
+          http.runWithClient(
+            () => notifier.createGroup('Whatever', ['u1', 'u2']),
+            () => mockClient,
+          ),
+          throwsA(
+            isA<GroupException>().having(
+              (e) => e.message,
+              'message',
+              contains('missing conversation id'),
+            ),
+          ),
+        );
+      },
+    );
+
     test(
       'network failure throws GroupException with _friendlyError translation',
       () async {


### PR DESCRIPTION
## Summary

After adding people to a new group and tapping Create, any server rejection (invalid member, name conflict, encryption-seed failure, 4xx of any kind) showed the same generic toast: \`Failed to create group\`. The real server message was captured by the client but never surfaced. Beta testers (Riley) hit this and reported "create button doesn't work."

Fixes #1161.

## Fixed

- **Group create errors now show the real reason.** A 409 with \`{"error": "Group name taken"}\` from the server now renders as a toast saying exactly that. A 4xx with no \`error\` field falls back to the generic message. A network outage surfaces the friendly "Unable to connect to server…" translation, matching DM behaviour.
- **Tighter contract on the create-group API.** \`createGroup\` now returns \`Future<String>\` (non-nullable) and throws \`GroupException\` on every failure — including the previously-silent case where the server returns 2xx but no conversation id. Callers can no longer accidentally navigate into a non-existent conversation.

## Behind the scenes

- New \`GroupException\` class in \`conversations_provider.dart\`, character-identical shape to the existing \`DmException\`.
- Both call sites updated (\`new_message_screen.dart\` + \`create_group_screen.dart\`) with the \`on GroupException catch\` pattern and the now-redundant \`isEmpty\` checks removed.
- 4 new unit tests in \`apps/client/test/providers/create_group_error_test.dart\` lock the four failure modes: server message preserved, empty body fallback, 2xx-missing-id contract, network friendly-error translation.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2278 passed**, 9 skipped (pre-existing), 0 failed (was 2274 → +4 net).