### PR TITLE
Friendlier signup error when username is taken (#1176)

### DIFF
--- a/apps/client/lib/src/providers/auth/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.dart
@@ -202,7 +202,16 @@ class AuthNotifier extends _$AuthNotifier
         String errorMsg = 'Registration failed';
         try {
           final data = jsonDecode(response.body) as Map<String, dynamic>;
-          errorMsg = data['error'] as String? ?? errorMsg;
+          final code = data['code'] as String?;
+          final serverMsg = data['error'] as String?;
+          // The most common signup-failure case deserves a friendlier
+          // toast than the server's literal 'Username already taken' —
+          // testers expect something they could plausibly act on (#1176).
+          if (response.statusCode == 409 && code == 'username-taken') {
+            errorMsg = 'That username is taken — try another.';
+          } else if (serverMsg != null && serverMsg.isNotEmpty) {
+            errorMsg = serverMsg;
+          }
         } catch (e) {
           debugPrint('[Auth] register response parse failed: $e');
           errorMsg = friendlyError(

--- a/apps/client/test/providers/auth/auth_provider_test.dart
+++ b/apps/client/test/providers/auth/auth_provider_test.dart
@@ -299,7 +299,43 @@ void main() {
       expect(st.userId, 'new-uid');
     });
 
-    test('register() returns 409 stays logged out with error', () async {
+    test(
+      'register() 409 username-taken yields friendly message (#1176)',
+      () async {
+        // Server's actual envelope on duplicate-username — see
+        // apps/server/src/error.rs ErrorCode::UsernameTaken.
+        when(
+          () => mockClient.post(
+            any(that: predicate<Uri>((u) => u.path == '/api/auth/register')),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            encoding: any(named: 'encoding'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'error': 'Username already taken',
+              'code': 'username-taken',
+            }),
+            409,
+          ),
+        );
+
+        final notifier = container.read(authProvider.notifier);
+        await http.runWithClient(
+          () => notifier.register('taken', 'pass'),
+          () => mockClient,
+        );
+
+        final st = container.read(authProvider);
+        expect(st.isLoggedIn, isFalse);
+        expect(st.error, 'That username is taken — try another.');
+      },
+    );
+
+    test('register() 4xx without code falls back to server message', () async {
+      // Server-supplied error.  Code field absent so the username-taken
+      // friendly path doesn't trigger.
       when(
         () => mockClient.post(
           any(that: predicate<Uri>((u) => u.path == '/api/auth/register')),
@@ -309,19 +345,16 @@ void main() {
         ),
       ).thenAnswer(
         (_) async =>
-            http.Response(jsonEncode({'error': 'Username already taken'}), 409),
+            http.Response(jsonEncode({'error': 'Password too weak'}), 400),
       );
 
       final notifier = container.read(authProvider.notifier);
       await http.runWithClient(
-        () => notifier.register('taken', 'pass'),
+        () => notifier.register('user', 'pw'),
         () => mockClient,
       );
 
-      final st = container.read(authProvider);
-      expect(st.isLoggedIn, isFalse);
-      expect(st.error, isNotNull);
-      expect(st.error, contains('already taken'));
+      expect(container.read(authProvider).error, 'Password too weak');
     });
 
     test('register() network error sets error', () async {


### PR DESCRIPTION
## Summary

Beta-readiness audit followup. The signup flow already surfaced the server's literal error string — but on the 409 \`username-taken\` case that means the tester saw 'Username already taken', which reads more like a system error than a friendly nudge to try a different handle.

Fixes #1176.

## Fixed

- **Friendly toast on duplicate username.** When the server returns 409 with \`code: 'username-taken'\`, the client shows: **'That username is taken — try another.'** All other 4xx still fall back to the server-supplied \`error\` field verbatim.

## Behind the scenes

- Single-branch addition in \`auth_provider.dart\`'s \`register\` error parser. Falls through to the existing \`data['error']\` path for any 4xx without the recognized code, so older server builds keep working.
- Updated the existing \`register() 409\` test to match the new wording + the actual server envelope shape (the server returns both \`error\` and \`code\` fields per \`apps/server/src/error.rs\`).
- Added a new \`register() 4xx without code\` test that mocks a 400 with only the \`error\` field and asserts the fallback path still surfaces the server message verbatim.

## Test results

- \`dart format --set-exit-if-changed\` — clean.
- \`flutter analyze --fatal-infos\` — clean.
- \`flutter test\` (full client suite) — **2294 passed**, 9 skipped (pre-existing), 0 failed (+1 new test).