### PR TITLE
Beta UX polish 2: empty state, new chat, group create, message grouping

### DIFF
--- a/apps/client/lib/src/app.dart
+++ b/apps/client/lib/src/app.dart
@@ -16,31 +16,29 @@ import 'widgets/shutdown_handler.dart';
 ThemeData _applyCustomColors(ThemeData base, CustomColorsState custom) {
   if (!custom.hasOverrides) return base;
   final scheme = base.colorScheme;
-  final primary = custom.primaryColor ?? scheme.primary;
-  final accent = custom.accentColor ?? scheme.secondary;
-  // Recompute on-color contrast for the new primary so text on sent bubbles
-  // + buttons stays readable on a custom accent.
-  final onPrimary =
-      ThemeData.estimateBrightnessForColor(primary) == Brightness.dark
-      ? Colors.white
-      : Colors.black;
-  final onSecondary =
+  // `context.accent` (the dominant accent reader, ~270 callsites) is
+  // wired to `colorScheme.primary`, so the user's accent override must
+  // land there for the picker to actually move the UI.
+  final accent = custom.accentColor ?? scheme.primary;
+  final secondary = custom.primaryColor ?? scheme.secondary;
+  final onAccent =
       ThemeData.estimateBrightnessForColor(accent) == Brightness.dark
       ? Colors.white
       : Colors.black;
-  // Propagate the override into EchoColorExtension so old + new message
-  // bubbles (sentBubble) and any accent-derived surface (accentLight) reflect
-  // the picker choice. Locked rule: sentBubble = primary.
+  final onSecondary =
+      ThemeData.estimateBrightnessForColor(secondary) == Brightness.dark
+      ? Colors.white
+      : Colors.black;
   final echoExt = base.extension<EchoColorExtension>();
   final updatedEcho = echoExt?.copyWith(
-    sentBubble: primary,
-    accentLight: primary.withValues(alpha: 0.2),
+    sentBubble: accent,
+    accentLight: accent.withValues(alpha: 0.2),
   );
   return base.copyWith(
     colorScheme: scheme.copyWith(
-      primary: primary,
-      onPrimary: onPrimary,
-      secondary: accent,
+      primary: accent,
+      onPrimary: onAccent,
+      secondary: secondary,
       onSecondary: onSecondary,
     ),
     extensions: [
@@ -50,7 +48,7 @@ ThemeData _applyCustomColors(ThemeData base, CustomColorsState custom) {
     filledButtonTheme: FilledButtonThemeData(
       style: FilledButton.styleFrom(
         backgroundColor: accent,
-        foregroundColor: onSecondary,
+        foregroundColor: onAccent,
       ),
     ),
     textButtonTheme: TextButtonThemeData(

--- a/apps/client/lib/src/providers/admin_realtime_provider.dart
+++ b/apps/client/lib/src/providers/admin_realtime_provider.dart
@@ -139,15 +139,10 @@ class AdminRealtimeNotifier
   }
 
   Future<void> _tick() async {
-    // Don't stomp on an in-progress request: only fire when the previous
-    // result has settled.  If the dashboard is offscreen or the user just
-    // switched tabs, autoDispose has already torn us down.
+    // Skip if previous request still in flight.
     if (state.isLoading || state.isRefreshing) return;
     final next = await AsyncValue.guard(_load);
-    // Don't overwrite a fresh data state with a transient error during a
-    // background tick — keep showing the last good numbers but stash the
-    // error so the UI can surface a small "stale" indicator. We use
-    // [AsyncValue.guard] above precisely so this branch is reachable.
+    // AsyncValue.guard preserves last-good data on transient error → stale indicator.
     state = next;
   }
 
@@ -165,9 +160,7 @@ class AdminRealtimeNotifier
         final json = jsonDecode(response.body) as Map<String, dynamic>;
         return AdminRealtimeStats.fromJson(json);
       case 401:
-        // The server emits `code: "reauth-required"` plus a
-        // WWW-Authenticate header.  We accept either as the signal so a
-        // stale token doesn't surface as a generic 401.
+        // Accept either code:"reauth-required" or WWW-Authenticate header.
         final wwwAuth = response.headers['www-authenticate'] ?? '';
         if (wwwAuth.contains('reauth_required') ||
             response.body.contains('reauth-required')) {

--- a/apps/client/lib/src/providers/auth/auth_provider.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.dart
@@ -62,10 +62,7 @@ class AuthState {
     this.isAdmin = false,
   });
 
-  // @S107: copyWith mirrors the AuthState constructor; refactoring to a param
-  // object would break the idiomatic `state = state.copyWith(field: value)`
-  // pattern used throughout the codebase. Each named param maps 1:1 to an
-  // immutable field on AuthState.
+  // S107: copyWith mirrors AuthState 1:1; param-object would break call sites.
   AuthState copyWith({
     bool? isLoggedIn,
     String? userId,
@@ -77,8 +74,7 @@ class AuthState {
     bool? isLoading,
     String? presenceStatus,
     bool? onboardingCompleted,
-    // Use the sentinel pattern so callers can explicitly clear statusText to
-    // null without copyWith silently keeping the previous value.
+    // Sentinel distinguishes "not passed" from "explicit null".
     Object? statusText = _kKeep,
     bool? isAdmin,
   }) {
@@ -152,11 +148,8 @@ class AuthNotifier extends _$AuthNotifier
   Future<void> register(String username, String password) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      // On web we MUST use the credentialed BrowserClient so the
-      // HttpOnly Set-Cookie refresh-token response header is actually stored
-      // by the browser. Without `withCredentials = true` the cookie is
-      // silently dropped from a CORS response and the user gets logged out
-      // on the next page refresh (#929).
+      // (#929) Credentialed BrowserClient required so HttpOnly Set-Cookie
+      // is actually stored across CORS responses.
       final client = buildHttpClient();
       final http.Response response;
       try {
@@ -174,9 +167,7 @@ class AuthNotifier extends _$AuthNotifier
       if (response.statusCode == 200 || response.statusCode == 201) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
         final accessToken = data['access_token'] as String;
-        // Server may or may not return refresh_token (backward compat).
-        // On web the token arrives as a Set-Cookie header handled by the
-        // browser; we deliberately ignore the body value to avoid storing it.
+        // Web: ignore body refresh_token; cookie path stores it via Set-Cookie.
         final refreshToken = kIsWeb ? null : data['refresh_token'] as String?;
         final userId = data['user_id'] as String;
         final isAdmin = data['is_admin'] as bool? ?? false;
@@ -204,9 +195,7 @@ class AuthNotifier extends _$AuthNotifier
           final data = jsonDecode(response.body) as Map<String, dynamic>;
           final code = data['code'] as String?;
           final serverMsg = data['error'] as String?;
-          // The most common signup-failure case deserves a friendlier
-          // toast than the server's literal 'Username already taken' —
-          // testers expect something they could plausibly act on (#1176).
+          // (#1176) Friendlier signup-collision copy than server's literal string.
           if (response.statusCode == 409 && code == 'username-taken') {
             errorMsg = 'That username is taken — try another.';
           } else if (serverMsg != null && serverMsg.isNotEmpty) {
@@ -228,11 +217,8 @@ class AuthNotifier extends _$AuthNotifier
   Future<void> login(String username, String password) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      // On web we MUST use the credentialed BrowserClient so the
-      // HttpOnly Set-Cookie refresh-token response header is actually stored
-      // by the browser. Without `withCredentials = true` the cookie is
-      // silently dropped from a CORS response and the user gets logged out
-      // on the next page refresh (#929).
+      // (#929) Credentialed BrowserClient required so HttpOnly Set-Cookie
+      // is actually stored across CORS responses.
       final client = buildHttpClient();
       final http.Response response;
       try {
@@ -250,8 +236,7 @@ class AuthNotifier extends _$AuthNotifier
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
         final accessToken = data['access_token'] as String;
-        // On web the refresh token arrives as a Set-Cookie header managed by
-        // the browser; ignore the body value to avoid storing it in JS memory.
+        // Web: ignore body refresh_token (cookie owns it; never store in JS memory).
         final refreshToken = kIsWeb ? null : data['refresh_token'] as String?;
         final userId = data['user_id'] as String;
         final avatarUrl = data['avatar_url'] as String?;
@@ -278,11 +263,8 @@ class AuthNotifier extends _$AuthNotifier
         // Start background service to keep WebSocket alive on mobile
         BackgroundService.instance.start();
       } else {
-        // Default to the status-code-driven copy so a 5xx never reads as a
-        // credentials problem. If the server returned a JSON `error` field
-        // AND we're in the credentials range (401/403), prefer the server
-        // copy (e.g. "Account locked"); otherwise the user-friendly status
-        // string wins.
+        // Status-driven copy by default; prefer server's 401/403 error string
+        // when present (e.g. "Account locked").
         String errorMsg = friendlyLoginError(statusCode: response.statusCode);
         if (response.statusCode == 401 || response.statusCode == 403) {
           try {
@@ -307,10 +289,7 @@ class AuthNotifier extends _$AuthNotifier
     state = state.copyWith(avatarUrl: url);
   }
 
-  /// Set of presence status values accepted by the server. Keeping the
-  /// client honest here avoids sending garbage that the server would just
-  /// reject with a 400 -- and protects callers that build the string from
-  /// user input or enum conversions.
+  /// Presence values accepted by the server (avoids 400 on enum/user input).
   static const _validPresenceStatuses = <String>{
     'online',
     'away',
@@ -385,8 +364,7 @@ class AuthNotifier extends _$AuthNotifier
     final origin = serverUrl ?? _serverUrl;
     final accessToken = state.token;
 
-    // Best-effort remote logout. On web this is the only way to clear the
-    // HttpOnly refresh cookie. On native it revokes the refresh-token row.
+    // Best-effort remote logout (clears HttpOnly cookie on web, revokes row on native).
     try {
       final client = buildHttpClient();
       try {
@@ -438,19 +416,9 @@ class AuthNotifier extends _$AuthNotifier
   @visibleForTesting
   Future<bool> refreshAccessTokenForTest({bool sendBody = true}) {
     if (!sendBody) {
-      // Temporarily null out the refresh token in state so _doRefreshAccessToken
-      // takes the kIsWeb-equivalent branch where no body field is included.
-      // We snapshot and restore so the test container stays consistent.
+      // Simulate web (no-body) branch to verify body contract in isolation.
       final saved = state;
-      state = state.copyWith(
-        isLoggedIn: true,
-        token: saved.token,
-        // refreshToken omitted so it stays as the current value in copyWith.
-        // Instead we manipulate _doRefreshAccessToken by patching state.
-      );
-      // Use the internal method directly -- it will see null refreshToken and
-      // on non-web that normally returns false.  For this test we override
-      // the guard so we can verify the body contract in isolation.
+      state = state.copyWith(isLoggedIn: true, token: saved.token);
       return _doRefreshAccessTokenNoBody();
     }
     return _doRefreshAccessToken();

--- a/apps/client/lib/src/providers/auth/auth_token_refresh.dart
+++ b/apps/client/lib/src/providers/auth/auth_token_refresh.dart
@@ -45,9 +45,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
       final storedUsername = prefs.getString(AuthNotifier._keyUsername);
 
       if (kIsWeb) {
-        // On web the refresh token lives in an HttpOnly cookie managed by the
-        // browser. We only need a stored userId/username to restore session
-        // state after a successful cookie-based refresh.
+        // Web: refresh token is in HttpOnly cookie; just need stored user info.
         if (storedUserId == null || storedUsername == null) {
           return false;
         }
@@ -58,9 +56,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
         );
       }
 
-      // Read refresh token from secure storage first, fall back to prefs
-      // (covers the case where secure storage was unavailable during
-      // migration or during a previous _storeTokens fallback write).
+      // Prefer secure storage; fall back to prefs if storage was unavailable.
       String? storedRefreshToken;
       try {
         storedRefreshToken = await SecureKeyStore.instance.readGlobal(
@@ -84,9 +80,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
             legacyToken.isNotEmpty &&
             storedUserId != null &&
             storedUsername != null) {
-          // Legacy mode: we have an access token but no refresh token.
-          // Restore the session optimistically -- it may be expired, but
-          // individual API calls will handle 401 gracefully.
+          // Legacy: optimistic restore from access token; 401 path handles expiry.
           await _setUserScope(storedUserId);
           final legacyOnboardingDone =
               prefs.getBool('onboarding_completed') ?? true;
@@ -123,18 +117,12 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
             data['refresh_token'] as String? ?? storedRefreshToken;
         final userId = data['user_id'] as String? ?? storedUserId ?? '';
         final username = data['username'] as String? ?? storedUsername ?? '';
-        // Server re-reads is_admin from the canonical users row on every
-        // refresh (apps/server/src/routes/auth.rs), so promotion /
-        // demotion since last login propagates here. Without parsing it
-        // the admin panel stays invisible after every cold restart on
-        // native clients — #1160.
+        // (#1160) Server re-reads is_admin on refresh so promotion propagates;
+        // without parsing it native cold-restart hides the admin panel.
         final isAdmin = data['is_admin'] as bool? ?? false;
 
-        // Persist new tokens BEFORE any other async work. The server
-        // already revoked the old refresh token during rotation, so if
-        // _setUserScope throws (e.g. Hive/IndexedDB error on web) or the
-        // page is refreshed before we finish, the new token is safe in
-        // localStorage and the next auto-login attempt will succeed.
+        // Persist tokens FIRST: server already revoked the old one in rotation,
+        // so a downstream throw must not lose the new token.
         await _storeTokens(
           accessToken: newAccessToken,
           refreshToken: newRefreshToken,
@@ -162,8 +150,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
       }
     } catch (e) {
       debugPrint('[Auth] tryAutoLogin failed: $e');
-      // Network error or other failure -- don't clear tokens, just fail
-      // so user can retry when connectivity is restored.
+      // Network failure: don't clear tokens — let user retry when online.
       state = const AuthState();
       return false;
     }
@@ -184,12 +171,8 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
             .post(
               Uri.parse('$_serverUrl/api/auth/refresh'),
               headers: _kJsonHeaders,
-              // Empty `{}` body, not no body: with `Content-Type:
-              // application/json` set, axum's `Option<Json<T>>` extractor
-              // tries to parse and fails with "EOF" on a zero-length body,
-              // which short-circuits before the cookie path runs and the
-              // user gets logged out on every refresh.  An empty object is
-              // valid JSON and makes serde's #[serde(default)] kick in.
+              // '{}' (not empty): axum's Option<Json<T>> fails on zero-length
+              // body with Content-Type: application/json, bypassing the cookie path.
               body: '{}',
             )
             .timeout(const Duration(seconds: 15));
@@ -199,9 +182,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
           final newAccessToken = data['access_token'] as String;
           final userId = data['user_id'] as String? ?? storedUserId;
           final username = data['username'] as String? ?? storedUsername;
-          // See companion comment in tryAutoLogin's body-token path. The
-          // server returns is_admin on every refresh; without it the
-          // admin panel stays invisible on the web client too — #1160.
+          // (#1160) Parse is_admin so promotion propagates on web too.
           final isAdmin = data['is_admin'] as bool? ?? false;
 
           await _storeTokens(
@@ -244,9 +225,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
   /// a new access token. Returns false if the refresh failed (in which case
   /// the user is logged out).
   Future<bool> refreshAccessToken() async {
-    // If a refresh is already in-flight, coalesce with it instead of
-    // sending a duplicate request (server-side token rotation consumes
-    // the token on first use, so the second request would fail).
+    // Coalesce in-flight refresh: server rotation consumes on first use.
     if (_refreshLock != null) {
       return _refreshLock!.future;
     }
@@ -265,8 +244,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
   }
 
   Future<bool> _doRefreshAccessToken() async {
-    // On web the refresh token is in the HttpOnly cookie; the client never
-    // holds it in memory. On native the token must be present in state.
+    // Web: token is in HttpOnly cookie. Native: must be in state.
     if (!kIsWeb) {
       final currentRefreshToken = state.refreshToken;
       if (currentRefreshToken == null || currentRefreshToken.isEmpty) {
@@ -277,11 +255,7 @@ mixin AuthTokenRefreshMixin on Notifier<AuthState>, AuthTokenStorageMixin {
     try {
       final http.Response response;
       if (kIsWeb) {
-        // Let the browser attach the cookie automatically.  Send an empty
-        // `{}` body rather than nothing -- axum's Option<Json<T>> extractor
-        // fails with "EOF" if Content-Type is application/json and the body
-        // is zero-length, which short-circuits before the cookie path can
-        // run.  See companion comment in tryAutoLogin's _tryRefreshWithCookie.
+        // Browser attaches cookie; '{}' body avoids axum EOF on Option<Json<T>>.
         final client = buildHttpClient();
         try {
           response = await client

--- a/apps/client/lib/src/providers/auth/auth_token_storage.dart
+++ b/apps/client/lib/src/providers/auth/auth_token_storage.dart
@@ -32,10 +32,8 @@ mixin AuthTokenStorageMixin on Notifier<AuthState> {
   }) async {
     final store = SecureKeyStore.instance;
 
-    // Write tokens to secure storage (global scope -- no user prefix).
-    // On web the refresh token is intentionally omitted -- the browser manages
-    // it as an HttpOnly cookie.  We also skip writing an empty string, which is
-    // the sentinel the web code path passes when no token is available.
+    // Global scope (called BEFORE _setUserScope). Web: refresh token stays in
+    // HttpOnly cookie; '' is the no-token sentinel.
     final shouldPersistRefresh = !kIsWeb && refreshToken.isNotEmpty;
     try {
       await store.writeGlobal(AuthNotifier._keyAccessToken, accessToken);
@@ -46,12 +44,8 @@ mixin AuthTokenStorageMixin on Notifier<AuthState> {
       debugPrint('[Auth] SecureKeyStore unavailable: $e');
     }
 
-    // Always write to SharedPreferences as well. On web, SecureKeyStore
-    // uses Web Crypto + encrypted localStorage which can fail to read
-    // back after a page refresh, causing unexpected logouts. Keeping a
-    // copy in SharedPreferences guarantees tryAutoLogin can recover.
-    // On native platforms the duplication is harmless (belt & suspenders).
-    // On web the refresh token is excluded for the same XSS-safety reason.
+    // Dup to SharedPreferences: belt-and-suspenders for native; web's
+    // SecureKeyStore can fail post-refresh, so prefs is the recovery path.
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(AuthNotifier._keyAccessToken, accessToken);
@@ -61,10 +55,8 @@ mixin AuthTokenStorageMixin on Notifier<AuthState> {
       await prefs.setString(AuthNotifier._keyUserId, userId);
       await prefs.setString(AuthNotifier._keyUsername, username);
 
-      // Mirror userId/username into per-host slots so the login screen on
-      // a known server can pre-fill the username after a server switch.
-      // The global keys above stay authoritative for the active session
-      // because tokens themselves remain global.
+      // Per-host mirror enables login pre-fill after server switch;
+      // global keys remain authoritative for the active session.
       final host = AuthNotifier._hostOf(_serverUrl);
       if (host.isNotEmpty) {
         await prefs.setString(AuthNotifier._userIdKeyFor(host), userId);
@@ -86,9 +78,7 @@ mixin AuthTokenStorageMixin on Notifier<AuthState> {
     try {
       await MessageCache.initForUser(userId, host);
     } catch (e) {
-      // Non-fatal: fall back to the default shared message cache.
-      // On web, Hive/IndexedDB box close/reopen can fail during
-      // page refresh; this must not prevent login.
+      // Non-fatal: web Hive/IndexedDB can fail mid-refresh; don't block login.
       debugPrint('[Auth] MessageCache.initForUser failed (non-fatal): $e');
       DebugLogService.instance.log(
         LogLevel.error,
@@ -106,8 +96,7 @@ mixin AuthTokenStorageMixin on Notifier<AuthState> {
     await store.deleteGlobal(AuthNotifier._keyAccessToken);
     await store.deleteGlobal(AuthNotifier._keyRefreshToken);
 
-    // Remove everything from SharedPreferences (tokens may exist there
-    // from pre-migration installs or secure-storage fallback writes).
+    // Also clear prefs (tokens may exist from pre-migration / fallback writes).
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(AuthNotifier._keyAccessToken);
@@ -133,8 +122,7 @@ mixin AuthTokenStorageMixin on Notifier<AuthState> {
     final prefs = await SharedPreferences.getInstance();
     final store = SecureKeyStore.instance;
 
-    // On web the refresh token must never be stored in JS-accessible storage,
-    // so skip migrating it.  Only migrate the access token on web.
+    // Web: skip refresh token migration (must stay in HttpOnly cookie only).
     final keysToMigrate = kIsWeb
         ? [AuthNotifier._keyAccessToken]
         : [AuthNotifier._keyAccessToken, AuthNotifier._keyRefreshToken];
@@ -144,10 +132,7 @@ mixin AuthTokenStorageMixin on Notifier<AuthState> {
       if (value != null && value.isNotEmpty) {
         try {
           await store.writeGlobal(key, value);
-          // On web, keep tokens in SharedPreferences as a reliable fallback.
-          // SecureKeyStore on web uses Web Crypto API encryption which can
-          // fail to decrypt after page refresh in some browsers, so
-          // SharedPreferences (plain localStorage) is the safety net.
+          // Web: keep prefs copy as recovery for SecureKeyStore decrypt failures.
           if (!kIsWeb) {
             await prefs.remove(key);
           }

--- a/apps/client/lib/src/providers/chat/chat_history.dart
+++ b/apps/client/lib/src/providers/chat/chat_history.dart
@@ -68,10 +68,7 @@ mixin ChatHistoryMixin on Notifier<ChatState> {
     _setLoadingHistory(historyKey, true);
 
     try {
-      // #557: pass our local device_id so the server can return device-aware
-      // ciphertexts via `message_device_contents`. Without this the server
-      // returns the canonical (originating-device) wire and secondary
-      // devices fail to decrypt their own DM history.
+      // (#557) Pass device_id so server returns device-scoped ciphertexts.
       final localDeviceId = crypto?.deviceId;
       final url = _buildHistoryUrl(
         conversationId,
@@ -122,9 +119,7 @@ mixin ChatHistoryMixin on Notifier<ChatState> {
     if (before != null) {
       url += '&before=${Uri.encodeComponent(before)}';
     }
-    // #557: device_id lets the server LEFT JOIN
-    // `message_device_contents` and return the row scoped to this device's
-    // ratchet rather than the originating device's wire.
+    // (#557) device_id scopes server LEFT JOIN to this device's ratchet.
     if (deviceId != null && deviceId > 0) {
       url += '&device_id=$deviceId';
     }
@@ -309,9 +304,7 @@ mixin ChatHistoryMixin on Notifier<ChatState> {
     // Skip decryption for non-encrypted group messages
     if (isGroup || !looksEncrypted(msg.content)) return msg;
 
-    // Check Hive cache first — Double Ratchet keys are consumed once and
-    // cannot be re-derived, so previously decrypted messages must come from
-    // the cache rather than re-decryption.
+    // Cache first: Ratchet keys are consumed once; re-decryption is impossible.
     if (conversationId != null) {
       final cached = await MessageCache.getCachedMessage(
         conversationId,
@@ -327,10 +320,8 @@ mixin ChatHistoryMixin on Notifier<ChatState> {
       return msg.copyWith(content: '[Encrypted history]', isEncrypted: true);
     }
 
-    // Use decryptHistoryMessage which never creates new sessions and returns
-    // null on failure instead of throwing.
-    // #557: pass the originating device so the right per-device ratchet is
-    // selected; null falls back to the legacy peer-only session key.
+    // (#557) decryptHistoryMessage: no new session, returns null on fail;
+    // fromDeviceId selects per-device ratchet (null → legacy key).
     final decrypted = await crypto.decryptHistoryMessage(
       msg.fromUserId,
       msg.content,

--- a/apps/client/lib/src/providers/chat/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat/chat_provider.dart
@@ -135,10 +135,14 @@ class Chat extends _$Chat
     String? replyToUsername,
   }) {
     final pendingId = 'pending_${DateTime.now().millisecondsSinceEpoch}';
+    // Use the user's own username so their message renders symmetrically
+    // with everyone else's (no asymmetric "You" label). Falls back to the
+    // generic "You" only if the username somehow isn't loaded yet.
+    final myName = ref.read(authProvider).username ?? 'You';
     final msg = ChatMessage(
       id: pendingId,
       fromUserId: myUserId,
-      fromUsername: 'You',
+      fromUsername: myName,
       conversationId: conversationId,
       channelId: channelId,
       content: content,

--- a/apps/client/lib/src/providers/chat/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat/chat_provider.dart
@@ -66,10 +66,7 @@ class Chat extends _$Chat
       _sendTimeouts.clear();
     });
 
-    // Plumb the GroupCryptoService 410-Gone callback into chat state.
-    // When the server reports "no envelope for this user at the latest
-    // version", flip the `groupsNeedingRotation` flag so the
-    // EncryptionStatusBanner surfaces the "Refresh key" affordance.
+    // 410-Gone callback → groupsNeedingRotation flag → EncryptionStatusBanner.
     final groupCrypto = ref.read(groupCryptoServiceProvider);
     void handler(String conversationId) {
       state = state.withGroupRotationNeeded(conversationId);
@@ -77,7 +74,7 @@ class Chat extends _$Chat
 
     groupCrypto.onGroupNeedsRotation = handler;
     ref.onDispose(() {
-      // Only detach if no later build installed its own handler.
+      // Only detach if a later build hasn't installed its own handler.
       if (identical(groupCrypto.onGroupNeedsRotation, handler)) {
         groupCrypto.onGroupNeedsRotation = null;
       }
@@ -89,17 +86,10 @@ class Chat extends _$Chat
   @override
   String get _serverUrl => ref.read(serverUrlProvider);
 
-  /// Add a single message to state. When [bumpReplyCount] is true (the live
-  /// WS path) and the message is a reply, the parent's `replyCount` is
-  /// incremented optimistically. Historical seeders (e.g. the thread panel's
-  /// `/replies` fetch) pass false because the parent's count already reflects
-  /// the server-authoritative total -- bumping again would inflate the badge
-  /// every time the panel was opened (#919).
+  /// (#919) Optimistic reply-count bump only when [bumpReplyCount] is true
+  /// (live WS); historical seeders pass false to avoid double-counting.
   void addMessage(ChatMessage msg, {bool bumpReplyCount = true}) {
-    // Detect duplicate-by-id BEFORE withMessage runs so we don't double-bump
-    // when the server echoes a message we've already counted (e.g. a group
-    // sender receiving their own broadcast back). withMessage dedups by id
-    // but _incrementReplyCount used to run regardless.
+    // Dedup-by-id BEFORE withMessage so server echoes don't double-bump.
     final alreadyKnown =
         state._messageIdIndex[msg.conversationId]?.contains(msg.id) ?? false;
 
@@ -135,9 +125,7 @@ class Chat extends _$Chat
     String? replyToUsername,
   }) {
     final pendingId = 'pending_${DateTime.now().millisecondsSinceEpoch}';
-    // Use the user's own username so their message renders symmetrically
-    // with everyone else's (no asymmetric "You" label). Falls back to the
-    // generic "You" only if the username somehow isn't loaded yet.
+    // Use real username for symmetry; "You" only as a last-resort fallback.
     final myName = ref.read(authProvider).username ?? 'You';
     final msg = ChatMessage(
       id: pendingId,
@@ -167,9 +155,9 @@ class Chat extends _$Chat
     _sendTimeouts.remove(pendingId)?.cancel();
     // Start a 15-second timeout — if no confirmSent() arrives, mark failed.
     _sendTimeouts[pendingId] = Timer(const Duration(seconds: 15), () {
-      // Atomically remove: if already cancelled by confirmSent(), skip.
+      // Atomic remove: skip if confirmSent() already cancelled it.
       final removed = _sendTimeouts.remove(pendingId);
-      if (removed == null) return; // timer was already cancelled
+      if (removed == null) return;
       _transitionToFailed(conversationId, pendingId, content);
     });
   }
@@ -257,10 +245,8 @@ class Chat extends _$Chat
     String? channelId,
     DateTime? expiresAt,
   }) {
-    // Replace the most recent pending/sending message in this conversation
-    // with the server-assigned ID so that delivery receipts can match it.
-    // Only clone the affected conversation's list; other entries stay
-    // reference-equal so Riverpod selectors for unaffected convs don't rebuild.
+    // Replace pending ID with server ID so delivery receipts match.
+    // Clone only the affected conv; other selectors stay reference-equal.
     final messages = state.messagesByConversation[conversationId];
     if (messages != null) {
       final (replacedPendingId, updatedMessages) = _replacePendingMessage(
@@ -343,10 +329,7 @@ class Chat extends _$Chat
     final messages = state.messagesByConversation[conversationId];
     if (messages == null) return;
 
-    // Detect transitions involving a failed reply so we can keep the parent
-    // replyCount in sync with the optimistic-bump bookkeeping (#830):
-    //   failed -> sending  (user retried)  : re-increment parent
-    //   sending|sent|... -> failed         : decrement parent (e.g. ws send threw)
+    // (#830) Keep parent replyCount in sync on failed↔retried transitions.
     ChatMessage? before;
     final idx = messages.indexWhere((m) => m.id == messageId);
     if (idx != -1) before = messages[idx];
@@ -396,9 +379,8 @@ class Chat extends _$Chat
       _sendTimeouts.remove(m.id)?.cancel();
     }
 
-    // Remove the conversation entry from both maps via full copies (removal
-    // cannot be expressed with spread syntax); this path is infrequent
-    // (leave/clear) so the cost is acceptable.
+    // Full copy required for removal (spread can't express it); leave/clear
+    // path is infrequent, cost acceptable.
     final newConvMap = Map<String, List<ChatMessage>>.from(
       state.messagesByConversation,
     )..remove(conversationId);

--- a/apps/client/lib/src/providers/conversations_http_actions.dart
+++ b/apps/client/lib/src/providers/conversations_http_actions.dart
@@ -85,11 +85,7 @@ mixin _ConversationsHttpActionsMixin on Notifier<ConversationsState> {
       if (convId != null && convId.isNotEmpty) {
         await loadConversations();
 
-        // The server sorts conversations by last-message time (LIMIT 50).
-        // A brand-new DM with no messages sorts last and may be excluded.
-        // If it is not in the refreshed list, add a minimal entry so the
-        // caller can navigate to it immediately; subsequent activity will
-        // populate the full data.
+        // Server LIMIT-50 excludes brand-new empty DMs; add stub so user can navigate.
         final found = state.conversations
             .where((c) => c.id == convId && !c.isGroup)
             .firstOrNull;
@@ -372,19 +368,14 @@ mixin _ConversationsHttpActionsMixin on Notifier<ConversationsState> {
           throw const GroupException('Server response missing conversation id');
         }
         await loadConversations();
-        // Only seed the initial group-key envelope when the creator
-        // actually opted into encryption. A plaintext group skips this
-        // entirely; sends go through the unencrypted path.
+        // Seed group-key envelope only when creator opted into encryption.
         if (isEncrypted) {
           try {
             await ref
                 .read(cryptoProvider.notifier)
                 .seedInitialGroupKey(conversationId);
           } catch (e) {
-            // Seeding failure is non-fatal at this point — the
-            // conversation row exists, the user is in the group, and
-            // self-heal in [GroupCryptoService.getGroupKey] will
-            // retry the rotation on the next message attempt.
+            // Non-fatal: self-heal retries on next message attempt.
             debugPrint(
               '[ConversationsHttp] seedInitialGroupKey failed for '
               '$conversationId: $e',

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -85,12 +85,8 @@ class CryptoState {
 /// not change.
 @Riverpod(keepAlive: true)
 class CryptoNotifier extends _$CryptoNotifier {
-  /// Per-conversation single-flight tracker for [seedInitialGroupKey].
-  /// Without this, multiple admins joining a group simultaneously (or one
-  /// admin firing the self-heal repeatedly) issue concurrent rotations:
-  /// each does probe + member fetch + N identity-key fetches + envelope
-  /// POST, and N-1 of those POSTs lose a 409 race. Audit P2 critical
-  /// finding (rotation storm).
+  /// Per-conversation single-flight to prevent rotation-storm (audit P2);
+  /// concurrent admins/self-heal would fan out to A×(N+2) parallel HTTP POSTs.
   final Set<String> _rotatingGroups = <String>{};
 
   @override
@@ -128,10 +124,7 @@ class CryptoNotifier extends _$CryptoNotifier {
   Future<void> retryStorageUnlock() async {
     if (!state.secureStorageUnavailable) return;
     state = state.copyWith(secureStorageUnavailable: false);
-    // The next decrypt against any session will re-read from secure storage.
-    // If the keyring is still locked the flag will be re-set automatically
-    // via the observer callback. Drain pending messages to give the retry
-    // an immediate chance to either succeed or re-flip the flag.
+    // Drain pending so retry either succeeds or re-flips the flag immediately.
     final myUserId = ref.read(authProvider).userId ?? '';
     if (myUserId.isNotEmpty) {
       ref.read(websocketProvider.notifier).drainPendingDecryptQueue(myUserId);
@@ -157,10 +150,7 @@ class CryptoNotifier extends _$CryptoNotifier {
           'Crypto',
           'Key upload attempt $attempt failed: $uploadError',
         );
-        // Don't retry on rate limit or identity conflict -- same error repeats.
-        // Identity-key conflicts now surface as the typed
-        // IdentityKeyConflictException (#664); UI is responsible for prompting
-        // the user to run resetThisDeviceKeys.
+        // (#664) Skip retry on rate limit / identity conflict — same error repeats.
         if (uploadError is IdentityKeyConflictException ||
             errorStr.contains('429') ||
             errorStr.contains('409')) {
@@ -194,9 +184,7 @@ class CryptoNotifier extends _$CryptoNotifier {
 
       final crypto = ref.read(cryptoServiceProvider);
       crypto.setToken(token);
-      // Audit P0-1 / P0-2: wire observability callbacks so transient
-      // keyring failures and exhausted upload-heal retries become visible
-      // UI banners instead of silent debugPrints.
+      // Audit P0-1/P0-2: surface keyring + upload-heal failures as UI banners.
       crypto.setObservers(
         onSecureStorageUnavailable: _markSecureStorageUnavailable,
         onKeyUploadTerminalFailure: _markKeyUploadTerminalFailure,
@@ -205,10 +193,8 @@ class CryptoNotifier extends _$CryptoNotifier {
       if (crypto.keysAreFresh) {
         final uploadError = await _uploadKeysWithRetry(crypto);
         if (uploadError != null) {
-          // Keys are initialized locally but upload to server failed.
-          // Mark initialized so incoming messages can still be decrypted
-          // with the valid local keys. The keysUploadFailed flag blocks
-          // outgoing encrypted sends and shows a degradation banner.
+          // Local keys OK but upload failed: mark initialized so inbound still
+          // decrypts; keysUploadFailed blocks outbound + shows banner.
           state = state.copyWith(
             isInitialized: true,
             isUploading: false,
@@ -244,9 +230,7 @@ class CryptoNotifier extends _$CryptoNotifier {
       final myUserId = ref.read(authProvider).userId ?? '';
       ref.read(websocketProvider.notifier).drainPendingDecryptQueue(myUserId);
     } on PlatformException catch (e) {
-      // Linux libsecret / keyring failures -- crypto is NOT available.
-      // Explicitly mark as not initialized so callers never send plaintext
-      // thinking encryption is active.
+      // Keyring failure: mark NOT initialized so callers don't send plaintext.
       debugPrint('[Crypto] PlatformException during init: $e');
       DebugLogService.instance.log(
         LogLevel.error,
@@ -421,12 +405,8 @@ class CryptoNotifier extends _$CryptoNotifier {
     String conversationId, {
     int? currentVersion,
   }) async {
-    // Single-flight per conversation. Drops concurrent attempts so a
-    // multi-admin group, an invite-link burst, or rapid Send retries
-    // can't fan out to A×(N+2) parallel HTTP requests per join (audit
-    // critical finding — rotation storm). The first caller does the
-    // work; subsequent callers get `null` and rely on the next
-    // group_key_rotated WS event to populate the local cache.
+    // Single-flight per conversation (rotation-storm guard). Losers return
+    // null and rely on group_key_rotated WS to populate the cache.
     if (_rotatingGroups.contains(conversationId)) {
       DebugLogService.instance.log(
         LogLevel.info,
@@ -460,13 +440,8 @@ class CryptoNotifier extends _$CryptoNotifier {
 
     final serverUrl = ref.read(serverUrlProvider);
 
-    // Recovery path for groups whose v=1 envelopes were uploaded with
-    // stale identity keys (and are therefore unwrappable). Probe
-    // /keys/latest — if a key already exists we rotate to version+1
-    // instead of hardcoding v=1, which would 409-conflict and leave the
-    // group wedged forever. Callers with a fresh version hint (e.g. the
-    // group_key_rotation_requested WS payload) can pass currentVersion
-    // and skip the probe entirely (TD-6).
+    // TD-6: probe /keys/latest so we rotate to version+1 instead of 409ing on
+    // hardcoded v=1 — leaves the group wedged forever otherwise.
     var nextVersion = 1;
     if (currentVersion != null) {
       nextVersion = currentVersion + 1;
@@ -481,9 +456,7 @@ class CryptoNotifier extends _$CryptoNotifier {
           final existing = body['key_version'] as int?;
           if (existing != null) nextVersion = existing + 1;
         } else if (probe.statusCode == 401 || probe.statusCode == 403) {
-          // TD-18: 401/403 means the rotation will also be rejected;
-          // bail rather than uploading v=1 envelopes the server can't
-          // accept. The caller's WS event will retry once auth refreshes.
+          // TD-18: rotation would also be rejected — let WS event retry on auth.
           DebugLogService.instance.log(
             LogLevel.warning,
             'GroupRotation',
@@ -495,9 +468,7 @@ class CryptoNotifier extends _$CryptoNotifier {
         }
         // 404 (no key yet) falls through with nextVersion == 1.
       } catch (e) {
-        // TD-18: network/decoder failures fall through to v=1 (the
-        // brand-new-group case). Log so a post-mortem can distinguish
-        // legitimate first-key rotations from blocked recovery attempts.
+        // TD-18: fall through to v=1 for brand-new-group; log for post-mortem.
         DebugLogService.instance.log(
           LogLevel.warning,
           'GroupRotation',
@@ -535,30 +506,15 @@ class CryptoNotifier extends _$CryptoNotifier {
           return [];
         }
       },
-      // For self, use the local public key derived from the in-memory
-      // identity keypair — that's the only key guaranteed to round-trip
-      // through our local private key on the unwrap side. A stale TOFU
-      // cache entry for self would otherwise wrap with an old public key
-      // and leave us unable to decrypt our own envelope.
-      //
-      // For other members, force a server refresh so we use whatever
-      // identity key the recipient currently has uploaded, not whatever
-      // we cached weeks ago. If the recipient's local private key has
-      // since drifted from the server-known public key, that's a
-      // recipient-side problem the server can't help with; the TOFU
-      // change-detection will flag it on the recipient's next fetch.
+      // Self: use local pubkey (only one guaranteed to unwrap via our private).
+      // Peers: force-refresh so we wrap under their current server-uploaded key.
       fetchIdentityKey: (userId) {
         if (userId == myUserId) {
           return crypto.getIdentityPublicKey();
         }
         return crypto.fetchPeerIdentityKey(userId, forceRefresh: true);
       },
-      // TD-4: refuse to wrap the group secret under a changed peer
-      // identity key. The force-refresh above silently updates the
-      // TOFU cache to whatever the server returned; the rotation
-      // checks the per-user "changed" flag and aborts if anyone's
-      // key is unconfirmed. Self is never flagged (we generate our
-      // own key) so the check is a no-op for myUserId.
+      // TD-4: refuse to wrap under an unconfirmed TOFU-changed peer key.
       hasIdentityKeyChanged: (userId) async {
         if (userId == myUserId) return false;
         return crypto.hasPeerIdentityKeyChanged(userId);

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
@@ -27,12 +27,8 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
       'LiveKitVoice',
       'setCaptureEnabled($enabled)',
     );
-    // Wrap the setMicrophoneEnabled call so a native audio-session error
-    // (e.g. AVAudioSession activation race on iOS) doesn't surface as an
-    // unhandled exception into the Riverpod error boundary.  State is still
-    // updated optimistically so the UI reflects the intended mute state;
-    // if the underlying track fails, LiveKit will emit a disconnect or
-    // error event through the room listener.
+    // Optimistic state update; native audio-session errors caught below to
+    // keep them out of Riverpod's error boundary.
     final future = _room?.localParticipant?.setMicrophoneEnabled(enabled);
     if (future != null) {
       // ignore: unawaited_futures
@@ -169,9 +165,7 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
     );
     try {
       if (defaultTargetPlatform == TargetPlatform.iOS) {
-        // iOS requires a ReplayKit Broadcast Upload Extension for screen
-        // capture. LiveKit's plugin reads RTCScreenSharingExtension from
-        // Info.plist and presents the system broadcast picker automatically.
+        // iOS: ReplayKit picker is auto-presented from Info.plist extension.
         await room.localParticipant?.setScreenShareEnabled(
           enabled,
           captureScreenAudio: true,
@@ -180,16 +174,8 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
         // Disable path: SDK handles unpublish + track stop internally.
         await room.localParticipant?.setScreenShareEnabled(false);
       } else {
-        // #910: Enable path bypasses `setScreenShareEnabled(true)` so we
-        // can pass explicit publish options. The SDK shortcut falls back
-        // to `roomOptions.defaultVideoPublishOptions`, which is tuned for
-        // camera (simulcast=true + a camera-shaped VideoEncoding). For
-        // screen-share that combination negotiates a multi-layer simulcast
-        // publish that the SFU silently drops for remote viewers — the
-        // sharer keeps their local preview (no SFU round-trip) but
-        // remotes see no track. A single-layer VP8 publish matches the
-        // LiveKit meet sample and is decodable wherever flutter_webrtc
-        // runs (Linux xdg-desktop-portal, web getDisplayMedia, Android).
+        // (#910) Single-layer VP8: camera-shaped simulcast was being dropped by
+        // SFU for remote viewers; matches LiveKit meet sample.
         final captureOptions =
             room.roomOptions.defaultScreenShareCaptureOptions;
         final track = await LocalVideoTrack.createScreenShareTrack(

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -114,11 +114,7 @@ class LiveKitVoiceState {
     this.rttMs = 0,
   });
 
-  // @S107: copyWith mirrors LiveKitVoiceState's 21 immutable fields one-to-one.
-  // Refactoring into grouped param objects would break the idiomatic
-  // `state = state.copyWith(field: value)` calls scattered across the LiveKit
-  // event handlers and would not reduce overall complexity — the fields are
-  // genuinely independent (capture, video, peers, quality, timing).
+  // S107: copyWith mirrors 21 independent fields; grouping would break call sites.
   LiveKitVoiceState copyWith({
     bool? isActive,
     bool? isJoining,
@@ -286,9 +282,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
   }) async {
     if (_disposed) return;
 
-    // Prevent concurrent join sequences from racing each other.  This can
-    // happen when the user taps a new lounge while the previous join is still
-    // in flight (token fetch, room.connect, etc.).
+    // Prevent concurrent join sequences from racing (tap new lounge mid-join).
     if (_isJoining) {
       DebugLogService.instance.log(
         LogLevel.warning,
@@ -307,11 +301,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
 
     _isJoining = true;
 
-    // Fully tear down any existing room BEFORE starting the new join sequence.
-    // Awaiting here ensures the previous Room's EventChannel streams (LiveKit
-    // internal) are cancelled before a second Room tries to open its own
-    // streams on the same native channel — otherwise Flutter throws
-    // PlatformException(error, No active stream to cancel, null, null).
+    // Await full teardown before new join: prevents EventChannel stream collision
+    // (PlatformException "No active stream to cancel") on the LiveKit native side.
     await _teardownCurrent();
 
     state = state.copyWith(
@@ -349,8 +340,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         'joinChannel: successfully joined channel $channelId',
       );
     } catch (e) {
-      // Surface the URL we tried so a 404 / DNS failure points ops at the
-      // exact subdomain that needs DNS or Traefik attention.
+      // Surface URL on failure so a 404/DNS error points ops at the right subdomain.
       final tried = attemptedUrl ?? '<token-fetch>';
       debugPrint('[LiveKitVoice] join failed at $tried: $e');
       DebugLogService.instance.log(
@@ -377,18 +367,9 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     String channelId,
     bool startMuted,
   ) async {
-    // ---- breadcrumb 0: pre-request microphone permission ------------------
-    // CRITICAL: iOS must grant mic permission BEFORE LiveKit's room.connect
-    // or any audio-track creation. LiveKit server logs from a real iOS
-    // crash showed: `room.connect` succeeded in 1.2s, then 22s later the
-    // peer connection died from watchdog SIGKILL. The 22s matches iOS
-    // killing the app for a blocked main thread, which is what happens
-    // when AVAudioSession activation in `setMicrophoneEnabled` collides
-    // with a TCC mic-permission prompt presented at the same time.
-    //
-    // Requesting permission FIRST drains the prompt into a clean idle
-    // context, so by the time room.connect/setMicrophoneEnabled run the
-    // permission is already .granted or .denied — no synchronous race.
+    // iOS: mic permission MUST resolve before room.connect / setMicrophoneEnabled
+    // or AVAudioSession activation races the TCC prompt and the watchdog SIGKILLs
+    // the app after ~22s of blocked main thread.
     final micPermitted = await _requestMicrophonePermission();
     if (!micPermitted) {
       DebugLogService.instance.log(
@@ -484,14 +465,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       rethrow;
     }
 
-    // Set display name so peers see a username instead of a UUID identity.
-    // Wrap in try/catch: setName triggers an UpdateOwnMetadata signal request
-    // that needs the `canUpdateOwnMetadata` grant in the LiveKit token. If
-    // the server-issued token is missing it, the SFU returns NOT_ALLOWED
-    // which closes the signal channel and cascades into every subsequent
-    // call (setMicrophoneEnabled, publish) failing. Server fix lives in
-    // routes/voice.rs but this guard stops a future grant regression from
-    // bricking the whole join flow.
+    // setName needs `canUpdateOwnMetadata` grant; missing grant closes signal
+    // channel and breaks every subsequent call. Guard against grant regression.
     final username = ref.read(authProvider).username;
     if (username != null && username.isNotEmpty) {
       try {
@@ -505,9 +480,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       }
     }
 
-    // ---- breadcrumb 4: microphone enable ------------------------------------
-    // Mic permission was already granted at the top of joinChannel
-    // (breadcrumb 0) so this call is non-blocking.
+    // Mic permission already resolved at breadcrumb 0; this call is non-blocking.
     final micEnabled = !startMuted;
     try {
       await room.localParticipant?.setMicrophoneEnabled(micEnabled);
@@ -520,11 +493,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       rethrow;
     }
 
-    // ---- PTT: start muted and install keyboard listener -------------------
-    // When push-to-talk is enabled the mic must be silent by default and
-    // only transmit while the configured key is held.  Override `micEnabled`
-    // so the mic is off at join time regardless of `startMuted`, then arm
-    // the listener that will call setCaptureEnabled on key-down/up.
+    // PTT: force mic off at join regardless of startMuted, then arm key listener.
     final voiceSettingsForPtt = ref.read(voiceSettingsProvider);
     final pttActive = voiceSettingsForPtt.pushToTalkEnabled;
     if (pttActive) {
@@ -559,17 +528,14 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     Room room,
     bool micEnabled,
   ) async {
-    // ---- breadcrumb 5: foreground service + CallKit -------------------------
     final resolvedChannelName = _resolveChannelName(conversationId, channelId);
     DebugLogService.instance.log(
       LogLevel.info,
       'LiveKitVoice',
       'joinChannel: starting background service / CallKit for "$resolvedChannelName"',
     );
-    // Promote the foreground service to voice mode (Android) and report
-    // an outgoing CallKit call (iOS) so the OS keeps the mic + audio
-    // session alive when the app is backgrounded.  Listen for Mute /
-    // Leave / End taps coming back from either UI.
+    // Foreground service (Android) + CallKit (iOS) keep mic/audio alive when
+    // backgrounded; listener routes their Mute/Leave taps back into state.
     _attachNotificationActionListener();
     unawaited(
       BackgroundService.instance.startVoice(
@@ -580,15 +546,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     );
     unawaited(
       VoiceCallKitService.instance.startCall(
-        // CallKit's iOS CXCall ID is required to be a valid UUID.
-        // flutter_callkit_incoming's Swift handler does
-        // `UUID(uuidString: params.id)!` and force-unwraps — passing the
-        // previous `"$conversationId:$channelId"` composite was not a
-        // valid UUID, so the force-unwrap crashed with EXC_BREAKPOINT
-        // (Swift fatal error) inside CallManager.startCall, killing the
-        // app every iOS voice join. channelId is already a UUID and is
-        // unique per voice room, which preserves the "rejoin same room
-        // is a no-op" dedup semantic.
+        // CallKit CXCall ID must be a valid UUID — Swift force-unwraps
+        // UUID(uuidString:); a composite "convId:chanId" crashed every iOS join.
         callId: channelId,
         channelName: resolvedChannelName,
         isMuted: !micEnabled,
@@ -604,10 +563,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
   /// LiveKit Room tries to open its EventChannel streams before the first
   /// Room's streams are fully closed.
   Future<void> _teardownCurrent() async {
-    // Stop background services and CallKit before cleaning up the room so
-    // the OS audio session is released in the right order.
+    // Stop background/CallKit before room so OS audio session releases in order.
     _detachNotificationActionListener();
-    // Use unawaited for fire-and-forget OS calls; errors are non-fatal.
     unawaited(BackgroundService.instance.stopVoice());
     unawaited(VoiceCallKitService.instance.endCall());
     unawaited(PipController.instance.disable());
@@ -615,9 +572,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     try {
       await _cleanupRoom();
     } on PlatformException catch (e) {
-      // Swallow "No active stream to cancel" that LiveKit's EventChannel
-      // emits when the room's broadcast stream is torn down a second time
-      // (e.g. disposed-screen navigation races a new joinChannel call).
+      // Swallow LiveKit "No active stream to cancel" on double-teardown races.
       debugPrint(
         '[LiveKitVoice] PlatformException during teardown (ignored): $e',
       );
@@ -670,10 +625,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
   /// Returns `true` if mic is available (granted or already authorised),
   /// `false` if denied / permanently denied.
   Future<bool> _requestMicrophonePermission() async {
-    // Web and non-mobile platforms handle permissions differently; the
-    // WebRTC stack requests them inline and the dialog is browser-native.
-    // Skip the explicit check on those platforms to avoid pulling record's
-    // platform channel into a path that doesn't need it.
+    // Web/desktop: WebRTC requests permission inline via browser-native dialog.
     if (kIsWeb ||
         defaultTargetPlatform == TargetPlatform.linux ||
         defaultTargetPlatform == TargetPlatform.windows ||
@@ -693,8 +645,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       }
       return granted;
     } catch (e) {
-      // Permission check itself threw (unusual). Log and proceed optimistically
-      // so a spurious error doesn't lock out users who already have permission.
+      // Proceed optimistically: don't lock out users when the check itself fails.
       DebugLogService.instance.log(
         LogLevel.warning,
         'LiveKitVoice',
@@ -799,9 +750,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       })
       ..on<ParticipantConnectionQualityUpdatedEvent>((event) {
         if (_disposed) return;
-        // Only the local participant's quality is surfaced in the dock —
-        // remote participants' quality is shown via individual presence
-        // dots elsewhere.
+        // Only local quality drives the dock badge; remote is shown elsewhere.
         if (event.participant.identity == room.localParticipant?.identity) {
           state = state.copyWith(
             localConnectionQuality: event.connectionQuality,
@@ -810,9 +759,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
       })
       ..on<ActiveSpeakersChangedEvent>((event) {
         if (_disposed) return;
-        // Push-based: reacts within ~RTT to the server-side detector,
-        // rather than waiting for the 100ms local audio-level poll to
-        // ramp past the static threshold (#907).
+        // Push-based: server-detected speakers react within RTT, not poll cadence (#907).
         final ids = <String>{};
         for (final p in event.speakers) {
           final id = p.identity.isNotEmpty ? p.identity : p.sid.toString();
@@ -863,10 +810,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         if (pub.track != null &&
             pub.subscribed &&
             pub.source == TrackSource.screenShareVideo) {
-          // Native side stores 16:9 default when 0 is passed; LiveKit
-          // doesn't surface frame dimensions synchronously, so we accept
-          // a slightly-off aspect for the first PiP entry.  Frame-size
-          // tracking via VideoTrackRenderer is a follow-up.
+          // Native stores 16:9 default for 0/0; LiveKit dims aren't sync-available.
           unawaited(PipController.instance.enable(width: 0, height: 0));
           return;
         }
@@ -919,13 +863,8 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
 
   void _startAudioLevelPolling() {
     _audioLevelTimer?.cancel();
-    // Web on CanvasKit is far more expensive per repaint than native, and
-    // every audio-level publish (currently observed by `ref.watch(
-    // livekitVoiceProvider)` callers in the lounge) triggers a wholesale
-    // rebuild of the participant grid. The 100 ms cadence that was fine
-    // on desktop/mobile crashed Chrome tabs in voice calls; throttle to
-    // 250 ms there and let `_pollAudioLevels` skip publishes when the
-    // numbers haven't meaningfully changed.
+    // Web CanvasKit repaint cost forces 250ms cadence (vs 100ms native) to avoid
+    // tab crashes; _pollAudioLevels also dedups when values barely change.
     final interval = kIsWeb
         ? const Duration(milliseconds: 250)
         : const Duration(milliseconds: 100);
@@ -966,21 +905,16 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     final room = _room;
     if (room == null || _disposed) return;
 
-    // Local audio level.
     final localLevel = room.localParticipant?.audioLevel ?? 0.0;
 
-    // Remote audio levels -- keyed by identity (stable, unique per participant)
-    // so the voice lounge UI can look them up consistently.
+    // Keyed by identity (stable+unique) so the lounge UI can look peers up.
     final peerLevels = <String, double>{};
     for (final p in room.remoteParticipants.values) {
       final key = p.identity.isNotEmpty ? p.identity : p.sid.toString();
       peerLevels[key] = p.audioLevel;
     }
 
-    // Dedup: when nobody is talking, the values are all near-zero on every
-    // tick — republishing identical state burns CanvasKit on web for no
-    // visual change. Compare to 0.01 because LiveKit returns floating
-    // noise around the silence floor that's not perceptible in the UI.
+    // Dedup near-silence (epsilon 0.01) so CanvasKit doesn't repaint on noise.
     if (!_disposed && _audioLevelsChanged(localLevel, peerLevels)) {
       state = state.copyWith(
         localAudioLevel: localLevel,
@@ -1028,13 +962,9 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     final room = _room;
     _room = null;
     if (room != null) {
-      // #927: restore per-participant track volumes to 1.0 BEFORE disconnect
-      // so the underlying MediaStreamTrack handles are still alive when the
-      // `Helper.setVolume` calls land. On Windows the per-track gain is
-      // applied via WASAPI session volume, which Windows persists across
-      // process lifetime — exiting with a reduced gain leaves the app
-      // visibly pinned at the lower level in the system mixer until the
-      // user manually re-adjusts it. Harmless no-op on other platforms.
+      // #927: restore per-track volumes to 1.0 BEFORE disconnect — Windows
+      // WASAPI persists session volume across process lifetime, leaving the
+      // system mixer pinned at the lowered level otherwise.
       try {
         await ParticipantVolumeController.instance.restoreAll(room);
       } catch (e) {
@@ -1070,19 +1000,14 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
     unawaited(BackgroundService.instance.stopVoice());
     unawaited(VoiceCallKitService.instance.endCall());
 
-    // Synchronously null out references so in-flight callbacks hit null checks
-    // instead of accessing freed memory. The actual network disconnect is
-    // fire-and-forget on captured local references.
+    // Null refs sync so in-flight callbacks hit null checks, not freed memory.
     final listener = _roomListener;
     final room = _room;
     _roomListener = null;
     _room = null;
     listener?.dispose();
     if (room != null) {
-      // #927: chain the volume restore before disconnect so per-track gain is
-      // returned to 1.0 while tracks are still alive. See `_cleanupRoom` for
-      // the long-form rationale. Fire-and-forget by design — dispose is
-      // synchronous from the framework's POV.
+      // #927: restore volumes before disconnect (see _cleanupRoom for rationale).
       unawaited(
         ParticipantVolumeController.instance
             .restoreAll(room)

--- a/apps/client/lib/src/providers/release_notes_provider.dart
+++ b/apps/client/lib/src/providers/release_notes_provider.dart
@@ -41,10 +41,7 @@ class ReleaseNotesNotifier extends AsyncNotifier<ReleaseNotesView?> {
   Future<ReleaseNotesView?> build() async {
     final prefs = await SharedPreferences.getInstance();
 
-    // Fresh install bootstrap: if we have no record of a previously-
-    // shown version, mark the CURRENT app version as seen and bail
-    // out.  The user gets release notes only on FUTURE updates, never
-    // on first launch (matches Discord / VS Code / GitHub Desktop UX).
+    // Fresh install: mark current version seen; notes only on future updates.
     final stored = prefs.getString(_lastShownVersionKey);
     if (stored == null) {
       if (appVersion != 'dev') {
@@ -56,25 +53,13 @@ class ReleaseNotesNotifier extends AsyncNotifier<ReleaseNotesView?> {
     // Already shown the notes for this version — done.
     if (stored == appVersion) return null;
 
-    // We have an outdated "last shown" record; the user updated since
-    // we last showed them notes.  Watch updateProvider for the body to
-    // arrive.  If updateProvider's check completed before this notifier
-    // built, ref.read returns the populated state immediately.
+    // Outdated last-shown: user updated since; watch updateProvider for body.
     final update = ref.watch(updateProvider);
     final body = update.releaseBody;
     final remote = update.latestVersion;
 
-    // Two cases for the version comparison:
-    //   1. updateProvider already saw the new release ⇒ remote == appVersion
-    //   2. server lags ⇒ remote is older than appVersion (still show
-    //      whatever notes were cached for the version we know about,
-    //      since the user has clearly updated past `stored`).
-    // Either way, we render the cached body if non-empty.
+    // Render whatever body the cache holds — server may lag but user updated.
     if (body == null || body.isEmpty) return null;
-
-    // Show notes for the running app version.  The body in cache may
-    // correspond to a slightly different release on the server, but
-    // for the user the headline is "you updated; here's what changed".
     return ReleaseNotesView(version: remote ?? appVersion, body: body);
   }
 

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -36,10 +36,7 @@ class AppTheme extends _$AppTheme {
     return AppThemeSelection.indigo;
   }
 
-  /// Legacy-string migration table. The 9 -> 6 palette reduction renamed
-  /// `dark` -> `indigo`, `light` -> `paper`, collapsed `highContrast{Dark,Light}`
-  /// into a single `highContrast`, and removed `neon` / `aurora`. Any value
-  /// not in [AppThemeSelection.values] by name is migrated silently here.
+  /// Legacy-string migration for the 9→6 palette reduction (silent).
   static AppThemeSelection _migrateLegacy(String? value) => switch (value) {
     'paper' => AppThemeSelection.paper,
     'indigo' => AppThemeSelection.indigo,
@@ -64,9 +61,7 @@ class AppTheme extends _$AppTheme {
     final value = prefs.getString(_kThemeKey);
     final migrated = _migrateLegacy(value);
     state = migrated;
-    // One-shot write-back: if the persisted string isn't already the new
-    // canonical name, normalise it so subsequent loads skip the migration
-    // path and a manual prefs-file inspection shows the new value.
+    // Write-back canonical name so subsequent loads skip migration.
     if (value != migrated.name) {
       await prefs.setString(_kThemeKey, migrated.name);
     }
@@ -121,12 +116,8 @@ class MessageLayoutNotifier extends _$MessageLayoutNotifier {
   }
 }
 
-/// Aliases preserving the legacy provider symbols used by existing call
-/// sites and tests. Riverpod codegen derives the provider name from the
-/// notifier class name; we keep `class AppTheme` (not `Theme`, which would
-/// collide with Flutter's Material `Theme`) and `class MessageLayoutNotifier`
-/// (not `MessageLayout`, which is the enum), then re-export the historical
-/// short names.
+/// Aliases preserving legacy provider symbols; classes are named to avoid
+/// colliding with Material `Theme` and the `MessageLayout` enum.
 final themeProvider = appThemeProvider;
 final messageLayoutProvider = messageLayoutNotifierProvider;
 final uiDensityProvider = uIDensityNotifierProvider;
@@ -145,9 +136,7 @@ class UIDensityNotifier extends _$UIDensityNotifier {
   @override
   UIDensity build() {
     _load();
-    // Today's effective default is compact: MessageLayoutNotifier defaults
-    // to MessageLayout.compact, which currently shrinks the sidebar.  Match
-    // that here so brand-new users (no prefs at all) see no behavior change.
+    // Compact matches MessageLayoutNotifier's compact default (sidebar parity).
     return UIDensity.compact;
   }
 
@@ -155,11 +144,7 @@ class UIDensityNotifier extends _$UIDensityNotifier {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_kUiDensityKey);
     if (raw == null) {
-      // First read after upgrade.  If the user explicitly chose a
-      // non-compact MessageLayout (bubbles or plain), their sidebar
-      // was rendering at the spacious 68px height — preserve that by
-      // setting density to normal.  Otherwise keep the build() default
-      // (compact), matching today's behavior.
+      // Upgrade migration: preserve spacious sidebar for non-compact legacy layout.
       final legacy = prefs.getString(_kMessageLayoutKey);
       if (legacy != null && legacy != 'compact') {
         state = UIDensity.normal;

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -65,16 +65,11 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       (_) => _cleanupTyping(),
     );
 
-    // Re-bind the websocket whenever the active server URL changes (#PR-2).
-    // We listen inside `build()`, so the subscription lasts as long as the
-    // notifier itself (matches the legacy constructor's lifetime).
+    // (#PR-2) Re-bind WS on server URL change; old origin must not see any frames.
     ref.listen<String>(serverUrlProvider, (previous, next) {
       if (previous == next) return;
-      // Always tear down the existing socket; the old origin must not see
-      // any further frames from this client.
       disconnect();
-      // Reconnect only if we still have an authenticated session.  The login
-      // flow will call `connect()` itself once auth completes.
+      // Login flow calls connect() itself if not yet authenticated.
       if (ref.read(authProvider).isLoggedIn) {
         connect();
       }
@@ -142,9 +137,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     final token = ref.read(authProvider).token;
     if (token == null) return;
 
-    // Cancel any pending reconnect timer before establishing a fresh
-    // connection — otherwise a queued backoff fire can race the manual
-    // connect and end up with two parallel channels (#830).
+    // (#830) Cancel pending reconnect — backoff fire would race connect into 2 channels.
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
 
@@ -164,9 +157,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
   }
 
   Future<void> _connectWithTicketOrFallback() async {
-    // Guard against concurrent reconnect calls that can create parallel channels.
-    // Channel is nulled in onDone/onError, so a non-null channel means we're
-    // actively connected or mid-connect.
+    // Non-null channel = active or mid-connect; prevents parallel channels.
     if (_channel != null) {
       return;
     }
@@ -195,9 +186,8 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     try {
       _channel = WebSocketChannel.connect(uri);
     } catch (e) {
-      // WebSocketChannel.connect can throw synchronously (e.g., invalid URI
-      // on web, mixed-content ws:// from https origin). Don't leave
-      // isConnected=true without a valid channel.
+      // WebSocketChannel.connect can throw sync (invalid URI on web, mixed-content);
+      // don't leave isConnected=true without a channel.
       debugPrint('[WebSocket] connect() threw: $e');
       DebugLogService.instance.log(
         LogLevel.error,
@@ -217,8 +207,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       'Connected to $wsBase',
     );
 
-    // Reload conversations now that WebSocket is connected -- ensures the
-    // list is up-to-date even if the initial REST call raced with connection.
+    // Reload conversations in case initial REST raced with the WS connect.
     ref.read(conversationsProvider.notifier).loadConversations();
 
     _lastMessageTime = DateTime.now();
@@ -227,8 +216,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     _subscription = _channel!.stream.listen(
       (data) => _onMessage(data as String),
       onDone: () {
-        // Null out channel/subscription so _connectWithTicketOrFallback
-        // guard passes on the next reconnect attempt.
+        // Null these so the guard in _connectWithTicketOrFallback passes next time.
         _subscription = null;
         _channel = null;
         DebugLogService.instance.log(
@@ -236,8 +224,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
           'WebSocket',
           'Connection closed (onDone)',
         );
-        // Mark all peers offline on disconnect; reconnect will deliver a
-        // fresh presence_list snapshot that reconciles actual state (#436).
+        // (#436) Mark peers offline; reconnect's presence_list reconciles.
         clearOnlineUsers();
         state = state.copyWith(isConnected: false);
         _scheduleReconnect();
@@ -298,8 +285,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     _reconnectAttempts++;
     state = state.copyWith(reconnectAttempts: _reconnectAttempts);
 
-    // First reconnect is normal after a connection drop -- only log repeated
-    // failures so the debug log stays clean.
+    // Skip log on first reconnect (normal after drop); only log retries.
     if (_reconnectAttempts > 1) {
       debugLog(
         'Reconnecting in ${delayMs}ms '
@@ -363,8 +349,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       await ref.read(cryptoProvider.notifier).retryKeyUpload();
     }
 
-    // Per-user device IDs collide across users (sender device 1 vs recipient
-    // device 1), so per-recipient maps are kept separate end-to-end (#522).
+    // (#522) Device IDs collide across users; keep per-recipient maps separate.
     final result = await _encryptMessageForSend(toUserId, content);
     if (result.payload == null) {
       _addFailedMessage(
@@ -586,10 +571,8 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     final isEncrypted = conversation?.isEncrypted ?? false;
 
     final String payload;
-    // GRP2 wires bind (conversation_id, message_id) into the sender
-    // signature, so when we pick the GRP2 path we have to mint the
-    // message_id BEFORE encrypting and tell the server to respect it.
-    // GRP1 paths leave this null and the server keeps minting its own.
+    // GRP2 binds (conv_id, msg_id) into the signature, so we mint msg_id
+    // pre-encrypt; GRP1 leaves null and server mints.
     String? clientMessageId;
     if (isEncrypted) {
       final encrypted = await _encryptForGroupSend(
@@ -634,9 +617,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       'content': payload,
     };
     if (clientMessageId != null) {
-      // Only set when we minted it for a GRP2 send. Server's
-      // SendMessage handler honours this id when storing the
-      // message; without it the server falls back to gen_random_uuid().
+      // Only set for GRP2 sends; server honours this id when storing.
       msg['client_message_id'] = clientMessageId;
     }
     if (channelId != null && channelId.isNotEmpty) {
@@ -678,10 +659,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       }
       final (_, keyBase64) = keyResult;
 
-      // Phase 2D dispatch: GRP2 if the cached envelope's
-      // min_wire_version pins us there, GRP1 otherwise. Old groups
-      // and groups whose rotator hasn't upgraded yet stay on GRP1
-      // until the next rotation bumps them.
+      // Phase 2D dispatch: GRP2 only when envelope's min_wire_version pins it.
       final minWireVersion =
           groupCrypto.cachedMinWireVersion(conversationId) ?? 1;
       if (minWireVersion >= 2) {
@@ -721,14 +699,8 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       return keyResult;
     }
 
-    // Self-heal: if there's no usable key and the sender is the
-    // group's admin/owner, the wedged envelope is theirs to rotate.
-    // Run seedInitialGroupKey (which probes /keys/latest and bumps
-    // past the existing version) and retry the fetch. This rescues
-    // the most common stuck case — an owner whose group was wedged
-    // by an earlier client and who would otherwise see "Message
-    // may not have been delivered" forever, with no banner to tap
-    // because send-failures don't bump the receive-failure counter.
+    // Self-heal: owner/admin re-seeds wedged envelope (send-failures don't
+    // bump receive-failure counter so banner never fires otherwise).
     if (!_isAdminOrOwnerOf(conversation)) {
       return null;
     }
@@ -738,11 +710,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     );
     await ref.read(cryptoProvider.notifier).seedInitialGroupKey(conversationId);
     keyResult = await groupCrypto.getGroupKey(conversationId);
-    // TD-5: if seedInitialGroupKey lost a 409 race the local
-    // cache may still be empty even though the server now has
-    // a fresh key version. Force a network refetch before we
-    // give up, so a rotation won-elsewhere doesn't bounce the
-    // sender into the failed-message retry loop.
+    // TD-5: force fetch in case seedInitialGroupKey lost a 409 race.
     keyResult ??= await groupCrypto.fetchGroupKey(conversationId);
     return keyResult;
   }
@@ -769,10 +737,8 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     final crypto = ref.read(cryptoServiceProvider);
     final signingKey = crypto.signingKeyPair;
     if (signingKey == null) {
-      // Identity signing key isn't loaded yet (mid-init). Refuse
-      // to fall back to GRP1 because the envelope is pinned to
-      // GRP2 — that would just bounce off the receiver's
-      // min_wire_version guard. Surface as a typed failure.
+      // No signing key yet (mid-init); GRP1 fallback would bounce off receiver's
+      // min_wire_version guard, so fail typed instead.
       _addFailedMessage(
         '',
         _friendlyEncryptionError('Signing key unavailable for GRP2 send'),
@@ -947,8 +913,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     final myUserId = ref.read(authProvider).userId ?? '';
     handleServerMessage(json, myUserId);
 
-    // If the handler flagged session_replaced, disconnect cleanly and do NOT
-    // auto-reconnect -- the other session is the active one.
+    // session_replaced: disconnect, do NOT auto-reconnect (other session is active).
     if (state.wasReplaced) {
       _heartbeatTimer?.cancel();
       _heartbeatTimer = null;

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -546,11 +546,13 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     String? conversationId = '',
     String? originalContent,
   }) {
-    final myUserId = ref.read(authProvider).userId ?? '';
+    final auth = ref.read(authProvider);
+    final myUserId = auth.userId ?? '';
+    final myName = auth.username ?? 'You';
     final msg = ChatMessage(
       id: 'failed_${DateTime.now().millisecondsSinceEpoch}',
       fromUserId: myUserId,
-      fromUsername: 'You',
+      fromUsername: myName,
       conversationId: conversationId ?? '',
       content: reason,
       timestamp: DateTime.now().toIso8601String(),

--- a/apps/client/lib/src/providers/ws_handlers/crypto_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/crypto_handlers.dart
@@ -6,9 +6,7 @@ extension CryptoHandlersOn on WsMessageHandler {
     final fromUsername = json['from_username'] as String? ?? 'Someone';
     final conversationId = json['conversation_id'] as String? ?? '';
 
-    // Invalidate the local session so the next message re-establishes X3DH.
-    // Also drop any cached prekey bundles so the next outgoing message
-    // re-fetches against the freshly-rotated keys (#662).
+    // (#662) Invalidate session + bundle cache so next message re-X3DHes.
     final crypto = ref.read(cryptoServiceProvider);
     crypto.invalidateSessionKey(fromUserId);
     if (fromUserId.isNotEmpty) {
@@ -46,8 +44,7 @@ extension CryptoHandlersOn on WsMessageHandler {
   }
 
   void _handleDeviceRevoked(Map<String, dynamic> json) {
-    // Use `num?` + toInt() so dart2js (web) doesn't blow up when the JSON
-    // number is decoded as a double rather than an int.
+    // num+toInt: dart2js may decode the JSON number as double, not int.
     final revokedDeviceId = (json['device_id'] as num?)?.toInt();
     final myDeviceId = ref.read(cryptoServiceProvider).isInitialized
         ? ref.read(cryptoServiceProvider).deviceId
@@ -87,18 +84,9 @@ extension CryptoHandlersOn on WsMessageHandler {
     groupCrypto.fetchGroupKey(conversationId);
   }
 
-  /// #656 — server signalled that a member was removed and the surviving
-  /// members need to regenerate the group AES key for the bumped version.
-  ///
-  /// Phase 3b adds a server-elected leader on top of the underlying
-  /// UNIQUE-constraint race. The event carries `leader_user_id` plus an
-  /// ordered `fallback_order` and a `deadline_ms` hint; the local client
-  /// uses its own position in `[leader, ...fallback_order]` to delay its
-  /// attempt. The leader fires immediately; each fallback waits one
-  /// `deadline_ms` per slot, re-checks whether the new version has
-  /// already arrived (via the cache populated by `group_key_rotated`),
-  /// and only then attempts to upload. The UNIQUE constraint remains the
-  /// safety net for any split-brain / pre-Phase-3b mixed-fleet case.
+  /// (#656) Server-elected leader rotation; this client waits its slot in
+  /// `[leader, ...fallback_order] * deadline_ms` and aborts if a peer wins.
+  /// UNIQUE constraint is the safety net for split-brain / mixed-fleet.
   void _handleGroupKeyRotationRequested(Map<String, dynamic> json) {
     final request = parseRotationRequested(json);
     if (request == null) return;
@@ -116,10 +104,7 @@ extension CryptoHandlersOn on WsMessageHandler {
     );
 
     if (delay == null) {
-      // Server did not see us as online when it elected the leader.
-      // Stay out of the fallback queue; the broadcast `group_key_rotated`
-      // event (or our next getGroupKey) will pull the winning envelope
-      // once any elected member completes the rotation.
+      // Not in elected set; group_key_rotated broadcast will pull winning envelope.
       DebugLogService.instance.log(
         LogLevel.info,
         'GroupRotation',
@@ -154,11 +139,7 @@ extension CryptoHandlersOn on WsMessageHandler {
       );
       await Future<void>.delayed(delay);
 
-      // After the wait, check whether someone earlier in the priority
-      // list already completed the rotation. The `group_key_rotated`
-      // broadcast invalidates our cache and pre-fetches the new
-      // envelope, so a successful peer rotation surfaces here as a
-      // current version >= the requested version.
+      // Check if a higher-priority peer already rotated (current >= target).
       final current = await groupCrypto.getGroupKey(request.conversationId);
       final currentVersion = current?.$1;
       if (shouldAbortRotation(
@@ -201,20 +182,14 @@ extension CryptoHandlersOn on WsMessageHandler {
           return [];
         }
       },
-      // Self-wrap uses the local pubkey so we can always unwrap our
-      // own envelope; peer wraps bypass the TOFU cache so we use the
-      // recipient's current server-known identity rather than a
-      // stale entry from a previous account session. See
-      // seedInitialGroupKey for the longer rationale.
+      // Self: local pubkey; peers: force-refresh past TOFU cache.
       fetchIdentityKey: (userId) {
         if (userId == myUserId) {
           return crypto.getIdentityPublicKey();
         }
         return crypto.fetchPeerIdentityKey(userId, forceRefresh: true);
       },
-      // TD-4: same TOFU-bypass guard as seedInitialGroupKey. If any
-      // peer's identity key changed on the most recent refresh,
-      // refuse to wrap the new group key under it.
+      // TD-4: refuse to wrap under TOFU-changed peer key.
       hasIdentityKeyChanged: (userId) async {
         if (userId == myUserId) return false;
         return crypto.hasPeerIdentityKeyChanged(userId);

--- a/apps/client/lib/src/providers/ws_handlers/message_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/message_handlers.dart
@@ -44,12 +44,7 @@ extension MessageHandlersOn on WsMessageHandler {
           channelId: channelId,
           expiresAt: expiresAt,
         );
-    // confirmSent already transitions status to sent atomically with the ID
-    // swap (chat_provider.dart:442); no follow-up updateMessageStatus needed.
-
-    // Update conversation list preview so the sender sees their own message
-    // reflected immediately (e.g. attachment markers, text). Without this the
-    // conversation preview stays stale until the next server fetch.
+    // Update conv preview so sender sees own message reflected immediately.
     final confirmed = ref
         .read(chatProvider)
         .messagesForConversation(conversationId)
@@ -102,14 +97,8 @@ extension MessageHandlersOn on WsMessageHandler {
       return;
     }
 
-    // #26: detect replayed offline messages via a synchronous Hive box check.
-    // isMessageCachedSync only returns true when the box for this conversation
-    // is already open in memory AND the key exists — no disk I/O, no async.
-    // On re-login the first loadConversations() call (triggered by WS connect)
-    // opens the per-conversation Hive boxes, so by the time the server drains
-    // the offline queue the boxes are open and this check is effective.
-    // Messages that are NOT yet in the open box (first time seen) return false,
-    // so genuinely new messages are never suppressed.
+    // (#26) Sync Hive check detects offline-queue replays without false positives;
+    // genuinely-new messages (box-miss) always return false.
     final alreadySeen =
         messageId.isNotEmpty &&
         MessageCache.isMessageCachedSync(conversationId, messageId);
@@ -190,15 +179,13 @@ extension MessageHandlersOn on WsMessageHandler {
       );
     }
 
-    // Only do a full HTTP reload if this is a new conversation we don't have
-    // locally. For existing conversations, onNewMessage() already updates state.
+    // Full reload only for unknown convs; existing ones use onNewMessage.
     if (!isKnownConversation) {
       ref.read(conversationsProvider.notifier).loadConversations();
     }
 
-    // When crypto is NOT initialized, notify with raw content (it's plaintext
-    // in that case). When crypto IS initialized, the notification fires AFTER
-    // decryption inside _decryptAndDeliverWithPreview.
+    // Crypto-not-ready: notify on raw plaintext; otherwise notification fires
+    // post-decrypt inside _decryptAndDeliverWithPreview.
     if (!cryptoState.isInitialized && fromUserId != myUserId && !alreadySeen) {
       _notifyIfAllowed(conversationId, senderUsername, rawContent);
     }
@@ -303,19 +290,15 @@ extension MessageHandlersOn on WsMessageHandler {
     String timestamp,
     String senderUsername,
   ) {
-    // Crypto not ready yet — show a placeholder and queue for decryption.
-    // The literal 'Securing message...' string is recognised by
-    // chat_provider.dart's `_placeholderContents` so the decrypted
-    // version replaces it in place when the queue drains (#430).
+    // (#430) Placeholder 'Securing message...' is recognised by chat_provider
+    // and replaced in-place when the queue drains.
     final placeholder = ChatMessage.fromServerJson({
       ...json,
       'content': 'Securing message...',
     }, myUserId).copyWith(isEncrypted: true);
     ref.read(chatProvider.notifier).addMessage(placeholder);
 
-    // Queue the raw JSON so it can be decrypted once crypto initializes.
-    // Bind the entry to the current user so a logout + re-login cannot
-    // leak this ciphertext into another account's state (#830 finding 4).
+    // (#830) Bind queue entry to current user — prevents leak on re-login.
     _enqueuePendingDecrypt(json, myUserId);
 
     ref

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -58,10 +58,8 @@ class WebSocketState {
   /// Updated from presence events that include the presence_status field.
   final Map<String, String> presenceStatuses;
 
-  /// Map of userId -> last seen timestamp. Populated from offline presence
-  /// events that include `last_seen_at`. Only peers we observe transition
-  /// online → offline during this session have an entry; truly long-offline
-  /// peers stay null and the header falls back to "offline" (#503).
+  /// (#503) userId -> last seen; only populated for peers observed going
+  /// offline this session, header falls back to "offline" otherwise.
   final Map<String, DateTime> lastSeenAt;
 
   /// True when the server sent a `session_replaced` event, meaning another
@@ -160,14 +158,8 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
   /// lists when another device is revoked.
   StreamController<Map<String, dynamic>> get deviceRevokedController;
 
-  /// Messages received before crypto was initialized.
-  /// Drained by [drainPendingDecryptQueue] once crypto is ready.
-  ///
-  /// Each entry carries the user ID that was authenticated at the time the
-  /// envelope was queued. The drain step refuses to decrypt entries whose
-  /// owner does not match the currently-authenticated user, so a logout +
-  /// re-login on the same process cannot leak user A's queued ciphertext
-  /// into user B's chat/conversations state (#830 finding 4).
+  /// (#830) Pre-crypto-init envelope queue; each entry binds an owner-userId
+  /// so drain after logout can't leak user A's ciphertext into user B.
   final List<_PendingDecryptEntry> _pendingDecryptQueue = [];
 
   /// Length of the pending decrypt queue. Exposed for tests asserting that
@@ -183,14 +175,8 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
     );
   }
 
-  /// Library-private state accessors used by the part-file extensions.
-  ///
-  /// `StateNotifier.state` is `@protected`, so accessing it from an
-  /// extension (even one defined in the same library) trips the analyzer's
-  /// `invalid_use_of_protected_member` lint. Reading/writing through these
-  /// instance members keeps the access within a subclass scope where the
-  /// lint is satisfied, while the underscore prefix keeps them private to
-  /// this library.
+  /// Library-private state accessor so part-file extensions avoid the
+  /// invalid_use_of_protected_member lint on `state`.
   WebSocketState get _state => state;
   set _state(WebSocketState value) => state = value;
 
@@ -227,9 +213,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
 
     for (final entry in queue) {
       if (entry.ownerUserId != myUserId) {
-        // Cross-account envelope from a previous session — discard silently.
-        // The cleanup hook should have already cleared this, but defence in
-        // depth: never deliver into the wrong user's chat state.
+        // Defence in depth: drop cross-account envelopes silently.
         DebugLogService.instance.log(
           LogLevel.warning,
           'WebSocket',
@@ -540,8 +524,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
             senderVerifyKey: senderVerifyKey,
           );
         } on GroupSenderSignatureException catch (e) {
-          // Render with a distinct placeholder so the chat UI can stripe
-          // the bubble in a danger color (different from key-out-of-sync).
+          // Distinct placeholder lets chat UI stripe in a danger color.
           debugLog(
             'GRP2 signature failed for $conversationId msg=$messageId: $e',
             'WebSocket',
@@ -550,9 +533,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
         }
       }
 
-      // GRP1 path. Reject when the envelope has been pinned to GRP2 —
-      // a hostile sender or compromised server cannot downgrade past
-      // the signature requirement once the key version is locked.
+      // GRP1 refused when envelope is pinned to GRP2 (downgrade attack).
       if (minWireVersion >= 2) {
         debugLog(
           'GRP1 wire refused at min_wire_version=$minWireVersion '
@@ -601,11 +582,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
     String myUserId,
     String decryptedContent,
   ) {
-    // Mention detection runs over the *decrypted* plaintext. Skip the
-    // sender's own messages — we don't want to badge someone for
-    // mentioning themselves. Sentinel-shaped strings (failed decrypt,
-    // placeholders) won't contain real mentions and are filtered by
-    // _decryptedPreviews logic upstream.
+    // Run over decrypted plaintext; skip self so users don't badge themselves.
     if (fromUserId == myUserId) return false;
     return containsMention(decryptedContent, ref.read(authProvider).username);
   }
@@ -627,10 +604,7 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
     final isMuted = conv?.isMuted ?? false;
     if (isMuted) return;
 
-    // Gate everything below on DND/quiet-hours so the user gets full silence
-    // when they've asked for it. The desktop NotificationService also checks
-    // shouldSuppressNotification, but pre-checking here keeps the sound and
-    // the platform toast aligned and skips a wasted async call.
+    // Gate sound+toast on DND/quiet-hours; pre-check keeps them aligned.
     shouldSuppressNotification().then((suppress) {
       if (suppress) return;
       if (isMention) {

--- a/apps/client/lib/src/screens/create_group_screen.dart
+++ b/apps/client/lib/src/screens/create_group_screen.dart
@@ -1,13 +1,19 @@
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../models/contact.dart';
+import '../providers/auth_provider.dart';
 import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../services/toast_service.dart';
+import '../services/upload_client.dart';
 import '../theme/echo_theme.dart';
+import '../widgets/avatar_crop_dialog.dart';
 import '../widgets/avatar_utils.dart' show buildAvatar, resolveAvatarUrl;
 import '../widgets/empty_state.dart';
 
@@ -25,6 +31,7 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
   bool _isCreating = false;
   bool _isPublic = false;
   bool _isEncrypted = false;
+  Uint8List? _pickedAvatarBytes;
 
   @override
   void initState() {
@@ -73,6 +80,14 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
       return;
     }
 
+    // Upload the picked avatar (if any) before navigating so the user
+    // lands on a chat that already shows their chosen icon.  Failures
+    // here are non-fatal — the toast inside the helper explains and the
+    // user can re-pick from Group Info.
+    if (_pickedAvatarBytes != null) {
+      await _uploadGroupAvatarAfterCreate(conversationId);
+    }
+
     if (!mounted) return;
     setState(() => _isCreating = false);
 
@@ -106,23 +121,147 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
       body: Center(
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600),
-          child: Column(
+          // Inner SingleChildScrollView so the avatar picker + form fields
+          // don't overflow on short viewports (phone landscape, dialog
+          // wrappers); the members list keeps its own Expanded inside so
+          // it still consumes the remaining space cleanly.
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return SingleChildScrollView(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: IntrinsicHeight(
+                    child: Column(
+                      children: [
+                        const SizedBox(height: 16),
+                        _buildAvatarPicker(),
+                        _buildNameField(),
+                        _buildDescriptionField(),
+                        const SizedBox(height: 16),
+                        _buildVisibilityToggle(),
+                        const SizedBox(height: 16),
+                        _buildEncryptionToggle(),
+                        const SizedBox(height: 16),
+                        _buildMembersHeader(),
+                        const SizedBox(height: 8),
+                        Expanded(child: _buildContactsList(contactsState)),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAvatarPicker() {
+    return Semantics(
+      label: 'pick group avatar',
+      button: true,
+      child: GestureDetector(
+        onTap: _isCreating ? null : _pickGroupAvatar,
+        child: Center(
+          child: Stack(
             children: [
-              _buildNameField(),
-              _buildDescriptionField(),
-              const SizedBox(height: 16),
-              _buildVisibilityToggle(),
-              const SizedBox(height: 16),
-              _buildEncryptionToggle(),
-              const SizedBox(height: 16),
-              _buildMembersHeader(),
-              const SizedBox(height: 8),
-              Expanded(child: _buildContactsList(contactsState)),
+              Container(
+                width: 96,
+                height: 96,
+                padding: const EdgeInsets.all(3),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(color: context.accent, width: 2),
+                ),
+                child: CircleAvatar(
+                  radius: 44,
+                  backgroundColor: context.surface,
+                  backgroundImage: _pickedAvatarBytes != null
+                      ? MemoryImage(_pickedAvatarBytes!)
+                      : null,
+                  child: _pickedAvatarBytes == null
+                      ? Icon(
+                          Icons.groups_outlined,
+                          size: 36,
+                          color: context.textMuted,
+                        )
+                      : null,
+                ),
+              ),
+              Positioned(
+                bottom: 0,
+                right: 0,
+                child: CircleAvatar(
+                  radius: 14,
+                  backgroundColor: context.accent,
+                  child: Icon(
+                    Icons.camera_alt,
+                    size: 14,
+                    color: context.surface,
+                  ),
+                ),
+              ),
             ],
           ),
         ),
       ),
     );
+  }
+
+  Future<void> _pickGroupAvatar() async {
+    final result = await FilePicker.pickFiles(
+      type: FileType.image,
+      withData: true,
+    );
+    if (result == null || result.files.isEmpty) return;
+    final file = result.files.first;
+    if (file.bytes == null) return;
+    if (!mounted) return;
+    final cropped = await showAvatarCropDialog(context, file.bytes!);
+    if (cropped == null) return;
+    if (!mounted) return;
+    setState(() => _pickedAvatarBytes = cropped);
+  }
+
+  /// PUT the picked avatar bytes to `/api/groups/<id>/avatar` right after
+  /// the group is created. Best-effort: a failure here surfaces a toast
+  /// but does NOT block navigation into the new group — the user can
+  /// re-upload from Group Info if it didn't take.
+  Future<void> _uploadGroupAvatarAfterCreate(String groupId) async {
+    final bytes = _pickedAvatarBytes;
+    if (bytes == null) return;
+    try {
+      final uploader = UploadClient(ref.read(authProvider.notifier));
+      final result = await uploader.uploadFile(
+        serverUrl: ref.read(serverUrlProvider),
+        path: '/api/groups/$groupId/avatar',
+        bytes: bytes,
+        fileName: 'avatar.jpg',
+        mimeType: 'image/jpeg',
+        method: 'PUT',
+        fieldName: 'avatar',
+      );
+      if (!mounted) return;
+      if (!result.ok) {
+        ToastService.show(
+          context,
+          result.errorMessage ??
+              'Avatar upload failed (${result.statusCode}). '
+                  'You can retry from Group Info.',
+          type: ToastType.warning,
+        );
+      }
+    } catch (e) {
+      debugPrint('[CreateGroup] avatar upload failed: $e');
+      if (mounted) {
+        ToastService.show(
+          context,
+          'Avatar upload failed. You can retry from Group Info.',
+          type: ToastType.warning,
+        );
+      }
+    }
   }
 
   Widget _buildNameField() {
@@ -158,44 +297,27 @@ class _CreateGroupScreenState extends ConsumerState<CreateGroupScreen> {
   }
 
   Widget _buildVisibilityToggle() {
+    // Aligned with the E2E encryption SwitchListTile below so the two
+    // toggles read as one consistent block. `value` here is "is private?"
+    // (the inverse of the underlying `_isPublic`) so the affordance reads
+    // as a positive privacy choice rather than a hidden public flip.
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Semantics(
-            label: 'visibility toggle',
-            child: SegmentedButton<bool>(
-              segments: const [
-                ButtonSegment<bool>(
-                  value: false,
-                  label: Text('Private'),
-                  icon: Icon(Icons.lock_outline, size: 16),
-                ),
-                ButtonSegment<bool>(
-                  value: true,
-                  label: Text('Public'),
-                  icon: Icon(Icons.public, size: 16),
-                ),
-              ],
-              selected: {_isPublic},
-              onSelectionChanged: (selection) {
-                setState(() => _isPublic = selection.first);
-              },
-              style: SegmentedButton.styleFrom(
-                selectedBackgroundColor: context.accentLight,
-                selectedForegroundColor: context.accent,
-              ),
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
+      child: Semantics(
+        label: 'private group toggle',
+        child: SwitchListTile(
+          value: !_isPublic,
+          onChanged: (private) => setState(() => _isPublic = !private),
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Private group'),
+          subtitle: Text(
             _isPublic
-                ? 'Anyone can discover and join'
-                : 'Only invited members can join',
+                ? 'Off: anyone can discover and join.'
+                : 'On: only invited members can join.',
             style: TextStyle(color: context.textMuted, fontSize: 12),
           ),
-        ],
+          activeThumbColor: context.accent,
+        ),
       ),
     );
   }

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -49,10 +49,7 @@ import 'discover_groups_screen.dart';
 import 'settings_screen.dart';
 import '../widgets/profile_sheets.dart';
 
-// Behaviour parts. Each part adds a mixin onto `_HomeScreenState` that
-// shares the same library scope (so private fields and methods are
-// freely visible across files). Mirrors `apps/client/lib/src/providers/
-// auth/` which uses the same `part of` + mixin pattern.
+// Behaviour mixins share the same library scope as `_HomeScreenState` via `part of`.
 part 'home_screen/parts/lifecycle.dart';
 part 'home_screen/parts/actions.dart';
 part 'home_screen/parts/listeners.dart';
@@ -149,16 +146,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   // Search focus node for Ctrl+K shortcut
   final _searchFocusNode = FocusNode();
 
-  // Inline "What's New" notes for the desktop overlay path. When non-null
-  // the body Stack renders a [WhatsNewInlineOverlay] above the page so
-  // the AppTitleBar remains draggable.
+  // Non-null = render WhatsNewInlineOverlay above the page so AppTitleBar stays draggable.
   ReleaseNotesView? _whatsNewNotes;
 
-  // Edge-swipe state for narrow chat → conversation-list navigation. Kept
-  // on the parent class because `_swipeSnapController` is initialised in
-  // `initState` and disposed in `dispose`, while the gesture handlers live
-  // in narrow_layout.dart — splitting the state across parts would scatter
-  // fragile animation timing across files.
+  // Edge-swipe state lives on parent so initState/dispose own the AnimationController
+  // even though gesture handlers live in narrow_layout.dart.
   double? _swipeStartX;
 
   // Progress of the in-flight edge swipe: 0.0 (idle) → 1.0 (threshold reached).
@@ -222,9 +214,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     if (state == AppLifecycleState.resumed) {
       ref.read(contactsProvider.notifier).loadPending(force: true);
     } else if (state == AppLifecycleState.detached) {
-      // Only leave voice on full app termination, not on background.
-      // Mobile users expect calls to continue when switching apps or
-      // locking the screen.
+      // Only leave voice on full app termination; backgrounded calls must keep running.
       _voiceRtcNotifier.leaveChannel();
     }
   }
@@ -249,10 +239,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           const SingleActivator(LogicalKeyboardKey.keyK, control: true): () {
             _showQuickSwitcher();
           },
-          // Ctrl+F and Ctrl+Shift+F both open the global search overlay.
-          // Ctrl+F matches the OS-native "find" muscle memory; the older
-          // Ctrl+Shift+F stays bound so existing users don't have to relearn.
-          // The per-chat magnifying glass was retired in #1135.
+          // Ctrl+F (native "find" muscle memory) + legacy Ctrl+Shift+F both open global search (#1135).
           const SingleActivator(LogicalKeyboardKey.keyF, control: true): () {
             _showGlobalSearch();
           },
@@ -266,9 +253,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           const SingleActivator(LogicalKeyboardKey.slash, control: true): () {
             _showKeyboardShortcuts();
           },
-          // Power-user shortcuts: open settings (matches the Discord /
-          // browser convention) and close settings with Esc so the panel
-          // never strands the user without a mouse.
+          // Ctrl+, opens settings (Discord/browser convention); Esc closes for no-mouse exit.
           const SingleActivator(LogicalKeyboardKey.comma, control: true): () {
             _openSettings();
           },

--- a/apps/client/lib/src/screens/home_screen/parts/actions.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/actions.dart
@@ -88,7 +88,22 @@ mixin _HomeScreenActionsMixin on ConsumerState<HomeScreen> {
   /// Opens the dedicated "New message" composer. Tapping a contact starts
   /// a DM and selects the resulting conversation. On desktop the composer
   /// is shown as a centered dialog; on mobile it pushes as a full screen.
+  ///
+  /// Zero-contacts short-circuit: with no contacts the picker would only
+  /// show "No contacts available", so we route the user to the contacts
+  /// screen instead (where Add-contact actually works) and surface a
+  /// toast explaining why.
   Future<void> _openNewMessage() async {
+    final contactsState = ref.read(contactsProvider);
+    if (contactsState.contacts.isEmpty) {
+      ToastService.show(
+        context,
+        'Add a contact first — there\'s no-one to message yet.',
+        type: ToastType.info,
+      );
+      _openContacts();
+      return;
+    }
     if (_self._isDesktop) {
       await showDialog<void>(
         context: context,

--- a/apps/client/lib/src/screens/home_screen/parts/actions.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/actions.dart
@@ -16,11 +16,7 @@ mixin _HomeScreenActionsMixin on ConsumerState<HomeScreen> {
       _self._pendingMessageId = messageId;
       _self._narrowPanelIndex = 1;
       _self._showSettings = false;
-      // Collapse the lounge so the selected chat is visible.
-      // Only lock the auto-show when voice is already active (i.e., the user
-      // is deliberately navigating away from an in-progress call).  When
-      // voice is NOT yet active, leaving _userDismissedLounge false lets the
-      // lounge auto-show the moment the user joins voice from this chat.
+      // Collapse lounge; only lock auto-show when voice is active (i.e., navigating away from a call).
       _self._showingLounge = false;
       if (ref.read(voiceRtcProvider).isActive) {
         _self._userDismissedLounge = true;

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -79,11 +79,7 @@ mixin _HomeScreenDesktopLayoutMixin
                 final displayName = conv.displayName(myUserId);
                 final isSelected = conv.id == _self._selectedConversation?.id;
 
-                // KeyedSubtree so element identity tracks conv.id rather
-                // than the position index — prevents the Stack +
-                // conditional selection-pill subtree from briefly
-                // binding to the wrong conversation when the list
-                // reorders after a new message / pin / delete (TD-10).
+                // KeyedSubtree binds element identity to conv.id so list reorders don't misbind (TD-10).
                 return KeyedSubtree(
                   key: ValueKey('conv-rail-${conv.id}'),
                   child: Padding(
@@ -99,10 +95,7 @@ mixin _HomeScreenDesktopLayoutMixin
                           child: SizedBox(
                             width: 44,
                             height: 44,
-                            // Stack so the left-edge selection pill can sit
-                            // alongside the centred avatar without affecting
-                            // its layout. Matches the pattern used in
-                            // conversation_item so both sidebars agree.
+                            // Stack lets the selection pill sit beside the centred avatar (matches conversation_item).
                             child: Stack(
                               children: [
                                 Center(
@@ -200,11 +193,7 @@ mixin _HomeScreenDesktopLayoutMixin
                         Positioned(
                           top: 10,
                           right: 10,
-                          // Ring needs to contrast with the surrounding chip,
-                          // not blend into it. The footer chip uses `mainBg`,
-                          // so a `mainBg` ring is invisible. `sidebarBg`
-                          // matches the surrounding rail and keeps the dot
-                          // legible regardless of theme.
+                          // `sidebarBg` ring contrasts with the footer chip's `mainBg` so the dot stays visible.
                           child: _DotBadge(
                             ringColor: context.sidebarBg,
                             bgColor: context.accent,
@@ -313,12 +302,7 @@ mixin _HomeScreenDesktopLayoutMixin
                     ..._buildMembersPanel(),
                   ],
                 ),
-                // Voice dock used to float here as an AnimatedPositioned
-                // overlay at bottom: 60, which made it occlude the sidebar
-                // chrome (bug-report row, update banner). It now renders
-                // inline inside ConversationPanel just above the bottom
-                // chrome so everything flows naturally and nothing is
-                // covered. F-029 in the 2026-05-19 UI audit.
+                // Voice dock moved inline into ConversationPanel — float overlay occluded sidebar chrome (F-029).
                 if (_self._whatsNewNotes != null)
                   WhatsNewInlineOverlay(
                     notes: _self._whatsNewNotes!,
@@ -425,12 +409,7 @@ mixin _HomeScreenDesktopLayoutMixin
       isCollapsed: _self._sidebarCollapsed,
       onHorizontalDragUpdate: (details) {
         if (_self._sidebarCollapsed) return;
-        // Allow dragging below `_sidebarMinWidth` so users can pull the
-        // handle through to compact mode and the drag-end handler can
-        // snap to collapsed. The lower clamp keeps the sidebar from
-        // disappearing entirely mid-drag (#739). The upper clamp now
-        // scales with viewport width via `_sidebarMaxWidthFor` so ultra-
-        // wide displays can grow the sidebar past 500 px (up to 720).
+        // Lower clamp allows pull-through to compact mode without hiding mid-drag (#739); upper scales with viewport.
         final maxWidth = _HomeScreenState._sidebarMaxWidthFor(
           MediaQuery.of(context).size.width,
         );

--- a/apps/client/lib/src/screens/home_screen/parts/lifecycle.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/lifecycle.dart
@@ -14,15 +14,10 @@ part of '../../home_screen.dart';
 /// extend behaviour via mixins that share the same library scope.
 mixin _HomeScreenLifecycleMixin
     on ConsumerState<HomeScreen>, _HomeScreenActionsMixin {
-  // `_self` is provided by `_HomeScreenActionsMixin` (the `on` clause
-  // guarantees it's in scope); used throughout to reach private fields
-  // declared on `_HomeScreenState`.
+  // `_self` is provided by `_HomeScreenActionsMixin` for reaching private parent fields.
 
   Future<void> _initData() async {
-    // 1. Initialize crypto (awaited -- must complete before anything else).
-    // SplashScreen calls initAndUploadKeys() during auto-login, so this is
-    // typically a no-op (CryptoNotifier guards against double-init internally).
-    // The guard below avoids the async round-trip in the common case.
+    // 1. Init crypto — usually a no-op (Splash already called it); guard avoids the async round-trip.
     final cryptoState = ref.read(cryptoProvider);
     if (!cryptoState.isInitialized) {
       final cryptoNotifier = ref.read(cryptoProvider.notifier);
@@ -61,23 +56,13 @@ mixin _HomeScreenLifecycleMixin
     // 5. Load privacy preferences used for read-receipt/plaintext behavior.
     await ref.read(privacyProvider.notifier).load();
 
-    // 6. Check for app updates.  Awaited so step 6b can read the
-    // resulting release-notes body and decide whether to show the
-    // What's New modal — without await the body isn't populated yet
-    // and the modal silently skips.  Cached path is sync (≤ 1ms);
-    // network path is a single 10s-timeout GET so worst-case impact
-    // on home-screen first paint is bounded.
+    // 6. Check updates — awaited so 6b sees the release-notes body. Network path bounded 10s.
     await ref.read(updateProvider.notifier).check();
 
-    // 6b. Show the What's New modal once per upgrade.  No-op on fresh
-    // install (releaseNotesProvider bootstraps last_shown = appVersion
-    // so first launch never surfaces a changelog).
+    // 6b. Show What's New once per upgrade; no-op on fresh install.
     await _showWhatsNewIfNeeded();
 
-    // 7b. Init system tray (desktop only; no-op on web/mobile). The
-    // "Check for updates" menu item routes through _handleTrayCheckForUpdates
-    // so the tray service stays UI-agnostic and the toast surfaces here
-    // where we have a BuildContext.
+    // 7b. Init system tray (desktop only); tray-triggered toasts need a BuildContext here.
     unawaited(
       TrayService.instance.init(onCheckForUpdates: _handleTrayCheckForUpdates),
     );
@@ -110,19 +95,14 @@ mixin _HomeScreenLifecycleMixin
     final update = ref.read(updateProvider);
     if (update.updateAvailable) {
       if (update.dismissed) {
-        // User previously dismissed the banner for this version; the
-        // explicit re-check is their signal that they actually want to
-        // see it again, so surface a toast that points back at the
-        // version (the banner stays hidden until the cache rolls).
+        // User dismissed the banner — explicit re-check signals they want to see it again, so toast.
         ToastService.show(
           context,
           'Update available: v${update.latestVersion}',
           type: ToastType.info,
         );
       }
-      // Otherwise the persistent update banner already shows "vX is
-      // available" with Update/Download/Later actions — a transient
-      // toast on top of it would be redundant noise.
+      // Otherwise the persistent banner already shows the version; a toast would be redundant.
       return;
     }
     ToastService.show(
@@ -134,9 +114,7 @@ mixin _HomeScreenLifecycleMixin
 
   Future<void> _showWhatsNewIfNeeded() async {
     if (!mounted) return;
-    // Force AsyncNotifier.build() to run before reading .value — the
-    // first read of an AsyncNotifierProvider returns AsyncLoading; we
-    // need the resolved snapshot.
+    // Force AsyncNotifier.build() before reading .value (first read is AsyncLoading).
     await ref.read(releaseNotesProvider.future);
     if (!mounted) return;
     await maybeShowWhatsNew(

--- a/apps/client/lib/src/screens/home_screen/parts/listeners.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/listeners.dart
@@ -94,10 +94,7 @@ mixin _HomeScreenListenersMixin
       _self._selectedConversation = fresh;
       return;
     }
-    // Permanently removed (left, deleted, kicked) — clear selection.
-    // Gate on isLoading rather than emptiness so deleting the very
-    // last conversation still clears the panel instead of getting
-    // stuck because convs.isEmpty.
+    // Clear selection on removal; gate on isLoading so deleting the last conversation still clears.
     if (fresh == null && !convState.isLoading) {
       _self._selectedConversation = null;
       _self._narrowPanelIndex = 0;

--- a/apps/client/lib/src/screens/new_message_screen.dart
+++ b/apps/client/lib/src/screens/new_message_screen.dart
@@ -12,24 +12,6 @@ import '../widgets/empty_state.dart';
 import '../widgets/settings/section_header.dart';
 import '../widgets/user_avatar.dart';
 
-// ---------------------------------------------------------------------------
-// NewMessageScreen
-//
-// Chip-based new-chat composer.
-//
-// UX flow:
-//   1. User types a name or @handle in the text field.
-//   2. An autocomplete dropdown shows matching contacts.
-//   3. Selecting a suggestion OR pressing Enter materialises the typed text
-//      as a chip; the field clears ready for the next recipient.
-//   4. Each chip has an × to remove it.
-//   5. Bottom action area:
-//      - 0 chips  → disabled "Start chat" button
-//      - 1 chip   → "Start chat with @username" → getOrCreateDm → navigate
-//      - 2+ chips → inline group-name step appears; "Create group" calls
-//                   createGroup → navigate
-// ---------------------------------------------------------------------------
-
 /// Modal-style "New message" composer with chip-based recipient selection.
 ///
 /// Pass [onStartConversation] to receive the resolved [Conversation] and

--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -70,10 +70,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
   void initState() {
     super.initState();
     _selectedTimezone = DateTime.now().timeZoneName;
-    // Pre-fill display name with the username so the Welcome page can be
-    // skipped without forcing the user to type anything. They can still
-    // edit it before continuing, but Skip no longer hard-blocks on an
-    // empty field — #1177.
+    // Pre-fill display name with username so Skip on Welcome doesn't hard-block (#1177).
     final username = ref.read(authProvider).username;
     if (username != null && username.isNotEmpty) {
       _displayNameController.text = username;
@@ -117,10 +114,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
   static const int _pageCount = 5;
 
   void _next() {
-    // The display-name field on the Welcome page is the only required
-    // input in the entire wizard. Block forward navigation until it has
-    // a value so the user can't land on home with a profile that's just
-    // `@nicolas` everywhere.
+    // Display name is the only required wizard field; block forward nav until set.
     if (_currentPage == 0 && _displayNameController.text.trim().isEmpty) {
       _showDisplayNameRequired();
       return;
@@ -218,9 +212,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
     final file = result.files.first;
     if (file.bytes == null) return;
 
-    // Show the same crop dialog the Settings → Profile flow uses (#728) so
-    // signup users get an aspect-correct avatar instead of whatever shape
-    // their gallery handed back. Dialog returns null on cancel.
+    // Reuse Settings → Profile crop dialog for aspect-correct avatar (#728).
     if (!mounted) return;
     final croppedBytes = await showAvatarCropDialog(context, file.bytes!);
     if (croppedBytes == null) return;
@@ -286,9 +278,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
           const AppTitleBar(),
           Expanded(
             child: SafeArea(
-              // top: true so the page content (and the narrow-layout
-              // EchoLogoIcon) doesn't collide with the iOS status bar /
-              // dynamic island. Bottom safe area continues to apply.
+              // top safe area: avoid iOS status bar / dynamic island collision.
               child: Center(
                 child: LayoutBuilder(
                   builder: (context, outerConstraints) {
@@ -316,11 +306,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         child: Column(
           children: [
-            // Standalone EchoLogoIcon removed from narrow layout — the
-            // Welcome page header already brands the screen and on iOS
-            // the logo collided with the dynamic island. The wide-layout
-            // brand panel still renders its own logo because it has the
-            // horizontal space to do so cleanly.
+            // Logo removed on narrow: Welcome header already brands, and iOS dynamic island collided.
             Expanded(child: _buildPageView()),
             const SizedBox(height: 16),
             _buildBottomControls(context),
@@ -427,9 +413,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
         ),
       ],
     );
-    // Backwards-only navigation: the user can click any step they've
-    // already completed to jump back. Future steps stay un-clickable so a
-    // hurried user can't skip required setup.
+    // Backwards-only step nav: completed steps clickable, future ones blocked.
     if (!isDone) return row;
     return Semantics(
       button: true,
@@ -488,11 +472,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
     return SingleChildScrollView(
       child: Column(
         children: [
-          // Beta callout was moved to the login/register screens (see
-          // BetaBanner) so new users see it before signing up and returning
-          // testers see it on every login. Keeping it out of the wizard
-          // also lets the welcome step lead with the actual setup CTA
-          // instead of a doom warning.
+          // Beta callout lives on login/register (BetaBanner); wizard leads with the setup CTA.
           Text(
             'Welcome to Echo!',
             style: TextStyle(
@@ -590,10 +570,7 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
           ],
           const SizedBox(height: 12),
           _buildTimezoneDropdown(context),
-          // Presence/Status dropdown removed from onboarding per direct
-          // user feedback — defaults to 'online' and remains editable in
-          // Settings → Status. Keeping the controller wired so the
-          // server still receives the default value on save.
+          // Presence dropdown removed; defaults to 'online', editable in Settings → Status.
         ],
       ),
     );

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -186,10 +186,7 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
     );
     if (!confirmed) return;
 
-    // Wipe scoped state. SecureKeyStore.deleteAllForUser only operates on
-    // the currently-set scope, so we briefly set it for the user we have
-    // stored against this server (if any), then restore the scope of the
-    // currently-logged-in session afterwards.
+    // deleteAllForUser only acts on the current scope, so briefly switch and then restore.
     try {
       final host = Uri.tryParse(target.url)?.host ?? target.url;
       final keystore = SecureKeyStore.instance;
@@ -857,12 +854,7 @@ class _DebugLogEntryTileState extends State<_DebugLogEntryTile> {
 
   @override
   Widget build(BuildContext context) {
-    // Whole row is clickable; tap copies the formatted entry to the
-    // clipboard. The dedicated trailing IconButton was retired in #1128
-    // because Copy All already lives in the header and the per-row icon
-    // wasted ~44px of vertical reserve, cutting visible rows in half.
-    // RepaintBoundary so hover state on one row doesn't invalidate the
-    // whole list's paint layer (the buffer can hold up to 5000 entries).
+    // Whole row clickable copies the entry (#1128); RepaintBoundary keeps hover from invalidating up to 5000 rows.
     return RepaintBoundary(
       child: MouseRegion(
         onEnter: (_) => setState(() => _hovered = true),

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -73,7 +73,6 @@ class AccountSection extends ConsumerStatefulWidget {
 class _AccountSectionState extends ConsumerState<AccountSection> {
   final _displayNameController = TextEditingController();
   final _bioController = TextEditingController();
-  final _statusController = TextEditingController();
   final _pronounsController = TextEditingController();
   final _timezoneController = TextEditingController();
   final _websiteController = TextEditingController();
@@ -99,7 +98,6 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
   void dispose() {
     _displayNameController.dispose();
     _bioController.dispose();
-    _statusController.dispose();
     _pronounsController.dispose();
     _currentPasswordController.dispose();
     _newPasswordController.dispose();
@@ -132,7 +130,6 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
         setState(() {
           _displayNameController.text = data['display_name'] as String? ?? '';
           _bioController.text = data['bio'] as String? ?? '';
-          _statusController.text = data['status_message'] as String? ?? '';
           _pronounsController.text = data['pronouns'] as String? ?? '';
           // Default the timezone to the device's current zone when the server
           // has no value persisted yet — saves the user a manual selection.
@@ -170,7 +167,6 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
       final body = <String, dynamic>{
         'display_name': _displayNameController.text,
         'bio': _bioController.text,
-        'status_message': _statusController.text,
         'pronouns': _pronounsController.text,
         'timezone': _timezoneController.text,
         'website': _websiteController.text,
@@ -573,19 +569,6 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
                     ],
                   ],
                 ),
-                if (_statusController.text.isNotEmpty) ...[
-                  const SizedBox(height: 4),
-                  Text(
-                    _statusController.text,
-                    style: TextStyle(
-                      color: context.textSecondary,
-                      fontSize: 13,
-                      fontStyle: FontStyle.italic,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
               ],
             ),
           ),
@@ -680,13 +663,6 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
           ),
           const SizedBox(height: 12),
           _buildPronounsField(),
-          const SizedBox(height: 12),
-          _profileField(
-            controller: _statusController,
-            label: 'Status',
-            hint: 'What are you up to?',
-            maxLength: 100,
-          ),
           const SizedBox(height: 12),
           _profileField(
             controller: _bioController,

--- a/apps/client/lib/src/screens/settings/advanced_theme_section.dart
+++ b/apps/client/lib/src/screens/settings/advanced_theme_section.dart
@@ -17,8 +17,9 @@ class AdvancedThemeSection extends ConsumerWidget {
     final custom = ref.watch(customColorsProvider);
     final scheme = Theme.of(context).colorScheme;
 
-    final effectivePrimary = custom.primaryColor ?? scheme.primary;
-    final effectiveAccent = custom.accentColor ?? scheme.secondary;
+    // Accent maps to colorScheme.primary so context.accent (the dominant
+    // accent reader app-wide) actually moves when the user picks a colour.
+    final effectiveAccent = custom.accentColor ?? scheme.primary;
 
     return SettingsPanelScaffold(
       children: [
@@ -32,7 +33,7 @@ class AdvancedThemeSection extends ConsumerWidget {
         ),
         const SizedBox(height: 4),
         Text(
-          'Override the active theme\'s primary and accent colors. '
+          'Override the active theme\'s accent colour. '
           'Changes apply immediately and survive restarts.',
           style: TextStyle(
             color: context.textSecondary,
@@ -42,19 +43,9 @@ class AdvancedThemeSection extends ConsumerWidget {
         ),
         const Divider(height: 32),
         _ColorPickerTile(
-          key: const Key('primary_color_tile'),
-          label: 'Primary color',
-          subtitle: 'Used for text highlights and UI elements',
-          currentColor: effectivePrimary,
-          isOverridden: custom.primaryColor != null,
-          onColorChanged: (c) =>
-              ref.read(customColorsProvider.notifier).setPrimaryColor(c),
-        ),
-        const SizedBox(height: 12),
-        _ColorPickerTile(
           key: const Key('accent_color_tile'),
-          label: 'Accent color',
-          subtitle: 'Used for buttons, links, and active states',
+          label: 'Accent colour',
+          subtitle: 'Buttons, links, sent bubbles, and active states',
           currentColor: effectiveAccent,
           isOverridden: custom.accentColor != null,
           onColorChanged: (c) =>
@@ -97,26 +88,15 @@ class AdvancedThemeInline extends ConsumerWidget {
     final custom = ref.watch(customColorsProvider);
     final scheme = Theme.of(context).colorScheme;
 
-    final effectivePrimary = custom.primaryColor ?? scheme.primary;
-    final effectiveAccent = custom.accentColor ?? scheme.secondary;
+    final effectiveAccent = custom.accentColor ?? scheme.primary;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _ColorPickerTile(
-          key: const Key('primary_color_tile'),
-          label: 'Primary color',
-          subtitle: 'Text highlights and UI elements',
-          currentColor: effectivePrimary,
-          isOverridden: custom.primaryColor != null,
-          onColorChanged: (c) =>
-              ref.read(customColorsProvider.notifier).setPrimaryColor(c),
-        ),
-        const SizedBox(height: 8),
-        _ColorPickerTile(
           key: const Key('accent_color_tile'),
-          label: 'Accent color',
-          subtitle: 'Buttons, links, and active states',
+          label: 'Accent colour',
+          subtitle: 'Buttons, links, sent bubbles, and active states',
           currentColor: effectiveAccent,
           isOverridden: custom.accentColor != null,
           onColorChanged: (c) =>

--- a/apps/client/lib/src/screens/settings/voice_section.dart
+++ b/apps/client/lib/src/screens/settings/voice_section.dart
@@ -227,13 +227,7 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
     if (_devicesLoaded) return;
     _devicesLoaded = true;
 
-    // TestFlight build 500 crashed on iOS 26.5 with
-    // -[__NSDictionaryM isEqualToString:]: unrecognized selector
-    // when opening this screen. The exception is native (Objective-C
-    // runtime), but the trigger is this Dart -> flutter_webrtc call.
-    // Capture step-by-step breadcrumbs so the next reproduction leaves
-    // forensic data in the on-disk debug log instead of a stripped
-    // stack with no context.
+    // TestFlight 500 crashed iOS 26.5 with isEqualToString: in flutter_webrtc; breadcrumbs for next repro.
     DebugLogService.instance.log(
       LogLevel.info,
       'VoiceSettings',
@@ -276,10 +270,7 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
           cameras.add({'id': d.deviceId, 'name': label});
         }
       }
-      // If the plugin returned nothing for a kind, keep a sentinel so the
-      // dropdown is never blank. Distinguish "zero devices enumerated"
-      // (Linux PulseAudio unavailable / sandboxed) from "devices returned
-      // but none matched this kind" (e.g. a server with no webcam).
+      // Keep a sentinel when empty so dropdowns aren't blank; distinguish no-enum vs no-matching-kind.
       final noEnum = devices.isEmpty;
       if (inputs.isEmpty) {
         inputs.add({
@@ -316,10 +307,7 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
             '${outputs.length} out / ${cameras.length} cam',
       );
     } catch (e, st) {
-      // Persist the error so we can see it on the next launch even if
-      // the app crashed afterward. The previous bare `catch (_) {}`
-      // swallowed everything including the type-confusion that may
-      // precede the native isEqualToString: crash.
+      // Persist the error: bare `catch (_)` swallowed the type-confusion preceding the native crash.
       DebugLogService.instance.log(
         LogLevel.error,
         'VoiceSettings',
@@ -684,10 +672,7 @@ class _CameraPreviewState extends State<_CameraPreview> {
   }
 
   Future<void> _restart() async {
-    // Only attempt a restart once the renderer has been initialized — a
-    // device-id change that races initialize() would otherwise call
-    // _startStream() against an uninitialized renderer and throw a
-    // StateError on some webrtc plugin versions.
+    // Skip if renderer not yet initialised — device-id change racing init() throws StateError.
     if (!_rendererInitialized) return;
     await _stopStream();
     await _startStream();
@@ -753,21 +738,13 @@ class _CameraPreviewState extends State<_CameraPreview> {
 
   @override
   void dispose() {
-    // dispose() must be synchronous; fire-and-forget of _stopStream() left
-    // the camera hardware live on Android until the next GC. Instead, stop
-    // tracks synchronously here so the OS camera indicator clears the
-    // moment the widget unmounts. The async stream/renderer dispose
-    // futures are issued unawaited in the correct order.
+    // Sync dispose: async stop() left the Android camera live until GC, with the OS indicator on.
     _generation++;
     final stream = _stream;
     final rendererInitialized = _rendererInitialized;
     _stream = null;
     _rendererInitialized = false;
-    // Guard the srcObject clear — the underlying RTCVideoRenderer throws
-    // "Call initialize before setting the stream" if dispose() fires
-    // without the renderer ever having been initialised (the settings
-    // screen mounts the preview widget but the user never opened the
-    // camera step). Skip the clear if there was no init.
+    // RTCVideoRenderer throws on srcObject=null without init; skip the clear when uninitialised.
     if (rendererInitialized) {
       _renderer.srcObject = null;
     }

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -243,11 +243,7 @@ class SettingsRootView extends ConsumerWidget {
               ),
             ],
           ),
-          // Log out lives in its own card so the destructive action sits
-          // alone, visually divorced from neutral chrome like "About".
-          // Pattern matches the standard "destructive action at the bottom"
-          // shape from iOS Settings / Discord / etc. F-039 in the
-          // 2026-05-19 UI audit.
+          // Log out in its own card — destructive-action-at-the-bottom pattern (F-039).
           const SizedBox(height: EchoSectionTokens.groupGap),
           _CardGroup(
             children: [
@@ -576,11 +572,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             ),
           ),
           Container(width: 1, color: context.border),
-          // Content area — caps at 960px so the form columns don't sprawl
-          // across an ultrawide display with a desert of empty pixels
-          // between the sidebar and the actual fields. Wider screens get
-          // the form left-aligned against the sidebar; the surplus space
-          // sits on the trailing edge.
+          // 960 px cap left-aligns the form against the sidebar on ultrawide displays.
           Expanded(
             child: Align(
               alignment: Alignment.topLeft,

--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -160,12 +160,6 @@ class SettingsRootView extends ConsumerWidget {
           const SectionHeader('Account preferences'),
           _CardGroup(
             children: [
-              _row(
-                context,
-                icon: Icons.mood_outlined,
-                iconColor: context.settingsIconPalette.status,
-                section: SettingsSection.status,
-              ),
               if (onSavedMessages != null)
                 CardRow(
                   icon: Icons.bookmark_outline,

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -76,16 +76,8 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
   Future<void> _init() async {
     final stopwatch = Stopwatch()..start();
 
-    // Slice 10: shrink the desktop window to a 320×440 splash before doing
-    // any async work, Discord-style. The window expands back to the user's
-    // last-known size after navigation lands on home/login.
+    // Slice 10: shrink desktop window to 320×440 splash before async work; restored on navigate.
     await WindowStateService.enterSplash();
-
-    // The iOS/macOS local-network permission explainer used to fire here
-    // before auto-login. Removed per direct user feedback — the bare OS
-    // dialog is enough, and the in-app overlay added friction on the
-    // splash that users didn't want. The service file is kept in case
-    // we want to restore a friendlier variant later.
 
     _setStatus('Checking session…');
     final loggedIn = await _attemptAutoLogin();
@@ -103,12 +95,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
       }
     }
 
-    // Keep the splash visible long enough to read the wordmark + tagline
-    // and let the indigo sweep complete one cycle on FIRST install. After
-    // that the user has seen the brand moment — veterans don't need to
-    // pay the 1500 ms on every cold launch. Drop to a small 400 ms floor
-    // so the cross-fade still feels intentional but doesn't actively
-    // hold up the app.
+    // 1500 ms brand moment on first install; 400 ms floor on subsequent launches.
     stopwatch.stop();
     final elapsed = stopwatch.elapsedMilliseconds;
     final prefs = await SharedPreferences.getInstance();
@@ -129,9 +116,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     // instead of navigating immediately.
     final updateState = ref.read(updateProvider);
     if (!kIsWeb && update_svc.canAutoUpdate && updateState.updateAvailable) {
-      // Grow the chromeless splash window to a size that comfortably fits
-      // the actionable update prompt — the 320×440 splash dimensions
-      // crowded the Download/Restart/Skip stack.
+      // 320×440 splash too cramped for the Download/Restart/Skip stack.
       await WindowStateService.enterUpdatePrompt();
       if (!mounted) return;
       setState(() {
@@ -207,9 +192,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     final isLoggedIn = ref.read(authProvider).isLoggedIn;
     final deepLink = ref.read(pendingDeepLinkProvider.notifier).takeAndClear();
 
-    // Slice 10: restore the user's last-known window geometry as soon as we
-    // know we're leaving the splash. Fire-and-forget — navigation must not
-    // wait for the OS window resize.
+    // Slice 10: fire-and-forget window-geometry restore; navigation must not wait on OS resize.
     unawaited(WindowStateService.restore());
 
     if (isLoggedIn && deepLink != null) {
@@ -235,9 +218,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     context.go('/home');
 
     final cryptoState = ref.read(cryptoProvider);
-    // Only warn about regenerated keys when the user had prior messages on
-    // this device. Fresh logins on a new device would otherwise see a
-    // scary "history unavailable" banner that doesn't apply to them.
+    // Only warn about regenerated keys when prior messages exist; fresh logins shouldn't see it.
     final hadPriorMessages = MessageCache.entryCount() > 0;
     if (cryptoState.keysWereRegenerated && hadPriorMessages && mounted) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -256,11 +237,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
   }
 
   Widget _buildUpdatePrompt(BuildContext context) {
-    // Desktop renders inside the 320×440 chromeless splash window, so the
-    // update prompt has to reuse the splash shell — same `mainBg`, same
-    // ambient halo, same brand block — and just swap the bottom action
-    // slot. Mobile/web fall through to full-screen with the same
-    // composition, mirroring [_SplashBody.compact].
+    // Desktop reuses the 320×440 splash shell and just swaps the action slot.
     final isCompact =
         !kIsWeb &&
         (defaultTargetPlatform == TargetPlatform.linux ||
@@ -320,10 +297,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     );
 
     if (isCompact) {
-      // Desktop: transparent Scaffold + rounded-clipped surface so the splash
-      // reads as a floating card on compositors that honour window
-      // transparency, and degrades gracefully to a squared-off card on those
-      // that don't.
+      // Transparent Scaffold + rounded clip: floating card on transparent compositors, squared elsewhere.
       return Scaffold(
         backgroundColor: Colors.transparent,
         body: ClipRRect(
@@ -502,19 +476,9 @@ class _UpdatePromptBody extends ConsumerWidget {
         ? const EdgeInsets.fromLTRB(28, 44, 28, 22)
         : const EdgeInsets.fromLTRB(36, 24, 36, 38);
 
-    // The previous layout used MainAxisAlignment.spaceBetween across the
-    // full viewport, which on anything larger than the 320×440 desktop
-    // splash window left huge empty gaps above and below the action block.
-    // Centring the brand + action as one tight stack and pinning the
-    // version label to the bottom keeps the prompt feeling like a focused
-    // card at every window size.
     return FadeTransition(
       opacity: fade,
-      // StackFit.expand forces the rounded card chain to fill the whole
-      // chromeless window. Without it the non-positioned Center wraps
-      // tightly around its content, the ClipRRect shrinks to that size,
-      // and the transparent window corners show through as black on
-      // compositors that don't paint window translucency.
+      // StackFit.expand: rounded card must fill chromeless window or transparent corners show through.
       child: Stack(
         fit: StackFit.expand,
         children: [
@@ -668,9 +632,7 @@ class _UpdatePromptBody extends ConsumerWidget {
             style: TextStyle(fontSize: 12, color: context.textMuted),
           ),
           const SizedBox(height: 6),
-          // Escape hatch for the user who tapped "Download" by accident
-          // on a 200 MB update — Skip is disabled while busy, so without
-          // this they're stuck waiting out the whole transfer.
+          // Escape hatch: Skip is disabled while downloading, so otherwise the user is stuck.
           Semantics(
             button: true,
             label: 'Cancel update download',

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -389,13 +389,7 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
 
   void _addImageByUrl(String url) {
     if (!mounted) return;
-    // Broadcast via canvasProvider so every participant (including this
-    // one, via VoiceCanvas's ref.watch on canvas state) renders the image.
-    // Previously also called _canvas?.addImageFromUrl(...) which placed a
-    // SECOND copy at canvas-center inside LoungeDrawingCanvas's local
-    // _images list -- that copy never broadcast and never moved when the
-    // shared one was dragged, producing the "stuck twin" the user
-    // reported in #752.
+    // Broadcast via canvasProvider only — local _canvas?.addImageFromUrl caused a "stuck twin" (#752).
     final img = CanvasImage(
       id: newCanvasId(),
       url: url,

--- a/apps/client/lib/src/screens/voice_lounge/echo_screen_select_dialog.dart
+++ b/apps/client/lib/src/screens/voice_lounge/echo_screen_select_dialog.dart
@@ -87,11 +87,7 @@ class _EchoScreenSelectDialogState extends State<_EchoScreenSelectDialog> {
     _disposed = true;
     _refreshTimer?.cancel();
     for (final sub in _subs) {
-      // flutter_webrtc's EventChannel can settle the cancel future with a
-      // PlatformException('No active stream to cancel') when the native
-      // broadcast stream has already torn down (e.g. picker closed during
-      // enumeration). Without `catchError` the rejection lands in the
-      // uncaught-async zone and surfaces as [FTL] flutter: — #1158.
+      // catchError needed: cancel can reject with "No active stream to cancel" → uncaught [FTL] (#1158).
       unawaited(
         sub.cancel().catchError((Object e) {
           debugPrint('[EchoScreenSelect] sub.cancel ignored: $e');

--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -225,11 +225,7 @@ class ParticipantGrid extends StatelessWidget {
     }
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Aim for a tile that's a comfortable ~220 px wide on desktop; the
-        // grid then naturally widens to fill ultrawide viewports rather than
-        // capping at 3 columns the way the old portrait/landscape heuristic
-        // did. Clamped to [2, 6] so tiny widths still get a 2-up layout and
-        // we never shrink avatars into illegibility on 4K monitors.
+        // ~220 px target tile; clamp [2, 6] so phones still get 2-up and 4K stays legible.
         const targetTileWidth = 220.0;
         final crossAxisCount = (constraints.maxWidth / targetTileWidth)
             .floor()
@@ -415,15 +411,7 @@ class _ParticipantTileState extends State<ParticipantTile> {
             clipBehavior: Clip.antiAlias,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(15),
-              // RepaintBoundary isolates the tile so audio-level rebuilds
-              // (~10 Hz) don't cascade into sibling tiles.
-              //
-              // BackdropFilter is desktop/mobile only. On web, CanvasKit
-              // composites the 12×12 Gaussian blur into an offscreen GPU
-              // texture every frame per tile — on Firefox/NVIDIA EGL that
-              // can saturate the CanvasRenderer thread and stall the
-              // lounge. The opaque `context.surface @ 0.30` underneath is
-              // enough on web without the blur.
+              // RepaintBoundary isolates ~10 Hz audio-level rebuilds; blur skipped on web (CanvasKit perf).
               child: RepaintBoundary(
                 child: _MaybeBackdropBlur(
                   enabled: !kIsWeb,

--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -415,12 +415,18 @@ class _ParticipantTileState extends State<ParticipantTile> {
             clipBehavior: Clip.antiAlias,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(15),
-              // RepaintBoundary isolates the blur layer so audio-level
-              // rebuilds (~10 Hz) don't re-rasterise the BackdropFilter
-              // for every tile in the grid.
+              // RepaintBoundary isolates the tile so audio-level rebuilds
+              // (~10 Hz) don't cascade into sibling tiles.
+              //
+              // BackdropFilter is desktop/mobile only. On web, CanvasKit
+              // composites the 12×12 Gaussian blur into an offscreen GPU
+              // texture every frame per tile — on Firefox/NVIDIA EGL that
+              // can saturate the CanvasRenderer thread and stall the
+              // lounge. The opaque `context.surface @ 0.30` underneath is
+              // enough on web without the blur.
               child: RepaintBoundary(
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                child: _MaybeBackdropBlur(
+                  enabled: !kIsWeb,
                   child: Container(
                     color: context.surface.withValues(alpha: 0.30),
                     child: Stack(
@@ -910,4 +916,23 @@ class _LocalScreenShareTrackState extends State<LocalScreenShareTrack> {
 
 Map<String, String>? _getAuthHeaders(String? authToken) {
   return authToken != null ? {'Authorization': 'Bearer $authToken'} : null;
+}
+
+/// BackdropFilter wrapper that skips the blur on web. The 12×12 Gaussian
+/// blur is a CanvasKit hotspot on Firefox/NVIDIA EGL — see the comment at
+/// the call site above for the perf rationale.
+class _MaybeBackdropBlur extends StatelessWidget {
+  final bool enabled;
+  final Widget child;
+
+  const _MaybeBackdropBlur({required this.enabled, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+    return BackdropFilter(
+      filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+      child: child,
+    );
+  }
 }

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -157,14 +157,7 @@ class _DraggableScreenShareWindowState
 
   @override
   Widget build(BuildContext context) {
-    // The widget is rendered as a Stack child by callers. Flutter
-    // requires direct Stack children to be Positioned (or
-    // unpositioned) — wrapping the Positioned inside a LayoutBuilder
-    // breaks that invariant and produced a parent-data exception
-    // widget tests had to drain. Wrap the whole tree in Positioned.fill
-    // so the outer Stack sees a Positioned; then put an inner Stack
-    // around the LayoutBuilder so the draggable Positioned still has a
-    // legitimate Stack parent.
+    // Stack requires Positioned children: wrap in Positioned.fill, then inner Stack for LayoutBuilder.
     return Positioned.fill(
       child: LayoutBuilder(
         builder: (ctx, constraints) {

--- a/apps/client/lib/src/screens/voice_lounge/screen_share_actions.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share_actions.dart
@@ -15,15 +15,7 @@ import '../../providers/screen_share_provider.dart';
 import 'echo_screen_select_dialog.dart';
 
 bool _useLiveKitPicker() {
-  // macOS, Windows, and Linux: use EchoScreenSelectDialog which enumerates
-  // sources via flutter_webrtc's DesktopCapturer (no portal dependency).
-  //
-  // Linux previously deferred to flutter_webrtc's setScreenShareEnabled which
-  // was supposed to route through xdg-desktop-portal. In practice the portal
-  // handshake is unreliable — it returns "source not found" when the portal
-  // daemon isn't running or dismisses the picker before flutter_webrtc reads
-  // the result (#12). Using the same custom picker path as macOS/Windows
-  // bypasses the portal entirely and gives consistent source enumeration.
+  // Desktop uses EchoScreenSelectDialog (DesktopCapturer); Linux xdg-portal handshake is flaky (#12).
   if (kIsWeb) return false;
   if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) return true;
   return false;
@@ -64,9 +56,7 @@ Future<void> _stopScreenShare(
   LiveKitVoiceNotifier lkNotifier,
   ScreenShare ssNotifier,
 ) async {
-  // #936: Explicitly unpublish + stop + dispose the screen-share publication
-  // so the next start request acquires a brand-new portal source instead of
-  // reusing a stale reference that would publish white frames.
+  // #936: Full unpublish/stop/dispose so the next start gets a fresh portal source, not white frames.
   final local = lkNotifier.room?.localParticipant;
   if (local != null) {
     await _cleanupScreenSharePubs(local);
@@ -84,9 +74,7 @@ Future<void> _startScreenShareWithPicker(
   ScreenShare ssNotifier,
 ) async {
   try {
-    // Use our custom picker instead of lk.ScreenSelectDialog, which has two
-    // bugs: Image.memory without errorBuilder (crashes on non-decodable
-    // thumbnail bytes) and a setState-after-dispose race on dismiss.
+    // lk.ScreenSelectDialog has two bugs (no errorBuilder, setState-after-dispose); use our picker.
     final source = await showEchoScreenSelectDialog(context);
     if (source == null || !context.mounted) return;
     final track = await lk.LocalVideoTrack.createScreenShareTrack(
@@ -94,15 +82,7 @@ Future<void> _startScreenShareWithPicker(
     );
     final room = lkNotifier.room;
     if (room != null) {
-      // #910: explicit single-layer VP8 publish for screen-share. Without
-      // this, the SDK falls back to `roomOptions.defaultVideoPublishOptions`
-      // which is tuned for camera (simulcast=true + a camera-shaped
-      // VideoEncoding). On macOS/Windows that combination negotiates a
-      // simulcast layout that the SFU silently drops for remote viewers —
-      // the sharer keeps their local preview (no SFU round-trip) but
-      // remotes see no track. A single-layer VP8 publish matches what
-      // LiveKit's own meet sample uses for screen-share and is decodable
-      // everywhere flutter_webrtc runs.
+      // #910: single-layer VP8 — camera-shaped simulcast default gets dropped by SFU on macOS/Windows.
       await room.localParticipant?.publishVideoTrack(
         track,
         publishOptions: const lk.VideoPublishOptions(
@@ -122,13 +102,7 @@ Future<void> _startScreenShareNative(
   LiveKitVoiceNotifier lkNotifier,
   ScreenShare ssNotifier,
 ) async {
-  // #936: defensively sweep any leftover screen-share publication before
-  // asking LiveKit to enable one. If the toggle state in
-  // [screenShareProvider] ever drifts out of sync with LiveKit's internal
-  // `getTrackPublicationBySource`, the SDK would take the
-  // `unmute(stale-track)` branch and publish white frames instead of
-  // creating a fresh track from the portal source the user just picked.
-  // Cheap no-op when there's nothing stale to clear.
+  // #936: sweep leftover pubs first — stale-track unmute publishes white frames if state drifts.
   final local = lkNotifier.room?.localParticipant;
   if (local != null) {
     await _cleanupScreenSharePubs(local);

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -91,11 +91,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   @override
   void initState() {
     super.initState();
-    // Breadcrumb: VoiceLoungeScreen mounted. This fires immediately after
-    // joinChannel succeeds and the route transitions to the lounge. If the
-    // app crashes before this appears in logs, the crash is in joinChannel
-    // itself (captured by channel_bar.dart breadcrumbs). If it appears but
-    // no further breadcrumbs follow, the crash is inside the lounge build.
+    // Breadcrumb fires post-joinChannel: missing = crash in joinChannel; present-but-alone = crash in build.
     final voiceLk = ref.read(livekitVoiceProvider);
     DebugLogService.instance.log(
       LogLevel.info,
@@ -755,11 +751,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   ) {
     return _buildLoungeScaffold(context, [
       Positioned.fill(child: _buildBackground(context)),
-      // Reserve the top strip for the floating header badge + the
-      // background-picker button so a remote screen share (or any other
-      // edge-to-edge contentArea like a video tile) doesn't sit under
-      // them. 64 px = badge/button top:16 + their ~32 px height + a
-      // little breathing room before the share frame begins.
+      // 64 px reserves top strip for header badge + background picker (top:16 + ~32 px + gap).
       Column(
         children: [
           const SizedBox(height: 64),
@@ -876,11 +868,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     final conversationId = voiceLk.conversationId ?? '';
     final channelId = voiceLk.channelId ?? '';
 
-    // Picture-in-Picture: render only the remote screen-share track in a
-    // bare full-bleed VideoTrackRenderer.  No header, no dock, no canvas
-    // chrome — the whole point of PiP is a tiny system window with just
-    // the relevant pixels.  Falls through to the regular layout if the
-    // OS reports PiP without a remote track (e.g. transient state).
+    // PiP: bare remote screen-share track only; falls through if PiP without a remote track.
     if (inPip) {
       final pipBody = _buildPipBody(ref);
       if (pipBody != null) return pipBody;

--- a/apps/client/lib/src/services/chunked_upload_client.dart
+++ b/apps/client/lib/src/services/chunked_upload_client.dart
@@ -1,21 +1,7 @@
-// Chunked / resumable upload client (#556).
-//
-// Mirrors the three Rust endpoints on `/api/media/upload`:
-//   1. POST   /init       → returns `{ upload_id, chunk_size }`
-//   2. PATCH  /{id}/chunk → appends one chunk at the next offset
-//   3. POST   /{id}/finalize → assembles the media row and returns
-//      the same shape the legacy single-shot endpoint does
-//   4. GET    /{id}       → re-sync after a 416 / crash
-//
-// The on-disk file is read incrementally in `chunk_size`-byte slices; no
-// part of the upload ever sits in RAM longer than one chunk.  Each chunk
-// gets up to [maxRetriesPerChunk] retries with exponential back-off; a
-// 416 from the server triggers a fresh GET so the client can pick the
-// right offset before retrying.
-//
-// The public return shape matches the existing [UploadClient.uploadFile]
-// result so callers can switch between the two paths without branching on
-// the return type.
+// (#556) Chunked/resumable upload client. Mirrors Rust /api/media/upload
+// endpoints (init/chunk/finalize/state). One chunk in RAM at a time;
+// retries with backoff and 416 → GET re-sync. Return shape matches
+// UploadClient.uploadFile so callers can swap without branching.
 
 import 'dart:async';
 import 'dart:convert';
@@ -324,29 +310,20 @@ class ChunkedUploadClient {
 
       if (resp.ok) return resp;
 
-      // 416 → re-sync from server and adjust the offset.  This is a
-      // one-shot correction; if the server tells us nothing, fall through
-      // to the regular retry path.
+      // 416 → one-shot re-sync from server offset, then fall back to retry.
       if (resp.statusCode == 416 && resp.bytesReceived >= 0) {
         final newStart = resp.bytesReceived;
-        // Don't keep bytes we've already shipped.  If the server is ahead
-        // of where we thought, advance; if behind, re-send the trailing
-        // slice.
         if (newStart > localStart) {
           final advance = newStart - localStart;
           if (advance >= localChunk.length) {
-            // Server already has more than we were about to send -- skip
-            // this whole chunk and let the outer loop fetch the next.
+            // Server is past our chunk; skip and let outer loop fetch next.
             return _ChunkResult.ok(bytesReceived: newStart);
           }
           localChunk = localChunk.sublist(advance);
           localStart = newStart;
           continue;
         }
-        // newStart < start: server lost progress; resume from there.
-        // We don't have the missing bytes here, so the caller's outer
-        // loop will re-derive the chunk on the next iteration.  Surface
-        // a synthetic ok=true so the outer loop re-reads from disk.
+        // Server lost progress; surface ok so outer loop re-reads from disk.
         return _ChunkResult.ok(bytesReceived: newStart);
       }
 
@@ -389,17 +366,14 @@ class ChunkedUploadClient {
     }
 
     if (resp.statusCode == 416) {
-      // Body shape mirrors the server-side `range_mismatch` AppError:
-      // `{ "bytes_received": N }`.  Defensive parse so a future body
-      // shape change doesn't crash the client.
+      // Server-side range_mismatch body: { "bytes_received": N }; defensive parse.
       var rebased = -1;
       try {
         final data = jsonDecode(text) as Map<String, dynamic>;
         final raw = data['bytes_received'];
         if (raw is num) rebased = raw.toInt();
       } catch (_) {
-        // Older servers may return an empty 416 body.  Trigger a state
-        // fetch as a fallback.
+        // Older servers may return empty 416 body — state fetch handles it.
       }
       if (rebased < 0) {
         rebased =
@@ -518,9 +492,7 @@ class ChunkedUploadClient {
   }
 
   Future<List<int>> _readSlice(File file, int start, int end) async {
-    // openRead is a `Stream<List<int>>` that lazily reads only the
-    // requested byte window from disk, so we never load the whole file
-    // into RAM even for multi-GB inputs.
+    // openRead lazily streams just the byte window — multi-GB safe.
     final out = <int>[];
     await for (final chunk in file.openRead(start, end)) {
       out.addAll(chunk);

--- a/apps/client/lib/src/services/crypto/init_extension.dart
+++ b/apps/client/lib/src/services/crypto/init_extension.dart
@@ -28,10 +28,7 @@ extension CryptoServiceInit on CryptoService {
 
     final prefs = await SharedPreferences.getInstance();
 
-    // On web, skip removing keys from SharedPreferences after copying to
-    // secure storage. SecureKeyStore on web uses Web Crypto API encryption
-    // which can fail to decrypt after page refresh in some browsers, so
-    // SharedPreferences (plain localStorage) is the reliable fallback.
+    // Web: keep prefs copy — SecureKeyStore decrypt can fail post-refresh.
     const removeFromPrefs = !kIsWeb;
 
     final namedOk = await _migrateNamedKeys(prefs, store, removeFromPrefs);
@@ -260,10 +257,8 @@ extension CryptoServiceInit on CryptoService {
 
       final store = SecureKeyStore.instance;
 
-      // On web, SecureKeyStore encrypts values with Web Crypto API. If the
-      // encryption key is lost (browser cleared storage, incognito, etc.),
-      // reads return null even though the keys were previously stored. Fall
-      // back to SharedPreferences which uses plain localStorage.
+      // Web fallback: SecureKeyStore null-reads after WebCrypto key loss
+      // (incognito, cleared storage) — prefs is the recovery path.
       final SharedPreferences? webFallbackPrefs = kIsWeb
           ? await SharedPreferences.getInstance()
           : null;
@@ -306,8 +301,7 @@ extension CryptoServiceInit on CryptoService {
     if (storedDeviceId != null) {
       _deviceId = int.tryParse(storedDeviceId) ?? 0;
     } else {
-      // Generate a random positive device ID (1..2^30) to avoid collision
-      // with legacy device_id=0 from single-device era.
+      // Positive random ID (1..2^30) avoids collision with legacy 0.
       _deviceId = Random.secure().nextInt(1 << 30) + 1;
       await store.write(CryptoService._deviceIdPref, _deviceId.toString());
       debugPrint('[Crypto] Generated new device_id: $_deviceId');
@@ -321,9 +315,7 @@ extension CryptoServiceInit on CryptoService {
     SecureKeyStore store, {
     required bool isFirstInstall,
   }) async {
-    // Only flag as "regenerated" when prior keys existed (device ID was
-    // already assigned). On a true first install there is nothing to
-    // regenerate, so suppress the misleading warning.
+    // Suppress regen warning on true first install (no prior keys existed).
     _keysWereRegenerated = !isFirstInstall;
     _identityKeyPair = await _x25519.newKeyPair();
     _signingKeyPair = await _ed25519.newKeyPair();
@@ -396,11 +388,7 @@ extension CryptoServiceInit on CryptoService {
 
     debugPrint('[Crypto] Signed prekey is ${age.inDays} days old -- rotating');
 
-    // Move current signed prekey to "previous" slot. The previous-created-
-    // at timestamp is the *current* prekey's createdAt — i.e. when the
-    // key we're about to demote was minted. `_cleanupPreviousPrekey`
-    // compares against this on the next init so the previous key is
-    // dropped exactly `_signedPrekeyGracePeriod` after its real birth.
+    // Move current → previous; track real birth so grace-period drop is exact.
     final currentPriv = await store.read(CryptoService._signedPrekeyPref);
     final currentPub = await store.read(CryptoService._signedPrekeyPubPref);
     if (currentPriv != null && currentPub != null) {
@@ -435,11 +423,7 @@ extension CryptoServiceInit on CryptoService {
     final prevCreatedAtStr = await store.read(
       CryptoService._signedPrekeyPreviousCreatedAtPref,
     );
-    // Pre-fix data has no previous-created-at timestamp. Treat as "old
-    // enough to clean up" — the worst case is a one-rotation-cycle drop
-    // of a key that might still have been within grace period, but a
-    // peer that can't decrypt against it would simply re-fetch the
-    // bundle and get the current key. Conservative and predictable.
+    // Pre-fix data lacks timestamp — drop it (peer just re-fetches bundle).
     if (prevCreatedAtStr == null) {
       await store.delete(CryptoService._signedPrekeyPreviousPref);
       await store.delete(CryptoService._signedPrekeyPreviousPubPref);

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -28,9 +28,7 @@ import 'session_cache.dart';
 import 'signal_session.dart';
 import 'signal_x3dh.dart';
 
-// Re-export the typed exceptions so external callers that already import
-// them from `crypto_service.dart` (e.g. websocket_provider, the test suite)
-// keep compiling without a coordinated import-rewrite across the codebase.
+// Re-export so existing callers don't need a coordinated import rewrite.
 export 'crypto_exceptions.dart';
 
 part 'crypto/init_extension.dart';
@@ -253,16 +251,8 @@ class CryptoService {
       'Loaded ${_sessions.length} session(s) from storage on init',
     );
 
-    // Audit P1-3: surface any torn-write intents that survived the last
-    // shutdown. Each entry means the process died between the pre- and
-    // post-decrypt session save; that session is now at risk of being
-    // out-of-sync with the sender's ratchet on its next inbound message.
-    // We log structured events for telemetry but do NOT auto-discard —
-    // forcing a session reset on every torn-write would over-correct,
-    // and the next decrypt will either succeed (sender's ratchet survived
-    // the same way ours did) or fail through the existing P0-3
-    // out-of-sync banner. Once we have a real rate from production we
-    // can decide whether to upgrade this to a true write-ahead log.
+    // Audit P1-3: log torn-write intents from last shutdown for telemetry.
+    // Do NOT auto-discard — next decrypt either succeeds or trips P0-3 banner.
     try {
       final torn = await scanAndClearTornSessionWrites();
       if (torn.isNotEmpty) {
@@ -298,30 +288,10 @@ class CryptoService {
     await store.write('$_sessionPrefix$peerId', jsonEncode(json));
   }
 
-  /// Audit P1-3: torn-write instrumentation. `_decryptNormalMessage` saves
-  /// session state twice — once as a pre-isolate write-ahead intent, once
-  /// after the post-decrypt state is back from the isolate. If the process
-  /// crashes between the two, on the next launch we'd silently keep the
-  /// pre-state on disk and re-decrypt the next inbound message against a
-  /// stale ratchet, wedging the session.
-  ///
-  /// To observe how often this actually happens, [_beginSessionWriteIntent]
-  /// drops a small intent marker into secure storage before the pre-save,
-  /// and [_endSessionWriteIntent] removes it after the post-save. On init,
-  /// [scanAndClearTornSessionWrites] surfaces any markers that survived as
-  /// a structured `crypto.session_torn_write` log line.
-  ///
-  /// We deliberately do NOT auto-discard the half-state: this is
-  /// observation only. If telemetry shows a non-negligible rate, the
-  /// follow-up is a real write-ahead log (audit P1-3 → "decide on full
-  /// WAL after instrumentation"). Hot path cost: one extra
-  /// `SecureKeyStore.write` per decrypt.
-  ///
-  /// **Prefix discipline**: deliberately does NOT start with
-  /// `_sessionPrefix` (`echo_signal_session_`). If it did, `_loadSessions`
-  /// would try to `jsonDecode` the timestamp value and quarantine the
-  /// intent entry as a "corrupted session", deleting the very signal
-  /// we're trying to surface. Keep this prefix orthogonal.
+  /// Audit P1-3 torn-write instrumentation marker prefix. Deliberately NOT
+  /// `_sessionPrefix` so `_loadSessions` doesn't quarantine the timestamp
+  /// value as a corrupted session. See `_beginSessionWriteIntent` /
+  /// `scanAndClearTornSessionWrites` for the surrounding flow.
   static const _sessionIntentPrefix = 'echo_session_writeahead_';
 
   Future<void> _beginSessionWriteIntent(String sessionKey) async {
@@ -382,11 +352,8 @@ class CryptoService {
       _sessions.put(key, session);
       return session;
     } on StorageUnavailableException {
-      // The keyring is locked / Keychain denied / etc.  This is NOT the same
-      // as "no session on disk" — the session very likely IS on disk, we just
-      // can't read it right now. Let the exception propagate so the caller
-      // can keep the in-memory session alive and surface a banner. Audit
-      // P0-1: "session_reload_failure_does_not_zero_in_memory_session".
+      // Audit P0-1: keyring locked is not "no session" — propagate so caller
+      // keeps in-memory session alive and surfaces a banner.
       rethrow;
     } catch (e) {
       debugPrint('[Crypto] Failed to reload session for $key: $e');
@@ -476,11 +443,8 @@ class CryptoService {
     final signingPub = await _signingKeyPair!.extractPublicKey();
     final signingPubB64 = base64Encode(signingPub.bytes);
 
-    // Only generate new OTP keys when replenishment is actually needed
-    // (fresh install, key regeneration, or server count is low).
-    // On normal restart, we keep existing OTP private keys intact to avoid
-    // the key-ID collision bug where the server holds old public keys but
-    // the client overwrites local private keys with new material.
+    // Only regenerate OTPs on fresh install / regen / low server count;
+    // restart-time overwrite would orphan keys the server still hands out.
     final otps = <Map<String, dynamic>>[];
     if (_needsOtpReplenishment) {
       await _generateAndPersistOtpKeys(otps);
@@ -512,9 +476,8 @@ class CryptoService {
     );
 
     if (response.statusCode == 409) {
-      // Server returns a structured `identity_key_conflict` envelope (#664)
-      // with `device_id`, `expected_fingerprint`, `actual_fingerprint`. Older
-      // servers emit a plain `{"error": "..."}` body; tolerate both.
+      // (#664) Tolerate both structured `identity_key_conflict` envelope and
+      // legacy plain `{"error": "..."}` from older servers.
       int conflictDeviceId = _deviceId;
       String? expected;
       String? actual;
@@ -629,11 +592,8 @@ class CryptoService {
       type: KeyPairType.x25519,
     );
 
-    // Block silent session establishment when the peer's identity key has
-    // changed since first contact. The user must explicitly accept the new
-    // key (via [acceptIdentityKeyChange]) after verifying the safety number;
-    // otherwise we would happily X3DH against an attacker-supplied key.
-    // (#580)
+    // (#580) TOFU: block X3DH against an attacker-substituted key. User must
+    // call [acceptIdentityKeyChange] after verifying safety number.
     final newIdentityKeyB64 = data['identity_key'] as String;
     final tofuStore = SecureKeyStore.instance;
     final existingIdentityKeyB64 = await tofuStore.read(
@@ -641,8 +601,7 @@ class CryptoService {
     );
     if (existingIdentityKeyB64 != null &&
         existingIdentityKeyB64 != newIdentityKeyB64) {
-      // Mark the change so the UI can show a banner even if the caller
-      // catches the exception silently.
+      // Persist change marker so UI shows banner even if caller swallows exception.
       await tofuStore.write(
         '$_peerIdentityChangedPrefix$peerUserId',
         DateTime.now().toIso8601String(),
@@ -672,9 +631,8 @@ class CryptoService {
       }
     }
 
-    // Perform X3DH as Alice (initiator) -- 4-DH with OTP if available.
-    // P1-4 timeline event lets us see how much of the encrypt budget is
-    // the one-time X3DH cost vs the per-message ratchet.
+    // X3DH as Alice (4-DH with OTP if available). P1-4 telemetry isolates
+    // one-time X3DH cost from per-message ratchet cost.
     final x3dhResult = await timedCryptoOp(
       'X3DH.initiate',
       () => X3DH.initiate(
@@ -775,9 +733,8 @@ class CryptoService {
 
     Uint8List wire;
     try {
-      // Write-ahead: save session state BEFORE mutation so that if the app
-      // crashes between encrypt and the post-save, the session reloads to the
-      // pre-mutation state.  The unsent message can safely be re-encrypted.
+      // Write-ahead: pre-mutation save so a crash mid-encrypt reloads to a
+      // state where the unsent message can be re-encrypted safely.
       if (!isNewSession) {
         await _saveSession(peerUserId, session);
       }
@@ -919,12 +876,8 @@ class CryptoService {
     try {
       plainBytes = await session.decrypt(sessionWire);
     } catch (e) {
-      // Initial X3DH wire failed AES-GCM auth -- almost always because our
-      // server-side bundle was stale and the sender encrypted against a
-      // signed prekey / OTP whose private half we no longer hold (#662).
-      // Re-upload our keys (fire-and-forget) so the NEXT message from this
-      // peer authenticates, and surface the failure as a typed exception so
-      // UI can show "couldn't establish secure session".
+      // (#662) Initial X3DH AES-GCM fail = stale server bundle; sender used
+      // a prekey/OTP whose private half we no longer hold. Re-upload to heal.
       debugPrint(
         '[Crypto] Initial X3DH decrypt failed for $peerUserId: $e -- '
         'scheduling key re-upload to heal stale bundle',
@@ -1039,11 +992,8 @@ class CryptoService {
     try {
       session ??= await _reloadSession(sessionKey);
     } on StorageUnavailableException catch (e) {
-      // Keyring locked at decrypt time. Do NOT clear anything — the session
-      // on disk is presumed intact, and our in-memory map is unchanged (the
-      // session var was never reassigned). Surface as a typed error so the
-      // chat layer can render a "keyring locked" banner instead of the
-      // generic "[Could not decrypt…]" placeholder.
+      // Keyring locked: don't clear anything (disk session presumed intact);
+      // surface typed error so UI shows "keyring locked" banner.
       _onSecureStorageUnavailable?.call();
       throw SessionStorageUnavailableException(sessionKey, e);
     }
@@ -1061,11 +1011,7 @@ class CryptoService {
     await _beginSessionWriteIntent(sessionKey);
     await _saveSession(sessionKey, session);
     try {
-      // Run pure Double Ratchet crypto off the UI thread.  The isolate
-      // receives a snapshot of the session state and the wire bytes; it
-      // returns the decrypted plaintext bytes and the mutated session state.
-      // No Hive boxes, SecureKeyStore handles, or singletons are touched
-      // inside the isolate -- it is a pure input → output computation.
+      // Pure crypto in isolate (no Hive / SecureKeyStore / singletons).
       final result = await compute(_decryptNormalInIsolate, {
         'session': sessionJsonBefore,
         'wire': fullWire,
@@ -1081,17 +1027,12 @@ class CryptoService {
       _sessions.put(sessionKey, updatedSession);
       return utf8.decode(result['plaintext'] as Uint8List);
     } on StorageUnavailableException catch (e) {
-      // Storage unavailable during post-save: don't touch the in-memory
-      // session, surface the typed error.  The recipient already got the
-      // plaintext from the isolate but we can't persist the new ratchet
-      // state — on next decrypt we'll see the same session and either
-      // succeed (if storage came back) or fail again the same way.
+      // Post-save storage failure: leave in-memory session alone, surface error.
+      // Plaintext already delivered; next decrypt retries or fails identically.
       _onSecureStorageUnavailable?.call();
       throw SessionStorageUnavailableException(sessionKey, e);
     } catch (e) {
-      // Session is stale/corrupted — clear it. The next incoming initial
-      // message from this peer will establish a fresh session via X3DH.
-      // We do NOT create a new outgoing session here (that would break sync).
+      // Clear stale session; do NOT create a new outgoing one (would break sync).
       debugPrint(
         '[Crypto] Normal decrypt failed for $sessionKey, '
         'clearing stale session: $e',
@@ -1135,14 +1076,8 @@ class CryptoService {
         return null;
       }
 
-      // #557: when the originating device is known, prefer the per-device
-      // session (`peerUserId:fromDeviceId`) so multi-device DM history is
-      // decrypted on the right ratchet. Falls through to the legacy
-      // peer-only key when there's no device-specific session yet.
-      // Track the actual key the session was loaded from so we save the
-      // advanced ratchet state back to the same slot it came from -- using
-      // `_sessions.containsKey(...)` after the fact would mis-route under
-      // LRU TTL expiry and write a foreign session over a fresh slot.
+      // #557: prefer per-device session; track loaded-from key so we save back
+      // to the same slot (containsKey-after-the-fact mis-routes under LRU TTL).
       final preferredKey = _sessionKeyFor(peerUserId, fromDeviceId);
       var loadedKey = preferredKey;
       var session = _sessions.get(preferredKey);
@@ -1281,10 +1216,7 @@ class CryptoService {
 
     final store = SecureKeyStore.instance;
 
-    // Drop in-memory + persisted self-sessions (`me:<deviceId>`) so the next
-    // outbound message to one of our own other devices runs a fresh X3DH
-    // against the regenerated keys. Peer sessions are intentionally
-    // preserved -- only OUR identity changed, the peer's didn't.
+    // Drop self-sessions only (peer sessions preserved — only OUR identity changed).
     if (myUserId != null && myUserId.isNotEmpty) {
       final allEntries = await store.readAll();
       for (final k in allEntries.keys) {
@@ -1312,9 +1244,8 @@ class CryptoService {
     final cur = int.tryParse(stored ?? '0') ?? 0;
     await store.write(_otpNextIdPref, '${cur + 100}');
 
-    // Regenerate identity / signing / signed-prekey IN PLACE (cannot route
-    // through init() because init's regen branch purges every session in
-    // storage, and we explicitly need to preserve peer sessions here).
+    // Regen in place: init()'s regen branch purges peer sessions, which we
+    // must preserve here (only OUR identity changed).
     _identityKeyPair = await _x25519.newKeyPair();
     _signingKeyPair = await _ed25519.newKeyPair();
     _signedPrekeyPair = await _x25519.newKeyPair();
@@ -1601,11 +1532,8 @@ class CryptoService {
     String peerUserId,
     String plaintext,
   ) async {
-    // First-send heal (#662): if we don't currently have ANY session for this
-    // peer (cache miss across all devices) but we DO hold a cached bundle
-    // from a prior fetch, evict the cached bundle so the upcoming
-    // _fetchAllBundles re-pulls fresh keys. Stale cached bundles are the root
-    // cause of the "first DM can't decrypt until peer replies" bug.
+    // (#662) First-send heal: stale cached bundle without any session = root
+    // cause of "first DM undecryptable"; evict so fetch re-pulls fresh keys.
     if (_bundleCache.containsKey(peerUserId) &&
         !_hasAnySessionForPeer(peerUserId)) {
       invalidateBundleCache(peerUserId);
@@ -1631,9 +1559,8 @@ class CryptoService {
           final session = info.session;
           final plaintextBytes = Uint8List.fromList(utf8.encode(plaintext));
 
-          // For an existing (cached or reloaded) session, write-ahead save
-          // before the ratchet mutation so a crash mid-encrypt is recoverable.
-          // For a brand-new X3DH session there is no previous state to save.
+          // Write-ahead save before ratchet mutation (recoverable mid-crash).
+          // Skip for fresh X3DH session — no previous state to save.
           if (info.x3dhResult == null) {
             await _saveSession(sessionKey, session);
           }

--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -116,10 +116,7 @@ class DebugLogService with ChangeNotifier {
     if (kIsWeb) return null;
     if (_logFilePath != null) return _logFilePath;
     try {
-      // getApplicationDocumentsDirectory works on iOS, Android, macOS,
-      // Linux, and Windows. On Linux this is ~/Documents/<app> which is
-      // less ideal than Support, but it's readable without a special
-      // entitlement on iOS — which is the primary target for this feature.
+      // Documents dir is readable on iOS without extra entitlement (primary target).
       final dir = await getApplicationDocumentsDirectory();
       _logFilePath = '${dir.path}/echo-debug.log';
       return _logFilePath;
@@ -197,12 +194,7 @@ class DebugLogService with ChangeNotifier {
   /// so elevated-severity breadcrumbs reach disk quickly and survive a crash
   /// that happens in the window immediately after logging.
   void log(LogLevel level, String source, String message) {
-    // Kick off a one-time file load so that any entries already on disk
-    // appear in the in-memory buffer before we start evicting.  This is
-    // async and may complete after several log() calls have already been
-    // added — that is fine; duplicates are not a concern because we only
-    // load once and subsequent log() calls append to the already-loaded
-    // buffer.
+    // Lazy one-shot file load; async-late completion is fine (load-once).
     if (!_loaded && !kIsWeb) {
       _loadFromFile();
     }

--- a/apps/client/lib/src/services/group_crypto_service.dart
+++ b/apps/client/lib/src/services/group_crypto_service.dart
@@ -456,9 +456,8 @@ class GroupCryptoService {
     final tag = wire.sublist(tagStart, sigStart);
     final signatureBytes = wire.sublist(sigStart);
 
-    // Verify the sender signature BEFORE running AEAD. Catching a forged
-    // signature early avoids paying the AEAD cost and prevents a
-    // timing channel that could leak whether AEAD passed independently.
+    // Verify signature BEFORE AEAD: avoids cost on forgery and closes a
+    // timing side-channel that would leak AEAD-pass independently.
     final sigPayload = _grpV2SignaturePayload(
       version: version,
       conversationIdBytes: expectedConversationIdBytes,
@@ -580,14 +579,11 @@ class GroupCryptoService {
         headers: {'Authorization': 'Bearer $_token'},
       );
 
-      // 410 Gone: the group has a current key version but the server has
-      // no per-user envelope for us at that version. Another member needs
-      // to rotate us in. Surface the recovery banner instead of caching a
-      // bogus sentinel string as if it were the AES key.
+      // 410 Gone = no envelope for us at current version; need re-rotation.
       if (response.statusCode == 410) {
         debugPrint(
-          '[GroupCrypto] $conversationId has no envelope for this user at '
-          'the latest key version — flagging for re-rotation.',
+          '[GroupCrypto] $conversationId: no envelope at latest version, '
+          'flagging for re-rotation.',
         );
         onGroupNeedsRotation?.call(conversationId);
         return null;
@@ -609,16 +605,8 @@ class GroupCryptoService {
       // Phase 2C dispatch is conservative against unknown servers.
       final minWireVersion = (data['min_wire_version'] as int?) ?? 1;
 
-      // Try to decrypt the envelope using our identity key.
-      // If _cryptoService is available, the encrypted_key is a per-member
-      // envelope that must be unwrapped. If not, assume legacy plaintext key.
-      //
-      // Audit P1-2: whichever branch produces the candidate key, validate
-      // it is 32 bytes (AES-256 key size) before caching. Pre-fix, an
-      // unwrap failure would silently cache the ~96-byte ciphertext blob
-      // as if it were the key, producing endless decrypt failures on
-      // every subsequent group message with no signal that the actual
-      // problem was a malformed envelope.
+      // Audit P1-2: structurally validate (32-byte) candidate key before cache
+      // to avoid silently caching an envelope-ciphertext as the key.
       String rawKeyB64;
       if (_cryptoService != null && encryptedKey != '__envelope__') {
         try {
@@ -627,10 +615,7 @@ class GroupCryptoService {
           );
           rawKeyB64 = base64Encode(rawKeyBytes);
         } catch (e) {
-          // Fallback: treat as legacy plaintext key (migration path).
-          // We accept this only if the structural check below confirms
-          // the bytes are AES-256-key-shaped; an envelope ciphertext
-          // would not pass.
+          // Legacy plaintext migration; only accepted if shape check passes below.
           debugPrint(
             '[GroupCrypto] Envelope decrypt failed, trying as legacy: $e',
           );
@@ -649,8 +634,7 @@ class GroupCryptoService {
       );
       return (version, rawKeyB64);
     } on GroupEnvelopeUnwrapException catch (e) {
-      // Typed structural failure — log and return null so the UI sees the
-      // group as "no key available" instead of caching a known-bad key.
+      // Return null instead of caching a known-bad key.
       debugPrint('[GroupCrypto] $e');
       return null;
     } catch (e) {
@@ -755,11 +739,8 @@ class GroupCryptoService {
     String? selfUserId,
     required String triggeredByEvent,
   }) async {
-    // Drop the stale key first so we never encrypt with the now-revoked
-    // material on the next outgoing message — even if we cannot finish the
-    // rotation right now (no CryptoService wired yet, or no envelopes
-    // built), we must NOT keep the old key around. A stale-cache leak is a
-    // correctness bug; a missing envelope is just a refetch.
+    // Purge stale key BEFORE rotation: stale-cache leak is a correctness bug;
+    // missing envelope is just a refetch.
     await _purgeKey(conversationId);
 
     if (_cryptoService == null) {
@@ -771,12 +752,8 @@ class GroupCryptoService {
     final newKeyBytes = Uint8List.fromList(base64Decode(generateGroupKey()));
     final newKeyB64 = base64Encode(newKeyBytes);
 
-    // Fetch all identity keys concurrently. The previous serial for-loop
-    // was O(N) round-trips before any envelope could be built — a
-    // 100-member group took 5–10s on mobile. Future.wait parallelises
-    // the N requests; the server's /api/keys/bundle endpoint is per-user
-    // but the calls overlap on the wire so the wall time collapses to
-    // roughly one RTT regardless of N. (TD-1 in TECHNICAL_DEBT.md.)
+    // TD-1: parallel identity key fetches (serial was O(N) RTTs → 5-10s on
+    // 100-member groups; Future.wait collapses to ~1 RTT).
     final userIds = members
         .map((m) => m['user_id'] as String?)
         .where((id) => id != null && id.isNotEmpty)
@@ -784,14 +761,8 @@ class GroupCryptoService {
         .toList();
     final identityKeys = await Future.wait(userIds.map(fetchIdentityKey));
 
-    // TD-21: if the rotator's own identity key is unavailable (e.g.
-    // keyring locked, secure storage migration in flight), uploading
-    // envelopes that exclude self would leave us unable to decrypt
-    // anything we send in this group until the next rotation re-
-    // includes us. Hard-abort so the caller can retry once the
-    // keyring is unlocked. Other members with null keys still get
-    // skipped further down — they'll be included in the next rotation
-    // once they publish.
+    // TD-21: abort if self's identity key is unavailable — uploading without
+    // self wedges us until the next rotation includes us back in.
     if (selfUserId != null) {
       for (var i = 0; i < userIds.length; i++) {
         if (userIds[i] == selfUserId && identityKeys[i] == null) {
@@ -805,14 +776,8 @@ class GroupCryptoService {
       }
     }
 
-    // TD-4: TOFU bypass guard. fetchPeerIdentityKey(forceRefresh: true)
-    // silently trusts whatever the server returned, so wrapping the
-    // group secret under a changed identity key would hand a fresh
-    // envelope to a key the user has never confirmed. Abort the
-    // rotation when any participant's TOFU flag is set — admins can
-    // acknowledge the change in the chat header and retry. Skipped
-    // when the caller didn't supply the checker (preserves the legacy
-    // performRotation contract).
+    // TD-4: TOFU bypass guard — abort rotation if any member's identity key
+    // changed silently; admins must acknowledge in the chat header.
     if (hasIdentityKeyChanged != null) {
       final changedFlags = await Future.wait(
         userIds.map(hasIdentityKeyChanged),
@@ -831,14 +796,8 @@ class GroupCryptoService {
       }
     }
 
-    // Abort if ANY member lacks an identity key. The previous behaviour
-    // silently `continue`d, which let rotation "complete" with a subset
-    // of envelopes — the unkeyed member then hit the server's
-    // `__envelope__` sentinel row and fed it to the AES unwrap path,
-    // producing "candidate key has wrong length: 9 bytes" errors with
-    // no actionable signal. Rotation = "make this group encrypted for
-    // these N members"; partial coverage is BUSTED state we must
-    // refuse to publish.
+    // Refuse partial rotation: unkeyed members hit the __envelope__ sentinel
+    // and produce silent decrypt failures. All-or-nothing.
     final missingKeyUserIds = <String>[
       for (var i = 0; i < userIds.length; i++)
         if (identityKeys[i] == null) userIds[i],
@@ -884,8 +843,7 @@ class GroupCryptoService {
       );
 
       if (response.statusCode == 409) {
-        // Another member raced us and won. Drop our candidate key — the
-        // server-broadcast `group_key_rotated` event will trigger a refetch.
+        // Lost rotation race; group_key_rotated WS event triggers refetch.
         debugPrint(
           '[GroupCrypto] performRotation: lost race (409); '
           'will fetch winning envelope',

--- a/apps/client/lib/src/services/message_cache.dart
+++ b/apps/client/lib/src/services/message_cache.dart
@@ -89,10 +89,7 @@ class MessageCache {
       entries[msg.id] = msg.toJson();
     }
     if (entries.isEmpty) return;
-    // Tests tear down Hive between cases and a stray cacheMessages future
-    // can fire after tearDown; bail out instead of throwing
-    // "Box has already been closed" which surfaces as a flaky
-    // failed-after-completion error in CI (#prod-2026-05-22).
+    // Bail on closed box: post-tearDown futures fire flaky CI failures (#prod-2026-05-22).
     if (!box.isOpen) return;
     try {
       await box.putAll(entries);

--- a/apps/client/lib/src/services/notification_service_stub.dart
+++ b/apps/client/lib/src/services/notification_service_stub.dart
@@ -80,21 +80,10 @@ class _NativeNotificationService implements NotificationService {
         requestSoundPermission: true,
       );
       const linux = LinuxInitializationSettings(defaultActionName: 'Open');
-      // Windows toast notifications require an app name, an AppUserModelID,
-      // and a stable activation GUID. Without these, the plugin silently
-      // fails to register and no notifications appear (#923).
-      //
-      // IMPORTANT: appUserModelId and guid MUST remain stable across
-      // releases — changing either will break notification activation on
-      // machines that already have the previous values registered with
-      // the Action Center. Do not modify these values.
-      //
-      // iconPath is intentionally omitted: the bundled app icon lives at
-      // windows/runner/resources/app_icon.ico (compiled into the
-      // executable's resources, not a Flutter asset path), and the plugin
-      // expects an absolute filesystem path at runtime. Letting the
-      // plugin fall back to the default icon is more reliable than
-      // shipping a path that may not resolve.
+      // (#923) Windows toast requires appName + appUserModelId + GUID;
+      // appUserModelId and guid MUST stay stable across releases (Action Center
+      // registration breaks otherwise). iconPath omitted: bundled .ico isn't
+      // a Flutter asset and the plugin needs an absolute filesystem path.
       const windows = WindowsInitializationSettings(
         appName: 'Echo Messenger',
         appUserModelId: 'EchoMessenger.EchoMessenger.Client',

--- a/apps/client/lib/src/services/tray_service_io.dart
+++ b/apps/client/lib/src/services/tray_service_io.dart
@@ -79,13 +79,7 @@ class TrayService with TrayListener, WindowListener {
     await windowManager.setPreventClose(true);
     windowManager.addListener(this);
 
-    // Each step is guarded so a failure later in the sequence (notably
-    // setContextMenu, which is flaky on some Linux compositors) doesn't
-    // leave the icon unresponsive: the click listener still attaches
-    // even if the menu can't be installed, which keeps Windows/macOS
-    // left-click usable.  On Linux the menu IS the interaction surface
-    // (see class docstring), so install failure here means tray is
-    // effectively dead until next login.
+    // Each step guarded so setContextMenu flakes don't kill the icon listener.
     var iconShown = false;
     try {
       await trayManager.setIcon(_iconPath());
@@ -136,10 +130,7 @@ class TrayService with TrayListener, WindowListener {
 
   @override
   void onWindowClose() async {
-    // Slice 10: persist window geometry before hiding to tray so that even
-    // a soft-close (close button -> tray) captures the user's latest
-    // layout. The true app quit also funnels through this listener via
-    // `Quit` -> `setPreventClose(false)` -> `close()`.
+    // Persist geometry before hide-to-tray; Quit also funnels through here.
     await WindowStateService.save();
     await windowManager.hide();
   }
@@ -148,10 +139,7 @@ class TrayService with TrayListener, WindowListener {
 
   @override
   void onTrayIconMouseDown() {
-    // Windows + macOS path: the OS delivers a real MouseDown, so we toggle
-    // the window directly.  Linux/libappindicator never fires this when a
-    // context menu is attached -- any click opens the menu instead, and
-    // the user toggles via the Show/Hide menu entries (#558).
+    // (#558) Win/macOS only; Linux fires context menu instead.
     _toggleWindow();
   }
 
@@ -186,10 +174,7 @@ class TrayService with TrayListener, WindowListener {
   }
 
   Future<void> _setContextMenu() async {
-    // Show / Hide are first-class menu items because on Linux any click on
-    // the icon opens this menu (libappindicator/SNI does not deliver
-    // MouseDown when a menu is attached) -- they are the only path to
-    // toggle window visibility on that platform (#558).
+    // (#558) Show/Hide are first-class — only toggle path on Linux SNI.
     await trayManager.setContextMenu(
       Menu(
         items: [

--- a/apps/client/lib/src/services/voice_callkit_service.dart
+++ b/apps/client/lib/src/services/voice_callkit_service.dart
@@ -34,10 +34,7 @@ class CallKitEndAction extends CallKitAction {
 class VoiceCallKitService {
   VoiceCallKitService._() {
     if (!_isIos) return;
-    // Subscribe defensively — on a fresh install the plugin may not be
-    // fully registered yet and getting `onEvent` can throw on some iOS
-    // versions.  A failure here must NOT crash the app; CallKit
-    // integration just becomes a no-op.
+    // Defensive subscribe: fresh-install plugin race can throw; degrade to no-op.
     try {
       _eventSub = FlutterCallkitIncoming.onEvent.listen(
         _handleEvent,
@@ -87,23 +84,10 @@ class VoiceCallKitService {
       await endCall();
     }
 
-    // Bare-minimum IOSParams — every optional field we set in v0.0.299 has
-    // been a candidate for the on-tap crash, so we drop everything that
-    // isn't strictly required to start an outgoing call.  Notably
-    // `iconName` is gone (it referenced a CallKitLogo.png we don't bundle,
-    // a hard-crash trigger when CallKit tries to resolve the asset) and
-    // audioSessionMode is reset to 'default' to match the upstream
-    // example.
-    //
-    // audioSessionActive: false — LiveKit's WebRTC stack already calls
-    // AVAudioSession.setActive(true) during room.connect() and again when
-    // setMicrophoneEnabled creates the LocalAudioTrack. CallKit asking to
-    // (re-)activate the session was racing those calls and producing a
-    // native EXC_BAD_ACCESS in the audio render thread on iOS 17+ — a
-    // crash outside any Dart try/catch, so the user just saw the app
-    // disappear when joining a voice lounge. Setting this to false makes
-    // CallKit observe the session LiveKit established rather than fight
-    // for it.
+    // Bare-minimum IOSParams: every optional field has been a crash candidate.
+    // audioSessionActive=false: LiveKit already activates session via room.connect
+    // and setMicrophoneEnabled; CallKit re-activating races into EXC_BAD_ACCESS
+    // on iOS 17+. Keep CallKit as observer, not contender.
     final params = CallKitParams(
       id: callId,
       nameCaller: channelName,
@@ -123,12 +107,8 @@ class VoiceCallKitService {
       ),
     );
 
-    // CallKit failure must NOT take down the voice join — LiveKit is
-    // already connected by the time we get here, and the user's
-    // experience of "voice works but iOS may suspend faster" is far
-    // better than "tap channel, app crashes."  Catch everything,
-    // including platform exceptions, asset-resolution errors, and
-    // permission failures.
+    // CallKit failure must NOT block voice join — LiveKit is already connected;
+    // worst case is faster iOS suspension, not crash.
     try {
       await FlutterCallkitIncoming.startCall(params);
       if (isMuted) {

--- a/apps/client/lib/src/services/window_state_service.dart
+++ b/apps/client/lib/src/services/window_state_service.dart
@@ -30,15 +30,9 @@ class WindowStateService {
   /// (no visible jump when the window grows).
   static const Offset _kTopLeftAnchor = Offset(40, 40);
 
-  /// Maximum allowed drift (in logical pixels) between the position we
-  /// requested via [setPosition] and the position the compositor actually
-  /// applied. When the drift exceeds this value we fall back to [center()].
-  ///
-  /// Wayland compositors that run with an XWayland fallback sometimes honour
-  /// `setPosition` on the first call but then silently undo it; compositors
-  /// without X11 support always ignore it. 200 px is large enough that a
-  /// compositor applying DPI scaling won't false-positive, but small enough to
-  /// catch the typical "window stayed at (0,0)" failure mode.
+  /// Drift tolerance (px) between requested and applied position; exceeding
+  /// triggers center() fallback. 200px catches "stuck at (0,0)" without
+  /// false-positives from DPI scaling.
   static const double _kPositionDriftTolerance = 200.0;
 
   /// True on a desktop platform where `window_manager` is supported.
@@ -100,16 +94,11 @@ class WindowStateService {
     try {
       final prefs = await SharedPreferences.getInstance();
       final size = await windowManager.getSize();
-      // Do not persist geometry while the window is in the small splash state.
-      // The splash is 320×440; the minimum restore size is 720×480. Any window
-      // smaller than those thresholds means we are still in (or were left in)
-      // the splash phase and the coordinates would corrupt the next launch.
+      // Don't persist splash geometry — would corrupt next-launch restore.
       if (size.width < 720.0 || size.height < 480.0) return;
       await prefs.setDouble(_kWidthKey, size.width);
       await prefs.setDouble(_kHeightKey, size.height);
-      // On Wayland, getPosition() returns compositor-local coordinates that
-      // don't map to global screen position. Skip saving x/y to prevent bogus
-      // values from corrupting the next restore.
+      // Wayland's getPosition is compositor-local; skip x/y to avoid bogus restore.
       if (!isWaylandSession) {
         try {
           final pos = await windowManager.getPosition();
@@ -146,38 +135,29 @@ class WindowStateService {
       final prefs = await SharedPreferences.getInstance();
       final width = prefs.getDouble(_kWidthKey) ?? defaultSize.width;
       final height = prefs.getDouble(_kHeightKey) ?? defaultSize.height;
-      // Clamp to sensible minimums so a stale 100x100 setting can't render
-      // a useless window.
+      // Clamp so a stale tiny setting can't render an unusable window.
       final size = Size(
         width.clamp(720.0, 10000.0),
         height.clamp(480.0, 10000.0),
       );
       await windowManager.setSize(size);
 
-      // On Wayland, setPosition is a compositor no-op. Skip position restore
-      // and let the compositor decide where to place the window.
+      // Wayland: skip position restore (compositor owns placement).
       if (!isWaylandSession) {
-        // Restore saved (x, y) only when both axes land inside at least one
-        // connected display. A multi-monitor disconnect or resolution change
-        // can park a previously valid coordinate off-screen.
+        // Only restore when (x, y) lands inside a connected display.
         final savedX = prefs.getDouble(_kXKey);
         final savedY = prefs.getDouble(_kYKey);
         if (savedX != null &&
             savedY != null &&
             await _isOnScreen(savedX, savedY, size)) {
           await windowManager.setPosition(Offset(savedX, savedY));
-          // Safety-net drift check: verify the compositor actually applied the
-          // position. If the window drifted by more than the tolerance (e.g.
-          // XWayland or a non-standard compositor silently ignored the hint),
-          // fall back to center() so the window is always visible.
+          // Drift check: fall back to center() if compositor ignored the hint.
           await _centerIfDrifted(savedX, savedY);
           return;
         }
       }
 
-      // Wayland, first-launch, or no valid saved position: let the compositor
-      // decide placement. center() handles multi-monitor work-area quirks
-      // better than hand-computing the offset.
+      // No valid saved position: center() handles multi-monitor quirks.
       try {
         await windowManager.center();
       } catch (_) {
@@ -214,20 +194,8 @@ class WindowStateService {
     }
   }
 
-  /// True when at least 100 px of the window's top-left corner stays inside
-  /// ANY connected display's work area, so the user can always grab the
-  /// integrated title bar to drag the window back into view.
-  ///
-  /// Previously this checked only the PRIMARY display, which caused false
-  /// positives (or negatives) when:
-  ///   - the window was on a secondary monitor,
-  ///   - a monitor was unplugged between sessions (saved coord from the
-  ///     now-gone display would fail the primary-only check and fall back to
-  ///     center — correct, but the inverse was also possible: a coord that was
-  ///     off the primary but within the secondary was wrongly rejected).
-  ///
-  /// Now we iterate all displays and accept the coordinate if it falls inside
-  /// any one of them.
+  /// True when ≥100 px of the window's top-left stays inside ANY connected
+  /// display's work area (covers secondary monitors and disconnects).
   static Future<bool> _isOnScreen(double x, double y, Size size) async {
     try {
       final displays = await screenRetriever.getAllDisplays();
@@ -251,11 +219,8 @@ class WindowStateService {
     }
   }
 
-  /// Keep the update prompt in the same chromeless 320×440 window the
-  /// splash uses, so the two screens read as the same surface and the
-  /// swap stays seamless. Previously this widened the window to 400×520,
-  /// which left a visible band of empty space around the centred card
-  /// because the splash background is transparent at the OS level.
+  /// Keep update prompt at splash size (320×440) so the swap is seamless;
+  /// resizing left transparent OS-level gaps around the centred card.
   static Future<void> enterUpdatePrompt() async {
     if (!_isDesktop) return;
     try {
@@ -282,20 +247,15 @@ class WindowStateService {
     try {
       await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
       await windowManager.setSize(const Size(320, 440));
-      // Make the window background transparent so the splash card's
-      // rounded corners blend into the desktop instead of being framed
-      // by a rectangular OS surface.
+      // Transparent bg so splash card's rounded corners aren't framed by OS chrome.
       try {
         await windowManager.setBackgroundColor(const Color(0x00000000));
         await windowManager.setHasShadow(false);
       } catch (_) {
         // Transparency is best-effort; not every compositor supports it.
       }
-      // Anchor the splash near the top-left of the primary display so the
-      // post-splash window (which restores to a saved position OR the same
-      // top-left anchor) doesn't visibly jump on first launch. Wayland/X11
-      // compositors can apply the size change asynchronously, so we set
-      // the position again on the next frame as a safety net.
+      // Anchor near top-left so post-splash growth doesn't visibly jump.
+      // Re-apply next frame as safety net for async compositor size changes.
       await windowManager.setPosition(_kTopLeftAnchor);
       await Future<void>.delayed(const Duration(milliseconds: 16));
       await windowManager.setPosition(_kTopLeftAnchor);

--- a/apps/client/lib/src/widgets/auth/animated_gradient_background.dart
+++ b/apps/client/lib/src/widgets/auth/animated_gradient_background.dart
@@ -27,9 +27,7 @@ class _AnimatedGradientBackgroundState
     with SingleTickerProviderStateMixin {
   AnimationController? _controller;
 
-  // Three gradient colour pairs the animation cycles through.
-  // Each entry is [begin-accent-stop, end-accent-stop]; the dark background
-  // is always present as the dominant colour so saturation stays very low.
+  // Each entry is [begin-accent, end-accent]; dark mainBg dominates so saturation stays low.
   static const _stops = [
     [Color(0xFF0D0D2B), Color(0xFF0A0A0B)], // blue-leaning -> mainBg
     [Color(0xFF0B0B1F), Color(0xFF0F0A1A)], // indigo-leaning -> purple tint
@@ -74,13 +72,7 @@ class _AnimatedGradientBackgroundState
     // Re-check reduce-motion at build time so live changes apply.
     final reduceMotion = ref.watch(accessibilityProvider).reducedMotion;
 
-    // Capture the controller in a local so the AnimatedBuilder closure binds
-    // to a non-null reference even if `_controller` is later nulled out by
-    // `_maybeStartController` (e.g. user toggles reduce-motion while a tick
-    // microtask is already in flight). Without this capture the builder body
-    // re-read `_controller!.value` on every tick and threw
-    // "Null check operator used on a null value" from inside the framework
-    // microtask loop. See #915.
+    // Capture local so AnimatedBuilder closure doesn't NPE if reduce-motion toggle nulls _controller mid-tick (#915).
     final controller = _controller;
     if (reduceMotion || controller == null) {
       return const _StaticGradient();

--- a/apps/client/lib/src/widgets/auth/server_subtitle.dart
+++ b/apps/client/lib/src/widgets/auth/server_subtitle.dart
@@ -1,8 +1,4 @@
-// Shared "Server: host ›" affordance + the switch-server dialog used on the
-// login and register screens. Tapping the subtitle opens the dialog which
-// lists known servers + accepts a custom URL. The custom URL is pre-flighted
-// against GET /api/server-info before the switch transaction runs so a typo
-// can't log the user out of the active server (#1063).
+// Custom-URL pre-flighted via GET /api/server-info so a typo can't log the user out (#1063).
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;

--- a/apps/client/lib/src/widgets/avatar_crop_dialog.dart
+++ b/apps/client/lib/src/widgets/avatar_crop_dialog.dart
@@ -31,10 +31,7 @@ Future<img.Image?> decodeAvatarImage(Uint8List bytes) {
   }
   if (direct != null) return Future.value(direct);
 
-  // Only try the platform decoder for formats `image` legitimately can't
-  // handle. Falling back unconditionally would hide truly malformed input
-  // and stall the dialog when the platform decoder isn't available
-  // (notably in widget tests, where instantiateImageCodec doesn't resolve).
+  // Platform codec only for HEIF family — unconditional fallback would hide malformed input and stall widget tests.
   if (_looksLikeHeifFamily(bytes)) {
     return _decodeViaPlatformCodec(bytes);
   }
@@ -115,9 +112,7 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
   // The decoded image (nullable until async decode completes).
   img.Image? _decoded;
 
-  // Viewport dimensions for the preview area. Picked at runtime in
-  // [didChangeDependencies] so the desktop window gets a roomier cropper
-  // (mouse users can't pinch-zoom; they pan + use the zoom slider).
+  // Desktop gets a roomier preview because mouse users can't pinch-zoom.
   static const _previewSizeMobile = 280.0;
   static const _previewSizeDesktop = 460.0;
   double _previewSize = _previewSizeMobile;
@@ -157,9 +152,7 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
     final isDesktop = w >= 800;
     final desired = isDesktop ? _previewSizeDesktop : _previewSizeMobile;
     if (_previewSize == desired) return;
-    // TD-12: wrap the size flip in setState so the next build sees the
-    // new viewport. The Custompaint mask, slider min, and crop preview
-    // all key off _previewSize.
+    // TD-12: setState so mask/slider-min/preview all see the new _previewSize.
     setState(() {
       _previewSize = desired;
       if (_decoded != null) {
@@ -195,9 +188,7 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
       }
       final imgW = decoded.width.toDouble();
       final imgH = decoded.height.toDouble();
-      // Scale so the shorter side covers the preview square. Cache the
-      // min so the build-time Slider doesn't recompute it every frame
-      // (TD-13).
+      // Cache minScale so the Slider doesn't recompute per frame (TD-13).
       final minScale = _previewSize / (imgW < imgH ? imgW : imgH);
       final scaledW = imgW * minScale;
       final scaledH = imgH * minScale;
@@ -457,9 +448,6 @@ class _AvatarCropDialogState extends State<_AvatarCropDialog> {
                   left: _offset.dx,
                   top: _offset.dy,
                   child: Image.memory(
-                    // Re-encode a thumbnail for display to avoid re-decoding
-                    // the full bitmap every frame. We cache the memory image
-                    // from rawBytes directly.
                     widget.rawBytes,
                     width: _decoded!.width * _scale,
                     height: _decoded!.height * _scale,

--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -41,10 +41,7 @@ Widget buildAvatar({
   );
 
   if (imageUrl != null && imageUrl.isNotEmpty) {
-    // Decode at ~3x the display size so the image cache holds a small
-    // bitmap instead of the source resolution. A 1024×1024 source decoded
-    // at 64dp display becomes a ~192×192 bitmap — roughly 28× less memory.
-    // 3× covers retina DPR; oversized sources never decode larger than this.
+    // Decode at 3× display size (covers retina DPR) so 1024² avatars don't sit in RAM as 1024² bitmaps.
     final memCacheWidth = (radius * 2 * 3).ceil();
     return ClipOval(
       key: ValueKey(imageUrl),

--- a/apps/client/lib/src/widgets/biometric_lock_guard.dart
+++ b/apps/client/lib/src/widgets/biometric_lock_guard.dart
@@ -56,12 +56,7 @@ class _BiometricLockGuardState extends ConsumerState<BiometricLockGuard>
 
   Future<void> _promptUnlock() async {
     if (_promptInFlight) return;
-    // Wrap both transitions in setState so the build() that captures the
-    // disabled state of the Unlock button (`onPressed: _promptInFlight ? null
-    // : _promptUnlock`) actually runs after each transition. Without the
-    // setState in the finally clause, the button stayed visually disabled
-    // after a failed/cancelled Face ID prompt, so users had to fully restart
-    // the app to retry.
+    // Both transitions go through setState — otherwise Unlock stays disabled after a cancelled Face ID prompt.
     setState(() => _promptInFlight = true);
     try {
       final ok = await ref.read(biometricProvider.notifier).authenticate();

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -299,10 +299,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
     if (mounted) setState(() => _joiningChannelId = channel.id);
 
     try {
-      // Breadcrumb: write and force-flush to disk synchronously before the
-      // LiveKit join so any iOS SIGKILL inside joinChannel still leaves a clear
-      // trail.  The blocking write completes in <5 ms on iOS flash storage
-      // (buffer is capped at 5000 NDJSON lines, well under 1 MB).
+      // Sync flush before join so iOS SIGKILL inside joinChannel still leaves a breadcrumb (<5ms).
       DebugLogService.instance.log(
         LogLevel.info,
         'VoiceLoungeUI',

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -181,19 +181,7 @@ class _ChannelColumnState extends ConsumerState<ChannelColumn> {
   }
 
   Future<void> _join(GroupChannel channel) async {
-    // Two-step join, mirroring channel_bar.dart's `_handleVoiceChipTap`:
-    //
-    //   1. POST to /api/groups/:id/voice/:chan/join — records membership
-    //      so the server's voice session reflects the new participant.
-    //   2. LiveKit join — opens the WebRTC connection that actually
-    //      streams audio and is what flips `livekitVoiceProvider.isActive`
-    //      to true.
-    //
-    // The old code only did step 1, so voiceActive stayed false, the
-    // home screen's `_resolveRightPanel` refused to render the lounge,
-    // and any `onShowLounge` callback flicker-dismissed almost
-    // immediately. Issue surfaced once Column mode shipped — bar mode
-    // never had this bug because it did both calls already.
+    // Two-step join (mirrors channel_bar's `_handleVoiceChipTap`): server membership POST then LiveKit connect — skipping step 2 leaves voiceActive false and the lounge refuses to render.
     DebugLogService.instance.log(
       LogLevel.info,
       'VoiceLoungeUI',

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -209,10 +209,7 @@ class ChatHeaderBar extends ConsumerWidget {
           )
         : null;
 
-    // For DMs, render an amber lock-open glyph when the conversation is not
-    // encrypted (explicit "plaintext DM" warning replaces the old banner).
-    // Groups never show the unlock-open glyph because group plaintext is
-    // expected today.
+    // Plaintext-DM warning glyph; groups skip it (group plaintext is currently expected).
     final Widget? unencryptedDmGlyph = !conv.isGroup
         ? const Padding(
             padding: EdgeInsets.only(left: 5),
@@ -395,10 +392,7 @@ class ChatHeaderBar extends ConsumerWidget {
             label: 'Shared media',
           ),
         ),
-      // "Members" is now always surfaced as an inline icon:
-      //   • narrow layout → people_outline button added by _buildNarrowActionButtons
-      //   • wide layout   → people_outline inline button in _buildWideActionButtons
-      // No overflow entry is needed for either layout.
+      // Members lives as an inline icon (narrow + wide layouts); no overflow entry needed.
       if (!conv.isGroup)
         PopupMenuItem<String>(
           value: 'disappearing',
@@ -510,13 +504,7 @@ class ChatHeaderBar extends ConsumerWidget {
   }
 
   void _openSharedMedia(BuildContext context, Conversation conv) {
-    // Two surfaces share this gallery:
-    //   • Wide viewports (>= 900 px) → a centred dialog sized so the
-    //     grid has enough breathing room to render 4-5 thumbnails per
-    //     row instead of the cramped 2-per-row a phone-shaped sheet
-    //     forced on desktop.
-    //   • Narrow viewports → the existing bottom-sheet treatment,
-    //     which feels native on phones.
+    // Wide viewports (>= 900px) get a centred dialog; narrow stays on bottom sheet.
     final screen = MediaQuery.of(context).size;
     if (screen.width >= 900) {
       showDialog<void>(

--- a/apps/client/lib/src/widgets/chat_header_widgets.dart
+++ b/apps/client/lib/src/widgets/chat_header_widgets.dart
@@ -77,9 +77,7 @@ class _IdentityChangedBadgeState extends ConsumerState<IdentityChangedBadge> {
   /// banner so the warning lives entirely in the header.
   Future<void> _showActions() async {
     final myName = ref.read(authProvider).username ?? 'You';
-    // Username is cosmetic on the safety-number screen; falling back to the
-    // userId keeps the badge self-contained without plumbing the peer's
-    // display name down from the header.
+    // peerLabel is cosmetic on the safety-number screen; fall back to userId.
     final peerLabel = widget.peerUserId;
 
     await showEchoBottomSheet<void>(
@@ -369,13 +367,7 @@ class _PinnedMessagesDialogState extends ConsumerState<PinnedMessagesDialog> {
         final list = decoded is List
             ? decoded
             : (decoded['messages'] as List? ?? []);
-        // The /pinned endpoint returns the raw stored content, which is
-        // ciphertext for encrypted DMs.  Re-hydrate from the per-conversation
-        // message cache (which stores the decrypted view) so users see the
-        // plaintext they expect.  Falls back to the server payload if the
-        // message isn't in the cache (e.g. pinned before this device joined
-        // the conversation) -- in that case the user still sees something is
-        // pinned, just as ciphertext, which matches the prior behavior (#724).
+        // /pinned returns ciphertext for encrypted DMs; rehydrate from message cache to show plaintext (#724).
         final messages = <ChatMessage>[];
         for (final e in list) {
           final raw = ChatMessage.fromServerJson(

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -113,11 +113,7 @@ class ChatInputBar extends ConsumerStatefulWidget {
 enum _MentionMove { up, down }
 
 class ChatInputBarState extends ConsumerState<ChatInputBar> {
-  // The text composer, focus node, edit-message state, and (in a later
-  // slice) mention controller live on [_controller]. Forwarders below
-  // preserve the existing `_messageController` / `_inputFocusNode` /
-  // `_editingMessage` call sites so the file diff stays focused on state
-  // ownership and the `GlobalKey<ChatInputBarState>` API contract.
+  // Text, focus, edit, mention state lives on [_controller]; getters preserve old call-site shape.
   late final ChatInputController _controller;
   TextEditingController get _messageController => _controller.text;
   FocusNode get _inputFocusNode => _controller.focus;
@@ -153,20 +149,14 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   // File picker guard
   bool _isPickingFile = false;
 
-  // Edit mode state — lives on [_controller]. The widget's `_editingMessage`
-  // setter funnels through `_controller.enterEditMode` / `exitEditMode` so
-  // the notifier-fire order stays consistent.
+  // Edit mode on [_controller]; setter goes through enterEditMode/exitEditMode for consistent notifier order.
   ChatMessage? get _editingMessage => _controller.editingMessage;
   bool get _isEditing => _controller.isEditing;
 
-  // Mention autocomplete state — owned by a controller so the logic is
-  // unit-testable without pumping the whole composer (#513). Composed
-  // (not inherited) by [_controller] so its dispose hook is wired through.
+  // Mention controller is composed (not inherited) for unit-testability (#513).
   MentionComposerController get _mentionController => _controller.mention;
 
-  // Pending attachments + voice recording state live on [_controller].
-  // Forwarders preserve the existing `_pendingAttachments` / `_isRecording`
-  // / `_recorder` call sites.
+  // Pending attachments + voice recording on [_controller]; getters preserve old call sites.
   List<PendingAttachment> get _pendingAttachments =>
       _controller.pendingAttachments;
   bool get _hasPendingAttachment => _controller.hasPendingAttachment;
@@ -198,9 +188,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
   int _mentionPickerIndex = 0;
   String _lastMentionQuery = '';
   bool _lastMentionShowing = false;
-  // Cached candidate list — recomputed only when picker state changes.
-  // Reading _mentionCandidates per keystroke was allocating a new filtered
-  // list each time (audit perf + frontend findings).
+  // Cached candidate list (recomputing per keystroke allocated a fresh filtered list each time).
   List<String> _cachedMentionCandidates = const [];
 
   @override
@@ -221,9 +209,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       _draftSaveTimer?.cancel();
 
       _mentionController.dismiss();
-      // Release every staged attachment's ValueNotifier — switching
-      // conversations was previously only releasing the last one (#623),
-      // leaking notifiers for the rest.
+      // Release ALL staged attachment notifiers on conv switch (#623 used to leak all but the last).
       _clearAllPendingAttachments();
       _messageController.clear();
       _controller.exitEditMode();
@@ -242,9 +228,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
     _draftSaveTimer?.cancel();
     _messageController.removeListener(_onTextChanged);
     _mentionController.removeListener(_onMentionChanged);
-    // [_controller.dispose] handles text controller + focus node + mention
-    // controller + voice ticker + recorder + pending attachments dispose
-    // so the cancel-then-tear-down order stays in one place (#513, #623).
+    // _controller.dispose tears down all sub-controllers in the right order (#513, #623).
     _controller.dispose();
     super.dispose();
   }
@@ -367,11 +351,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
       chatProvider.select((s) => s.replyToMessage),
     );
 
-    // Recompute the multiline threshold from the viewport width so the
-    // input row only flips to multi-line when the message is long enough
-    // to actually wrap visually.  Inter 14px averages ~7-8px/char; we
-    // subtract a generous fixed budget for icons/padding (~120px), divide
-    // the remainder by 8, and clamp to a sane band.
+    // Multiline threshold derived from viewport so flip happens when text actually wraps.
     final width = MediaQuery.sizeOf(context).width;
     _multilineCharThreshold = ((width - 120) / 8).clamp(35, 120).round();
 
@@ -428,9 +408,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                       statusText: inputStatusText,
                       onCancelEdit: _cancelEditMode,
                     ),
-                  // Reply preview bar — wrap in AnimatedSize so the bar
-                  // slides in/out instead of snapping when reply mode
-                  // is entered or dismissed (UX roadmap motion expansion).
+                  // AnimatedSize slides reply bar in/out instead of snapping.
                   AnimatedSize(
                     duration: MotionDurations.standard,
                     curve: MotionCurves.entrance,
@@ -451,10 +429,7 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                       onCancel: _removePendingAttachment,
                       onAnnotate: _annotatePendingAttachment,
                     ),
-                  // Markdown formatting toolbar (bold, italic, strike, code,
-                  // quote, link). Always visible on desktop. On mobile it's
-                  // hidden by default and toggled from the "+" attach sheet so
-                  // it doesn't permanently eat ~36 px of vertical real estate.
+                  // Markdown toolbar: always-on desktop; mobile is opt-in via "+" sheet so it doesn't eat 36px.
                   if (!isMobileLayout || _showFormatToolbarOnMobile)
                     MarkdownToolbar(
                       controller: _messageController,

--- a/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/file_pickers.dart
@@ -198,10 +198,7 @@ Future<void> _dispatchPickedFiles(
   _PickAndDispatchParams params,
   List<PlatformFile> files,
 ) async {
-  // Single pick → preview flow (caption + send). Multi pick → send all
-  // immediately as separate messages; mixing the two creates races where
-  // the user may interact with the pending preview while the rest are
-  // still uploading in the background.
+  // Single = caption+send preview; multi = immediate send. Mixing races the preview with background uploads.
   final isMulti = files.length > 1;
   if (isMulti && context.mounted) {
     ToastService.show(

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/attachments.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/attachments.dart
@@ -161,16 +161,11 @@ extension _Attachments on ChatInputBarState {
     required String mimeType,
     void Function(int sent, int total)? onProgress,
   }) async {
-    // If the user has the "preserve original filenames" privacy toggle off,
-    // upload the file under a generic name keyed off the extension. The file
-    // contents are unchanged.
+    // Privacy toggle: generic name when "preserve original filenames" is off (contents unchanged).
     final preserve = await readPreserveOriginalFilenames();
     final uploadFileName = preserve ? fileName : genericFilename(fileName);
 
-    // Files above the chunked-upload threshold go through the resumable
-    // PATCH pipeline (#556).  Cloudflare's edge cap is 100 MB; the chunked
-    // path streams 5 MB chunks server-side so it can ferry files multiples
-    // of that without ever pinning the whole payload in server RAM.
+    // Resumable chunked PATCH (#556): 5MB chunks bypass Cloudflare's 100MB cap without pinning payload in RAM.
     Future<UploadResult> uploadChunked() async {
       final auth = ref.read(authProvider.notifier);
       final chunked = ChunkedUploadClient(

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/build_helpers.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/build_helpers.dart
@@ -13,9 +13,7 @@ extension _BuildHelpers on ChatInputBarState {
     required VoiceSettingsState voiceSettings,
     required String? effectiveActiveVoiceChannelId,
   }) {
-    // Clamp the composer to 6 lines on mobile so a long draft with the
-    // keyboard up doesn't eat more than ~half the available height. Desktop
-    // keeps the original 10-line allowance.
+    // Mobile clamp to 6 lines so the keyboard+draft don't eat >50% height.
     final composerMaxLines = isMobileLayout ? 6 : 10;
     return Expanded(
       child: Focus(
@@ -132,9 +130,6 @@ extension _BuildHelpers on ChatInputBarState {
       );
     }
 
-    // Three-element design: bordered round + button on the left, pill input
-    // (with emoji glyph inside on the right), bordered round mic/send on
-    // the right. Edit mode tints the pill border accent.
     final pillBorderColor = _isEditing ? context.accent : context.border;
 
     return Row(

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/draft_persistence.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/draft_persistence.dart
@@ -37,10 +37,7 @@ extension _DraftPersistence on ChatInputBarState {
   void _onTextChanged() {
     final text = _messageController.text;
     final empty = text.trim().isEmpty;
-    // Detect multiline either via explicit newlines or content long enough
-    // to soft-wrap at the current viewport width. The character threshold
-    // is recomputed in build() from MediaQuery so a 4K-wide input doesn't
-    // jump to multi-line halfway through a normal sentence.
+    // Threshold recomputed from viewport so 4K doesn't flip mid-sentence.
     final multiline =
         text.contains('\n') || text.length > _multilineCharThreshold;
     if (empty != _isTextEmpty || multiline != _isMultiline) {

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/edit_mode.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/edit_mode.dart
@@ -24,9 +24,7 @@ extension _EditMode on ChatInputBarState {
     if (text.isEmpty || _editingMessage == null) return;
 
     final conv = widget.conversation;
-    // #582: belt-and-suspenders for the parent UI gate. Editing on an
-    // encrypted conversation would broadcast plaintext to every member, so
-    // we never submit it. The server also returns 409.
+    // #582: never submit edits on encrypted convs (broadcasts plaintext); server also returns 409.
     if (conv.isEncrypted) {
       _cancelEditMode();
       if (mounted) {
@@ -58,9 +56,7 @@ extension _EditMode on ChatInputBarState {
               body: jsonEncode({'content': text}),
             ),
           );
-      // The server returns 409 when an encrypted conversation rejects an
-      // edit (#582). Surface a non-fatal toast so the user understands
-      // why the change rolled back.
+      // 409 = encrypted-conv edit rejection (#582); surface non-fatal toast for rollback.
       if (response.statusCode == 409 && mounted) {
         ToastService.show(
           context,

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/keyboard_handling.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/keyboard_handling.dart
@@ -208,11 +208,7 @@ extension _KeyboardHandling on ChatInputBarState {
     return KeyEventResult.ignored;
   }
 
-  // Mention picker keyboard nav takes precedence — Tab/Enter accept the
-  // selected row, arrows move it, Escape closes the picker (without
-  // also bubbling Escape through to message edit-cancel). Space falls
-  // through — extractMentionQuery sees the space and closes the picker,
-  // leaving the literal "@" in the text.
+  // Mention picker nav takes precedence; Escape doesn't bubble to edit-cancel. Space falls through to close.
   KeyEventResult _handleMentionPickerIfActive(KeyDownEvent event) {
     if (!_mentionController.showPicker) return KeyEventResult.ignored;
     return _handleMentionPickerKey(event);

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/recording_handling.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/recording_handling.dart
@@ -60,10 +60,7 @@ extension _RecordingHandling on ChatInputBarState {
         path: path,
       );
     } catch (e) {
-      // record's iOS / Android backends can throw on session-init failures
-      // (audio session in use by another app, codec unavailable, etc.).
-      // Without surfacing this, the user just saw nothing happen when they
-      // tried to record (#554).
+      // Surface session-init failures (audio busy, codec missing) — previously failed silently (#554).
       debugPrint('[ChatInput] _recorder.start failed: $e');
       if (mounted) {
         ToastService.show(
@@ -135,9 +132,7 @@ extension _RecordingHandling on ChatInputBarState {
       final bytes = await file.readAsBytes();
       _recordingAmplitudes.clear();
 
-      // Reject empty / near-empty recordings rather than uploading a
-      // 0-byte file that the server will reject anyway. The threshold is
-      // generous — even a 100ms aac frame is hundreds of bytes (#554).
+      // Reject <256B (server rejects 0-byte; 100ms aac is hundreds of bytes) (#554).
       if (bytes.length < 256) {
         if (mounted) {
           ToastService.show(

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/send_handling.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/send_handling.dart
@@ -200,9 +200,7 @@ extension _SendHandling on ChatInputBarState {
           replyToUsername: replyTo?.fromUsername,
         );
 
-    // Soft tactile feedback + send chime once the message is committed
-    // locally. The platform haptic is a no-op on desktop and respects
-    // the OS-level system-haptics setting on iOS.
+    // Haptic + chime on local commit (desktop no-op; iOS respects system-haptics setting).
     HapticFeedback.lightImpact();
     SoundService().playMessageSent().ignore();
 
@@ -271,9 +269,7 @@ extension _SendHandling on ChatInputBarState {
     final text = _messageController.text;
     final cursorPos = _messageController.selection.baseOffset;
 
-    // No selection (-1) means the field has never been focused; bail out
-    // before insertMention's no-op path so we don't dismiss the picker
-    // without inserting anything (would be a silent UX failure).
+    // cursorPos < 0 = field never focused; bail before silently dismissing the picker.
     if (cursorPos < 0) return;
 
     _messageController.value = insertMention(

--- a/apps/client/lib/src/widgets/chat_input_bar/send_button.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/send_button.dart
@@ -149,10 +149,7 @@ class SendButton extends ConsumerWidget {
         cryptoState.isInitialized && !cryptoState.keysUploadFailed;
     final canSend = hasContent && (cryptoReady || !isDm);
 
-    // Three visual modes share one container so the transitions between
-    // them animate via AnimatedContainer + AnimatedSwitcher rather than
-    // snapping (mic ↔ send-arrow on first keystroke; send-arrow ↔ check
-    // on edit-mode entry; disabled ↔ enabled fill color).
+    // Shared container so mic↔send↔check transitions animate, not snap.
     final bool showMic = !hasContent && !isEditing && !kIsWeb;
 
     final state = _resolveButtonState(

--- a/apps/client/lib/src/widgets/chat_input_controller.dart
+++ b/apps/client/lib/src/widgets/chat_input_controller.dart
@@ -20,10 +20,7 @@ class ChatInputController extends ChangeNotifier {
   final FocusNode focus = FocusNode();
   final MentionComposerController mention;
 
-  // Single-pick stages one entry (caption-and-send flow); multi-pick stages
-  // all picked files so the user can review / cancel / watch progress before
-  // sending. Each entry carries a ValueNotifier for upload progress so chip
-  // rebuilds don't ripple through the whole input bar.
+  // Per-attachment ValueNotifier so chip progress rebuilds don't ripple through the input bar.
   final List<PendingAttachment> pendingAttachments = [];
 
   bool get hasPendingAttachment => pendingAttachments.isNotEmpty;
@@ -33,9 +30,7 @@ class ChatInputController extends ChangeNotifier {
       pendingAttachments.isNotEmpty &&
       pendingAttachments.every((a) => a.uploadedUrl != null);
 
-  // Voice amplitude tick runs every 100ms while [isRecording] is true.
-  // [recordingTimer] is cancelled in [dispose] before [recorder] is torn
-  // down so a late tick can't fire `getAmplitude` on a disposed recorder.
+  // recordingTimer cancelled in dispose BEFORE recorder teardown so a late tick can't hit a disposed recorder.
   final AudioRecorder recorder = AudioRecorder();
   bool isRecording = false;
   DateTime? recordingStartTime;

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -125,9 +125,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   int get _unreadBoundaryCount => _controller.unreadBoundaryCount;
   set _unreadBoundaryCount(int v) => _controller.unreadBoundaryCount = v;
 
-  // GlobalKeys for rendered message items, keyed by ID. Used by
-  // `_scrollToMessage` for pixel-accurate scrolling and by
-  // `_updateFloatingDate` to detect the topmost visible message.
+  // Per-message GlobalKeys for pixel-accurate scroll + topmost-visible detection.
   final _messageKeys = <String, GlobalKey>{};
 
   ChatMessage? _threadParent;
@@ -160,9 +158,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   Timer? _liveRegionClearTimer;
   OverlayEntry? _reactionOverlay;
 
-  // Previous-state trackers for transition-only toasts (replacing the
-  // four full-width banners). A toast fires when the relevant state
-  // crosses a boundary, never on every rebuild.
+  // Edge-detect trackers so toasts fire on state crossings, not every rebuild.
   bool? _prevWsConnected;
   bool? _prevWsReplaced;
   bool _prevWsMaxAttempts = false;
@@ -184,9 +180,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       if (mounted) _controller.deletedForMeIds = DeletedForMeStorage.ids;
     });
     _pendingInitialMessageId = widget.initialMessageId;
-    // Poll the peer-specific crypto flags every 4s while a DM is open. The
-    // old IdentityChangedBadge/SessionCorruptedBanner widgets each polled
-    // independently on rebuild; this single timer covers both transitions.
+    // Single 4s timer covers identity/corruption polls; was previously two independent rebuild polls.
     _peerStateTimer = Timer.periodic(
       const Duration(seconds: 4),
       (_) => _refreshPeerCryptoFlags(),
@@ -197,16 +191,11 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   void didUpdateWidget(covariant ChatPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.conversation?.id != oldWidget.conversation?.id) {
-      // Save scroll offset + current channel for the old conversation so a
-      // later return restores both. Order matters: capture channel BEFORE
-      // resetting selectedTextChannelId, and cache offset under the still-
-      // current cacheKeyFor (which uses that channel id).
+      // Save BEFORE resetting selectedTextChannelId so cacheKeyFor uses the right channel.
       final oldId = oldWidget.conversation?.id;
       if (oldId != null) _saveOldConversationState(oldId);
 
-      // Restore the channel the user last viewed in this conversation BEFORE
-      // anything reads cacheKeyFor — otherwise the per-channel scroll cache
-      // misses on the very lookup that should be hitting.
+      // Restore last-viewed channel BEFORE anything reads cacheKeyFor or the per-channel cache misses.
       final newId = widget.conversation?.id;
       _selectedTextChannelId = newId != null
           ? _controller.lastChannelByConversation[newId]
@@ -816,11 +805,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       ),
     );
 
-    // Watch only this conversation's message list reference and the loading
-    // flag for this channel — `messagesByConversation` keeps inner list
-    // refs stable across copyWith for unaffected conversations, so adding
-    // a message to conv B no longer rebuilds conv A's panel (#834 F6).
-    // PR #838 perf: keep this as .select
+    // Per-conv selector — inner list refs stay stable so conv-A doesn't rebuild on conv-B traffic (#834 F6, #838).
     final convMessages = ref.watch(
       chatProvider.select((s) => s.messagesByConversation[conv.id]),
     );
@@ -906,11 +891,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
       } else if (_unreadBoundaryMessageId != null) {
         _scrollToUnreadBoundary();
       } else {
-        // First open: history is loading async in parallel and may render
-        // additional rows over the next several hundred ms. Mark the scroll
-        // as pending so we re-trigger it when the load completes; landing
-        // on the genuinely-newest message requires waiting for the layout
-        // pass that includes those new rows (#919).
+        // First open: re-trigger scroll after history load lands so we end on the actual newest row (#919).
         _initialScrollPending = true;
         _scrollToBottom(settleRetries: 3);
       }
@@ -921,10 +902,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   /// load finishes. Only active while [_initialScrollPending] is true (#919).
   void _listenForInitialHistoryLoad(Conversation conv) {
     if (!_initialScrollPending) return;
-    // Re-scroll to bottom when the initial history load completes. The first
-    // `_scrollToBottom` fires before any rows are rendered; once the server
-    // returns and the list grows downward, we want to land at the newest
-    // message rather than wherever the partial list ended (#919).
+    // Re-scroll once initial history load finishes — first `_scrollToBottom` ran before rows existed (#919).
     ref.listen(
       chatProvider.select(
         (s) => s.isLoadingHistory(conv.id, channelId: _selectedTextChannelId),

--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -1,11 +1,3 @@
-// Message-list rendering extracted from ChatPanel (round 2 refactor).
-//
-// Pure mechanical extraction: no behavior change. Owns the
-// skeleton/empty-state/list-with-scrollbar AnimatedSwitcher and the
-// per-row build logic (date dividers, unread divider, grouping windows,
-// system timeline rows). The parent ChatPanel still owns the
-// ScrollController (which drives the floating-date pill / new-messages
-// pill) and passes it down.
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
@@ -137,10 +129,7 @@ class ChatMessageList extends ConsumerWidget {
     return msg.content.startsWith('[system:');
   }
 
-  // TD-79: helpers take the cached `parsedTimestamp` directly so each call
-  // is O(1) lookup instead of a fresh `DateTime.parse` per neighbour. For a
-  // 30-row viewport this drops ~120 parses per repaint to zero on warm
-  // messages.
+  // TD-79: use cached `parsedTimestamp` to avoid re-parsing per neighbour on repaint.
   static bool _withinGroupingWindow(DateTime dt1, DateTime dt2) {
     return dt2.difference(dt1).inMinutes.abs() < 5;
   }
@@ -219,10 +208,7 @@ class ChatMessageList extends ConsumerWidget {
                 ? onDeleteFailed
                 : onConfirmDelete,
             onRetry: msg.status == MessageStatus.failed ? onRetryMessage : null,
-            // #582: editing on an encrypted conversation would broadcast
-            // plaintext to every member, breaking E2E. Until per-device
-            // ciphertext fanout for edits ships, suppress the affordance
-            // entirely on encrypted conversations. Server enforces with 409.
+            // #582: suppress edit on encrypted convs — would broadcast plaintext until per-device edit fanout ships.
             onEdit: conv.isEncrypted ? null : onEnterEditMode,
             onReply: onReply,
             onViewThread: onOpenThread,
@@ -249,16 +235,8 @@ class ChatMessageList extends ConsumerWidget {
       child: ListView.builder(
         controller: scrollController,
         padding: const EdgeInsets.only(bottom: 16),
-        // Pre-build ~one viewport of off-screen messages on each side so that
-        // momentum scrolling doesn't flash blank space while items mount. The
-        // Flutter default of 250 is too tight for chat where rows include
-        // images, reactions, and reply quotes that each take a frame to lay
-        // out. Tuned conservatively to keep memory in check on long histories.
-        //
-        // Flutter 3.41+ renames this to scrollCacheExtent. We keep the old
-        // name + ignore the deprecation so the build works against both the
-        // pinned SDK (3.41.x) and any local dev SDK that still predates the
-        // rename. Drop the ignore once .flutter-version moves above 3.41.9.
+        // 600 (vs default 250) keeps momentum scrolling from flashing blank rows.
+        // Flutter 3.41+ renames to scrollCacheExtent; drop ignore when .flutter-version > 3.41.9.
         // ignore: deprecated_member_use
         cacheExtent: 600,
         itemCount: messages.length + 1,

--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -184,7 +184,8 @@ class ChatMessageList extends ConsumerWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (needsDateDivider) DateDivider(timestamp: msg.timestamp),
+        if (needsDateDivider)
+          DateDivider(timestamp: msg.timestamp, isStartOfConversation: i == 0),
         if (showUnreadDivider) UnreadDivider(count: unreadBoundaryCount),
         AnimatedContainer(
           key: messageKey,

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -224,11 +224,7 @@ Widget buildChatContentBox(
         : BoxDecoration(color: context.chatBg),
     child: Stack(
       children: [
-        // Hidden live region for screen-reader announcements when peer
-        // messages arrive (#495 / #630). Mounted as the first child of
-        // the outer Stack so it lives at a stable index in the build
-        // tree — Flutter won't recreate the Semantics node when the
-        // floating-date pill or new-messages-below pill toggle.
+        // Hidden live region (#495/#630); first Stack child so its index stays stable across pill toggles.
         Semantics(
           liveRegion: true,
           label: p.liveRegionAnnouncement,
@@ -243,9 +239,7 @@ Widget buildChatContentBox(
               onBack: p.onBack,
               onMembersToggle: p.onMembersToggle,
               onGroupInfo: p.onGroupInfo,
-              // Column mode's left rail already shows the group avatar +
-              // name + member count in its own header; rendering them
-              // here too produced the duplicate label the user reported.
+              // Column-mode rail already shows group identity; suppress duplicate label here.
               hideGroupIdentity: useColumn,
             ),
             if (p.conv.isGroup && !useColumn && !useColumnDrawer)
@@ -258,10 +252,7 @@ Widget buildChatContentBox(
                 onVoiceChannelChanged: p.onVoiceChannelChanged,
                 onShowLounge: p.onShowLounge,
               ),
-            // Audit P0-1/P0-2/P0-3: surface keyring-lock, OTP-heal failure,
-            // and wedged-session states above the message list with an
-            // action button where applicable. Renders a SizedBox.shrink()
-            // when no flag is active.
+            // Audit P0-1/P0-2/P0-3: surface keyring/OTP/wedged-session states (renders shrink when idle).
             EncryptionStatusBanner(conversation: p.conv),
             if (p.isLoadingHistory)
               LinearProgressIndicator(

--- a/apps/client/lib/src/widgets/chat_panel/date_divider.dart
+++ b/apps/client/lib/src/widgets/chat_panel/date_divider.dart
@@ -8,11 +8,24 @@ import '../../theme/echo_theme.dart';
 class DateDivider extends ConsumerWidget {
   final String timestamp;
 
+  /// True when this divider sits above the *first* message in the
+  /// conversation. In that case the day label adds little signal
+  /// ("Today" with nothing above it just frames the start of history),
+  /// so we render a "Start of conversation" marker instead — closer to
+  /// the iMessage default + Discord's "This is the start of #channel"
+  /// pattern.
+  final bool isStartOfConversation;
+
   /// Optional density override; defaults to the value from
   /// [uiDensityProvider]. Tests can pin a specific tier via this param.
   final UIDensity? density;
 
-  const DateDivider({super.key, required this.timestamp, this.density});
+  const DateDivider({
+    super.key,
+    required this.timestamp,
+    this.isStartOfConversation = false,
+    this.density,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -21,7 +34,11 @@ class DateDivider extends ConsumerWidget {
       final now = DateTime.now();
       final yesterday = now.subtract(const Duration(days: 1));
       String label;
-      if (dt.year == now.year && dt.month == now.month && dt.day == now.day) {
+      if (isStartOfConversation) {
+        label = 'Start of conversation';
+      } else if (dt.year == now.year &&
+          dt.month == now.month &&
+          dt.day == now.day) {
         label = 'Today';
       } else if (dt.year == yesterday.year &&
           dt.month == yesterday.month &&

--- a/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
+++ b/apps/client/lib/src/widgets/chat_panel/history_loaders.dart
@@ -68,9 +68,7 @@ _HistoryAuth? _resolveAuth(WidgetRef ref, Conversation conv) {
       : null;
   groupCrypto?.setToken(token);
 
-  // For 1:1 DMs, pass the crypto service so encrypted messages can be
-  // decrypted. Without this, `_decryptIfNeeded` sees crypto==null and
-  // shows "[Encrypted history]" instead of the actual message content.
+  // Pass crypto for 1:1 DM decrypt; without it `_decryptIfNeeded` shows "[Encrypted history]".
   final cryptoState = ref.read(cryptoProvider);
   final crypto = (!conv.isGroup && cryptoState.isInitialized)
       ? ref.read(cryptoServiceProvider)
@@ -120,11 +118,7 @@ void loadOlderMessages({
   required ChatPanelController controller,
 }) {
   final chatState = ref.read(chatProvider);
-  // Use the channel-aware helpers — the underlying maps key by
-  // `conversationId:channelId` (or `conversationId:` for the unchanneled
-  // group root), so a raw lookup by `conv.id` always missed in
-  // channelized groups, hiding active history loads and triggering
-  // duplicate paginate requests (#510).
+  // Channel-aware helpers (maps keyed by conv:channel) — raw conv.id lookup misses on channelized groups (#510).
   if (chatState.isLoadingHistory(conv.id, channelId: selectedTextChannelId) ||
       !chatState.conversationHasMore(
         conv.id,
@@ -142,9 +136,7 @@ void loadOlderMessages({
       : chatState.messagesForConversation(conv.id);
   if (messages.isEmpty) return;
 
-  // Use the oldest channel-scoped non-system message as the pagination
-  // cursor — see `ChatPanelController.paginationCursor` for the
-  // `#prod-2026-05-08` rationale.
+  // Oldest channel-scoped non-system msg as cursor (see ChatPanelController.paginationCursor / #prod-2026-05-08).
   final oldestTimestamp = controller.paginationCursor(messages).timestamp;
   final a = _resolveAuth(ref, conv);
   if (a == null) return;
@@ -278,9 +270,7 @@ Future<void> jumpToReplyQuote(JumpToReplyQuoteParams params) async {
     return;
   }
 
-  // Slow path: paginate older history until the target appears or
-  // `hasMore` flips to false.  Cap to 30 rounds (~1500 msgs at 50/round)
-  // so a stale or removed parent can't spin forever.
+  // Paginate older history until target or !hasMore; cap 30 rounds (~1500 msgs) so a removed parent can't spin.
   final a = _resolveAuth(ref, conv);
   if (a == null) return;
 

--- a/apps/client/lib/src/widgets/chat_panel/message_actions.dart
+++ b/apps/client/lib/src/widgets/chat_panel/message_actions.dart
@@ -106,10 +106,7 @@ Future<void> sendForwardedMessage(
             .firstOrNull;
         peerUserId = peer?.userId ?? '';
       } else {
-        // Look up the default text channel so the optimistic message has the
-        // same channelId that the server will return in message_sent.
-        // Without this, _replacePendingMessage's channelId filter never
-        // matches and the pending message times out to failed.
+        // Default text channel id needed so _replacePendingMessage's filter matches message_sent (otherwise → timeout/failed).
         final channels = ref.read(channelsProvider).channelsFor(target.id);
         channelId = channels.where((c) => c.isText).firstOrNull?.id;
       }

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -28,16 +28,11 @@ class ChatPanelController extends ChangeNotifier {
   String? loadedChannelsConversationId;
   String? autoScrollConversationKey;
 
-  // Per-channel scroll position cache, keyed by `${conversationId}:${channelId ?? ""}`
-  // so switching text channels within a group preserves separate positions.
-  // Capped to avoid unbounded growth; oldest entries evict first.
+  // Per-channel scroll cache keyed `${convId}:${channelId ?? ""}`; capped (oldest evicts first).
   static const int kMaxScrollPositions = 50;
   final Map<String, double> scrollPositions = {};
 
-  // Last viewed channel per conversation. Lets a re-entered group restore the
-  // user to the channel they left off on (which in turn lets [scrollPositions]
-  // hit on its `"convId:channelId"` key — otherwise the channel id is null at
-  // restore time and the lookup misses, falling through to scroll-to-bottom).
+  // Last-viewed channel per conv — restores channel BEFORE scrollPositions lookup so its "convId:channelId" key hits.
   final Map<String, String?> lastChannelByConversation = {};
 
   void evictScrollPositions() {
@@ -49,10 +44,7 @@ class ChatPanelController extends ChangeNotifier {
   String cacheKeyFor(String conversationId) =>
       '$conversationId:${selectedTextChannelId ?? ""}';
 
-  // Unread boundary is captured ONCE per channel session (on first open with
-  // `unreadCount > 0`, or first arrival after an empty open). Setting
-  // [unreadBoundaryMessageId] to `null` re-arms the capture; the widget
-  // does so on conversation switch and `onTextChannelChanged`.
+  // Unread boundary captured once per channel session; set null to re-arm on conv/channel switch.
   String? unreadBoundaryMessageId;
   int unreadBoundaryCount = 0;
 
@@ -64,10 +56,7 @@ class ChatPanelController extends ChangeNotifier {
   bool floatingDateVisible = false;
   Timer? floatingDateTimer;
 
-  // [wasNearBottom] is updated on every scroll event BEFORE the soft keyboard
-  // shrinks the viewport. `handleKeyboardScroll` reads this pre-resize
-  // snapshot — the live `isNearBottom()` is unreliable after the resize
-  // because `maxScrollExtent` has already shifted.
+  // Snapshotted pre-keyboard-resize because isNearBottom() reads a shifted maxScrollExtent after resize.
   bool wasNearBottom = true;
   double lastKeyboardInset = 0;
 

--- a/apps/client/lib/src/widgets/confirm_dialog.dart
+++ b/apps/client/lib/src/widgets/confirm_dialog.dart
@@ -56,10 +56,7 @@ Future<bool> showEchoConfirmDialog(
         title: Text(
           title,
           style: TextStyle(
-            // Destructive confirms colour the title red as an extra
-            // signal beyond the red confirm button — matches the
-            // pattern conversation_panel and chat_header_bar already
-            // used by hand.
+            // Destructive: red title + red button (matches conversation_panel/chat_header_bar).
             color: destructive ? EchoTheme.danger : dialogCtx.textPrimary,
             fontSize: 16,
             fontWeight: FontWeight.w600,

--- a/apps/client/lib/src/widgets/connection_status_badge.dart
+++ b/apps/client/lib/src/widgets/connection_status_badge.dart
@@ -196,9 +196,7 @@ class _ConnectionStatusBadgeState extends ConsumerState<ConnectionStatusBadge>
     );
     if (kind != _lastKind) {
       _lastKind = kind;
-      // Defer to post-frame: MediaQuery isn't safe to read in build for
-      // the controller side-effect, and the pulse state only needs to be
-      // accurate within a frame of the kind change.
+      // Post-frame because MediaQuery isn't safe to read in build for controller side-effects.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _syncPulse(kind);
       });
@@ -251,9 +249,7 @@ class _ConnectionStatusBadgeState extends ConsumerState<ConnectionStatusBadge>
       ],
     );
 
-    // Mobile: keep the system tooltip (long-press hint). Desktop uses the
-    // custom OverlayPortal popover, so we drop the tooltip to avoid the
-    // double-hover affect (system tooltip overlaps + covers the popover).
+    // Mobile keeps system tooltip; desktop drops it so the custom OverlayPortal popover isn't double-hovered.
     if (isMobile) {
       return Semantics(
         button: true,

--- a/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
+++ b/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
@@ -55,15 +55,7 @@ ContextMenuSection _primarySection(MessageTarget t) {
         icon: Icons.forward_outlined,
         onTap: t.onForward,
       ),
-    // Discoverable "Add reaction" entry for right-click. The four-emoji
-    // inline header is fast for power users but isn't labeled, so casual
-    // users miss it entirely (validated on prod). Keeping the inline
-    // header *and* this row gives both audiences a path:
-    //   - inline header: one-click pick of the four most-recent emojis
-    //   - this row:      jumps straight into the full picker
-    // Hidden when the message is encrypted-unreadable (no reactions on
-    // a "[Could not decrypt…]" bubble) or when the parent didn't wire
-    // a reactions callback.
+    // Labeled "Add reaction" complements the unlabeled inline emoji header that casual users miss.
     if (!t.isEncryptedUnreadable && t.onOpenFullPicker != null)
       ContextMenuAction(
         label: 'Add reaction',
@@ -75,9 +67,7 @@ ContextMenuSection _primarySection(MessageTarget t) {
 }
 
 ContextMenuSection _utilitySection(MessageTarget t) {
-  // Pin/unpin and save/unsave are mutually exclusive — only one
-  // variant is wired at any moment, so we just expose whichever
-  // callback the caller provided.
+  // Pin/unpin and save/unsave are mutually exclusive — only the wired callback is exposed.
   final pinRow = _pinRow(t);
   final saveRow = _saveRow(t);
 

--- a/apps/client/lib/src/widgets/context_menu/context_menu_overlay.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_overlay.dart
@@ -106,9 +106,7 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay> {
       return;
     }
     Navigator.of(context).pop();
-    // Run the action AFTER the route is gone so it sees the parent
-    // context unobstructed (showSnackBar, navigation, dialogs all
-    // need the post-dismiss tree).
+    // Defer so onTap sees the post-dismiss tree (snackbar/nav/dialogs need it).
     WidgetsBinding.instance.addPostFrameCallback((_) => action.onTap?.call());
   }
 
@@ -119,10 +117,7 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay> {
     final current = _stack.last;
     final isSubmenu = _stack.length > 1;
 
-    // Anchor + clamp. We always try to place the menu's top-left at
-    // the click; if that overflows the viewport (right or bottom),
-    // clamp inside the safe area. No flipping — keeps geometry
-    // predictable when menus contain submenus of differing heights.
+    // Clamp (don't flip) so submenu geometry stays predictable across varying heights.
     final menuHeight = _estimateMenuHeight(current);
     var left = widget.anchor.dx;
     var top = widget.anchor.dy;
@@ -135,9 +130,7 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay> {
     if (left < _viewportPadding) left = _viewportPadding;
     if (top < _viewportPadding) top = _viewportPadding;
 
-    // Origin for the scale-from-anchor transform is the click point
-    // relative to the menu's own rect — so the menu visually expands
-    // from where the user clicked.
+    // Scale origin is the click point in menu-local coords so the menu expands from the click.
     final originX = ((widget.anchor.dx - left) / _menuWidth).clamp(0.0, 1.0);
     final originY = ((widget.anchor.dy - top) / menuHeight).clamp(0.0, 1.0);
 
@@ -257,9 +250,7 @@ class _MenuContents extends StatelessWidget {
       }
     }
 
-    // Dismiss on Esc — keyboard navigation proper is deferred to a
-    // follow-up, but Esc-to-close is one shortcut and ubiquitous
-    // enough that omitting it would surprise people.
+    // Esc-to-close; full keyboard nav deferred.
     return Shortcuts(
       shortcuts: const {
         SingleActivator(LogicalKeyboardKey.escape): _DismissIntent(),

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -198,9 +198,7 @@ class MessageTarget extends ContextMenuTarget {
   final VoidCallback? onDelete;
   final VoidCallback? onCopyId;
 
-  // Inline reactions header — null disables the header even when
-  // !isEncryptedUnreadable, useful for forwarded-message bubbles that
-  // shouldn't accept reactions at all.
+  // Null disables header even when !isEncryptedUnreadable (e.g. forwarded bubbles reject reactions).
   final void Function(String emoji)? onPickReaction;
   final VoidCallback? onOpenFullPicker;
   final List<String> recentReactions;

--- a/apps/client/lib/src/widgets/conversation_item.dart
+++ b/apps/client/lib/src/widgets/conversation_item.dart
@@ -175,11 +175,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     final conv = widget.conversation;
     String? snippet = conv.lastMessage;
 
-    // System sentinels (e.g. `__system__:member_joined:UUID:USERNAME`) must
-    // be rendered as the friendly event line, not the raw sentinel and not
-    // with a "You: " sender prefix. They never come through the WS preview
-    // path — only the HTTP last_msg_cte fetch surfaces them — so this is the
-    // only place the sidebar gets to translate them.
+    // System sentinels reach the sidebar only via HTTP last_msg_cte — translate to friendly line here.
     if (snippet != null && snippet.startsWith('__system__:')) {
       final translated = ChatMessage.translateSystemSentinel(
         snippet,
@@ -212,13 +208,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
 
   String? _maskEncryptedSnippet(String? snippet) {
     if (snippet == null) return null;
-    // Normalise all encrypted-looking previews to a friendly placeholder.
-    // Anything starting with a "[Could not decrypt..." / "[Could not verify
-    // sender]" / "[Encrypted" / "[E2E]" bracketed sentinel is a protocol
-    // status string that should never read like a real message in the
-    // sidebar. We also catch raw GRP1:/GRP2: ciphertext + base64-shaped
-    // blobs that slipped past the WS decrypt path (missing key envelope,
-    // sender device not on file yet).
+    // Mask all crypto sentinels + raw ciphertext blobs that slipped past WS decrypt.
     if (snippet.startsWith('[Could not decrypt') ||
         snippet.startsWith('[Could not verify sender') ||
         snippet.startsWith('[Encrypted') ||
@@ -231,13 +221,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
 
   String? _applyMediaLabel(String? snippet) {
     if (snippet == null) return null;
-    // Match a leading [kind:url] marker, optionally followed by a newline and
-    // a caption (the seed scripts emit `[img:URL]\ncaption` for captioned
-    // attachments).  The previous `^\[img:.+\]$` regex only matched bare
-    // markers, so captioned messages leaked the raw `[img:...]` text into
-    // the conversation preview (#prod-2026-05-08). TD-80: regex itself
-    // lifted to a top-level final so the sidebar doesn't recompile it on
-    // every tile rebuild.
+    // Captioned `[kind:URL]\ncaption` previews used to leak the raw marker (#prod-2026-05-08).
     final match = _mediaMarkerRegExp.firstMatch(snippet);
     if (match == null) return snippet;
     final kind = match.group(1)!;
@@ -302,13 +286,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
               onSecondaryTapUp: (details) {
                 widget.onContextMenu?.call(details.globalPosition);
               },
-              // Mobile long-press now routes through the same
-              // onContextMenu callback as desktop right-click — the
-              // parent (conversation_panel) opens the centralised
-              // EchoContextMenu so the item itself no longer carries
-              // its own bottom-sheet implementation. The anchor
-              // coordinate is irrelevant on mobile (renders as a
-              // bottom sheet), so Offset.zero is a fine sentinel.
+              // Mobile long-press routes through onContextMenu → centralised EchoContextMenu (bottom sheet, anchor unused).
               onLongPress: _enableLongPressMenu
                   ? () => widget.onContextMenu?.call(Offset.zero)
                   : null,
@@ -324,9 +302,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                 padding: EdgeInsets.symmetric(
                   horizontal: _resolveHorizontalPadding(isCozy, isCompact),
                 ),
-                // Visual children re-announce muted/unread/timestamp via
-                // their own Semantics nodes; suppress those so the composed
-                // outer label is the single announcement (#631).
+                // ExcludeSemantics: outer composed label is the single screen-reader announcement (#631).
                 child: ExcludeSemantics(
                   child: Row(
                     children: [
@@ -350,9 +326,6 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
                 ),
               ),
             ),
-            // Active-conversation accent pill — 4px wide left-edge marker
-            // with fully rounded ends so it reads as a Discord-style
-            // selection pill rather than a sharp-cornered bar.
             // IgnorePointer so taps pass through to the InkWell.
             if (widget.isSelected)
               Positioned(
@@ -405,10 +378,6 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     String displayName, {
     UIDensity density = UIDensity.normal,
   }) {
-    // Density tier sizes (UX roadmap Phase 2):
-    //   compact -> 14px radius (28px diameter), 10px dot, 14px group icon
-    //   normal  -> 20px radius (40px diameter), 12px dot, 18px group icon
-    //   cozy    -> 22px radius (44px diameter), 13px dot, 20px group icon
     final double avatarRadius = switch (density) {
       UIDensity.cozy => 22,
       UIDensity.normal => 20,
@@ -637,9 +606,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
     }
 
     if (widget.timestamp.isNotEmpty) {
-      // If the conversation's latest message is one we sent, show a Signal-
-      // style status tick next to the timestamp (#507). Falls back silently
-      // when local chat state hasn't loaded the conversation yet.
+      // Signal-style status tick on our latest sent message (#507).
       final tick = _buildOwnStatusTick(context);
       return Row(
         mainAxisSize: MainAxisSize.min,
@@ -703,10 +670,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
   /// pre-existing layout in that case.
   Widget? _buildOwnStatusTick(BuildContext context) {
     final conv = widget.conversation;
-    // Selector: only watch the last message of *this* conversation so that
-    // messages arriving in other conversations don't trigger a rebuild here
-    // (#578). The spread-copy fix in #676 keeps unaffected list references
-    // stable, so select() equality holds for untouched conversations.
+    // Per-conv selector so other conversations' messages don't trigger rebuilds (#578, #676).
     final last = ref.watch(
       chatProvider.select((s) => s.messagesByConversation[conv.id]?.lastOrNull),
     );
@@ -743,10 +707,7 @@ class _ConversationItemState extends ConsumerState<ConversationItem> {
               color: context.mutedSurface,
             ),
           ),
-        // Mention badge sits to the LEFT of the unread count badge so it
-        // remains visible when the unread count is multi-digit.  Distinct
-        // color (mentionBadgeBg) so "you were mentioned" reads differently
-        // from "X unread."
+        // Mention badge left of unread count so multi-digit counts don't hide it.
         if (conv.mentionCount > 0)
           Semantics(
             label: '${conv.mentionCount} mentions',

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -118,8 +118,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel>
   @override
   void didUpdateWidget(covariant ConversationPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // When a conversation is selected externally, reset the filter so the
-    // selected conversation is visible and highlighted.
+    // Reset filter on external selection so the picked conversation is visible.
     if (widget.selectedConversationId != null &&
         widget.selectedConversationId != oldWidget.selectedConversationId &&
         ref.read(conversationFilterTypeProvider) !=
@@ -165,8 +164,6 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel>
 
     final pendingCount = contactsState.pendingRequests.length;
 
-    // Derived list is precomputed by sortedConversationsProvider — no
-    // sort/filter work happens here in the build path.
     final conversations = ref.watch(sortedConversationsProvider);
 
     return Container(
@@ -176,10 +173,6 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel>
           Column(
             children: [
               _buildLogoHeader(context, pendingCount),
-              // Mobile used to render a separate "Search conversations"
-              // filter bar here; removed in favour of the header's
-              // global-search icon (matches desktop, per the
-              // feedback_desktop_search memory rule).
               _buildFilterChips(),
               _buildReplacedBanner(context, wsReplaced),
               if (pendingCount > 0) _buildPendingBanner(pendingCount),
@@ -193,25 +186,9 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel>
                   wsOnlineUsers,
                 ),
               ),
-              // Hide the status bar on mobile narrow — redundant with the
-              // bottom tab bar that already exposes Settings + identity.
-              //
-              // Stack from top → bottom of the sidebar bottom chrome:
-              //   1. VoiceDock — full call controls when voice is active
-              //      (renders SizedBox.shrink() otherwise)
-              //   2. Update banner / bug-report row
-              //   3. VoiceFooter — slim "tap to return to lounge" handle
-              //      while voice is active (collapses when inactive)
-              //   4. User status bar
-              // VoiceDock used to be a floating AnimatedPositioned overlay
-              // at `bottom: 60` which occluded everything beneath it
-              // (F-029 in the 2026-05-19 UI audit) — flowing it inline
-              // means the bug-report and update affordances stay reachable
-              // during a call.
+              // VoiceDock is inline (not floating) so update/bug-report stay reachable during calls (F-029).
               if (MediaQuery.sizeOf(context).width >= 600)
-                // LayoutBuilder hands the dock the actual column width so
-                // it doesn't under-fill (sidebar default is 350, dock
-                // used to hardcode 320) or overflow on resize. TD-11.
+                // LayoutBuilder gives dock actual column width to avoid under-fill/overflow on resize (TD-11).
                 LayoutBuilder(
                   builder: (context, constraints) => VoiceDock(
                     width: constraints.maxWidth,
@@ -222,10 +199,7 @@ class _ConversationPanelState extends ConsumerState<ConversationPanel>
                 _buildSidebarUpdateBanner(context),
               if (MediaQuery.sizeOf(context).width >= 600)
                 const SizedBox(height: 4),
-              // On narrow (mobile), VoiceFooter is rendered at the Scaffold
-              // level in home_screen.dart above the bottom tab bar — desktop
-              // exposes the same tap-to-return-to-lounge through VoiceDock
-              // above, so we don't double up on a second voice ribbon.
+              // Mobile renders VoiceFooter at Scaffold level (home_screen.dart); desktop uses VoiceDock above.
               if (MediaQuery.sizeOf(context).width < 600)
                 VoiceFooter(onNavigateToLounge: widget.onNavigateToLounge),
               if (MediaQuery.sizeOf(context).width >= 600)

--- a/apps/client/lib/src/widgets/conversation_panel/parts/actions.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/actions.dart
@@ -118,9 +118,7 @@ mixin _ConversationPanelActionsMixin on ConsumerState<ConversationPanel> {
     );
   }
 
-  // The owner of a group with other members can't leave (the server
-  // enforces this); per the cross-cutting decision we hide the row
-  // entirely rather than render it disabled.
+  // Server forbids owner-leave with other members; hide the row rather than render disabled.
   bool _resolveCanLeave(Conversation conv, String myRole, String myUserId) {
     if (!conv.isGroup) return false;
     final ownerWithMembers =

--- a/apps/client/lib/src/widgets/conversation_panel/parts/banners.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/banners.dart
@@ -35,11 +35,7 @@ mixin _ConversationPanelBannersMixin on ConsumerState<ConversationPanel> {
     );
   }
 
-  // NOTE: This banner stays hand-rolled (not EchoBanner) because the whole
-  // surface is a tap target that triggers reconnect, while the trailing
-  // close button is a *nested* tap target that must NOT bubble up to the
-  // outer GestureDetector. EchoBanner is a one-action shape; mapping this
-  // two-zone behaviour onto it would be more confusing than the duplication.
+  // Hand-rolled (not EchoBanner): needs two tap zones — surface reconnects, close button must not bubble.
   Widget _buildReplacedBanner(BuildContext context, bool wsReplaced) {
     if (!wsReplaced || _replacedBannerDismissed) return const SizedBox.shrink();
     return Column(
@@ -201,12 +197,7 @@ mixin _ConversationPanelBannersMixin on ConsumerState<ConversationPanel> {
   ({String label, Widget? action, bool showDismiss, Widget? progress})
   _resolveAvailableUpdateState(BuildContext context, UpdateState update) {
     if (kIsWeb) {
-      // Web bundle is stale — the browser is serving cached JS until the
-      // user hard-refreshes (we ship --pwa-strategy=none so there's no
-      // service-worker auto-refresh either). Make the banner
-      // non-dismissible with explicit hard-refresh instructions and the
-      // current → latest version delta, so beta testers don't keep
-      // hitting a half-finished build without noticing (#1175).
+      // Web bundle stale: --pwa-strategy=none means no SW auto-refresh; non-dismissible banner forces hard-refresh (#1175).
       return (
         label:
             'New version v${update.latestVersion} available — '
@@ -257,9 +248,7 @@ mixin _ConversationPanelBannersMixin on ConsumerState<ConversationPanel> {
         update.updateAvailable ||
         isActive ||
         update.status == UpdateStatus.error;
-    // When no update banner is showing, fall back to a small "Report a bug"
-    // affordance so the user can reach the feedback dialog without leaving
-    // the sidebar / opening Settings.
+    // Fall back to bug-report when no update banner.
     if (!isVisible) return _buildBugReportRow(context);
     if (update.dismissed && !isActive) return _buildBugReportRow(context);
 

--- a/apps/client/lib/src/widgets/conversation_panel/parts/header.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/header.dart
@@ -25,11 +25,7 @@ mixin _ConversationPanelHeaderMixin
           Expanded(
             child: Row(
               children: [
-                // Anchor the connection status dot to a small fixed-size
-                // icon on every layout. Wrapping it around the large
-                // "Chats" text on mobile placed the dot at the lower-right
-                // of the "s" — visually awkward; the icon variant matches
-                // desktop and gives the dot a predictable anchor.
+                // Anchor status dot to a fixed-size icon (wrapping "Chats" text placed dot at "s" lower-right).
                 const ConnectionStatusBadge(child: EchoLogoIcon(size: 22)),
                 const SizedBox(width: 10),
                 Text(
@@ -76,11 +72,7 @@ mixin _ConversationPanelHeaderMixin
               ),
             ),
           ],
-          // Global-search entrypoint on both mobile and desktop. The
-          // mobile build used to expose a separate "filter conversations"
-          // search bar below the header; we dropped that to match the
-          // single-search-entrypoint pattern the desktop already uses
-          // (see the feedback_desktop_search memory rule).
+          // Single search entrypoint on mobile + desktop (feedback_desktop_search memory rule).
           if (widget.onGlobalSearch != null) ...[
             const SizedBox(width: 2),
             Semantics(
@@ -300,10 +292,7 @@ mixin _ConversationPanelHeaderMixin
     IconData? icon,
   }) {
     final isSelected = activeFilter == filter;
-    // Selected chip bg is always `context.accent` (a saturated indigo across
-    // every theme variant), so white reads cleanly. The previous reliance on
-    // `colorScheme.onPrimary` broke on themes where onPrimary resolves dark
-    // (graphite/ember/neon).
+    // White, not onPrimary — onPrimary resolves dark on graphite/ember/neon themes.
     final chipColor = isSelected ? Colors.white : context.textSecondary;
     final chipWeight = isSelected ? FontWeight.w600 : FontWeight.w500;
     return GestureDetector(

--- a/apps/client/lib/src/widgets/conversation_panel/parts/list_renderer.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/list_renderer.dart
@@ -112,14 +112,7 @@ mixin _ConversationPanelListRendererMixin
       );
     }
 
-    // No conversations yet — show onboarding guidance.
-    //
-    // On wide (desktop / tablet) layouts the main pane already renders its
-    // own \"No conversation selected\" empty state with Add-contact /
-    // Browse-groups CTAs, so duplicating the same panel in the sidebar
-    // gives first-time users two identical pieces of guidance side by
-    // side. Suppress the sidebar copy in that case and leave the column
-    // visually empty; the main pane carries the affordance.
+    // Wide layouts already show the empty-state CTAs in the main pane; suppress sidebar duplicate.
     final isMobile = MediaQuery.sizeOf(context).width < 600;
     if (!isMobile) {
       return const SizedBox.shrink();
@@ -209,10 +202,7 @@ mixin _ConversationPanelListRendererMixin
       color: context.accent,
       child: Scrollbar(
         thumbVisibility: defaultTargetPlatform != TargetPlatform.iOS,
-        // Wrap the list in SlidableAutoCloseBehavior so opening a second row's
-        // swipe-action panel automatically closes any previously-open one —
-        // matches the iOS Mail / Messages pattern. Without this wrapper each
-        // Slidable is independent and several rows can sit half-open at once.
+        // SlidableAutoCloseBehavior closes other open swipe rows (iOS Mail pattern).
         child: SlidableAutoCloseBehavior(
           child: ListView.builder(
             physics: const AlwaysScrollableScrollPhysics(),

--- a/apps/client/lib/src/widgets/conversation_panel/parts/list_renderer.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/list_renderer.dart
@@ -113,23 +113,23 @@ mixin _ConversationPanelListRendererMixin
     }
 
     // No conversations yet — show onboarding guidance.
+    //
+    // On wide (desktop / tablet) layouts the main pane already renders its
+    // own \"No conversation selected\" empty state with Add-contact /
+    // Browse-groups CTAs, so duplicating the same panel in the sidebar
+    // gives first-time users two identical pieces of guidance side by
+    // side. Suppress the sidebar copy in that case and leave the column
+    // visually empty; the main pane carries the affordance.
     final isMobile = MediaQuery.sizeOf(context).width < 600;
+    if (!isMobile) {
+      return const SizedBox.shrink();
+    }
     return EmptyState(
       icon: Icons.forum_outlined,
       title: 'No conversations yet',
       body: 'Start a new chat or wait for friends to message you.',
       ctaLabel: 'Start a new chat',
       onCta: widget.onNewChat,
-      footer: (!isMobile && widget.onShowKeyboardShortcuts != null)
-          ? Text(
-              'Keyboard shortcuts (Ctrl+/)',
-              style: TextStyle(
-                color: context.textMuted,
-                fontSize: 12,
-                fontWeight: FontWeight.w500,
-              ),
-            )
-          : null,
     );
   }
 

--- a/apps/client/lib/src/widgets/empty_state.dart
+++ b/apps/client/lib/src/widgets/empty_state.dart
@@ -97,9 +97,7 @@ class EmptyState extends StatelessWidget {
             ],
             if (ctaLabel != null) ...[
               const SizedBox(height: 16),
-              // Wrap so the secondary CTA tucks under the primary on narrow
-              // viewports (e.g. 750 px wide_layout with the sidebar taking
-              // ~360 px) instead of triggering a horizontal overflow.
+              // Wrap so secondary CTA tucks under primary on narrow viewports instead of overflowing.
               Wrap(
                 spacing: 8,
                 runSpacing: 8,

--- a/apps/client/lib/src/widgets/encryption_status_banner.dart
+++ b/apps/client/lib/src/widgets/encryption_status_banner.dart
@@ -77,12 +77,7 @@ class EncryptionStatusBanner extends ConsumerWidget {
     }
 
     if (sigFailed && conversation.isGroup) {
-      // GRP2 signature verification failed — a member of this group
-      // signed a message with a key that doesn't match their device's
-      // published verify key. Could be a benign device-rotation race,
-      // but it could also be forgery. We don't auto-recover; the user
-      // explicitly dismisses after they've contacted an admin / the
-      // sender out-of-band.
+      // GRP2 signature mismatch could be device-rotation race OR forgery — no auto-recover; user dismisses explicitly.
       return EchoBanner(
         icon: Icons.gpp_bad_outlined,
         severity: EchoBannerSeverity.danger,
@@ -101,15 +96,7 @@ class EncryptionStatusBanner extends ConsumerWidget {
     }
 
     if ((needsRotation || outOfSync) && conversation.isGroup) {
-      // Two paths funnel into the same banner:
-      // 1. needsRotation — the server reported 410 Gone from
-      //    /keys/latest because no envelope exists for this user at
-      //    the current key version. Another member must rotate us in.
-      // 2. outOfSync — repeated "[Could not decrypt...]" placeholders
-      //    crossed the threshold; the local cached key is probably
-      //    stale and a fresh envelope is sitting on the server.
-      // "Refresh key" drops the local cache + refetches; if the fetch
-      // returns 410 again the callback re-flags the conversation.
+      // needsRotation = server 410 (no envelope at current version); outOfSync = decrypt-failure threshold tripped.
       final message = needsRotation
           ? "This group's encryption key was rotated without you. Ask any "
                 'active member to refresh and send a message — the new '
@@ -178,14 +165,8 @@ class EncryptionStatusBanner extends ConsumerWidget {
   }
 
   String? _peerUserIdFor(Conversation conv, WidgetRef ref) {
-    // 1:1 conversations have exactly one "other" member.
     if (conv.members.length < 2) return null;
-    // The store-side userId of the current user is needed to exclude self,
-    // but the banner is constructed inside the per-conversation tree where
-    // myUserId isn't directly threaded. Walk members and pick the first
-    // non-self entry; the chat panel already filters self from member lists
-    // upstream, so members[0] is a safe heuristic here. For non-1:1 the
-    // banner is suppressed above.
+    // Chat panel already filters self from member lists upstream, so members.first is the peer.
     return conv.members.first.userId;
   }
 }

--- a/apps/client/lib/src/widgets/feedback_dialog.dart
+++ b/apps/client/lib/src/widgets/feedback_dialog.dart
@@ -129,10 +129,7 @@ class _FeedbackDialogState extends ConsumerState<_FeedbackDialog> {
     final body = _bodyController.text.trim();
     if (body.isEmpty) return;
 
-    // Capture the root overlay BEFORE we start awaiting so success / error
-    // toasts can still resolve an `Overlay` after the dialog pops -- using
-    // the dialog's own context after `Navigator.pop` returns a disposed
-    // overlay and the toast never renders (#928).
+    // Capture root overlay before await — dialog's own context is disposed by the time the toast resolves (#928).
     final rootOverlay = Overlay.of(context, rootOverlay: true);
 
     setState(() {

--- a/apps/client/lib/src/widgets/global_search_overlay.dart
+++ b/apps/client/lib/src/widgets/global_search_overlay.dart
@@ -288,9 +288,7 @@ class _GlobalSearchOverlayState extends ConsumerState<GlobalSearchOverlay> {
     // Responsive width: tablets (< 900) get screen-48, desktops get fixed 560
     final width = _resolveOverlayWidth(isMobile, screenWidth);
 
-    // A non-focusable Focus observer: it sees raw key events but never owns
-    // primary focus, so it can't steal the user's first keystroke from the
-    // TextField below.
+    // Non-focusable Focus: observes keys without stealing the first keystroke from the TextField.
     return Focus(
       canRequestFocus: false,
       descendantsAreFocusable: true,

--- a/apps/client/lib/src/widgets/group_members_sheet.dart
+++ b/apps/client/lib/src/widgets/group_members_sheet.dart
@@ -89,9 +89,7 @@ class _GroupMembersSheetState extends ConsumerState<GroupMembersSheet> {
 
     final members = conv.members;
 
-    // Resolve online/status for each member: self is never broadcast by
-    // the WS, so substitute auth's local status. Everyone else uses the
-    // central presenceFor lookup.
+    // WS doesn't broadcast self presence; substitute auth's local status.
     UserPresence presenceFor(ConversationMember m) {
       if (m.userId == myUserId) {
         return UserPresence(status: myPresenceStatus, isOnline: true);

--- a/apps/client/lib/src/widgets/image_gallery_viewer.dart
+++ b/apps/client/lib/src/widgets/image_gallery_viewer.dart
@@ -399,10 +399,7 @@ class _GalleryPageState extends State<_GalleryPage> {
     final opacity = (1.0 - (_dragY.abs() / 280)).clamp(0.0, 1.0);
 
     return GestureDetector(
-      // Tap on the scrim area (anywhere not occupied by the image itself)
-      // dismisses the gallery (#901). The inner GestureDetector below
-      // swallows taps on the image so this only fires for the letterbox
-      // scrim around the contained image.
+      // Tap on scrim (letterbox area) dismisses (#901); inner GestureDetector swallows taps on the image itself.
       onTap: _isZoomed ? null : widget.onDismiss,
       behavior: HitTestBehavior.translucent,
       onVerticalDragUpdate: _onVerticalDragUpdate,
@@ -419,10 +416,6 @@ class _GalleryPageState extends State<_GalleryPage> {
             onInteractionEnd: (_) => widget.onZoomChanged(),
             child: Center(
               child: GestureDetector(
-                // Swallow taps directly on the image so they don't bubble up
-                // to the outer scrim-dismiss handler. Pan / pinch still reach
-                // the InteractiveViewer above because those are different
-                // gesture kinds.
                 onTap: () {},
                 behavior: HitTestBehavior.opaque,
                 child: _buildImage(),

--- a/apps/client/lib/src/widgets/input/markdown_toolbar.dart
+++ b/apps/client/lib/src/widgets/input/markdown_toolbar.dart
@@ -158,9 +158,7 @@ class _ToolbarButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Use the Echo muted colour when the extension is present (production),
-    // fall back to the Material icon colour so the widget renders in plain
-    // MaterialApp test harnesses without throwing.
+    // Fall back to Material icon colour so plain MaterialApp test harnesses don't throw.
     final iconColor =
         Theme.of(context).extension<EchoColorExtension>()?.textMuted ??
         Theme.of(context).iconTheme.color;

--- a/apps/client/lib/src/widgets/input/mention_autocomplete.dart
+++ b/apps/client/lib/src/widgets/input/mention_autocomplete.dart
@@ -72,10 +72,7 @@ class MentionAutocomplete extends StatelessWidget {
 
   List<_BroadcastMention> get _filteredBroadcasts {
     if (mentionQuery.isEmpty) return _broadcasts;
-    // Defensive lowercase: callers from this codebase already pass a
-    // lowercased query (extractMentionQuery normalizes it), but the
-    // public API should not silently drop suggestions for a mixed-case
-    // query supplied by a future caller.
+    // Defensive lowercase for future callers; extractMentionQuery already normalises.
     final q = mentionQuery.toLowerCase();
     return _broadcasts.where((b) => b.keyword.startsWith(q)).toList();
   }
@@ -88,10 +85,7 @@ class MentionAutocomplete extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    // ListView uses `reverse: true`, so item 0 paints at the bottom (next
-    // to the text field).  Members come first (lower indices) so they sit
-    // closest to the cursor; broadcasts get pushed to the top of the
-    // picker — they're rarer and visually distinct.
+    // ListView is reverse:true — members first so they sit next to the cursor; broadcasts to the top.
     final total = memberRows.length + broadcastRows.length;
 
     return Container(

--- a/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
+++ b/apps/client/lib/src/widgets/keyboard_shortcuts_overlay.dart
@@ -28,10 +28,7 @@ class _KeyboardShortcutsOverlayState extends State<KeyboardShortcutsOverlay> {
     super.dispose();
   }
 
-  // Keep this list in sync with the actual `CallbackShortcuts` bindings in
-  // `home_screen.dart` and the message-composer key handlers. Listing keys
-  // here that aren't really bound is worse than listing fewer — users try
-  // them, nothing happens, and the whole overlay loses trust.
+  // Keep in sync with CallbackShortcuts in home_screen.dart + composer handlers — unbound entries erode trust.
   static const _sections = <_ShortcutSection>[
     _ShortcutSection('Navigation', [
       _Shortcut('Ctrl+K', 'Quick-switch conversations'),
@@ -249,9 +246,7 @@ class _ShortcutRow extends StatelessWidget {
   /// Splits a shortcut string like "Ctrl+K" into ["Ctrl", "K"].
   /// Preserves multi-word tokens (e.g. "Long press" stays as one part).
   static List<String> _splitKeys(String keys) {
-    // Use + as separator only when surrounded by identifier-like chars.
-    // e.g. "Ctrl+K" → ["Ctrl", "K"], "Hover + ❤" → ["Hover ", " ❤"]
-    // Simple heuristic: split on bare `+` (not surrounded by spaces).
+    // Split on bare `+` only; " + " is kept (e.g. "Hover + ❤").
     if (keys.contains('+') && !keys.contains(' + ')) {
       return keys.split('+');
     }

--- a/apps/client/lib/src/widgets/member_role.dart
+++ b/apps/client/lib/src/widgets/member_role.dart
@@ -59,10 +59,7 @@ class MemberRoleBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     if (role != 'owner' && role != 'admin') return const SizedBox.shrink();
     final isOwner = role == 'owner';
-    // Reserve amber (EchoTheme.warning) for actual warnings — away
-    // presence, "Experimental" feature pills, etc. Owner gets the
-    // brighter `accentHover` accent variant so it still reads as
-    // distinct from Admin's `accent` at lower alpha.
+    // Owner uses accentHover (not amber) — amber is reserved for actual warnings.
     final bgColor = isOwner
         ? EchoTheme.accentHover.withValues(alpha: 0.22)
         : context.accent.withValues(alpha: 0.15);

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -57,9 +57,7 @@ class MembersPanel extends ConsumerWidget {
     final isOwner = myRole == 'owner';
     final canRemove = isOwner || myRole == 'admin';
 
-    // Slice 7: group members by role (OWNER / ADMIN / MEMBERS) instead of
-    // online/offline. Online presence is still surfaced as a subtle dot
-    // and "online"/"away" activity line within each row.
+    // Group by role; presence stays surfaced via the per-row dot + activity line.
     int sortByName(ConversationMember a, ConversationMember b) =>
         a.username.toLowerCase().compareTo(b.username.toLowerCase());
 
@@ -100,10 +98,7 @@ class MembersPanel extends ConsumerWidget {
             ),
             child: Align(
               alignment: Alignment.centerLeft,
-              // The conversation header already shows "<N> members" as a
-              // subtitle (chat_header_bar.dart). Repeating the count on the
-              // right-rail header was redundant; keep the count off this
-              // surface and just label what the panel is.
+              // Chat header already shows "<N> members"; just label the panel here.
               child: Text(
                 'Members',
                 style: TextStyle(

--- a/apps/client/lib/src/widgets/message/hover_action_button.dart
+++ b/apps/client/lib/src/widgets/message/hover_action_button.dart
@@ -33,9 +33,7 @@ class HoverActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 33×33 hit target (scaled down from 44×44 per slice 4) — still
-    // comfortably above the 24px Material minimum for hit testing on
-    // desktop, while keeping the visual bar dense like Discord/Slack.
+    // 33×33 hit target — denser than Material's 24px minimum but tighter than 44px to match Discord/Slack.
     return Semantics(
       label: tooltip,
       button: true,

--- a/apps/client/lib/src/widgets/message/image_attachment.dart
+++ b/apps/client/lib/src/widgets/message/image_attachment.dart
@@ -89,21 +89,11 @@ class ImageAttachment extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Prefer explicit dimensions; fall back to the session-scoped cache
-    // (pre-populated by the upload path or by prior renders).
     final cached = imageDimensionCache[imageUrl];
     final resolvedWidth = imageWidth ?? cached?.width.toInt();
     final resolvedHeight = imageHeight ?? cached?.height.toInt();
 
-    // Cache-key keying: stripping the entire query string is too aggressive
-    // because the media-ticket on web flips between two states (null → fresh
-    // ticket) over the lifetime of a single chat session. A first render
-    // before the ticket arrives produces a no-ticket URL that 401s; once the
-    // ticket lands and the widget rebuilds with a ?ticket=… URL the
-    // image lookup HIT against the poisoned cache slot and the user sees
-    // [Image failed to load] permanently (#1094). Include a coarse
-    // ticket-bucket in the cache key so the failed-without-auth attempt
-    // doesn't poison the with-auth fetch.
+    // Bucket cache key by ticket presence so a no-auth 401 doesn't poison the with-auth fetch (#1094).
     final hasTicketSuffix =
         Uri.tryParse(imageUrl)?.queryParameters.containsKey('ticket') == true;
     final cachedImage = CachedNetworkImage(
@@ -140,8 +130,6 @@ class ImageAttachment extends StatelessWidget {
       placeholder: (_, _) => _skeleton(context, resolvedWidth, resolvedHeight),
     );
 
-    // When dimensions are known, wrap in AspectRatio so the bubble reserves
-    // the exact pixel proportion before any bytes arrive.
     if (resolvedWidth != null && resolvedHeight != null) {
       return AspectRatio(
         aspectRatio: resolvedWidth / resolvedHeight,

--- a/apps/client/lib/src/widgets/message/media_content.dart
+++ b/apps/client/lib/src/widgets/message/media_content.dart
@@ -17,10 +17,7 @@ import 'image_attachment.dart';
 import 'video_player.dart';
 import 'voice_message_widget.dart';
 
-// Markers may be followed by a newline + caption (the seed script and the
-// chat input both produce `[img:URL]\nCaption`), so the regex is anchored at
-// the start, uses a lazy capture, and does NOT require the closing `]` to
-// be at end-of-string. See #795.
+// Markers may be followed by `\nCaption`, so regex is start-anchored, not end-anchored (#795).
 
 /// Regex for detecting image markers: [img:URL]
 final _imgRegex = RegExp(r'^\[img:([^\]\n]+)\]');
@@ -101,9 +98,7 @@ String resolveMediaUrl(
       resolved = '$base$url';
     }
   }
-  // On web, <img> tags cannot carry Authorization headers, so pass a
-  // media ticket via query parameter.  Tickets are scoped to media only
-  // and expire after 5 minutes (unlike JWTs which grant full API access).
+  // <img> tags can't carry Authorization on web; ticket query param is media-scoped, 5-min TTL.
   if (kIsWeb && mediaTicket != null && mediaTicket.isNotEmpty) {
     final separator = resolved.contains('?') ? '&' : '?';
     resolved = '$resolved${separator}ticket=$mediaTicket';
@@ -391,9 +386,7 @@ class MediaContentState extends State<MediaContent> {
                   : ImageAttachment(
                       imageUrl: fullUrl,
                       headers: _headers(),
-                      // Cap decode at 300px * DPR so a 4K JPEG isn't
-                      // held in RAM at full size for a 300px inline
-                      // bubble (#639).
+                      // Cap decode at 300px*DPR — keeps 4K JPEGs out of RAM for a 300px bubble (#639).
                       memCacheWidth:
                           (300 * MediaQuery.devicePixelRatioOf(context))
                               .round(),
@@ -411,12 +404,7 @@ class MediaContentState extends State<MediaContent> {
       builder: (ctx, ref, _) {
         final gif = ref.watch(gifPlaybackProvider);
         if (gif.isAnimating) {
-          // Route GIF playback through the disk cache so
-          // switching conversations doesn't re-fetch the
-          // animation each time (#562).
-          // Cap decode at 300px * DPR so a 4K GIF
-          // doesn't get fully decoded for a 300px
-          // bubble (#639).
+          // Disk-cache GIFs (#562); decode capped at 300px*DPR (#639).
           final dpr = MediaQuery.devicePixelRatioOf(ctx);
           return Image(
             image: ResizeImage(
@@ -681,9 +669,6 @@ class _ImageViewerDialog extends StatelessWidget {
               minScale: 0.8,
               maxScale: 4,
               child: GestureDetector(
-                // Tap on the image (or its letterbox padding) dismisses
-                // the viewer. Pinch / pan are different gesture kinds
-                // and still flow up to InteractiveViewer.
                 onTap: () => Navigator.of(context).pop(),
                 behavior: HitTestBehavior.opaque,
                 child: _buildViewerImage(viewerCacheWidth),

--- a/apps/client/lib/src/widgets/message/message_status_icon.dart
+++ b/apps/client/lib/src/widgets/message/message_status_icon.dart
@@ -44,11 +44,7 @@ class MessageStatusIcon extends StatelessWidget {
       padding: const EdgeInsets.only(left: 4),
       child: Tooltip(
         message: tooltip,
-        // AnimatedSwitcher gives the sending → sent → delivered → read
-        // progression a brief scale transition so each status hand-off
-        // reads as 'something happened' instead of an instant icon swap.
-        // The ValueKey on the icon ensures the switcher detects the
-        // status change (icons of the same type still differ).
+        // Scale transition makes each status hand-off feel like 'something happened'; ValueKey lets switcher detect same-icon changes.
         child: AnimatedSwitcher(
           duration: MotionDurations.quick,
           switchInCurve: MotionCurves.emphasis,

--- a/apps/client/lib/src/widgets/message/reaction_bar.dart
+++ b/apps/client/lib/src/widgets/message/reaction_bar.dart
@@ -87,9 +87,7 @@ class ReactionBar extends StatelessWidget {
                       ),
                     )
                   : _ReactionPill(
-                      // Stable key so reordering this list doesn't let Flutter
-                      // recycle a different emoji's _ReactionPillState (whose
-                      // entry-scale animation has already played).
+                      // Stable key so reorder doesn't recycle another emoji's state (entry anim already played).
                       key: ValueKey('reaction-${entry.key}'),
                       emoji: entry.key,
                       count: entry.value.length,

--- a/apps/client/lib/src/widgets/message/retry_row.dart
+++ b/apps/client/lib/src/widgets/message/retry_row.dart
@@ -38,9 +38,7 @@ class RetryRow extends StatelessWidget {
           const SizedBox(width: 6),
           const Flexible(
             child: Text(
-              // Unified failure label across voice + text. Retry / Delete
-              // sit right next to this text, so the previous "Tap to retry"
-              // suffix was redundant. See F-030 in the 2026-05-19 UI audit.
+              // Unified label; "Tap to retry" suffix dropped since buttons sit alongside (F-030).
               "Couldn't send",
               style: TextStyle(
                 fontSize: 12,

--- a/apps/client/lib/src/widgets/message/video_player.dart
+++ b/apps/client/lib/src/widgets/message/video_player.dart
@@ -146,11 +146,7 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
   ///      corner is the explicit entry point for users who don't discover
   ///      the gesture.
   Widget _buildVideoArea() {
-    // Server generates a JPEG first-frame thumbnail at upload time (#561).
-    // If that endpoint 404s (older upload, ffmpeg missing, etc.), the
-    // CachedNetworkImage's errorWidget falls back to the previous solid tile.
-    // Use the pre-resolved thumbUrl from the widget so that query params
-    // (e.g. ?ticket= on web) appear after /thumb, not before it (#411).
+    // Server JPEG thumbnail (#561); pre-resolved thumbUrl keeps `?ticket=` after `/thumb` (#411).
     final thumbUrl = widget.thumbUrl;
     // Inline thumbnail is 170px tall; cap decode height at 170 * DPR so
     // we don't hold a 4K still-frame in RAM for a thumbnail (#639).
@@ -211,9 +207,7 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
       );
     }
 
-    // States 1 + 2: thumbnail with a play button. Tapping starts inline
-    // playback; if init has already failed once we route to the standalone
-    // fullscreen player which renders a richer error UI.
+    // Thumbnail + play. Init-failure routes to fullscreen player for richer error UI.
     return Semantics(
       label: 'play video',
       button: true,

--- a/apps/client/lib/src/widgets/message/voice_message_widget.dart
+++ b/apps/client/lib/src/widgets/message/voice_message_widget.dart
@@ -203,9 +203,7 @@ class _VoiceMessageWidgetState extends State<VoiceMessageWidget> {
     if (response.statusCode >= 200 && response.statusCode < 300) {
       await _player.play(BytesSource(response.bodyBytes));
     } else {
-      // Surface the failure to the user instead of silently no-op'ing.
-      // Without this, mobile users tapped the play button and saw
-      // nothing happen (#554).
+      // Surface fetch failure — previously played button no-op'd silently (#554).
       final reason = 'fetch failed (${response.statusCode})';
       debugPrint('[VoiceMsg] $reason');
       if (mounted) {

--- a/apps/client/lib/src/widgets/message/youtube_iframe_view.dart
+++ b/apps/client/lib/src/widgets/message/youtube_iframe_view.dart
@@ -1,9 +1,3 @@
-// Cross-platform shim for the inline YouTube iframe player.
-//
-// On web (`dart.library.html`) we render a privacy-respecting
-// `youtube-nocookie.com` iframe through a Flutter `HtmlElementView`.
-// On every other platform there is no in-process browser engine we can
-// trust, so the stub returns `null` and the embed widget falls back to
-// launching the system YouTube app / browser.
+// Web uses youtube-nocookie.com HtmlElementView; other platforms get the stub (falls back to launching system browser).
 export 'youtube_iframe_view_stub.dart'
     if (dart.library.html) 'youtube_iframe_view_web.dart';

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -168,11 +168,7 @@ class MessageItem extends StatefulWidget {
 
 class _MessageItemState extends State<MessageItem>
     with SingleTickerProviderStateMixin {
-  // Hover state is intentionally a ValueNotifier rather than `setState`-driven
-  // state: scoping mouse-enter/exit to the three subtrees that actually depend
-  // on it (the row-tint Container, the inline timestamp, and the action
-  // overlay) avoids rebuilding the bubble — including any embedded media —
-  // every time the cursor crosses the row (#834, closes #872).
+  // ValueNotifier (not setState) so hover-driven rebuilds skip the bubble + embedded media (#834, closes #872).
   final _hoverNotifier = ValueNotifier<bool>(false);
   double _swipeDx = 0;
   bool _swipeTriggered = false;
@@ -431,8 +427,6 @@ class _MessageItemState extends State<MessageItem>
       builder: (dialogContext) {
         return Stack(
           children: [
-            // Dismiss layer — covers entire screen. Tapping anywhere outside
-            // the image closes the viewer.
             Positioned.fill(
               child: GestureDetector(
                 onTap: () => Navigator.of(dialogContext).pop(),
@@ -451,9 +445,6 @@ class _MessageItemState extends State<MessageItem>
                   minScale: 0.8,
                   maxScale: 4,
                   child: GestureDetector(
-                    // Tap on the image / letterbox padding dismisses; pinch
-                    // and pan are different gesture kinds and still reach
-                    // InteractiveViewer.
                     onTap: () => Navigator.of(dialogContext).pop(),
                     behavior: HitTestBehavior.opaque,
                     child: CachedNetworkImage(
@@ -590,10 +581,7 @@ class _MessageItemState extends State<MessageItem>
         child: Builder(
           builder: (btnContext) => InkWell(
             onTap: () {
-              // Anchor at the button's bottom-left so the menu opens
-              // directly below it. globalPaintBounds resolves the
-              // RenderBox to viewport coords without us having to
-              // pass GlobalKeys around.
+              // Anchor menu at button's bottom-left.
               final box = btnContext.findRenderObject() as RenderBox?;
               final origin =
                   box?.localToGlobal(Offset(0, box.size.height)) ?? Offset.zero;
@@ -661,13 +649,7 @@ class _MessageItemState extends State<MessageItem>
   /// Resolve text color for message content.
   Color _contentTextColor({required bool isMine, required bool isFailed}) {
     if (isFailed) return EchoTheme.danger;
-    // Plain (Slack) AND Compact (Discord) layouts both drop the bubble
-    // fill (#564, see _bubbleColor → Colors.transparent), so the message
-    // sits directly on the chat background. onPrimary is calibrated for
-    // an accent-coloured bubble that no longer exists — using it against
-    // chatBg produces near-black-on-near-black on dark themes such as
-    // Graphite (#13AF9D bubble's onPrimary is #0A1114). Fall back to
-    // textPrimary so own messages stay readable in bubble-less layouts.
+    // Plain/Compact drop the bubble fill (#564), so onPrimary (calibrated for accent bubble) reads as black-on-black on dark themes.
     if (widget._isPlain || widget._isCompact) return context.textPrimary;
     if (isMine) return Theme.of(context).colorScheme.onPrimary;
     return context.textPrimary;
@@ -728,9 +710,7 @@ class _MessageItemState extends State<MessageItem>
                   httpHeaders: headers,
                   cacheManager: chatMediaCacheManager,
                   errorWidget: (_, _, _) => const SizedBox.shrink(),
-                  // Reserve the expected image area while loading so
-                  // the scroll position does not jump when the image
-                  // finally decodes.
+                  // Reserve area while loading to avoid scroll jump on decode.
                   placeholder: (_, _) => Container(
                     height: 200,
                     width: 300,
@@ -790,9 +770,7 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  // Forwarded messages: strip the `[Forwarded] ` prefix so the marker
-  // regex inside MediaContent can match. The "Forwarded" badge above the
-  // bubble still signals provenance.
+  // Strip `[Forwarded] ` so MediaContent's start-anchored marker regex still matches.
   Widget _buildMediaBubble({
     required ChatMessage msg,
     required bool isMine,
@@ -826,11 +804,7 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  // Sender side: if WE drafted this message and the system preserved the
-  // original text in failedContent, show the user what they wrote (dimmed)
-  // with a Resend/Delete footer rather than the generic "couldn't decrypt"
-  // pill — the pill makes it look like the message was sent by someone
-  // else. F-006 / expert recommendation in the 2026-05-19 UI audit.
+  // Show our own preserved draft (with Resend/Delete) instead of generic decrypt pill that looks like another sender (F-006).
   Widget _buildDecryptFailureBubble({
     required ChatMessage msg,
     required bool isMine,
@@ -861,9 +835,6 @@ class _MessageItemState extends State<MessageItem>
     );
 
     final embeddedImages = extractEmbeddedImageUrls(displayContent);
-    // Link preview for the first URL (skip attachment-only messages and
-    // internal server links). YouTube URLs short-circuit to an embed card
-    // with thumbnail + red play button.
     final linkPreview = _buildLinkPreviewWidget(displayContent);
 
     if (embeddedImages.isEmpty && linkPreview == null) return textWidget;
@@ -904,13 +875,7 @@ class _MessageItemState extends State<MessageItem>
   }) {
     return [
       if (msg.pinnedAt != null) PinnedIndicator(isMine: isMine),
-      // Sender name + inline timestamp is shown ONCE per consecutive run
-      // of messages from the same author (Discord-style grouping). The
-      // earlier "always show in compact" branch made every continuation
-      // bubble repeat the author + time, which read as visual noise on
-      // back-to-back replies — see the user-reported screenshots from
-      // 2026-05-26. Now keyed solely on `showHeader` (computed by the
-      // chat list from the previous neighbour).
+      // Show sender name once per author-run; the prior "always show in compact" reproduced author/time on every continuation (2026-05-26 regression).
       if (widget.showHeader && (!isMine || widget.compactLayout))
         SenderNameLabel(
           message: msg,
@@ -984,11 +949,7 @@ class _MessageItemState extends State<MessageItem>
       };
     }
 
-    // Compact / Plain layouts (#794) flow to the full chat-pane width like
-    // Discord/Slack — no centered-bubble cap. Bubble layout keeps 520px so
-    // bubbles don't stretch awkwardly on wide windows; ultrawide (≥1600px)
-    // grows the cap up to 720px or 45% of viewport, whichever is smaller
-    // (#403).
+    // Bubble cap: 520px (520 keeps reading line tight); ultrawide ≥1600px grows to min(720, 45%vw) (#403, #794).
     final width = MediaQuery.of(context).size.width;
     final maxBubble = width >= 1600 ? math.min(720.0, width * 0.45) : 520.0;
     final bubbleConstraints = widget.compactLayout
@@ -1002,10 +963,7 @@ class _MessageItemState extends State<MessageItem>
         color: _bubbleColor(isMine: isMine, isFailed: isFailed),
         borderRadius: _bubbleBorderRadius(isMine: isMine),
       ),
-      // Merge semantics for the bubble's inner content so the screen reader
-      // announces a single composite label (handled in build()) instead of
-      // separate header/body/timestamp/lock fragments. Avatar and hover bar
-      // sit OUTSIDE this merge so their own semantics survive.
+      // Merge inner semantics so the screen reader announces one composite label; avatar/hover sit outside the merge.
       child: MergeSemantics(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -1028,10 +986,7 @@ class _MessageItemState extends State<MessageItem>
     required Widget reactionPill,
   }) {
     if (!hasReactions) return bubble;
-    // Slice 5: in plain (Slack) mode, render reactions inline directly
-    // beneath the message body instead of using a Stack overlay — Slack's
-    // reactions sit in the same column as the timestamp row, never as a
-    // floating pill.
+    // Plain (Slack) mode: render reactions inline beneath body, not as overlay pill.
     if (widget._isPlain) {
       return Column(
         crossAxisAlignment: isMine
@@ -1194,10 +1149,7 @@ class _MessageItemState extends State<MessageItem>
         child: child,
       ),
       child: Padding(
-        // Compact / plain layouts left-align every message regardless of
-        // sender, so even "my" messages need the 36px avatar-gutter inset
-        // to line up with the bubble.  Only bubbles-layout sent messages
-        // sit flush right and warrant `left: 0`.
+        // Compact/plain left-align all messages, so even own messages need the 36px avatar-gutter inset.
         padding: EdgeInsets.only(
           top: 2,
           left: (isMine && !widget.compactLayout) ? 0 : 36,
@@ -1228,20 +1180,11 @@ class _MessageItemState extends State<MessageItem>
     required String? mediaUrl,
   }) {
     final style = _hoverStyle;
-    // Always anchor to the right side of the row at a fixed inset,
-    // matching the Discord convention: action bar is always top-right
-    // regardless of which side the bubble is on. This removes the
-    // bubbleOnRight branching that used to vary left/right per sender.
+    // Always top-right (Discord convention), regardless of bubble side.
     return Positioned(
       top: style.overlayTop,
       right: 8,
-      // Defensive `IntrinsicWidth` wrap: in CanvasKit (web) the action
-      // row's `Container > Row(MainAxisSize.min)` was still expanding to
-      // the full Stack width despite the Positioned only setting one
-      // edge — see the production screenshot reported on 2026-05-08.
-      // IntrinsicWidth forces the child subtree to size to its
-      // own intrinsic content regardless of the parent's loose
-      // constraints, giving us the snug action bar everywhere.
+      // IntrinsicWidth: CanvasKit otherwise stretches the Row to full Stack width when only one edge is set (prod 2026-05-08).
       child: ValueListenableBuilder<bool>(
         valueListenable: _hoverNotifier,
         builder: (context, isHovered, child) => ExcludeSemantics(
@@ -1279,13 +1222,7 @@ class _MessageItemState extends State<MessageItem>
       return [Flexible(child: bubbleWithReactions)];
     }
 
-    // Continuation messages (same author as the row above) reserve the
-    // avatar column with a blank spacer so the bubble/row stays aligned
-    // with the header row, but DO NOT repeat the avatar. This matches the
-    // Discord / Slack / iMessage behaviour where back-to-back messages
-    // from one user read as a single grouped column with one header.
-    // Applies to every layout — bubbles included — so received-message
-    // groups don't smear a small avatar against each follow-up bubble.
+    // Continuation rows reserve the avatar column with a spacer (no repeated avatar) — Discord/Slack/iMessage grouping.
     if (!widget.showHeader) {
       return [
         SizedBox(width: _resolveAvatarWidth()),
@@ -1401,9 +1338,7 @@ class _MessageItemState extends State<MessageItem>
       onEdit: _wrapMsgCallback(widget.onEdit, msg),
       onDelete: _wrapMsgCallback(widget.onDelete, msg),
       onCopyId: () => _copyMessageId(msg),
-      // Inline reactions header is hidden by the registry when
-      // isEncryptedUnreadable; we still wire the callbacks so the
-      // registry can decide.
+      // Registry decides visibility based on isEncryptedUnreadable; we still wire callbacks.
       onPickReaction: widget.onReactionSelect == null
           ? null
           : (emoji) => widget.onReactionSelect!(msg, emoji),
@@ -1481,19 +1416,14 @@ class _MessageItemState extends State<MessageItem>
   /// Density+header-aware top padding for the message row.
   double _buildTopPad() {
     if (widget.showHeader) {
-      // Phase 2 follow-up: density-driven gap between bubbles from
-      // the same sender, replacing the old MessageLayout-derived
-      // ternary so layout (bubble style) and density (vertical
-      // spacing) are independent knobs.
+      // Density-driven gap so layout and density are independent knobs.
       return switch (widget.density) {
         UIDensity.cozy => 12,
         UIDensity.normal => 8,
         UIDensity.compact => 3,
       };
     }
-    // Continuation row in the same group — pull subsequent messages
-    // tighter so a multi-line group reads as one paragraph (Discord +
-    // iMessage rhythm).
+    // Continuation rows: tighter spacing so a group reads as one paragraph.
     return switch (widget.density) {
       UIDensity.cozy => 1,
       UIDensity.normal => 1,
@@ -1549,9 +1479,7 @@ class _MessageItemState extends State<MessageItem>
               mainAxisAlignment: isAlignedEnd
                   ? MainAxisAlignment.end
                   : MainAxisAlignment.start,
-              // Bubbles: avatar anchors to the bottom of the bubble (iMessage
-              // style). Discord/Slack: avatar anchors to the top so it lines
-              // up with the sender name on the first line of the group.
+              // Bubbles: avatar bottom (iMessage); compact: top (lines up with sender name).
               crossAxisAlignment: widget.compactLayout
                   ? CrossAxisAlignment.start
                   : CrossAxisAlignment.end,
@@ -1606,9 +1534,7 @@ class _MessageItemState extends State<MessageItem>
     return GestureDetector(
       onLongPressStart: (details) =>
           _handleLongPress(details, msg, isMine, mediaUrl, hasReactions),
-      // Desktop right-click on the bubble opens the same centralised
-      // context menu. Hover-bar "..." remains as a discoverable
-      // mouse affordance but routes to the same _openContextMenu.
+      // Right-click routes through _openContextMenu like the hover-bar overflow.
       onSecondaryTapDown: (details) =>
           _openContextMenu(details.globalPosition, msg, isMine, mediaUrl),
       onHorizontalDragUpdate: canSwipeToReply
@@ -1654,10 +1580,7 @@ class _MessageItemState extends State<MessageItem>
       return const SizedBox.shrink();
     }
 
-    // Strip the `[Forwarded] ` prefix before regex media detection — the
-    // media-marker patterns are start-anchored (`^\[video:`) so the
-    // prefix would otherwise hide the marker and render `[video:url]`
-    // raw in the bubble.
+    // Strip `[Forwarded] ` before media regex (start-anchored patterns would otherwise miss the marker).
     final contentForMedia = msg.content.startsWith(_forwardedPrefix)
         ? msg.content.substring(_forwardedPrefix.length)
         : msg.content;
@@ -1692,10 +1615,6 @@ class _MessageItemState extends State<MessageItem>
     final canSwipeToReply =
         _isMobileTouch && widget.onReply != null && !msg.isSystemEvent;
     final topPad = _buildTopPad();
-    // On hover: tint the row background and draw a subtle border so the
-    // focused message stands out. Plain (Slack) layout also keeps its
-    // 3px left accent rule. All colors come from _HoverStyleSpec so
-    // they are fully theme-aware.
     final hoverSpec = _hoverStyle;
 
     final messageWidget = ValueListenableBuilder<bool>(
@@ -1729,10 +1648,7 @@ class _MessageItemState extends State<MessageItem>
         onExit: (_) => _hoverNotifier.value = false,
         child: Semantics(
           label: _composeMessageSemanticsLabel(msg, isMine),
-          // Audit #830 finding 11: the row's only direct gesture is
-          // long-press to open the action sheet; advertising `button: true`
-          // lied to screen readers ("activate" was announced even though
-          // a tap is a no-op). Declare the action that actually fires.
+          // Declare the actual gesture (long-press); `button: true` lied to screen readers (#830 finding 11).
           onLongPress: () => _handleLongPress(
             const LongPressStartDetails(),
             msg,

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1280,11 +1280,13 @@ class _MessageItemState extends State<MessageItem>
     }
 
     // Continuation messages (same author as the row above) reserve the
-    // avatar column with a blank spacer so the bubble stays aligned with
-    // the header row, but DO NOT repeat the avatar. This matches the
-    // Discord behaviour where back-to-back messages from one user read
-    // as a single grouped column with one header.
-    if (widget.compactLayout && !widget.showHeader) {
+    // avatar column with a blank spacer so the bubble/row stays aligned
+    // with the header row, but DO NOT repeat the avatar. This matches the
+    // Discord / Slack / iMessage behaviour where back-to-back messages
+    // from one user read as a single grouped column with one header.
+    // Applies to every layout — bubbles included — so received-message
+    // groups don't smear a small avatar against each follow-up bubble.
+    if (!widget.showHeader) {
       return [
         SizedBox(width: _resolveAvatarWidth()),
         const SizedBox(width: 8),
@@ -1489,11 +1491,13 @@ class _MessageItemState extends State<MessageItem>
         UIDensity.compact => 3,
       };
     }
-    // Slice 3: collapse same-sender gap to 1-2px to remove "floaty" look.
+    // Continuation row in the same group — pull subsequent messages
+    // tighter so a multi-line group reads as one paragraph (Discord +
+    // iMessage rhythm).
     return switch (widget.density) {
-      UIDensity.cozy => 2,
-      UIDensity.normal => 2,
-      UIDensity.compact => 1,
+      UIDensity.cozy => 1,
+      UIDensity.normal => 1,
+      UIDensity.compact => 0,
     };
   }
 

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -904,11 +904,14 @@ class _MessageItemState extends State<MessageItem>
   }) {
     return [
       if (msg.pinnedAt != null) PinnedIndicator(isMine: isMine),
-      // Slice 5: in compact mode (Discord-style) show the sender name on
-      // EVERY message, not only first-in-group. In bubbles/plain we keep
-      // the grouped-header behaviour.
-      if ((widget._isCompact || widget.showHeader) &&
-          (!isMine || widget.compactLayout))
+      // Sender name + inline timestamp is shown ONCE per consecutive run
+      // of messages from the same author (Discord-style grouping). The
+      // earlier "always show in compact" branch made every continuation
+      // bubble repeat the author + time, which read as visual noise on
+      // back-to-back replies — see the user-reported screenshots from
+      // 2026-05-26. Now keyed solely on `showHeader` (computed by the
+      // chat list from the previous neighbour).
+      if (widget.showHeader && (!isMine || widget.compactLayout))
         SenderNameLabel(
           message: msg,
           hasMedia: hasMedia,
@@ -1276,12 +1279,14 @@ class _MessageItemState extends State<MessageItem>
       return [Flexible(child: bubbleWithReactions)];
     }
 
-    // In compact mode, show a small avatar for every follow-up message too
-    // (Discord / Slack compact style). The avatar is visually smaller than the
-    // header avatar and has no name row — it just anchors the bubble spatially.
+    // Continuation messages (same author as the row above) reserve the
+    // avatar column with a blank spacer so the bubble stays aligned with
+    // the header row, but DO NOT repeat the avatar. This matches the
+    // Discord behaviour where back-to-back messages from one user read
+    // as a single grouped column with one header.
     if (widget.compactLayout && !widget.showHeader) {
       return [
-        _buildAvatarSection(msg: msg, forceShow: true),
+        SizedBox(width: _resolveAvatarWidth()),
         const SizedBox(width: 8),
         Flexible(child: bubbleWithReactions),
       ];

--- a/apps/client/lib/src/widgets/mobile_channel_drawer.dart
+++ b/apps/client/lib/src/widgets/mobile_channel_drawer.dart
@@ -153,10 +153,7 @@ class _ConversationRail extends StatelessWidget {
                     child: InkResponse(
                       onTap: () => onSelect(c.id),
                       radius: 24,
-                      // Avatars without an image fall back to a single
-                      // initial letter; without this exclude, that letter
-                      // gets merged into the row's accessibility label
-                      // (e.g. "chat with jake J").
+                      // ExcludeSemantics so the fallback initial doesn't append to the row's label.
                       child: ExcludeSemantics(child: avatar),
                     ),
                   ),

--- a/apps/client/lib/src/widgets/shared_media_gallery.dart
+++ b/apps/client/lib/src/widgets/shared_media_gallery.dart
@@ -23,10 +23,7 @@ class SharedMediaGallery extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // TD-60: subscribe only to *this* conversation's message list, not the
-    // whole `ChatState`. Before, opening this screen and idling on any other
-    // conversation rebuilt the gallery (and every CachedNetworkImage tile)
-    // on every inbound message system-wide.
+    // TD-60: per-conv selector so messages in other convs don't rebuild the gallery.
     final messages = ref.watch(
       chatProvider.select((s) => s.messagesForConversation(conversationId)),
     );
@@ -152,11 +149,7 @@ class _MediaGrid extends StatelessWidget {
       return _buildEmpty(context);
     }
 
-    // For images, the resolved URL points to the file itself. For videos, the
-    // file URL would be the .mp4/.webm bytes, so we resolve `<rawUrl>/thumb`
-    // for the tile preview instead. Building the `/thumb` path off the raw URL
-    // (before resolveMediaUrl appends any `?ticket=`) keeps the query string
-    // at the very end of the URL — matches the InlineVideoPlayer fix in #411.
+    // Videos resolve `<rawUrl>/thumb` for tile previews; build path BEFORE resolveMediaUrl appends `?ticket=` (#411).
     final resolvedThumbUrls = [
       for (final item in items)
         resolveMediaUrl(
@@ -180,9 +173,7 @@ class _MediaGrid extends StatelessWidget {
         : resolvedThumbUrls;
     final headers = mediaHeaders(authToken: authToken);
 
-    // Use a max-extent delegate so the grid scales: 3 columns on a phone,
-    // 5-6 on a wide desktop dialog. A fixed `crossAxisCount: 3` looked
-    // sparse when the gallery opened on desktop.
+    // Max-extent delegate so grid scales from 3 cols (phone) to 5-6 (desktop dialog).
     return GridView.builder(
       padding: const EdgeInsets.all(4),
       gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(

--- a/apps/client/lib/src/widgets/shutdown_handler.dart
+++ b/apps/client/lib/src/widgets/shutdown_handler.dart
@@ -36,10 +36,7 @@ class _ShutdownHandlerState extends ConsumerState<ShutdownHandler>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    // Force-instantiate the websocket provider so we don't have to discover
-    // it lazily inside _handleShutdown — at OS-shutdown time the framework
-    // is mid-tear-down and provider creation can race the dispose pipeline.
-    // Using read() (not watch()) avoids unnecessary rebuilds.
+    // Pre-instantiate so OS-shutdown handler doesn't race provider creation against dispose.
     ref.read(websocketProvider.notifier);
   }
 
@@ -65,10 +62,7 @@ class _ShutdownHandlerState extends ConsumerState<ShutdownHandler>
       // Provider may already be disposed during forced teardown — ignore.
     }
 
-    // 2. Flush pending Hive writes.  `Hive.close()` is async; since
-    //    `didChangeAppLifecycleState` is a synchronous callback we cannot
-    //    await it.  Fire-and-forget: even starting the close is far better
-    //    than an abrupt kill mid-write which would corrupt box files.
+    // 2. Fire-and-forget Hive.close (sync callback can't await); starting close beats mid-write kill.
     Hive.close().ignore();
   }
 

--- a/apps/client/lib/src/widgets/thread_view_panel.dart
+++ b/apps/client/lib/src/widgets/thread_view_panel.dart
@@ -139,9 +139,6 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
     final isMobile = Responsive.isMobile(context);
     final parent = widget.parentMessage;
 
-    // Watch the full conversation message list and filter for replies to this
-    // parent.  Any WS-delivered message that has replyToId == parent.id will
-    // automatically appear here because chatProvider notifies on addMessage().
     final allMessages = ref.watch(
       chatProvider.select(
         (s) => s.messagesForConversation(parent.conversationId),
@@ -377,11 +374,7 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
               color: isMine ? context.sentBubble : context.recvBubble,
               borderRadius: BorderRadius.circular(10),
             ),
-            // Per #449-2: swap plain Text for RichTextContent so
-            // markdown bold/italic, @mentions, and URL autolinks
-            // render in thread replies the same way they do in the
-            // main chat. Compact mode matches the thread's denser
-            // visual rhythm.
+            // #449-2: RichTextContent so threads render markdown/mentions/links like the main chat.
             child: RichTextContent(
               text: reply.content,
               textColor: context.textPrimary,
@@ -406,12 +399,7 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
         button: true,
         child: GestureDetector(
           onTap: () {
-            // Per #449-1: stop closing the thread on reply. Users were
-            // losing context every time they tapped Reply because the
-            // panel collapsed back to the main chat. Fire the parent
-            // reply handler so the composer goes into reply-to-thread
-            // mode, but keep the thread panel open so the user can
-            // read context while composing.
+            // #449-1: don't close the thread on reply; keep panel open for context.
             widget.onReply?.call(widget.parentMessage);
           },
           child: Container(

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -465,9 +465,26 @@ class _CanvasPainter extends CustomPainter {
 
   const _CanvasPainter({required this.canvas});
 
+  bool _hasEraserStrokes() {
+    for (final s in canvas.strokes) {
+      if (s.kind == StrokeKind.eraser) return true;
+    }
+    if (canvas.activePoints.isNotEmpty &&
+        canvas.selectedTool == CanvasTool.eraser) {
+      return true;
+    }
+    return false;
+  }
+
   @override
   void paint(Canvas c, Size size) {
-    c.saveLayer(Offset.zero & size, Paint());
+    // saveLayer is required for BlendMode.clear (eraser) to carve only
+    // the strokes rather than punching through the underlying canvas.
+    // Skip the layer when there are no eraser strokes — drawing directly
+    // saves a viewport-sized offscreen buffer per paint, which on
+    // CanvasKit/Firefox is one of the heaviest GPU ops.
+    final needsLayer = _hasEraserStrokes();
+    if (needsLayer) c.saveLayer(Offset.zero & size, Paint());
 
     for (final stroke in canvas.strokes) {
       _paintStroke(c, size, stroke);
@@ -486,7 +503,7 @@ class _CanvasPainter extends CustomPainter {
       _paintStroke(c, size, activeStroke);
     }
 
-    c.restore();
+    if (needsLayer) c.restore();
   }
 
   void _paintStroke(Canvas c, Size size, CanvasStroke stroke) {
@@ -541,9 +558,20 @@ class _CanvasPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_CanvasPainter old) =>
-      old.canvas.strokes != canvas.strokes ||
-      old.canvas.activePoints != canvas.activePoints;
+  bool shouldRepaint(_CanvasPainter old) {
+    // Reference equality on the lists isn't enough — the provider may
+    // hand back a fresh List each tick. Compare lengths and the most-
+    // recent stroke id so identical state short-circuits the repaint.
+    if (old.canvas.strokes.length != canvas.strokes.length) return true;
+    if (old.canvas.activePoints.length != canvas.activePoints.length) {
+      return true;
+    }
+    if (canvas.strokes.isNotEmpty &&
+        canvas.strokes.last.id != old.canvas.strokes.last.id) {
+      return true;
+    }
+    return false;
+  }
 }
 
 class _ParticipantInfo {
@@ -615,6 +643,13 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   /// Only ticks while the buffer holds at least one sample.
   late final Ticker _trailTicker;
 
+  /// Tick counter the trail's CustomPainter watches via `repaint:`. Bumping
+  /// this triggers a scoped repaint of just the _TrailPainter — without
+  /// rebuilding the rest of the avatar (video tile, opacity/scale animators,
+  /// etc.) on every Ticker frame. Previously the Ticker called
+  /// `setState({})` 60 Hz per participant, rebuilding the whole subtree.
+  final ValueNotifier<int> _trailTick = ValueNotifier<int>(0);
+
   /// Cached reduce-motion value; refreshed on `didChangeDependencies`
   /// and `didUpdateWidget` so we don't sample inside `MediaQuery.of`
   /// during paint.
@@ -648,6 +683,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   @override
   void dispose() {
     _trailTicker.dispose();
+    _trailTick.dispose();
     _trail.clear();
     super.dispose();
   }
@@ -669,7 +705,10 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
     if (_trail.isEmpty) {
       _trailTicker.stop();
     }
-    if (mounted) setState(() {});
+    // Bump the notifier instead of setState — the CustomPainter listens to
+    // it via `repaint:` so only the trail layer repaints, not the whole
+    // avatar subtree.
+    if (mounted) _trailTick.value = _trailTick.value + 1;
   }
 
   @override
@@ -789,29 +828,30 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   }
 
   Widget _buildAvatarWithTrail(Widget avatar) {
-    final trailSamples = _reduceMotion
-        ? const <RenderedTrailSample>[]
-        : _trail.render(
-            current: _localPos ?? widget.currentPos,
-            canvasSize: widget.canvasSize,
-            now: DateTime.now(),
-          );
+    if (_reduceMotion) return avatar;
 
-    if (trailSamples.isEmpty) {
-      return avatar;
-    }
-
+    // Keep the trail layer mounted whenever the avatar is — its painter
+    // listens to `_trailTick` and returns immediately when the buffer is
+    // empty, so an idle puck pays no per-frame cost beyond shouldRepaint
+    // staying false. This avoids re-mounting the CustomPaint (and the
+    // ensuing layout pass) whenever the trail buffer flips between
+    // empty and non-empty.
     return Stack(
       clipBehavior: Clip.none,
       alignment: Alignment.center,
       children: [
         IgnorePointer(
-          child: CustomPaint(
-            size: const Size(_kAvatarSize, _kAvatarSize),
-            painter: _TrailPainter(
-              samples: trailSamples,
-              color: EchoTheme.online,
-              radius: _kAvatarHalfSize * 0.45,
+          child: RepaintBoundary(
+            child: CustomPaint(
+              size: const Size(_kAvatarSize, _kAvatarSize),
+              painter: _TrailPainter(
+                trail: _trail,
+                currentPos: _localPos ?? widget.currentPos,
+                canvasSize: widget.canvasSize,
+                color: EchoTheme.online,
+                radius: _kAvatarHalfSize * 0.45,
+                tick: _trailTick,
+              ),
             ),
           ),
         ),
@@ -977,26 +1017,37 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
 /// Paints fading ghost circles at past positions of a puck so motion
 /// reads as "presence" rather than a snapping cursor.
 ///
-/// Phase 3a sub-slice 2 of `docs/ux-roadmap.md`.  `samples` is built
-/// fresh each frame by `PuckTrail.render`; the painter just iterates
-/// and draws.  No allocations beyond the per-call `Paint` — and we
-/// reuse a single Paint instance across the loop.
+/// Phase 3a sub-slice 2 of `docs/ux-roadmap.md`. Samples are computed
+/// inside paint() from the live [PuckTrail] so the parent doesn't have
+/// to rebuild on every Ticker frame just to pass a fresh sample list.
+/// Repaint is driven by [repaint] (the per-avatar tick notifier).
 class _TrailPainter extends CustomPainter {
-  final List<RenderedTrailSample> samples;
+  final PuckTrail trail;
+  final CanvasPoint currentPos;
+  final Size canvasSize;
   final Color color;
 
   /// Radius of each ghost circle.  Smaller than the puck itself so
   /// trails read as a wake, not a doppelgänger.
   final double radius;
 
-  const _TrailPainter({
-    required this.samples,
+  _TrailPainter({
+    required this.trail,
+    required this.currentPos,
+    required this.canvasSize,
     required this.color,
     required this.radius,
-  });
+    required Listenable tick,
+  }) : super(repaint: tick);
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (trail.isEmpty) return;
+    final samples = trail.render(
+      current: currentPos,
+      canvasSize: canvasSize,
+      now: DateTime.now(),
+    );
     if (samples.isEmpty) return;
     final center = Offset(size.width / 2, size.height / 2);
     final paint = Paint()..style = PaintingStyle.fill;
@@ -1012,7 +1063,12 @@ class _TrailPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _TrailPainter old) =>
-      !identical(old.samples, samples) ||
+      // The repaint Listenable drives ticks; only structural changes need
+      // shouldRepaint to fire (canvas resize, position handoff).
+      !identical(old.trail, trail) ||
+      old.canvasSize != canvasSize ||
+      old.currentPos.x != currentPos.x ||
+      old.currentPos.y != currentPos.y ||
       old.color != color ||
       old.radius != radius;
 }

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -478,11 +478,7 @@ class _CanvasPainter extends CustomPainter {
 
   @override
   void paint(Canvas c, Size size) {
-    // saveLayer is required for BlendMode.clear (eraser) to carve only
-    // the strokes rather than punching through the underlying canvas.
-    // Skip the layer when there are no eraser strokes — drawing directly
-    // saves a viewport-sized offscreen buffer per paint, which on
-    // CanvasKit/Firefox is one of the heaviest GPU ops.
+    // saveLayer needed only for eraser BlendMode.clear; skip otherwise — offscreen buffer is heavy on CanvasKit.
     final needsLayer = _hasEraserStrokes();
     if (needsLayer) c.saveLayer(Offset.zero & size, Paint());
 
@@ -559,9 +555,7 @@ class _CanvasPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_CanvasPainter old) {
-    // Reference equality on the lists isn't enough — the provider may
-    // hand back a fresh List each tick. Compare lengths and the most-
-    // recent stroke id so identical state short-circuits the repaint.
+    // Provider may hand back fresh List each tick; compare lengths + last stroke id.
     if (old.canvas.strokes.length != canvas.strokes.length) return true;
     if (old.canvas.activePoints.length != canvas.activePoints.length) {
       return true;
@@ -705,9 +699,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
     if (_trail.isEmpty) {
       _trailTicker.stop();
     }
-    // Bump the notifier instead of setState — the CustomPainter listens to
-    // it via `repaint:` so only the trail layer repaints, not the whole
-    // avatar subtree.
+    // Bump notifier (CustomPainter `repaint:`) so only the trail layer repaints, not the avatar subtree.
     if (mounted) _trailTick.value = _trailTick.value + 1;
   }
 
@@ -830,12 +822,7 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   Widget _buildAvatarWithTrail(Widget avatar) {
     if (_reduceMotion) return avatar;
 
-    // Keep the trail layer mounted whenever the avatar is — its painter
-    // listens to `_trailTick` and returns immediately when the buffer is
-    // empty, so an idle puck pays no per-frame cost beyond shouldRepaint
-    // staying false. This avoids re-mounting the CustomPaint (and the
-    // ensuing layout pass) whenever the trail buffer flips between
-    // empty and non-empty.
+    // Keep trail layer mounted (idle painter returns early) to avoid CustomPaint remount when buffer flips empty/non-empty.
     return Stack(
       clipBehavior: Clip.none,
       alignment: Alignment.center,

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -458,11 +458,7 @@ class VoiceDock extends ConsumerWidget {
       tooltip: 'Leave',
       iconSize: m.btnIconSize,
       onPressed: () async {
-        // Call the shared helper instead of bare setScreenShareEnabled(false)
-        // so that Linux portal cleanup (removePublishedTrack + track.stop +
-        // track.dispose) runs before disconnect. Guard with the sharing flag
-        // so toggleScreenShare only takes the stop-sharing branch, never the
-        // start-sharing branch.
+        // Use shared helper for Linux portal cleanup before disconnect; guard so toggleScreenShare only stops.
         if (screenShare.isScreenSharing) {
           await toggleScreenShare(context, ref);
         }

--- a/apps/client/lib/src/widgets/voice_speaking_ring.dart
+++ b/apps/client/lib/src/widgets/voice_speaking_ring.dart
@@ -85,9 +85,7 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
       ..addStatusListener(_onPulseStatus);
     _waves = AnimationController(
       vsync: this,
-      // Full expansion cycle = one tight-ring pulse half-cycle, so a
-      // wave is born ~every 700ms by default.  Two staggered rings at
-      // half-cycle offset give a continuous radar feel.
+      // Half-cycle stagger between two rings = continuous radar feel.
       duration: widget.pulseDuration,
     );
 
@@ -131,10 +129,7 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
   void didUpdateWidget(VoiceSpeakingRing oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.pulseDuration != oldWidget.pulseDuration) {
-      // Keep the controllers in sync if the parent retunes the pulse.
-      // AnimationController.duration is a setter that takes effect on
-      // the next tick, so an in-flight animation continues to its
-      // current end state at the new rate.
+      // Duration setter applies on next tick; in-flight anim finishes its current cycle.
       _pulse.duration = widget.pulseDuration;
       _waves.duration = widget.pulseDuration;
     }
@@ -167,11 +162,7 @@ class VoiceSpeakingRingState extends State<VoiceSpeakingRing>
       );
     }
 
-    // Tight ring oscillates between a floor and the level peak each
-    // pulse cycle.  When the speaker is loud, the floor is 0.55; when
-    // they are quiet (level < 0.55), we collapse the floor to the
-    // level itself so the pulse never *exceeds* the audio-derived
-    // peak (which would make quiet speakers misleadingly opaque).
+    // Collapse floor to level when quiet so pulse never exceeds the audio peak.
     final pulseFloor = math.min(0.55, levelOpacity);
     return AnimatedBuilder(
       animation: Listenable.merge([_pulse, _waves]),
@@ -254,9 +245,7 @@ class _AudioRadiusPainter extends CustomPainter {
     // Tight ring sits on the child's outer edge; expansion starts there.
     final innerRadius = math.min(size.width, size.height) / 2;
 
-    // Single Paint reused across both waves — only `color` changes
-    // between calls.  The doc-comment promise of "no per-frame
-    // allocations" depends on this.
+    // Reuse one Paint across both waves to honour the no-per-frame-allocs guarantee.
     final paint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = stroke * 0.65;

--- a/apps/client/lib/src/widgets/whats_new_modal.dart
+++ b/apps/client/lib/src/widgets/whats_new_modal.dart
@@ -245,10 +245,7 @@ class WhatsNewInlineOverlay extends ConsumerWidget {
             // the dim layer above.
             behavior: HitTestBehavior.opaque,
             onTap: () {},
-            // The modal's own button handlers call markShown(); this
-            // callback only needs to clear the overlay state. Calling
-            // markShown twice doesn't corrupt anything (idempotent
-            // SharedPreferences write), but signals broken ownership.
+            // Modal buttons call markShown(); this callback only clears overlay state.
             child: WhatsNewModal(
               notes: notes,
               isDialog: true,

--- a/apps/client/lib/src/widgets/window_chrome.dart
+++ b/apps/client/lib/src/widgets/window_chrome.dart
@@ -141,10 +141,7 @@ class AppTitleBar extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    // Clamp the OS text scaler inside the 36-px title bar. At 1.5x system
-    // scaling the title would overflow the fixed-height bar and clip into the
-    // window controls; clamping to 1.2x keeps a11y while preserving the
-    // chrome's geometry. Buttons are icon-only so they're unaffected.
+    // Clamp text scale to 1.2x — 1.5x overflows the 36px title bar into the window controls.
     return MediaQuery.withClampedTextScaling(
       maxScaleFactor: 1.2,
       child: Container(
@@ -157,9 +154,7 @@ class AppTitleBar extends StatelessWidget {
           children: [
             // Full-width drag area underneath everything.
             const Positioned.fill(child: AppDragArea(child: SizedBox.expand())),
-            // Centered name — IgnorePointer so clicks fall through to drag
-            // area. Reserve room on macOS so the title can't slide under the
-            // red/yellow/green traffic-light cluster anchored to the left.
+            // IgnorePointer so clicks fall through to drag; macOS padding avoids the traffic-light cluster.
             if (title != null && title!.isNotEmpty)
               Padding(
                 padding: EdgeInsets.only(left: Platform.isMacOS ? 72.0 : 0.0),

--- a/apps/client/test/widgets/conversation_panel_test.dart
+++ b/apps/client/test/widgets/conversation_panel_test.dart
@@ -316,18 +316,46 @@ void main() {
       },
     );
 
-    testWidgets('empty state shows message when no conversations', (
-      tester,
-    ) async {
-      await tester.pumpApp(
-        ConversationPanel(onConversationTap: (_) {}),
-        overrides: standardOverrides(conversations: []),
-      );
-      await tester.pump();
+    testWidgets(
+      'empty state shows message when no conversations (mobile only)',
+      (tester) async {
+        // Mobile viewport keeps the sidebar empty-state guidance — the
+        // main pane is hidden on narrow layouts so the sidebar is the
+        // only place to show the affordance.
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
 
-      // With no conversations, the empty state shows "No conversations yet"
-      expect(find.text('No conversations yet'), findsOneWidget);
-    });
+        await tester.pumpApp(
+          ConversationPanel(onConversationTap: (_) {}),
+          overrides: standardOverrides(conversations: []),
+        );
+        await tester.pump();
+
+        expect(find.text('No conversations yet'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'empty state is suppressed on wide layouts (main pane carries it)',
+      (tester) async {
+        // Wide viewport — the main pane's "No conversation selected"
+        // panel already carries Add-contact / Browse-groups CTAs, so the
+        // sidebar leaves the column blank instead of duplicating the
+        // guidance side-by-side with the main pane.
+        tester.view.physicalSize = const Size(1280, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpApp(
+          ConversationPanel(onConversationTap: (_) {}),
+          overrides: standardOverrides(conversations: []),
+        );
+        await tester.pump();
+
+        expect(find.text('No conversations yet'), findsNothing);
+      },
+    );
 
     testWidgets('header renders without a duplicate connection dot', (
       tester,

--- a/apps/client/test/widgets/create_group_screen_test.dart
+++ b/apps/client/test/widgets/create_group_screen_test.dart
@@ -112,7 +112,9 @@ void main() {
       expect(find.text('My Test Group'), findsOneWidget);
     });
 
-    testWidgets('has private/public visibility toggle', (tester) async {
+    testWidgets('has Private-group switch styled like the E2E toggle', (
+      tester,
+    ) async {
       final router = _buildRouter();
 
       await tester.pumpWidget(
@@ -128,8 +130,12 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Private'), findsOneWidget);
-      expect(find.text('Public'), findsOneWidget);
+      // The Private/Public segmented button was replaced with a Private-
+      // group SwitchListTile so it reads consistently with the E2E
+      // toggle directly below it.
+      expect(find.text('Private group'), findsOneWidget);
+      // Default is "private" (ON) → subtitle reflects that.
+      expect(find.textContaining('only invited members'), findsOneWidget);
     });
   });
 }

--- a/apps/client/test/widgets/settings/advanced_theme_section_test.dart
+++ b/apps/client/test/widgets/settings/advanced_theme_section_test.dart
@@ -38,12 +38,11 @@ void main() {
   });
 
   group('AdvancedThemeInline', () {
-    testWidgets('renders primary and accent color tiles', (tester) async {
+    testWidgets('renders accent colour tile', (tester) async {
       await tester.pumpWidget(_wrap(const AdvancedThemeInline()));
       await tester.pump();
 
-      expect(find.text('Primary color'), findsOneWidget);
-      expect(find.text('Accent color'), findsOneWidget);
+      expect(find.text('Accent colour'), findsOneWidget);
     });
 
     testWidgets('does not show reset button when no overrides', (tester) async {
@@ -53,14 +52,14 @@ void main() {
       expect(find.text('Reset to theme defaults'), findsNothing);
     });
 
-    testWidgets('shows reset button when primary override is set', (
+    testWidgets('shows reset button when accent override is set', (
       tester,
     ) async {
       await tester.pumpWidget(
         _wrap(
           const AdvancedThemeInline(),
           initialColors: const CustomColorsState(
-            primaryColor: Color(0xFFFF0000),
+            accentColor: Color(0xFFFF0000),
           ),
         ),
       );
@@ -90,11 +89,7 @@ void main() {
       await tester.pump();
 
       expect(
-        find.bySemanticsLabel(RegExp('Primary color picker')),
-        findsOneWidget,
-      );
-      expect(
-        find.bySemanticsLabel(RegExp('Accent color picker')),
+        find.bySemanticsLabel(RegExp('Accent colour picker')),
         findsOneWidget,
       );
       semantics.dispose();

--- a/apps/client/test/widgets/settings_screen_test.dart
+++ b/apps/client/test/widgets/settings_screen_test.dart
@@ -102,7 +102,8 @@ void main() {
 
       // Profile is reached via the UserHeaderCard at the top, not a row.
       // Encryption keys is gone (was redundant with Privacy).
-      expect(find.text('Status'), findsOneWidget);
+      // Status was removed from the sidebar in batch 3.
+      expect(find.text('Status'), findsNothing);
       expect(find.text('Appearance'), findsOneWidget);
       expect(find.text('Language'), findsOneWidget);
       expect(find.text('Notifications'), findsOneWidget);

--- a/apps/server/src/auth/jwt.rs
+++ b/apps/server/src/auth/jwt.rs
@@ -138,14 +138,10 @@ mod tests {
 
     #[test]
     fn test_expired_token_is_rejected() {
-        // Mint a token whose exp is in the past and confirm validate_token
-        // rejects it.  Guards against regressions that disable expiry checks
-        // (e.g. flipping `validation.validate_exp` off).
+        // Guards against regressions that disable validate_exp.
         let user_id = Uuid::new_v4();
         let now = chrono::Utc::now().timestamp() as usize;
-        // jsonwebtoken's Validation::default() has a 60-second clock-skew
-        // leeway, so the expiry must be more than 60s in the past for the
-        // assertion to be meaningful.
+        // Default 60s clock-skew leeway — push exp >60s past for a real test.
         let expired = Claims {
             sub: user_id.to_string(),
             exp: now - 3600,

--- a/apps/server/src/auth/middleware.rs
+++ b/apps/server/src/auth/middleware.rs
@@ -37,10 +37,7 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
         let user_id = Uuid::parse_str(&claims.sub)
             .map_err(|_| AppError::unauthorized("Invalid user ID in token"))?;
 
-        // CR-4: reject tokens whose `iat` predates the user's last
-        // revocation event (device revoke, password change, "log out
-        // everywhere"). Closes the 15-minute access-token window where a
-        // revoked credential continued to authorize every REST call.
+        // CR-4: reject access tokens minted before the last revocation event.
         if !state
             .token_invalidator
             .is_token_valid(user_id, claims.iat as i64)
@@ -51,10 +48,7 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
             ));
         }
 
-        // Light up the `user_id` slot reserved by the per-request tracing
-        // span (see `routes::create_router`). The TraceLayer span is opened
-        // before handler extractors run, so this is the only point at which
-        // we know which user (if any) the request belongs to (#1173).
+        // #1173: only point we know `user_id` for the request's tracing span.
         tracing::Span::current().record("user_id", tracing::field::display(user_id));
 
         Ok(AuthUser { user_id })

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -34,9 +34,7 @@ impl Config {
                 if trimmed.is_empty() {
                     return None;
                 }
-                // Accept bare IPs (e.g. `127.0.0.1`) by normalising them to
-                // host routes (`/32` for IPv4, `/128` for IPv6) so the storage
-                // type is always `IpNet`.
+                // Normalise bare IPs to /32 or /128 host routes.
                 trimmed
                     .parse::<IpNet>()
                     .ok()
@@ -203,11 +201,8 @@ mod tests {
         assert_eq!(proxies.len(), 2);
     }
 
-    // -----------------------------------------------------------------
-    // SERVER_HOST/SERVER_PORT precedence + legacy HOST/PORT fallback.
-    // Closure-based fake env keeps these tests parallel-safe -- no
-    // std::env::set_var, which would race against the other test threads.
-    // -----------------------------------------------------------------
+    // SERVER_HOST/PORT precedence + legacy fallback.
+    // Closure fake-env keeps tests parallel-safe (no set_var races).
     use std::collections::HashMap;
 
     fn fake_env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
@@ -262,9 +257,7 @@ mod tests {
 
     #[test]
     fn resolve_port_legacy_unparseable_falls_through_to_default() {
-        // Belt-and-suspenders branch coverage: same parse logic on the legacy
-        // arm should also default rather than panic if a future refactor
-        // diverges the two paths.
+        // Branch coverage for the legacy arm's parse defaulting.
         let port = resolve_port(fake_env(&[("PORT", "garbage")]));
         assert_eq!(port, 8080);
     }

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -59,11 +59,8 @@ pub async fn create_group_with_visibility(
 ) -> Result<GroupInfo, sqlx::Error> {
     let mut tx = pool.begin().await?;
 
-    // E2E encryption is an explicit opt-in (see CreateGroupRequest).
-    // The Phase 5 (audit OQ-3) default-on stance was rolled back when
-    // groups created with the GRP1 envelope path wedged under
-    // identity-key drift; the client now passes is_encrypted=true only
-    // when the creator explicitly chose the experimental toggle.
+    // OQ-3: E2E is opt-in only (default-on was rolled back due to GRP1 wedge
+    // under identity-key drift).
     let group: GroupInfo = sqlx::query_as(
         "INSERT INTO conversations (kind, title, is_public, description, is_encrypted) \
          VALUES ('group', $1, $2, $3, $4) \
@@ -111,12 +108,8 @@ pub async fn create_group_with_visibility(
         .execute(&mut *tx)
         .await?;
 
-    // Seed the default text + voice channels in the same transaction.
-    // Before TD-3, channel inserts ran AFTER tx.commit(); a partial
-    // failure (e.g. voice channel insert errors) left the group rows
-    // committed but with a missing channel, surfacing to the client as
-    // a 500 with no way to recover. Folding them in means the entire
-    // group either exists with both channels or doesn't exist at all.
+    // TD-3: seed default channels in the same tx so a partial failure
+    // doesn't leave a group with no channels.
     sqlx::query(
         "INSERT INTO channels (conversation_id, name, kind, topic, position, category) \
          VALUES ($1, 'general', 'text', NULL, 0, 'Text Channels')",
@@ -839,11 +832,8 @@ pub async fn bump_key_version_and_purge_envelopes(
         .execute(&mut *tx)
         .await?;
 
-    // We intentionally leave rows in `group_keys` alone — they only carry the
-    // sentinel "__envelope__" placeholder and the version number, which lets
-    // existing duplicate-version protection (UNIQUE(conversation_id,
-    // key_version)) continue to work for the next rotation upload. Old
-    // envelopes carry the actual ciphertext and are gone.
+    // Leave sentinel `group_keys` rows in place so UNIQUE(conv_id, key_version)
+    // still gates the next rotation upload.
 
     tx.commit().await?;
     Ok(row.0)
@@ -974,9 +964,8 @@ pub async fn accept_invite_token(
 ) -> Result<AcceptInviteOutcome, sqlx::Error> {
     let mut tx = pool.begin().await?;
 
-    // Lock the token row for update so concurrent accepts are serialised.
-    // #829: fetch expires_at / max_uses / use_count under the same lock so
-    // the post-pre-tx-check window cannot be exploited.
+    // #829: FOR UPDATE + lock-scoped re-read closes the TOCTOU window between
+    // the route's pre-tx check and use_count++.
     let row: (Uuid, Option<DateTime<Utc>>, Option<i32>, i32) = sqlx::query_as(
         "SELECT conversation_id, expires_at, max_uses, use_count \
          FROM group_invite_tokens WHERE token = $1 FOR UPDATE",
@@ -986,10 +975,7 @@ pub async fn accept_invite_token(
     .await?;
     let (conversation_id, expires_at, max_uses, use_count) = row;
 
-    // Re-validate under the lock (#829).  Bail out before mutating membership
-    // or incrementing use_count so concurrent accepts cannot over-consume a
-    // max-uses=N token.  The caller maps these outcomes to the same error
-    // shape the pre-tx checks already use.
+    // #829: bail before any mutation so a max-uses=N token can't over-consume.
     if expires_at.is_some_and(|exp| Utc::now() > exp) {
         // Read-only tx; rollback is implicit on drop, but be explicit.
         let _ = tx.rollback().await;

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -92,14 +92,8 @@ pub async fn find_or_create_dm_conversation(
         return Ok(row.0);
     }
 
-    // Slow path: create the conversation and claim the canonical slot.
-    // Acquire a transaction-scoped advisory lock keyed on the canonical
-    // (lo, hi) pair so concurrent creators for the same user pair serialize
-    // here rather than contending at the UNIQUE constraint level.  We
-    // concatenate the lexicographically smaller UUID first so both argument
-    // orderings hash to the same i64.  `pg_advisory_xact_lock` (not the
-    // `try_` variant) blocks until the lock is available and releases
-    // automatically when the transaction ends.
+    // Slow path: transaction-scoped advisory lock on the canonical (lo, hi)
+    // pair so concurrent creators serialize here, not at the UNIQUE constraint.
     let mut tx = pool.begin().await?;
 
     sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1::text || $2::text))")
@@ -145,10 +139,8 @@ pub async fn find_or_create_dm_conversation(
         .execute(&mut *tx)
         .await?;
 
-    // Atomically claim the (lo, hi) slot.  If another concurrent request
-    // already committed a row for this pair, the DO UPDATE is a no-op that
-    // returns the *existing* conversation_id, letting us discard the one we
-    // just created by rolling back.
+    // Atomically claim the (lo, hi) slot; on race the DO UPDATE returns the
+    // existing conversation_id and we roll back our orphan rows below.
     let winner: (Uuid,) = sqlx::query_as(
         "INSERT INTO direct_conversations (user_lo, user_hi, conversation_id) \
          VALUES ($1, $2, $3) \
@@ -191,10 +183,8 @@ pub async fn store_message(
     content: &str,
     reply_to_id: Option<Uuid>,
     ttl_seconds: Option<i64>,
-    // GRP2 senders mint a UUID client-side and bind it into their
-    // signature payload (audit OQ-12). When supplied the server uses
-    // it verbatim; otherwise the column default (`gen_random_uuid`)
-    // assigns one. v4 collisions surface as a unique-constraint error.
+    // GRP2 senders bind a client-minted UUID into their signature payload
+    // (audit OQ-12); when None the column default assigns one.
     client_message_id: Option<Uuid>,
 ) -> Result<MessageRow, sqlx::Error> {
     let expires_at: Option<DateTime<Utc>> =
@@ -236,11 +226,7 @@ pub async fn get_messages(
     requesting_user_id: Uuid,
     requesting_device_id: Option<i32>,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
-    // Single query handles both cursor and non-cursor cases via optional $3 param.
-    // When device_id is supplied, COALESCE per-device ciphertext over the
-    // canonical content. reply_count is computed via a single aggregating
-    // subquery joined once (O(N+M)) instead of a LATERAL correlated subquery
-    // that re-executes per row (O(N*M)).
+    // reply_count joined once (O(N+M)) instead of LATERAL (O(N*M)).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -328,32 +314,10 @@ pub async fn get_undelivered(
         Some((ts, id)) => (Some(ts), Some(id)),
         None => (None, None),
     };
-    // reply_count is computed via a single aggregating subquery joined once
-    // (O(N+M)) rather than a LATERAL correlated subquery that re-executes for
-    // every returned row (O(N*M)).
-    //
-    // #829: this query MUST NOT filter on `m.delivered = false`. The global
-    // `delivered` flag is flipped on first-device delivery (see
-    // `send_delivery_confirmation`), so a sibling device coming online later
-    // would never receive a replay. The per-device `message_deliveries`
-    // ledger is the correct gate -- the fanout path is responsible for
-    // populating it for online deliveries.
-    //
-    // System messages (sentinel-prefixed; e.g. `__system__:member_joined:...`)
-    // are best-effort UI pills broadcast at the moment of the event via
-    // `broadcast_json`; they intentionally do not flow through the ledger or
-    // mark_delivered path. We exclude them from replay so a member who was
-    // offline when a join/leave happened does NOT get a stale pill on
-    // reconnect, while real chat traffic still replays through the ledger.
-    //
-    // The NOT EXISTS guard filters messages that were already pushed to THIS
-    // device (either successfully decryptable or as an undecryptable marker).
-    // Without it a device that can't decrypt a frame would receive the same
-    // placeholder on every reconnect.
-    // reply_count is scoped to the specific message IDs being returned rather
-    // than a full-table GROUP BY.  The CTE `batch` captures the IDs first;
-    // the reply_count subquery filters `WHERE reply_to_id = ANY(SELECT id FROM batch)`
-    // which is O(batch_size) instead of O(total messages).
+    // #829: gate on the per-device `message_deliveries` ledger, NOT the global
+    // `m.delivered` flag — that flips on first-device delivery and would starve
+    // sibling devices. System messages (`__system__:` prefix) are excluded so
+    // offline members don't get stale join/leave pills on reconnect.
     sqlx::query_as::<_, MessageWithSender>(
         "WITH batch AS ( \
              SELECT m.id \
@@ -631,12 +595,9 @@ pub async fn search_messages(
     query: &str,
     limit: i64,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
-    // reply_count is computed via a single aggregating subquery joined once
-    // (O(N+M)) rather than the prior LATERAL correlated subquery that
-    // re-executed per row (O(N*M)). The partial index on
+    // reply_count joined once (O(N+M)); backed by the partial index on
     // `(reply_to_id) WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL`
-    // (added in an earlier migration) backs the GROUP BY scan (#834
-    // finding 8).
+    // (#834 finding 8).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \
@@ -1007,12 +968,9 @@ pub async fn get_thread_replies(
     before: Option<chrono::DateTime<chrono::Utc>>,
     limit: i64,
 ) -> Result<Vec<MessageWithSender>, sqlx::Error> {
-    // reply_count is computed via a single aggregating subquery joined once
-    // (O(N+M)) rather than the prior LATERAL correlated subquery that
-    // re-executed per row (O(N*M)). The partial index on
+    // reply_count joined once (O(N+M)); backed by the partial index on
     // `(reply_to_id) WHERE reply_to_id IS NOT NULL AND deleted_at IS NULL`
-    // (added in an earlier migration) backs the GROUP BY scan (#834
-    // finding 8).
+    // (#834 finding 8).
     sqlx::query_as::<_, MessageWithSender>(
         "SELECT m.id, m.conversation_id, m.channel_id, m.sender_id, \
                 m.sender_device_id, \

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -35,10 +35,7 @@ pub async fn create_pool(database_url: &str) -> PgPool {
     const MAX_RETRIES: u32 = 5;
     let mut delay_secs = 1u64;
 
-    // TD-56: keep a small warm pool so the first request after a long
-    // idle stretch doesn't pay 50–200 ms of TCP+TLS+startup latency. The
-    // 15 s acquire timeout (up from 5 s) gives heavy bursts room to drain
-    // without surfacing pool exhaustion as 500s on the readyz probe.
+    // TD-56: warm pool + 15s acquire so idle-recovery + bursts don't 500.
     let min_conns: u32 = std::env::var("DB_MIN_CONNECTIONS")
         .ok()
         .and_then(|s| s.parse().ok())

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -40,28 +40,12 @@ pub async fn create_user(
     username: &str,
     password_hash: &str,
 ) -> Result<CreatedUser, sqlx::Error> {
-    // TD-44: first-user bootstrap — by default the first registration on an
-    // empty users table is promoted to admin (the original behaviour, kept
-    // so a fresh self-host install can get its operator in two HTTP calls).
-    //
-    // Self-hosters who plan to open registration up to other users BEFORE
-    // promoting themselves should set `ECHO_BOOTSTRAP_ADMIN_USERNAME` to
-    // their intended operator name; that locks first-user promotion to a
-    // single specific username and prevents the "first random signup
-    // becomes a permanent admin" race that the audit flagged. When the env
-    // var is set and the registration does not match, the row is created
-    // as a regular user even if it would otherwise satisfy the empty-table
-    // condition.
-    //
-    // The original race-safety property (a single statement so only one
-    // concurrent INSERT can see the table empty) is preserved: the env-var
-    // match is evaluated client-side as `$3` and the snapshot inside the
-    // statement still picks at most one winner.
+    // TD-44: first-user bootstrap. By default any first signup is promoted;
+    // setting `ECHO_BOOTSTRAP_ADMIN_USERNAME` pins promotion to that exact
+    // username. Single-statement INSERT preserves race-safety either way.
     let bootstrap_username = std::env::var("ECHO_BOOTSTRAP_ADMIN_USERNAME").ok();
     let matches_bootstrap = match bootstrap_username.as_deref() {
-        // When the env var is unset, retain legacy behaviour: any first
-        // signup is promoted. When it is set, only the exact-match
-        // username may be promoted.
+        // Unset → any first signup; set → exact-match only.
         None => true,
         Some(expected) => expected == username,
     };
@@ -298,9 +282,7 @@ pub async fn update_profile(
     user_id: Uuid,
     fields: &ProfileUpdate<'_>,
 ) -> Result<UserProfileRow, sqlx::Error> {
-    // NULL = field not in request (keep existing value).
-    // Empty string = user cleared the field (set to NULL in DB).
-    // Non-empty string = user set a value (store it).
+    // Tri-state: NULL = keep, empty = clear (DB NULL), non-empty = set.
     sqlx::query_as::<_, UserProfileRow>(
         "UPDATE users SET \
          display_name = CASE WHEN $2 IS NULL THEN display_name ELSE NULLIF($2, '') END, \

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -168,9 +168,7 @@ impl AppError {
             | ErrorCode::InvalidCredentials
             | ErrorCode::TokenExpired
             | ErrorCode::TokenRevoked => StatusCode::UNAUTHORIZED,
-            // TD-34: "not a member of this conversation" is a permission
-            // failure, not an authentication failure. Returning 401 made
-            // clients trigger a global re-auth/logout. 403 is correct.
+            // TD-34: NotMember is 403, not 401 — avoids forced re-auth/logout.
             ErrorCode::Forbidden | ErrorCode::RegistrationDisabled | ErrorCode::NotMember => {
                 StatusCode::FORBIDDEN
             }
@@ -222,12 +220,8 @@ impl IntoResponse for AppError {
 
 impl From<sqlx::Error> for AppError {
     fn from(err: sqlx::Error) -> Self {
-        // TD-71: log structured fields instead of the raw Debug formatting.
-        // The Debug repr of a Postgres error can echo back column *values*
-        // from constraint violations (the unique-key column data, the
-        // failing FK row, etc.). That's a PII leak waiting to happen.
-        // Logging the SQLSTATE + constraint name keeps the operator
-        // diagnostic signal intact.
+        // TD-71: Debug-format Postgres errors can echo column VALUES — log
+        // structured fields (SQLSTATE + constraint) instead.
         match &err {
             sqlx::Error::Database(db_err) => {
                 tracing::error!(
@@ -424,9 +418,7 @@ mod tests {
 
     #[test]
     fn with_code_not_member_is_403() {
-        // TD-34: "not a member" is a permission failure, not an
-        // authentication failure. Returning 401 made clients trigger global
-        // re-auth/logout when they hit a stale conversation.
+        // TD-34: NotMember is 403, not 401.
         let err = AppError::with_code(ErrorCode::NotMember, "Not a member");
         assert_eq!(err.status, StatusCode::FORBIDDEN);
         assert_eq!(err.code, ErrorCode::NotMember);

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -41,10 +41,7 @@ async fn main() {
         token_invalidator: echo_server::auth::TokenInvalidator::new(),
     });
 
-    // TD-37: cooperative shutdown token. Every periodic task takes a clone
-    // and exits on `cancelled()`; the main task awaits all handles in the
-    // shutdown path so DELETE/UPDATE batches finish cleanly instead of being
-    // torn at an arbitrary instruction by tokio runtime drop.
+    // TD-37: cooperative shutdown so DELETE/UPDATE batches finish cleanly.
     let shutdown_token = tokio_util::sync::CancellationToken::new();
     let mut periodic_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
@@ -180,13 +177,8 @@ async fn main() {
         .await
         .expect("Failed to bind");
 
-    // Graceful shutdown via Ctrl+C — TD-37.
-    //
-    // Two-stage drain: (1) cancel the background-task token so periodic
-    // loops finish their current batch and exit; (2) let axum complete
-    // in-flight HTTP/WS responses via `with_graceful_shutdown`. After axum
-    // returns we await every periodic handle so the process only exits
-    // once each cleanup task is fully resolved.
+    // TD-37: two-stage drain — cancel periodics, then axum graceful shutdown,
+    // then await every periodic handle before exit.
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     {
         let shutdown_token = shutdown_token.clone();
@@ -208,9 +200,7 @@ async fn main() {
     .await
     .expect("Server error");
 
-    // axum has stopped accepting new requests and drained in-flight ones;
-    // also ensure the background cleanup loops are fully wound down before
-    // the process exits.
+    // Wind down background loops too before exit.
     shutdown_token.cancel();
     for handle in periodic_handles {
         if let Err(e) = handle.await {
@@ -252,9 +242,7 @@ where
                 _ = interval.tick() => {}
             }
 
-            // Inside the tick, also race the work future against shutdown so
-            // we don't begin a fresh DELETE/UPDATE batch when the operator is
-            // already trying to bring the server down.
+            // Race against shutdown so we don't start a fresh batch mid-drain.
             let fut = make_fut();
             let work = std::panic::AssertUnwindSafe(Box::pin(fut)).catch_unwind();
             let result = tokio::select! {

--- a/apps/server/src/metrics.rs
+++ b/apps/server/src/metrics.rs
@@ -83,9 +83,7 @@ impl MessageRateCounter {
         let now = Instant::now();
         let mut history = self.history.lock().expect("metrics mutex poisoned");
 
-        // Roll the in-progress bucket out whenever a full second has
-        // elapsed.  We always pull the AtomicU64 to zero (swap) so two
-        // back-to-back `per_second` calls can't double-count.
+        // swap-to-zero so back-to-back per_second calls can't double-count.
         if now.duration_since(history.current_started) >= Duration::from_secs(1) {
             let count = self.current_bucket.swap(0, Ordering::Relaxed);
             let started = history.current_started;

--- a/apps/server/src/middleware/rate_limit.rs
+++ b/apps/server/src/middleware/rate_limit.rs
@@ -192,9 +192,7 @@ fn extract_ip(req: &Request<Body>, trusted_proxies: &[IpNet]) -> IpAddr {
         return ip;
     }
 
-    // Fallback to X-Forwarded-For -- use the LAST IP (appended by our proxy),
-    // not the first (attacker-controlled).  Reject private/loopback IPs to
-    // prevent spoofing bypass.
+    // X-Forwarded-For: use LAST IP (proxy-appended); first is attacker-set.
     if let Some(xff) = req.headers().get("x-forwarded-for")
         && let Ok(value) = xff.to_str()
         && let Some(last_ip) = value.rsplit(',').next()
@@ -435,9 +433,7 @@ mod tests {
 
     #[test]
     fn test_is_private_ipv4_mapped_ipv6() {
-        // TD-32: ::ffff:10.0.0.1 must be treated as the private v4 10.0.0.1.
-        // Without unwrapping, a trusted proxy passing the mapped form would
-        // let an attacker pick the rate-limit bucket key.
+        // TD-32: mapped form must unwrap or attacker picks the bucket key.
         let mapped_private = IpAddr::V6(Ipv4Addr::new(10, 0, 0, 1).to_ipv6_mapped());
         assert!(
             is_private(mapped_private),
@@ -655,10 +651,7 @@ mod tests {
         // sweep interval so no sweep fires during this test.
         let limiter = RateLimiter::new(100, 3600);
 
-        // Pre-fill 1000 distinct IPs with expired buckets (window_start = epoch,
-        // which is far in the past relative to any real Instant).  We can't
-        // directly set window_start to an "ancient" Instant from outside, so we
-        // insert at address-space level via the DashMap.
+        // Pre-fill 1000 expired buckets via the DashMap directly (epoch Instant).
         let ancient = limiter.sweep.epoch; // epoch itself: 0 nanos since epoch
         for i in 0u32..1000 {
             let ip = IpAddr::V4(std::net::Ipv4Addr::from(0x0A00_0001 + i));
@@ -671,9 +664,7 @@ mod tests {
             );
         }
 
-        // The sweep timer starts at 0 (never swept).  SWEEP_INTERVAL_SECS is 60 s.
-        // Set last_sweep_nanos to "right now" so the 60-second interval has NOT
-        // elapsed -- no sweep will be triggered during check().
+        // Force "just swept" so the 60s gate prevents sweep during check().
         let now_nanos = Instant::now()
             .duration_since(limiter.sweep.epoch)
             .as_nanos() as u64;
@@ -687,10 +678,7 @@ mod tests {
         let allowed = limiter.check(fresh_ip);
 
         assert!(allowed, "fresh IP should be allowed");
-        // Stale entries still present -- sweep did NOT run on this hot path.
-        // Deterministic check; the wall-clock perf claim is covered by the
-        // sweep-gate logic itself (verified by the entries.len() == 1001
-        // invariant, which only holds if retain() was never called).
+        // entries.len() == 1001 confirms retain() was not called on hot path.
         assert_eq!(
             limiter.entries.len(),
             1001, // 1000 pre-filled + 1 for fresh_ip

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -153,10 +153,7 @@ pub async fn notify_offline_users(
         return;
     }
 
-    // Drop recipients who muted this conversation so they don't get an APNs
-    // alert for messages they would not be notified about locally either.
-    // Fail open on database errors -- it is better to over-notify than to
-    // silently drop legitimate notifications.
+    // Fail open: over-notify beats silently dropping legitimate alerts.
     let unmuted =
         match db::messages::get_unmuted_user_ids(pool, conversation_id, offline_user_ids).await {
             Ok(u) => u,
@@ -181,11 +178,8 @@ pub async fn notify_offline_users(
         return;
     }
 
-    // TD-58: fan out APNs pushes concurrently with a bounded semaphore so a
-    // 50-recipient group doesn't serialise N×50–200 ms HTTP RTTs in one
-    // tokio task. APNs HTTP/2 connections support multiple streams so 16
-    // concurrent sends per call is well within their per-connection budget
-    // and keeps the latency under ~1 s for typical group sizes.
+    // TD-58: bounded-concurrency fanout (16) so big groups don't serialise
+    // N×100ms HTTP RTTs; APNs HTTP/2 multiplexes streams comfortably.
     use futures_util::stream::StreamExt;
     let pool = pool.clone();
     const PUSH_FANOUT_CONCURRENCY: usize = 16;
@@ -384,9 +378,7 @@ mod tests {
 
     #[test]
     fn multibyte_boundary_mid_char_no_panic() {
-        // "e\u{0301}" = 'e' (1 byte) + combining acute U+0301 (2 bytes) = 3 bytes per unit.
-        // 47 units = 141 bytes (> 140). Byte 140 is 0x81, the continuation byte of the
-        // 47th combining accent. floor_char_boundary(140) = 139, the start of that accent.
+        // 47 × "e\u{0301}" = 141 bytes; truncating at 140 must back off to 139.
         let accent = "e\u{0301}".repeat(47); // 141 bytes
         assert_eq!(accent.len(), 141);
         let body = format_push_body(&accent, false);

--- a/apps/server/src/routes/admin.rs
+++ b/apps/server/src/routes/admin.rs
@@ -56,11 +56,7 @@ impl FromRequestParts<Arc<AppState>> for AdminUser {
             return Err(AppError::forbidden("Admin access required").into_response());
         }
 
-        // Re-auth window: the same JWT used for normal API calls is fine
-        // for admin endpoints only when it was minted recently.  Stale
-        // tokens get 401 with the `reauth_required` indicator so the
-        // client can prompt for the password without forcing a full
-        // logout.
+        // Admin endpoints require a recent token; stale → 401 reauth_required.
         if !admin_token_is_fresh(parts, &state.jwt_secret) {
             return Err(reauth_required_response());
         }
@@ -121,21 +117,15 @@ pub async fn get_stats(
     State(state): State<Arc<AppState>>,
     _admin: AdminUser,
 ) -> Result<impl IntoResponse, AppError> {
-    // One round trip per metric keeps the SQL readable.  All seven scans
-    // hit indexed columns (`identity_keys.last_seen`, `messages.created_at`,
-    // `feedback.status` / `created_at`) so even on a busy server the
-    // dashboard load stays cheap; we can fold this into one CTE later if
-    // it shows up in slow-query logs.
+    // One query per metric — all hit indexed columns; fold into a CTE later
+    // if it shows up in slow-query logs.
     let (users_total,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
         .fetch_one(&state.pool)
         .await
         .db_ctx("admin/users_total")?;
 
-    // "Active in last 24h" approximates presence via the MAX(last_seen)
-    // across each user's device fingerprints in `identity_keys`. That's
-    // the column the WS hub bumps on every connect (`update_last_seen`
-    // in `db::keys`). Users with no devices fall back to `created_at`
-    // so brand-new sign-ups still count for the first 24h.
+    // Presence via MAX(identity_keys.last_seen); brand-new users with no
+    // devices fall back to `created_at` so they still count for 24h.
     let (users_active_24h,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM users u \
          WHERE COALESCE( \
@@ -161,11 +151,8 @@ pub async fn get_stats(
             .await
             .db_ctx("admin/groups_total")?;
 
-    // Hub-level counter: the WS hub keeps one DashMap entry per connected
-    // device, but we can't reach that map from a thread-state extractor
-    // without lifetime gymnastics.  Use the DB's view instead -- it
-    // approximates "currently online" via identity_keys.last_seen within
-    // the last 90 seconds.
+    // DB approximation of "online" (last 90s) since reaching the hub DashMap
+    // from a state extractor needs lifetime gymnastics.
     let (online_devices,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM identity_keys \
          WHERE last_seen > NOW() - INTERVAL '90 seconds'",
@@ -231,9 +218,7 @@ pub async fn list_feedback(
     _admin: AdminUser,
     Query(q): Query<ListFeedbackQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Whitelist status values to keep the predicate sargable against the
-    // `feedback_status_created_at_idx` index.  Anything else 400s rather
-    // than silently returning an empty page.
+    // Whitelist keeps the predicate sargable against the status index.
     if !matches!(q.status.as_str(), "open" | "triaged" | "closed") {
         return Err(AppError::bad_request(
             "status must be one of: open, triaged, closed",

--- a/apps/server/src/routes/auth.rs
+++ b/apps/server/src/routes/auth.rs
@@ -20,23 +20,9 @@ use super::AuthExtract;
 
 // ---------------------------------------------------------------------------
 // Refresh token cookie helpers
-//
-// The web client stores the refresh token in an HttpOnly + Secure +
-// SameSite=None cookie scoped to `/api/auth`. Mobile/desktop continue to
-// receive the token in the JSON body for backward compatibility. `/refresh`
-// accepts either; cookie wins when both are present.
-//
-// SameSite=None (relaxed from Strict in Phase 2 of the domain migration,
-// #1063) is required because the web build lives at `web.echo-messenger.us`
-// while the API lives at `us-east.echo-messenger.us` — Strict cookies are
-// dropped on the cross-site fetch. The remaining CSRF surface is bounded:
-// only `/api/auth/refresh` and `/api/auth/logout` read the cookie, and the
-// credentialed-CORS allow-list (explicit origins in `CORS_ORIGINS`, see
-// `routes/mod.rs`) prevents a malicious origin from reading the response.
-// Worst case is a forced session rotation or logout — annoying, not
-// credential-stealing. A proper CSRF token (double-submit cookie pattern)
-// is a post-beta hardening item.
 // ---------------------------------------------------------------------------
+// SameSite=None is required across the web↔API origin split (#1063); CSRF is
+// bounded by the credentialed-CORS allow-list (see `routes/mod.rs`).
 
 const REFRESH_COOKIE_NAME: &str = "echo_refresh";
 const REFRESH_COOKIE_MAX_AGE_SECS: i64 = 7 * 24 * 60 * 60;
@@ -69,9 +55,7 @@ fn allowed_origins() -> &'static [String] {
             "https://echo-messenger.us,https://web.echo-messenger.us,http://localhost:8081".into()
         });
         if raw.trim() == "*" {
-            // Wildcard CORS disables credentials anyway — no Origin check
-            // applies, leave empty so `validate_origin_for_credentialed` is
-            // a no-op.
+            // Wildcard CORS disables credentials → no Origin check applies.
             return Vec::new();
         }
         raw.split(',')
@@ -255,11 +239,8 @@ pub async fn login(
     jar: CookieJar,
     Json(body): Json<AuthRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Pre-computed Argon2id hash of a random string. Used when the requested
-    // user does not exist so that the response latency is indistinguishable
-    // from a wrong-password attempt (prevents username enumeration via timing).
-    // The 32-byte output (43 base64 chars) matches Argon2::default() output
-    // length to avoid measurable timing differences in the finalization pass.
+    // Dummy hash used when the user is missing so login latency does not leak
+    // username existence; output length matches Argon2::default().
     const DUMMY_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$bm9uZXhpc3RlbnQ$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
     let maybe_user = db::users::find_by_username(&state.pool, &body.username).await?;
@@ -317,21 +298,16 @@ pub async fn refresh(
     State(state): State<AuthExtract>,
     headers: HeaderMap,
     jar: CookieJar,
-    // `Result<Json<_>, _>` (not `Option<Json<_>>`): when the web client sends
-    // `Content-Type: application/json` with a zero-length body, axum's
-    // `Option<Json<T>>` extractor errors out before we get to look at the
-    // cookie, and the user gets logged out on every page refresh. With
-    // `Result<...>` we receive the rejection in-band and ignore it -- the
-    // cookie is still readable and the request can succeed.
+    // `Result<Json<_>, _>` not `Option<Json<_>>`: an empty body would otherwise
+    // reject before we read the cookie and log the web client out on refresh.
     body: Result<Json<RefreshRequest>, JsonRejection>,
 ) -> Result<impl IntoResponse, AppError> {
     // TD-43: forbid credentialed cookie use from origins outside the
     // allow-list. Absent Origin (mobile/desktop) passes through.
     validate_origin_for_credentialed(&headers)?;
 
-    // Cookie wins when both are present so the web client's HttpOnly cookie
-    // can never be silently overridden by a malicious JSON body. Mobile/desktop
-    // clients keep sending the token in the body and that path still works.
+    // Cookie wins over body so a malicious JSON body cannot override the
+    // web client's HttpOnly cookie; mobile/desktop continue to send via body.
     let cookie_token = jar
         .get(REFRESH_COOKIE_NAME)
         .map(|c| c.value().to_string())
@@ -400,9 +376,8 @@ pub async fn refresh(
         ));
     }
 
-    // Sentinel revoke: only one transaction can flip `revoked` from false to
-    // true.  If `fetch_optional` returns `None`, another request beat us to
-    // it — treat as concurrent reuse and revoke the family.
+    // Sentinel revoke: only one tx can flip `revoked` false→true; `None`
+    // means a concurrent reuse — family-revoke.
     let revoked: Option<(uuid::Uuid,)> = sqlx::query_as::<_, (uuid::Uuid,)>(
         "UPDATE refresh_tokens SET revoked = true \
          WHERE id = $1 AND revoked = false RETURNING id",
@@ -457,9 +432,7 @@ pub async fn refresh(
 
     let access_token = jwt::create_token(row.user_id, &state.jwt_secret)?;
 
-    // Re-read is_admin from the canonical row so promotion / demotion that
-    // happens between login and refresh propagates to the client on its
-    // next 15-minute access-token roll.
+    // Re-read is_admin so promotion/demotion propagates on the next refresh.
     let (is_admin,): (bool,) = sqlx::query_as("SELECT is_admin FROM users WHERE id = $1")
         .bind(row.user_id)
         .fetch_one(&state.pool)
@@ -547,11 +520,8 @@ pub async fn forgot_password(
             .await
             .is_ok()
         {
-            // SECURITY: never log the token. A token in the log stream is a
-            // 15-minute account-takeover oracle for anyone with log-read
-            // access (Loki, CloudWatch, syslog, dev workstation). Operators
-            // honor a reset by reading the `password_reset_tokens` table
-            // directly and delivering the token out-of-band.
+            // SECURITY: never log the token — log access would equal account
+            // takeover. Operators read it from `password_reset_tokens` directly.
             tracing::info!(
                 user_id = %user.id,
                 expires = %expires_at,
@@ -562,10 +532,8 @@ pub async fn forgot_password(
         }
     }
 
-    // Always 200 -- do not reveal whether the username exists.
-    // TD-73: return a JSON body for consistency with the rest of the API;
-    // some HTTP clients (and older fetch wrappers) trip on an empty body
-    // when the response carries a Content-Type expectation.
+    // Always 200 — do not reveal whether the username exists. TD-73: JSON body
+    // (not empty) keeps fetch wrappers happy with the Content-Type expectation.
     Ok((StatusCode::OK, Json(serde_json::json!({"ok": true}))))
 }
 
@@ -628,9 +596,8 @@ pub async fn reset_password(
         .await
         .map_err(|_| AppError::internal("Database error"))?;
 
-    // CR-4: invalidate outstanding 15-minute access tokens after the
-    // password change commits. Refresh tokens were already revoked inside
-    // the tx; this closes the access-token side of the same window.
+    // CR-4: invalidate outstanding access tokens too (refresh tokens were
+    // revoked inside the tx above).
     state.token_invalidator.invalidate(row.user_id);
 
     tracing::info!(

--- a/apps/server/src/routes/feedback.rs
+++ b/apps/server/src/routes/feedback.rs
@@ -96,10 +96,7 @@ pub async fn create_feedback(
         )));
     }
 
-    // Rolling-window rate limit.  We count the caller's reports in the last
-    // 24h, including triaged + closed ones, so closing a report can't be
-    // used to refill the quota.  `feedback_user_id_created_at_idx` keeps
-    // this cheap even as the table grows.
+    // Count includes triaged/closed so closing a report can't refill quota.
     let (recent,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM feedback \
          WHERE user_id = $1 AND created_at > NOW() - INTERVAL '24 hours'",

--- a/apps/server/src/routes/group_keys.rs
+++ b/apps/server/src/routes/group_keys.rs
@@ -140,10 +140,7 @@ fn validate_upload_request(body: &UploadGroupKeyRequest) -> Result<(), AppError>
             "key_version must be a positive integer",
         ));
     }
-    // The CHECK constraint on the column enforces 1..=255, but a clear
-    // 400 with a typed message beats the bare 23514 db error on the
-    // happy mistake (a client passing 0 to "disable" or a future GRPN
-    // value the server hasn't shipped support for yet).
+    // Mirror the column CHECK (1..=255) so clients see 400 not 23514.
     if !(1..=255).contains(&body.min_wire_version) {
         return Err(AppError::bad_request(
             "min_wire_version must be between 1 and 255",
@@ -262,12 +259,8 @@ async fn persist_group_key_and_envelopes(
     .await
     .map_err(map_store_group_key_error)?;
 
-    // Store per-member envelopes inside the same tx. Every envelope at a
-    // given key_version shares the same min_wire_version — the constraint
-    // is "this key version requires GRP-N or newer", not "this member
-    // requires GRP-N". Per-member differences would let a hostile rotator
-    // pin GRP1 for one recipient and GRP2 for another, leaving the GRP1
-    // recipient open to downgrade.
+    // All envelopes at a given key_version share min_wire_version — per-member
+    // differences would let a hostile rotator pin one recipient on GRP1.
     for envelope in &body.envelopes {
         db::keys::store_group_key_envelope(
             &mut *tx,
@@ -281,12 +274,8 @@ async fn persist_group_key_and_envelopes(
         .db_ctx("upload_group_key/store_envelope")?;
     }
 
-    // OQ-13: append the rotation to the audit log inside the same tx
-    // as the envelope writes so the audit trail and the envelope
-    // table commit together. `completed_by_user_id` mirrors
-    // `triggered_by_user_id` for now — server-led leader election
-    // (where the leader != the trigger source) is a follow-up that
-    // can populate it differently without a schema change.
+    // OQ-13: audit log written in the same tx as the envelopes so they commit
+    // atomically; leader election is a future enhancement.
     db::group_key_rotations::insert_completed_rotation(
         &mut *tx,
         group_id,
@@ -374,25 +363,14 @@ pub async fn get_latest_group_key(
         return Ok(Json(GroupKeyEnvelopeResponse::from_row(env)).into_response());
     }
 
-    // No envelope for this caller — figure out which sub-case we're in.
-    // - If the group has NO key version at all -> 400 "no group key" (legacy
-    //   shape; pre-encryption groups and tests rely on this).
-    // - If the group HAS a key version but the caller's envelope is missing
-    //   at that version -> 410 Gone. Previously we fell back to serving the
-    //   sentinel `"__envelope__"` placeholder string out of `group_keys`,
-    //   which the client tried to decrypt as if it were a wrapped AES key
-    //   and exploded with `candidate key has wrong length: 9 bytes`. The
-    //   410 lets the client mark the group as "needs rotation" and surface
-    //   the recovery banner instead.
+    // No envelope for caller: 400 if group has no key at all, 410 if a sentinel
+    // exists (so the client can surface the "needs rotation" banner).
     let row = db::keys::get_latest_group_key(&state.pool, group_id)
         .await
         .db_ctx("get_latest_group_key/fetch")?
         .ok_or_else(|| AppError::bad_request("No group key found for this conversation"))?;
 
-    // A sentinel row means envelope-based distribution is in effect for this
-    // group AND we already confirmed (above) that no envelope exists for the
-    // caller. Anything else is a legacy plaintext key — preserve the old
-    // behaviour so groups created before the envelope scheme keep working.
+    // Sentinel = envelope distribution; non-sentinel = legacy plaintext key.
     if row.encrypted_key == "__envelope__" {
         let body = serde_json::json!({
             "error": "No group-key envelope exists for this user at the latest version",
@@ -444,12 +422,8 @@ pub async fn get_group_key_version(
 // -------------------------------------------------------------------------
 // GET /api/groups/:id/encryption-activity -- list completed rotations
 // -------------------------------------------------------------------------
-//
-// Audit OQ-13: server-side audit log of group key rotations. Returns
-// the audit rows newest-first for the admin "Encryption activity"
-// view. Restricted to admins+ because the rotation cadence and
-// trigger-source labels are a meaningful operational signal — a
-// regular member doesn't need a malicious-admin radar; an admin does.
+// OQ-13: admin-only audit log. Rotation cadence is an operational signal an
+// admin needs (malicious-admin radar) and a regular member does not.
 
 #[derive(Debug, Serialize)]
 pub struct GroupKeyRotationResponse {

--- a/apps/server/src/routes/groups/create.rs
+++ b/apps/server/src/routes/groups/create.rs
@@ -20,10 +20,7 @@ pub async fn create_group(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateGroupRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Trim before the empty check so " " can't slip past as a valid name,
-    // and use chars().count() so multi-byte CJK / emoji characters don't
-    // burn the budget faster than ASCII names of the same visual length
-    // (TD-15 in TECHNICAL_DEBT.md).
+    // TD-15: trim before empty-check; chars().count() for CJK/emoji fairness.
     let trimmed = body.name.trim();
     let char_count = trimmed.chars().count();
     if trimmed.is_empty() || char_count > 100 {
@@ -32,11 +29,8 @@ pub async fn create_group(
         ));
     }
 
-    // Refuse encrypted-group creation when the caller hasn't published
-    // identity + one-time prekeys yet. Without keys the group lands in
-    // a wedged state on day one — the creator can't decrypt its own
-    // messages and no admin can rotate (no key material exists to wrap
-    // envelopes against). TD-2 in TECHNICAL_DEBT.md.
+    // TD-2: creating an encrypted group without published keys wedges it
+    // permanently — the creator can't decrypt their own messages.
     if body.is_encrypted {
         let has_keys = db::keys::has_publishable_keys(&state.pool, auth.user_id)
             .await
@@ -50,13 +44,8 @@ pub async fn create_group(
         }
     }
 
-    // Best-effort duplicate-name check for public groups by the same creator.
-    // This is a read-then-write race: a concurrent create can slip through
-    // between the SELECT and the INSERT. TD-20 tracks the hardened solution
-    // (unique partial index on (creator_id, lower(title)) WHERE is_public)
-    // which needs a schema migration adding creator_id to conversations.
-    // For now the race is harmless — two duplicate groups are visually
-    // identical but each is independently usable.
+    // TD-20: best-effort dup-name check; the read-then-write race is harmless
+    // (two duplicates are each independently usable) until the partial index lands.
     if body.is_public {
         let already_exists =
             db::groups::user_has_public_group_named(&state.pool, auth.user_id, trimmed)
@@ -80,11 +69,6 @@ pub async fn create_group(
     )
     .await
     .db_ctx("create_group/create")?;
-
-    // Default channels (`general` text + `lounge` voice) are now seeded
-    // inside `create_group_with_visibility` so they share the same
-    // transaction. TD-3 closes the partial-state window where a channel
-    // insert failure used to leave an orphan group committed.
 
     let members = db::groups::get_group_members(&state.pool, group.id)
         .await

--- a/apps/server/src/routes/groups/invite.rs
+++ b/apps/server/src/routes/groups/invite.rs
@@ -208,10 +208,7 @@ pub async fn accept_invite(
         })));
     }
 
-    // #829: the in-tx revalidation can surface `Expired` / `Exhausted` if a
-    // concurrent accept raced past the pre-tx fast path above. Map those
-    // outcomes to the same error shape the fast-path checks use so the API
-    // response is consistent.
+    // #829: surface race-discovered Expired/Exhausted with the same error shape.
     let outcome = db::groups::accept_invite_token(&state.pool, &token, auth.user_id)
         .await
         .db_ctx("accept_invite/insert")?;

--- a/apps/server/src/routes/groups/members.rs
+++ b/apps/server/src/routes/groups/members.rs
@@ -111,11 +111,8 @@ async fn broadcast_rotation_requested(state: &Arc<AppState>, group_id: Uuid, new
     let elected = elect_rotation_leader(&online);
 
     let Some(leader) = elected else {
-        // No online member can act on this trigger. Suppress the event
-        // (it would land in nobody's inbox anyway) and rely on the
-        // client-side getGroupKey path to recover when a member next
-        // returns. A deferred-trigger queue keyed by reconnect is a
-        // sensible follow-up; see CLAUDE.md / docs/group-e2e-design.
+        // No online member — suppress event; client getGroupKey recovers on
+        // reconnect. Deferred-trigger queue is a follow-up.
         tracing::info!(
             "rotate_group_key({group_id}): no online member at trigger time; \
              new_version={new_version} stored but rotation-requested event suppressed"
@@ -246,10 +243,7 @@ pub async fn add_member(
         ));
     }
 
-    // Fetch the canonical member list once inside the tx. Previously this
-    // happened twice (once for the `member_added` broadcast and once for
-    // the system-message broadcast); the duplicate fetch could even
-    // observe a stale list when other mutations raced.
+    // One in-tx fetch — duplicate reads could observe a stale list under races.
     let all_members = db::groups::get_conversation_member_ids(&mut *tx, group_id)
         .await
         .unwrap_or_default();

--- a/apps/server/src/routes/groups/settings.rs
+++ b/apps/server/src/routes/groups/settings.rs
@@ -116,9 +116,7 @@ pub async fn upload_group_avatar(
         .await
         .map_err(|e| AppError::bad_request(format!("Invalid multipart data: {e}")))?
     {
-        // Accept either "avatar" (historical) or "file" (matches the
-        // /api/media/upload convention used by the seed scripts and most
-        // generic upload pickers).
+        // Accept "avatar" (historical) or "file" (matches /api/media/upload).
         let field_name = field.name().unwrap_or_default().to_string();
         if field_name != "avatar" && field_name != "file" {
             continue;

--- a/apps/server/src/routes/groups/types.rs
+++ b/apps/server/src/routes/groups/types.rs
@@ -76,9 +76,7 @@ pub struct AddMemberRequest {
 pub struct UpdateGroupRequest {
     pub title: Option<String>,
     pub description: Option<String>,
-    // DO NOT add `is_encrypted` here. See the doc-comment on
-    // `CreateGroupRequest::is_encrypted`. The test below enforces the
-    // invariant at compile time so this stays catchable on CI.
+    // DO NOT add `is_encrypted` here (TD-7); the lockdown test below enforces.
 }
 
 #[cfg(test)]
@@ -93,18 +91,14 @@ mod update_group_request_lockdown {
     /// security-reviewed. See TD-7 in TECHNICAL_DEBT.md.
     #[test]
     fn is_encrypted_is_silently_dropped() {
-        // serde defaults to `deny_unknown_fields = false`, so unknown keys
-        // are dropped on parse. This deserialization MUST succeed and MUST
-        // NOT carry the encryption flag anywhere downstream.
+        // Unknown `is_encrypted` MUST be silently dropped (not propagated).
         let parsed: UpdateGroupRequest = serde_json::from_value(json!({
             "title": "x",
             "is_encrypted": true,
         }))
         .expect("title-only update should still deserialize");
         assert_eq!(parsed.title.as_deref(), Some("x"));
-        // No is_encrypted field on the struct — proven by virtue of this
-        // file compiling. Touch the other fields to keep the assertion
-        // intentional rather than smoke-test.
+        // No is_encrypted field — compile-time proof; assert intentionally.
         assert!(parsed.description.is_none());
     }
 }

--- a/apps/server/src/routes/keys.rs
+++ b/apps/server/src/routes/keys.rs
@@ -157,38 +157,17 @@ pub async fn upload_bundle(
 
     let device_id = body.device_id;
 
-    // Decode and verify signing_key + signature (required for MITM prevention).
-    //
-    // Proof-of-possession rationale (#74): requiring the client to provide a
-    // valid Ed25519 signature over `signed_prekey` bytes using `signing_key`
-    // implicitly proves possession of the signing private key -- an attacker
-    // that does not hold the private key cannot produce a valid signature.
-    // This is equivalent to a challenge-response: the signed_prekey bytes act
-    // as the message being signed, and the server verifies the signature with
-    // the uploaded public key.  The identity binding fingerprint (stored on
-    // first upload, checked on every subsequent upload) further prevents an
-    // attacker from swapping the identity key while keeping the signing key or
-    // vice-versa.  A separate explicit nonce challenge would add no additional
-    // security here because the attacker is already unable to forge the
-    // signature without the private key.
+    // #74: Ed25519 signature over `signed_prekey` proves possession of the
+    // signing private key (MITM prevention). Identity binding via fingerprint
+    // prevents swapping identity key while keeping signing key, or vice-versa.
     let signing_key_bytes = BASE64
         .decode(&body.signing_key)
         .map_err(|_| AppError::bad_request("Invalid base64 for signing_key"))?;
     verify_signed_prekey_signature(&signing_key_bytes, &signed_prekey, &signed_prekey_signature)?;
 
-    // --- Identity binding check (per-device) ---
-    // On first upload for this (user, device) the identity+signing key
-    // fingerprint is recorded on the identity_keys row. Subsequent uploads
-    // for the same device MUST match or the request is rejected with 409
-    // and a structured body the client uses to drive the
-    // `IdentityKeyConflictException` reset flow. Rotation requires
-    // POST /api/keys/reset_device (single device) or /api/keys/reset
-    // (full account).
-    //
-    // Legacy fallback: if the per-device fingerprint hasn't been bound yet
-    // (e.g. a device 0 row created before the migration backfill), fall back
-    // to the legacy per-user fingerprint so existing single-device users
-    // stay enforced during the rollout.
+    // Per-device identity binding: subsequent uploads must match the recorded
+    // fingerprint or 409 (drives client reset flow). Falls back to the legacy
+    // per-user fingerprint for unmigrated device-0 rows.
     let new_fingerprint = identity_fingerprint(&identity_key, &signing_key_bytes);
     let device_fp =
         db::keys::get_device_fingerprint(&state.pool, auth_user.user_id, device_id).await?;
@@ -241,9 +220,8 @@ pub async fn upload_bundle(
     )
     .await?;
 
-    // Bind the per-device fingerprint on first upload (or after a reset that
-    // cleared it). Done AFTER store_identity_key so the upsert above guarantees
-    // the row exists for `set_device_fingerprint` to update.
+    // First-upload (or post-reset) bind; must follow store_identity_key so
+    // the row exists for the UPDATE.
     if stored_fingerprint.is_none() {
         db::keys::set_device_fingerprint(&mut *tx, auth_user.user_id, device_id, &new_fingerprint)
             .await?;
@@ -312,10 +290,8 @@ pub async fn get_bundle(
     _auth_user: AuthUser,
     Path(user_id): Path<Uuid>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Try device 0 first (legacy single-device clients). TD-53: when no
-    // device-0 row exists, ask the DB for the *lowest* active device id in
-    // a single query instead of looping over `get_user_devices` and firing
-    // a 3-statement `get_prekey_bundle` per device.
+    // TD-53: fall through to the lowest active device id in a single query
+    // instead of looping over `get_user_devices`.
     let bundle = match db::keys::get_prekey_bundle(&state.pool, user_id, 0).await? {
         Some(b) => b,
         None => match db::keys::get_first_active_device_id(&state.pool, user_id).await? {
@@ -491,10 +467,8 @@ pub async fn revoke_other_devices(
     use crate::ws::handler::ServerMessage;
     use axum::extract::ws::Message as WsMessage;
 
-    // Self-lockout guard: refuse the request if the caller's current_device_id
-    // is not actually registered for this user. Without this check a client
-    // that passed a bogus ID (e.g. after a botched re-install) would silently
-    // wipe every one of its own devices.
+    // Self-lockout guard: without this a bogus current_device_id would wipe
+    // every one of the caller's own devices.
     let devices = db::keys::get_user_devices(&state.pool, auth_user.user_id).await?;
     if !devices
         .iter()
@@ -512,9 +486,7 @@ pub async fn revoke_other_devices(
             .await
             .db_ctx("revoke_other_devices")?;
 
-    // CR-4: invalidate every outstanding access token for this user. The
-    // current_device_id keeps its session via the next /refresh + login; the
-    // dropped devices lose access immediately rather than at JWT TTL.
+    // CR-4: drop access tokens now so revoked devices can't ride out the JWT TTL.
     if !revoked_ids.is_empty() {
         state.token_invalidator.invalidate(auth_user.user_id);
     }
@@ -640,11 +612,8 @@ pub async fn reset_device(
         return Err(AppError::unauthorized("Invalid password"));
     }
 
-    // Clear the device's fingerprint AND delete its identity_keys row +
-    // signed/one-time prekeys so the next upload binds cleanly. Both steps
-    // must commit together; a crash between them previously left the
-    // identity slot half-cleared and the next bundle upload could rebind
-    // to a different identity silently (TD-38).
+    // Both steps must commit together (TD-38): a crash between them previously
+    // left the identity slot half-cleared and let a re-upload rebind silently.
     let mut tx = state.pool.begin().await.db_ctx("reset_device/begin_tx")?;
     db::keys::clear_device_fingerprint(&mut *tx, auth_user.user_id, body.device_id)
         .await

--- a/apps/server/src/routes/link_preview.rs
+++ b/apps/server/src/routes/link_preview.rs
@@ -154,18 +154,14 @@ async fn validate_url(url: &str) -> Result<ValidatedUrl, AppError> {
 
     let port = parsed.port_or_known_default().unwrap_or(80);
 
-    // TD-31: lock down the egress port so a bug elsewhere can't be used to
-    // probe internal services on uncommon ports (Redis 6379, Memcached
-    // 11211, ElasticSearch 9200, internal admin UIs on 8080, …).
+    // TD-31: egress port allow-list blocks SSRF probes of internal services.
     if !ALLOWED_PORTS.contains(&port) {
         return Err(AppError::bad_request(
             "URL port not permitted (only 80 and 443)",
         ));
     }
 
-    // TD-31: async DNS lookup so we don't stall a tokio worker. `lookup_host`
-    // also handles dual-stack (returns both v4 and v6) so the per-address
-    // SSRF check runs for every candidate the OS would have chosen.
+    // TD-31: dual-stack async lookup so SSRF check runs over every candidate.
     let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), port))
         .await
         .map_err(|_| AppError::bad_request("Could not resolve hostname"))?
@@ -177,9 +173,7 @@ async fn validate_url(url: &str) -> Result<ValidatedUrl, AppError> {
         ));
     }
 
-    // Validate ALL resolved addresses are safe (reject if any is private).
-    // Checking the whole set defeats split-horizon DNS games where one
-    // record is public and another is internal.
+    // Validate ALL addrs — defeats split-horizon DNS games.
     for addr in &addrs {
         if is_ssrf_target(addr.ip()) {
             return Err(AppError::bad_request(
@@ -207,9 +201,7 @@ pub async fn fetch_preview(
 ) -> Result<Json<LinkPreviewResponse>, AppError> {
     let validated = validate_url(&body.url).await?;
 
-    // Pin the resolved IP so reqwest cannot re-resolve to a different
-    // (potentially private) address after our validation -- closes the
-    // TOCTOU DNS rebinding window.
+    // Pin the resolved IP so reqwest can't re-resolve (DNS rebinding TOCTOU).
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .redirect(reqwest::redirect::Policy::none())

--- a/apps/server/src/routes/media.rs
+++ b/apps/server/src/routes/media.rs
@@ -141,10 +141,8 @@ fn validate_bytes(data: &[u8], declared_mime: &str) -> Result<String, AppError> 
     match infer::get(data) {
         Some(inferred) => {
             let m = inferred.mime_type();
-            // M4A audio files share the same MP4 container magic bytes as
-            // video/mp4.  Different `infer` versions disambiguate differently:
-            // some report video/mp4 (and we trust the declared audio MIME),
-            // others report audio/m4a directly (which we accept on its own).
+            // M4A shares MP4 magic bytes; `infer` returns either depending on
+            // version, so trust an audio declared MIME when shape matches.
             let effective = if (m == "video/mp4" || m == "audio/m4a")
                 && matches!(
                     declared_mime,
@@ -262,9 +260,7 @@ pub(super) fn validate_head(head: &[u8], declared_mime: &str) -> Result<String, 
     match infer::get(head) {
         Some(inferred) => {
             let m = inferred.mime_type();
-            // M4A audio files share the same MP4 container magic bytes as
-            // video/mp4.  Different `infer` versions disambiguate differently
-            // (see validate_bytes for details).
+            // M4A shares MP4 magic bytes (see validate_bytes for details).
             let effective = if (m == "video/mp4" || m == "audio/m4a")
                 && matches!(
                     declared_mime,
@@ -711,10 +707,8 @@ pub async fn download(
     let ext = extension_for_mime(&row.mime_type);
     let disk_path = format!("./uploads/{id}.{ext}");
 
-    // Stat the file once so we can advertise Content-Length and serve byte
-    // ranges. iOS AVFoundation refuses to play video URLs that don't
-    // properly support `Range:` requests ("the server is not correctly
-    // configured" — the symptom the user hit on their iPhone).
+    // iOS AVFoundation requires Content-Length + Range support or refuses to
+    // play video URLs ("the server is not correctly configured").
     let metadata = fs::metadata(&disk_path).await.map_err(|e| {
         tracing::error!("Failed to stat media file {}: {}", disk_path, e);
         AppError {
@@ -748,9 +742,7 @@ pub async fn download(
     };
     let disposition = format!("inline; filename=\"{}\"", safe_filename);
 
-    // Honor a Range request if present. We support a single open or closed
-    // range; the multi-range form is rare in practice and AVFoundation
-    // doesn't issue it.
+    // Single-range only; multi-range is rare and AVFoundation never issues it.
     if let Some(range_header) = headers.get(RANGE).and_then(|v| v.to_str().ok()) {
         match parse_byte_range(range_header, total_size) {
             Ok((start, end)) => {
@@ -805,9 +797,7 @@ pub async fn download_thumb(
         return Err(AppError::unauthorized("Missing authentication"));
     };
 
-    // Fetch the media row first so we can derive the disk path from
-    // DB-validated state — this also acts as a CodeQL sanitizer for the
-    // path-traversal check on `id` (matching `download()`'s flow).
+    // Fetch the row first so the disk path is DB-validated (CodeQL sanitizer).
     let row = db::media::get_media(&state.pool, id)
         .await?
         .ok_or_else(|| AppError {
@@ -952,10 +942,7 @@ mod tests {
     // Minimal ELF header (magic 7F 45 4C 46).
     const ELF_BYTES: &[u8] = b"\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
-    // Minimal M4V header -- ftyp box with "M4V " brand, padded to 512 bytes.
-    // Apple M4V files use this brand; infer detects them as "video/x-m4v".
-    // These were rejected before the fix because "video/x-m4v" was missing
-    // from ALLOWED_MIME_TYPES (#411).
+    // #411: Apple M4V ftyp box, padded to 512 bytes.
     fn make_m4v_head() -> Vec<u8> {
         let mut v = vec![
             0x00, 0x00, 0x00, 0x14, // box size = 20
@@ -977,10 +964,7 @@ mod tests {
         assert_eq!(mime, "video/x-m4v");
     }
 
-    // Minimal M4A header -- ftyp box with "M4A " brand, padded to 512 bytes.
-    // The `record` plugin on iOS/Android produces this brand for AAC-LC voice
-    // recordings.  Different `infer` crate versions return either "video/mp4"
-    // or "audio/m4a" for this magic; both must round-trip through validation.
+    // #837: `record` plugin AAC-LC voice ftyp box, padded to 512 bytes.
     fn make_m4a_head() -> Vec<u8> {
         let mut v = vec![
             0x00, 0x00, 0x00, 0x14, // box size = 20
@@ -995,10 +979,7 @@ mod tests {
 
     #[test]
     fn validate_bytes_accepts_m4a_voice_recording() {
-        // Regression for #837: voice messages from mobile (record plugin,
-        // AAC-LC in MP4 container) were rejected because the declared MIME
-        // path only accepted infer="video/mp4", and infer can also report
-        // "audio/m4a" for the same magic bytes.
+        // Regression for #837: AAC-LC voice in MP4 container.
         let head = make_m4a_head();
         let mime = validate_bytes(&head, "audio/mp4")
             .expect("M4A voice recordings should be accepted when declared as audio/mp4");
@@ -1024,9 +1005,7 @@ mod tests {
 
     #[test]
     fn validate_bytes_rejects_elf_executable() {
-        // Either infer detects it as a disallowed executable type, or it
-        // returns None and falls through to the "Could not detect" branch.
-        // Both paths must reject, regardless of the declared MIME.
+        // Both the inferred-disallowed and infer-None paths must reject.
         let err = validate_bytes(ELF_BYTES, "application/octet-stream")
             .expect_err("ELF should be rejected");
         assert!(

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -443,9 +443,7 @@ pub async fn edit_message(
     Path(message_id): Path<Uuid>,
     Json(body): Json<EditMessageRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Reject empty *and* whitespace-only edits.  Without the trim, a
-    // user could replace a real message with `"   "` and surface a
-    // blank bubble in the timeline.
+    // Trim before the empty-check so `"   "` doesn't surface a blank bubble.
     if body.content.trim().is_empty() {
         return Err(AppError::bad_request("Content cannot be empty"));
     }
@@ -453,11 +451,8 @@ pub async fn edit_message(
         return Err(AppError::bad_request("Content too long"));
     }
 
-    // Edits on encrypted conversations would broadcast plaintext to every
-    // member, breaking E2E confidentiality. Reject up front and surface a 409
-    // so the client can hide / disable the edit affordance.
-    // TODO: once per-device ciphertext fanout for edits is implemented,
-    // replace this guard with the proper edit-with-ciphertext path.
+    // Edits on encrypted conversations would broadcast plaintext — reject with
+    // 409 until per-device ciphertext fanout for edits lands (TODO).
     let convo_meta =
         db::messages::get_message_conversation_security(&state.pool, message_id, auth.user_id)
             .await
@@ -593,9 +588,7 @@ pub async fn search_messages(
         ));
     }
 
-    // Server-side full-text search is meaningless on encrypted conversations:
-    // the content column holds ciphertext, so matches would be false positives
-    // and the server should not attempt to index or scan E2E-encrypted content.
+    // Server-side search on encrypted conversations would scan ciphertext.
     let security = db::messages::get_conversation_security(&state.pool, conversation_id)
         .await
         .db_ctx("search_messages/security")?;

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -107,13 +107,8 @@ impl FromRef<Arc<AppState>> for AuthExtract {
 }
 
 pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Router {
-    // The built-in default covers the centralised deployment so a fresh
-    // self-hoster doesn't have to think about CORS. Self-hosters on a
-    // different apex MUST set CORS_ORIGINS explicitly; otherwise the web
-    // build can't refresh tokens against their server. `web.echo-messenger.us`
-    // is included as part of the domain migration (docs/domain-migration/)
-    // — Phase 1 serves the web build at BOTH apex and web.* so the new
-    // origin needs to be in the credentialed allow-list.
+    // Default targets the centralised deployment; self-hosters on a different
+    // apex MUST set CORS_ORIGINS or the web build can't refresh tokens.
     let cors_origins = std::env::var("CORS_ORIGINS").unwrap_or_else(|_| {
         "https://echo-messenger.us,https://web.echo-messenger.us,http://localhost:8081".into()
     });
@@ -129,10 +124,8 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
     let allowed_headers = [header::CONTENT_TYPE, header::AUTHORIZATION];
 
     let cors = if cors_origins == "*" {
-        // Browsers reject `Access-Control-Allow-Credentials: true` paired with
-        // `Access-Control-Allow-Origin: *`, so the wildcard branch CANNOT enable
-        // credentials. The web client's HttpOnly refresh cookie requires
-        // explicit origins -- set `CORS_ORIGINS` to a comma-separated list.
+        // Wildcard CORS cannot enable credentials (browsers reject the pair),
+        // so the refresh cookie requires explicit `CORS_ORIGINS` entries.
         tracing::warn!(
             "CORS_ORIGINS is set to '*' — allowing all origins WITHOUT credentials. \
              This is insecure for production and disables cookie-based refresh. \
@@ -306,12 +299,9 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
         .route("/device/{device_id}", delete(keys::revoke_device))
         .route("/otp-count", get(keys::get_otp_count));
 
-    // Chunked-upload routes (#556).  These coexist with the legacy
-    // `POST /api/media/upload` single-shot endpoint at `/upload`.  Each
-    // chunked route carries its own DefaultBodyLimit (32 MB, comfortably
-    // above the 16 MB hard cap on a single PATCH body) so the parent
-    // router's 100 MB MAX_FILE_SIZE limit -- which protects the legacy
-    // multipart upload -- isn't accidentally applied to chunks too.
+    // Chunked-upload routes (#556): each carries its own 32 MB DefaultBodyLimit
+    // so the parent's 100 MB MAX_FILE_SIZE (for the legacy multipart upload)
+    // doesn't apply to per-chunk PATCH bodies.
     let chunk_body_limit = DefaultBodyLimit::max(32 * 1024 * 1024);
 
     let media_routes = Router::new()
@@ -444,9 +434,7 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
     let push_routes = Router::new()
         .route("/register", post(push::register_token))
         .route("/unregister", post(push::unregister_token))
-        // Server-switching teardown (#PR-2): clears every push token bound to
-        // the caller. Idempotent — calling with no tokens registered still
-        // returns 200 so clients can call it unconditionally before logout.
+        // #PR-2: idempotent push-token teardown for server switching.
         .route("/token", delete(push::delete_all_tokens));
 
     Router::new()
@@ -499,33 +487,16 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
         ))
         .layer(SetResponseHeaderLayer::overriding(
             header::CONTENT_SECURITY_POLICY,
-            // API responses are JSON or binary (avatars, media files served
-            // via /api/{users,groups}/.../avatar and /api/media/{id}).
-            // Allow self-origin img + media so Firefox does not block their
-            // use in <img>/<video> embeds with the page's CSP fallback
-            // (#732, #733).  Everything else stays locked to 'none'.
-            // The Flutter web client (HTML+JS) is served by nginx with its
-            // own broader CSP that covers script/style/font/connect.
+            // #732, #733: self-origin img/media so Firefox doesn't block avatar
+            // and media embeds via the CSP fallback. Everything else 'none';
+            // the web client itself has a broader CSP set by nginx.
             header::HeaderValue::from_static(
                 "default-src 'none'; img-src 'self'; media-src 'self'; \
                  frame-ancestors 'none'; base-uri 'none'",
             ),
         ))
-        // Per-request tracing + request-id correlation (#1173).
-        //
-        // Layer order matters: axum's `.layer()` wraps the LAST-applied
-        // layer outermost, so the chain below produces — from outside in —
-        //   SetRequestIdLayer  → stamps `x-request-id` on the request
-        //                        (using inbound header if present, else a
-        //                        fresh UUID v4)
-        //   PropagateRequestIdLayer → mirrors that id onto the response so
-        //                             clients can log + report it
-        //   TraceLayer         → opens an `http.request` span that captures
-        //                        the request_id + leaves a `user_id` slot
-        //                        for the AuthUser middleware to fill in.
-        //
-        // SetRequestIdLayer must be outermost so the header is present by
-        // the time TraceLayer reads it.
+        // #1173: tracing + request-id. Layer order matters — SetRequestIdLayer
+        // must be outermost so TraceLayer sees the header.
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|request: &axum::http::Request<_>| {
@@ -575,9 +546,7 @@ pub async fn readyz(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     match result {
         Ok(Ok(_)) => (StatusCode::OK, Json(serde_json::json!({ "status": "ok" }))),
         Ok(Err(e)) => {
-            // Log the underlying error server-side; do NOT expose connection
-            // details (hostnames, usernames, etc.) on the unauthenticated
-            // /readyz endpoint.
+            // Never expose DB connection details on the unauth /readyz.
             tracing::warn!(error = %e, "/readyz: db query failed");
             (
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/apps/server/src/routes/server_info.rs
+++ b/apps/server/src/routes/server_info.rs
@@ -30,12 +30,8 @@ pub struct ServerInfoResponse {
 pub async fn server_info(
     State(state): State<Arc<AppState>>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Singleton bootstrap. Two concurrent first-boot requests both attempt
-    // an INSERT but the UNIQUE PRIMARY KEY on `singleton` causes one of
-    // them to no-op via ON CONFLICT, so the row's `id` stays stable across
-    // every subsequent SELECT. ON CONFLICT DO NOTHING guarantees idempotent
-    // success even when our INSERT lost the race -- we follow up with a
-    // SELECT to read back whichever row won.
+    // Idempotent singleton bootstrap; concurrent first-boots race safely via
+    // the UNIQUE PK + ON CONFLICT DO NOTHING.
     sqlx::query("INSERT INTO server_metadata (singleton) VALUES (TRUE) ON CONFLICT DO NOTHING")
         .execute(&state.pool)
         .await

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -347,11 +347,8 @@ async fn broadcast_presence_with_status(
         }
     };
 
-    // Privacy: when the user's stored status is "invisible", the contact-
-    // visible payload is "offline". Do NOT leak the raw "invisible" value in
-    // the `presence_status` field -- a patched client could otherwise observe
-    // it and defeat the invisibility. The user's own session keeps the raw
-    // value via the PATCH response, which is separate from this broadcast.
+    // Privacy: stored "invisible" must surface as "offline" — leaking the raw
+    // value would let a patched client defeat invisibility.
     let hide_presence_status = presence_status == "invisible" && broadcast_status == "offline";
 
     let presence = if hide_presence_status {
@@ -434,9 +431,7 @@ pub async fn change_password(
         .db_ctx("change_password/find_user")?
         .ok_or_else(|| AppError::not_found("User not found"))?;
 
-    // Argon2 verify takes ~50-150ms of pure CPU. Without spawn_blocking it
-    // stalls a tokio worker for the whole duration -- login/register already
-    // do this; change_password was missing it.
+    // spawn_blocking: Argon2 verify is 50-150ms CPU — keep tokio workers free.
     let stored_hash = user.password_hash.clone();
     let current_password = body.current_password.clone();
     let valid = tokio::task::spawn_blocking(move || {
@@ -663,11 +658,7 @@ pub async fn upload_avatar(
         .await
         .map_err(|e| AppError::bad_request(format!("Invalid multipart data: {e}")))?
     {
-        // Accept either "avatar" (historical) or "file" (matches the
-        // /api/media/upload convention used by the seed scripts and most
-        // generic upload pickers).  Mismatch was returning a confusing
-        // "Missing 'avatar' field in multipart form data" even when a
-        // perfectly valid PNG was attached under the wrong field name.
+        // Accept "avatar" (historical) or "file" (matches /api/media/upload).
         let field_name = field.name().unwrap_or_default().to_string();
         if field_name != "avatar" && field_name != "file" {
             continue;

--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -70,10 +70,7 @@ pub async fn generate_token(
     state: State<Arc<AppState>>,
     Json(body): Json<TokenRequest>,
 ) -> Result<Json<TokenResponse>, AppError> {
-    // Look up the username so LiveKit participants display human-readable
-    // names instead of UUIDs.  The identity field doubles as the display
-    // name inside LiveKit, so using the username here means the client no
-    // longer has to race a post-connect `setName` call.
+    // Username doubles as the LiveKit display name; avoids a setName race.
     let user = db::users::find_by_id(&state.pool, auth.user_id)
         .await
         .db_ctx("looking up user for voice token")?
@@ -82,21 +79,15 @@ pub async fn generate_token(
     let username = user.username;
     let identity = body.identity.unwrap_or_else(|| username.clone());
 
-    // The provided identity must be either the username or the user_id.
-    // This prevents impersonation while still allowing legacy clients that
-    // send the UUID.
+    // Identity must be the username or user_id — prevents impersonation.
     if identity != username && identity != auth.user_id.to_string() {
         return Err(AppError::bad_request(
             "Identity must match authenticated user",
         ));
     }
 
-    // Security: derive the LiveKit room name from the conversation the caller
-    // claims membership of, then check membership against THAT same value.
-    // Earlier code accepted a separate `body.room` that was used as the JWT
-    // claim while membership was checked against `conversation_id`, so a
-    // member of conv A could request `{room: "<victim>", conversation_id: "<A>"}`
-    // and receive a token granting access to the victim's room.
+    // SECURITY: room name derives from the SAME conversation the membership
+    // check runs against; the old `body.room` allowed cross-room escalation.
     let conversation_id_str = body.conversation_id.or(body.channel_id).ok_or_else(|| {
         AppError::bad_request("conversation_id or channel_id is required for voice token")
     })?;
@@ -153,9 +144,7 @@ pub async fn generate_token(
         AppError::internal("Failed to generate voice token")
     })?;
 
-    // Optional explicit URL — lets ops redirect to a managed LiveKit or a
-    // non-default subdomain without a client release.  When unset the client
-    // falls back to deriving `wss://livekit.<server-host>`.
+    // Optional override; client falls back to `wss://livekit.<server-host>`.
     let url = std::env::var("LIVEKIT_URL")
         .ok()
         .filter(|u| !u.trim().is_empty());

--- a/apps/server/src/ws/events/dispatch.rs
+++ b/apps/server/src/ws/events/dispatch.rs
@@ -62,10 +62,7 @@ pub(in crate::ws) async fn handle_text_message(
     let msg: ClientMessage = match serde_json::from_str(text) {
         Ok(m) => m,
         Err(e) => {
-            // TD-74: don't echo the serde_json parser's internal byte/line
-            // position back to the client — it lets attackers fingerprint
-            // the parser and probe field tolerances cheaply. Log the
-            // detail server-side instead so we still have it for support.
+            // TD-74: don't echo parser position to clients (fingerprinting).
             tracing::debug!(sender_id = %sender_id, error = %e, "invalid client frame");
             send_error(state, sender_id, "Invalid message");
             return;
@@ -121,9 +118,8 @@ pub(in crate::ws) async fn handle_text_message(
             to_user_id,
             signal,
         } => {
-            // TD-35: bound the inner JSON payload before relaying. The 64 KB
-            // frame cap alone let one peer cost N×64 KB per ICE candidate
-            // across an in-call group.
+            // TD-35: bound the inner payload — the 64 KB frame cap alone lets
+            // one peer cost N×64 KB per ICE candidate in a group call.
             let signal_bytes = json_bytes(&signal);
             if signal_bytes > MAX_VOICE_SIGNAL_BYTES {
                 tracing::warn!(
@@ -184,10 +180,8 @@ pub(in crate::ws) async fn handle_text_message(
             kind,
             payload,
         } => {
-            // TD-35: bound the canvas payload before relaying/persisting.
-            // Stroke segments and pointer moves should each fit in a few
-            // hundred bytes; 16 KB is loose enough to allow image-add
-            // descriptors without enabling a fan-out amplifier.
+            // TD-35: bound canvas payload — strokes are tiny, 16 KB allows
+            // image-add descriptors without enabling a fan-out amplifier.
             let payload_bytes = json_bytes(&payload);
             if payload_bytes > MAX_CANVAS_PAYLOAD_BYTES {
                 tracing::warn!(

--- a/apps/server/src/ws/handler.rs
+++ b/apps/server/src/ws/handler.rs
@@ -70,15 +70,9 @@ pub async fn handle_socket(
     };
     tokio::pin!(send_fut);
 
-    // Task: send heartbeat every 30 seconds to keep the connection alive
-    // through reverse-proxy (Traefik/Cloudflare) idle timeouts.
-    //
-    // We send BOTH a WebSocket protocol Ping (for proxy keepalive) and an
-    // application-level JSON heartbeat. Browser WebSocket APIs handle
-    // Ping/Pong transparently without surfacing them to JavaScript, so the
-    // client's heartbeat monitor would never see protocol Pings.  The JSON
-    // heartbeat triggers the browser's onMessage callback, letting the
-    // client know the connection is still alive.
+    // 30s heartbeat keeps the connection alive through Traefik/Cloudflare idle
+    // timeouts. Send BOTH a Ping (proxy keepalive) and a JSON heartbeat —
+    // browsers hide protocol Ping/Pong from JS so the client only sees JSON.
     let ping_hub = state.hub.clone();
     let ping_user_id = user_id;
     let ping_device_id = device_id;
@@ -94,9 +88,7 @@ pub async fn handle_socket(
                 ping_device_id,
                 WsMessage::Ping(vec![].into()),
             );
-            // Application-level heartbeat (visible to all clients).
-            // #829: payload is a module-level `&'static str` to avoid the
-            // per-tick `String` allocation.
+            // #829: `&'static str` payload avoids per-tick allocation.
             if !ping_hub.send_to_device(
                 &ping_user_id,
                 ping_device_id,
@@ -129,24 +121,16 @@ pub async fn handle_socket(
 
     let leftover_rx: Option<mpsc::Receiver<WsMessage>> = tokio::select! {
         _ = &mut recv_fut => {
-            // Receive loop ended -- the send half might still have pending
-            // frames in `rx`. Unregister so no new ones land, then attempt a
-            // brief drain (50ms) to flush what's already buffered.
+            // Recv ended: unregister to stop new frames, then briefly drain
+            // anything already buffered in `rx`.
             state.hub.unregister(user_id, device_id);
-            // Pull the sink + rx back out of the send future by polling
-            // it once with a tight timeout. If the channel was already
-            // closed by `unregister` (which dropped the tx) the future
-            // resolves immediately; otherwise the timeout caps it.
             match tokio::time::timeout(Duration::from_millis(50), &mut send_fut).await {
                 Ok((_sender, rx)) => Some(rx),
                 Err(_) => None,
             }
         }
         (_sender, rx) = &mut send_fut => {
-            // Send half ended (peer TCP died, or rx was closed). Stop
-            // accepting new inbound frames by unregistering, then let the
-            // recv future complete naturally as the underlying socket
-            // surfaces the error.
+            // Send ended: unregister and let recv finish on the socket error.
             state.hub.unregister(user_id, device_id);
             // Best-effort: give the recv loop a moment to observe the
             // socket close before we drop it.
@@ -155,11 +139,7 @@ pub async fn handle_socket(
         }
     };
     drop(leftover_rx);
-    // #829: abort the heartbeat task on any disconnect path (clean close OR
-    // the err arm of the recv loop both flow through this select! cleanup).
-    // Without the explicit abort, the 30 s tick keeps firing until
-    // `send_to_device` returns false on the dropped queue -- one or two
-    // extra ticks past the disconnect under load.
+    // #829: explicit abort avoids extra 30s ticks past disconnect under load.
     ping_task.abort();
 
     cleanup_user_voice_sessions(&state, user_id).await;

--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -114,13 +114,8 @@ impl Hub {
     /// ledger can be populated even on the legacy/plaintext code path that
     /// doesn't carry a per-device frame map.
     pub fn send_to_user_collecting(&self, user_id: &Uuid, msg: WsMessage) -> SmallVec<[i32; 4]> {
-        // Snapshot the device IDs while holding the read ref so we can
-        // mutate `connections` (via `unregister`) without re-entrant locks
-        // on the slow-consumer eviction path below.
-        //
-        // SmallVec<[_; 4]> keeps the snapshot and accepted-IDs buffer on
-        // the stack for the typical 1-4 devices/user case so the hot
-        // fanout path stays heap-free (#834).
+        // Snapshot first so slow-consumer eviction below doesn't re-enter the
+        // map lock. #834: SmallVec<[_; 4]> keeps the hot path heap-free.
         let device_ids: SmallVec<[(i32, WsTx); 4]> = {
             let Some(devices) = self.inner.connections.get(user_id) else {
                 return SmallVec::new();

--- a/apps/server/src/ws/message_service/fanout.rs
+++ b/apps/server/src/ws/message_service/fanout.rs
@@ -97,10 +97,7 @@ pub(in crate::ws::message_service) fn build_per_device_json(
     fields: &NewMessageFields,
     recipient_device_contents: &ParsedRecipientDeviceContents,
 ) -> HashMap<Uuid, Vec<(i32, WsMessage)>> {
-    // Sentinel chosen so it cannot collide with any legitimate string in the
-    // serialized JSON: includes characters that would be JSON-escaped, plus
-    // a per-call UUID. Anchored to a fixed, unmistakable prefix so a future
-    // reader can grep for it.
+    // Per-call UUID sentinel; cannot collide with any legitimate JSON content.
     let sentinel = format!("__ECHO_CONTENT_PLACEHOLDER_{}__", Uuid::new_v4());
 
     let base_msg = ServerMessage::NewMessage {
@@ -123,10 +120,7 @@ pub(in crate::ws::message_service) fn build_per_device_json(
         return HashMap::new();
     };
 
-    // The sentinel was a String and goes through JSON string-escape, so the
-    // exact substring to match is `"<sentinel>"`. The sentinel never
-    // contains any character requiring escape (only ASCII alphanumerics +
-    // `_`), so we can rely on a direct surround-with-quotes match.
+    // Sentinel is ASCII-safe so the JSON-escaped form is just `"<sentinel>"`.
     let sentinel_quoted = format!("\"{sentinel}\"");
     let Some(pos) = serialized.find(&sentinel_quoted) else {
         return HashMap::new();
@@ -201,10 +195,8 @@ pub(in crate::ws::message_service) fn deliver_to_member(
         };
     }
     if let Some(msg) = legacy_msg {
-        // #829: the legacy/plaintext path also needs to populate the per-device
-        // ledger so sibling devices that come online later don't re-receive
-        // the message via `get_undelivered` replay. Use the collecting variant
-        // so we know which device queues actually accepted the frame.
+        // #829: legacy path also needs to populate the per-device ledger so
+        // late-arriving sibling devices don't re-replay via `get_undelivered`.
         let accepted = hub.send_to_user_collecting(member_id, msg.clone());
         return MemberDeliveryOutcome {
             delivered: !accepted.is_empty(),
@@ -380,10 +372,8 @@ pub(in crate::ws::message_service) async fn fanout_message(
         None => None,
     };
 
-    // Pre-build per-recipient WsMessage values and the legacy fallback once
-    // before the fanout loop so no serialization or String allocation happens
-    // per recipient (#690). Both paths store Bytes-backed WsMessage::Text;
-    // clone inside the loop is O(1).
+    // #690: pre-build per-recipient frames so the fanout loop only does
+    // O(1) Bytes-backed clones, no serialization per recipient.
     let per_recipient_json = recipient_device_contents
         .as_ref()
         .map(|rdc| build_per_device_json(&fields, rdc));
@@ -393,10 +383,8 @@ pub(in crate::ws::message_service) async fn fanout_message(
 
     let mut any_delivered = false;
     let mut offline_user_ids = Vec::new();
-    // #829: collect (recipient_user_id, device_id) pairs that the hub actually
-    // accepted on the per-device path. After fanout we batch-insert them into
-    // `message_deliveries` so a sibling device that comes online later does
-    // NOT receive the same message again via `get_undelivered` replay.
+    // #829: accepted (user, device) pairs feed the per-device ledger so late
+    // siblings don't replay via `get_undelivered`.
     let mut accepted_device_pairs: Vec<(Uuid, i32)> = Vec::new();
 
     let eligible = member_ids
@@ -420,12 +408,8 @@ pub(in crate::ws::message_service) async fn fanout_message(
         }
     }
 
-    // #829: populate the per-device ledger for every recipient device whose
-    // queue accepted the frame. Without this, sibling devices that were
-    // offline at fan-out time would never receive the message: the global
-    // `messages.delivered` flag was the historical gate but now only serves
-    // the read-receipt UI; the per-device ledger is the authoritative replay
-    // gate (see `db::messages::get_undelivered`).
+    // #829: per-device ledger is the authoritative replay gate (the global
+    // `messages.delivered` flag only feeds read-receipt UI now).
     if !accepted_device_pairs.is_empty()
         && let Err(e) = db::messages::mark_devices_delivered_pairs(
             &state.pool,
@@ -444,14 +428,8 @@ pub(in crate::ws::message_service) async fn fanout_message(
         send_delivery_confirmation(state, sender_id, sender_device_id, stored_id, conv_id).await;
     }
 
-    // #451: `@here` only notifies online members.  When the plaintext body
-    // contains a standalone `@here`, drop the offline list so no APNs push
-    // fires.
-    //
-    // Privacy trade-off: this is the only path where the server inspects
-    // message body content outside of storage / sender-routing.  We keep
-    // the read narrow (single substring scan, no logging of body bytes)
-    // and gate it on `!is_encrypted` so encrypted groups are unaffected.
+    // #451: `@here` only notifies online members. Body inspection is gated on
+    // `!is_encrypted` so encrypted groups are unaffected.
     let suppress_offline_push = should_suppress_offline_push(
         offline_user_ids.len(),
         is_group,
@@ -460,9 +438,7 @@ pub(in crate::ws::message_service) async fn fanout_message(
     );
 
     if suppress_offline_push {
-        // Audit trail for #451: suppressing pushes is observable abuse
-        // surface (any member can silence offline notifications). Log
-        // counts only — no body or recipient identifiers.
+        // Audit #451 abuse surface: counts only, no body or recipient IDs.
         tracing::info!(
             %sender_id,
             %conv_id,

--- a/apps/server/src/ws/message_service/mod.rs
+++ b/apps/server/src/ws/message_service/mod.rs
@@ -60,9 +60,8 @@ pub(super) async fn handle_send_message(
     reply_to_id: Option<Uuid>,
     recipient_device_contents: Option<RecipientDeviceContents>,
     ttl_seconds: Option<i64>,
-    // GRP2 senders mint this client-side and bind it into the sender
-    // signature; the server has to honour it or signature verification
-    // breaks (audit OQ-12). Plaintext / GRP1 senders leave it `None`.
+    // GRP2: client-minted, bound into the sender signature (OQ-12). The server
+    // MUST honour it or signature verification breaks.
     client_message_id: Option<Uuid>,
 ) {
     if !validate_message_length(state, sender_id, &content) {
@@ -80,10 +79,8 @@ pub(super) async fn handle_send_message(
         return;
     };
 
-    // Belt-and-suspenders ciphertext shape gate. When a conversation is marked
-    // `is_encrypted`, the server must refuse any payload that isn't shaped like
-    // an Echo wire frame (initial V1/V2 or normal-message header). This closes
-    // the confidentiality hole left open by client-only enforcement.
+    // Server-side ciphertext shape gate: refuse non-wire-frame payloads on
+    // encrypted conversations (closes the client-only enforcement hole).
     if conv_security.is_encrypted
         && !validate_encrypted_payload(
             state,
@@ -97,15 +94,8 @@ pub(super) async fn handle_send_message(
         return;
     }
 
-    // Phase 1.5 (audit P1-2): encrypted-group sender-membership gate.
-    //
-    // `resolve_conversation` already verifies membership for every send,
-    // but the migration plan in `docs/group-e2e-design/04-migration-plan.md`
-    // calls out the "kicked member tries to send" attack as a distinct
-    // surface that deserves its own structured rejection (`sender-not-member`).
-    // Running this only on the encrypted-group branch keeps the signal
-    // unambiguous in logs/metrics and adds a defence-in-depth re-check
-    // for any future code path that resolves the conversation differently.
+    // P1-2: encrypted-group sender-membership re-check (kicked-member attack);
+    // structured `sender-not-member` rejection + defence-in-depth.
     if conv_security.is_encrypted
         && conv_kind == Some(ConversationKind::Group)
         && !enforce_group_sender_membership(state, sender_id, conv_id).await
@@ -113,12 +103,8 @@ pub(super) async fn handle_send_message(
         return;
     }
 
-    // TD-30: encrypted-DM recipient-inclusion gate. The shape validator
-    // already requires `recipient_device_contents` to be non-empty, but it
-    // doesn't check that the actual peer is in the map. Without this check
-    // a sender could populate only their own devices and let the fanout
-    // fallback deliver `legacy_msg` to the peer with whatever bytes pass
-    // the structural shape gate.
+    // TD-30: encrypted-DM peer must be in `recipient_device_contents`, else
+    // a sender could ship arbitrary bytes via the legacy fallback.
     if conv_security.is_encrypted
         && conv_kind == Some(ConversationKind::Direct)
         && let Some(rdc) = recipient_device_contents.as_ref()
@@ -127,11 +113,7 @@ pub(super) async fn handle_send_message(
         return;
     }
 
-    // #834 finding 15: parse the wire-shape recipient_device_contents exactly
-    // once here, after validation. Downstream consumers (store_and_confirm,
-    // fanout_message, build_per_device_json, the self-device-delivery loop)
-    // all read the typed `HashMap<Uuid, HashMap<i32, String>>` instead of
-    // reparsing the same UUID + i32 fields up to three times per device.
+    // #834 finding 15: parse rdc once instead of reparsing per device downstream.
     let parsed_rdc = recipient_device_contents
         .as_ref()
         .map(ParsedRecipientDeviceContents::from_wire);
@@ -159,11 +141,7 @@ pub(super) async fn handle_send_message(
         return;
     };
 
-    // Bump the dashboard "messages per second" counter exactly once per
-    // accepted relay (post-store, pre-fanout). Hot path: a single relaxed
-    // atomic fetch-add, no allocation, no lock except for the once-per-second
-    // bucket roll inside `MessageRateCounter`.  Carries no per-user or
-    // per-content data — see `metrics.rs` for the privacy invariant.
+    // Aggregate rate only — privacy invariant in `metrics.rs`.
     state.message_rate.record();
 
     let deliver = ServerMessage::NewMessage {

--- a/apps/server/src/ws/message_service/replay.rs
+++ b/apps/server/src/ws/message_service/replay.rs
@@ -117,26 +117,19 @@ async fn deliver_one_batch(
             .await
             .unwrap_or_default();
 
-    // Messages that have a per-device row for SOME device of this user but not
-    // for the connecting device are undecryptable on this device. Distinguishing
-    // this from "no per-device fanout at all" (groups, plaintext, legacy rows)
-    // prevents shipping the wrong wire and permanently losing the message.
+    // Distinguish "per-device fanout exists but not for this device" from "no
+    // per-device fanout" so we ship the right wire (undecryptable vs canonical).
     let has_any_device_row =
         db::messages::message_ids_with_any_device_content(&state.pool, &all_ids, user_id)
             .await
             .unwrap_or_default();
 
-    // Track only IDs that the hub actually accepted into the recipient's
-    // outbound queue. Marking a message delivered without confirmed enqueue
-    // loses it if the queue was full or the socket had just closed.
+    // Only IDs the hub actually accepted — confirmed enqueue prevents loss.
     let mut delivered_ids: Vec<Uuid> = Vec::with_capacity(undelivered.len());
     let mut delivered_msgs: Vec<&db::messages::MessageWithSender> =
         Vec::with_capacity(undelivered.len());
-    // #584: per-device ledger — ALL frames that were successfully enqueued
-    // (decryptable AND undecryptable placeholders) must be recorded so this
-    // device doesn't see them again on the next reconnect.  messages.delivered
-    // stays false for undecryptable frames so sibling devices can still pick
-    // them up, but the per-device ledger prevents re-replay to THIS device.
+    // #584: ledger records ALL enqueued frames (including undecryptable
+    // placeholders) so this device doesn't re-replay them.
     let mut ledger_ids: Vec<Uuid> = Vec::with_capacity(undelivered.len());
 
     for msg in &undelivered {
@@ -176,11 +169,8 @@ async fn deliver_one_batch(
             continue;
         }
         if undecryptable.unwrap_or(false) {
-            // Don't mark messages.delivered = true: another device of the same
-            // user may still have a per-device row and should be able to replay
-            // it.  But DO record into the per-device ledger so this device
-            // doesn't re-receive the same undecryptable placeholder on the next
-            // reconnect (#584).
+            // #584: don't flip messages.delivered (sibling devices may still
+            // replay), but ledger this device so it stops re-receiving.
             tracing::warn!(
                 message_id = %msg.id,
                 user_id = %user_id,

--- a/apps/server/src/ws/message_service/storage.rs
+++ b/apps/server/src/ws/message_service/storage.rs
@@ -193,10 +193,7 @@ pub(in crate::ws::message_service) async fn store_and_confirm(
 ) -> Option<db::messages::MessageRow> {
     let effective_ttl = resolve_effective_ttl(ttl_seconds, conv_ttl_seconds);
 
-    // Store message in DB. `RowNotFound` from `store_message` means the
-    // requested `reply_to_id` does not refer to a message in this conversation
-    // (cross-conversation reply, deleted parent, or non-existent id). Surface
-    // a targeted error to the sender instead of a generic store failure.
+    // `RowNotFound` here = bad/cross-conversation reply_to_id; surface targeted.
     let stored = match db::messages::store_message(
         &state.pool,
         conv_id,
@@ -228,11 +225,8 @@ pub(in crate::ws::message_service) async fn store_and_confirm(
         Err(sqlx::Error::Database(db_err))
             if db_err.is_unique_violation() && client_message_id.is_some() =>
         {
-            // Client minted a UUID that collides with an existing row.
-            // Returning a typed error lets the sender retry with a
-            // fresh UUID (and re-sign for GRP2). Vanishingly rare for
-            // v4 UUIDs but still worth handling explicitly so the
-            // confirm/fanout path doesn't run on someone else's row.
+            // Client UUID collision — typed error so sender retries (re-sign
+            // for GRP2) instead of confirming someone else's row.
             tracing::warn!(
                 user_id = %sender_id,
                 conversation_id = %conv_id,

--- a/apps/server/src/ws/message_service/validate.rs
+++ b/apps/server/src/ws/message_service/validate.rs
@@ -56,9 +56,7 @@ pub(in crate::ws::message_service) const GROUP_WIRE_PREFIX_V2: &str = "GRP2:";
 ///   The group form is checked BEFORE base64 decoding because the `:`
 ///   character is not a valid base64 alphabet member.
 pub(in crate::ws::message_service) fn is_valid_ciphertext_shape(payload: &str) -> bool {
-    // Group wires carry a textual prefix that breaks naive base64 decode.
-    // Strip the prefix and verify the remainder is non-empty + valid base64
-    // with enough bytes for `nonce(12) || ct || tag(16)`.
+    // Group prefix must be stripped before base64 decode.
     for prefix in [GROUP_WIRE_PREFIX_V1, GROUP_WIRE_PREFIX_V2] {
         if let Some(after_prefix) = payload.strip_prefix(prefix) {
             let Ok(bytes) = BASE64.decode(after_prefix.as_bytes()) else {
@@ -75,10 +73,8 @@ pub(in crate::ws::message_service) fn is_valid_ciphertext_shape(payload: &str) -
         return false;
     };
 
-    // Initial-message wires (V1 / V2) start with the 0xEC magic byte plus
-    // a known version. We require the keys+ratchet wire to follow but only
-    // gate the prefix here; full structural validation lives in the crypto
-    // layer.
+    // V1/V2 initial wires: gate the magic+version prefix only; full struct
+    // validation lives in the crypto layer.
     if bytes.len() >= 2
         && bytes[0] == ECHO_WIRE_MAGIC
         && (bytes[1] == ECHO_WIRE_INITIAL_V1 || bytes[1] == ECHO_WIRE_INITIAL_V2)
@@ -256,10 +252,8 @@ pub(in crate::ws::message_service) fn validate_encrypted_payload(
 ) -> bool {
     match conv_kind {
         Some(ConversationKind::Direct) => {
-            // The canonical content field is persisted and relayed in
-            // NewMessage events, so it must be ciphertext-shaped — otherwise
-            // a client could pass valid recipient_device_contents while
-            // smuggling plaintext in `content`.
+            // Canonical `content` is persisted + relayed; must be ciphertext-
+            // shaped or a client could smuggle plaintext alongside valid rdc.
             if !validate_dm_canonical_content(state, sender_id, conversation_id, content) {
                 return false;
             }
@@ -327,9 +321,7 @@ pub(in crate::ws::message_service) async fn enforce_dm_recipient_includes_peer(
         }
     };
 
-    // The DM has exactly two members; everyone besides the sender is a peer
-    // that must receive ciphertext. `rdc` keys are user_id strings, so build
-    // a string-set view of the expected peers for the membership check.
+    // Every non-sender member must appear as an rdc key.
     let mut missing_peer = false;
     for member_id in &members {
         if *member_id == sender_id {
@@ -568,10 +560,7 @@ mod tests {
 
     #[test]
     fn shape_grp2_prefix_accepted() {
-        // Future GRP2 wires also flow through this validator without a
-        // coordinated server flip. Payload after the prefix is base64 of
-        // version(1) + nonce(12) + ct + tag(16) + sig(64); the structural
-        // floor here is just "≥ 28 bytes of decoded payload".
+        // GRP2 wires flow through without a server flip; floor is ≥28 bytes.
         let payload = format!("{GROUP_WIRE_PREFIX_V2}{}", group_envelope(64));
         assert!(is_valid_ciphertext_shape(&payload));
     }
@@ -616,9 +605,7 @@ mod tests {
             is_valid_ciphertext_shape(&payload),
             "GRP1-prefixed group ciphertext must be accepted",
         );
-        // Sanity-check the failure mode the fix corrects: dropping the prefix
-        // recovers a base64-decodable payload, but the FULL string with the
-        // `:` does not.
+        // Full string (with `:`) is not base64-decodable; stripped is.
         assert!(BASE64.decode(payload.as_bytes()).is_err());
     }
 }

--- a/apps/server/src/ws/rate_limit.rs
+++ b/apps/server/src/ws/rate_limit.rs
@@ -216,10 +216,8 @@ fn handle_other_frame(
     user_id: Uuid,
     bucket: &mut BucketState,
 ) -> bool {
-    // TD-36: every binary/ping/pong frame consumes one message token. Without
-    // this check an attacker can blast 1000 zero-byte pings per second; the
-    // byte bucket sees 0 cost and never throttles, but each frame still
-    // triggers a tokio wakeup + axum parse + dispatch round.
+    // TD-36: each frame costs a message token — byte bucket alone misses
+    // zero-byte ping floods.
     if bucket.tokens < 1.0 {
         return record_violation(
             state,

--- a/apps/server/src/ws/rotation.rs
+++ b/apps/server/src/ws/rotation.rs
@@ -76,9 +76,7 @@ pub fn elect_rotation_leader(online_members: &[Uuid]) -> Option<RotationLeader> 
     }
     let mut sorted: Vec<Uuid> = online_members.to_vec();
     sorted.sort();
-    // Deduplicate in case the caller handed us repeated entries (e.g. a
-    // multi-device user with 3 connections — the leader is per-user, not
-    // per-device). The sort above puts duplicates adjacent so dedup is O(n).
+    // Leader is per-user, not per-device — dedup adjacent multi-device entries.
     sorted.dedup();
     let leader = sorted.remove(0);
     Some(RotationLeader {
@@ -147,10 +145,7 @@ mod tests {
 
     #[test]
     fn deduplicates_repeated_user_ids() {
-        // The Hub keys connections per (user_id, device_id); if a future
-        // refactor accidentally passes the per-connection list instead
-        // of the per-user list, the election must still produce a sane
-        // leader rather than duplicating slots.
+        // Guards against a future caller passing per-connection (vs per-user) ids.
         let a = u("00000000-0000-0000-0000-000000000001");
         let b = u("00000000-0000-0000-0000-000000000002");
         let got = elect_rotation_leader(&[a, b, a, b, a]).expect("non-empty");
@@ -178,10 +173,7 @@ mod tests {
 
     #[test]
     fn default_deadline_is_documented_value() {
-        // Locked at 7.5s in the design doc; bumping it is a wire-format
-        // change in spirit even though the field is just a hint. Any
-        // change should land with a docs update — this assert is here
-        // to make sure that pairing doesn't drift silently.
+        // Locked at 7.5s in the design doc; bumping requires a docs update.
         assert_eq!(DEFAULT_ROTATION_DEADLINE_MS, 7_500);
     }
 }

--- a/apps/server/src/ws/typing_service.rs
+++ b/apps/server/src/ws/typing_service.rs
@@ -279,9 +279,7 @@ pub(super) async fn send_presence_snapshot(state: &AppState, user_id: Uuid) {
         return;
     }
 
-    // Build per-user status entries, filtering out invisible contacts.
-    // Batched lookup (#834 finding 7): one round-trip with ANY($1) replaces
-    // the prior per-contact query inside this loop.
+    // #834 finding 7: batched ANY($1) replaces the per-contact query.
     let statuses = db::users::get_presence_statuses_for(&state.pool, &online_contacts)
         .await
         .unwrap_or_default();
@@ -337,12 +335,8 @@ pub(super) async fn broadcast_presence(
         }
     };
 
-    // When coming online, look up stored presence_status so we broadcast
-    // the right status (e.g. "away" or "dnd") rather than always "online".
-    // For "offline" (disconnect), always broadcast "offline" regardless of
-    // stored status. Invisible users also appear offline -- and we omit
-    // the presence_status field entirely so observers cannot distinguish
-    // invisible from truly offline.
+    // Invisible → "offline" with no presence_status field, so observers
+    // cannot distinguish invisible from truly offline.
     let (broadcast_status, presence_status) = if status == "offline" {
         ("offline".to_string(), None)
     } else {

--- a/apps/server/tests/ws_fanout.rs
+++ b/apps/server/tests/ws_fanout.rs
@@ -248,6 +248,7 @@ async fn revoked_device_excluded_from_fanout_and_storage() {
     let (alice_token, alice_id, _) = common::register_and_login(&client, &base, "rflt_alice").await;
     let (bob_token, bob_id, bob_name) =
         common::register_and_login(&client, &base, "rflt_bob").await;
+    let bob_username = bob_name.clone();
 
     common::make_contacts(&client, &base, &alice_token, &bob_token, &bob_id, &bob_name).await;
 
@@ -263,6 +264,12 @@ async fn revoked_device_excluded_from_fanout_and_storage() {
         .await
         .expect("revoke request failed");
     assert!(revoke_resp.status().is_success(), "revoke device 22 failed");
+
+    // CR-4: revoke_device bumps the per-user min-iat invalidator, so Bob's
+    // pre-revoke token may be rejected on subsequent AuthUser checks under
+    // CI load when iat seconds roll over. Re-login to obtain a fresh token.
+    let (bob_token, _) =
+        common::login(&client, &base, &bob_username, common::TEST_USER_PASSWORD).await;
 
     // Connect both devices (even revoked ones can maintain a WS session;
     // only the fanout filter should silence them).

--- a/docs/ux-research/discord-message-ui.md
+++ b/docs/ux-research/discord-message-ui.md
@@ -55,6 +55,34 @@ On message hover, a floating chip strip appears at the **top-right of the row, s
 
 Caveat from Discord's own users: the toolbar can occlude the inline reply-preview chip when hovering a reply, which is a known issue — worth designing around (e.g. shifting the toolbar down a few pixels when a reply preview is present).
 
+## 11. Density / Compactness Controls
+
+Discord exposes density as a first-class user preference: **Settings → Text & Images → Message Display** offers exactly two modes, **Cozy** (default) and **Compact**. There's no third tier and no per-channel override — the choice is account-global. Discord treats this as one of its core accessibility/comfort knobs, not a hidden power-user toggle.
+
+What actually changes between the two modes:
+
+- **Cozy:** 40 px circular avatars in the left gutter, the author name + long-form timestamp render on their own header line above the body, message bodies wrap as multi-line blocks, and each row carries roughly 16 px of vertical padding. Follow-up messages in a group omit the avatar but keep the indent — hovering the row reveals a dim short-form timestamp (`2:14 PM`) in the avatar column. The result feels conversational and breathes.
+- **Compact:** IRC-style single-line layout. The author name and timestamp render **inline with the body** (`2:14 PM DisplayName body text…`), avatars shrink to ~16-20 px (and only render on the first row of a group), vertical padding drops to roughly 4 px, and follow-ups lose the indented gutter — every row reads as a single horizontal line wherever possible.
+
+Crucially, **grouping logic is unchanged across modes**. The 7-minute same-author window still collapses runs into groups in Compact; only the padding and typography scale. This separation matters: density is a presentation concern, grouping is a semantic one.
+
+**Translation to Echo:** Echo's three-tier (Cozy / Normal / Compact) is a fine evolution — Normal sits between Discord's two modes and gives users a middle ground Discord doesn't ship. The principle to mirror is Discord's: only padding + avatar size scale with the density setting, never the grouping rules.
+
+## 12. Channel Navigation (Sidebar vs Top Bar)
+
+Discord's signature layout is a **four-column desktop shell**: a 72 px server-picker rail on the far left, a 240 px channel sidebar listing channels for the selected server, the message stream in the flex middle, and a collapsible 240 px member list on the right. Channels are grouped under collapsible category headers (`Text Channels`, `Voice Channels`, plus any custom categories the server admin defines) inside the channel sidebar.
+
+Voice channels live in the **same sidebar** as text channels — they're a different *type* of channel, not a separate area of the app. Joining a voice channel doesn't navigate away: the text-channel UI stays visible above a small voice dock that appears at the bottom of the sidebar. This keeps voice ambient rather than modal.
+
+**What in the message UI actually depends on the sidebar?** Almost nothing. The message-row layout, hover toolbar, grouping rules, reaction chips, reply previews, day/unread dividers, and welcome card are all identical regardless of whether channels live on a sidebar or top tabs. The only sidebar-coupled affordances are:
+
+- The "Above unread messages" jump-to indicator (works the same in either layout — it's anchored to the message list, not the sidebar)
+- Drag-to-rearrange channels (a sidebar-only affordance, but unrelated to message rendering)
+
+Echo's top-tab pattern (visible in the current screenshot: `general | lounge` tabs across the top of the channel) is **legitimate** — many chat products use it, and Microsoft Teams runs a hybrid (left rail for teams, top tabs for channels within a team). The message-UI guidance from this document applies regardless of which navigation shape Echo lands on.
+
+Summary: channel-nav choice (sidebar vs top tabs) does **not** affect the message-list patterns Echo should borrow from Discord.
+
 ---
 
 ## Sources

--- a/docs/ux-research/discord-message-ui.md
+++ b/docs/ux-research/discord-message-ui.md
@@ -1,0 +1,69 @@
+# Discord Message UI — desktop/web research
+
+Focused notes on how Discord's web client renders its message list, and which patterns are worth borrowing for Echo. Discord is the closest analogue to our Flutter web chat surface, so the structural choices here are a useful baseline.
+
+## 1. Message item layout (no bubbles)
+
+Discord renders messages as **flat rows on the channel background**, not as chat bubbles. The row has three regions: a left avatar gutter (~40px wide), the message body column, and a hover-only action toolbar that floats at the top-right of the row. The first message in a group carries the avatar plus a header line (`DisplayName · timestamp`); follow-up messages in the same group are pure body text indented into the avatar gutter's column. Reasoning: bubbles are optimised for two-party SMS-style conversations; multi-party servers need denser scanning and a clear "author header → reply body" hierarchy. Bubbles also waste horizontal space on wide desktop viewports.
+
+## 2. Avatars
+
+Circular, ~40px in Cozy mode, positioned flush in the left gutter. The avatar appears **only on the first message of a group**. Subsequent messages from the same author within the grouping window omit the avatar entirely; the body text starts at the same x-offset as the prior message's body, preserving the vertical column. On hover of a follow-up message, a dim short timestamp (e.g. `2:14 PM`) appears in the gutter where the avatar would otherwise be. This trades persistent timestamps for visual calm without losing the data — you can always recover it with a hover.
+
+## 3. Sender labels
+
+The display name renders inline at the start of the group header, **tinted by the member's highest-priority role colour** ([Discord roles & permissions](https://support.discord.com/hc/en-us/articles/214836687-Discord-Roles-and-Permissions)). To the right of the name, dim secondary text shows a long-form timestamp (`Today at 2:14 PM`). Follow-up messages within the group have no name and no inline timestamp — the hover-timestamp in the gutter is the only time signal.
+
+Per-role colour is **Discord-specific**: it depends on a server role hierarchy we don't have. Echo could keep a single accent colour per author (deterministic hash → palette) to get the same scanability benefit without inventing roles.
+
+## 4. Grouping rules
+
+Discord groups consecutive messages when **(a) same author, (b) no other sender interleaved, (c) sent within ~7 minutes of the previous message** ([community discussion of the grouping change](https://support.discord.com/hc/en-us/community/posts/12799818806551-Undo-the-recent-change-to-message-grouping)). A grouped run gets minimal vertical spacing between rows (just line-height). Between two groups Discord inserts a larger vertical gap (~17px) so the eye can find author boundaries. The 7-minute heuristic is a good Echo default; the exact value is less important than picking one and treating it as a budget.
+
+## 5. Cozy vs Compact mode
+
+Discord ships two density presets ([COMPOZY userstyle reference](https://userstyles.org/styles/129570/compozy-a-cleaner-cozier-more-compact-discord), [community feedback](https://support.discord.com/hc/en-us/community/posts/6226580777239-Keep-old-compact-mode-as-an-option-resolved)):
+
+- **Cozy** (default): avatar gutter visible, name + timestamp on a separate header line above the body, generous padding.
+- **Compact**: no avatar, each message renders as a single line — `[HH:MM] DisplayName body…` — with smaller name text and reduced vertical padding. Optimised for high-throughput reading (logs, fast servers).
+
+Reasoning: power users in active servers want IRC-density; casual users want breathing room. Two presets, one toggle, no in-between.
+
+## 6. Edit / reactions / replies
+
+- **Edited**: a dim `(edited)` marker appears inline at the end of the message body. Hovering it shows the edit timestamp.
+- **Reactions**: render as small pill chips in a wrap row directly under the message body, each chip showing emoji + count. The user's own reactions are tinted; clicking a chip toggles your reaction.
+- **Reply**: replied-to messages render a **compact quoted preview line above the new message** (small avatar, name, single-line truncated body). Clicking the preview scrolls to the original.
+
+## 7. System events & dividers
+
+- **Unread divider**: a thin red horizontal rule with the label `New` appears above the first unread message in the channel.
+- **Day divider**: a thin grey horizontal rule with the date centred (`December 14, 2026`) splits the list at midnight boundaries.
+- **Join/leave/pin events**: rendered as single-line system rows with a small left-side glyph (arrow, pin, etc.) and muted text — they sit in the flow but visibly differ from author messages.
+
+## 8. First message in a brand-new channel
+
+Discord renders a **welcome card** at the very top of an empty channel: a large `#` icon, a heading `Welcome to #channel-name!`, and a subtitle `This is the start of the #channel-name channel.`. It anchors the scroll and doubles as onboarding copy. Directly applicable to Echo's "Start of group" idea — same purpose, replace `#channel` with group/DM context.
+
+## 9. Self vs others
+
+Discord makes **no visual distinction for your own messages**. Your row uses your display name, your avatar, the same layout and colour as everyone else's row. There is no "You" label and no right-alignment. Reasoning: in multi-party chat the author identity matters; in two-party SMS it's redundant, which is why bubble apps right-align self. For a group-first product like ours, Discord's treatment is the right default.
+
+## 10. Hover toolbar
+
+On message hover, a floating chip strip appears at the **top-right of the row, slightly overlapping the message** ([hover toolbar feedback](https://support.discord.com/hc/en-us/community/posts/9426030716951-Hovering-over-a-message-that-is-a-reply-to-a-message-covers-reply-so-you-can-t-navigate-to-it)). Default order: three quick-reaction emoji, an emoji-picker `+` button, then an ellipsis menu for reply/forward/edit/delete/copy-link/etc. ([reactions FAQ](https://support.discord.com/hc/en-us/articles/12102061808663-Reactions-and-Super-Reactions-FAQ)). Hover-only keeps the resting list calm; the strip lifts on a subtle shadow so it reads as floating rather than inline.
+
+Caveat from Discord's own users: the toolbar can occlude the inline reply-preview chip when hovering a reply, which is a known issue — worth designing around (e.g. shifting the toolbar down a few pixels when a reply preview is present).
+
+---
+
+## Sources
+
+- [Discord Roles and Permissions](https://support.discord.com/hc/en-us/articles/214836687-Discord-Roles-and-Permissions)
+- [Reactions and Super Reactions FAQ](https://support.discord.com/hc/en-us/articles/12102061808663-Reactions-and-Super-Reactions-FAQ)
+- [Discord Display Name Styles FAQ](https://support.discord.com/hc/en-us/articles/33833879643927-Discord-Display-Name-Styles-FAQ)
+- [Enhanced Role Styles](https://support.discord.com/hc/en-us/articles/31444213087255-Enhanced-Role-Styles)
+- [Community: Undo the recent change to message grouping (7-min rule)](https://support.discord.com/hc/en-us/community/posts/12799818806551-Undo-the-recent-change-to-message-grouping)
+- [Community: Keep old compact mode as an option](https://support.discord.com/hc/en-us/community/posts/6226580777239-Keep-old-compact-mode-as-an-option-resolved)
+- [Community: Hover toolbar covers reply preview](https://support.discord.com/hc/en-us/community/posts/9426030716951-Hovering-over-a-message-that-is-a-reply-to-a-message-covers-reply-so-you-can-t-navigate-to-it)
+- [COMPOZY userstyle — secondary description of Cozy vs Compact diff](https://userstyles.org/styles/129570/compozy-a-cleaner-cozier-more-compact-discord)

--- a/docs/ux-research/imessage-message-ui.md
+++ b/docs/ux-research/imessage-message-ui.md
@@ -31,3 +31,16 @@ iMessage shows a **large centered group avatar cluster** (overlapping member ava
 
 ## 10. First-of-Day / First-of-Group Divider
 Critically, **iMessage does not show a "Today" label** for the current day's first message — the assumption is that the most recent message is from today. The first divider you see is for the **previous** day ("Yesterday") once you scroll up past today's messages, then day-of-week ("Monday"), then full date for older. The first message of a new sender-run within the same time window gets only the sender label (§3), not a divider. **Translates well** and saves vertical space versus Slack/Discord's always-on day headers — recommend we adopt this rule rather than mirror Slack.
+
+## 11. Density / Compactness Controls
+- iMessage does **not** expose a Cozy / Compact toggle the way Slack and Discord do. Density on iOS/macOS is controlled at the OS level: the system Dynamic Type setting scales text up/down, and Reduce Motion / Reduce Transparency adjust the bubble feel.
+- Bubble vertical rhythm is fixed: ~2 px gap within a same-sender run, ~8–10 px between senders. The app's "compactness" comes entirely from the run-length grouping logic + Dynamic Type — there is no separate density preset.
+- macOS Messages uses a tighter list-row look (smaller avatars, less inter-row padding) by default than iOS, but neither offers a user-facing preference.
+- **Translation to Echo:** treat density as an Echo-side preset rather than something iMessage informs directly. The lesson is that *good defaults* matter more than offering a toggle — iMessage hits a single tight default and lives with it.
+
+## 12. Channel Navigation (Sidebar vs Top Bar)
+- iMessage has **no concept of channels** within a conversation. Each conversation (1:1 or group) is a single message stream — there is no "general" / "voice" / "off-topic" sub-channel split. The left sidebar lists *conversations*, not channels within a conversation.
+- The closest analogue is iOS's per-conversation **details pane** (tap the conversation header), which surfaces attachments, links, and shared photos — adjacent to the message stream but not navigation.
+- **Translation to Echo:** because iMessage is single-stream, none of its message-UI patterns depend on whether channels are presented as a left sidebar or top tabs. The grouping, divider, and timestamp behaviour all work identically regardless of the channel-nav choice. If Echo chooses top-tab channels (like the screenshot showing `general | lounge` at the top), the message stream below those tabs can lift iMessage's patterns 1:1.
+
+**Summary:** the channel-nav choice (left sidebar vs top tabs) does not affect any of the message-list patterns documented above from iMessage.

--- a/docs/ux-research/imessage-message-ui.md
+++ b/docs/ux-research/imessage-message-ui.md
@@ -1,0 +1,33 @@
+# iMessage Message List UI — Research Notes
+
+Reference notes on how Apple Messages (iOS 17+/macOS Sonoma+) renders its message list, intended to inform our Flutter chat redesign. Sources: Apple HIG Messages page (https://developer.apple.com/design/human-interface-guidelines/messages), Apple Messages user guide (https://support.apple.com/guide/messages/), and secondary teardowns by Sebastiaan de With (https://blog.halide.cam) and Luke Wroblewski's chat UX writeups (https://lukew.com/ff/entry.asp?1939).
+
+## 1. Bubble Layout
+Bubbles are pill-shaped with ~18 px corner radius and a small "tail" pointing to the sender side on the **last** bubble of a consecutive run only. Sent bubbles align right with **iMessage blue** (#007AFF-ish) or **SMS green** (#34C759-ish); received bubbles align left with system gray (#E9E9EB light / #262628 dark). Text is white on blue/green, label color on gray. Max bubble width is roughly 75% of the available column. Internal padding is ~10 px vertical, ~12 px horizontal. The blue/green/gray triad is load-bearing — it's the only protocol signal in the UI. **Translates well** to Flutter; the tail is the only fiddly bit (custom `BubbleClipper` or a `CustomPainter`).
+
+## 2. Avatars
+1:1 chats show **no avatars in the message list** — identity is implied by side alignment and the navigation bar's avatar at top center. Group chats show small (~28 px) circular avatars on the left **only on the last bubble** of a run from that sender. Tapping a bubble or scrolling does not collapse avatars; they're always rendered at the same position. **Translates well**, and avatar-only-on-last-of-run is a cheap clarity win.
+
+## 3. Sender Labels
+Sender name appears **above the first bubble of a run** in group chats, in a small caption-style gray label (~12 pt, secondary label color), indented to align with the bubble's leading edge. Never shown in 1:1. Never shown on subsequent bubbles in a run. **Translates well.**
+
+## 4. Grouping & Spacing
+Consecutive bubbles from the same sender are **tightly stacked** (~2 px gap) and share an alignment edge; the corners facing the neighbor are squared off (~4 px radius) while the outer corners keep the full ~18 px radius, producing a "stacked pills" look. Different-sender transitions get a larger ~8–10 px gap. Only the final bubble in a run draws the tail. This visual rhythm is what makes long iMessage threads scan-able. **Translates well** but requires per-bubble state ("is first in run / is last in run / is alone") passed from the list builder — worth a small helper.
+
+## 5. Timestamp Behavior
+Inline timestamps are rare. iMessage inserts a **full-row centered timestamp divider** (e.g. "Mon 3:42 PM") whenever a gap of roughly **>15 minutes (>1h after the first one of the session)** opens between messages. The killer pattern is **swipe-left-to-reveal**: dragging the message list horizontally exposes a right-edge column of exact send times for every bubble, which springs back on release (iOS only; macOS shows times on hover). **Partially translates** — the gap-based divider is trivial; the swipe-reveal column is doable on touch but feels weird on desktop, so we'd want hover-to-reveal there.
+
+## 6. Read Receipts / Status
+Status text sits **below the last sent bubble only**, right-aligned, in tiny secondary-label gray: "Delivered", or "Read 3:42 PM" if the recipient has read receipts on. As soon as the sender posts another message, the previous "Delivered/Read" disappears and only the new last bubble carries status. No checkmarks, no per-bubble status. **Translates well** and is far less noisy than WhatsApp/Telegram tick marks.
+
+## 7. Reactions (Tapbacks)
+Six fixed reactions (heart, thumbs up/down, haha, !!, ?). Rendered as a small **circular badge overhanging the top-outer corner** of the bubble (top-left on sent, top-right on received), in the bubble's own color family. Multiple reactors stack with a count. They never reflow the bubble or push it down. **Translates well** and matches the "reactions overhang the far edge" note already in our project memory.
+
+## 8. System Events / Dividers
+Centered, full-row, ~12 pt secondary-label text. Used for date breaks ("Yesterday", "Monday", or "Mon, May 26"), "Read receipts turned on", and Tapback summaries on macOS. No background pill, no rule lines — just centered text with generous vertical padding (~16 px). **Translates well.**
+
+## 9. Empty Group / First-Conversation State
+iMessage shows a **large centered group avatar cluster** (overlapping member avatars) plus the group name and an "iMessage" subtitle, with no messages and no placeholder copy. Tapping the avatar cluster opens group details. There's no "Say hi!" call to action. The blankness itself signals "fresh thread." **Translates well** and is a nice antidote to the AI-generated "Start the conversation!" empty states.
+
+## 10. First-of-Day / First-of-Group Divider
+Critically, **iMessage does not show a "Today" label** for the current day's first message — the assumption is that the most recent message is from today. The first divider you see is for the **previous** day ("Yesterday") once you scroll up past today's messages, then day-of-week ("Monday"), then full date for older. The first message of a new sender-run within the same time window gets only the sender label (§3), not a divider. **Translates well** and saves vertical space versus Slack/Discord's always-on day headers — recommend we adopt this rule rather than mirror Slack.

--- a/docs/ux-research/slack-message-ui.md
+++ b/docs/ux-research/slack-message-ui.md
@@ -1,0 +1,45 @@
+# Slack message-list UI — patterns reference
+
+Focused notes on how Slack renders its message list on desktop/web, captured for cross-reference against our Discord-adjacent Flutter client. Sources: Slack Help Center (`slack.com/help`), Slack Design blog (`slack.design`), and the public Slack Brand Guidelines (`brand.slack.com`).
+
+## 1. Message item layout
+No bubbles. Each message is a horizontal row composed of a fixed-width left **avatar gutter** (~40 px), then a flexible column containing a one-line header (display name + timestamp) followed by the body. The body extends to a wide max-width (~700 px in Cozy) so attachments/code blocks render naturally. Hover surfaces a floating **action toolbar** anchored to the top-right of the row. Discord uses the same bubbleless model; the main divergence is Slack's tighter gutter and squared avatars.
+
+## 2. Avatars
+Slack's signature is the **rounded-square avatar** (~4 px corner radius), not a circle. Cozy uses 36 px; Compact uses 20 px. The avatar appears **only on the first message in a group**; follow-ups in the same group leave that gutter empty (or render a hover-only timestamp — see §4). Discord uses circular avatars at 40 px; the rounded square is the most immediately recognisable Slack tell.
+
+## 3. Sender labels
+The header is `**Display Name** · 10:42 AM`. Display name is bold, slightly larger than body text, with a small horizontal gap before a muted timestamp. Edited messages append an **"(edited)" pill in brand grey** (`#616061`-ish) at the end of the message body, not the header. Bots get a small "APP" pill next to the name. Discord puts "(edited)" inline too, but Slack's pill is more visually distinct as a separate small token.
+
+## 4. Grouping rules
+Consecutive messages from the same author **within ~5 minutes** group into a single visual block. Follow-up messages reuse the same left gutter alignment as the first — no indent — but **suppress the avatar and header**. On hover, the gutter of a follow-up reveals an **inline timestamp** (HH:MM, muted, right-aligned in the gutter). This is the single biggest density win versus a naïve "every message is full-chrome" layout. Discord's rule is similar (7-minute window) but it does indent slightly and shows the hover timestamp identically.
+
+## 5. Compact vs Cozy
+Two density themes (Preferences → Messages & media → Theme).
+- **Cozy** (default): 36 px avatar, generous vertical padding, header above body.
+- **Compact**: 20 px avatar, header **inline** with the first line of the body (single-line layout, IRC-style), reduced row padding (~50% vertical). Grouping still applies; follow-ups hide the avatar entirely. Discord ships a similar "Compact" mode but Slack's was the original.
+
+## 6. Threads
+Slack's signature pattern. Any message can spawn a **threaded reply**; replies live in a right-side pane, not inline. The parent message shows a **reply preview footer** ("3 replies · Last reply 2h ago · View thread") with stacked avatars of repliers. An optional checkbox "Also send to #channel" surfaces threaded replies back into the main timeline. Discord adopted threads later as separate sub-channels; Slack's model is lighter (no new channel, ephemeral pane). Likely beyond MVP for us but informs future surface.
+
+## 7. Reactions
+Emoji chips render **below the message body**, left-aligned to the body column (not the gutter). Each chip is `[emoji] count` with subtle border; viewer's own reactions get a coloured background. A small **"+" add-reaction control** trails the chip row. The primary react entrypoint is the **hover toolbar** (smiley icon, top-right). Discord is nearly identical.
+
+## 8. System events and dividers
+- **Date dividers**: thin horizontal line with a centred pill — "Today", "Yesterday", or "Friday, May 23".
+- **"New messages" divider**: red horizontal line with "New" pill, anchored at the last-read boundary; persists until the user scrolls past or marks read.
+- **Join/leave/system messages**: small, muted, no avatar — e.g. "alice joined #general". Channel-topic changes render the same way.
+
+## 9. First message in a brand-new channel
+Slack pins a generated header at the very top: **"This is the very beginning of the #channel-name channel."** with a description and a "Add people" / "Set a topic" CTA pair. It is non-removable and acts as both empty-state and channel meta. Discord shows a similar "Welcome to #channel" hero but with channel icon art.
+
+## 10. Self vs others
+Slack does **not** label your own messages "You" or right-align them. Your messages render with your own display name and avatar, on the left, identical to everyone else's. This mirrors Discord/IRC and contrasts with iMessage/WhatsApp's right-aligned self-bubbles. The visual asymmetry of self-vs-other is reserved for DMs in iMessage-style apps; chat-room apps treat all participants symmetrically.
+
+## 11. Hover toolbar
+Floats at the **top-right** of the message row on hover, slightly overlapping the row above. Default actions, left-to-right: **react** (smiley), **reply in thread** (speech bubble), **share message** (arrow), **save for later** (bookmark), **more** (overflow `…`). The overflow opens copy-link, pin, remind-me, mark-unread, edit (own messages), delete (own messages). Discord's hover toolbar lives in the same position but defaults to react / reply / forward / more — Slack's "save for later" and "share" are the differentiators.
+
+---
+
+### Design reasoning summary
+Slack's choices optimise for **scannability of long, dense channel histories**: small avatars, aggressive grouping, no bubbles, and hover-revealed chrome keep the signal-to-noise ratio high. The rounded-square avatar is brand identity, not function. Threads sidestep the "long reply derails the channel" problem without fragmenting into sub-channels. For our app, the highest-leverage borrowings are: (a) 5-minute author grouping with hover-timestamp follow-ups, (b) Compact density theme, (c) rounded-square avatar option, (d) symmetric self-vs-other rendering.

--- a/docs/ux-research/slack-message-ui.md
+++ b/docs/ux-research/slack-message-ui.md
@@ -43,3 +43,27 @@ Floats at the **top-right** of the message row on hover, slightly overlapping th
 
 ### Design reasoning summary
 Slack's choices optimise for **scannability of long, dense channel histories**: small avatars, aggressive grouping, no bubbles, and hover-revealed chrome keep the signal-to-noise ratio high. The rounded-square avatar is brand identity, not function. Threads sidestep the "long reply derails the channel" problem without fragmenting into sub-channels. For our app, the highest-leverage borrowings are: (a) 5-minute author grouping with hover-timestamp follow-ups, (b) Compact density theme, (c) rounded-square avatar option, (d) symmetric self-vs-other rendering.
+
+## 12. Density / Compactness Controls
+Slack exposes density as a single binary toggle, not a multi-tier picker. It lives under **Preferences → Themes → Compact** as a plain checkbox — there is no "Cozy / Normal / Compact" three-way selector. The two states are:
+
+- **Cozy (default):** 36 px rounded-square avatar in the left gutter, the sender's display name rendered **bold on its own header line** above the body, generous ~12-14 px row padding, and a multi-line body that wraps naturally below the header. This is the layout the rest of this document describes by default.
+- **Compact:** avatar shrinks to 20 px, the header (name + timestamp) collapses **inline with the body** as a single IRC-style line — conceptually identical to Discord's Compact mode — and row padding drops to ~4-6 px vertical. Follow-up messages in a 5-minute group still suppress the avatar entirely; the gutter just gets narrower to match the smaller avatar width. No indentation is introduced past the gutter.
+
+Crucially, **both modes preserve the same 5-minute same-author grouping rule** (§4). Compact does not change *what* groups; it only changes the chrome around each group. Names also stay **bold in both modes** — neither Slack nor Discord ever de-emphasises the sender label, which is the reader's primary scan anchor.
+
+**Translation to Echo:** Echo's existing Cozy / Normal / Compact tri-state is denser than Slack's binary, but where Slack and Discord agree, Echo should match: scale only padding and avatar size between tiers, and never touch the grouping logic, the bold-name treatment, or the gutter-alignment of follow-ups. Treat density as a chrome-only knob.
+
+## 13. Channel Navigation (Sidebar vs Top Bar)
+Slack's signature shell is a two-column **left sidebar**: a 60 px workspace-picker rail on the far left, then a ~240 px channel sidebar with collapsible sections (**Channels**, **Direct messages**, **Apps**). Channels are listed as `#channel-name` with mute/unread weight applied to the label. The whole channel sidebar can be collapsed to icon-only.
+
+Slack has **no built-in voice channels** in the Discord sense. Voice calls live as **Huddles**, launched from inside a channel and surfaced as a floating dock pinned to the bottom of the sidebar. There is no "voice channel" as a navigable node in Slack's tree — voice is an action you take *within* a text channel, not a sibling of it.
+
+**What in the message UI actually depends on the sidebar?** Almost nothing. List virtualization, 5-minute grouping, the hover toolbar, threading, reactions, date dividers, and the bubbleless row layout are all **sidebar-agnostic** — they're properties of the message column, not the shell around it. Two coupling points worth flagging:
+
+- The **"New messages" red divider** (§8) is part of the message list and survives identically across sidebar-shell or top-tab-shell layouts.
+- Slack's **Threads** tab is a top-level sidebar entry (not per-channel), so it *is* sidebar-coupled — but Echo has no threads at MVP, so this isn't load-bearing for the patterns Echo is borrowing now.
+
+Echo's existing top-tab channel layout (visible in the reference screenshot: `general | lounge` tabs at the top, with voice rendered as a sibling channel rather than a Huddle dock) **does not break** any Slack message-list pattern Echo wants to borrow.
+
+**Summary:** the channel-nav choice (sidebar vs top tabs) does **not** affect the message-list patterns Echo should borrow from Slack.

--- a/tests/e2e/group_create_ui.spec.ts
+++ b/tests/e2e/group_create_ui.spec.ts
@@ -182,18 +182,16 @@ test.describe('Group Creation UI Flow', () => {
     await page.waitForTimeout(300);
     await ss(page, '03-form-filled');
 
-    // Step 6: Verify visibility toggle -- Private should be selected by default
-    // The SegmentedButton renders 'Private' and 'Public' as accessible buttons.
-    const privateBtn = page.getByRole('button', { name: /private/i });
-    const publicBtn = page.getByRole('button', { name: /public/i });
-    await expect(privateBtn).toBeVisible({ timeout: 3000 });
-    await expect(publicBtn).toBeVisible({ timeout: 3000 });
-
-    // Toggle to Public then back to Private to verify interactability
-    await publicBtn.click();
+    // Step 6: Verify visibility toggle — the Private/Public SegmentedButton
+    // was replaced with a single "Private group" SwitchListTile that reads
+    // consistently with the E2E toggle directly below it. Default is ON
+    // (private); toggling off makes the group public.
+    const privateTile = page.getByText('Private group').first();
+    await expect(privateTile).toBeVisible({ timeout: 3000 });
+    await privateTile.click();
     await page.waitForTimeout(500);
     await ss(page, '04-toggled-public');
-    await privateBtn.click();
+    await privateTile.click();
     await page.waitForTimeout(500);
     console.log('  Visibility toggle works');
 

--- a/tests/e2e/group_create_ui.spec.ts
+++ b/tests/e2e/group_create_ui.spec.ts
@@ -183,15 +183,15 @@ test.describe('Group Creation UI Flow', () => {
     await ss(page, '03-form-filled');
 
     // Step 6: Verify visibility toggle — the Private/Public SegmentedButton
-    // was replaced with a single "Private group" SwitchListTile that reads
-    // consistently with the E2E toggle directly below it. Default is ON
-    // (private); toggling off makes the group public.
-    const privateTile = page.getByText('Private group').first();
-    await expect(privateTile).toBeVisible({ timeout: 3000 });
-    await privateTile.click();
+    // was replaced with a single "Private group" SwitchListTile (wrapped in
+    // a Semantics(label: 'private group toggle') in create_group_screen.dart).
+    // Default is ON (private); toggling makes the group public.
+    const privateToggle = page.getByLabel(/private group toggle/i);
+    await expect(privateToggle).toBeVisible({ timeout: 5000 });
+    await privateToggle.click();
     await page.waitForTimeout(500);
     await ss(page, '04-toggled-public');
-    await privateTile.click();
+    await privateToggle.click();
     await page.waitForTimeout(500);
     console.log('  Visibility toggle works');
 


### PR DESCRIPTION
## Summary

Second visual-QA pass on the auth-to-chat flow. Addresses six items the user flagged after the previous polish PR (#1197) merged.

| # | Item | Fix |
|---|------|-----|
| 1 | Duplicate empty-state UI on first launch (sidebar + main pane) | Suppress sidebar copy on ≥ 600 px; main pane carries the CTA |
| 2 | "Grey-black-grey-black" stripe pattern on the chat column | Side-effect of item 6 fix — avatar column no longer repeats per message |
| 3 | New chat affordance opens an empty picker when user has no contacts | Short-circuit to the Contacts screen + info toast when contacts list is empty |
| 4 | Chip picker autocomplete + group-DM type | **Deferred** — bigger feature work. Tracked separately for a follow-up. |
| 5 | Create Group — Private/Public segmented button mismatch with E2E toggle, no avatar at creation | Switched to a "Private group" `SwitchListTile` matching the E2E toggle. Added tappable avatar circle at the top of the form, uploads to `PUT /api/groups/<id>/avatar` after create. |
| 6 | Discord-style message grouping wrong (avatar + name + time on every bubble) | Sender label keyed only on `showHeader`; continuation messages render a blank spacer in the avatar column. One header per group; bubbles below are bare. |

## Test plan

- [x] `flutter analyze` (no issues)
- [x] `flutter test test/widgets/ test/screens/` — 925 pass / 1 skipped / 0 fail
  - Updated `create_group_screen_test` to assert the new "Private group" switch copy
  - Updated `conversation_panel_test` to split the empty-state assertion into mobile-shows / wide-hides
- [x] `flutter test test/widgets/message_item_test.dart` — 37 pass
- [ ] CI green on Flutter CI / Rust CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)