### PR TITLE
Add 'Trouble signing in?' support link on auth screens (#1174)

### DIFF
--- a/apps/client/lib/src/screens/login_screen.dart
+++ b/apps/client/lib/src/screens/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
@@ -195,6 +196,23 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                               foregroundColor: context.textSecondary,
                             ),
                             child: const Text('Create an account'),
+                          ),
+                          // Last-resort escape hatch for testers stuck at
+                          // auth (#1174). The in-app feedback dialog needs
+                          // login, so a stuck user can't reach it; a
+                          // mailto: works without a session.
+                          TextButton(
+                            onPressed: () => launchUrl(
+                              Uri.parse(
+                                'mailto:admin@echo-messenger.us'
+                                '?subject=Echo%20support%3A%20trouble%20signing%20in',
+                              ),
+                            ),
+                            style: TextButton.styleFrom(
+                              foregroundColor: context.textMuted,
+                              textStyle: const TextStyle(fontSize: 12),
+                            ),
+                            child: const Text('Trouble signing in?'),
                           ),
                         ],
                       ),

--- a/apps/client/lib/src/screens/register_screen.dart
+++ b/apps/client/lib/src/screens/register_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
@@ -211,6 +212,22 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                             overflow: TextOverflow.visible,
                             softWrap: true,
                           ),
+                        ),
+                        // Escape hatch for testers who can't complete
+                        // signup (#1174). The in-app feedback dialog
+                        // requires a session, so we fall back to mailto.
+                        TextButton(
+                          onPressed: () => launchUrl(
+                            Uri.parse(
+                              'mailto:admin@echo-messenger.us'
+                              '?subject=Echo%20support%3A%20trouble%20signing%20up',
+                            ),
+                          ),
+                          style: TextButton.styleFrom(
+                            foregroundColor: context.textMuted,
+                            textStyle: const TextStyle(fontSize: 12),
+                          ),
+                          child: const Text('Trouble signing up?'),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Summary

Beta testers stuck at the login/signup screen had no in-app way to reach the maintainer — the feedback dialog requires login, the splash exposes no contact. This PR adds a discreet \`Trouble signing in?\` (login) / \`Trouble signing up?\` (register) link at the bottom of both auth screens that opens a pre-filled \`mailto:admin@echo-messenger.us\` so users without a working session can still send for help.

Fixes #1174.

## Fixed

- **In-app escape hatch on the auth screens.** Falls back to email (the same support address already exposed on \`forgot_password_screen.dart:182\`), with a context-specific subject line so the maintainer can triage signup vs sign-in.

## Behind the scenes

- Both screens already have the same TextButton style at the bottom of the form — added the link directly below in matching style at \`textMuted\` color so it doesn't visually compete with the primary affordances.
- Uses \`launchUrl\` from \`package:url_launcher\` (already used by Settings → About → Privacy and other external-link surfaces). No new dependencies.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2293 passed**, 9 skipped (pre-existing), 0 failed.