### PR TITLE
Show the real reason when pinning a message fails (#1162)

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel/message_actions.dart
+++ b/apps/client/lib/src/widgets/chat_panel/message_actions.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
@@ -278,6 +280,24 @@ Future<void> deleteForEveryone(
   }
 }
 
+/// Pull a user-facing error message out of a JSON response body of shape
+/// `{"error": "..."}`. Falls back to [fallback] when the body is empty,
+/// non-JSON, not a map, missing the `error` field, or `error` is empty.
+/// Visible-for-testing so the pin/unpin failure UX can be pinned (#1162).
+@visibleForTesting
+String parsePinErrorMessage(String body, String fallback) {
+  try {
+    final data = jsonDecode(body);
+    if (data is Map<String, dynamic>) {
+      final msg = data['error'] as String?;
+      if (msg != null && msg.isNotEmpty) return msg;
+    }
+  } catch (_) {
+    // Non-JSON body (HTML error page, empty string) — fall through.
+  }
+  return fallback;
+}
+
 Future<void> pinMessage({
   required BuildContext context,
   required WidgetRef ref,
@@ -314,7 +334,7 @@ Future<void> pinMessage({
           .updateMessagePin(conv.id, message.id, null, null);
       ToastService.show(
         context,
-        'Failed to pin message',
+        parsePinErrorMessage(response.body, 'Failed to pin message'),
         type: ToastType.error,
       );
     }
@@ -366,7 +386,7 @@ Future<void> unpinMessage({
           .updateMessagePin(conv.id, message.id, prevPinnedById, prevPinnedAt);
       ToastService.show(
         context,
-        'Failed to unpin message',
+        parsePinErrorMessage(response.body, 'Failed to unpin message'),
         type: ToastType.error,
       );
     }

--- a/apps/client/test/widgets/chat_panel/message_actions_pin_error_test.dart
+++ b/apps/client/test/widgets/chat_panel/message_actions_pin_error_test.dart
@@ -1,0 +1,54 @@
+// Unit test for the response-body parser surfaced by #1162. Pin/unpin used
+// to show the same `Failed to pin message` toast regardless of what the
+// server said. The parser pulls `error` out of the JSON body so the real
+// reason (DM not allowed, non-admin, conversation not found) reaches the
+// user.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/chat_panel/message_actions.dart';
+
+void main() {
+  group('parsePinErrorMessage', () {
+    test('returns server error when JSON body contains an error field', () {
+      expect(
+        parsePinErrorMessage(
+          '{"error": "Only admins can pin in this group"}',
+          'Failed to pin message',
+        ),
+        'Only admins can pin in this group',
+      );
+    });
+
+    test('falls back when the body is empty / no error field', () {
+      expect(
+        parsePinErrorMessage('{}', 'Failed to pin message'),
+        'Failed to pin message',
+      );
+    });
+
+    test('falls back when error field is an empty string', () {
+      expect(
+        parsePinErrorMessage('{"error": ""}', 'Failed to unpin message'),
+        'Failed to unpin message',
+      );
+    });
+
+    test('falls back when body is non-JSON (HTML error page)', () {
+      expect(
+        parsePinErrorMessage(
+          '<html><body>500 Internal Server Error</body></html>',
+          'Failed to pin message',
+        ),
+        'Failed to pin message',
+      );
+    });
+
+    test('falls back when body is not a JSON map', () {
+      expect(
+        parsePinErrorMessage('"oops"', 'Failed to pin message'),
+        'Failed to pin message',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Pin/unpin used to show the same toast — \`Failed to pin message\` — whether the user lacked admin in the group, the message was in a DM, the conversation was gone, or the server was down. The server's actual error message in the response body was silently discarded.

Fixes #1162.

## Fixed

- **Pin and unpin failures now show the real reason.** Server messages like 'Only admins can pin in this group' or 'Conversation not found' surface verbatim. Non-JSON bodies (HTML 500 page) still fall back to the generic so users never see raw error pages.

## Behind the scenes

- New \`@visibleForTesting String parsePinErrorMessage(String body, String fallback)\` helper. JSON-only path with a \`try { jsonDecode(...) } catch { fallback }\` so malformed bodies never crash the pin flow.
- 5 unit tests cover: server-message preserved, empty body fallback, empty-error-string fallback, HTML body fallback, non-map JSON fallback.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2283 passed**, 9 skipped (pre-existing), 0 failed (was 2278 → +5 net).