### PR TITLE
Default onboarding display name to username so Skip works on page 1 (#1177)

### DIFF
--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -69,6 +69,14 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
   void initState() {
     super.initState();
     _selectedTimezone = DateTime.now().timeZoneName;
+    // Pre-fill display name with the username so the Welcome page can be
+    // skipped without forcing the user to type anything. They can still
+    // edit it before continuing, but Skip no longer hard-blocks on an
+    // empty field — #1177.
+    final username = ref.read(authProvider).username;
+    if (username != null && username.isNotEmpty) {
+      _displayNameController.text = username;
+    }
     _loadNotificationPrefs();
   }
 


### PR DESCRIPTION
## Summary

The onboarding wizard's Welcome page hard-blocked Skip with a toast (\`'Pick a display name before continuing.'\`) when the display-name field was empty — even though Skip is meant to be a first-class option throughout the rest of the wizard. New users either had to type something they'd likely re-type later, or got stuck on page 1.

Fixes #1177.

## Fixed

- **Welcome page pre-fills display name with the registered username.** Skip works immediately. User can still edit it before continuing, but the empty-field hard-block is gone.

## Behind the scenes

- One-line change in \`onboarding_wizard.dart\`'s \`initState\`: \`ref.read(authProvider).username\` → \`_displayNameController.text\`.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2293 passed**, 9 skipped (pre-existing), 0 failed.