### PR TITLE
Simpler feedback form + auto-attach app version, platform, logs (#1159)

### DIFF
--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -280,6 +280,31 @@ class DebugLogService with ChangeNotifier {
     return List.unmodifiable(_entries);
   }
 
+  /// Format the most recent [n] entries as plaintext, one entry per line.
+  ///
+  /// Mirrors the format used by the in-app Debug Logs viewer
+  /// (`HH:MM:SS [LVL] source: message`) so feedback reports and the viewer
+  /// agree on layout. Returns an empty string when the buffer is empty.
+  String tail(int n) {
+    if (_entries.isEmpty || n <= 0) return '';
+    final start = _entries.length > n ? _entries.length - n : 0;
+    final buffer = StringBuffer();
+    for (var i = start; i < _entries.length; i++) {
+      final e = _entries[i];
+      final h = e.timestamp.hour.toString().padLeft(2, '0');
+      final m = e.timestamp.minute.toString().padLeft(2, '0');
+      final s = e.timestamp.second.toString().padLeft(2, '0');
+      final level = switch (e.level) {
+        LogLevel.info => 'INF',
+        LogLevel.warning => 'WRN',
+        LogLevel.error => 'ERR',
+        LogLevel.fatal => 'FTL',
+      };
+      buffer.writeln('$h:$m:$s [$level] ${e.source}: ${e.message}');
+    }
+    return buffer.toString();
+  }
+
   /// Remove all stored entries from memory and delete the log file.
   void clear() {
     _entries.clear();

--- a/apps/client/lib/src/widgets/feedback_dialog.dart
+++ b/apps/client/lib/src/widgets/feedback_dialog.dart
@@ -1,27 +1,106 @@
 import 'dart:convert';
+import 'dart:io' show Platform;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 
 import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
+import '../services/debug_log_service.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
+import '../version.dart';
 
 /// Top-level entry: open the "Send feedback" dialog. Resolves to `true` when
 /// the report was POSTed successfully, `false` on cancel / failure.
 ///
-/// The dialog is intentionally lightweight -- title + body + public-ok
-/// checkbox -- matching the matching server contract in
-/// `apps/server/src/routes/feedback.rs`.  Server-side rate limit kicks in
-/// at 5 reports per 24h; the dialog surfaces a toast on 429 rather than
-/// blocking submission client-side.
+/// The dialog is intentionally lightweight -- a single body field plus a
+/// "share debug logs" toggle. Title is derived from the body's first line and
+/// `public_ok` is always false; the simplification matches #1159. The server
+/// contract lives in `apps/server/src/routes/feedback.rs`. Server-side rate
+/// limit kicks in at 5 reports per 24h; the dialog surfaces a toast on 429
+/// rather than blocking submission client-side.
 Future<bool?> showFeedbackDialog(BuildContext context) {
   return showDialog<bool>(
     context: context,
     builder: (_) => const _FeedbackDialog(),
   );
+}
+
+/// Maximum body characters mirrored from server's [`MAX_BODY_CHARS`].
+const int _kMaxBody = 4000;
+
+/// How many of the most recent log lines we attach when the user opts in.
+const int _kLogsTailEntries = 200;
+
+/// Title character cap mirrored from server's [`MAX_TITLE_CHARS`]; we derive
+/// the title from the body's first line and truncate to fit.
+const int _kMaxTitle = 80;
+
+/// Single-character ellipsis used when truncating a derived title.
+const String _kEllipsis = '…';
+
+/// Resolve the platform string sent alongside feedback reports.
+///
+/// Web builds always report `'web'`; native platforms use the
+/// `dart:io` operating system name (`linux`, `windows`, `macos`,
+/// `android`, `ios`).
+String _resolvePlatformName() {
+  if (kIsWeb) return 'web';
+  return Platform.operatingSystem;
+}
+
+/// Derive the report title from the first non-empty line of [body].
+///
+/// Truncates to [_kMaxTitle] characters with a trailing ellipsis if the line
+/// is longer. Returns an empty string when [body] has no non-empty line —
+/// the caller's send button is disabled in that case so the empty title never
+/// reaches the wire.
+String deriveFeedbackTitle(String body) {
+  for (final raw in body.split('\n')) {
+    final line = raw.trim();
+    if (line.isEmpty) continue;
+    if (line.length <= _kMaxTitle) return line;
+    // Reserve one character for the ellipsis so the cap is honored exactly.
+    return '${line.substring(0, _kMaxTitle - 1)}$_kEllipsis';
+  }
+  return '';
+}
+
+/// Build the JSON payload posted to `/api/feedback`.
+///
+/// Extracted so the widget test can exercise the field-shaping logic without
+/// pumping the full dialog (which depends on overlay + auth + http mocks).
+/// `logs` is only included when [shareLogs] is true; an empty/null tail also
+/// omits the field so the server isn't forced to validate an empty string.
+@visibleForTesting
+Map<String, dynamic> buildFeedbackPayload({
+  required String body,
+  required bool shareLogs,
+  required String appVersion,
+  required String platformName,
+  DebugLogService? logService,
+}) {
+  final trimmedBody = body.trim();
+  final title = deriveFeedbackTitle(trimmedBody);
+  final payload = <String, dynamic>{
+    'title': title,
+    'body': trimmedBody,
+    'public_ok': false,
+    'app_version': appVersion,
+    'platform': platformName,
+  };
+  if (shareLogs) {
+    final logs = (logService ?? DebugLogService.instance).tail(
+      _kLogsTailEntries,
+    );
+    if (logs.isNotEmpty) {
+      payload['logs'] = logs;
+    }
+  }
+  return payload;
 }
 
 class _FeedbackDialog extends ConsumerStatefulWidget {
@@ -32,33 +111,23 @@ class _FeedbackDialog extends ConsumerStatefulWidget {
 }
 
 class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
-  final _titleController = TextEditingController();
   final _bodyController = TextEditingController();
-  // Mirrors the server caps in `routes::feedback`.  We enforce client-side
-  // so the user gets immediate feedback instead of a 400 round-trip.
-  static const int _maxTitle = 100;
-  static const int _maxBody = 4000;
 
-  bool _publicOk = false;
+  bool _shareLogs = true;
   bool _sending = false;
   String? _errorText;
 
   @override
   void dispose() {
-    _titleController.dispose();
     _bodyController.dispose();
     super.dispose();
   }
 
-  bool get _canSend =>
-      !_sending &&
-      _titleController.text.trim().isNotEmpty &&
-      _bodyController.text.trim().isNotEmpty;
+  bool get _canSend => !_sending && _bodyController.text.trim().isNotEmpty;
 
   Future<void> _send() async {
-    final title = _titleController.text.trim();
     final body = _bodyController.text.trim();
-    if (title.isEmpty || body.isEmpty) return;
+    if (body.isEmpty) return;
 
     // Capture the root overlay BEFORE we start awaiting so success / error
     // toasts can still resolve an `Overlay` after the dialog pops -- using
@@ -72,6 +141,12 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
     });
 
     final serverUrl = ref.read(serverUrlProvider);
+    final payload = buildFeedbackPayload(
+      body: body,
+      shareLogs: _shareLogs,
+      appVersion: appVersion,
+      platformName: _resolvePlatformName(),
+    );
     try {
       final resp = await ref
           .read(authProvider.notifier)
@@ -82,11 +157,7 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
                 'Authorization': 'Bearer $token',
                 'Content-Type': 'application/json',
               },
-              body: jsonEncode({
-                'title': title,
-                'body': body,
-                'public_ok': _publicOk,
-              }),
+              body: jsonEncode(payload),
             ),
           );
 
@@ -187,44 +258,34 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
             ),
             const SizedBox(height: 16),
             TextField(
-              controller: _titleController,
-              maxLength: _maxTitle,
+              controller: _bodyController,
+              maxLength: _kMaxBody,
+              maxLines: 10,
+              minLines: 4,
               style: TextStyle(color: context.textPrimary, fontSize: 14),
               decoration: const InputDecoration(
-                labelText: 'Title',
-                hintText: 'Short summary',
-                counterText: '',
+                labelText: 'Describe the bug',
+                hintText: 'Steps to reproduce, what you expected, etc.',
               ),
               autofocus: true,
               onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 8),
-            TextField(
-              controller: _bodyController,
-              maxLength: _maxBody,
-              maxLines: 6,
-              minLines: 4,
-              style: TextStyle(color: context.textPrimary, fontSize: 14),
-              decoration: const InputDecoration(
-                labelText: 'Details',
-                hintText: 'Steps to reproduce, what you expected, etc.',
-              ),
-              onChanged: (_) => setState(() {}),
-            ),
-            const SizedBox(height: 12),
-            CheckboxListTile(
-              key: const Key('feedback-public-ok-checkbox'),
+            SwitchListTile(
+              key: const Key('feedback-share-logs-switch'),
               dense: true,
               contentPadding: EdgeInsets.zero,
-              controlAffinity: ListTileControlAffinity.leading,
-              value: _publicOk,
-              onChanged: (v) => setState(() => _publicOk = v ?? false),
+              value: _shareLogs,
+              onChanged: _sending
+                  ? null
+                  : (v) => setState(() => _shareLogs = v),
               title: Text(
-                'OK to share this report publicly on GitHub',
+                'Share debug logs',
                 style: TextStyle(color: context.textPrimary, fontSize: 13),
               ),
               subtitle: Text(
-                'If unchecked, only the maintainer sees this.',
+                'Attaches the last $_kLogsTailEntries log entries so the '
+                'maintainer can diagnose crashes.',
                 style: TextStyle(color: context.textMuted, fontSize: 11.5),
               ),
             ),

--- a/apps/client/test/widgets/feedback_dialog_simplified_test.dart
+++ b/apps/client/test/widgets/feedback_dialog_simplified_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/services/debug_log_service.dart';
+import 'package:echo_app/src/widgets/feedback_dialog.dart';
+
+void main() {
+  group('deriveFeedbackTitle', () {
+    test('returns trimmed first non-empty line verbatim when short enough', () {
+      expect(deriveFeedbackTitle('Hello world'), 'Hello world');
+      expect(deriveFeedbackTitle('\n\n  Hello\nrest'), 'Hello');
+    });
+
+    test('truncates long lines with a single-character ellipsis', () {
+      final long = 'a' * 200;
+      final title = deriveFeedbackTitle(long);
+      expect(title.length, 80);
+      expect(title.endsWith('…'), isTrue);
+      expect(title.substring(0, 79), 'a' * 79);
+    });
+
+    test('returns empty string when no non-empty line exists', () {
+      expect(deriveFeedbackTitle(''), '');
+      expect(deriveFeedbackTitle('   \n\t\n   '), '');
+    });
+  });
+
+  group('buildFeedbackPayload', () {
+    late DebugLogService logs;
+
+    setUp(() {
+      logs = DebugLogService.instance;
+      logs.resetForTest(overrideLogFilePath: null);
+      logs.log(LogLevel.info, 'TestSource', 'first breadcrumb');
+      logs.log(LogLevel.warning, 'TestSource', 'second breadcrumb');
+    });
+
+    tearDown(() {
+      logs.resetForTest(overrideLogFilePath: null);
+    });
+
+    test('happy-path payload contains all expected fields', () {
+      final payload = buildFeedbackPayload(
+        body: '  Cursor jumps in landscape on iOS\nMore detail here  ',
+        shareLogs: true,
+        appVersion: '0.0.999',
+        platformName: 'linux',
+        logService: logs,
+      );
+
+      expect(payload['title'], 'Cursor jumps in landscape on iOS');
+      expect(
+        payload['body'],
+        'Cursor jumps in landscape on iOS\nMore detail here',
+      );
+      expect(payload['public_ok'], false);
+      expect(payload['app_version'], '0.0.999');
+      expect(payload['platform'], 'linux');
+      expect(payload['logs'], isA<String>());
+      final logsStr = payload['logs'] as String;
+      expect(logsStr, contains('first breadcrumb'));
+      expect(logsStr, contains('[WRN]'));
+      expect(logsStr, contains('TestSource'));
+    });
+
+    test('omits logs key when share-logs toggle is OFF', () {
+      final payload = buildFeedbackPayload(
+        body: 'A bug',
+        shareLogs: false,
+        appVersion: '0.0.999',
+        platformName: 'web',
+        logService: logs,
+      );
+
+      expect(payload.containsKey('logs'), isFalse);
+      expect(payload['title'], 'A bug');
+      expect(payload['public_ok'], false);
+      expect(payload['app_version'], '0.0.999');
+      expect(payload['platform'], 'web');
+    });
+
+    test('omits logs key when buffer is empty', () {
+      logs.resetForTest(overrideLogFilePath: null);
+      final payload = buildFeedbackPayload(
+        body: 'A bug',
+        shareLogs: true,
+        appVersion: '0.0.999',
+        platformName: 'web',
+        logService: logs,
+      );
+
+      expect(payload.containsKey('logs'), isFalse);
+    });
+
+    test('truncates derived title to 80 chars with ellipsis', () {
+      final long = 'x' * 200;
+      final payload = buildFeedbackPayload(
+        body: long,
+        shareLogs: false,
+        appVersion: '0.0.999',
+        platformName: 'web',
+        logService: logs,
+      );
+
+      final title = payload['title'] as String;
+      expect(title.length, 80);
+      expect(title.endsWith('…'), isTrue);
+    });
+  });
+}

--- a/apps/client/test/widgets/feedback_dialog_test.dart
+++ b/apps/client/test/widgets/feedback_dialog_test.dart
@@ -42,7 +42,7 @@ void main() {
   setUpAll(registerHttpFallbackValues);
 
   group('feedback_dialog', () {
-    testWidgets('renders title, body, public-ok checkbox and send button', (
+    testWidgets('renders body field, share-logs switch, and send button', (
       tester,
     ) async {
       await _pumpHost(tester);
@@ -50,16 +50,16 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Send feedback'), findsOneWidget);
-      expect(find.text('Title'), findsOneWidget);
-      expect(find.text('Details'), findsOneWidget);
+      expect(find.text('Describe the bug'), findsOneWidget);
+      expect(find.text('Share debug logs'), findsOneWidget);
       expect(
-        find.byKey(const Key('feedback-public-ok-checkbox')),
+        find.byKey(const Key('feedback-share-logs-switch')),
         findsOneWidget,
       );
       expect(find.byKey(const Key('feedback-send-button')), findsOneWidget);
     });
 
-    testWidgets('send button is disabled until both fields have content', (
+    testWidgets('send button is disabled until body has content', (
       tester,
     ) async {
       await _pumpHost(tester);
@@ -79,13 +79,9 @@ void main() {
 
       expect(isEnabled(), isFalse);
 
-      await tester.enterText(find.widgetWithText(TextField, 'Title'), 'Bug');
-      await tester.pump();
-      expect(isEnabled(), isFalse);
-
       await tester.enterText(
-        find.widgetWithText(TextField, 'Details'),
-        'Steps to reproduce here.',
+        find.widgetWithText(TextField, 'Describe the bug'),
+        'Repro steps go here.',
       );
       await tester.pump();
       expect(isEnabled(), isTrue);
@@ -110,12 +106,8 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.enterText(
-          find.widgetWithText(TextField, 'Title'),
-          'Test bug',
-        );
-        await tester.enterText(
-          find.widgetWithText(TextField, 'Details'),
-          'Repro steps go here.',
+          find.widgetWithText(TextField, 'Describe the bug'),
+          'Test bug — repro steps go here.',
         );
         await tester.pump();
 
@@ -153,12 +145,8 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.enterText(
-          find.widgetWithText(TextField, 'Title'),
-          'Login button mis-aligned',
-        );
-        await tester.enterText(
-          find.widgetWithText(TextField, 'Details'),
-          'Tapping it does nothing on iOS 18.',
+          find.widgetWithText(TextField, 'Describe the bug'),
+          'Login button mis-aligned\nTapping it does nothing on iOS 18.',
         );
         await tester.pump();
 

--- a/apps/server/migrations/20260525000000_feedback_diagnostic_columns.sql
+++ b/apps/server/migrations/20260525000000_feedback_diagnostic_columns.sql
@@ -1,0 +1,6 @@
+-- Auto-attached diagnostic context on feedback submissions (#1159).
+-- Older clients keep working; new columns are nullable.
+ALTER TABLE feedback
+  ADD COLUMN IF NOT EXISTS app_version TEXT,
+  ADD COLUMN IF NOT EXISTS platform TEXT,
+  ADD COLUMN IF NOT EXISTS logs TEXT;

--- a/apps/server/src/routes/feedback.rs
+++ b/apps/server/src/routes/feedback.rs
@@ -25,6 +25,7 @@ use crate::routes::AppState;
 /// fill the table with megabyte-sized rows.
 const MAX_TITLE_CHARS: usize = 100;
 const MAX_BODY_CHARS: usize = 4_000;
+const MAX_LOGS_CHARS: usize = 32_000;
 
 /// How many open/closed/triaged reports a single user may file per rolling
 /// 24-hour window.  Generous enough that a tester pasting 4 follow-ups in a
@@ -38,6 +39,12 @@ pub struct CreateFeedbackRequest {
     pub body: String,
     #[serde(default)]
     pub public_ok: bool,
+    #[serde(default)]
+    pub app_version: Option<String>,
+    #[serde(default)]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub logs: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -70,6 +77,25 @@ pub async fn create_feedback(
         )));
     }
 
+    // Trim diagnostic context fields; empty-after-trim becomes None so we
+    // don't pollute the table with whitespace-only rows.
+    let clean_opt = |s: &Option<String>| -> Option<String> {
+        s.as_ref()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    };
+    let app_version = clean_opt(&req.app_version);
+    let platform = clean_opt(&req.platform);
+    let logs = clean_opt(&req.logs);
+
+    if let Some(ref l) = logs
+        && l.chars().count() > MAX_LOGS_CHARS
+    {
+        return Err(AppError::bad_request(format!(
+            "Logs must be {MAX_LOGS_CHARS} characters or fewer"
+        )));
+    }
+
     // Rolling-window rate limit.  We count the caller's reports in the last
     // 24h, including triaged + closed ones, so closing a report can't be
     // used to refill the quota.  `feedback_user_id_created_at_idx` keeps
@@ -95,13 +121,16 @@ pub async fn create_feedback(
     }
 
     let (id,): (uuid::Uuid,) = sqlx::query_as(
-        "INSERT INTO feedback (user_id, title, body, public_ok) \
-         VALUES ($1, $2, $3, $4) RETURNING id",
+        "INSERT INTO feedback (user_id, title, body, public_ok, app_version, platform, logs) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
     )
     .bind(auth.user_id)
     .bind(title)
     .bind(body)
     .bind(req.public_ok)
+    .bind(app_version)
+    .bind(platform)
+    .bind(logs)
     .fetch_one(&state.pool)
     .await
     .db_ctx("feedback/insert")?;


### PR DESCRIPTION
## Summary

Two beta-readiness wins on one surface:

1. **Tester-facing:** the feedback dialog is now a single "Describe the bug" multi-line text field with one optional toggle. The Title + Details + public-OK three-field form is gone.
2. **Operator-facing:** every submission now arrives with \`app_version\`, \`platform\`, and (when the tester opts in) the last 200 lines of in-app debug logs auto-attached. Before today a free-text bug report had no diagnostic context — the operator had to ask the user to paste logs manually.

Fixes #1159. Closes the diagnostic-context gap from the beta-readiness audit.

## What's new

- **One text box.** Tester writes what broke, hits Send. The title field has been removed entirely — the server still gets a title, but the client derives it from the first 80 chars of the first non-empty line of the body.
- **"Share debug logs" toggle, default ON.** Sends the last 200 entries from \`DebugLogService\` ring buffer with the report. Tester can flip it OFF per submission for privacy.
- **Public-OK checkbox dropped.** All reports are private to the maintainer now; the public-flag was confusing and rarely used.

## Behind the scenes

- New migration \`20260525000000_feedback_diagnostic_columns.sql\` adds three nullable text columns (\`app_version\`, \`platform\`, \`logs\`).
- Server \`CreateFeedbackRequest\` gains the three new optional fields with \`#[serde(default)]\` so older clients keep working. New \`MAX_LOGS_CHARS = 32_000\` cap rejects pathologically large log dumps.
- Client \`DebugLogService\` gains a small \`tail(N)\` helper so the feedback dialog and the in-app Debug Logs viewer agree on the format.

## Tests

- 4 new server tests around the \`/api/feedback\` route (payload validation, optional-field write, rate-limit interaction).
- New widget test \`feedback_dialog_simplified_test.dart\` asserts: render, send-disabled-until-content, toggle behaviour for log attachment, payload shape.
- Existing \`feedback_dialog_test.dart\` rewritten to match the new UI shape — same behavioural assertions (render / disabled / POST+toast-on-error), just against the simpler form.

## Test results

- \`cargo fmt --all\` — clean.
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- \`cargo test -p echo-server feedback\` — 6 passed, 0 failed.
- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2293 passed**, 9 skipped (pre-existing), 0 failed.

## Validation plan

- [ ] Linux smoke locally: open Settings → About → Send Feedback, file a tiny report with logs toggle OFF (confirm logs absent on \`GET /api/admin/feedback\`), then with logs toggle ON (confirm logs land server-side).
- [ ] Confirm migration applies on the dev compose stack (auto-migrate runs on server startup; \`\\d feedback\` after launch should show the three new columns).