### PR TITLE
Non-dismissible hard-refresh banner for stale web builds (#1175)

### DIFF
--- a/apps/client/lib/src/widgets/conversation_panel/parts/banners.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/banners.dart
@@ -201,10 +201,18 @@ mixin _ConversationPanelBannersMixin on ConsumerState<ConversationPanel> {
   ({String label, Widget? action, bool showDismiss, Widget? progress})
   _resolveAvailableUpdateState(BuildContext context, UpdateState update) {
     if (kIsWeb) {
+      // Web bundle is stale — the browser is serving cached JS until the
+      // user hard-refreshes (we ship --pwa-strategy=none so there's no
+      // service-worker auto-refresh either). Make the banner
+      // non-dismissible with explicit hard-refresh instructions and the
+      // current → latest version delta, so beta testers don't keep
+      // hitting a half-finished build without noticing (#1175).
       return (
-        label: 'New version available',
+        label:
+            'New version v${update.latestVersion} available — '
+            'hard-refresh to update (Ctrl+Shift+R / Cmd+Shift+R)',
         action: null,
-        showDismiss: true,
+        showDismiss: false,
         progress: null,
       );
     }


### PR DESCRIPTION
## Summary

On the web client, an out-of-date bundle persists in the user's browser tab forever — auto-update is gated to Linux/Windows, and we ship \`--pwa-strategy=none\` so the service worker doesn't auto-refresh either. The existing sidebar banner just said 'New version available' with a dismiss X, leaving beta testers stuck on stale builds without realising it.

Fixes #1175.

## Fixed

- **Non-dismissible 'hard-refresh' banner on web** with the explicit version delta and the keyboard shortcut (Ctrl+Shift+R / Cmd+Shift+R). The dismiss X is gone for this state — testers can't accidentally swat the only signal they have that the bundle is stale.

## Behind the scenes

- Touched only the \`kIsWeb\` branch of \`_resolveAvailableUpdateState\` in \`apps/client/lib/src/widgets/conversation_panel/parts/banners.dart\`. Native / mobile flows are unchanged.
- Banner copy includes the latest version so the tester can quote it in a bug report if they hit the page on the wrong build.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2293 passed**, 9 skipped (pre-existing), 0 failed.