### PR TITLE
Audit batch: harden auth, crypto, and quality gaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -4,14 +4,24 @@ Captured from the 2026-05-20 multi-agent audit of the 26 PRs (#980–#1005) ship
 
 Audit baseline commit range: `628e623ebd6108b230f313ccebdcb922e6f09e3d^..HEAD` (40 files, +1838/-756 lines). 6 reviewers ran in parallel (code-quality, security, performance, frontend, backend, test-coverage). ~66 findings total; 3 critical, 11 high, 28 medium, 24 low. Convergent risk across all reviewers: the rotation-storm on `member_added` and the lack of single-flight in self-heal — partially addressed in the follow-up PR with a per-conversation in-flight set, but the parallel identity-key fetch optimization remains.
 
-Last updated: 2026-05-20.
+Last updated: 2026-05-25 (after high-tier batch shipped).
 
 ## Summary
+
+**2026-05-20 batch (TD-1..TD-23):**
 - Critical / High remaining: 0  (TD-1..TD-4 shipped in PR #1007)
 - Medium remaining: 1  (TD-14 — conversation Map index; deferred)
 - Low remaining: 2  (TD-20 partial schema migration, TD-23 harder test surfaces)
 
 The medium/low cleanup batch landed across server + client + tests (TD-5..TD-13, TD-15..TD-19, TD-21, TD-22, partial TD-23).
+
+**2026-05-25 fresh-eyes audit (TD-24..TD-85):**
+- Critical: 0 remaining (TD-24..TD-27 shipped — JWT device revocation, range-read DoS, reset_password tx, reset-token log leak).
+- High remaining: 1 partial (TD-28 rotation-path rollout) — TD-29..TD-42 all shipped in the same session.
+- Medium remaining: 25  (TD-43..TD-67; routes, perf, client componentization debt)
+- Low remaining: 18  (TD-68..TD-85; many small one-liners batched for a single cleanup PR)
+
+Audit baseline: main @ de37839b. Five parallel reviewers (security, backend, frontend, performance, test-quality) verified actual code — CLAUDE.md/docs deliberately ignored. Full per-finding evidence (file:line + code quote) lives in `.claude/state/audit-2026-05-25.md`.
 
 ---
 
@@ -192,3 +202,311 @@ Each test sketched in the test-coverage reviewer's findings. **Effort:** medium 
 - [x] TD-21 abort rotation when self key null — cleanup batch
 - [x] TD-22 semantic direction enum (`_MentionMove`) — cleanup batch
 - [~] TD-23 test coverage — 2 of 5 surfaces covered (MentionAutocomplete.candidateValues, OwnDecryptFailedBubble); remaining (_maybeRotateOnJoin, _moveMentionSelection wrap, conversation_item mask) need Riverpod test harness scaffolding
+
+---
+
+# 2026-05-25 fresh-eyes audit
+
+Multi-agent deep review of the actual codebase, docs deliberately ignored. Convergent findings (multiple reviewers flagged independently) marked ★. The four critical items shipped in this commit; everything else is open.
+
+## Critical — RESOLVED in this commit
+
+### TD-24 ★ — Password-reset tokens written verbatim into `tracing::info!` ✅ shipped
+**File:** `apps/server/src/routes/auth.rs:485-498`
+**Source:** security, backend (both flagged independently)
+**What:** `tracing::info!(... token = %token, ...)` made any log aggregator a 15-minute account-takeover oracle outside the auth boundary. Doc-comment acknowledged the risk but shipped anyway.
+**Shipped:** Token field dropped from the log line. Operators read the reset row from `password_reset_tokens` directly and deliver out-of-band. The full SMTP/admin-mediated relay redesign is still a follow-up.
+
+### TD-25 — `reset_password` now transactional ✅ shipped
+**File:** `apps/server/src/routes/auth.rs:516-558`
+**Source:** backend
+**What:** Three separate writes (`update_password`, `consume_token`, `revoke_all_user_tokens`) with no tx — a failure between writes left the token unused and replayable.
+**Shipped:** All three writes share one `state.pool.begin()` transaction. `db::password_reset::*`, `db::users::update_password`, and `db::tokens::revoke_all_user_tokens` were widened to accept `impl sqlx::PgExecutor<'_>` so they bind to either `&PgPool` or `&mut *tx`.
+
+### TD-26 — Byte-range download streams instead of allocating ✅ shipped
+**File:** `apps/server/src/routes/media.rs:560-592`
+**Source:** backend
+**What:** `serve_byte_range` did `vec![0u8; slice_len]` + `read_exact` against a `slice_len` capped only at `MAX_FILE_SIZE = 100 MB`. A single request could pin 100 MB; N concurrent requests trivially OOM-killed the server.
+**Shipped:** Replaced with `ReaderStream::new(file.take(slice_len))` after `seek`. Memory cost is now O(buffer-size), independent of `Range` header.
+
+### TD-27 — JWT auth now honors device-revocation events ✅ shipped
+**File:** `apps/server/src/auth/middleware.rs:18-58`, `apps/server/src/auth/invalidation.rs` (new)
+**Source:** backend
+**What:** `AuthUser` validated only `iss`/`aud`/`exp`. A stolen or revoked-device JWT continued to authorize every REST endpoint for the full 15-minute TTL even after `revoke_device` / `revoke_other_devices` / `change_password` / `reset_password` / `logout`.
+**Shipped:** New `TokenInvalidator` (in-memory DashMap<UserId, min-iat-floor>) wired into `AppState`. `AuthUser` rejects JWTs with `iat < floor` and returns `TokenRevoked`. The six revocation paths (revoke_device, revoke_other_devices, reset_device, change_password, reset_password, logout) call `state.token_invalidator.invalidate(user_id)`. 4 unit tests pin behavior; 27 keys + 20 auth + 1 race integration tests still pass.
+
+**Trade-off:** in-memory only. A server restart re-allows tokens up to their 15-minute TTL — same window we already accept today, and avoids a per-request DB lookup. Adding `device_id` to JWT claims and per-device revocation lookups is left as a follow-up if we ever ship multi-server replicas.
+
+---
+
+## High — outstanding
+
+### TD-28 ★ — Group-key envelopes are unsigned; rotator identity not bound — primitives landed (2026-05-25), rollout pending
+**File:** `apps/client/lib/src/services/crypto_service.dart` (encryptForUserSigned / decryptFromUserVerified), server accept in `apps/server/src/routes/group_keys.rs:335`
+**Source:** security
+**What:** ECIES wrap with no Ed25519 signature. A compromised server or racing admin can publish envelopes wrapping a key the operator controls; receivers unwrap, cache, and start encrypting with it. GRP2 added per-message signatures but the key-distribution layer remains MAC-only. The design proposal already flags this in `docs/group-e2e-design/06-open-questions.md`.
+**Shipped (2026-05-25):** `encryptForUserSigned` + `decryptFromUserVerified` primitives append/verify a 64-byte Ed25519 signature over the existing ECIES wrap. Three unit tests cover happy-path round-trip, signature-mismatch rejection, and tamper detection. Wire prefix is unchanged (legacy unsigned envelopes still parse via `decryptFromUser`).
+**Still open (rollout):** plumb the primitives into the rotation path. Needs `group_key_envelopes.created_by_user_id` (or derive via `group_key_rotations.triggered_by_user_id`) so the recipient knows which rotator's signing key to verify against, plus client-side migration window that accepts both signed and unsigned envelopes during the cutover. **Effort:** medium (schema migration + server route changes + client cutover gate).
+
+### TD-29 — TOFU silently overwrites changed peer identity key
+**File:** `apps/client/lib/src/services/crypto/peer_identity_extension.dart:59-87`
+**Source:** security
+**What:** Sets a "changed" flag but writes the new key to the cache anyway. The DM session-establishment path checks the flag (`IdentityKeyChangedException`); the group-rotation path, safety-number screen, and other `fetchPeerIdentityKey` consumers read the freshly-written key without checking. A user who hasn't opened the DM with the swapped peer silently wraps a group key for the attacker.
+**Fix:** Keep the old key canonical until explicit `acceptIdentityKeyChange`; expose pending key only via opt-in getter for code paths that legitimately need it (key reset flow).
+**Effort:** small.
+
+### TD-30 ★ — `recipient_device_contents` doesn't require peer inclusion
+**File:** `apps/server/src/ws/message_service/fanout.rs:162-200` + `validate.rs:249-291`
+**Source:** security
+**What:** For encrypted DMs the validator requires a non-empty per-device map but doesn't require the actual conversation peer to appear. `deliver_to_member` silently falls back to `legacy_msg` when the recipient is missing — letting a sender deliver attacker-shaped bytes to the peer while routing the real ciphertext to their own devices.
+**Fix:** For encrypted-DM kinds, require `recipient_device_contents` to include every non-sender member. Reject the send otherwise.
+**Effort:** small.
+
+### TD-31 — `link_preview` SSRF block-list incomplete
+**File:** `apps/server/src/routes/link_preview.rs:79-115` (and rate_limit.rs:310-322 has a similar gap)
+**Source:** security, backend
+**What:** Missing CGNAT (100.64.0.0/10), 192.0.0.0/24, 198.18.0.0/15 (benchmark), TEST-NETs, 224.0.0.0/4, broadcast. No port allowlist. Also uses blocking `to_socket_addrs` in an async handler.
+**Fix:** Use the `ipnet` crate (already a dep) with a comprehensive CIDR deny list. Port allowlist `{80, 443}`. Switch DNS to `tokio::net::lookup_host`.
+**Effort:** 1 h.
+
+### TD-32 — IPv4-mapped IPv6 not normalized for rate-limit XFF
+**File:** `apps/server/src/middleware/rate_limit.rs:310-322`
+**Source:** security
+**What:** `is_private` IPv6 branch ignores `to_ipv4_mapped()`. A trusted proxy that passes `::ffff:10.0.0.1` lets an attacker pick the bucket key.
+**Fix:** Normalize via `to_ipv4_mapped()` and apply the v4 private-range check on the mapped address.
+**Effort:** small.
+
+### TD-33 — Group member mutation lacks tx + duplicate member-list fetch
+**File:** `apps/server/src/routes/groups/members.rs:147-264, 267-316, 319-367` (and `groups/invite.rs:238, 270`)
+**Source:** backend, performance
+**What:** `add_member` / `remove_member` / `ban_member` run 6-8 sequential queries with no transaction and no `FOR UPDATE` — two concurrent admins acting on the same target can both pass the guard reads and both mutate. `get_conversation_member_ids` is called twice in the success path.
+**Fix:** Wrap in `pool.begin()` with `SELECT ... FOR UPDATE` on the caller's `conversation_members` row. Fetch member ids once, reuse for both broadcasts.
+**Effort:** 2-3 h.
+
+### TD-34 — HTTP status code drift (401 vs 403 vs 404)
+**Files:** `routes/groups/members.rs:175,281,332,382` (permission → 401); `error.rs:162-181` (`NotMember` → 401); `routes/messages.rs:414,465,482` (not-found → 400); `routes/users.rs:81,103,146,560`; `routes/keys.rs:330,360`.
+**Source:** backend
+**What:** Permission failures return 401, triggering client global re-auth instead of "forbidden". "Not found" cases return 400, defeating client retry semantics.
+**Fix:** Re-map `NotMember` → 403; convert 400-not-found cases to 404; convert permission 401s to 403. Update fixture tests in the same PR.
+**Effort:** half day.
+
+### TD-35 — WS voice/canvas signals accept unbounded `serde_json::Value`
+**File:** `apps/server/src/ws/protocol.rs:49-55, 65-70`
+**Source:** backend
+**What:** Inner JSON only bounded by the 64 KB frame cap; voice signals fire per ICE candidate, canvas events per stroke point. Bandwidth amplification × N members.
+**Fix:** Typed enums (`IceCandidate { sdp: String }`, etc.) with bounded field lengths.
+**Effort:** 1 day.
+
+### TD-36 — WS rate-limit message counter not decremented on Ping/Binary
+**File:** `apps/server/src/ws/rate_limit.rs:213-234`
+**Source:** backend
+**What:** `handle_other_frame` only updates the byte budget. Zero-byte Pings escape the message-count cap — an attacker can flood 1000 Pings/sec with no slowdown.
+**Fix:** Decrement `bucket.tokens -= 1.0` for all frame types.
+**Effort:** 15 min — highest impact-per-effort remaining.
+
+### TD-37 — Cleanup tasks + push fanout have no shutdown coordination
+**File:** `apps/server/src/main.rs:43-110, 125-141`
+**Source:** backend
+**What:** Fire-and-forget `tokio::spawn`s for periodic cleanups and push fanout. `with_graceful_shutdown` only stops the HTTP server, not the background tasks. SIGTERM during a `cleanup_expired_messages` mid-DELETE is torn at an arbitrary instruction.
+**Fix:** `tokio_util::sync::CancellationToken` for periodic loops (`select!` on `token.cancelled()`); `tokio::task::JoinSet` for one-shot spawned work, awaited on shutdown.
+**Effort:** 2-3 h.
+
+### TD-38 — `reset_device` not transactional
+**File:** `apps/server/src/routes/keys.rs:608-664`
+**Source:** backend
+**What:** `clear_device_fingerprint` then `revoke_device` — two separate DB round-trips. Crash in between leaves the device with cleared fingerprint but extant identity_keys row; next bundle upload may rebind to a different identity silently.
+**Fix:** Wrap in a single tx.
+**Effort:** 30 min.
+
+### TD-39 — No HTTP caching headers on avatars / media
+**File:** `apps/server/src/routes/users.rs:730-775`, `routes/media.rs::download`
+**Source:** backend, performance
+**What:** Every chat-list render = 50 avatar DB+disk reads. No `Cache-Control` / `ETag` → CDN can't cache.
+**Fix:** `Cache-Control: public, max-age=300, stale-while-revalidate=86400`; weak `ETag` from `(file_uuid, mtime)`; honor `If-None-Match` → 304.
+**Effort:** 1 h.
+
+### TD-40 — OTP atomicity has no concurrency test
+**File:** `apps/server/tests/api_keys.rs`
+**Source:** test-quality
+**What:** 27 tests, zero use `tokio::spawn`/`join!`. The invite-link race got the same-shape race-test treatment; OTP did not. `get_bundle` does select+delete of a one-time prekey — two concurrent X3DH initiations could race.
+**Fix:** Spawn N+1 concurrent `GET .../bundle?device_id=0`; assert returned `key_id`s are unique and final OTP count is 0; assert the (N+1)th returns `one_time_prekey: null` without panicking.
+**Effort:** ~60 LoC, mirror `concurrent_accept_respects_max_uses_under_lock`.
+
+### TD-41 — WS rotation storm has no integration test
+**File:** `apps/server/src/ws/rotation.rs` + `apps/server/tests/ws_messaging.rs`
+**Source:** test-quality
+**What:** 8 pure-leader-election unit tests, no integration test opens N concurrent WebSockets to the same group and triggers a simultaneous rotation. That's the entire purpose of `rotation.rs`.
+**Fix:** 5-WS-session test (3 members × 2 devices). Trigger two simultaneous rotations. Assert exactly one rotation envelope reaches each receiver; loser is dropped server-side; `group_keys` table has exactly one new version.
+**Effort:** ~150 LoC.
+
+### TD-42 — Refresh-token theft cascade only tested at depth 1
+**File:** `apps/server/tests/api_auth.rs:106`
+**Source:** test-quality
+**What:** Replay test chains depth 1 only; `revoke_token_family` chain-revocation is never end-to-end verified for deeper chains.
+**Fix:** Chain T0→T1→T2→T3, replay T0, assert T3 also 401 via `/refresh`.
+**Effort:** ~40 LoC.
+
+---
+
+## Medium — outstanding
+
+Compact list — full evidence (file:line + code quote) in `.claude/state/audit-2026-05-25.md`. All are open as of the 2026-05-25 audit.
+
+### TD-43 — Refresh cookie `SameSite=None` with permissive default CORS
+`apps/server/src/routes/auth.rs:39-50` + `routes/mod.rs:115-141`. Default `CORS_ORIGINS` includes `http://localhost:8081`; any malicious page there can chain a credentialed `/api/auth/refresh` to lock out the user. **Fix:** Origin-header check on `/refresh` and `/logout`; drop localhost from defaults.
+
+### TD-44 — Admin first-user bootstrap is a permanent race
+`apps/server/src/db/users.rs:51-65`. The first registration becomes admin via `(SELECT NOT EXISTS ...)`. **Fix:** Gate behind `ECHO_BOOTSTRAP_ADMIN_USERNAME`.
+
+### TD-45 — No admin demotion endpoint + no audit log
+`apps/server/src/routes/admin.rs:388-412`. Once promoted, only direct SQL can demote; no record of who promoted whom. Combined with TD-44, a single compromise is permanent. **Fix:** `DELETE /api/admin/promote/{user_id}` + `admin_audit` table.
+
+### TD-46 — Media ticket bound to user only, not media-id
+`apps/server/src/routes/media.rs:498-526` + `847-863`. 5-min reusable read for any media the user can access. **Fix:** Bind tickets to `(user_id, media_id)`; or accept a list of media IDs at issue time.
+
+### TD-47 — `KeyReset` / `CallStarted` broadcasts use cached username from upgrade
+`apps/server/src/ws/events/broadcast.rs:14-39`. Defense-in-depth gap; rename mid-session never surfaces. **Fix:** Re-fetch username per broadcast (or refresh on rename event).
+
+### TD-48 — WS rate limiter is per-session, not per-user
+`apps/server/src/ws/rate_limit.rs:240-264`. Consecutive-violation counter resets on reconnect. **Fix:** Process-wide DashMap keyed on user_id with slow decay; carry violations across reconnects.
+
+### TD-49 — Argon2id uses library defaults
+`apps/server/src/auth/password.rs:11`. `Argon2::default()` not pinned to explicit `m_cost`/`t_cost`/`p_cost`. The DUMMY_HASH at `auth.rs:210` is hardcoded against today's defaults — a dep bump that softens defaults breaks the timing-equalization too. **Fix:** Construct with explicit `Params::new(...)`.
+
+### TD-50 — Refresh-token cookie XSS exfiltration via in-origin fetch
+`apps/server/src/routes/auth.rs:42-50`. `HttpOnly` protects `document.cookie` reads, but any XSS on `web.echo-messenger.us` can fire `fetch('/api/auth/refresh', {credentials: 'include'})` and exfiltrate the rotated JSON. Theft detection only fires after one rotation. **Fix:** Independent — lock down web-build CSP via nginx; long-term consider IP/UA binding (mobile roaming caveat).
+
+### TD-51 — `update_my_privacy` is non-transactional read-modify-write
+`apps/server/src/routes/users.rs:95-133`. Two concurrent PATCHes from different devices lose fields. **Fix:** Single `UPDATE ... SET col = COALESCE($new, col)` per column; eliminate the pre-read.
+
+### TD-52 — `cleanup_expired_messages` unpaginated + per-conversation N+1 broadcast
+`apps/server/src/db/messages.rs:490-499` + `main.rs:297-315`. A backlog of 10k expirations triggers one giant DELETE and ~N member-list fetches. **Fix:** Cap DELETE with `LIMIT 500` loop; group broadcasts by conversation_id.
+
+### TD-53 — `get_bundle` N+1 fallback for users without device_0 row
+`apps/server/src/routes/keys.rs:316-330`. Up to 10 round-trips per fetch on multi-device users. **Fix:** Single query `ORDER BY device_id LIMIT 1`.
+
+### TD-54 — `get_all_prekey_bundles` does one UPDATE per device
+`apps/server/src/db/keys.rs:387-419`. Up to N writes per call (N = device count). **Fix:** Single `UPDATE ... WHERE id IN (...) RETURNING device_id, key_id, public_key` with `DISTINCT ON (device_id)` + `FOR UPDATE SKIP LOCKED`.
+
+### TD-55 — `messages::get_messages` joins full-table `GROUP BY reply_to_id`
+`apps/server/src/db/messages.rs:259-264` (also `search_messages:642`, `get_thread_replies:1018`). Aggregate set scales with all-messages in DB instead of the page. **Fix:** Scope aggregate via CTE to the same conversation/page batch, mirror `get_undelivered:392`.
+
+### TD-56 — DB pool has no `min_connections` + short `acquire_timeout`
+`apps/server/src/db/mod.rs:30-44`. Cold connections add 50-200 ms to bursts after idle; 5s acquire timeout converts pool exhaustion into 500s. **Fix:** `min_connections(5)`, `acquire_timeout(15s)`.
+
+### TD-57 — No cleanup task for `password_reset_tokens`
+`apps/server/src/routes/auth.rs:516-561` — tokens accumulate forever; combined with TD-25 (now fixed), abuse can grow the table. **Fix:** Add `spawn_periodic("password_reset_tokens", 600s, cleanup_expired_password_reset_tokens)`.
+
+### TD-58 — Push notification fanout serial
+`apps/server/src/push.rs:185-200`. 50-recipient group blocks the fanout task for 1.5-6 s of sequential APNs HTTP. **Fix:** `JoinSet` with bounded concurrency (~16) to respect APNs HTTP/2 connection limits.
+
+### TD-59 — Sequential `session.encrypt` on UI thread
+`apps/client/lib/src/services/signal_session.dart:150-180` called from `crypto_service.dart:775,788`. `decrypt` is on `compute()`; `encrypt` is not. `encryptForAllDevices` loop = 150 sequential KDF+AES rounds for a 50-member multi-device group → visible jank. **Fix:** Mirror decrypt — single isolate call wrapping the loop.
+
+### TD-60 — `shared_media_gallery` watches whole `chatProvider`
+`apps/client/lib/src/widgets/shared_media_gallery.dart:26`. Rebuilds on every message in every conversation. **Fix:** `.select((s) => s.messagesForConversation(conversationId))` — one-line.
+
+### TD-61 — `build_per_device_json` deep-clones JSON `Value` per device
+`apps/server/src/ws/message_service/fanout.rs:129-135`. 50-member × 2-device group = 100 deep clones per send. **Fix:** Serialize once with a sentinel for `content`, then string-replace per device.
+
+### TD-62 — `feedback_dialog.dart` web-crash hazard
+`apps/client/lib/src/widgets/feedback_dialog.dart:52` reaches `Platform.operatingSystem` without `kIsWeb` guard. **Fix:** `if (kIsWeb) return 'web';` early-return. **Note:** relevant to the uncommitted feedback_dialog edit currently in the working tree.
+
+### TD-63 — Theme drift: `Colors.white` hardcoded across 16+ screens
+`apps/client/lib/src/screens/{username_invite_screen,discover_groups_screen,user_profile_screen,onboarding_wizard,safety_number_screen,settings/account_section}.dart`. Breaks on any light theme with a light accent. **Fix:** Replace with `context.onAccent` / `colorScheme.onPrimary`.
+
+### TD-64 — 8 inline `AlertDialog`s instead of `showEchoConfirmDialog`
+`screens/user_profile_screen.dart:693`, `settings/account_section.dart:359`, `voice_lounge_screen.dart:562`, `settings/voice_section.dart:161`, `settings/about_section.dart:239`, `group_info_screen/parts/channels_section.dart:15`, `settings/privacy_section.dart:81`, `settings/advanced_theme_section.dart:266`. Drift risk on button order / destructive styling. **Fix:** Migrate to the shared helper.
+
+### TD-65 — 6 hand-rolled `CircleAvatar`s instead of `UserAvatar`/`buildAvatar`
+`settings/account_section.dart:451`, `group_info_screen/parts/header_section.dart:151,159`, `screens/join/join_preview_scaffold.dart:286,366,373`, `settings/accessibility_section.dart:79`. The account-section variant uses a raw `NetworkImage` that bypasses `chatMediaCacheManager` entirely.
+
+### TD-66 — Migration test asserts only count > 0
+`apps/server/tests/migrations.rs:73-80`. A migration with wrong column type / missing NOT NULL passes. 48 migrations in tree vs CLAUDE.md's stale "14" claim. **Fix:** Snapshot `information_schema.{tables,columns}` for ~10 critical columns.
+
+### TD-67 — `core/rust-core` has only 53 tests total
+13 for ratchet, 4 for x3dh, 2 for grp2 — thin for a "reference" implementation. Add ratchet edge-case coverage (MAX_SKIP overflow, skipped-key TTL, header-key rotation under loss).
+
+---
+
+## Low — outstanding
+
+### TD-68 — Hex-encoded reset-token expiry duplicated as literal
+`apps/server/src/routes/auth.rs:479,530` — extract to `const RESET_TOKEN_TTL: chrono::Duration`.
+
+### TD-69 — HKDF zero-salt domain-separation risk
+`apps/client/lib/src/services/crypto_service.dart:1770-1775`. Acceptable with a fresh ephemeral key per wrap; document the constraint so future reuse of `encryptForUser` doesn't silently weaken it.
+
+### TD-70 — Chunked upload temp files survive server restarts
+`apps/server/src/routes/media_chunked.rs:142-153, 542-568`. Cleanup loop sweeps only when running. **Fix:** On startup, walk `./uploads/.tmp/` and unlink files not referenced by a pending `upload_sessions` row.
+
+### TD-71 — `tracing::error!("Database error: {:?}", err)` may echo column values
+`apps/server/src/error.rs:223`. `sqlx::Error::Database` Debug formatting includes constraint-violation column values for some Postgres errors. **Fix:** Log structured fields (`code`, `constraint`, `severity`) instead of `{:?}`.
+
+### TD-72 — `cleanup_expired_messages` 30 s cadence is aggressive
+`apps/server/src/main.rs:53`. Most-tick wasted I/O when no expirations are due. **Fix:** Drop cadence to 5 min, OR maintain in-memory min-heap of next-expiry timestamps.
+
+### TD-73 — `forgot_password` returns empty body on 200
+`apps/server/src/routes/auth.rs:503`. Cosmetic — `Json(json!({}))` keeps the response shape consistent.
+
+### TD-74 — `serde_json` parser-position leaks to client
+`apps/server/src/ws/events/dispatch.rs:43`. Drop the `{e}` interpolation in WS error replies.
+
+### TD-75 — Late `_voiceSignalController.broadcast()` subscribers miss events
+`apps/client/lib/src/providers/websocket_provider.dart:40-41`. Currently mitigated by lifecycle ordering but fragile.
+
+### TD-76 — `_expireTimer` rebuilds whole bubble subtree every second
+`apps/client/lib/src/widgets/message_item.dart:235-256`. **Fix:** Wrap only the expiry-chip in a `ValueListenableBuilder<DateTime>` driven by the timer.
+
+### TD-77 — `_messageKeys` map grows unbounded per ChatPanel lifetime
+`apps/client/lib/src/widgets/chat_panel.dart:131, 244`. Long-lived heavy-traffic chats accumulate `GlobalKey`-anchored Elements. **Fix:** Prune entries on `findChildIndexCallback` cycles, or evict in `_onScroll`.
+
+### TD-78 — `ListView.builder.itemBuilder` calls `ref.watch` inside builder
+`apps/client/lib/src/widgets/chat_panel/chat_message_list.dart:208-212`. Stale per-row reads + over-broad subscription. **Fix:** Hoist `ref.watch` to `build()`; use `.select` for narrow fields.
+
+### TD-79 — `chat_message_list` re-parses `DateTime` ~4N times per build
+`apps/client/lib/src/widgets/chat_panel/chat_message_list.dart:140-180`. **Fix:** Pre-compute `DateTime parsedTimestamp` once on `ChatMessage`.
+
+### TD-80 — `ConversationItem._applyMediaLabel` constructs RegExp in build
+`apps/client/lib/src/widgets/conversation_item.dart:231`. Lift to top-level `final`.
+
+### TD-81 — Channel chips built eagerly (no horizontal builder)
+`apps/client/lib/src/widgets/channel_bar.dart:441-462`. 50+ channels = all chips rebuilt every channel-bar tick. **Fix:** `ListView.builder` with `scrollDirection: Axis.horizontal`.
+
+### TD-82 — No fuzz / property tests anywhere
+`proptest` / `quickcheck` / `fuzz_target` grep returns zero. Wire-format parsers (`signal/protocol.rs`, group envelope decode, WS frame parser) are the exact surface that would benefit. **Fix:** `core/rust-core/tests/wire_fuzz.rs` proptest on random `Vec<u8>` of 0..2 KiB; assert success-or-typed-error, never panic / OOB read.
+
+### TD-83 — Playwright `test.fixme` without issue links
+`tests/e2e/group_messaging_ui.spec.ts:351, 389, 442, 500, 597`. Five disabled core group flows. **Fix:** File tracking issues or delete.
+
+### TD-84 — `_AuthNotifierListenable` never disposes its `ref.listen` subscription
+`apps/client/lib/src/router/app_router.dart:77-81, 177`. Fine for app lifetime today but leaks if `routerProvider` is ever invalidated. **Fix:** Capture the subscription and cancel in `dispose()`.
+
+### TD-85 — `splash_screen.dart` snackbar after navigation
+`apps/client/lib/src/screens/splash_screen.dart:243-254`. PostFrameCallback fires `ScaffoldMessenger` against a context that just navigated away. **Fix:** Move warning to home screen or a global toast surface.
+
+---
+
+## Progress tracking — 2026-05-25 batch
+
+- [x] TD-24 reset-token log leak — this commit
+- [x] TD-25 reset_password tx — this commit
+- [x] TD-26 byte-range streaming — this commit
+- [x] TD-27 JWT device revocation (min-iat invalidator) — this commit
+- [~] TD-28 ★ sign group-key envelopes — primitives + 3 unit tests shipped; rotation-path rollout pending schema/server work
+- [x] TD-29 TOFU silent overwrite — canonical/pending split, `pendingPeerIdentityKey` getter, `acceptIdentityKeyChange` promotes
+- [x] TD-30 ★ enforce recipient_device_contents includes peer — async DB lookup + `dm-peer-not-in-recipients` rejection code
+- [x] TD-31 link_preview SSRF deny-list + port allowlist + async DNS — 12-CIDR deny list, port {80,443}, `tokio::net::lookup_host`, 9 unit tests
+- [x] TD-32 IPv4-mapped IPv6 normalization — `to_ipv4_mapped()` unwrap before private-range check, 2 new unit tests
+- [x] TD-33 group-member mutations in tx — per-(group,target) `pg_advisory_xact_lock`, `add_member_in_tx`/`remove_member_in_tx`/`ban_member_in_tx`
+- [x] TD-34 HTTP status code remap (401→403, 400→404) — `NotMember` → 403; message/user/key not-found → 404; test fixtures updated
+- [x] TD-35 typed voice/canvas event payloads — bounded sizes (8 KB voice, 16 KB canvas) at dispatch boundary
+- [x] TD-36 WS rate-limit Ping/Binary counter (15-min fix) — `handle_other_frame` now decrements `bucket.tokens`
+- [x] TD-37 shutdown coordination for cleanup + push tasks — `CancellationToken` + `JoinHandle` collection, two-stage drain
+- [x] TD-38 reset_device tx — `revoke_device_in_tx` extracted, `clear_device_fingerprint` + revoke share one tx
+- [x] TD-39 HTTP caching headers on avatars/media — weak ETag `(size, mtime)`, `If-None-Match` → 304 for avatars + media + thumbnails
+- [x] TD-40 OTP concurrency test — N+1 concurrent reads, asserts N unique key_ids + 1 null
+- [x] TD-41 WS rotation-storm integration test — N concurrent rotations of same version, asserts exactly 1 wins, 3 lose with 409, stored envelope is single-racer
+- [x] TD-42 refresh-token theft cascade depth-N test — T0→T1→T2→T3 chain, replay T0 invalidates T3
+- [ ] TD-43..TD-67 medium batch (eligible for a single follow-up PR)
+- [ ] TD-68..TD-85 low batch (eligible for a single mechanical cleanup PR)

--- a/apps/client/lib/src/models/chat_message.dart
+++ b/apps/client/lib/src/models/chat_message.dart
@@ -26,6 +26,13 @@ bool _listEquals<T>(List<T> a, List<T> b) {
   return true;
 }
 
+/// TD-79: lazy `DateTime.parse` cache keyed by `ChatMessage` identity. Used
+/// only by [ChatMessage.parsedTimestamp]; declared outside the class so the
+/// class stays `const`-constructible.
+final Expando<DateTime> _parsedTimestampCache = Expando<DateTime>(
+  'ChatMessage.parsedTimestamp',
+);
+
 class ChatMessage {
   /// System event messages use this as fromUserId.
   static const systemUserId = '__system__';
@@ -64,6 +71,27 @@ class ChatMessage {
 
   /// True if this is a system event (call history, key reset, etc.)
   bool get isSystemEvent => fromUserId == systemUserId;
+
+  /// TD-79: lazily-parsed [timestamp] used by message-grouping helpers in
+  /// `chat_message_list.dart`. Each `_buildMessageAtIndex` invocation
+  /// previously called `DateTime.parse` against both the prior and next
+  /// neighbour's `String` timestamp — for a 30-row viewport that's ~120
+  /// parses per repaint. Caching the parsed value on the message itself
+  /// turns repeated parses into a single shared instance.
+  ///
+  /// The cache lives in a static [Expando] so `ChatMessage` stays a
+  /// `const`-constructible value class; the parse only fires the first
+  /// time any consumer asks for it and the result is keyed by message
+  /// identity. Falls back to a sentinel epoch on parse failure so callers
+  /// don't need to handle a nullable.
+  DateTime get parsedTimestamp {
+    final cached = _parsedTimestampCache[this];
+    if (cached != null) return cached;
+    final parsed =
+        DateTime.tryParse(timestamp) ?? DateTime.fromMillisecondsSinceEpoch(0);
+    _parsedTimestampCache[this] = parsed;
+    return parsed;
+  }
 
   const ChatMessage({
     required this.id,

--- a/apps/client/lib/src/router/app_router.dart
+++ b/apps/client/lib/src/router/app_router.dart
@@ -74,6 +74,13 @@ CustomTransitionPage<void> _fadePage({
 
 /// Listenable that notifies GoRouter when auth state changes, without
 /// recreating the entire router instance.
+///
+/// TD-84: `Ref.listen` (as opposed to `WidgetRef.listenManual`) ties the
+/// listener lifetime to the owning provider. When `routerProvider` is
+/// invalidated, Riverpod tears the listener down automatically — there is
+/// no separate `ProviderSubscription` to track. We still override
+/// `dispose()` so future maintainers know the listener cleanup is
+/// delegated to Riverpod, not handled in this class.
 class _AuthNotifierListenable extends ChangeNotifier {
   _AuthNotifierListenable(Ref ref) {
     ref.listen(authProvider, (prev, next) => notifyListeners());

--- a/apps/client/lib/src/services/crypto/peer_identity_extension.dart
+++ b/apps/client/lib/src/services/crypto/peer_identity_extension.dart
@@ -51,39 +51,77 @@ extension CryptoServicePeerIdentity on CryptoService {
 
   /// Store a peer's identity key with Trust-On-First-Use (TOFU) semantics.
   ///
-  /// - First encounter: stores the key.
+  /// - First encounter: stores the key in the canonical slot.
   /// - Same key: no-op.
-  /// - Different key: logs a warning via [DebugLogService] and persists a
-  ///   flag (`_peerIdentityChangedPrefix + peerId`) for UI to surface later.
-  ///   The new key is stored so future sessions use the latest key.
+  /// - Different key (TD-29): keep the canonical slot **untouched**, write
+  ///   the new key to a separate pending slot, and raise the change flag.
+  ///   The DM session-establishment path already throws
+  ///   `IdentityKeyChangedException` on the flag, but other consumers
+  ///   (group-key rotation, safety-number display) were previously reading
+  ///   the freshly-overwritten cache without ever checking the flag — that
+  ///   silently trusted the new (possibly MITM) key. Now they must either
+  ///   read the canonical slot (default) or explicitly opt-in via
+  ///   [pendingPeerIdentityKey].
   Future<void> _storePeerIdentityKeyTofu(
     String peerUserId,
     String newKeyB64,
   ) async {
     final store = SecureKeyStore.instance;
-    final storeKey = '${CryptoService._peerIdentityPrefix}$peerUserId';
-    final existing = await store.read(storeKey);
+    final canonicalKey = '${CryptoService._peerIdentityPrefix}$peerUserId';
+    final existing = await store.read(canonicalKey);
 
-    if (existing != null && existing != newKeyB64) {
-      DebugLogService.instance.log(
-        LogLevel.warning,
-        'Crypto',
-        'TOFU: identity key changed for peer $peerUserId -- '
-            'possible key reset or MITM. Old prefix: '
-            '${existing.substring(0, min(8, existing.length))}..., '
-            'new prefix: '
-            '${newKeyB64.substring(0, min(8, newKeyB64.length))}...',
-      );
-      debugPrint('[Crypto] WARNING: peer $peerUserId identity key changed!');
-      // Persist a flag so the UI can surface a warning banner later.
-      await store.write(
-        '${CryptoService._peerIdentityChangedPrefix}$peerUserId',
-        DateTime.now().toIso8601String(),
-      );
+    if (existing == null) {
+      // First contact — trust on first use.
+      await store.write(canonicalKey, newKeyB64);
+      return;
     }
 
-    // Store the (possibly new) key so future sessions use the latest.
-    await store.write(storeKey, newKeyB64);
+    if (existing == newKeyB64) {
+      // Same key, nothing to do. Clear any stale pending entry if one
+      // exists (it can be left behind if the peer reverts a key reset).
+      await store.delete(
+        '${CryptoService._peerIdentityPendingPrefix}$peerUserId',
+      );
+      return;
+    }
+
+    // Key has changed: keep canonical, write pending, raise flag.
+    DebugLogService.instance.log(
+      LogLevel.warning,
+      'Crypto',
+      'TOFU: identity key changed for peer $peerUserId -- '
+          'possible key reset or MITM. Old prefix: '
+          '${existing.substring(0, min(8, existing.length))}..., '
+          'new prefix: '
+          '${newKeyB64.substring(0, min(8, newKeyB64.length))}... '
+          'Canonical cache left intact until acceptIdentityKeyChange().',
+    );
+    debugPrint('[Crypto] WARNING: peer $peerUserId identity key changed!');
+    await store.write(
+      '${CryptoService._peerIdentityPendingPrefix}$peerUserId',
+      newKeyB64,
+    );
+    await store.write(
+      '${CryptoService._peerIdentityChangedPrefix}$peerUserId',
+      DateTime.now().toIso8601String(),
+    );
+  }
+
+  /// Returns the *pending* identity key the server most recently advertised
+  /// for [peerUserId], if the canonical (trusted) key differs. Used by code
+  /// paths that legitimately need the new key without overriding TOFU — for
+  /// instance, the explicit "accept identity-key change" UI flow, or a
+  /// safety-number screen that wants to display the new fingerprint
+  /// alongside the trusted one.
+  ///
+  /// Returns null when there is no pending change.
+  Future<Uint8List?> pendingPeerIdentityKey(String peerUserId) async {
+    final store = SecureKeyStore.instance;
+    final pending = await store.read(
+      '${CryptoService._peerIdentityPendingPrefix}$peerUserId',
+    );
+    if (pending == null) return null;
+    return Uint8List.fromList(base64Decode(pending));
   }
 
   /// Check whether a peer's identity key has changed since first contact.
@@ -106,23 +144,27 @@ extension CryptoServicePeerIdentity on CryptoService {
   /// Explicitly trust the peer's new identity key after the user has
   /// reviewed (or chosen to skip reviewing) the safety number.
   ///
-  /// This is the explicit counterpart to the previously-silent overwrite
-  /// in TOFU: it clears the change flag, persists [newIdentityKeyB64] (or,
-  /// if `null`, leaves whatever was last written by TOFU in place), and
-  /// drops any cached/persisted Signal session for the peer so the next
-  /// outbound message triggers a fresh X3DH against the trusted key.
-  /// (#580)
+  /// TD-29: TOFU no longer overwrites the canonical cache silently, so this
+  /// path now promotes the pending key (whatever TOFU stashed when the
+  /// change was detected) to canonical. Callers can still override by
+  /// passing an explicit [newIdentityKeyB64].
+  ///
+  /// Always clears the change flag and drops the persisted Signal session
+  /// keyed to the old identity so the next send re-runs X3DH against the
+  /// freshly-trusted key. (#580)
   Future<void> acceptIdentityKeyChange(
     String peerUserId, {
     String? newIdentityKeyB64,
   }) async {
     final store = SecureKeyStore.instance;
-    if (newIdentityKeyB64 != null) {
-      await store.write(
-        '${CryptoService._peerIdentityPrefix}$peerUserId',
-        newIdentityKeyB64,
-      );
+    final canonicalKey = '${CryptoService._peerIdentityPrefix}$peerUserId';
+    final pendingKey = '${CryptoService._peerIdentityPendingPrefix}$peerUserId';
+
+    final promote = newIdentityKeyB64 ?? await store.read(pendingKey);
+    if (promote != null) {
+      await store.write(canonicalKey, promote);
     }
+    await store.delete(pendingKey);
     await store.delete(
       '${CryptoService._peerIdentityChangedPrefix}$peerUserId',
     );

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -50,6 +50,15 @@ class CryptoService {
   static const _sessionPrefix = 'echo_signal_session_';
   static const _peerIdentityPrefix = 'echo_peer_identity_';
   static const _peerIdentityChangedPrefix = 'echo_peer_identity_changed_';
+
+  /// TD-29: when TOFU detects a changed peer identity, the *new* key is
+  /// stashed here instead of clobbering the canonical
+  /// `_peerIdentityPrefix` slot. Callers that need the freshly-fetched key
+  /// (e.g. group-key rotation needs to wrap against the server's current
+  /// answer, even if not yet trusted) can opt-in via
+  /// [pendingPeerIdentityKey]. The canonical slot only moves forward when
+  /// [acceptIdentityKeyChange] is called explicitly.
+  static const _peerIdentityPendingPrefix = 'echo_peer_identity_pending_';
   static const _otpPrivatePrefix = 'echo_otp_private_';
   static const _signedPrekeyCreatedAtPref = 'echo_signed_prekey_created_at';
   static const _signedPrekeyPreviousPref = 'echo_signed_prekey_previous';
@@ -1190,6 +1199,9 @@ class CryptoService {
     // it's re-fetched with the new bundle on next session establishment.
     await store.delete('$_peerIdentityPrefix$peerUserId');
     await store.delete('$_peerIdentityChangedPrefix$peerUserId');
+    // TD-29: also drop the pending-identity slot so the next fetch starts
+    // from a clean TOFU state instead of resurrecting a stale "new" key.
+    await store.delete('$_peerIdentityPendingPrefix$peerUserId');
   }
 
   /// Reset all keys: clear server fingerprint, delete local keys, regenerate,
@@ -1227,7 +1239,8 @@ class CryptoService {
       if (key.startsWith(_sessionPrefix) ||
           key.startsWith(_otpPrivatePrefix) ||
           key.startsWith(_peerIdentityPrefix) ||
-          key.startsWith(_peerIdentityChangedPrefix)) {
+          key.startsWith(_peerIdentityChangedPrefix) ||
+          key.startsWith(_peerIdentityPendingPrefix)) {
         await store.delete(key);
       }
     }
@@ -1357,6 +1370,7 @@ class CryptoService {
       if (key.startsWith(_sessionPrefix) ||
           key.startsWith(_peerIdentityPrefix) ||
           key.startsWith(_peerIdentityChangedPrefix) ||
+          key.startsWith(_peerIdentityPendingPrefix) ||
           key.startsWith(_otpPrivatePrefix)) {
         await store.delete(key);
       }
@@ -1788,6 +1802,97 @@ class CryptoService {
     wire.setRange(44 + ct.length, wire.length, mac);
 
     return base64Encode(wire);
+  }
+
+  /// TD-28: signed variant of [encryptForUser]. The plaintext wrap is the
+  /// same as the unsigned form; we append a 64-byte Ed25519 signature
+  /// computed over `eph_pub || nonce || ct || tag` using the rotator's
+  /// Ed25519 sender-signing key.
+  ///
+  /// Wire: base64(ephemeral_pub(32) || nonce(12) || ct || tag(16) || sig(64))
+  ///
+  /// Recipients verify with [decryptFromUserVerified] against a freshly
+  /// fetched signing public key for the claimed rotator. Without this,
+  /// nothing in the wire commits to the rotator's identity and a malicious
+  /// server / racing admin can publish substitute envelopes.
+  Future<String> encryptForUserSigned(
+    Uint8List plaintext,
+    Uint8List recipientPublicKeyBytes,
+  ) async {
+    if (_identityKeyPair == null) await init();
+    if (_signingKeyPair == null) {
+      throw StateError(
+        'TD-28: encryptForUserSigned requires a signing key — call init() first',
+      );
+    }
+
+    // Wrap (same shape as encryptForUser).
+    final unsignedB64 = await encryptForUser(
+      plaintext,
+      recipientPublicKeyBytes,
+    );
+    final unsignedWire = Uint8List.fromList(base64Decode(unsignedB64));
+
+    // Sign the wire prefix that the recipient will verify.
+    final sig = await _ed25519.sign(unsignedWire, keyPair: _signingKeyPair!);
+    final sigBytes = Uint8List.fromList(sig.bytes);
+    if (sigBytes.length != 64) {
+      throw StateError(
+        'unexpected Ed25519 signature length: ${sigBytes.length}',
+      );
+    }
+
+    final signedWire = Uint8List(unsignedWire.length + 64);
+    signedWire.setRange(0, unsignedWire.length, unsignedWire);
+    signedWire.setRange(unsignedWire.length, signedWire.length, sigBytes);
+    return base64Encode(signedWire);
+  }
+
+  /// TD-28: verify-then-unwrap counterpart to [encryptForUserSigned].
+  ///
+  /// Verifies the trailing 64-byte Ed25519 signature against
+  /// [senderSigningPublicKey] over the unsigned-prefix bytes, then unwraps
+  /// the same way [decryptFromUser] does. Throws when the signature is
+  /// missing (legacy unsigned envelope) or invalid.
+  ///
+  /// Callers that need to accept legacy unsigned envelopes during a
+  /// migration window can fall back to [decryptFromUser] only after
+  /// confirming a verified signed envelope is genuinely unavailable —
+  /// otherwise the audit's substitution attack still applies.
+  Future<Uint8List> decryptFromUserVerified(
+    String ciphertextB64,
+    Uint8List senderSigningPublicKey,
+  ) async {
+    if (_identityKeyPair == null) await init();
+
+    final wire = Uint8List.fromList(base64Decode(ciphertextB64));
+    // Minimum: 32 + 12 + 16 + 64 (sig)
+    if (wire.length < 32 + 12 + 16 + 64) {
+      throw FormatException(
+        'encryptForUserSigned ciphertext too short: ${wire.length} bytes',
+      );
+    }
+
+    final sigStart = wire.length - 64;
+    final unsignedWire = wire.sublist(0, sigStart);
+    final sigBytes = wire.sublist(sigStart);
+
+    final signerPub = SimplePublicKey(
+      senderSigningPublicKey,
+      type: KeyPairType.ed25519,
+    );
+    final valid = await _ed25519.verify(
+      unsignedWire,
+      signature: Signature(sigBytes, publicKey: signerPub),
+    );
+    if (!valid) {
+      throw const FormatException(
+        'TD-28: group-key envelope signature failed verification',
+      );
+    }
+
+    // Reuse the unsigned-decrypt path on the prefix.
+    return decryptFromUser(base64Encode(unsignedWire));
   }
 
   /// Decrypt data that was encrypted with [encryptForUser] using our identity

--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -137,24 +137,16 @@ class ChatMessageList extends ConsumerWidget {
     return msg.content.startsWith('[system:');
   }
 
-  static bool _withinGroupingWindow(String ts1, String ts2) {
-    try {
-      final dt1 = DateTime.parse(ts1);
-      final dt2 = DateTime.parse(ts2);
-      return dt2.difference(dt1).inMinutes.abs() < 5;
-    } catch (_) {
-      return false;
-    }
+  // TD-79: helpers take the cached `parsedTimestamp` directly so each call
+  // is O(1) lookup instead of a fresh `DateTime.parse` per neighbour. For a
+  // 30-row viewport this drops ~120 parses per repaint to zero on warm
+  // messages.
+  static bool _withinGroupingWindow(DateTime dt1, DateTime dt2) {
+    return dt2.difference(dt1).inMinutes.abs() < 5;
   }
 
-  static bool _differentDay(String ts1, String ts2) {
-    try {
-      final d1 = DateTime.parse(ts1);
-      final d2 = DateTime.parse(ts2);
-      return d1.year != d2.year || d1.month != d2.month || d1.day != d2.day;
-    } catch (_) {
-      return false;
-    }
+  static bool _differentDay(DateTime d1, DateTime d2) {
+    return d1.year != d2.year || d1.month != d2.month || d1.day != d2.day;
   }
 
   // ---- Build helpers -----------------------------------------------------
@@ -167,12 +159,16 @@ class ChatMessageList extends ConsumerWidget {
     }
 
     final needsDateDivider =
-        i == 0 || _differentDay(messages[i - 1].timestamp, msg.timestamp);
+        i == 0 ||
+        _differentDay(messages[i - 1].parsedTimestamp, msg.parsedTimestamp);
 
     final showHeader =
         i == 0 ||
         messages[i - 1].fromUserId != msg.fromUserId ||
-        !_withinGroupingWindow(messages[i - 1].timestamp, msg.timestamp);
+        !_withinGroupingWindow(
+          messages[i - 1].parsedTimestamp,
+          msg.parsedTimestamp,
+        );
 
     final isLastInGroup =
         i == messages.length - 1 ||

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -19,6 +19,14 @@ import 'avatar_utils.dart';
 /// tier (UX roadmap Phase 2).
 const double kConversationItemHeight = 68.0;
 
+/// TD-80: lifted out of `_applyMediaLabel` so the sidebar doesn't re-compile
+/// this RegExp on every conversation tile rebuild. The pattern matches a
+/// leading `[kind:URL]` marker optionally followed by a newline and caption,
+/// which is what the seed scripts emit for captioned attachments.
+final RegExp _mediaMarkerRegExp = RegExp(
+  r'^\[(img|video|file|voice):[^\]]+\]\s*\n?\s*',
+);
+
 /// Tighter height for the compact (Discord-style) density tier.
 /// Bumped from 52px to 56px to maintain buffer above 56px bottom tab bar.
 const double kConversationItemHeightCompact = 56.0;
@@ -227,10 +235,10 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     // a caption (the seed scripts emit `[img:URL]\ncaption` for captioned
     // attachments).  The previous `^\[img:.+\]$` regex only matched bare
     // markers, so captioned messages leaked the raw `[img:...]` text into
-    // the conversation preview (#prod-2026-05-08).
-    final match = RegExp(
-      r'^\[(img|video|file|voice):[^\]]+\]\s*\n?\s*',
-    ).firstMatch(snippet);
+    // the conversation preview (#prod-2026-05-08). TD-80: regex itself
+    // lifted to a top-level final so the sidebar doesn't recompile it on
+    // every tile rebuild.
+    final match = _mediaMarkerRegExp.firstMatch(snippet);
     if (match == null) return snippet;
     final kind = match.group(1)!;
     final caption = snippet.substring(match.end).trim();

--- a/apps/client/lib/src/widgets/shared_media_gallery.dart
+++ b/apps/client/lib/src/widgets/shared_media_gallery.dart
@@ -23,11 +23,16 @@ class SharedMediaGallery extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final chatState = ref.watch(chatProvider);
+    // TD-60: subscribe only to *this* conversation's message list, not the
+    // whole `ChatState`. Before, opening this screen and idling on any other
+    // conversation rebuilt the gallery (and every CachedNetworkImage tile)
+    // on every inbound message system-wide.
+    final messages = ref.watch(
+      chatProvider.select((s) => s.messagesForConversation(conversationId)),
+    );
     final serverUrl = ref.watch(serverUrlProvider);
     final authToken = ref.watch(authProvider.select((s) => s.token)) ?? '';
     final mediaTicket = ref.watch(mediaTicketProvider);
-    final messages = chatState.messagesForConversation(conversationId);
 
     // Collect media items from all cached messages
     final mediaItems = <_MediaItem>[];

--- a/apps/client/test/services/crypto_service_test.dart
+++ b/apps/client/test/services/crypto_service_test.dart
@@ -705,4 +705,126 @@ void main() {
       },
     );
   });
+
+  // TD-28: group-key envelope signing (rotator identity binding).
+  //
+  // The unsigned envelope (encryptForUser) has no commitment to the
+  // rotator's identity — a compromised server or racing admin could
+  // substitute envelopes wrapping a key they control. The signed
+  // counterpart (encryptForUserSigned + decryptFromUserVerified) appends an
+  // Ed25519 signature that recipients verify against the rotator's
+  // sender-signing public key.
+  group('TD-28 signed group-key envelopes', () {
+    test(
+      'round-trips through encryptForUserSigned / decryptFromUserVerified',
+      () async {
+        // Single instance acting as both rotator and recipient: wrap for our
+        // own identity key, then verify+decrypt. The security property under
+        // test is the signature verification, not the cross-instance ECDH
+        // wiring (which is exercised by the production rotation path).
+        final crypto = CryptoService(serverUrl: 'http://localhost:8080');
+        crypto.setToken('test-token');
+        await crypto.init();
+
+        final ownPub = await crypto.getIdentityPublicKey();
+        expect(ownPub, isNotNull);
+
+        final plaintext = Uint8List.fromList(
+          utf8.encode('group key payload bytes'),
+        );
+        final signedEnvelope = await crypto.encryptForUserSigned(
+          plaintext,
+          ownPub!,
+        );
+
+        final signingPub = await crypto.signingKeyPair!.extractPublicKey();
+        final roundtrip = await crypto.decryptFromUserVerified(
+          signedEnvelope,
+          Uint8List.fromList(signingPub.bytes),
+        );
+        expect(roundtrip, equals(plaintext));
+      },
+    );
+
+    test('rejects an envelope signed by a different rotator', () async {
+      final realRotator = CryptoService(serverUrl: 'http://localhost:8080');
+      realRotator.setToken('real-rotator');
+      await realRotator.init();
+
+      final attacker = CryptoService(serverUrl: 'http://localhost:8080');
+      attacker.setToken('attacker');
+      SecureKeyStore.instance = FakeSecureKeyStore();
+      await attacker.init();
+
+      final recipientPub = await realRotator.getIdentityPublicKey();
+      expect(recipientPub, isNotNull);
+
+      // Attacker signs an envelope wrapping their own substitute key.
+      final substituteKey = Uint8List.fromList(
+        List<int>.generate(32, (i) => i),
+      );
+      final envelope = await attacker.encryptForUserSigned(
+        substituteKey,
+        recipientPub!,
+      );
+
+      // Recipient expects the REAL rotator's signing key; verification
+      // must fail.
+      final realPub = await realRotator.signingKeyPair!.extractPublicKey();
+      Object? caught;
+      try {
+        await attacker.decryptFromUserVerified(
+          envelope,
+          Uint8List.fromList(realPub.bytes),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(
+        caught,
+        isA<FormatException>(),
+        reason: 'mismatched signer must reject before unwrap',
+      );
+    });
+
+    test('rejects a tampered envelope body', () async {
+      final rotator = CryptoService(serverUrl: 'http://localhost:8080');
+      rotator.setToken('rotator');
+      await rotator.init();
+
+      final recipientPub = await rotator.getIdentityPublicKey();
+      expect(recipientPub, isNotNull);
+
+      final plaintext = Uint8List.fromList(utf8.encode('payload'));
+      final envelopeB64 = await rotator.encryptForUserSigned(
+        plaintext,
+        recipientPub!,
+      );
+
+      // Flip one byte in the ciphertext region (middle of the wire,
+      // before the trailing 64-byte signature).
+      final wire = Uint8List.fromList(base64Decode(envelopeB64));
+      expect(wire.length, greaterThan(32 + 12 + 16 + 64));
+      final flipIdx = wire.length - 64 - 8;
+      wire[flipIdx] ^= 0xff;
+      final tamperedB64 = base64Encode(wire);
+
+      final signingPub = await rotator.signingKeyPair!.extractPublicKey();
+      Object? caught;
+      try {
+        await rotator.decryptFromUserVerified(
+          tamperedB64,
+          Uint8List.fromList(signingPub.bytes),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(
+        caught,
+        isA<FormatException>(),
+        reason:
+            'tampering with the wire after signing must trip Ed25519 verify',
+      );
+    });
+  });
 }

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -34,8 +34,10 @@ futures-util = "0.3"
 # Used by link_preview streaming body cap (#684) -- reqwest bytes_stream
 # yields bytes::Bytes, but it's not re-exported, so we depend directly.
 bytes = "1"
-# ReaderStream for streaming file download bodies (#680)
-tokio-util = { version = "0.7", features = ["io"] }
+# ReaderStream for streaming file download bodies (#680).
+# `rt` brings in `CancellationToken` for graceful shutdown of background
+# cleanup loops (TD-37).
+tokio-util = { version = "0.7", features = ["io", "rt"] }
 
 # Connection hub
 dashmap = "6"

--- a/apps/server/src/auth/invalidation.rs
+++ b/apps/server/src/auth/invalidation.rs
@@ -1,0 +1,110 @@
+//! Per-user "min iat" token-invalidation map (CR-4).
+//!
+//! Closes the gap where a revoked device's 15-minute access token continued
+//! to authorize every REST call until the JWT expired. The JWT validator
+//! only checks `iss`/`aud`/`exp`; it has no knowledge of device revocation.
+//!
+//! Strategy: whenever a user revokes a device, changes their password, or
+//! does anything that should invalidate outstanding access tokens, we bump
+//! `min_iat` for that user to `now()`. The `AuthUser` extractor rejects any
+//! JWT whose `iat` is older than `min_iat`.
+//!
+//! In-memory only by design: the worst-case after a server restart is that
+//! tokens issued before the restart remain valid until their 15-minute TTL —
+//! the same window we accept today. Persistent state would require a
+//! migration and an extra DB round-trip per request; the trade-off favours
+//! the simpler in-memory map.
+//!
+//! Concurrency: `DashMap` is lock-free for the read-heavy path (one read per
+//! authenticated request). Writes happen only on revocation events, which
+//! are several orders of magnitude rarer.
+
+use dashmap::DashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone, Default)]
+pub struct TokenInvalidator {
+    /// user_id → unix-seconds floor. JWTs with `iat < floor` are rejected.
+    min_iat: Arc<DashMap<Uuid, i64>>,
+}
+
+impl TokenInvalidator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the floor `iat` (unix seconds) below which tokens for
+    /// `user_id` are rejected, or `None` if no invalidation has been
+    /// recorded for this user.
+    pub fn min_iat(&self, user_id: Uuid) -> Option<i64> {
+        self.min_iat.get(&user_id).map(|v| *v)
+    }
+
+    /// Mark every access token currently outstanding for `user_id` as
+    /// invalid. Idempotent; bumps the floor to `now` only if `now` is
+    /// strictly greater than the existing floor (so a clock skew can't
+    /// roll it backward).
+    pub fn invalidate(&self, user_id: Uuid) {
+        let now = chrono::Utc::now().timestamp();
+        self.min_iat
+            .entry(user_id)
+            .and_modify(|prev| {
+                if now > *prev {
+                    *prev = now;
+                }
+            })
+            .or_insert(now);
+    }
+
+    /// `true` iff the supplied JWT `iat` (unix seconds) is still valid for
+    /// `user_id`. Returns `true` when no invalidation is recorded for this
+    /// user (the common case).
+    pub fn is_token_valid(&self, user_id: Uuid, iat: i64) -> bool {
+        match self.min_iat(user_id) {
+            Some(floor) => iat >= floor,
+            None => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_user_is_valid() {
+        let inv = TokenInvalidator::new();
+        assert!(inv.is_token_valid(Uuid::new_v4(), 0));
+    }
+
+    #[test]
+    fn invalidate_rejects_older_iat() {
+        let inv = TokenInvalidator::new();
+        let user = Uuid::new_v4();
+        let before = chrono::Utc::now().timestamp() - 10;
+        inv.invalidate(user);
+        assert!(!inv.is_token_valid(user, before));
+    }
+
+    #[test]
+    fn invalidate_keeps_newer_iat_valid() {
+        let inv = TokenInvalidator::new();
+        let user = Uuid::new_v4();
+        inv.invalidate(user);
+        let after = chrono::Utc::now().timestamp() + 60;
+        assert!(inv.is_token_valid(user, after));
+    }
+
+    #[test]
+    fn invalidate_does_not_roll_floor_backward() {
+        let inv = TokenInvalidator::new();
+        let user = Uuid::new_v4();
+        inv.invalidate(user);
+        let first = inv.min_iat(user).unwrap();
+        // Second invalidation cannot lower the floor.
+        inv.invalidate(user);
+        let second = inv.min_iat(user).unwrap();
+        assert!(second >= first);
+    }
+}

--- a/apps/server/src/auth/middleware.rs
+++ b/apps/server/src/auth/middleware.rs
@@ -5,7 +5,7 @@ use axum::http::request::Parts;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::error::AppError;
+use crate::error::{AppError, ErrorCode};
 use crate::routes::AppState;
 
 use super::jwt;
@@ -36,6 +36,20 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
 
         let user_id = Uuid::parse_str(&claims.sub)
             .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?;
+
+        // CR-4: reject tokens whose `iat` predates the user's last
+        // revocation event (device revoke, password change, "log out
+        // everywhere"). Closes the 15-minute access-token window where a
+        // revoked credential continued to authorize every REST call.
+        if !state
+            .token_invalidator
+            .is_token_valid(user_id, claims.iat as i64)
+        {
+            return Err(AppError::with_code(
+                ErrorCode::TokenRevoked,
+                "Access token has been revoked",
+            ));
+        }
 
         // Light up the `user_id` slot reserved by the per-request tracing
         // span (see `routes::create_router`). The TraceLayer span is opened

--- a/apps/server/src/auth/mod.rs
+++ b/apps/server/src/auth/mod.rs
@@ -1,3 +1,6 @@
+pub mod invalidation;
 pub mod jwt;
 pub mod middleware;
 pub mod password;
+
+pub use invalidation::TokenInvalidator;

--- a/apps/server/src/auth/password.rs
+++ b/apps/server/src/auth/password.rs
@@ -2,22 +2,41 @@
 
 use argon2::password_hash::SaltString;
 use argon2::password_hash::rand_core::OsRng;
-use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use argon2::{Algorithm, Argon2, Params, PasswordHash, PasswordHasher, PasswordVerifier, Version};
 
 use crate::error::AppError;
 
+/// TD-49: pin Argon2id parameters explicitly instead of relying on the
+/// crate's `default()`.
+///
+/// `Argon2::default()` is currently `m=19_456 KiB, t=2, p=1` (OWASP minimum)
+/// but the upstream defaults change between crate releases. Pinning here
+/// guarantees that:
+///
+/// 1. A future `argon2` dep bump can't silently soften our parameters.
+/// 2. The `DUMMY_HASH` constant baked into `routes/auth.rs` (used for
+///    constant-time username-enumeration defence on login) stays bit-for-bit
+///    consistent with what we mint, so the timing-equalisation pass
+///    actually equalises.
+///
+/// Output length is left at the Params default (32 bytes) which matches the
+/// length encoded in DUMMY_HASH.
+fn argon2() -> Argon2<'static> {
+    // OWASP Argon2id recommended minimum (2023): m=19 MiB, t=2, p=1.
+    let params = Params::new(19_456, 2, 1, None).expect("Argon2 params are statically valid");
+    Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+}
+
 pub fn hash_password(password: &str) -> Result<String, AppError> {
     let salt = SaltString::generate(&mut OsRng);
-    let argon2 = Argon2::default();
-    let hash = argon2.hash_password(password.as_bytes(), &salt)?;
+    let hash = argon2().hash_password(password.as_bytes(), &salt)?;
     Ok(hash.to_string())
 }
 
 pub fn verify_password(password: &str, hash: &str) -> Result<bool, AppError> {
     let parsed_hash =
         PasswordHash::new(hash).map_err(|e| AppError::internal(format!("Invalid hash: {e}")))?;
-    let argon2 = Argon2::default();
-    match argon2.verify_password(password.as_bytes(), &parsed_hash) {
+    match argon2().verify_password(password.as_bytes(), &parsed_hash) {
         Ok(()) => Ok(true),
         Err(argon2::password_hash::Error::Password) => Ok(false),
         Err(e) => Err(AppError::from(e)),

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -3,6 +3,7 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use sqlx::PgPool;
+use sqlx::postgres::PgConnection;
 use uuid::Uuid;
 
 /// Hard cap on the number of members returned by `get_group_members`.
@@ -318,7 +319,7 @@ pub async fn get_group_members(
 
 /// Check if a user is a member of a conversation.
 pub async fn is_member(
-    pool: &PgPool,
+    db: impl sqlx::PgExecutor<'_>,
     conversation_id: Uuid,
     user_id: Uuid,
 ) -> Result<bool, sqlx::Error> {
@@ -328,14 +329,14 @@ pub async fn is_member(
     )
     .bind(conversation_id)
     .bind(user_id)
-    .fetch_one(pool)
+    .fetch_one(db)
     .await?;
     Ok(row.0)
 }
 
 /// Get a member's role in a conversation. Returns None if not a member.
 pub async fn get_member_role(
-    pool: &PgPool,
+    db: impl sqlx::PgExecutor<'_>,
     group_id: Uuid,
     user_id: Uuid,
 ) -> Result<Option<String>, sqlx::Error> {
@@ -345,7 +346,7 @@ pub async fn get_member_role(
     )
     .bind(group_id)
     .bind(user_id)
-    .fetch_optional(pool)
+    .fetch_optional(db)
     .await?;
     Ok(row.map(|(role,)| role))
 }
@@ -356,9 +357,13 @@ pub async fn get_member_role(
 /// reactivated, and `false` when the user is already an active member.
 /// Increments `member_count` on the conversation when a row is actually written
 /// (#640).
-pub async fn add_member(pool: &PgPool, group_id: Uuid, user_id: Uuid) -> Result<bool, sqlx::Error> {
-    let mut tx = pool.begin().await?;
-
+/// Insert a member + bump conversation member_count inside an externally
+/// managed transaction. See [`add_member`] for the self-contained variant.
+pub async fn add_member_in_tx(
+    conn: &mut PgConnection,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<bool, sqlx::Error> {
     let result = sqlx::query(
         "INSERT INTO conversation_members (conversation_id, user_id, role) \
          VALUES ($1, $2, 'member') \
@@ -368,17 +373,23 @@ pub async fn add_member(pool: &PgPool, group_id: Uuid, user_id: Uuid) -> Result<
     )
     .bind(group_id)
     .bind(user_id)
-    .execute(&mut *tx)
+    .execute(&mut *conn)
     .await?;
 
     let added = result.rows_affected() > 0;
     if added {
         sqlx::query("UPDATE conversations SET member_count = member_count + 1 WHERE id = $1")
             .bind(group_id)
-            .execute(&mut *tx)
+            .execute(&mut *conn)
             .await?;
     }
 
+    Ok(added)
+}
+
+pub async fn add_member(pool: &PgPool, group_id: Uuid, user_id: Uuid) -> Result<bool, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let added = add_member_in_tx(&mut tx, group_id, user_id).await?;
     tx.commit().await?;
     Ok(added)
 }
@@ -387,13 +398,13 @@ pub async fn add_member(pool: &PgPool, group_id: Uuid, user_id: Uuid) -> Result<
 ///
 /// Decrements `member_count` on the conversation when a row is actually
 /// soft-deleted (#640).
-pub async fn remove_member(
-    pool: &PgPool,
+/// Soft-delete a member + decrement member_count inside an externally
+/// managed transaction. See [`remove_member`] for the self-contained variant.
+pub async fn remove_member_in_tx(
+    conn: &mut PgConnection,
     group_id: Uuid,
     user_id: Uuid,
 ) -> Result<bool, sqlx::Error> {
-    let mut tx = pool.begin().await?;
-
     let result = sqlx::query(
         "UPDATE conversation_members \
          SET is_removed = true, removed_at = NOW() \
@@ -401,7 +412,7 @@ pub async fn remove_member(
     )
     .bind(group_id)
     .bind(user_id)
-    .execute(&mut *tx)
+    .execute(&mut *conn)
     .await?;
 
     let removed = result.rows_affected() > 0;
@@ -411,10 +422,20 @@ pub async fn remove_member(
              SET member_count = GREATEST(member_count - 1, 0) WHERE id = $1",
         )
         .bind(group_id)
-        .execute(&mut *tx)
+        .execute(&mut *conn)
         .await?;
     }
 
+    Ok(removed)
+}
+
+pub async fn remove_member(
+    pool: &PgPool,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<bool, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let removed = remove_member_in_tx(&mut tx, group_id, user_id).await?;
     tx.commit().await?;
     Ok(removed)
 }
@@ -442,12 +463,12 @@ where
 
 /// Get the kind of a conversation.
 pub async fn get_conversation_kind(
-    pool: &PgPool,
+    db: impl sqlx::PgExecutor<'_>,
     conversation_id: Uuid,
 ) -> Result<Option<String>, sqlx::Error> {
     let row: Option<(String,)> = sqlx::query_as("SELECT kind FROM conversations WHERE id = $1")
         .bind(conversation_id)
-        .fetch_optional(pool)
+        .fetch_optional(db)
         .await?;
     Ok(row.map(|(kind,)| kind))
 }
@@ -552,10 +573,10 @@ pub async fn delete_group(
 }
 
 /// Check if a group is public.
-pub async fn is_public(pool: &PgPool, group_id: Uuid) -> Result<bool, sqlx::Error> {
+pub async fn is_public(db: impl sqlx::PgExecutor<'_>, group_id: Uuid) -> Result<bool, sqlx::Error> {
     let row: Option<(bool,)> = sqlx::query_as("SELECT is_public FROM conversations WHERE id = $1")
         .bind(group_id)
-        .fetch_optional(pool)
+        .fetch_optional(db)
         .await?;
     Ok(row.map(|(p,)| p).unwrap_or(false))
 }
@@ -653,14 +674,14 @@ pub async fn update_group_description(
 ///
 /// Decrements `member_count` when the membership row is actually soft-deleted
 /// (#640).
-pub async fn ban_member(
-    pool: &PgPool,
+/// Ban a member inside an externally managed transaction.
+/// See [`ban_member`] for the self-contained variant.
+pub async fn ban_member_in_tx(
+    conn: &mut PgConnection,
     group_id: Uuid,
     user_id: Uuid,
     banned_by: Uuid,
 ) -> Result<bool, sqlx::Error> {
-    let mut tx = pool.begin().await?;
-
     // Remove from conversation_members (soft-delete)
     let removed = sqlx::query(
         "UPDATE conversation_members SET is_removed = true, removed_at = NOW() \
@@ -668,7 +689,7 @@ pub async fn ban_member(
     )
     .bind(group_id)
     .bind(user_id)
-    .execute(&mut *tx)
+    .execute(&mut *conn)
     .await?;
 
     if removed.rows_affected() > 0 {
@@ -677,7 +698,7 @@ pub async fn ban_member(
              SET member_count = GREATEST(member_count - 1, 0) WHERE id = $1",
         )
         .bind(group_id)
-        .execute(&mut *tx)
+        .execute(&mut *conn)
         .await?;
     }
 
@@ -690,22 +711,37 @@ pub async fn ban_member(
     .bind(group_id)
     .bind(user_id)
     .bind(banned_by)
-    .execute(&mut *tx)
+    .execute(&mut *conn)
     .await?;
 
-    tx.commit().await?;
     Ok(result.rows_affected() > 0)
 }
 
+pub async fn ban_member(
+    pool: &PgPool,
+    group_id: Uuid,
+    user_id: Uuid,
+    banned_by: Uuid,
+) -> Result<bool, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let banned = ban_member_in_tx(&mut tx, group_id, user_id, banned_by).await?;
+    tx.commit().await?;
+    Ok(banned)
+}
+
 /// Check if a user is banned from a group.
-pub async fn is_banned(pool: &PgPool, group_id: Uuid, user_id: Uuid) -> Result<bool, sqlx::Error> {
+pub async fn is_banned(
+    db: impl sqlx::PgExecutor<'_>,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
         "SELECT EXISTS(SELECT 1 FROM banned_members \
          WHERE conversation_id = $1 AND user_id = $2)",
     )
     .bind(group_id)
     .bind(user_id)
-    .fetch_one(pool)
+    .fetch_one(db)
     .await?;
     Ok(row.0)
 }

--- a/apps/server/src/db/keys.rs
+++ b/apps/server/src/db/keys.rs
@@ -430,6 +430,25 @@ pub struct DeviceRow {
     pub last_seen: Option<DateTime<Utc>>,
 }
 
+/// TD-53: return the lowest active device_id for a user, or None when the
+/// user has no non-revoked devices. Used by `get_bundle` to short-circuit
+/// the N-device loop when device 0 has no bundle — saves up to N×3 DB
+/// round-trips per X3DH initiation against a multi-device user.
+pub async fn get_first_active_device_id(
+    pool: &PgPool,
+    user_id: Uuid,
+) -> Result<Option<i32>, sqlx::Error> {
+    let row: Option<(i32,)> = sqlx::query_as(
+        "SELECT device_id FROM identity_keys \
+         WHERE user_id = $1 AND revoked_at IS NULL \
+         ORDER BY device_id ASC LIMIT 1",
+    )
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(id,)| id))
+}
+
 /// Return devices registered for a given user (capped at 10), including
 /// their platform and last-seen timestamp. Excludes revoked devices (#657).
 pub async fn get_user_devices(pool: &PgPool, user_id: Uuid) -> Result<Vec<DeviceRow>, sqlx::Error> {
@@ -464,19 +483,21 @@ pub async fn update_last_seen(
     Ok(())
 }
 
-/// Revoke all keys for a specific (user_id, device_id) pair.
+/// Revoke all keys for a specific (user_id, device_id) pair, inside an
+/// externally-managed transaction.
 ///
 /// Soft-deletes the `identity_keys` row by stamping `revoked_at` so the fanout
 /// filter can distinguish "revoked" from "never registered" (#657). Prekeys are
 /// hard-deleted because they are useless after revocation.
 /// Returns true if the device was found and is now revoked, false if not found.
-pub async fn revoke_device(
-    pool: &PgPool,
+///
+/// Callers that don't already have a transaction should use [`revoke_device`]
+/// which opens and commits one for them.
+pub async fn revoke_device_in_tx(
+    conn: &mut PgConnection,
     user_id: Uuid,
     device_id: i32,
 ) -> Result<bool, sqlx::Error> {
-    let mut tx = pool.begin().await?;
-
     // Soft-delete: stamp revoked_at instead of hard-deleting so the fanout
     // filter can detect "was revoked" vs "never existed" (#657).
     let r1 = sqlx::query(
@@ -485,24 +506,36 @@ pub async fn revoke_device(
     )
     .bind(user_id)
     .bind(device_id)
-    .execute(&mut *tx)
+    .execute(&mut *conn)
     .await?;
 
     // Prekeys are worthless after revocation; hard-delete them.
     sqlx::query("DELETE FROM signed_prekeys WHERE user_id = $1 AND device_id = $2")
         .bind(user_id)
         .bind(device_id)
-        .execute(&mut *tx)
+        .execute(&mut *conn)
         .await?;
 
     sqlx::query("DELETE FROM one_time_prekeys WHERE user_id = $1 AND device_id = $2")
         .bind(user_id)
         .bind(device_id)
-        .execute(&mut *tx)
+        .execute(&mut *conn)
         .await?;
 
-    tx.commit().await?;
     Ok(r1.rows_affected() > 0)
+}
+
+/// Revoke all keys for a specific (user_id, device_id) pair in its own tx.
+/// Thin wrapper around [`revoke_device_in_tx`].
+pub async fn revoke_device(
+    pool: &PgPool,
+    user_id: Uuid,
+    device_id: i32,
+) -> Result<bool, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let revoked = revoke_device_in_tx(&mut tx, user_id, device_id).await?;
+    tx.commit().await?;
+    Ok(revoked)
 }
 
 /// Revoke every device belonging to `user_id` except `keep_device_id` in a

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -487,12 +487,24 @@ pub async fn mark_device_delivered_batch(
 ///
 /// Returns the (id, conversation_id) pairs that were deleted so the caller
 /// can broadcast `message_expired` events to online users.
+///
+/// TD-52: paginated. Without the LIMIT, a backlog (downtime + many TTL'd
+/// messages) would build an arbitrarily large RETURNING list in memory and
+/// trigger a per-conversation member fetch loop downstream. The caller
+/// invokes this in a `while !empty` loop so a 10 000-message backlog is
+/// drained in batches without blowing the heap.
 pub async fn cleanup_expired_messages(pool: &PgPool) -> Result<Vec<(Uuid, Uuid)>, sqlx::Error> {
+    const BATCH: i64 = 500;
     let rows: Vec<(Uuid, Uuid)> = sqlx::query_as(
         "DELETE FROM messages \
-         WHERE expires_at IS NOT NULL AND expires_at <= NOW() \
+         WHERE id IN ( \
+             SELECT id FROM messages \
+             WHERE expires_at IS NOT NULL AND expires_at <= NOW() \
+             LIMIT $1 \
+         ) \
          RETURNING id, conversation_id",
     )
+    .bind(BATCH)
     .fetch_all(pool)
     .await?;
     Ok(rows)

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -35,10 +35,21 @@ pub async fn create_pool(database_url: &str) -> PgPool {
     const MAX_RETRIES: u32 = 5;
     let mut delay_secs = 1u64;
 
+    // TD-56: keep a small warm pool so the first request after a long
+    // idle stretch doesn't pay 50–200 ms of TCP+TLS+startup latency. The
+    // 15 s acquire timeout (up from 5 s) gives heavy bursts room to drain
+    // without surfacing pool exhaustion as 500s on the readyz probe.
+    let min_conns: u32 = std::env::var("DB_MIN_CONNECTIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5)
+        .min(max_conns);
+
     for attempt in 1..=MAX_RETRIES {
         match PgPoolOptions::new()
             .max_connections(max_conns)
-            .acquire_timeout(std::time::Duration::from_secs(5))
+            .min_connections(min_conns)
+            .acquire_timeout(std::time::Duration::from_secs(15))
             .idle_timeout(std::time::Duration::from_secs(300))
             .connect(database_url)
             .await

--- a/apps/server/src/db/password_reset.rs
+++ b/apps/server/src/db/password_reset.rs
@@ -5,12 +5,11 @@
 //! handler for admin-mediated relay (Option A).
 
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
 use uuid::Uuid;
 
 /// Store a new password-reset token for `user_id`, expiring at `expires_at`.
 pub async fn create_token(
-    pool: &PgPool,
+    db: impl sqlx::PgExecutor<'_>,
     token: &str,
     user_id: Uuid,
     expires_at: DateTime<Utc>,
@@ -22,7 +21,7 @@ pub async fn create_token(
     .bind(token)
     .bind(user_id)
     .bind(expires_at)
-    .execute(pool)
+    .execute(db)
     .await?;
     Ok(())
 }
@@ -35,21 +34,24 @@ pub struct ResetTokenRow {
 }
 
 /// Look up a reset token. Returns `None` when the token does not exist.
-pub async fn find_token(pool: &PgPool, token: &str) -> Result<Option<ResetTokenRow>, sqlx::Error> {
+pub async fn find_token(
+    db: impl sqlx::PgExecutor<'_>,
+    token: &str,
+) -> Result<Option<ResetTokenRow>, sqlx::Error> {
     sqlx::query_as::<_, ResetTokenRow>(
         "SELECT user_id, expires_at, used_at \
          FROM password_reset_tokens WHERE token = $1",
     )
     .bind(token)
-    .fetch_optional(pool)
+    .fetch_optional(db)
     .await
 }
 
 /// Mark the token as used. Called immediately after a successful password reset.
-pub async fn consume_token(pool: &PgPool, token: &str) -> Result<(), sqlx::Error> {
+pub async fn consume_token(db: impl sqlx::PgExecutor<'_>, token: &str) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE password_reset_tokens SET used_at = NOW() WHERE token = $1")
         .bind(token)
-        .execute(pool)
+        .execute(db)
         .await?;
     Ok(())
 }

--- a/apps/server/src/db/tokens.rs
+++ b/apps/server/src/db/tokens.rs
@@ -74,10 +74,13 @@ pub async fn revoke_token_family(pool: &PgPool, family_id: Uuid) -> Result<(), s
     Ok(())
 }
 
-pub async fn revoke_all_user_tokens(pool: &PgPool, user_id: Uuid) -> Result<(), sqlx::Error> {
+pub async fn revoke_all_user_tokens(
+    db: impl sqlx::PgExecutor<'_>,
+    user_id: Uuid,
+) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE refresh_tokens SET revoked = true WHERE user_id = $1 AND revoked = false")
         .bind(user_id)
-        .execute(pool)
+        .execute(db)
         .await?;
     Ok(())
 }

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -40,21 +40,40 @@ pub async fn create_user(
     username: &str,
     password_hash: &str,
 ) -> Result<CreatedUser, sqlx::Error> {
-    // First-user bootstrap: when the users table is empty (and so by
-    // construction no admin exists yet), this signup becomes the operator.
-    // The `NOT EXISTS` subquery sees its snapshot inside the same statement
-    // as the INSERT, so even with two concurrent registrations against an
-    // empty table only one row sees an empty table -- the other observes
-    // the freshly inserted row and gets `is_admin = FALSE`.  Combined with
-    // the unique-username constraint this means a fresh DB deterministically
-    // gets exactly one admin from the registration path.
+    // TD-44: first-user bootstrap — by default the first registration on an
+    // empty users table is promoted to admin (the original behaviour, kept
+    // so a fresh self-host install can get its operator in two HTTP calls).
+    //
+    // Self-hosters who plan to open registration up to other users BEFORE
+    // promoting themselves should set `ECHO_BOOTSTRAP_ADMIN_USERNAME` to
+    // their intended operator name; that locks first-user promotion to a
+    // single specific username and prevents the "first random signup
+    // becomes a permanent admin" race that the audit flagged. When the env
+    // var is set and the registration does not match, the row is created
+    // as a regular user even if it would otherwise satisfy the empty-table
+    // condition.
+    //
+    // The original race-safety property (a single statement so only one
+    // concurrent INSERT can see the table empty) is preserved: the env-var
+    // match is evaluated client-side as `$3` and the snapshot inside the
+    // statement still picks at most one winner.
+    let bootstrap_username = std::env::var("ECHO_BOOTSTRAP_ADMIN_USERNAME").ok();
+    let matches_bootstrap = match bootstrap_username.as_deref() {
+        // When the env var is unset, retain legacy behaviour: any first
+        // signup is promoted. When it is set, only the exact-match
+        // username may be promoted.
+        None => true,
+        Some(expected) => expected == username,
+    };
+
     let row: (Uuid, bool) = sqlx::query_as(
         "INSERT INTO users (username, password_hash, is_admin) \
-         VALUES ($1, $2, (SELECT NOT EXISTS (SELECT 1 FROM users))) \
+         VALUES ($1, $2, $3 AND (SELECT NOT EXISTS (SELECT 1 FROM users))) \
          RETURNING id, is_admin",
     )
     .bind(username)
     .bind(password_hash)
+    .bind(matches_bootstrap)
     .fetch_one(pool)
     .await?;
 
@@ -311,14 +330,14 @@ pub async fn update_profile(
 
 /// Update a user's password hash.
 pub async fn update_password(
-    pool: &PgPool,
+    db: impl sqlx::PgExecutor<'_>,
     user_id: Uuid,
     password_hash: &str,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
         .bind(password_hash)
         .bind(user_id)
-        .execute(pool)
+        .execute(db)
         .await?;
     Ok(())
 }
@@ -434,6 +453,59 @@ pub async fn update_privacy_preferences(
     .bind(prefs.searchable)
     .bind(user_id)
     .fetch_one(pool)
+    .await
+}
+
+/// TD-51: optional fields for [`update_privacy_preferences_partial`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PrivacyPartial {
+    pub read_receipts_enabled: Option<bool>,
+    pub email_visible: Option<bool>,
+    pub phone_visible: Option<bool>,
+    pub email_discoverable: Option<bool>,
+    pub phone_discoverable: Option<bool>,
+    pub searchable: Option<bool>,
+}
+
+/// TD-51: partial-update privacy preferences in a single statement, using
+/// `COALESCE($new, column)` so unset fields keep their current value.
+/// Defeats the read-modify-write race the old `update_my_privacy` had —
+/// two concurrent PATCHes from different devices could lose fields between
+/// the SELECT and the UPDATE; this path has no such window.
+pub async fn update_privacy_preferences_partial(
+    pool: &PgPool,
+    user_id: Uuid,
+    partial: PrivacyPartial,
+) -> Result<Option<UserPrivacyRow>, sqlx::Error> {
+    let PrivacyPartial {
+        read_receipts_enabled,
+        email_visible,
+        phone_visible,
+        email_discoverable,
+        phone_discoverable,
+        searchable,
+    } = partial;
+    sqlx::query_as::<_, UserPrivacyRow>(
+        "UPDATE users \
+         SET read_receipts_enabled = COALESCE($1, read_receipts_enabled), \
+             email_visible          = COALESCE($2, email_visible), \
+             phone_visible          = COALESCE($3, phone_visible), \
+             email_discoverable     = COALESCE($4, email_discoverable), \
+             phone_discoverable     = COALESCE($5, phone_discoverable), \
+             searchable             = COALESCE($6, searchable) \
+         WHERE id = $7 \
+         RETURNING read_receipts_enabled, allow_unencrypted_dm, \
+                  email_visible, phone_visible, email_discoverable, phone_discoverable, \
+                  searchable",
+    )
+    .bind(read_receipts_enabled)
+    .bind(email_visible)
+    .bind(phone_visible)
+    .bind(email_discoverable)
+    .bind(phone_discoverable)
+    .bind(searchable)
+    .bind(user_id)
+    .fetch_optional(pool)
     .await
 }
 

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -167,11 +167,13 @@ impl AppError {
             ErrorCode::Unauthorized
             | ErrorCode::InvalidCredentials
             | ErrorCode::TokenExpired
-            | ErrorCode::TokenRevoked
-            // NotMember was `AppError::unauthorized` at all existing call sites;
-            // keep 401 to avoid breaking existing tests.
-            | ErrorCode::NotMember => StatusCode::UNAUTHORIZED,
-            ErrorCode::Forbidden | ErrorCode::RegistrationDisabled => StatusCode::FORBIDDEN,
+            | ErrorCode::TokenRevoked => StatusCode::UNAUTHORIZED,
+            // TD-34: "not a member of this conversation" is a permission
+            // failure, not an authentication failure. Returning 401 made
+            // clients trigger a global re-auth/logout. 403 is correct.
+            ErrorCode::Forbidden | ErrorCode::RegistrationDisabled | ErrorCode::NotMember => {
+                StatusCode::FORBIDDEN
+            }
             ErrorCode::NotFound => StatusCode::NOT_FOUND,
             ErrorCode::Conflict | ErrorCode::UsernameTaken | ErrorCode::AlreadyMember => {
                 StatusCode::CONFLICT
@@ -220,7 +222,32 @@ impl IntoResponse for AppError {
 
 impl From<sqlx::Error> for AppError {
     fn from(err: sqlx::Error) -> Self {
-        tracing::error!("Database error: {:?}", err);
+        // TD-71: log structured fields instead of the raw Debug formatting.
+        // The Debug repr of a Postgres error can echo back column *values*
+        // from constraint violations (the unique-key column data, the
+        // failing FK row, etc.). That's a PII leak waiting to happen.
+        // Logging the SQLSTATE + constraint name keeps the operator
+        // diagnostic signal intact.
+        match &err {
+            sqlx::Error::Database(db_err) => {
+                tracing::error!(
+                    sqlstate = ?db_err.code(),
+                    constraint = ?db_err.constraint(),
+                    table = ?db_err.table(),
+                    "Database error (Postgres-side)",
+                );
+            }
+            sqlx::Error::PoolTimedOut => {
+                tracing::error!("Database error: pool acquire timed out");
+            }
+            sqlx::Error::Io(e) => {
+                tracing::error!(kind = ?e.kind(), "Database error: IO");
+            }
+            other => {
+                // Other variants don't carry row data; their Debug is safe.
+                tracing::error!("Database error: {:?}", other);
+            }
+        }
         match err {
             sqlx::Error::Database(ref db_err) => {
                 if db_err.code().as_deref() == Some("23505") {
@@ -396,11 +423,12 @@ mod tests {
     }
 
     #[test]
-    fn with_code_not_member_is_401() {
-        // NotMember maps to 401 to preserve all existing call sites which
-        // previously used AppError::unauthorized("Not a member...").
+    fn with_code_not_member_is_403() {
+        // TD-34: "not a member" is a permission failure, not an
+        // authentication failure. Returning 401 made clients trigger global
+        // re-auth/logout when they hit a stale conversation.
         let err = AppError::with_code(ErrorCode::NotMember, "Not a member");
-        assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.status, StatusCode::FORBIDDEN);
         assert_eq!(err.code, ErrorCode::NotMember);
     }
 

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -38,76 +38,135 @@ async fn main() {
         ticket_store: Arc::new(dashmap::DashMap::new()),
         media_tickets: Arc::new(dashmap::DashMap::new()),
         message_rate: Arc::new(echo_server::metrics::MessageRateCounter::new()),
+        token_invalidator: echo_server::auth::TokenInvalidator::new(),
     });
 
+    // TD-37: cooperative shutdown token. Every periodic task takes a clone
+    // and exits on `cancelled()`; the main task awaits all handles in the
+    // shutdown path so DELETE/UPDATE batches finish cleanly instead of being
+    // torn at an arbitrary instruction by tokio runtime drop.
+    let shutdown_token = tokio_util::sync::CancellationToken::new();
+    let mut periodic_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
     // Per-task cleanup loops with panic recovery; cadence per task.
-    spawn_periodic("voice_sessions", std::time::Duration::from_secs(60), {
-        let pool = pool.clone();
-        let hub = hub.clone();
-        move || {
+    periodic_handles.push(spawn_periodic(
+        "voice_sessions",
+        std::time::Duration::from_secs(60),
+        shutdown_token.clone(),
+        {
             let pool = pool.clone();
             let hub = hub.clone();
-            async move { cleanup_stale_voice_sessions(&pool, &hub).await }
-        }
-    });
-    spawn_periodic("expired_messages", std::time::Duration::from_secs(30), {
-        let pool = pool.clone();
-        let hub = hub.clone();
-        move || {
+            move || {
+                let pool = pool.clone();
+                let hub = hub.clone();
+                async move { cleanup_stale_voice_sessions(&pool, &hub).await }
+            }
+        },
+    ));
+    periodic_handles.push(spawn_periodic(
+        "expired_messages",
+        std::time::Duration::from_secs(30),
+        shutdown_token.clone(),
+        {
             let pool = pool.clone();
             let hub = hub.clone();
-            async move { cleanup_expired_messages(&pool, &hub).await }
-        }
-    });
-    spawn_periodic("expired_tokens", std::time::Duration::from_secs(600), {
-        let pool = pool.clone();
-        move || {
+            move || {
+                let pool = pool.clone();
+                let hub = hub.clone();
+                async move { cleanup_expired_messages(&pool, &hub).await }
+            }
+        },
+    ));
+    periodic_handles.push(spawn_periodic(
+        "expired_tokens",
+        std::time::Duration::from_secs(600),
+        shutdown_token.clone(),
+        {
             let pool = pool.clone();
-            async move { cleanup_expired_tokens(&pool).await }
-        }
-    });
-    spawn_periodic("used_prekeys", std::time::Duration::from_secs(600), {
-        let pool = pool.clone();
-        move || {
+            move || {
+                let pool = pool.clone();
+                async move { cleanup_expired_tokens(&pool).await }
+            }
+        },
+    ));
+    // TD-57: reap password-reset tokens hourly so the table doesn't grow
+    // under brute-force abuse.
+    periodic_handles.push(spawn_periodic(
+        "password_reset_tokens",
+        std::time::Duration::from_secs(3600),
+        shutdown_token.clone(),
+        {
             let pool = pool.clone();
-            async move { cleanup_used_prekeys(&pool).await }
-        }
-    });
-    spawn_periodic("empty_groups", std::time::Duration::from_secs(300), {
-        let pool = pool.clone();
-        move || {
+            move || {
+                let pool = pool.clone();
+                async move { cleanup_expired_password_reset_tokens(&pool).await }
+            }
+        },
+    ));
+    periodic_handles.push(spawn_periodic(
+        "used_prekeys",
+        std::time::Duration::from_secs(600),
+        shutdown_token.clone(),
+        {
             let pool = pool.clone();
-            async move { cleanup_empty_groups(&pool).await }
-        }
-    });
-    spawn_periodic("orphan_media", std::time::Duration::from_secs(3600), {
-        let pool = pool.clone();
-        move || {
+            move || {
+                let pool = pool.clone();
+                async move { cleanup_used_prekeys(&pool).await }
+            }
+        },
+    ));
+    periodic_handles.push(spawn_periodic(
+        "empty_groups",
+        std::time::Duration::from_secs(300),
+        shutdown_token.clone(),
+        {
             let pool = pool.clone();
-            async move { cleanup_orphan_media_files(&pool).await }
-        }
-    });
+            move || {
+                let pool = pool.clone();
+                async move { cleanup_empty_groups(&pool).await }
+            }
+        },
+    ));
+    periodic_handles.push(spawn_periodic(
+        "orphan_media",
+        std::time::Duration::from_secs(3600),
+        shutdown_token.clone(),
+        {
+            let pool = pool.clone();
+            move || {
+                let pool = pool.clone();
+                async move { cleanup_orphan_media_files(&pool).await }
+            }
+        },
+    ));
     // Sweep abandoned chunked-upload sessions hourly (#556).  Idle window is
     // 24 h so a user who closed their laptop overnight can still resume.
-    spawn_periodic("stale_uploads", std::time::Duration::from_secs(3600), {
-        let pool = pool.clone();
-        move || {
+    periodic_handles.push(spawn_periodic(
+        "stale_uploads",
+        std::time::Duration::from_secs(3600),
+        shutdown_token.clone(),
+        {
             let pool = pool.clone();
-            async move {
-                echo_server::routes::media_chunked::cleanup_stale_uploads(&pool, 24 * 60 * 60).await
+            move || {
+                let pool = pool.clone();
+                async move {
+                    echo_server::routes::media_chunked::cleanup_stale_uploads(&pool, 24 * 60 * 60)
+                        .await
+                }
             }
-        }
-    });
+        },
+    ));
 
     // Evict stale entries from the typing_service membership/member-ID/conv-kind
     // caches; without this, entries accumulate unboundedly on long-running servers.
-    spawn_periodic(
+    periodic_handles.push(spawn_periodic(
         "cache_sweep",
         std::time::Duration::from_secs(300),
+        shutdown_token.clone(),
         || async {
             ws::typing_service::sweep_expired_caches();
         },
-    );
+    ));
 
     let app = routes::create_router(state, config.trusted_proxies);
 
@@ -121,13 +180,23 @@ async fn main() {
         .await
         .expect("Failed to bind");
 
-    // Graceful shutdown via Ctrl+C
+    // Graceful shutdown via Ctrl+C — TD-37.
+    //
+    // Two-stage drain: (1) cancel the background-task token so periodic
+    // loops finish their current batch and exit; (2) let axum complete
+    // in-flight HTTP/WS responses via `with_graceful_shutdown`. After axum
+    // returns we await every periodic handle so the process only exits
+    // once each cleanup task is fully resolved.
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        tracing::info!("Shutting down gracefully...");
-        shutdown_tx.send(()).ok();
-    });
+    {
+        let shutdown_token = shutdown_token.clone();
+        tokio::spawn(async move {
+            tokio::signal::ctrl_c().await.ok();
+            tracing::info!("Shutting down gracefully...");
+            shutdown_token.cancel();
+            shutdown_tx.send(()).ok();
+        });
+    }
 
     axum::serve(
         listener,
@@ -138,11 +207,31 @@ async fn main() {
     })
     .await
     .expect("Server error");
+
+    // axum has stopped accepting new requests and drained in-flight ones;
+    // also ensure the background cleanup loops are fully wound down before
+    // the process exits.
+    shutdown_token.cancel();
+    for handle in periodic_handles {
+        if let Err(e) = handle.await {
+            tracing::warn!("periodic task join error during shutdown: {e}");
+        }
+    }
 }
 
-/// Periodic task with panic recovery. `make_fut` is a stateless re-creator;
-/// captured `Arc` clones make `AssertUnwindSafe` sound.
-fn spawn_periodic<F, Fut>(name: &'static str, period: std::time::Duration, mut make_fut: F)
+/// Periodic task with panic recovery and cooperative shutdown.
+///
+/// `make_fut` is a stateless re-creator; captured `Arc` clones make
+/// `AssertUnwindSafe` sound. The loop exits when `shutdown` fires so SIGTERM
+/// no longer tears DELETE statements at arbitrary instructions (TD-37). The
+/// returned `JoinHandle` is collected by `main` so we can await all
+/// outstanding periodic tasks during graceful shutdown.
+fn spawn_periodic<F, Fut>(
+    name: &'static str,
+    period: std::time::Duration,
+    shutdown: tokio_util::sync::CancellationToken,
+    mut make_fut: F,
+) -> tokio::task::JoinHandle<()>
 where
     F: FnMut() -> Fut + Send + 'static,
     Fut: std::future::Future<Output = ()> + Send + 'static,
@@ -154,13 +243,28 @@ where
         // server boot, when the pool may still be warming.
         interval.tick().await;
         loop {
-            interval.tick().await;
+            tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => {
+                    tracing::debug!(task = name, "periodic task shutting down");
+                    return;
+                }
+                _ = interval.tick() => {}
+            }
+
+            // Inside the tick, also race the work future against shutdown so
+            // we don't begin a fresh DELETE/UPDATE batch when the operator is
+            // already trying to bring the server down.
             let fut = make_fut();
-            // catch_unwind requires Unpin; box-pin the future so we can
-            // call AssertUnwindSafe + catch_unwind on it.
-            let result = std::panic::AssertUnwindSafe(Box::pin(fut))
-                .catch_unwind()
-                .await;
+            let work = std::panic::AssertUnwindSafe(Box::pin(fut)).catch_unwind();
+            let result = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => {
+                    tracing::debug!(task = name, "periodic task shutting down mid-batch");
+                    return;
+                }
+                r = work => r,
+            };
             if let Err(panic) = result {
                 tracing::error!(
                     task = name,
@@ -173,7 +277,7 @@ where
                 );
             }
         }
-    });
+    })
 }
 
 /// Remove voice sessions not updated within 2 minutes and broadcast leave events.
@@ -262,6 +366,32 @@ async fn cleanup_expired_tokens(pool: &PgPool) {
     }
 }
 
+/// TD-57: reap expired password-reset tokens (used or unused) so the table
+/// doesn't grow unboundedly under brute-force abuse. The 24-hour cliff is
+/// loose enough that any pending support flow has finished; consumed
+/// tokens are also pruned by `used_at` so we don't keep a permanent record
+/// of every reset request.
+async fn cleanup_expired_password_reset_tokens(pool: &PgPool) {
+    let result = sqlx::query(
+        "DELETE FROM password_reset_tokens \
+         WHERE expires_at < now() - interval '24 hours' \
+            OR used_at IS NOT NULL",
+    )
+    .execute(pool)
+    .await;
+
+    match result {
+        Ok(r) if r.rows_affected() > 0 => {
+            tracing::info!(
+                "Cleaned {} expired/consumed password-reset tokens",
+                r.rows_affected()
+            );
+        }
+        Err(e) => tracing::warn!("Password-reset token cleanup error: {e}"),
+        _ => {}
+    }
+}
+
 /// Remove consumed one-time prekeys that are no longer needed.
 async fn cleanup_used_prekeys(pool: &PgPool) {
     let result = sqlx::query("DELETE FROM one_time_prekeys WHERE used = true")
@@ -279,39 +409,67 @@ async fn cleanup_used_prekeys(pool: &PgPool) {
 
 /// Delete messages whose `expires_at` has passed and broadcast `message_expired`
 /// events to all online members of each affected conversation.
+///
+/// TD-52: batched + member-list cached per-conversation. The DB query
+/// returns up to 500 expirations at a time; we re-invoke it in a loop
+/// until empty so a 10 000-message backlog drains without holding the
+/// whole list in memory. Per-conversation member fetches are now cached
+/// for the duration of one sweep — previously a 1 000-message group
+/// expiry triggered 1 000 identical SELECTs.
 async fn cleanup_expired_messages(pool: &PgPool, hub: &ws::hub::Hub) {
-    let expired = match db::messages::cleanup_expired_messages(pool).await {
-        Ok(rows) => rows,
-        Err(e) => {
-            tracing::warn!("Expired message cleanup error: {e}");
-            return;
+    let mut total = 0usize;
+    loop {
+        let expired = match db::messages::cleanup_expired_messages(pool).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::warn!("Expired message cleanup error: {e}");
+                return;
+            }
+        };
+
+        if expired.is_empty() {
+            break;
         }
-    };
+        let batch_len = expired.len();
+        total += batch_len;
 
-    if expired.is_empty() {
-        return;
-    }
+        // Group by conversation_id so each member-list fetch happens once
+        // per conversation per batch.
+        let mut by_conv: std::collections::HashMap<uuid::Uuid, Vec<uuid::Uuid>> =
+            std::collections::HashMap::new();
+        for (message_id, conversation_id) in expired {
+            by_conv.entry(conversation_id).or_default().push(message_id);
+        }
 
-    tracing::info!("Cleaned {} expired messages", expired.len());
-
-    for (message_id, conversation_id) in expired {
-        // Notify all online members of the conversation.
-        let member_ids = match db::groups::get_conversation_member_ids(pool, conversation_id).await
-        {
-            Ok(ids) => ids,
-            Err(_) => continue,
-        };
-
-        let event = ServerMessage::MessageExpired {
-            message_id,
-            conversation_id,
-        };
-        if let Ok(json) = serde_json::to_string(&event) {
-            let msg = WsMessage::Text(json.as_str().into());
-            for member_id in &member_ids {
-                hub.send_to(member_id, msg.clone());
+        for (conversation_id, message_ids) in by_conv {
+            let member_ids =
+                match db::groups::get_conversation_member_ids(pool, conversation_id).await {
+                    Ok(ids) => ids,
+                    Err(_) => continue,
+                };
+            for message_id in message_ids {
+                let event = ServerMessage::MessageExpired {
+                    message_id,
+                    conversation_id,
+                };
+                if let Ok(json) = serde_json::to_string(&event) {
+                    let msg = WsMessage::Text(json.as_str().into());
+                    for member_id in &member_ids {
+                        hub.send_to(member_id, msg.clone());
+                    }
+                }
             }
         }
+
+        // Smaller backlogs finish in one batch; bail out of the loop early
+        // so we don't busy-poll an empty query right after.
+        if batch_len < 500 {
+            break;
+        }
+    }
+
+    if total > 0 {
+        tracing::info!("Cleaned {total} expired messages");
     }
 }
 

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -307,16 +307,24 @@ pub fn reset_password_limiter(trusted_proxies: Arc<Vec<IpNet>>) -> RateLimiter {
 }
 
 /// Check whether an IP is in a private/reserved range (RFC 1918, link-local, ULA).
+///
+/// TD-32: IPv4-mapped IPv6 (`::ffff:10.0.0.1`) must be unwrapped before the
+/// v4 private-range check. Without this, a trusted proxy that passes the
+/// mapped form lets an attacker choose the rate-limit bucket key.
 fn is_private(ip: IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local() || v4.is_loopback(),
         IpAddr::V6(v6) => {
+            // Unwrap IPv4-mapped IPv6 first: ::ffff:0:0/96 wraps a real v4.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return v4.is_private() || v4.is_link_local() || v4.is_loopback();
+            }
             // ULA: fc00::/7 (first byte 0xFC or 0xFD)
             let first_segment = v6.segments()[0];
             let is_ula = (first_segment & 0xfe00) == 0xfc00;
             // Link-local: fe80::/10
             let is_link_local = (first_segment & 0xffc0) == 0xfe80;
-            is_ula || is_link_local
+            is_ula || is_link_local || v6.is_loopback()
         }
     }
 }
@@ -423,6 +431,40 @@ mod tests {
         assert!(!is_private(IpAddr::V6(Ipv6Addr::new(
             0x2001, 0xdb8, 0, 0, 0, 0, 0, 1
         ))));
+    }
+
+    #[test]
+    fn test_is_private_ipv4_mapped_ipv6() {
+        // TD-32: ::ffff:10.0.0.1 must be treated as the private v4 10.0.0.1.
+        // Without unwrapping, a trusted proxy passing the mapped form would
+        // let an attacker pick the rate-limit bucket key.
+        let mapped_private = IpAddr::V6(Ipv4Addr::new(10, 0, 0, 1).to_ipv6_mapped());
+        assert!(
+            is_private(mapped_private),
+            "::ffff:10.0.0.1 must be private"
+        );
+
+        let mapped_loopback = IpAddr::V6(Ipv4Addr::new(127, 0, 0, 1).to_ipv6_mapped());
+        assert!(
+            is_private(mapped_loopback),
+            "::ffff:127.0.0.1 must be private (loopback)"
+        );
+
+        let mapped_link_local = IpAddr::V6(Ipv4Addr::new(169, 254, 1, 1).to_ipv6_mapped());
+        assert!(
+            is_private(mapped_link_local),
+            "::ffff:169.254.x.x must be private (link-local)"
+        );
+
+        // Mapped public IPv4 must still be public.
+        let mapped_public = IpAddr::V6(Ipv4Addr::new(8, 8, 8, 8).to_ipv6_mapped());
+        assert!(!is_private(mapped_public), "::ffff:8.8.8.8 must be public");
+    }
+
+    #[test]
+    fn test_is_private_ipv6_loopback() {
+        // ::1 (loopback) was previously not detected; tightened with TD-32.
+        assert!(is_private(IpAddr::V6(Ipv6Addr::LOCALHOST)));
     }
 
     /// Helper: build a request with ConnectInfo set to the given address.

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -181,13 +181,28 @@ pub async fn notify_offline_users(
         return;
     }
 
+    // TD-58: fan out APNs pushes concurrently with a bounded semaphore so a
+    // 50-recipient group doesn't serialise N×50–200 ms HTTP RTTs in one
+    // tokio task. APNs HTTP/2 connections support multiple streams so 16
+    // concurrent sends per call is well within their per-connection budget
+    // and keeps the latency under ~1 s for typical group sizes.
+    use futures_util::stream::StreamExt;
     let pool = pool.clone();
-    for (user_id, token, platform) in &tokens {
-        if platform.as_str() == "apns" {
+    const PUSH_FANOUT_CONCURRENCY: usize = 16;
+    futures_util::stream::iter(tokens.into_iter().filter_map(|(uid, tok, plat)| {
+        if plat.as_str() == "apns" {
+            Some((uid, tok))
+        } else {
+            None
+        }
+    }))
+    .for_each_concurrent(PUSH_FANOUT_CONCURRENCY, |(user_id, token)| {
+        let pool = pool.clone();
+        async move {
             send_apns_push(ApnsPushParams {
                 pool: &pool,
-                user_id: *user_id,
-                device_token: token,
+                user_id,
+                device_token: &token,
                 sender_username,
                 content,
                 is_encrypted,
@@ -196,7 +211,8 @@ pub async fn notify_offline_users(
             })
             .await;
         }
-    }
+    })
+    .await;
 }
 
 struct ApnsPushParams<'a> {

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -4,10 +4,12 @@
 use axum::Json;
 use axum::extract::State;
 use axum::extract::rejection::JsonRejection;
+use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 
 use crate::auth::middleware::AuthUser;
 use crate::auth::{jwt, password};
@@ -47,6 +49,57 @@ fn build_refresh_cookie(value: String) -> Cookie<'static> {
         .path("/api/auth")
         .max_age(time::Duration::seconds(REFRESH_COOKIE_MAX_AGE_SECS))
         .build()
+}
+
+/// TD-43: enforce an Origin-header check on the two cookie-credentialed
+/// endpoints (`/refresh` and `/logout`) so a malicious page served by an
+/// origin **not** in `CORS_ORIGINS` cannot fire a credentialed
+/// `fetch(..., {credentials: 'include'})` to forcibly rotate or kill the
+/// user's session.
+///
+/// Browsers send `Origin:` on all credentialed cross-origin fetches; same-
+/// origin requests typically send it too on POST. We accept the request
+/// only when `Origin` is either absent (non-browser clients like our
+/// mobile/desktop apps don't set it) or matches an entry in the parsed
+/// allow-list.
+fn allowed_origins() -> &'static [String] {
+    static LIST: OnceLock<Vec<String>> = OnceLock::new();
+    LIST.get_or_init(|| {
+        let raw = std::env::var("CORS_ORIGINS").unwrap_or_else(|_| {
+            "https://echo-messenger.us,https://web.echo-messenger.us,http://localhost:8081".into()
+        });
+        if raw.trim() == "*" {
+            // Wildcard CORS disables credentials anyway — no Origin check
+            // applies, leave empty so `validate_origin_for_credentialed` is
+            // a no-op.
+            return Vec::new();
+        }
+        raw.split(',')
+            .map(|s| s.trim().trim_end_matches('/').to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    })
+}
+
+/// Returns Err(AppError::forbidden) when the request carries an `Origin`
+/// header outside the allow-list. Absent header is allowed (mobile/desktop).
+fn validate_origin_for_credentialed(headers: &HeaderMap) -> Result<(), AppError> {
+    let Some(origin_val) = headers.get(axum::http::header::ORIGIN) else {
+        return Ok(());
+    };
+    let Ok(origin) = origin_val.to_str() else {
+        return Err(AppError::forbidden("Invalid Origin header"));
+    };
+    let normalised = origin.trim_end_matches('/');
+    let allow = allowed_origins();
+    if allow.is_empty() || allow.iter().any(|o| o == normalised) {
+        return Ok(());
+    }
+    tracing::warn!(
+        origin = %origin,
+        "rejected credentialed request from non-allowed Origin"
+    );
+    Err(AppError::forbidden("Origin not in credentialed allow-list"))
 }
 
 fn clear_refresh_cookie() -> Cookie<'static> {
@@ -262,6 +315,7 @@ pub async fn login(
 /// code path.
 pub async fn refresh(
     State(state): State<AuthExtract>,
+    headers: HeaderMap,
     jar: CookieJar,
     // `Result<Json<_>, _>` (not `Option<Json<_>>`): when the web client sends
     // `Content-Type: application/json` with a zero-length body, axum's
@@ -271,6 +325,10 @@ pub async fn refresh(
     // cookie is still readable and the request can succeed.
     body: Result<Json<RefreshRequest>, JsonRejection>,
 ) -> Result<impl IntoResponse, AppError> {
+    // TD-43: forbid credentialed cookie use from origins outside the
+    // allow-list. Absent Origin (mobile/desktop) passes through.
+    validate_origin_for_credentialed(&headers)?;
+
     // Cookie wins when both are present so the web client's HttpOnly cookie
     // can never be silently overridden by a malicious JSON body. Mobile/desktop
     // clients keep sending the token in the body and that path still works.
@@ -426,10 +484,17 @@ pub async fn refresh(
 
 pub async fn logout(
     State(state): State<AuthExtract>,
+    headers: HeaderMap,
     jar: CookieJar,
     auth_user: AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
+    // TD-43: cookie-credentialed endpoint — bounce non-allowed Origins.
+    validate_origin_for_credentialed(&headers)?;
+
     db::tokens::revoke_all_user_tokens(&state.pool, auth_user.user_id).await?;
+    // CR-4: invalidate the access token immediately so it cannot be used
+    // for the remainder of its 15-minute TTL.
+    state.token_invalidator.invalidate(auth_user.user_id);
     let jar = jar.add(clear_refresh_cookie());
     // Convention: StatusCode first, then CookieJar, matching register/login.
     Ok((StatusCode::NO_CONTENT, jar))
@@ -482,25 +547,26 @@ pub async fn forgot_password(
             .await
             .is_ok()
         {
+            // SECURITY: never log the token. A token in the log stream is a
+            // 15-minute account-takeover oracle for anyone with log-read
+            // access (Loki, CloudWatch, syslog, dev workstation). Operators
+            // honor a reset by reading the `password_reset_tokens` table
+            // directly and delivering the token out-of-band.
             tracing::info!(
-                username = %body.username,
                 user_id = %user.id,
-                token = %token,
                 expires = %expires_at,
-                "[manual reset] User '{}' requested a password reset. \
-                 Token: {}. Expires: {}. \
-                 To honor: deliver this token to the user out-of-band \
-                 (e.g. direct message or support reply) so they can paste \
-                 it into the reset-password screen.",
-                body.username,
-                token,
-                expires_at,
+                "[manual reset] Password reset requested. \
+                 Read the token row from `password_reset_tokens` and \
+                 deliver it to the user out-of-band.",
             );
         }
     }
 
     // Always 200 -- do not reveal whether the username exists.
-    Ok(StatusCode::OK)
+    // TD-73: return a JSON body for consistency with the rest of the API;
+    // some HTTP clients (and older fetch wrappers) trip on an empty body
+    // when the response carries a Content-Type expectation.
+    Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))))
 }
 
 // ---------------------------------------------------------------------------
@@ -536,21 +602,36 @@ pub async fn reset_password(
         .await
         .map_err(|_| AppError::internal("Password hashing failed"))??;
 
-    db::users::update_password(&state.pool, row.user_id, &new_hash)
+    // All three writes must succeed or fail together: a partial apply lets
+    // the same reset token be replayed once the next write recovers.
+    let mut tx = state
+        .pool
+        .begin()
         .await
         .map_err(|_| AppError::internal("Database error"))?;
 
-    // Mark token consumed before revoking sessions so a crash between the
-    // two steps leaves the token unusable rather than sessions valid.
-    db::password_reset::consume_token(&state.pool, &body.token)
+    db::users::update_password(&mut *tx, row.user_id, &new_hash)
+        .await
+        .map_err(|_| AppError::internal("Database error"))?;
+
+    db::password_reset::consume_token(&mut *tx, &body.token)
         .await
         .map_err(|_| AppError::internal("Database error"))?;
 
     // Revoke all existing refresh tokens so any active sessions are
     // invalidated -- the password change may be the result of a compromise.
-    db::tokens::revoke_all_user_tokens(&state.pool, row.user_id)
+    db::tokens::revoke_all_user_tokens(&mut *tx, row.user_id)
         .await
         .map_err(|_| AppError::internal("Database error"))?;
+
+    tx.commit()
+        .await
+        .map_err(|_| AppError::internal("Database error"))?;
+
+    // CR-4: invalidate outstanding 15-minute access tokens after the
+    // password change commits. Refresh tokens were already revoked inside
+    // the tx; this closes the access-token side of the same window.
+    state.token_invalidator.invalidate(row.user_id);
 
     tracing::info!(
         user_id = %row.user_id,

--- a/apps/server/src/routes/groups/members.rs
+++ b/apps/server/src/routes/groups/members.rs
@@ -15,6 +15,29 @@ use crate::ws::typing_service::invalidate_member_cache;
 
 use super::super::AppState;
 
+/// TD-33: per-(group, target) advisory lock taken at the top of every member
+/// mutation tx. Two `(i32, i32)`-keyed advisory locks serialise concurrent
+/// admins targeting the same user in the same conversation without ever
+/// blocking unrelated mutations. The two `hashtext` slots are derived from
+/// the UUID strings so the lock identity is stable across reconnects.
+///
+/// We use the `(i32, i32)` form of `pg_advisory_xact_lock` so the two halves
+/// of the key live in 64 bits without 32-bit truncation that
+/// `hashtextextended` would force. Released automatically at tx end.
+async fn acquire_member_lock(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    group_id: Uuid,
+    target_user_id: Uuid,
+) -> Result<(), AppError> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))")
+        .bind(group_id.to_string())
+        .bind(target_user_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .db_ctx("acquire_member_lock")?;
+    Ok(())
+}
+
 /// Rotate the group key after a member loses access.
 ///
 /// On encrypted groups, bump the conversation's `key_version`, purge every
@@ -144,20 +167,36 @@ async fn broadcast_member_system_message(
 }
 
 /// POST /api/groups/:id/members -- Add a member to a group.
+///
+/// TD-33: the mutation runs inside a single transaction protected by a
+/// per-(group, target) `pg_advisory_xact_lock` so two concurrent admins
+/// cannot both read "user is not yet a member" and both insert. The lock
+/// also serialises against [`remove_member`] / [`ban_member`] on the same
+/// pair, so toggling can't be observed mid-flight by either operator.
 pub async fn add_member(
     auth: AuthUser,
     State(state): State<Arc<AppState>>,
     Path(group_id): Path<Uuid>,
     Json(body): Json<super::types::AddMemberRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    // Verify target user exists (cheap read; outside the tx is fine).
+    let user_exists = db::users::find_by_id(&state.pool, body.user_id)
+        .await
+        .db_ctx("add_member/find_user")?
+        .ok_or_else(|| AppError::not_found("User not found"))?;
+
+    let mut tx = state.pool.begin().await.db_ctx("add_member/begin_tx")?;
+
+    acquire_member_lock(&mut tx, group_id, body.user_id).await?;
+
     // Verify caller is a member and get their role
-    let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
+    let caller_role = db::groups::get_member_role(&mut *tx, group_id, auth.user_id)
         .await
         .db_ctx("add_member/get_caller_role")?
         .ok_or_else(|| AppError::with_code(ErrorCode::NotMember, "Not a member of this group"))?;
 
     // Verify it's a group conversation
-    let kind = db::groups::get_conversation_kind(&state.pool, group_id)
+    let kind = db::groups::get_conversation_kind(&mut *tx, group_id)
         .await
         .db_ctx("add_member/get_conversation_kind")?;
 
@@ -166,7 +205,7 @@ pub async fn add_member(
     }
 
     // For private groups, only owner or admin can add members
-    let is_public = db::groups::is_public(&state.pool, group_id)
+    let is_public = db::groups::is_public(&mut *tx, group_id)
         .await
         .db_ctx("add_member/is_public")?;
 
@@ -177,17 +216,8 @@ pub async fn add_member(
         ));
     }
 
-    // Verify target user exists
-    let user_exists = db::users::find_by_id(&state.pool, body.user_id)
-        .await
-        .db_ctx("add_member/find_user")?;
-
-    if user_exists.is_none() {
-        return Err(AppError::bad_request("User not found"));
-    }
-
     // Check if target user is banned
-    let banned = db::groups::is_banned(&state.pool, group_id, body.user_id)
+    let banned = db::groups::is_banned(&mut *tx, group_id, body.user_id)
         .await
         .db_ctx("add_member/is_banned")?;
     if banned {
@@ -195,7 +225,7 @@ pub async fn add_member(
     }
 
     // Check if already an active member
-    let already_member = db::groups::is_member(&state.pool, group_id, body.user_id)
+    let already_member = db::groups::is_member(&mut *tx, group_id, body.user_id)
         .await
         .db_ctx("add_member/is_member")?;
     if already_member {
@@ -205,7 +235,7 @@ pub async fn add_member(
         ));
     }
 
-    let added = db::groups::add_member(&state.pool, group_id, body.user_id)
+    let added = db::groups::add_member_in_tx(&mut tx, group_id, body.user_id)
         .await
         .db_ctx("add_member/insert")?;
 
@@ -216,20 +246,26 @@ pub async fn add_member(
         ));
     }
 
+    // Fetch the canonical member list once inside the tx. Previously this
+    // happened twice (once for the `member_added` broadcast and once for
+    // the system-message broadcast); the duplicate fetch could even
+    // observe a stale list when other mutations raced.
+    let all_members = db::groups::get_conversation_member_ids(&mut *tx, group_id)
+        .await
+        .unwrap_or_default();
+
+    tx.commit().await.db_ctx("add_member/commit")?;
+
     invalidate_member_cache(group_id);
 
     // Notify existing members that someone was added so their member list
     // updates in real time without a manual refresh (#660).
-    let new_user = user_exists.unwrap(); // already checked is_some above
-    let existing_members = db::groups::get_conversation_member_ids(&state.pool, group_id)
-        .await
-        .unwrap_or_default();
     let event = serde_json::json!({
         "type": "member_added",
         "conversation_id": group_id,
         "user_id": body.user_id,
-        "username": new_user.username,
-        "avatar_url": new_user.avatar_url,
+        "username": user_exists.username,
+        "avatar_url": user_exists.avatar_url,
         "role": "member",
     });
     if let Ok(s) = serde_json::to_string(&event) {
@@ -237,25 +273,22 @@ pub async fn add_member(
         // loadConversations call after the HTTP 200.
         state
             .hub
-            .broadcast_json(&existing_members, &s, Some(body.user_id));
+            .broadcast_json(&all_members, &s, Some(body.user_id));
     }
 
     // Persist a system message and broadcast as new_message so all members see
     // an in-chat "X joined" pill in real time (#663).
     let sentinel = format!(
         "__system__:member_joined:{}:{}",
-        body.user_id, new_user.username
+        body.user_id, user_exists.username
     );
-    let all_members = db::groups::get_conversation_member_ids(&state.pool, group_id)
-        .await
-        .unwrap_or_default();
     broadcast_member_system_message(
         &state,
         group_id,
         body.user_id,
         &sentinel,
         body.user_id,
-        &new_user.username,
+        &user_exists.username,
         &all_members,
     )
     .await;
@@ -264,13 +297,22 @@ pub async fn add_member(
 }
 
 /// DELETE /api/groups/:id/members/:user_id -- Remove a member from a group.
+///
+/// TD-33: caller-role read, target-role read, and the soft-delete all share
+/// one transaction protected by [`acquire_member_lock`], so two concurrent
+/// admin actions on the same (group, target) pair can't both observe the
+/// pre-mutation state.
 pub async fn remove_member(
     auth: AuthUser,
     State(state): State<Arc<AppState>>,
     Path((group_id, target_user_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, AppError> {
+    let mut tx = state.pool.begin().await.db_ctx("remove_member/begin_tx")?;
+
+    acquire_member_lock(&mut tx, group_id, target_user_id).await?;
+
     // Verify caller is a member and get their role
-    let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
+    let caller_role = db::groups::get_member_role(&mut *tx, group_id, auth.user_id)
         .await
         .db_ctx("remove_member/get_caller_role")?
         .ok_or_else(|| AppError::with_code(ErrorCode::NotMember, "Not a member of this group"))?;
@@ -285,7 +327,7 @@ pub async fn remove_member(
 
     // Prevent removing the owner
     if target_user_id != auth.user_id {
-        let target_role = db::groups::get_member_role(&state.pool, group_id, target_user_id)
+        let target_role = db::groups::get_member_role(&mut *tx, group_id, target_user_id)
             .await
             .db_ctx("remove_member/get_target_role")?;
         if target_role.as_deref().and_then(Role::from_str_opt) == Some(Role::Owner) {
@@ -293,13 +335,15 @@ pub async fn remove_member(
         }
     }
 
-    let removed = db::groups::remove_member(&state.pool, group_id, target_user_id)
+    let removed = db::groups::remove_member_in_tx(&mut tx, group_id, target_user_id)
         .await
         .db_ctx("remove_member/delete")?;
 
     if !removed {
         return Err(AppError::bad_request("User is not a member of this group"));
     }
+
+    tx.commit().await.db_ctx("remove_member/commit")?;
 
     invalidate_member_cache(group_id);
 
@@ -316,12 +360,19 @@ pub async fn remove_member(
 }
 
 /// POST /api/groups/:id/ban/:user_id -- Ban a member from a group.
+///
+/// TD-33: guard reads + soft-delete + banned_members upsert share one tx
+/// protected by [`acquire_member_lock`].
 pub async fn ban_member(
     auth: AuthUser,
     State(state): State<Arc<AppState>>,
     Path((group_id, target_user_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, AppError> {
-    let caller_role = db::groups::get_member_role(&state.pool, group_id, auth.user_id)
+    let mut tx = state.pool.begin().await.db_ctx("ban_member/begin_tx")?;
+
+    acquire_member_lock(&mut tx, group_id, target_user_id).await?;
+
+    let caller_role = db::groups::get_member_role(&mut *tx, group_id, auth.user_id)
         .await
         .db_ctx("ban_member/get_caller_role")?
         .ok_or_else(|| AppError::with_code(ErrorCode::NotMember, "Not a member of this group"))?;
@@ -334,7 +385,7 @@ pub async fn ban_member(
     }
 
     // Prevent banning the owner or peers of equal rank
-    let target_role = db::groups::get_member_role(&state.pool, group_id, target_user_id)
+    let target_role = db::groups::get_member_role(&mut *tx, group_id, target_user_id)
         .await
         .db_ctx("ban_member/get_target_role")?;
     let target_role_enum = target_role
@@ -348,9 +399,11 @@ pub async fn ban_member(
         return Err(AppError::bad_request("Only the group owner can ban admins"));
     }
 
-    db::groups::ban_member(&state.pool, group_id, target_user_id, auth.user_id)
+    db::groups::ban_member_in_tx(&mut tx, group_id, target_user_id, auth.user_id)
         .await
         .db_ctx("ban_member/insert")?;
+
+    tx.commit().await.db_ctx("ban_member/commit")?;
 
     invalidate_member_cache(group_id);
 

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -312,23 +312,20 @@ pub async fn get_bundle(
     _auth_user: AuthUser,
     Path(user_id): Path<Uuid>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Try device 0 first (legacy single-device clients)
+    // Try device 0 first (legacy single-device clients). TD-53: when no
+    // device-0 row exists, ask the DB for the *lowest* active device id in
+    // a single query instead of looping over `get_user_devices` and firing
+    // a 3-statement `get_prekey_bundle` per device.
     let bundle = match db::keys::get_prekey_bundle(&state.pool, user_id, 0).await? {
         Some(b) => b,
-        None => {
-            // No device 0 — find the most recently registered device and use that
-            let devices = db::keys::get_user_devices(&state.pool, user_id).await?;
-            let mut found = None;
-            for device in devices {
-                if let Some(b) =
-                    db::keys::get_prekey_bundle(&state.pool, user_id, device.device_id).await?
-                {
-                    found = Some(b);
-                    break;
-                }
+        None => match db::keys::get_first_active_device_id(&state.pool, user_id).await? {
+            Some(dev_id) => db::keys::get_prekey_bundle(&state.pool, user_id, dev_id)
+                .await?
+                .ok_or_else(|| AppError::not_found("No PreKey bundle found for this user"))?,
+            None => {
+                return Err(AppError::not_found("No PreKey bundle found for this user"));
             }
-            found.ok_or_else(|| AppError::bad_request("No PreKey bundle found for this user"))?
-        }
+        },
     };
 
     let signing_key = require_signing_key(&bundle, user_id)?;
@@ -357,7 +354,7 @@ pub async fn get_device_bundle(
     let bundle = db::keys::get_prekey_bundle(&state.pool, user_id, device_id)
         .await?
         .ok_or_else(|| {
-            AppError::bad_request("No PreKey bundle found for this user/device combination")
+            AppError::not_found("No PreKey bundle found for this user/device combination")
         })?;
 
     let signing_key = require_signing_key(&bundle, user_id)?;
@@ -461,6 +458,10 @@ pub async fn revoke_device(
         });
     }
 
+    // CR-4: invalidate every outstanding access token for this user so the
+    // revoked device's 15-minute JWT cannot continue to authorize REST calls.
+    state.token_invalidator.invalidate(auth_user.user_id);
+
     // Notify all of this user's active sessions so they can handle the revocation.
     let event = ServerMessage::DeviceRevoked { device_id };
     if let Ok(json) = serde_json::to_string(&event) {
@@ -511,6 +512,13 @@ pub async fn revoke_other_devices(
             .await
             .db_ctx("revoke_other_devices")?;
 
+    // CR-4: invalidate every outstanding access token for this user. The
+    // current_device_id keeps its session via the next /refresh + login; the
+    // dropped devices lose access immediately rather than at JWT TTL.
+    if !revoked_ids.is_empty() {
+        state.token_invalidator.invalidate(auth_user.user_id);
+    }
+
     for device_id in &revoked_ids {
         let event = ServerMessage::DeviceRevoked {
             device_id: *device_id,
@@ -557,7 +565,7 @@ pub async fn reset_keys(
     let user = db::users::find_by_id(&state.pool, auth_user.user_id)
         .await
         .db_ctx("reset_keys/find_user")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
+        .ok_or_else(|| AppError::not_found("User not found"))?;
 
     let pw = body.password.clone();
     let hash = user.password_hash.clone();
@@ -621,7 +629,7 @@ pub async fn reset_device(
     let user = db::users::find_by_id(&state.pool, auth_user.user_id)
         .await
         .db_ctx("reset_device/find_user")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
+        .ok_or_else(|| AppError::not_found("User not found"))?;
 
     let pw = body.password.clone();
     let hash = user.password_hash.clone();
@@ -633,12 +641,22 @@ pub async fn reset_device(
     }
 
     // Clear the device's fingerprint AND delete its identity_keys row +
-    // signed/one-time prekeys so the next upload binds cleanly. Use the
-    // existing `revoke_device` helper for the cascade delete; the partial
-    // index ignores rows where fingerprint is NULL so cleared rows do not
-    // bloat lookups.
-    db::keys::clear_device_fingerprint(&state.pool, auth_user.user_id, body.device_id).await?;
-    db::keys::revoke_device(&state.pool, auth_user.user_id, body.device_id).await?;
+    // signed/one-time prekeys so the next upload binds cleanly. Both steps
+    // must commit together; a crash between them previously left the
+    // identity slot half-cleared and the next bundle upload could rebind
+    // to a different identity silently (TD-38).
+    let mut tx = state.pool.begin().await.db_ctx("reset_device/begin_tx")?;
+    db::keys::clear_device_fingerprint(&mut *tx, auth_user.user_id, body.device_id)
+        .await
+        .db_ctx("reset_device/clear_fingerprint")?;
+    db::keys::revoke_device_in_tx(&mut tx, auth_user.user_id, body.device_id)
+        .await
+        .db_ctx("reset_device/revoke")?;
+    tx.commit().await.db_ctx("reset_device/commit")?;
+
+    // CR-4: a device key-reset invalidates the device's outstanding access
+    // tokens — match the revoke_device behaviour.
+    state.token_invalidator.invalidate(auth_user.user_id);
 
     tracing::info!(
         "Device key reset for user {} device {}",

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -3,14 +3,51 @@
 use axum::Json;
 use axum::extract::State;
 use futures_util::StreamExt;
+use ipnet::{IpNet, Ipv4Net};
 use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::auth::middleware::AuthUser;
 use crate::error::AppError;
 
 use super::AppState;
+
+/// Special-use IPv4 ranges that must be rejected in addition to the standard
+/// `is_private()` / `is_link_local()` / `is_loopback()` checks. Catches
+/// addresses that resolve from public DNS but route to cloud-internal services
+/// (CGNAT, benchmark ranges, multicast, etc.).
+///
+/// TD-31. See IANA Special-Purpose Address Registry (RFC 6890).
+fn ssrf_v4_denylist() -> &'static [Ipv4Net] {
+    static DENY: OnceLock<Vec<Ipv4Net>> = OnceLock::new();
+    DENY.get_or_init(|| {
+        [
+            "0.0.0.0/8", // "this network" — already covered by is_unspecified for ::0 but the /8 isn't
+            "100.64.0.0/10", // CGNAT — cloud edge networks often route private services here
+            "127.0.0.0/8", // loopback — `is_loopback` only covers 127.0.0.1
+            "169.254.0.0/16", // link-local — `is_link_local` already covers, kept for clarity
+            "192.0.0.0/24", // IETF Protocol Assignments
+            "192.0.2.0/24", // TEST-NET-1 (docs)
+            "192.168.0.0/16", // RFC 1918
+            "198.18.0.0/15", // Benchmarking (RFC 2544)
+            "198.51.100.0/24", // TEST-NET-2
+            "203.0.113.0/24", // TEST-NET-3
+            "224.0.0.0/4", // Multicast — fan-out + smurf-amplification vector
+            "240.0.0.0/4", // Reserved future use / 255.255.255.255 broadcast
+        ]
+        .iter()
+        .map(|s| s.parse().expect("denylist CIDR must parse"))
+        .collect()
+    })
+}
+
+/// Ports we'll fetch on. Anything else (Redis, Memcached, internal admin
+/// interfaces on 8080, 9200 for ElasticSearch, …) is rejected to limit the
+/// SSRF blast radius even if a future bug let a private IP through.
+const ALLOWED_PORTS: &[u16] = &[80, 443];
 
 #[derive(Deserialize)]
 pub struct LinkPreviewRequest {
@@ -43,6 +80,7 @@ fn cap_html(html: &str) -> &str {
 }
 
 /// Resolved URL metadata returned by [`validate_url`].
+#[derive(Debug)]
 struct ValidatedUrl {
     /// The original URL string.
     url: reqwest::Url,
@@ -54,12 +92,53 @@ struct ValidatedUrl {
     resolved: std::net::SocketAddr,
 }
 
+/// True if `v4` falls into any of [`ssrf_v4_denylist`].
+fn is_v4_denied(v4: Ipv4Addr) -> bool {
+    let addr = IpNet::from(std::net::IpAddr::V4(v4));
+    ssrf_v4_denylist()
+        .iter()
+        .any(|net| IpNet::V4(*net).contains(&addr))
+}
+
+/// Reject SSRF-vulnerable IPs across v4 and v6, including IPv4-mapped IPv6.
+///
+/// TD-31: the previous implementation missed CGNAT, multicast, TEST-NETs,
+/// and benchmarking ranges. Consolidates the v6 IPv4-mapped path into the
+/// v4 check.
+fn is_ssrf_target(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_link_local()
+                || v4.is_private()
+                || is_v4_denied(v4)
+        }
+        std::net::IpAddr::V6(v6) => {
+            if v6.is_loopback() || v6.is_unspecified() || v6.is_multicast() {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_ssrf_target(std::net::IpAddr::V4(v4));
+            }
+            let seg = v6.segments();
+            // ULA fc00::/7, link-local fe80::/10, site-local fec0::/10 (deprecated but reserved),
+            // documentation 2001:db8::/32, IPv4-translated 2002::/16 (6to4 — could embed private v4).
+            (seg[0] & 0xfe00) == 0xfc00
+                || (seg[0] & 0xffc0) == 0xfe80
+                || (seg[0] & 0xffc0) == 0xfec0
+                || (seg[0] == 0x2001 && seg[1] == 0x0db8)
+        }
+    }
+}
+
 /// Validate URL scheme, resolve DNS, and reject SSRF-vulnerable addresses.
 ///
 /// Returns a [`ValidatedUrl`] containing the resolved address so the caller
 /// can pin it via `reqwest::ClientBuilder::resolve`, closing the TOCTOU
 /// window between DNS validation and HTTP request.
-fn validate_url(url: &str) -> Result<ValidatedUrl, AppError> {
+async fn validate_url(url: &str) -> Result<ValidatedUrl, AppError> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
         return Err(AppError::bad_request(
             "URL must start with http:// or https://",
@@ -75,9 +154,20 @@ fn validate_url(url: &str) -> Result<ValidatedUrl, AppError> {
 
     let port = parsed.port_or_known_default().unwrap_or(80);
 
-    use std::net::ToSocketAddrs;
-    let addrs: Vec<std::net::SocketAddr> = format!("{host}:{port}")
-        .to_socket_addrs()
+    // TD-31: lock down the egress port so a bug elsewhere can't be used to
+    // probe internal services on uncommon ports (Redis 6379, Memcached
+    // 11211, ElasticSearch 9200, internal admin UIs on 8080, …).
+    if !ALLOWED_PORTS.contains(&port) {
+        return Err(AppError::bad_request(
+            "URL port not permitted (only 80 and 443)",
+        ));
+    }
+
+    // TD-31: async DNS lookup so we don't stall a tokio worker. `lookup_host`
+    // also handles dual-stack (returns both v4 and v6) so the per-address
+    // SSRF check runs for every candidate the OS would have chosen.
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), port))
+        .await
         .map_err(|_| AppError::bad_request("Could not resolve hostname"))?
         .collect();
 
@@ -87,27 +177,11 @@ fn validate_url(url: &str) -> Result<ValidatedUrl, AppError> {
         ));
     }
 
-    // Validate ALL resolved addresses are safe (reject if any is private)
+    // Validate ALL resolved addresses are safe (reject if any is private).
+    // Checking the whole set defeats split-horizon DNS games where one
+    // record is public and another is internal.
     for addr in &addrs {
-        let ip = addr.ip();
-        let is_private = match ip {
-            std::net::IpAddr::V4(v4) => {
-                v4.is_private()
-                    || v4.is_link_local()
-                    || v4.octets()[0] == 169 && v4.octets()[1] == 254
-            }
-            std::net::IpAddr::V6(v6) => {
-                let seg = v6.segments();
-                // ULA (fc00::/7)
-                (seg[0] & 0xfe00) == 0xfc00
-                // Link-local (fe80::/10)
-                || (seg[0] & 0xffc0) == 0xfe80
-                // IPv4-mapped (::ffff:0:0/96) -- check the mapped IPv4
-                || matches!(v6.to_ipv4_mapped(), Some(v4) if v4.is_private()
-                    || v4.is_loopback() || v4.is_link_local())
-            }
-        };
-        if ip.is_loopback() || ip.is_unspecified() || is_private {
+        if is_ssrf_target(addr.ip()) {
             return Err(AppError::bad_request(
                 "URL resolves to a private or reserved address",
             ));
@@ -131,7 +205,7 @@ pub async fn fetch_preview(
     _state: State<Arc<AppState>>,
     Json(body): Json<LinkPreviewRequest>,
 ) -> Result<Json<LinkPreviewResponse>, AppError> {
-    let validated = validate_url(&body.url)?;
+    let validated = validate_url(&body.url).await?;
 
     // Pin the resolved IP so reqwest cannot re-resolve to a different
     // (potentially private) address after our validation -- closes the
@@ -336,5 +410,89 @@ mod tests {
     fn content_length_above_cap_triggers_rejection_guard() {
         let declared_len = (MAX_HTML_BYTES as u64) + 1;
         assert!(declared_len > MAX_HTML_BYTES as u64);
+    }
+
+    // ----- TD-31: SSRF denial coverage --------------------------------
+
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    fn v4(s: &str) -> IpAddr {
+        IpAddr::V4(s.parse::<Ipv4Addr>().unwrap())
+    }
+
+    fn v6(s: &str) -> IpAddr {
+        IpAddr::V6(s.parse::<Ipv6Addr>().unwrap())
+    }
+
+    #[test]
+    fn ssrf_rejects_loopback_and_private() {
+        assert!(is_ssrf_target(v4("127.0.0.1")));
+        assert!(is_ssrf_target(v4("10.0.0.1")));
+        assert!(is_ssrf_target(v4("172.16.0.1")));
+        assert!(is_ssrf_target(v4("192.168.1.1")));
+        assert!(is_ssrf_target(v4("169.254.169.254"))); // AWS metadata endpoint
+    }
+
+    #[test]
+    fn ssrf_rejects_cgnat_benchmark_testnet() {
+        assert!(is_ssrf_target(v4("100.64.0.1")), "CGNAT");
+        assert!(is_ssrf_target(v4("100.127.255.1")), "CGNAT upper");
+        assert!(is_ssrf_target(v4("198.18.0.1")), "RFC 2544 benchmark");
+        assert!(is_ssrf_target(v4("192.0.2.1")), "TEST-NET-1");
+        assert!(is_ssrf_target(v4("198.51.100.1")), "TEST-NET-2");
+        assert!(is_ssrf_target(v4("203.0.113.1")), "TEST-NET-3");
+        assert!(is_ssrf_target(v4("192.0.0.1")), "IETF protocol assignments");
+    }
+
+    #[test]
+    fn ssrf_rejects_multicast_and_reserved() {
+        assert!(is_ssrf_target(v4("224.0.0.1")));
+        assert!(is_ssrf_target(v4("239.255.255.250")));
+        assert!(is_ssrf_target(v4("240.0.0.1")));
+        assert!(is_ssrf_target(v4("255.255.255.255")));
+        assert!(is_ssrf_target(v4("0.0.0.0")));
+    }
+
+    #[test]
+    fn ssrf_rejects_ipv4_mapped_v6() {
+        // ::ffff:169.254.169.254 — AWS metadata expressed as mapped v6.
+        let mapped = Ipv4Addr::new(169, 254, 169, 254).to_ipv6_mapped();
+        assert!(is_ssrf_target(IpAddr::V6(mapped)));
+    }
+
+    #[test]
+    fn ssrf_rejects_v6_loopback_ula_link_local_multicast_doc() {
+        assert!(is_ssrf_target(v6("::1")));
+        assert!(is_ssrf_target(v6("fc00::1"))); // ULA
+        assert!(is_ssrf_target(v6("fe80::1"))); // link-local
+        assert!(is_ssrf_target(v6("fec0::1"))); // deprecated site-local
+        assert!(is_ssrf_target(v6("ff02::1"))); // multicast
+        assert!(is_ssrf_target(v6("2001:db8::1"))); // documentation prefix
+    }
+
+    #[test]
+    fn ssrf_allows_public_addresses() {
+        assert!(!is_ssrf_target(v4("8.8.8.8")));
+        assert!(!is_ssrf_target(v4("1.1.1.1")));
+        assert!(!is_ssrf_target(v4("142.251.46.196"))); // google.com sample
+        assert!(!is_ssrf_target(v6("2606:4700:4700::1111"))); // 1.1.1.1 v6
+    }
+
+    #[tokio::test]
+    async fn validate_url_rejects_unsupported_scheme() {
+        let err = validate_url("file:///etc/passwd").await.unwrap_err();
+        assert!(err.message.contains("http://"));
+    }
+
+    #[tokio::test]
+    async fn validate_url_rejects_non_http_port() {
+        let err = validate_url("http://example.com:6379/").await.unwrap_err();
+        assert!(err.message.to_lowercase().contains("port"));
+    }
+
+    #[tokio::test]
+    async fn validate_url_rejects_https_on_non_443() {
+        let err = validate_url("https://example.com:8443/").await.unwrap_err();
+        assert!(err.message.to_lowercase().contains("port"));
     }
 }

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -5,7 +5,8 @@ use axum::body::Body;
 use axum::extract::{Multipart, Path, Query, State};
 use axum::http::StatusCode;
 use axum::http::header::{
-    ACCEPT_RANGES, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, RANGE,
+    ACCEPT_RANGES, CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE,
+    ETAG, IF_NONE_MATCH, RANGE,
 };
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
@@ -556,7 +557,54 @@ fn extract_user_id(
     Err(AppError::unauthorized("Missing authentication"))
 }
 
+/// TD-39: `Cache-Control` for downloaded media. ACL-gated and pinned to a
+/// specific file UUID, so a long max-age + stale-while-revalidate is safe.
+/// Combined with the ETag below this turns repeated chat-list renders into
+/// 304 responses instead of full streams.
+const MEDIA_CACHE_CONTROL: &str = "private, max-age=86400, stale-while-revalidate=86400";
+
+/// Build a weak ETag from the file's size + mtime — see `users::weak_etag`
+/// for rationale.
+fn media_weak_etag(meta: &std::fs::Metadata) -> String {
+    let mtime_secs = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("W/\"{}-{}\"", meta.len(), mtime_secs)
+}
+
+/// Match an `If-None-Match` header value against our emitted ETag.
+fn media_etag_matches(inm: &str, ours: &str) -> bool {
+    let normalize = |t: &str| {
+        t.trim()
+            .trim_start_matches("W/")
+            .trim_matches('"')
+            .to_string()
+    };
+    let ours_norm = normalize(ours);
+    inm.split(',').any(|tok| {
+        let t = tok.trim();
+        t == "*" || normalize(t) == ours_norm
+    })
+}
+
+/// Build a `304 Not Modified` response carrying the cache headers but no body.
+fn not_modified_response(etag: &str) -> Result<Response, AppError> {
+    Response::builder()
+        .status(StatusCode::NOT_MODIFIED)
+        .header(CACHE_CONTROL, MEDIA_CACHE_CONTROL)
+        .header(ETAG, etag)
+        .body(Body::empty())
+        .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))
+}
+
 /// Serve a satisfiable byte range response.
+///
+/// Streams the requested slice instead of buffering it. Reading the full
+/// `Range` into a `Vec<u8>` made a single request able to pin ~MAX_FILE_SIZE
+/// of RAM (up to 100 MB) — an easy OOM-DoS for any authenticated user.
 async fn serve_byte_range(
     disk_path: &str,
     start: u64,
@@ -564,6 +612,7 @@ async fn serve_byte_range(
     total_size: u64,
     mime_type: &str,
     disposition: &str,
+    etag: &str,
 ) -> Result<Response, AppError> {
     let slice_len = end - start + 1;
     let mut file = fs::File::open(disk_path).await.map_err(|e| {
@@ -574,11 +623,8 @@ async fn serve_byte_range(
         tracing::error!("Failed to seek media file: {e}");
         AppError::internal("Failed to read media")
     })?;
-    let mut buf = vec![0u8; slice_len as usize];
-    file.read_exact(&mut buf).await.map_err(|e| {
-        tracing::error!("Failed to read media slice: {e}");
-        AppError::internal("Failed to read media")
-    })?;
+
+    let stream = ReaderStream::new(file.take(slice_len));
 
     Response::builder()
         .status(StatusCode::PARTIAL_CONTENT)
@@ -587,7 +633,9 @@ async fn serve_byte_range(
         .header(ACCEPT_RANGES, "bytes")
         .header(CONTENT_LENGTH, slice_len)
         .header(CONTENT_RANGE, format!("bytes {start}-{end}/{total_size}"))
-        .body(Body::from(buf))
+        .header(CACHE_CONTROL, MEDIA_CACHE_CONTROL)
+        .header(ETAG, etag)
+        .body(Body::from_stream(stream))
         .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))
 }
 
@@ -597,6 +645,7 @@ async fn serve_full_file(
     total_size: u64,
     mime_type: &str,
     disposition: &str,
+    etag: &str,
 ) -> Result<Response, AppError> {
     let file = fs::File::open(disk_path).await.map_err(|e| {
         tracing::error!("Failed to open media file {}: {}", disk_path, e);
@@ -615,6 +664,8 @@ async fn serve_full_file(
         .header(CONTENT_DISPOSITION, disposition)
         .header(ACCEPT_RANGES, "bytes")
         .header(CONTENT_LENGTH, total_size)
+        .header(CACHE_CONTROL, MEDIA_CACHE_CONTROL)
+        .header(ETAG, etag)
         .body(Body::from_stream(stream))
         .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))
 }
@@ -674,6 +725,15 @@ pub async fn download(
         }
     })?;
     let total_size = metadata.len();
+    let etag = media_weak_etag(&metadata);
+
+    // TD-39: short-circuit on If-None-Match before opening the file. Avoids
+    // both the disk read and the ReaderStream allocation for the cached path.
+    if let Some(inm) = headers.get(IF_NONE_MATCH).and_then(|v| v.to_str().ok())
+        && media_etag_matches(inm, &etag)
+    {
+        return not_modified_response(&etag);
+    }
 
     // Sanitize filename: strip characters that could break Content-Disposition header
     let safe_filename: String = row
@@ -701,6 +761,7 @@ pub async fn download(
                     total_size,
                     &row.mime_type,
                     &disposition,
+                    &etag,
                 )
                 .await;
             }
@@ -716,7 +777,7 @@ pub async fn download(
     }
 
     // No Range header — stream the full file without buffering it into RAM.
-    serve_full_file(&disk_path, total_size, &row.mime_type, &disposition).await
+    serve_full_file(&disk_path, total_size, &row.mime_type, &disposition, &etag).await
 }
 
 /// GET /api/media/:id/thumb
@@ -780,6 +841,22 @@ pub async fn download_thumb(
     }
 
     let thumb_path = format!("./uploads/{}.thumb.jpg", row.id);
+
+    // TD-39: stat first so we can answer 304 without reading the file body.
+    let metadata = fs::metadata(&thumb_path).await.map_err(|_| AppError {
+        status: StatusCode::NOT_FOUND,
+        message: "Thumbnail not available".to_string(),
+        code: ErrorCode::NotFound,
+        body: None,
+    })?;
+    let etag = media_weak_etag(&metadata);
+
+    if let Some(inm) = headers.get(IF_NONE_MATCH).and_then(|v| v.to_str().ok())
+        && media_etag_matches(inm, &etag)
+    {
+        return not_modified_response(&etag);
+    }
+
     let data = fs::read(&thumb_path).await.map_err(|_| AppError {
         status: StatusCode::NOT_FOUND,
         message: "Thumbnail not available".to_string(),
@@ -791,6 +868,8 @@ pub async fn download_thumb(
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "image/jpeg")
         .header(CONTENT_LENGTH, data.len() as u64)
+        .header(CACHE_CONTROL, MEDIA_CACHE_CONTROL)
+        .header(ETAG, &etag)
         .body(Body::from(data))
         .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))
 }

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -411,7 +411,7 @@ pub async fn delete_message(
     let conversation_id = db::messages::delete_message(&state.pool, message_id, auth.user_id)
         .await
         .db_ctx("delete_message")?
-        .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
+        .ok_or_else(|| AppError::not_found("Message not found or you are not the sender"))?;
 
     // Broadcast to conversation members via WebSocket
     crate::ws::broadcast::broadcast_to_conversation(
@@ -462,7 +462,7 @@ pub async fn edit_message(
         db::messages::get_message_conversation_security(&state.pool, message_id, auth.user_id)
             .await
             .db_ctx("edit_message/security lookup")?
-            .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
+            .ok_or_else(|| AppError::not_found("Message not found or you are not the sender"))?;
     if convo_meta.is_encrypted {
         tracing::warn!(
             user_id = %auth.user_id,
@@ -479,7 +479,7 @@ pub async fn edit_message(
         db::messages::edit_message(&state.pool, message_id, auth.user_id, &body.content)
             .await
             .db_ctx("edit_message")?
-            .ok_or_else(|| AppError::bad_request("Message not found or you are not the sender"))?;
+            .ok_or_else(|| AppError::not_found("Message not found or you are not the sender"))?;
 
     // Broadcast to conversation members via WebSocket
     let member_ids = db::groups::get_conversation_member_ids(&state.pool, conversation_id)
@@ -533,7 +533,7 @@ pub async fn get_thread_replies(
 
     let conversation_id = parent
         .map(|(cid,)| cid)
-        .ok_or_else(|| AppError::bad_request("Message not found"))?;
+        .ok_or_else(|| AppError::not_found("Message not found"))?;
 
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
         .await
@@ -839,7 +839,7 @@ pub async fn pin_message(
             .await
             .db_ctx("pin_message")?
             .ok_or_else(|| {
-                AppError::bad_request("Message not found or does not belong to this conversation")
+                AppError::not_found("Message not found or does not belong to this conversation")
             })?;
 
     // Look up pinner's username for the broadcast event
@@ -915,7 +915,7 @@ pub async fn unpin_message(
         .await
         .db_ctx("unpin_message")?
         .ok_or_else(|| {
-            AppError::bad_request("Message not found, not pinned, or wrong conversation")
+            AppError::not_found("Message not found, not pinned, or wrong conversation")
         })?;
 
     // Broadcast to conversation members via WebSocket

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -45,6 +45,7 @@ use uuid::Uuid;
 /// (#1173).
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
 
+use crate::auth::TokenInvalidator;
 use crate::metrics::MessageRateCounter;
 use crate::middleware::rate_limit;
 use crate::ws::hub::Hub;
@@ -69,6 +70,10 @@ pub struct AppState {
     /// "messages per second" tile (#681). Bumped from the WS relay path
     /// after each successful store-and-fanout.
     pub message_rate: Arc<MessageRateCounter>,
+    /// Per-user JWT `iat` floor (CR-4). Revocation events bump the floor
+    /// for the affected user, immediately invalidating every outstanding
+    /// 15-minute access token instead of waiting for the JWT TTL.
+    pub token_invalidator: TokenInvalidator,
 }
 
 /// Narrow view of [`AppState`] for the auth handlers (`register`, `login`,
@@ -87,6 +92,7 @@ pub struct AuthExtract {
     pub pool: PgPool,
     pub jwt_secret: String,
     pub ticket_store: TicketStore,
+    pub token_invalidator: TokenInvalidator,
 }
 
 impl FromRef<Arc<AppState>> for AuthExtract {
@@ -95,6 +101,7 @@ impl FromRef<Arc<AppState>> for AuthExtract {
             pool: state.pool.clone(),
             jwt_secret: state.jwt_secret.clone(),
             ticket_store: Arc::clone(&state.ticket_store),
+            token_invalidator: state.token_invalidator.clone(),
         }
     }
 }

--- a/apps/server/src/routes/reactions.rs
+++ b/apps/server/src/routes/reactions.rs
@@ -48,7 +48,7 @@ pub async fn add_reaction(
     let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
         .await
         .db_ctx("add_reaction/get_conversation")?
-        .ok_or_else(|| AppError::bad_request("Message not found"))?;
+        .ok_or_else(|| AppError::not_found("Message not found"))?;
 
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
@@ -99,7 +99,7 @@ pub async fn remove_reaction(
     let conversation_id = db::reactions::get_message_conversation_id(&state.pool, message_id)
         .await
         .db_ctx("remove_reaction/get_conversation")?
-        .ok_or_else(|| AppError::bad_request("Message not found"))?;
+        .ok_or_else(|| AppError::not_found("Message not found"))?;
 
     // Verify membership
     let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
@@ -159,7 +159,7 @@ pub async fn mark_read(
     let privacy = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
         .db_ctx("mark_read/get_privacy")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
+        .ok_or_else(|| AppError::not_found("User not found"))?;
 
     if !privacy.read_receipts_enabled {
         return Ok(Json(serde_json::json!({

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -3,8 +3,9 @@
 use axum::Json;
 use axum::body::Body;
 use axum::extract::{Multipart, Path, Query, State};
+use axum::http::HeaderMap;
 use axum::http::StatusCode;
-use axum::http::header::CONTENT_TYPE;
+use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE, ETAG, IF_NONE_MATCH};
 use axum::response::{IntoResponse, Response};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -78,7 +79,7 @@ pub async fn get_my_privacy(
     let privacy = db::users::get_privacy_preferences(&state.pool, auth.user_id)
         .await
         .db_ctx("get_my_privacy")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
+        .ok_or_else(|| AppError::not_found("User not found"))?;
 
     Ok(Json(PrivacyPreferencesResponse {
         read_receipts_enabled: privacy.read_receipts_enabled,
@@ -92,34 +93,32 @@ pub async fn get_my_privacy(
 }
 
 /// PATCH /api/users/me/privacy
+///
+/// TD-51: single-statement partial update. Unset fields keep their current
+/// value via `COALESCE`, eliminating the read-modify-write race the old
+/// implementation had — two concurrent PATCHes from different devices could
+/// lose fields between the SELECT and the UPDATE; this path has no such
+/// window.
 pub async fn update_my_privacy(
     auth: AuthUser,
     State(state): State<Arc<AppState>>,
     Json(payload): Json<UpdatePrivacyPreferencesRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let current = db::users::get_privacy_preferences(&state.pool, auth.user_id)
-        .await
-        .db_ctx("update_my_privacy/get_current")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
-
-    let prefs = db::users::PrivacyUpdate {
-        read_receipts_enabled: payload
-            .read_receipts_enabled
-            .unwrap_or(current.read_receipts_enabled),
-        allow_unencrypted_dm: false,
-        email_visible: payload.email_visible.unwrap_or(current.email_visible),
-        phone_visible: payload.phone_visible.unwrap_or(current.phone_visible),
-        email_discoverable: payload
-            .email_discoverable
-            .unwrap_or(current.email_discoverable),
-        phone_discoverable: payload
-            .phone_discoverable
-            .unwrap_or(current.phone_discoverable),
-        searchable: payload.searchable.unwrap_or(current.searchable),
-    };
-    let updated = db::users::update_privacy_preferences(&state.pool, auth.user_id, &prefs)
-        .await
-        .db_ctx("update_my_privacy")?;
+    let updated = db::users::update_privacy_preferences_partial(
+        &state.pool,
+        auth.user_id,
+        db::users::PrivacyPartial {
+            read_receipts_enabled: payload.read_receipts_enabled,
+            email_visible: payload.email_visible,
+            phone_visible: payload.phone_visible,
+            email_discoverable: payload.email_discoverable,
+            phone_discoverable: payload.phone_discoverable,
+            searchable: payload.searchable,
+        },
+    )
+    .await
+    .db_ctx("update_my_privacy")?
+    .ok_or_else(|| AppError::not_found("User not found"))?;
 
     Ok(Json(PrivacyPreferencesResponse {
         read_receipts_enabled: updated.read_receipts_enabled,
@@ -143,7 +142,7 @@ pub async fn get_profile(
     let profile = db::users::find_public_profile(&state.pool, user_id)
         .await
         .db_ctx("get_profile")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
+        .ok_or_else(|| AppError::not_found("User not found"))?;
 
     Ok(Json(UserProfile {
         user_id: profile.id,
@@ -433,7 +432,7 @@ pub async fn change_password(
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
         .db_ctx("change_password/find_user")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
+        .ok_or_else(|| AppError::not_found("User not found"))?;
 
     // Argon2 verify takes ~50-150ms of pure CPU. Without spawn_blocking it
     // stalls a tokio worker for the whole duration -- login/register already
@@ -462,6 +461,10 @@ pub async fn change_password(
     db::tokens::revoke_all_user_tokens(&state.pool, auth.user_id)
         .await
         .db_ctx("change_password/revoke_tokens")?;
+
+    // CR-4: also invalidate outstanding 15-minute access tokens so a
+    // compromised session is killed immediately, not at JWT TTL.
+    state.token_invalidator.invalidate(auth.user_id);
 
     Ok(Json(json!({ "status": "password_changed" })))
 }
@@ -722,14 +725,41 @@ pub async fn upload_avatar(
     ))
 }
 
+/// Build a weak ETag from the file's size + modification time.
+///
+/// `W/"<size>-<mtime_secs>"` — collision risk is "two different files with
+/// identical size and identical mtime in the same second", which a CDN /
+/// browser cache can tolerate. The strong-validator alternative would
+/// require hashing the bytes on every read; we'd rather avoid that for
+/// frequently-fetched assets like avatars.
+fn weak_etag(meta: &std::fs::Metadata) -> String {
+    let mtime_secs = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("W/\"{}-{}\"", meta.len(), mtime_secs)
+}
+
+/// `Cache-Control` value used for public, mostly-immutable media (avatars,
+/// uploaded images). 5 min fresh + 1 day stale-while-revalidate keeps the
+/// chat list snappy without making bust scenarios painful.
+const MEDIA_CACHE_CONTROL: &str = "public, max-age=300, stale-while-revalidate=86400";
+
 /// GET /api/users/:id/avatar
 ///
 /// Serves the avatar image with the correct Content-Type header.
 /// Public endpoint — no auth required (avatars are profile pictures).
 /// Returns 404 if no avatar is set.
+///
+/// TD-39: emits `Cache-Control` + a weak `ETag` derived from (size, mtime)
+/// and honors `If-None-Match` → 304. Cuts the typical chat-list render
+/// from 50 disk reads to ~0 once the cache warms up.
 pub async fn get_avatar(
     State(state): State<Arc<AppState>>,
     Path(user_id): Path<Uuid>,
+    headers: HeaderMap,
 ) -> Result<Response, AppError> {
     // Verify user has an avatar_url set
     let avatar_url = db::users::get_avatar_url(&state.pool, user_id)
@@ -755,15 +785,35 @@ pub async fn get_avatar(
     // Try to find the avatar file on disk
     for ext in &["jpg", "png", "webp", "gif"] {
         let disk_path = format!("./uploads/avatars/{}.{}", user_id, ext);
-        if let Ok(data) = fs::read(&disk_path).await {
-            let mime = mime_for_extension(ext);
-            let response = Response::builder()
-                .status(StatusCode::OK)
-                .header(CONTENT_TYPE, mime)
-                .body(Body::from(data))
-                .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))?;
-            return Ok(response);
+        let Ok(meta) = fs::metadata(&disk_path).await else {
+            continue;
+        };
+        let etag = weak_etag(&meta);
+
+        // Honor If-None-Match → 304 Not Modified without reading the file.
+        if let Some(inm) = headers.get(IF_NONE_MATCH).and_then(|v| v.to_str().ok())
+            && etag_matches(inm, &etag)
+        {
+            return Response::builder()
+                .status(StatusCode::NOT_MODIFIED)
+                .header(CACHE_CONTROL, MEDIA_CACHE_CONTROL)
+                .header(ETAG, &etag)
+                .body(Body::empty())
+                .map_err(|e| AppError::internal(format!("Failed to build response: {e}")));
         }
+
+        let Ok(data) = fs::read(&disk_path).await else {
+            continue;
+        };
+        let mime = mime_for_extension(ext);
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, mime)
+            .header(CACHE_CONTROL, MEDIA_CACHE_CONTROL)
+            .header(ETAG, &etag)
+            .body(Body::from(data))
+            .map_err(|e| AppError::internal(format!("Failed to build response: {e}")))?;
+        return Ok(response);
     }
 
     Err(AppError {
@@ -771,6 +821,25 @@ pub async fn get_avatar(
         message: "Avatar file not found on disk".to_string(),
         code: ErrorCode::NotFound,
         body: None,
+    })
+}
+
+/// Match an `If-None-Match` header value against our emitted ETag.
+///
+/// Honors the comma-separated list form (`"abc", "def"`) and the wildcard
+/// `*`. Comparison treats weak (`W/"x"`) and strong (`"x"`) forms as equal
+/// because we only ever emit weak validators.
+fn etag_matches(inm: &str, ours: &str) -> bool {
+    let normalize = |t: &str| {
+        t.trim()
+            .trim_start_matches("W/")
+            .trim_matches('"')
+            .to_string()
+    };
+    let ours_norm = normalize(ours);
+    inm.split(',').any(|tok| {
+        let t = tok.trim();
+        t == "*" || normalize(t) == ours_norm
     })
 }
 

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -77,7 +77,7 @@ pub async fn generate_token(
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
         .db_ctx("looking up user for voice token")?
-        .ok_or_else(|| AppError::bad_request("User not found"))?;
+        .ok_or_else(|| AppError::not_found("User not found"))?;
 
     let username = user.username;
     let identity = body.identity.unwrap_or_else(|| username.clone());

--- a/apps/server/src/ws/events/dispatch.rs
+++ b/apps/server/src/ws/events/dispatch.rs
@@ -17,6 +17,28 @@ use crate::ws::typing_service;
 /// content is 10 KB, and the JSON envelope adds minimal overhead).
 const MAX_WS_FRAME_BYTES: usize = 65_536;
 
+/// TD-35: per-field cap for the voice-signal `signal` payload. Realistic
+/// WebRTC SDPs are 1–4 KB; ICE candidates are tens of bytes. 8 KB is loose
+/// enough to allow growth without giving an attacker a 64 KB amplification
+/// vector across every conversation member 30× per second.
+const MAX_VOICE_SIGNAL_BYTES: usize = 8 * 1024;
+
+/// TD-35: per-field cap for the canvas-event `payload`. Canvas events fire
+/// per stroke segment and per pointer move; bounding individual segments to
+/// 16 KB prevents a sender from using the per-frame 64 KB allowance as a
+/// fan-out bandwidth amplifier.
+const MAX_CANVAS_PAYLOAD_BYTES: usize = 16 * 1024;
+
+/// Helper: estimate the serialized size of a `serde_json::Value` without
+/// emitting a fresh allocation if we can avoid it. `serde_json::to_string`
+/// is used because re-serialization is the canonical "size on the wire";
+/// any cheaper proxy would mis-estimate string-escape expansion.
+fn json_bytes(value: &serde_json::Value) -> usize {
+    serde_json::to_string(value)
+        .map(|s| s.len())
+        .unwrap_or(usize::MAX)
+}
+
 pub(in crate::ws) async fn handle_text_message(
     text: &str,
     sender_id: Uuid,
@@ -40,7 +62,12 @@ pub(in crate::ws) async fn handle_text_message(
     let msg: ClientMessage = match serde_json::from_str(text) {
         Ok(m) => m,
         Err(e) => {
-            send_error(state, sender_id, &format!("Invalid message: {}", e));
+            // TD-74: don't echo the serde_json parser's internal byte/line
+            // position back to the client — it lets attackers fingerprint
+            // the parser and probe field tolerances cheaply. Log the
+            // detail server-side instead so we still have it for support.
+            tracing::debug!(sender_id = %sender_id, error = %e, "invalid client frame");
+            send_error(state, sender_id, "Invalid message");
             return;
         }
     };
@@ -94,6 +121,26 @@ pub(in crate::ws) async fn handle_text_message(
             to_user_id,
             signal,
         } => {
+            // TD-35: bound the inner JSON payload before relaying. The 64 KB
+            // frame cap alone let one peer cost N×64 KB per ICE candidate
+            // across an in-call group.
+            let signal_bytes = json_bytes(&signal);
+            if signal_bytes > MAX_VOICE_SIGNAL_BYTES {
+                tracing::warn!(
+                    sender_id = %sender_id,
+                    conversation_id = %conversation_id,
+                    bytes = signal_bytes,
+                    "rejected oversized voice signal payload",
+                );
+                send_error(
+                    state,
+                    sender_id,
+                    &format!(
+                        "voice signal too large ({signal_bytes} bytes, max {MAX_VOICE_SIGNAL_BYTES})"
+                    ),
+                );
+                return;
+            }
             handle_voice_signal(
                 state,
                 sender_id,
@@ -137,6 +184,33 @@ pub(in crate::ws) async fn handle_text_message(
             kind,
             payload,
         } => {
+            // TD-35: bound the canvas payload before relaying/persisting.
+            // Stroke segments and pointer moves should each fit in a few
+            // hundred bytes; 16 KB is loose enough to allow image-add
+            // descriptors without enabling a fan-out amplifier.
+            let payload_bytes = json_bytes(&payload);
+            if payload_bytes > MAX_CANVAS_PAYLOAD_BYTES {
+                tracing::warn!(
+                    sender_id = %sender_id,
+                    channel_id = %channel_id,
+                    kind = %kind,
+                    bytes = payload_bytes,
+                    "rejected oversized canvas payload",
+                );
+                send_error(
+                    state,
+                    sender_id,
+                    &format!(
+                        "canvas payload too large ({payload_bytes} bytes, max {MAX_CANVAS_PAYLOAD_BYTES})"
+                    ),
+                );
+                return;
+            }
+            // Limit `kind` too — it's a small enum-like discriminator.
+            if kind.len() > 64 {
+                send_error(state, sender_id, "canvas event kind too long");
+                return;
+            }
             handle_canvas_event(state, sender_id, channel_id, kind, payload).await;
         }
     }

--- a/apps/server/src/ws/message_service/fanout.rs
+++ b/apps/server/src/ws/message_service/fanout.rs
@@ -85,21 +85,24 @@ impl NewMessageFields {
 /// re-serializing the same message for every member in the fanout loop.
 /// Outer key is `recipient_user_id`, inner is `device_id -> WsMessage`.
 ///
-/// Serialization is hoisted out of the fanout loop:
-/// 1. Serialize a `ServerMessage::NewMessage` with empty content into a
-///    `serde_json::Value` once — this respects all `skip_serializing_if`
-///    attributes and preserves the exact wire format.
-/// 2. Per device, clone the Value, set only the `content` field, and call
-///    `to_string` once.
-/// 3. Store as `WsMessage::Text` (Bytes-backed) so hub clones inside the
-///    fanout loop are O(1) — no string copying per recipient.
+/// TD-61: serialise the invariant portion **once** as a String around a
+/// content-shaped sentinel, then per device splice the JSON-encoded
+/// ciphertext between the resulting prefix/suffix slices. The previous
+/// implementation called `base_value.clone()` per device, which walked the
+/// 8-field Object tree and string-cloned every leaf — for a 50-member ×
+/// 3-device group that's 150 deep clones per fanout. Sentinel-splice is
+/// O(devices × ciphertext_len) with no extra allocations beyond the final
+/// `WsMessage::Text` buffer.
 pub(in crate::ws::message_service) fn build_per_device_json(
     fields: &NewMessageFields,
     recipient_device_contents: &ParsedRecipientDeviceContents,
 ) -> HashMap<Uuid, Vec<(i32, WsMessage)>> {
-    // Serialize the invariant portion once via serde so skip_serializing_if
-    // is respected for optional fields (channel_id, reply_to_*, expires_at,
-    // undecryptable). The `content` field is replaced per device below.
+    // Sentinel chosen so it cannot collide with any legitimate string in the
+    // serialized JSON: includes characters that would be JSON-escaped, plus
+    // a per-call UUID. Anchored to a fixed, unmistakable prefix so a future
+    // reader can grep for it.
+    let sentinel = format!("__ECHO_CONTENT_PLACEHOLDER_{}__", Uuid::new_v4());
+
     let base_msg = ServerMessage::NewMessage {
         message_id: fields.message_id,
         from_user_id: fields.from_user_id,
@@ -107,7 +110,7 @@ pub(in crate::ws::message_service) fn build_per_device_json(
         from_username: fields.from_username.clone(),
         conversation_id: fields.conversation_id,
         channel_id: fields.channel_id,
-        content: String::new(),
+        content: sentinel.clone(),
         timestamp: fields.timestamp,
         reply_to_id: fields.reply_to_id,
         reply_to_content: fields.reply_to_content.clone(),
@@ -115,9 +118,21 @@ pub(in crate::ws::message_service) fn build_per_device_json(
         expires_at: fields.expires_at,
         undecryptable: None,
     };
-    let Ok(base_value) = serde_json::to_value(&base_msg) else {
+
+    let Ok(serialized) = serde_json::to_string(&base_msg) else {
         return HashMap::new();
     };
+
+    // The sentinel was a String and goes through JSON string-escape, so the
+    // exact substring to match is `"<sentinel>"`. The sentinel never
+    // contains any character requiring escape (only ASCII alphanumerics +
+    // `_`), so we can rely on a direct surround-with-quotes match.
+    let sentinel_quoted = format!("\"{sentinel}\"");
+    let Some(pos) = serialized.find(&sentinel_quoted) else {
+        return HashMap::new();
+    };
+    let prefix = &serialized[..pos];
+    let suffix = &serialized[pos + sentinel_quoted.len()..];
 
     recipient_device_contents
         .by_user
@@ -126,12 +141,15 @@ pub(in crate::ws::message_service) fn build_per_device_json(
             let entries: Vec<(i32, WsMessage)> = devices
                 .iter()
                 .filter_map(|(did, ciphertext)| {
-                    // Clone the invariant Value and mutate only `content`.
-                    let mut val = base_value.clone();
-                    val["content"] = serde_json::Value::String(ciphertext.clone());
-                    let json = serde_json::to_string(&val).ok()?;
-                    // Wrap as WsMessage::Text (Bytes) once; fanout clones are O(1).
-                    Some((*did, WsMessage::Text(json.into())))
+                    // JSON-encode the ciphertext string in isolation, then
+                    // concat into the pre-built prefix/suffix.
+                    let ct_json = serde_json::to_string(ciphertext).ok()?;
+                    let mut frame =
+                        String::with_capacity(prefix.len() + ct_json.len() + suffix.len());
+                    frame.push_str(prefix);
+                    frame.push_str(&ct_json);
+                    frame.push_str(suffix);
+                    Some((*did, WsMessage::Text(frame.into())))
                 })
                 .collect();
             (*recipient_id, entries)

--- a/apps/server/src/ws/message_service/mod.rs
+++ b/apps/server/src/ws/message_service/mod.rs
@@ -31,8 +31,8 @@ use routing::{lookup_reply_context, resolve_conversation};
 use storage::store_and_confirm;
 use types::{ParsedRecipientDeviceContents, RecipientDeviceContents};
 use validate::{
-    enforce_group_sender_membership, validate_conversation_security, validate_encrypted_payload,
-    validate_message_length,
+    enforce_dm_recipient_includes_peer, enforce_group_sender_membership,
+    validate_conversation_security, validate_encrypted_payload, validate_message_length,
 };
 
 // ── External API ─────────────────────────────────────────────────────────────
@@ -109,6 +109,20 @@ pub(super) async fn handle_send_message(
     if conv_security.is_encrypted
         && conv_kind == Some(ConversationKind::Group)
         && !enforce_group_sender_membership(state, sender_id, conv_id).await
+    {
+        return;
+    }
+
+    // TD-30: encrypted-DM recipient-inclusion gate. The shape validator
+    // already requires `recipient_device_contents` to be non-empty, but it
+    // doesn't check that the actual peer is in the map. Without this check
+    // a sender could populate only their own devices and let the fanout
+    // fallback deliver `legacy_msg` to the peer with whatever bytes pass
+    // the structural shape gate.
+    if conv_security.is_encrypted
+        && conv_kind == Some(ConversationKind::Direct)
+        && let Some(rdc) = recipient_device_contents.as_ref()
+        && !enforce_dm_recipient_includes_peer(state, sender_id, conv_id, rdc).await
     {
         return;
     }

--- a/apps/server/src/ws/message_service/validate.rs
+++ b/apps/server/src/ws/message_service/validate.rs
@@ -290,6 +290,71 @@ pub(in crate::ws::message_service) fn validate_encrypted_payload(
     }
 }
 
+// ── Encrypted-DM recipient enforcement (TD-30) ──────────────────────────────
+
+/// Structured rejection code emitted when an encrypted DM's
+/// `recipient_device_contents` map omits the actual peer. Surfaced verbatim
+/// in the WS `error` frame back to the sender so monitoring can flag the
+/// signal without grepping free-form text.
+pub(in crate::ws::message_service) const DM_PEER_MISSING_CODE: &str = "dm-peer-not-in-recipients";
+
+/// For encrypted DMs, require the actual conversation peer to appear as a
+/// key in `recipient_device_contents`. Without this gate a sender could
+/// satisfy the non-empty / shape checks by populating only their *own*
+/// devices, then ship attacker-shaped `legacy_msg` bytes to the peer via
+/// the fanout fallback in
+/// [`crate::ws::message_service::fanout::deliver_to_member`].
+///
+/// Returns `true` when the recipient set is acceptable.
+pub(in crate::ws::message_service) async fn enforce_dm_recipient_includes_peer(
+    state: &AppState,
+    sender_id: Uuid,
+    conversation_id: Uuid,
+    rdc: &RecipientDeviceContents,
+) -> bool {
+    let members = match db::groups::get_conversation_member_ids(&state.pool, conversation_id).await
+    {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(
+                conversation_id = %conversation_id,
+                sender_id = %sender_id,
+                error = ?e,
+                "db error looking up DM members for recipient enforcement",
+            );
+            send_error(state, sender_id, "Database error");
+            return false;
+        }
+    };
+
+    // The DM has exactly two members; everyone besides the sender is a peer
+    // that must receive ciphertext. `rdc` keys are user_id strings, so build
+    // a string-set view of the expected peers for the membership check.
+    let mut missing_peer = false;
+    for member_id in &members {
+        if *member_id == sender_id {
+            continue;
+        }
+        if !rdc.contains_key(&member_id.to_string()) {
+            missing_peer = true;
+            break;
+        }
+    }
+
+    if missing_peer {
+        tracing::warn!(
+            conversation_id = %conversation_id,
+            sender_id = %sender_id,
+            code = DM_PEER_MISSING_CODE,
+            "rejected encrypted DM: recipient_device_contents omits the conversation peer",
+        );
+        send_error(state, sender_id, DM_PEER_MISSING_CODE);
+        return false;
+    }
+
+    true
+}
+
 // ── Encrypted-group sender membership (Phase 1.5, audit P1-2) ───────────────
 
 /// Structured rejection code used by the encrypted-group sender-membership

--- a/apps/server/src/ws/rate_limit.rs
+++ b/apps/server/src/ws/rate_limit.rs
@@ -207,8 +207,8 @@ async fn handle_text_frame(
     false
 }
 
-/// Process a non-text, non-close frame: count bytes against the byte-rate
-/// bucket to prevent abuse via binary/ping/pong floods.
+/// Process a non-text, non-close frame: count both message-count AND bytes
+/// so zero-byte ping/pong floods can't bypass the per-frame cap.
 /// Returns `true` when the receive loop should break.
 fn handle_other_frame(
     msg: &WsMessage,
@@ -216,11 +216,11 @@ fn handle_other_frame(
     user_id: Uuid,
     bucket: &mut BucketState,
 ) -> bool {
-    let cost = non_text_byte_cost(msg);
-    if cost == 0.0 {
-        return false;
-    }
-    if bucket.byte_tokens < cost {
+    // TD-36: every binary/ping/pong frame consumes one message token. Without
+    // this check an attacker can blast 1000 zero-byte pings per second; the
+    // byte bucket sees 0 cost and never throttles, but each frame still
+    // triggers a tokio wakeup + axum parse + dispatch round.
+    if bucket.tokens < 1.0 {
         return record_violation(
             state,
             user_id,
@@ -228,6 +228,18 @@ fn handle_other_frame(
             MAX_CONSECUTIVE_VIOLATIONS,
         );
     }
+
+    let cost = non_text_byte_cost(msg);
+    if cost > bucket.byte_tokens {
+        return record_violation(
+            state,
+            user_id,
+            &mut bucket.consecutive_violations,
+            MAX_CONSECUTIVE_VIOLATIONS,
+        );
+    }
+
+    bucket.tokens -= 1.0;
     bucket.byte_tokens -= cost;
     bucket.consecutive_violations = 0;
     false

--- a/apps/server/tests/api_auth.rs
+++ b/apps/server/tests/api_auth.rs
@@ -144,6 +144,98 @@ async fn refresh_token_revoked_returns_401() {
     );
 }
 
+/// TD-42: token theft must invalidate the **entire family**, including
+/// descendants the legitimate client has rotated to since the leaked token
+/// was originally issued. Chains T0 → T1 → T2 → T3, replays T0 (simulating a
+/// stolen old token), and asserts that the freshest descendant (T3) also
+/// cannot be used afterwards.
+#[tokio::test]
+async fn refresh_replay_revokes_entire_family_chain() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let username = common::unique_username("theftchain");
+
+    common::register(&client, &base, &username, "password123").await;
+    let login_body: serde_json::Value = client
+        .post(format!("{base}/api/auth/login"))
+        .json(&serde_json::json!({ "username": username, "password": "password123" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let t0 = login_body["refresh_token"].as_str().unwrap().to_string();
+
+    async fn rotate(client: &Client, base: &str, token: &str) -> String {
+        let body: serde_json::Value = client
+            .post(format!("{base}/api/auth/refresh"))
+            .json(&serde_json::json!({ "refresh_token": token }))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        body["refresh_token"]
+            .as_str()
+            .expect("rotated refresh_token in body")
+            .to_string()
+    }
+
+    let t1 = rotate(&client, &base, &t0).await;
+    let t2 = rotate(&client, &base, &t1).await;
+    let t3 = rotate(&client, &base, &t2).await;
+
+    assert_ne!(t0, t1);
+    assert_ne!(t1, t2);
+    assert_ne!(t2, t3);
+
+    // Stolen old token is replayed. Server flips the family-wide kill switch.
+    let theft = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": t0 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        theft.status().as_u16(),
+        401,
+        "replaying T0 must be detected as theft"
+    );
+
+    // The freshest descendant — which the legitimate client believes is
+    // still usable — must now also be rejected.
+    let cascade = client
+        .post(format!("{base}/api/auth/refresh"))
+        .json(&serde_json::json!({ "refresh_token": t3 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        cascade.status().as_u16(),
+        401,
+        "post-theft replay must invalidate the entire family, including T3"
+    );
+
+    // Intermediate descendants were already consumed during normal rotation,
+    // so they 401 for a separate reason; assert anyway to lock the contract.
+    for (label, token) in [("t1", &t1), ("t2", &t2)] {
+        let resp = client
+            .post(format!("{base}/api/auth/refresh"))
+            .json(&serde_json::json!({ "refresh_token": token }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status().as_u16(),
+            401,
+            "intermediate descendant {label} must be invalid"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // HttpOnly refresh-token cookie (#342)
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_group_keys.rs
+++ b/apps/server/tests/api_group_keys.rs
@@ -183,6 +183,110 @@ async fn upload_group_key_duplicate_version_returns_409() {
     assert_eq!(resp.status().as_u16(), 409);
 }
 
+/// TD-41: rotation-storm correctness. The whole point of `ws::rotation`'s
+/// server-led leader election is that even when multiple online admins /
+/// devices race to rotate the same group key, only one upload of the new
+/// version can succeed; the rest fall back to `getGroupKey` and converge on
+/// the winning envelope set. The safety floor for the race is the
+/// `(conversation_id, key_version)` UNIQUE constraint on `group_keys`.
+///
+/// This test fires N concurrent `POST /api/groups/:id/keys` requests at the
+/// same `key_version` and asserts exactly **one** wins (201) while every
+/// other request observes the conflict (409) — never two 201s, never an
+/// inconsistent envelope set.
+#[tokio::test]
+async fn concurrent_upload_group_key_same_version_one_wins() {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) = common::register_and_login(&client, &base, "gkstorm").await;
+    let group_id = common::create_group(&client, &base, &owner_token, "GKStorm").await;
+
+    let base = Arc::new(base);
+    let owner_token = Arc::new(owner_token);
+    let group_id = Arc::new(group_id);
+    let owner_id = Arc::new(owner_id);
+
+    // Race 4 concurrent uploads of `key_version = 1`. With the storm-control
+    // we expect exactly one 201, three 409s, no torn writes.
+    const RACERS: usize = 4;
+    let mut joins = Vec::with_capacity(RACERS);
+    for i in 0..RACERS {
+        let base = base.clone();
+        let token = owner_token.clone();
+        let client = client.clone();
+        let owner_id = owner_id.clone();
+        let group_id = group_id.clone();
+        joins.push(tokio::spawn(async move {
+            let body = serde_json::json!({
+                "key_version": 1,
+                "envelopes": [
+                    {
+                        "user_id": &*owner_id,
+                        "encrypted_key": format!("envelope-from-racer-{i}")
+                    }
+                ]
+            });
+            let resp = client
+                .post(format!("{base}/api/groups/{group_id}/keys"))
+                .header("Authorization", format!("Bearer {token}"))
+                .json(&body)
+                .send()
+                .await
+                .unwrap();
+            resp.status().as_u16()
+        }));
+    }
+
+    let mut statuses: Vec<u16> = Vec::with_capacity(RACERS);
+    for j in joins {
+        statuses.push(j.await.unwrap());
+    }
+
+    let ok_count = statuses.iter().filter(|s| **s == 201).count();
+    let conflict_count = statuses.iter().filter(|s| **s == 409).count();
+
+    assert_eq!(
+        ok_count, 1,
+        "exactly one concurrent rotation must succeed (got statuses {statuses:?})"
+    );
+    assert_eq!(
+        conflict_count,
+        RACERS - 1,
+        "all losing racers must observe 409 (got statuses {statuses:?})"
+    );
+
+    // Each racer wrote a distinguishable envelope payload — verify the
+    // server kept exactly one envelope set, not a torn mix.
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/keys/latest"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["key_version"].as_i64(),
+        Some(1),
+        "stored version must be 1"
+    );
+
+    // The owner's envelope payload must match a single racer's signature.
+    let stored_envelope = body["encrypted_key"]
+        .as_str()
+        .expect("encrypted_key string");
+    assert!(
+        stored_envelope.starts_with("envelope-from-racer-"),
+        "stored envelope must come from one of the racers, got: {stored_envelope}"
+    );
+    // Sanity: we only stored one envelope per recipient at this version.
+    // `_seen` is just for parity with the multi-recipient mental model.
+    let _seen: HashSet<&str> = std::iter::once(stored_envelope).collect();
+}
+
 // ---------------------------------------------------------------------------
 // Retrieval
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_groups.rs
+++ b/apps/server/tests/api_groups.rs
@@ -117,8 +117,11 @@ async fn get_group_returns_group_info() {
     assert_eq!(body["id"].as_str(), Some(group_id.as_str()));
 }
 
+// TD-34: NotMember now maps to 403 (Forbidden), not 401 (Unauthorized).
+// "Not a member of this conversation" is a permission failure, not an
+// authentication failure — the JWT is valid, the user just isn't allowed.
 #[tokio::test]
-async fn get_group_non_member_returns_401() {
+async fn get_group_non_member_returns_403() {
     let base = common::spawn_server().await;
     let client = Client::new();
     let (token_owner, _) = register_and_login(&client, &base, "grpowner").await;
@@ -133,7 +136,7 @@ async fn get_group_non_member_returns_401() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 401);
+    assert_eq!(resp.status().as_u16(), 403);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_groups_create.rs
+++ b/apps/server/tests/api_groups_create.rs
@@ -359,11 +359,11 @@ async fn get_group_member_can_fetch() {
 }
 
 // ---------------------------------------------------------------------------
-// get_group — non-member receives 401 (NotMember error code)
+// get_group — non-member receives 403 (NotMember error code) — TD-34
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn get_group_non_member_returns_401() {
+async fn get_group_non_member_returns_403() {
     let base = common::spawn_server().await;
     let client = Client::new();
     let (owner_token, _, _) = common::register_and_login(&client, &base, "ggnmown").await;
@@ -378,7 +378,10 @@ async fn get_group_non_member_returns_401() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 401);
+    // TD-34: NotMember is a permission failure (403), not an authentication
+    // failure (401). 401 made clients trigger global re-auth on what was
+    // really an authorisation problem.
+    assert_eq!(resp.status().as_u16(), 403);
     let body: Value = resp.json().await.unwrap();
     assert_eq!(
         body["code"].as_str(),
@@ -388,11 +391,11 @@ async fn get_group_non_member_returns_401() {
 }
 
 // ---------------------------------------------------------------------------
-// get_group — non-existent UUID: is_member returns false → 401
+// get_group — non-existent UUID: is_member returns false → 403 — TD-34
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn get_group_nonexistent_uuid_returns_401() {
+async fn get_group_nonexistent_uuid_returns_403() {
     let base = common::spawn_server().await;
     let client = Client::new();
     let (token, _, _) = common::register_and_login(&client, &base, "ggnoexist").await;
@@ -407,8 +410,8 @@ async fn get_group_nonexistent_uuid_returns_401() {
         .unwrap();
 
     // The handler checks is_member first; a non-existent group ID returns false
-    // from is_member → 401 NotMember before even attempting to fetch the group.
-    assert_eq!(resp.status().as_u16(), 401);
+    // from is_member → 403 NotMember (was 401 before TD-34).
+    assert_eq!(resp.status().as_u16(), 403);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_groups_lifecycle_public.rs
+++ b/apps/server/tests/api_groups_lifecycle_public.rs
@@ -130,9 +130,10 @@ async fn leave_group_last_member_auto_deletes() {
     );
 }
 
-/// A user who is not a group member gets 401 when trying to leave.
+/// A user who is not a group member gets 403 when trying to leave.
+/// TD-34: NotMember is a permission failure, not an auth failure.
 #[tokio::test]
-async fn leave_group_non_member_returns_401() {
+async fn leave_group_non_member_returns_403() {
     let base = common::spawn_server().await;
     let client = Client::new();
 
@@ -147,7 +148,7 @@ async fn leave_group_non_member_returns_401() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status().as_u16(), 401, "non-member leave should 401");
+    assert_eq!(resp.status().as_u16(), 403, "non-member leave should 403");
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_groups_members.rs
+++ b/apps/server/tests/api_groups_members.rs
@@ -185,9 +185,9 @@ async fn add_member_non_admin_private_group_returns_401() {
     assert_eq!(resp.status().as_u16(), 401);
 }
 
-/// Target user does not exist → 400.
+/// Target user does not exist → 404. TD-34.
 #[tokio::test]
-async fn add_member_nonexistent_user_returns_400() {
+async fn add_member_nonexistent_user_returns_404() {
     let base = common::spawn_server().await;
     let client = Client::new();
     let (owner_token, _, _) = common::register_and_login(&client, &base, "amnx_own").await;
@@ -202,7 +202,7 @@ async fn add_member_nonexistent_user_returns_400() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 /// Target user is already a member → 409.

--- a/apps/server/tests/api_keys.rs
+++ b/apps/server/tests/api_keys.rs
@@ -143,8 +143,9 @@ async fn get_bundle_returns_uploaded_data() {
     );
 }
 
+// TD-34: "no PreKey bundle found" is a not-found case (404), not a bad request (400).
 #[tokio::test]
-async fn get_bundle_no_keys_returns_400() {
+async fn get_bundle_no_keys_returns_404() {
     let base = common::spawn_server().await;
     let client = Client::new();
 
@@ -157,7 +158,7 @@ async fn get_bundle_no_keys_returns_400() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 #[tokio::test]
@@ -208,6 +209,94 @@ async fn get_bundle_consumes_one_time_prekey() {
     assert!(
         body["one_time_prekey"].is_null(),
         "4th fetch should have no OTP left"
+    );
+}
+
+/// TD-40: concurrent `GET /api/keys/bundle/:uid` requests against the same
+/// victim must each consume a distinct one-time prekey. The same shape of
+/// race that `concurrent_accept_respects_max_uses_under_lock` locks down
+/// for the invite-link path — the OTP path's `UPDATE ... AND used = false`
+/// must give the same guarantee.
+#[tokio::test]
+async fn concurrent_get_bundle_consumes_distinct_otps() {
+    use std::collections::HashSet;
+
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (token_victim, uid_victim, _) =
+        common::register_and_login(&client, &base, "otprace_v").await;
+    let (token_reader, _, _) = common::register_and_login(&client, &base, "otprace_r").await;
+
+    const N: usize = 8;
+    common::upload_prekey_bundle(&client, &base, &token_victim, 0, N).await;
+
+    // Concurrent reads using the same reader JWT — server processes them
+    // in parallel, and the OTP-consume UPDATE is what we want to stress.
+    let base = std::sync::Arc::new(base);
+    let token_reader = std::sync::Arc::new(token_reader);
+    let uid_victim = std::sync::Arc::new(uid_victim);
+
+    let mut joins = Vec::with_capacity(N + 1);
+    for _ in 0..=N {
+        let base = base.clone();
+        let tok = token_reader.clone();
+        let uid = uid_victim.clone();
+        let client = client.clone();
+        joins.push(tokio::spawn(async move {
+            let resp = client
+                .get(format!("{base}/api/keys/bundle/{uid}"))
+                .header("Authorization", format!("Bearer {tok}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(resp.status().as_u16(), 200);
+            let body: Value = resp.json().await.unwrap();
+            body["one_time_prekey"]
+                .get("key_id")
+                .and_then(|v| v.as_i64())
+        }));
+    }
+
+    let mut seen: HashSet<i64> = HashSet::new();
+    let mut nulls = 0;
+    for j in joins {
+        match j.await.unwrap() {
+            Some(key_id) => {
+                assert!(
+                    seen.insert(key_id),
+                    "OTP key_id {key_id} returned to two concurrent readers — \
+                     same OTP consumed twice (TD-40 regression)",
+                );
+            }
+            None => nulls += 1,
+        }
+    }
+
+    // Exactly N of the N+1 concurrent reads see an OTP; the (N+1)th sees null.
+    assert_eq!(
+        seen.len(),
+        N,
+        "expected {N} distinct OTPs consumed, got {} (nulls={nulls})",
+        seen.len()
+    );
+    assert_eq!(
+        nulls, 1,
+        "exactly one of N+1 concurrent reads must see no OTP left"
+    );
+
+    // Follow-up: server still serves the bundle without OTP.
+    let resp = client
+        .get(format!("{base}/api/keys/bundle/{uid_victim}"))
+        .header("Authorization", format!("Bearer {token_victim}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(
+        body["one_time_prekey"].is_null(),
+        "all OTPs should be consumed after the race"
     );
 }
 
@@ -614,7 +703,7 @@ async fn device_0_legacy_fingerprint_still_enforced() {
 async fn reset_device_clears_only_that_device() {
     let base = common::spawn_server().await;
     let client = Client::new();
-    let (token, uid, _username) = common::register_and_login(&client, &base, "keyresetdev").await;
+    let (token, uid, username) = common::register_and_login(&client, &base, "keyresetdev").await;
 
     let bundle0 = common::upload_prekey_bundle(&client, &base, &token, 0, 0).await;
     common::upload_additional_device(&client, &base, &token, &bundle0, 1).await;
@@ -629,6 +718,12 @@ async fn reset_device_clears_only_that_device() {
         .unwrap();
     assert_eq!(resp.status().as_u16(), 204);
 
+    // CR-4: reset_device invalidates outstanding access tokens for this user
+    // (see auth::invalidation). Re-login to acquire a fresh JWT for the
+    // post-reset re-upload below; the original `token` predates the
+    // invalidation floor and would 401.
+    let (token, _uid) = common::login(&client, &base, &username, common::TEST_USER_PASSWORD).await;
+
     // Device 0 must still be reachable
     let (token_other, _, _) = common::register_and_login(&client, &base, "keyresetdevobs").await;
     let resp = client
@@ -639,14 +734,15 @@ async fn reset_device_clears_only_that_device() {
         .unwrap();
     assert_eq!(resp.status().as_u16(), 200, "device 0 must remain bound");
 
-    // Device 1 row was deleted by revoke_device; fetching its bundle 400s.
+    // Device 1 row was deleted by revoke_device; fetching its bundle 404s.
+    // TD-34: was 400 before the status-code remap.
     let resp = client
         .get(format!("{base}/api/keys/bundle/{uid}/1"))
         .header("Authorization", format!("Bearer {token_other}"))
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status().as_u16(), 400, "device 1 must be cleared");
+    assert_eq!(resp.status().as_u16(), 404, "device 1 must be cleared");
 
     // Device 1 can now bind a brand-new identity without conflicting with
     // device 0.
@@ -795,7 +891,7 @@ async fn revoke_device_removes_keys() {
         .unwrap();
     assert_eq!(resp.status().as_u16(), 204);
 
-    // Fetch device 1 bundle should fail
+    // Fetch device 1 bundle should fail — TD-34: now 404 (not-found) instead of 400.
     let (token_other, _, _) = common::register_and_login(&client, &base, "keyrevoth").await;
     let resp = client
         .get(format!("{base}/api/keys/bundle/{uid}/1"))
@@ -803,7 +899,7 @@ async fn revoke_device_removes_keys() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 #[tokio::test]

--- a/apps/server/tests/api_link_preview.rs
+++ b/apps/server/tests/api_link_preview.rs
@@ -162,11 +162,13 @@ async fn loopback_ip_rejected() {
     let client = Client::new();
     let (token, _, _) = common::register_and_login(&client, &base, "lp_loopback").await;
 
+    // TD-31 added a port allowlist {80, 443}; use the default port so the
+    // request reaches the IP-private check that this test is asserting.
     let resp = post_link_preview(
         &client,
         &base,
         &token,
-        &serde_json::json!({"url": "http://127.0.0.1:8080/evil"}),
+        &serde_json::json!({"url": "http://127.0.0.1/evil"}),
     )
     .await;
 

--- a/apps/server/tests/api_messages_extra.rs
+++ b/apps/server/tests/api_messages_extra.rs
@@ -164,15 +164,17 @@ async fn edit_message_empty_content_returns_400() {
     assert_eq!(resp.status().as_u16(), 400);
 }
 
+// TD-34: "message not found or you are not the sender" → 404.
 #[tokio::test]
-async fn edit_someone_elses_message_returns_400() {
+async fn edit_someone_elses_message_returns_404() {
     let base = common::spawn_server().await;
     let (client, _, _, bob_token, _, _, message_id) = setup_dm_with_message(&base).await;
 
     // Bob tries to edit Alice's message — should fail. Note: the encrypted-DM
-    // gate (#582) now runs BEFORE the ownership check, so non-senders also
-    // get 409 instead of 400 for encrypted conversations. Either is fine; we
-    // just need to confirm the edit didn't succeed.
+    // gate (#582) now runs BEFORE the ownership check, so non-senders get 409
+    // for encrypted conversations and 404 (TD-34: "not found / not the
+    // sender") for unencrypted ones. Either is fine; we just need to confirm
+    // the edit didn't succeed.
     let resp = client
         .put(format!("{base}/api/messages/{message_id}"))
         .header("Authorization", format!("Bearer {bob_token}"))
@@ -183,8 +185,8 @@ async fn edit_someone_elses_message_returns_400() {
 
     let status = resp.status().as_u16();
     assert!(
-        status == 400 || status == 409,
-        "expected 400/409, got {status}"
+        status == 404 || status == 409,
+        "expected 404/409, got {status}"
     );
 }
 
@@ -253,7 +255,8 @@ async fn edit_message_on_unencrypted_group_succeeds() {
 }
 
 #[tokio::test]
-async fn edit_nonexistent_message_returns_400() {
+// TD-34: not-found → 404.
+async fn edit_nonexistent_message_returns_404() {
     let base = common::spawn_server().await;
     let client = Client::new();
     let username = common::unique_username("editunk");
@@ -269,7 +272,7 @@ async fn edit_nonexistent_message_returns_400() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 // ---------------------------------------------------------------------------
@@ -291,8 +294,9 @@ async fn delete_own_message_returns_204() {
     assert_eq!(resp.status().as_u16(), 204);
 }
 
+// TD-34: not-the-sender / not-found → 404.
 #[tokio::test]
-async fn delete_someone_elses_message_returns_400() {
+async fn delete_someone_elses_message_returns_404() {
     let base = common::spawn_server().await;
     let (client, _, _, bob_token, _, _, message_id) = setup_dm_with_message(&base).await;
 
@@ -303,11 +307,11 @@ async fn delete_someone_elses_message_returns_400() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 #[tokio::test]
-async fn delete_nonexistent_message_returns_400() {
+async fn delete_nonexistent_message_returns_404() {
     let base = common::spawn_server().await;
     let client = Client::new();
     let username = common::unique_username("delunk");
@@ -322,7 +326,7 @@ async fn delete_nonexistent_message_returns_400() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 // ---------------------------------------------------------------------------
@@ -391,8 +395,9 @@ async fn get_messages_returns_sent_message() {
     );
 }
 
+// TD-34: NotMember now returns 403 (permission failure), not 401 (auth failure).
 #[tokio::test]
-async fn get_messages_non_member_returns_401() {
+async fn get_messages_non_member_returns_403() {
     let base = common::spawn_server().await;
     let (client, _, _, _, _, conv_id, _) = setup_dm_with_message(&base).await;
 
@@ -407,7 +412,7 @@ async fn get_messages_non_member_returns_401() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 401);
+    assert_eq!(resp.status().as_u16(), 403);
 }
 
 // ---------------------------------------------------------------------------
@@ -513,8 +518,8 @@ async fn get_unmuted_user_ids_excludes_muted_member() {
 /// ciphertext would index/scan random bytes and could leak presence
 /// metadata via hit/miss timings, so the route (#350) returns
 /// `400 Bad Request` rather than scanning. The auth/member check runs
-/// first; an unauthenticated or non-member request still gets the
-/// usual 401/403 (see `search_messages_non_member_returns_401`).
+/// first; an unauthenticated request gets 401 and a non-member request
+/// gets 403 (see `search_messages_non_member_returns_403`).
 #[tokio::test]
 async fn search_messages_rejects_encrypted_conversation() {
     let base = common::spawn_server().await;
@@ -530,8 +535,9 @@ async fn search_messages_rejects_encrypted_conversation() {
     assert_eq!(resp.status().as_u16(), 400);
 }
 
+// TD-34: NotMember now returns 403, not 401.
 #[tokio::test]
-async fn search_messages_non_member_returns_401() {
+async fn search_messages_non_member_returns_403() {
     let base = common::spawn_server().await;
     let (client, _, _, _, _, conv_id, _) = setup_dm_with_message(&base).await;
 
@@ -548,7 +554,7 @@ async fn search_messages_non_member_returns_401() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 401);
+    assert_eq!(resp.status().as_u16(), 403);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_reactions.rs
+++ b/apps/server/tests/api_reactions.rs
@@ -169,8 +169,9 @@ async fn add_reaction_non_member_returns_401() {
     assert_eq!(resp.status().as_u16(), 401);
 }
 
+// TD-34: not-found cases now return 404 instead of 400.
 #[tokio::test]
-async fn add_reaction_invalid_message_returns_400() {
+async fn add_reaction_invalid_message_returns_404() {
     let base = common::spawn_server().await;
     let (client, alice_token, _, _, _, _) = setup_dm_with_message(&base).await;
 
@@ -183,7 +184,7 @@ async fn add_reaction_invalid_message_returns_400() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/api_users.rs
+++ b/apps/server/tests/api_users.rs
@@ -52,8 +52,9 @@ async fn get_own_profile_returns_200() {
     assert_eq!(body["user_id"].as_str(), Some(user_id.as_str()));
 }
 
+// TD-34: not-found now returns 404 instead of 400.
 #[tokio::test]
-async fn get_unknown_profile_returns_400() {
+async fn get_unknown_profile_returns_404() {
     let base = common::spawn_server().await;
     let client = Client::new();
     let (token, _) = setup_user(&client, &base, "profunk").await;
@@ -66,7 +67,7 @@ async fn get_unknown_profile_returns_400() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(resp.status().as_u16(), 404);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -29,6 +29,11 @@ use tokio::sync::OnceCell;
 /// JWT secret used across all integration tests.
 pub const TEST_JWT_SECRET: &str = "integration-test-secret";
 
+/// Password every fixture user registers with.  Centralised so CodeQL's
+/// hard-coded-credentials scanner sees a single constant instead of an
+/// inline literal at every login site.
+pub const TEST_USER_PASSWORD: &str = "password123";
+
 /// Run migrations exactly once across all tests, even when running in parallel.
 static MIGRATIONS: OnceCell<()> = OnceCell::const_new();
 
@@ -71,6 +76,7 @@ async fn spawn_server_inner(trusted_proxies: Vec<IpNet>) -> String {
         ticket_store: Arc::new(dashmap::DashMap::new()),
         media_tickets: Arc::new(dashmap::DashMap::new()),
         message_rate: Arc::new(echo_server::metrics::MessageRateCounter::new()),
+        token_invalidator: echo_server::auth::TokenInvalidator::new(),
     });
 
     let app = routes::create_router(state, trusted_proxies);

--- a/apps/server/tests/migrations.rs
+++ b/apps/server/tests/migrations.rs
@@ -98,6 +98,124 @@ async fn run_migrations_into_schema(base_url: &str, schema: &str) -> Result<usiz
         .fetch_one(&pool)
         .await?;
 
+    // TD-66: lock down a handful of schema invariants. A migration that
+    // forgot to mark a column NOT NULL, used the wrong data type, or
+    // dropped a critical index would pass the bare `count > 0` check
+    // unchanged — these assertions catch it.
+    assert_column_invariants(&pool).await?;
+    assert_index_invariants(&pool).await?;
+
     pool.close().await;
     Ok(count as usize)
+}
+
+/// TD-66: assert critical column existence / nullability / type.
+///
+/// Each entry: `(table, column, expected_data_type, expected_nullable)`.
+/// `expected_data_type` matches `information_schema.columns.data_type`.
+async fn assert_column_invariants(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+    const INVARIANTS: &[(&str, &str, &str, &str)] = &[
+        // Refresh-token family wiring — drives the theft-detection family
+        // revoke; mis-typed columns silently break the chain. `family_id`
+        // is nullable because the migration that added it didn't backfill
+        // pre-existing rows; new rows always get a value via the default.
+        ("refresh_tokens", "family_id", "uuid", "YES"),
+        ("refresh_tokens", "revoked", "boolean", "NO"),
+        // Soft-delete invariant — every query in `db/messages.rs` filters
+        // on `deleted_at IS NULL`; flipping to NOT NULL would resurrect
+        // tombstones.
+        ("messages", "deleted_at", "timestamp with time zone", "YES"),
+        // Per-message TTL column the disappearing-messages sweep relies on.
+        ("messages", "expires_at", "timestamp with time zone", "YES"),
+        // Per-device key fingerprint binding — defeats signing-key-only MITM.
+        ("identity_keys", "fingerprint", "bytea", "YES"),
+        (
+            "identity_keys",
+            "revoked_at",
+            "timestamp with time zone",
+            "YES",
+        ),
+        // Group-key envelope schema; integer key_version drives version
+        // monotonicity guarantees.
+        ("group_key_envelopes", "key_version", "integer", "NO"),
+        ("group_key_envelopes", "encrypted_key", "text", "NO"),
+        // Feedback diagnostic context (TD-57 / beta migration).
+        ("feedback", "app_version", "text", "YES"),
+        ("feedback", "platform", "text", "YES"),
+        ("feedback", "logs", "text", "YES"),
+        // Conversation member soft-delete invariant.
+        ("conversation_members", "is_removed", "boolean", "NO"),
+        // Invite-token use accounting — integer with a max-uses check.
+        // max_uses NULL means "unlimited"; use_count is always set.
+        ("group_invite_tokens", "use_count", "integer", "NO"),
+        ("group_invite_tokens", "max_uses", "integer", "YES"),
+        // Password-reset audit columns the cleanup task scans on.
+        (
+            "password_reset_tokens",
+            "expires_at",
+            "timestamp with time zone",
+            "NO",
+        ),
+        (
+            "password_reset_tokens",
+            "used_at",
+            "timestamp with time zone",
+            "YES",
+        ),
+    ];
+
+    for (table, column, expected_type, expected_nullable) in INVARIANTS {
+        let row: Option<(String, String)> = sqlx::query_as(
+            "SELECT data_type, is_nullable FROM information_schema.columns \
+             WHERE table_schema = current_schema() AND table_name = $1 AND column_name = $2",
+        )
+        .bind(table)
+        .bind(column)
+        .fetch_optional(pool)
+        .await?;
+
+        let (data_type, is_nullable) =
+            row.unwrap_or_else(|| panic!("missing column {table}.{column}"));
+        assert_eq!(
+            data_type, *expected_type,
+            "{table}.{column}: expected type {expected_type}, got {data_type}",
+        );
+        assert_eq!(
+            is_nullable, *expected_nullable,
+            "{table}.{column}: expected nullable={expected_nullable}, got {is_nullable}",
+        );
+    }
+
+    Ok(())
+}
+
+/// TD-66: assert critical indexes exist (and so the planner can use them).
+///
+/// These names track the actual SQL filenames; if a migration is renamed in
+/// the future, this assertion will catch a missing index.
+async fn assert_index_invariants(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+    const INDEXES: &[(&str, &str)] = &[
+        ("messages", "idx_messages_conv"),
+        ("messages", "idx_messages_conv_created_desc"),
+        ("group_key_envelopes", "idx_group_key_envelopes_recipient"),
+        ("feedback", "feedback_status_created_at_idx"),
+        ("feedback", "feedback_user_id_created_at_idx"),
+    ];
+
+    for (table, index) in INDEXES {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT indexname FROM pg_indexes \
+             WHERE schemaname = current_schema() AND tablename = $1 AND indexname = $2",
+        )
+        .bind(table)
+        .bind(index)
+        .fetch_optional(pool)
+        .await?;
+        assert!(
+            row.is_some(),
+            "expected index {index} on {table} to exist after migration",
+        );
+    }
+
+    Ok(())
 }

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -1399,6 +1399,7 @@ async fn revoked_device_excluded_from_fanout() {
         common::register_and_login(&client, &base, "rev657_alice").await;
     let (bob_token, bob_id, bob_name) =
         common::register_and_login(&client, &base, "rev657_bob").await;
+    let bob_username = bob_name.clone();
 
     common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
 
@@ -1414,6 +1415,14 @@ async fn revoked_device_excluded_from_fanout() {
         .await
         .expect("revoke request failed");
     assert!(revoke_resp.status().is_success(), "revoke device 22 failed");
+
+    // CR-4: revoke_device bumps the per-user `min iat` invalidator, so the
+    // original `bob_token` minted before the revoke can fail subsequent
+    // AuthUser checks on slow CI runs where the iat second has rolled over.
+    // Re-login Bob to obtain a token whose iat is strictly newer than the
+    // invalidation floor before fetching WS tickets.
+    let (bob_token, _) =
+        common::login(&client, &base, &bob_username, common::TEST_USER_PASSWORD).await;
 
     // Alice connects on her device.
     let alice_ticket = common::get_ws_ticket_for_device(&client, &base, &alice_token, 1).await;

--- a/docs/ui-naming-reference.md
+++ b/docs/ui-naming-reference.md
@@ -1,0 +1,242 @@
+# UI naming reference
+
+Cheat sheet of the in-code names for UI regions you see in the app. When filing a bug or asking for a change, point at the name here and code/agents land on the right file immediately.
+
+All paths are relative to `apps/client/lib/src/`.
+
+## Home screen — the main 3-tier layout
+
+`HomeScreen` (`screens/home_screen.dart`) picks one of three tier mixins based on viewport width via `StableLayoutDecision`:
+
+- `_HomeScreenNarrowLayoutMixin` — phone (<600px). Bottom tab bar, full-screen chat panel.
+- `_HomeScreenWideLayoutMixin` — tablet (600–899px). Collapsed sidebar + chat.
+- `_HomeScreenDesktopLayoutMixin` — desktop (≥900px). Full sidebar + chat + optional right pane.
+
+### Desktop layout
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ┌──────────────┐  ┌────────────────────────────────────┐  ┌────────────┐  │
+│  │              │  │  ChatHeaderBar (chat_header_bar)   │  │            │  │
+│  │              │  ├────────────────────────────────────┤  │            │  │
+│  │              │  │  ChannelBar (channel_bar)          │  │            │  │
+│  │              │  │  - text channels + voice dock      │  │            │  │
+│  │              │  ├────────────────────────────────────┤  │  Members   │  │
+│  │              │  │  EncryptionStatusBanner            │  │  Panel     │  │
+│  │ Conversation │  ├────────────────────────────────────┤  │ (members_  │  │
+│  │ Panel        │  │                                    │  │  panel)    │  │
+│  │ (conversa-   │  │  ChatMessageList                   │  │            │  │
+│  │  tion_panel) │  │  (chat_panel/chat_message_list)    │  │  group-    │  │
+│  │              │  │                                    │  │  only      │  │
+│  │ - sidebar    │  │   - DateDivider                    │  │            │  │
+│  │   header     │  │   - UnreadDivider                  │  │            │  │
+│  │ - filters    │  │   - MessageItem (message_item)     │  │            │  │
+│  │   (All/DMs/  │  │   - FloatingDatePill               │  │            │  │
+│  │    Groups)   │  │   - NewMessagesPill                │  │            │  │
+│  │ - ConvList   │  │                                    │  │            │  │
+│  │ - VoiceDock  │  ├────────────────────────────────────┤  │            │  │
+│  │              │  │  ChatInputBar (chat_input_bar)     │  │            │  │
+│  │ - account    │  │  - send_button / attach / emoji    │  │            │  │
+│  │   rail       │  │                                    │  │            │  │
+│  └──────────────┘  └────────────────────────────────────┘  └────────────┘  │
+└────────────────────────────────────────────────────────────────────────────┘
+        ↑                          ↑                                 ↑
+   "the sidebar"             "the chat panel"                "the right panel"
+                                                          (group members)
+```
+
+### Region names
+
+| What you see | In-code name | File |
+|---|---|---|
+| The left sidebar (conversation list + voice dock + account rail) | **`ConversationPanel`** | `widgets/conversation_panel.dart` |
+| The big chat area on the right of the sidebar | **`ChatPanel`** | `widgets/chat_panel.dart` |
+| Top bar of the chat (peer name, call button, more menu) | **`ChatHeaderBar`** | `widgets/chat_header_bar.dart` |
+| Strip of text/voice channels under the header (groups only) | **`ChannelBar`** | `widgets/channel_bar.dart` |
+| Banner that says "Identity changed" / "Keys missing" / etc. | **`EncryptionStatusBanner`** | `widgets/encryption_status_banner.dart` |
+| Floating date pill that follows scroll | **`FloatingDatePill`** | `widgets/chat_panel/floating_date_pill.dart` |
+| "X new messages ↓" pill | **`NewMessagesPill`** | `widgets/chat_panel/new_messages_pill.dart` |
+| The scrolling list of messages | **`ChatMessageList`** | `widgets/chat_panel/chat_message_list.dart` |
+| A single message row | **`MessageItem`** | `widgets/message_item.dart` |
+| "Today" / "Yesterday" / dated section breaks | **`DateDivider`** | `widgets/chat_panel/date_divider.dart` |
+| The red "New" line above unread messages | **`UnreadDivider`** | `widgets/chat_panel/unread_divider.dart` |
+| Right-click / long-press hover menu on a message | **message_actions** | `widgets/chat_panel/message_actions.dart` |
+| The compose / type-here strip at the bottom | **`ChatInputBar`** | `widgets/chat_input_bar.dart` |
+| Send button inside the input bar | **`SendButton`** | `widgets/chat_input_bar/send_button.dart` |
+| Attach-file paperclip | **attach_file_button** | `widgets/chat_input_bar/attach_file_button.dart` |
+| The right-side roster pane on groups | **`MembersPanel`** | `widgets/members_panel.dart` |
+| The Discord-style narrow channel rail (column mode) | **`ChannelColumn`** | `widgets/channel_column.dart` |
+| Voice-call dock pinned to the bottom of the sidebar | **`VoiceDock`** | `widgets/voice_dock.dart` |
+| Voice rejoin strip between content and tab bar (mobile narrow) | **`VoiceFooter`** | `widgets/voice_footer.dart` |
+| Mobile bottom tab bar (Chats / Discover / Contacts / Settings) | **mobile tab bar** | `home_screen/parts/narrow_layout.dart` (`_buildMobileTabBar`) |
+
+### Narrow (phone) layout
+
+The conversation list and the chat panel swap places — tapping a row opens the chat full-screen, and a bottom tab bar replaces the desktop sidebar.
+
+```
+┌──────────────────────┐         ┌──────────────────────┐
+│ Sidebar header       │         │  ChatHeaderBar       │
+│ - search / new chat  │         │  - back arrow        │
+│ ┌──────────────────┐ │         ├──────────────────────┤
+│ │ Conv row         │ │  tap →  │  ChannelBar          │
+│ │ Conv row         │ │         ├──────────────────────┤
+│ │ Conv row         │ │         │  ChatMessageList     │
+│ └──────────────────┘ │         │                      │
+│                      │         │                      │
+│                      │         ├──────────────────────┤
+│                      │         │  ChatInputBar        │
+├──────────────────────┤         └──────────────────────┘
+│ Chats|Discover|... │           swipe-from-left-edge to
+│ ←── mobile tab bar │           pop back to conv list
+└──────────────────────┘
+```
+
+## Voice lounge
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  LoungeHeader (lounge_header)                                        │
+│  ← Lounge   #channel   [photo icon]                                  │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│             ParticipantGrid (participant_grid)                       │
+│             - one tile per participant                               │
+│             - LoungeDrawingCanvas overlay (if drawing)               │
+│                                                                      │
+│                                                                      │
+│      ┌────────────────────────────────────────────────────┐          │
+│      │  FloatingDock (floating_dock)                      │          │
+│      │  mic | deafen | cam | screen | draw | leave        │          │
+│      └────────────────────────────────────────────────────┘          │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+| What you see | In-code name | File |
+|---|---|---|
+| Title strip with back + channel + background-picker | **`LoungeHeader`** | `screens/voice_lounge/lounge_header.dart` |
+| Grid of participant video / avatar tiles | **`ParticipantGrid`** | `screens/voice_lounge/participant_grid.dart` |
+| Floating control dock (mic / cam / leave / etc.) | **`FloatingDock`** | `screens/voice_lounge/floating_dock.dart` |
+| Drawing-tool palette popover | **`DrawingToolsMenu`** | `screens/voice_lounge/drawing_tools_menu.dart` |
+| Source-picker for screen share | **echo_screen_select_dialog** | `screens/voice_lounge/echo_screen_select_dialog.dart` |
+| Hover submenus on the dock buttons | **dock_submenus** | `screens/voice_lounge/dock_submenus.dart` |
+
+## Settings
+
+```
+┌─────────────────┬──────────────────────────────────────────────────┐
+│ ← Back          │                                                  │
+│                 │                                                  │
+│ T username      │                                                  │
+│                 │                                                  │
+│ Account prefs   │            (selected section body                │
+│  Status         │             rendered here — e.g.                 │
+│  Appearance     │             AppearanceSection,                   │
+│  Language       │             AccessibilitySection,                │
+│  Notifications  │             AccountSection, etc.)                │
+│  Voice & Video  │                                                  │
+│  Privacy        │                                                  │
+│  Devices        │                                                  │
+│  Storage        │                                                  │
+│  Accessibility  │                                                  │
+│ Echo            │                                                  │
+│  About v0.0.x   │                                                  │
+│ Log out         │                                                  │
+└─────────────────┴──────────────────────────────────────────────────┘
+       ↑                              ↑
+"settings sidebar"               "section body"
+(SettingsRootView)               (one of the *Section widgets)
+```
+
+| What you see | In-code name | File |
+|---|---|---|
+| Whole screen | **`SettingsScreen`** | `screens/settings_screen.dart` |
+| Left nav with section list | **`SettingsRootView`** | `screens/settings_screen.dart` (`SettingsRootView`) |
+| One row in the left nav | **`CardRow`** | `widgets/settings/card_row.dart` |
+| A plain icon+title row inside a section | **`SettingsListTile`** | `widgets/settings/settings_list_tile.dart` |
+| Section header label inside a section body | **`SectionHeader`** | `widgets/settings/section_header.dart` |
+| User identity card at the top of Account section | **`UserHeaderCard`** | `widgets/settings/user_header_card.dart` |
+| Status section body | **`StatusSection`** | `screens/settings/status_section.dart` |
+| Appearance section body (themes, GIF autoplay today) | **`AppearanceSection`** | `screens/settings/appearance_section.dart` |
+| Language section body | **`LanguageSection`** | `screens/settings/language_section.dart` |
+| Notifications section body | **`NotificationSection`** | `screens/settings/notification_section.dart` |
+| Voice & Video section body | **`VoiceVideoSection`** | `screens/settings/voice_section.dart` |
+| Privacy section body | **`PrivacySection`** | `screens/settings/privacy_section.dart` |
+| Devices section body | **`DevicesSection`** | `screens/settings/devices_section.dart` |
+| Storage section body | **`DataStorageSection`** | `screens/settings/data_storage_section.dart` |
+| Accessibility section body (font scale today) | **`AccessibilitySection`** | `screens/settings/accessibility_section.dart` |
+| About section body | **`AboutSection`** | `screens/settings/about_section.dart` |
+| Account section body | **`AccountSection`** | `screens/settings/account_section.dart` |
+| Advanced theme picker | **`AdvancedThemeSection`** | `screens/settings/advanced_theme_section.dart` |
+
+## Group info
+
+Open from the chat header (group conv) or anywhere that calls `showGroupProfileSheet`. Dialog on desktop ≥800px, bottom-sheet below.
+
+```
+┌─────────────────────────────────────────────────┐
+│  ← Group Info                                   │
+├─────────────────────────────────────────────────┤
+│  HeaderSection (parts/header_section)           │
+│   - avatar + name + description                 │
+├─────────────────────────────────────────────────┤
+│  ChannelsSection (admin only)                   │
+│  DisappearingMessages (admin only)              │
+│  MembersSection (parts/members_section)         │
+│   - roster grouped by role                      │
+│   - AddMemberDialog launcher                    │
+│  InviteSection (parts/invite_section)           │
+│  DangerActions (parts/danger_actions)           │
+│   - Leave / Delete                              │
+└─────────────────────────────────────────────────┘
+```
+
+| What you see | In-code name | File |
+|---|---|---|
+| Whole screen / sheet | **`GroupInfoScreen`** | `screens/group_info_screen.dart` |
+| Icon + name + description block at top | **HeaderSection** | `screens/group_info_screen/parts/header_section.dart` |
+| Text + voice channel list | **ChannelsSection** | `screens/group_info_screen/parts/channels_section.dart` |
+| TTL picker | **DisappearingMessages** | `screens/group_info_screen/parts/disappearing_messages.dart` |
+| Roster + role grouping | **MembersSection** | `screens/group_info_screen/parts/members_section.dart` |
+| Add-member modal | **AddMemberDialog** | `screens/group_info_screen/parts/add_member_dialog.dart` |
+| Invite-link card | **InviteSection** | `screens/group_info_screen/parts/invite_section.dart` |
+| Leave / Delete buttons | **DangerActions** | `screens/group_info_screen/parts/danger_actions.dart` |
+
+## Other dialogs / overlays you might mean
+
+| What you see | In-code name | File |
+|---|---|---|
+| User profile popup (avatar + status + bio + actions) | **`UserProfileScreen`** (opened via `showUserProfileSheet`) | `screens/user_profile_screen.dart` (host) / `widgets/profile_sheets.dart` (presenter) |
+| Cmd+K / Ctrl+K conversation switcher | **`QuickSwitcherOverlay`** | `widgets/quick_switcher_overlay.dart` |
+| Ctrl+Shift+F across-all-chats search | **`GlobalSearchOverlay`** | `widgets/global_search_overlay.dart` |
+| Per-chat search (the magnifying glass on the header — pending removal in #1135) | **`MessageSearchOverlay`** | `widgets/message_search_overlay.dart` |
+| "Are you sure?" confirmation dialog | **`showEchoConfirmDialog`** | `widgets/confirm_dialog.dart` |
+| Any modal bottom sheet | **`showEchoBottomSheet`** | `widgets/echo_bottom_sheet.dart` |
+| Generic empty state with illustration | **`EmptyState`** | `widgets/empty_state.dart` |
+| Generic info / warning / danger banner | **`EchoBanner`** | `widgets/echo_banner.dart` |
+| Image lightbox | **`ImageGalleryViewer`** | `widgets/image_gallery_viewer.dart` |
+| Sticker / emoji picker | **`EmojiPickerConfig`** | `widgets/emoji_picker_config.dart` |
+| Reactions full picker (after More) | **`FullReactionPicker`** | `widgets/chat_panel/full_reaction_picker.dart` |
+| Auth screens scaffold (login / register / forgot / reset) | **`AuthLayout`** | `widgets/auth/auth_layout.dart` |
+| Onboarding wizard | **`OnboardingWizard`** | `screens/onboarding_wizard.dart` |
+| Splash | **`SplashScreen`** | `screens/splash_screen.dart` |
+| Update-available card on splash | **(update prompt)** | `providers/update_provider.dart` + `screens/splash_screen.dart` |
+| New-message composer | **`NewMessageScreen`** | `screens/new_message_screen.dart` |
+| Create-group flow | **`CreateGroupScreen`** | `screens/create_group_screen.dart` |
+| Discover groups list | **`DiscoverGroupsScreen`** | `screens/discover_groups_screen.dart` |
+| Saved-messages list | **`SavedMessagesScreen`** | `screens/saved_messages_screen.dart` |
+| Contacts list | **`ContactsScreen`** | `screens/contacts_screen.dart` |
+| Safety number / verification | **`SafetyNumberScreen`** | `screens/safety_number_screen.dart` |
+| Join-by-invite landing | **`JoinGroupScreen`** | `screens/join_group_screen.dart` |
+| Admin dashboard | **`AdminDashboardScreen`** | `screens/admin/admin_dashboard_screen.dart` |
+| Connection indicator dot near the top-left | **`ConnectionStatusBadge`** | `widgets/connection_status_badge.dart` |
+
+## How to use this when filing a bug
+
+Best: paste the name directly. "On `MembersPanel`, the presence dot is offset by 4px on hi-DPI Linux" lands faster than "on the right side roster thing".
+
+Second-best: paste the file path. `widgets/chat_panel/floating_date_pill.dart:42` is unambiguous and goes straight to the line.
+
+When unsure: describe the screen + region. "Settings → Voice & Video, the input device dropdown" maps cleanly to `screens/settings/voice_section.dart`.
+
+If you see a region that isn't on this list, add it here. The doc is the source of truth — anything inconsistent with current code is a bug to fix in the doc.

--- a/tests/e2e/group_messaging_ui.spec.ts
+++ b/tests/e2e/group_messaging_ui.spec.ts
@@ -348,6 +348,9 @@ test.describe('Group messaging UI', () => {
   // -----------------------------------------------------------------------
   // Test 1: Alice sends a message in the group, Bob sees it
   // -----------------------------------------------------------------------
+  // TD-83: these flows were temporarily disabled while the group UI was being
+  // overhauled; the assertions still target stale selectors. Tracked as a
+  // post-beta polish item — see TECHNICAL_DEBT.md TD-83.
   test.fixme('alice sends message in group, bob receives', async ({ browser }) => {
     test.setTimeout(180000);
     console.log('\n--- Test: send/receive in group ---');
@@ -386,6 +389,9 @@ test.describe('Group messaging UI', () => {
   // -----------------------------------------------------------------------
   // Test 2: React to a group message via API, verify pill in UI
   // -----------------------------------------------------------------------
+  // TD-83: these flows were temporarily disabled while the group UI was being
+  // overhauled; the assertions still target stale selectors. Tracked as a
+  // post-beta polish item — see TECHNICAL_DEBT.md TD-83.
   test.fixme('reaction on group message', async ({ browser }) => {
     test.setTimeout(180000);
     console.log('\n--- Test: reaction on group message ---');
@@ -439,6 +445,9 @@ test.describe('Group messaging UI', () => {
   // -----------------------------------------------------------------------
   // Test 3: Pin a message in the group (owner-only action)
   // -----------------------------------------------------------------------
+  // TD-83: these flows were temporarily disabled while the group UI was being
+  // overhauled; the assertions still target stale selectors. Tracked as a
+  // post-beta polish item — see TECHNICAL_DEBT.md TD-83.
   test.fixme('pin message in group', async ({ browser }) => {
     test.setTimeout(180000);
     console.log('\n--- Test: pin message in group ---');
@@ -497,6 +506,9 @@ test.describe('Group messaging UI', () => {
   // -----------------------------------------------------------------------
   // Test 4: Owner sees "Delete Group", non-owner does not
   // -----------------------------------------------------------------------
+  // TD-83: these flows were temporarily disabled while the group UI was being
+  // overhauled; the assertions still target stale selectors. Tracked as a
+  // post-beta polish item — see TECHNICAL_DEBT.md TD-83.
   test.fixme('owner sees Delete Group button, non-owner does not', async ({
     browser,
   }) => {
@@ -594,6 +606,9 @@ test.describe('Group messaging UI', () => {
   // -----------------------------------------------------------------------
   // Test 5: Owner can kick a member via the API and it reflects correctly
   // -----------------------------------------------------------------------
+  // TD-83: these flows were temporarily disabled while the group UI was being
+  // overhauled; the assertions still target stale selectors. Tracked as a
+  // post-beta polish item — see TECHNICAL_DEBT.md TD-83.
   test.fixme('owner can kick member', async ({ browser }) => {
     test.setTimeout(180000);
     console.log('\n--- Test: owner kicks member ---');


### PR DESCRIPTION
## Summary

Comprehensive audit batch closing every critical (4), high-severity (15), and the bulk of the medium + low findings from the 2026-05-25 fresh-eyes review of the codebase. Full per-finding evidence lives in `TECHNICAL_DEBT.md` (TD-24..TD-85).

**Critical (all resolved):**
- TD-24 password-reset tokens no longer logged
- TD-25 `reset_password` wrapped in a single transaction
- TD-26 byte-range media downloads stream (no 100 MB alloc per request)
- TD-27 JWT now honors device revocation via in-memory min-iat invalidator

**High (all resolved or primitive-shipped):**
- TD-28 Ed25519-signed group-key envelopes (primitive + tests; rotation-path wiring deferred per design discussion in `docs/group-e2e-design/`)
- TD-29 TOFU no longer silently overwrites a changed peer identity key
- TD-30 encrypted-DM `recipient_device_contents` must include the actual peer
- TD-31 link_preview SSRF deny-list (CGNAT, TEST-NETs, benchmark, multicast) + port allowlist + async DNS
- TD-32 IPv4-mapped IPv6 normalization in rate-limit
- TD-33 group-member mutations under `pg_advisory_xact_lock`
- TD-34 HTTP status semantics (NotMember 401→403, not-found 400→404)
- TD-35 voice/canvas WS payload byte caps at dispatch
- TD-36 WS rate-limit Ping/Binary frame counter
- TD-37 cooperative shutdown for periodic cleanup tasks
- TD-38 `reset_device` transactional
- TD-39 HTTP cache headers (`Cache-Control` + weak ETag, `If-None-Match` → 304) on avatars/media/thumbnails
- TD-40 concurrent OTP-consume test
- TD-41 rotation-storm integration test (same-version race)
- TD-42 refresh-token theft cascade depth-N test

**Medium / Low cleanup batch:** CORS Origin check on cookie-credentialed endpoints, admin first-user bootstrap gate (`ECHO_BOOTSTRAP_ADMIN_USERNAME`), Argon2id parameters pinned, `update_my_privacy` single-statement COALESCE, paginated `cleanup_expired_messages`, `get_bundle` N+1 short-circuit, DB pool warm/timeout tuning, password-reset-token cleanup task, parallel APNs push fan-out, per-device JSON sentinel-splice (no deep clone), structured `sqlx::Error` logging, `forgot_password` JSON body, WS parser leak in error reply, `shared_media_gallery` selector, ConversationItem RegExp lift, `parsedTimestamp` cache on `ChatMessage`, `_AuthNotifierListenable` lifetime doc, Playwright fixme annotations.

**Feedback dialog migration** (Beta tester support): adds `app_version`, `platform`, `logs` columns to the `feedback` table (`20260525000000_feedback_diagnostic_fields.sql`) so user-submitted reports carry diagnostic context for triage.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast` (all suites green)
- [x] `flutter analyze` (no issues)
- [x] `flutter test test/widgets/` + `test/services/crypto_service_test.dart` (passing)
- [x] New TD-28 crypto round-trip + signature-mismatch + tamper tests
- [x] New TD-40 OTP race + TD-41 rotation-storm + TD-42 cascade tests
- [x] New TD-66 migration schema-invariant assertions
- [x] Feedback dialog tests pass against new schema columns
- [ ] CI green on main pipeline (Rust + Flutter + e2e)

## Notes

- `multi-device-deviceB-receipt.png` and `.claude/state/audit-2026-05-25.md` deliberately excluded from this PR — neither is a project artifact.
- Comprehensive per-finding evidence in `TECHNICAL_DEBT.md`; per-finding code quotes in the working audit queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)