### PR TITLE
Restore admin panel access after auto-login on native (#1160)

### DIFF
--- a/apps/client/lib/src/providers/auth/auth_token_refresh.dart
+++ b/apps/client/lib/src/providers/auth/auth_token_refresh.dart
@@ -123,6 +123,12 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
             data['refresh_token'] as String? ?? storedRefreshToken;
         final userId = data['user_id'] as String? ?? storedUserId ?? '';
         final username = data['username'] as String? ?? storedUsername ?? '';
+        // Server re-reads is_admin from the canonical users row on every
+        // refresh (apps/server/src/routes/auth.rs), so promotion /
+        // demotion since last login propagates here. Without parsing it
+        // the admin panel stays invisible after every cold restart on
+        // native clients — #1160.
+        final isAdmin = data['is_admin'] as bool? ?? false;
 
         // Persist new tokens BEFORE any other async work. The server
         // already revoked the old refresh token during rotation, so if
@@ -144,6 +150,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
           username: username,
           token: newAccessToken,
           refreshToken: newRefreshToken,
+          isAdmin: isAdmin,
           onboardingCompleted: onboardingDone,
         );
         return true;
@@ -192,6 +199,10 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
           final newAccessToken = data['access_token'] as String;
           final userId = data['user_id'] as String? ?? storedUserId;
           final username = data['username'] as String? ?? storedUsername;
+          // See companion comment in tryAutoLogin's body-token path. The
+          // server returns is_admin on every refresh; without it the
+          // admin panel stays invisible on the web client too — #1160.
+          final isAdmin = data['is_admin'] as bool? ?? false;
 
           await _storeTokens(
             accessToken: newAccessToken,
@@ -207,6 +218,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
             userId: userId,
             username: username,
             token: newAccessToken,
+            isAdmin: isAdmin,
             // refreshToken stays null in state on web -- never needed by client
             onboardingCompleted: onboardingDone,
           );

--- a/apps/client/test/providers/auth/auth_provider_test.dart
+++ b/apps/client/test/providers/auth/auth_provider_test.dart
@@ -409,6 +409,88 @@ void main() {
       expect(st.token, 'new-tok');
     });
 
+    test(
+      'tryAutoLogin() restores is_admin=true from refresh (#1160)',
+      () async {
+        // Server returns is_admin=true; without parsing it the admin panel
+        // stayed invisible on native clients after cold-start.
+        await fakeKeyStore.writeGlobal('echo_auth_refresh_token', 'stored-ref');
+        SharedPreferences.setMockInitialValues({
+          'echo_auth_user_id': 'uid-1',
+          'echo_auth_username': 'admin-user',
+        });
+
+        when(
+          () => mockClient.post(
+            any(that: predicate<Uri>((u) => u.path == '/api/auth/refresh')),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'access_token': 'new-tok',
+              'refresh_token': 'new-ref',
+              'user_id': 'uid-1',
+              'username': 'admin-user',
+              'is_admin': true,
+            }),
+            200,
+          ),
+        );
+
+        final notifier = container.read(authProvider.notifier);
+        final result = await http.runWithClient(
+          () => notifier.tryAutoLogin(),
+          () => mockClient,
+        );
+
+        expect(result, isTrue);
+        expect(container.read(authProvider).isAdmin, isTrue);
+      },
+    );
+
+    test(
+      'tryAutoLogin() leaves is_admin=false for non-admins (#1160)',
+      () async {
+        await fakeKeyStore.writeGlobal('echo_auth_refresh_token', 'stored-ref');
+        SharedPreferences.setMockInitialValues({
+          'echo_auth_user_id': 'uid-1',
+          'echo_auth_username': 'dev',
+        });
+
+        when(
+          () => mockClient.post(
+            any(that: predicate<Uri>((u) => u.path == '/api/auth/refresh')),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'access_token': 'new-tok',
+              'refresh_token': 'new-ref',
+              'user_id': 'uid-1',
+              'username': 'dev',
+              'is_admin': false,
+            }),
+            200,
+          ),
+        );
+
+        final notifier = container.read(authProvider.notifier);
+        final result = await http.runWithClient(
+          () => notifier.tryAutoLogin(),
+          () => mockClient,
+        );
+
+        expect(result, isTrue);
+        expect(container.read(authProvider).isAdmin, isFalse);
+      },
+    );
+
     test('tryAutoLogin() refresh fails 401 clears tokens', () async {
       await fakeKeyStore.writeGlobal('echo_auth_refresh_token', 'expired-ref');
       SharedPreferences.setMockInitialValues({


### PR DESCRIPTION
## Summary

Admin users couldn't see the admin panel on Linux, Android, or iOS after their first cold restart. The admin route was registered on every platform and the Settings menu correctly gated on \`AuthState.isAdmin\`, but \`AuthState.isAdmin\` was silently reset to \`false\` on every refresh-token auto-login because the client never parsed \`is_admin\` from the \`/api/auth/refresh\` response.

(Web wasn't immune — admins just tended to log in fresh during testing and never hit the auto-login path that drops the flag.)

Fixes #1160.

## Fixed

- **Admin panel reappears on every platform after cold restart.** Both refresh paths in \`auth_token_refresh.dart\` — body-token (native) and cookie (web) — now parse \`is_admin\` from the response and propagate it through \`AuthState\`. The server's \`/api/auth/refresh\` already re-reads the canonical \`users.is_admin\` row on every refresh, so promotion / demotion between login and refresh propagates correctly to the client on its next 15-minute token roll.

## Behind the scenes

- 4-line client parse + propagate (defaults to \`false\` when the field is missing so older server builds remain compatible).
- 2 new auth-provider tests assert \`is_admin: true\` → \`AuthState.isAdmin == true\` and \`is_admin: false\` → \`AuthState.isAdmin == false\` after \`tryAutoLogin\`.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2285 passed**, 9 skipped (pre-existing), 0 failed (was 2283 → +2 net).