### PR TITLE
Correlate feedback reports with server logs via x-request-id (#1173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,6 +3124,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -20,7 +20,7 @@ axum-extra = { version = "0.12", features = ["typed-header", "cookie"] }
 # Used by cookie max_age (#342). Matches the version pulled in by `cookie`.
 time = "0.3"
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace", "set-header"] }
+tower-http = { version = "0.6", features = ["cors", "request-id", "set-header", "trace"] }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "json", "migrate"] }

--- a/apps/server/src/auth/middleware.rs
+++ b/apps/server/src/auth/middleware.rs
@@ -37,6 +37,12 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
         let user_id = Uuid::parse_str(&claims.sub)
             .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?;
 
+        // Light up the `user_id` slot reserved by the per-request tracing
+        // span (see `routes::create_router`). The TraceLayer span is opened
+        // before handler extractors run, so this is the only point at which
+        // we know which user (if any) the request belongs to (#1173).
+        tracing::Span::current().record("user_id", tracing::field::display(user_id));
+
         Ok(AuthUser { user_id })
     }
 }

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -33,8 +33,17 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Instant;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
+use tower_http::trace::{DefaultOnResponse, TraceLayer};
+use tracing::Level;
 use uuid::Uuid;
+
+/// Header name used for end-to-end request-id correlation. Echoed back in
+/// every response and attached to the per-request tracing span so server
+/// logs can be cross-referenced to a feedback report's stashed value
+/// (#1173).
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
 
 use crate::metrics::MessageRateCounter;
 use crate::middleware::rate_limit;
@@ -494,6 +503,48 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
                 "default-src 'none'; img-src 'self'; media-src 'self'; \
                  frame-ancestors 'none'; base-uri 'none'",
             ),
+        ))
+        // Per-request tracing + request-id correlation (#1173).
+        //
+        // Layer order matters: axum's `.layer()` wraps the LAST-applied
+        // layer outermost, so the chain below produces — from outside in —
+        //   SetRequestIdLayer  → stamps `x-request-id` on the request
+        //                        (using inbound header if present, else a
+        //                        fresh UUID v4)
+        //   PropagateRequestIdLayer → mirrors that id onto the response so
+        //                             clients can log + report it
+        //   TraceLayer         → opens an `http.request` span that captures
+        //                        the request_id + leaves a `user_id` slot
+        //                        for the AuthUser middleware to fill in.
+        //
+        // SetRequestIdLayer must be outermost so the header is present by
+        // the time TraceLayer reads it.
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &axum::http::Request<_>| {
+                    let request_id = request
+                        .headers()
+                        .get(REQUEST_ID_HEADER)
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("?");
+                    tracing::info_span!(
+                        "http.request",
+                        method = %request.method(),
+                        uri = %request.uri(),
+                        request_id = %request_id,
+                        // Filled in by `AuthUser` after JWT validation
+                        // succeeds; stays empty for anonymous routes.
+                        user_id = tracing::field::Empty,
+                    )
+                })
+                .on_response(DefaultOnResponse::new().level(Level::INFO)),
+        )
+        .layer(PropagateRequestIdLayer::new(
+            header::HeaderName::from_static(REQUEST_ID_HEADER),
+        ))
+        .layer(SetRequestIdLayer::new(
+            header::HeaderName::from_static(REQUEST_ID_HEADER),
+            MakeRequestUuid,
         ))
         .with_state(state)
 }

--- a/apps/server/tests/request_id_tracing.rs
+++ b/apps/server/tests/request_id_tracing.rs
@@ -1,0 +1,121 @@
+//! Verifies the request-id middleware stack wired in `routes::create_router`
+//! (#1173): `x-request-id` is either propagated from an inbound header or
+//! freshly minted as a UUID v4, and is always present on the response so a
+//! feedback report's stored value can be cross-referenced to server logs.
+//!
+//! These tests construct a minimal `Router` with the same layer chain as
+//! production but no DB or app state, so they run without a Postgres
+//! fixture and stay fast.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use axum::routing::get;
+use tower::ServiceExt; // for `oneshot`
+use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
+use tower_http::trace::{DefaultOnResponse, TraceLayer};
+use tracing::Level;
+
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+fn test_router() -> Router {
+    Router::new()
+        .route("/ping", get(|| async { "pong" }))
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &axum::http::Request<_>| {
+                    let request_id = request
+                        .headers()
+                        .get(REQUEST_ID_HEADER)
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("?");
+                    tracing::info_span!(
+                        "http.request",
+                        method = %request.method(),
+                        uri = %request.uri(),
+                        request_id = %request_id,
+                        user_id = tracing::field::Empty,
+                    )
+                })
+                .on_response(DefaultOnResponse::new().level(Level::INFO)),
+        )
+        .layer(PropagateRequestIdLayer::new(
+            header::HeaderName::from_static(REQUEST_ID_HEADER),
+        ))
+        .layer(SetRequestIdLayer::new(
+            header::HeaderName::from_static(REQUEST_ID_HEADER),
+            MakeRequestUuid,
+        ))
+}
+
+/// When the caller does NOT send `x-request-id`, the middleware mints a
+/// fresh UUID and the response carries it back.
+#[tokio::test]
+async fn mints_fresh_request_id_when_header_absent() {
+    let app = test_router();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/ping")
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let header_value = resp
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .expect("x-request-id header missing on response")
+        .to_str()
+        .expect("x-request-id header not valid UTF-8");
+
+    // MakeRequestUuid emits a UUID v4 (36 chars, four dashes). We don't pin
+    // the exact format because tower-http is free to evolve the generator;
+    // we only need to assert the slot is populated and non-empty.
+    assert!(
+        !header_value.is_empty(),
+        "x-request-id should be a non-empty generated id, got {header_value:?}"
+    );
+    assert!(
+        header_value.len() >= 8,
+        "x-request-id looks too short to be a UUID: {header_value:?}"
+    );
+}
+
+/// When the caller DOES send `x-request-id`, the middleware preserves the
+/// caller's value end-to-end (no overwrite). This is what lets a feedback
+/// report's stashed id be looked up in server logs after the fact.
+#[tokio::test]
+async fn echoes_caller_supplied_request_id() {
+    let app = test_router();
+
+    let supplied = "my-trace-1";
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/ping")
+                .header(REQUEST_ID_HEADER, supplied)
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let header_value = resp
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .expect("x-request-id header missing on response")
+        .to_str()
+        .expect("x-request-id header not valid UTF-8");
+
+    assert_eq!(
+        header_value, supplied,
+        "request-id should round-trip the caller's value, not be replaced"
+    );
+}


### PR DESCRIPTION
## Summary

PR #1188 just landed auto-attached \`app_version\` / \`platform\` / \`logs\` on every feedback submission. This PR closes the loop on the server side: every HTTP request now gets a stable \`x-request-id\` that's surfaced in both the response header AND the server's \`tracing\` spans, alongside the authenticated user_id. The operator can grep for \`request_id=…\` (echoed back to a tester) or \`user_id=…\` (from any feedback row) to find the matching server-side log line.

Fixes #1173.

## What's new

- **Every response carries \`x-request-id\`.** If the client sent one, it's echoed verbatim. Otherwise the server stamps a fresh UUID and returns it.
- **Every \`tracing\` span carries \`request_id\` and \`user_id\` fields.** Authenticated requests get \`user_id\` filled in by the \`AuthUser\` extractor immediately after JWT validation; anonymous requests leave it empty.
- **Smoke-verified** locally:
  - \`curl -H 'x-request-id: smoke-trace-abc' /healthz\` → response echoes \`smoke-trace-abc\`.
  - \`curl /healthz\` (no header) → response carries a freshly-minted UUID v4.
  - Server log: \`INFO http.request{method=GET uri=/healthz request_id=smoke-trace-abc}: ... status=200\`.

## Behind the scenes

- New tower-http layer stack in \`apps/server/src/routes/mod.rs\` (outermost first): \`SetRequestIdLayer(MakeRequestUuid)\` → \`PropagateRequestIdLayer\` → \`TraceLayer\` with a custom \`make_span_with\` that captures method, uri, request_id, plus an Empty \`user_id\` slot.
- \`AuthUser\` extractor (\`apps/server/src/auth/middleware.rs\`) now calls \`Span::current().record("user_id", …)\` after JWT validation, lighting up the user_id field on the in-flight span.
- \`tower-http\` Cargo features extended to include \`request-id\` alongside the existing \`cors\`, \`set-header\`, \`trace\`.
- New \`REQUEST_ID_HEADER\` \`pub const\` so future call sites can reference the canonical name (avoids the S1192 duplicate-string trap).
- New integration test \`apps/server/tests/request_id_tracing.rs\` asserts: no inbound header → response carries a fresh UUID; inbound header echoed verbatim.

## Test results

- \`cargo fmt --all -- --check\` — clean.
- \`cargo clippy -p echo-server --all-targets -- -D warnings\` — clean.
- \`cargo test -p echo-server\` — **677 passed** (includes 2 new tests in request_id_tracing.rs).

## Validation plan

Pairs naturally with the diagnostic-context PR #1188 just merged. To validate the full loop:

- [ ] Open the in-app feedback dialog (now simplified, post-#1159).
- [ ] Send a report with debug logs toggled ON.
- [ ] In \`GET /api/admin/feedback\`, find the row — note the \`user_id\` field.
- [ ] In the server log buffer, \`grep user_id=<uuid>\` from around the submission timestamp — every request that user made in that window is now correlatable.