### PR TITLE
fix(client): promote server picker to labeled button (#1183)

### DIFF
--- a/apps/client/lib/src/widgets/auth/server_subtitle.dart
+++ b/apps/client/lib/src/widgets/auth/server_subtitle.dart
@@ -50,25 +50,27 @@ class _ServerSubtitleState extends ConsumerState<ServerSubtitle> {
   @override
   Widget build(BuildContext context) {
     final host = _host(widget.serverUrl);
+    // Labeled outlined button so testers see the row is interactive (#1183).
+    // The previous low-contrast chevron subtitle was being missed, and beta
+    // testers landed on the maintainer's prod server by accident.
     return Semantics(
       button: true,
-      label: 'switch server',
-      child: InkWell(
-        borderRadius: BorderRadius.circular(4),
-        onTap: _showSwitchDialog,
-        child: Padding(
+      label: 'choose server',
+      child: OutlinedButton.icon(
+        onPressed: _showSwitchDialog,
+        icon: Icon(Icons.dns_outlined, size: 16, color: context.textSecondary),
+        label: Text(
+          'Connect to server: $host',
+          style: TextStyle(color: context.textSecondary, fontSize: 12),
+          overflow: TextOverflow.ellipsis,
+        ),
+        style: OutlinedButton.styleFrom(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'Server: $host',
-                style: TextStyle(color: context.textMuted, fontSize: 12),
-              ),
-              const SizedBox(width: 2),
-              Icon(Icons.chevron_right, size: 14, color: context.textMuted),
-            ],
-          ),
+          minimumSize: const Size(0, 32),
+          side: BorderSide(color: context.border),
+          foregroundColor: context.textSecondary,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         ),
       ),
     );

--- a/apps/client/test/widgets/auth/server_subtitle_test.dart
+++ b/apps/client/test/widgets/auth/server_subtitle_test.dart
@@ -33,8 +33,8 @@ void main() {
       await tester.pumpWidget(
         host(const ServerSubtitle(serverUrl: 'https://echo-messenger.us')),
       );
-      expect(find.text('Server: echo-messenger.us'), findsOneWidget);
-      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      expect(find.text('Connect to server: echo-messenger.us'), findsOneWidget);
+      expect(find.byIcon(Icons.dns_outlined), findsOneWidget);
     });
 
     testWidgets('falls back to the raw URL when host is unparseable', (
@@ -43,7 +43,7 @@ void main() {
       await tester.pumpWidget(
         host(const ServerSubtitle(serverUrl: 'not-a-url')),
       );
-      expect(find.text('Server: not-a-url'), findsOneWidget);
+      expect(find.text('Connect to server: not-a-url'), findsOneWidget);
     });
 
     testWidgets('exposes a semantics button labelled "switch server"', (
@@ -54,7 +54,7 @@ void main() {
       );
       expect(
         find.byWidgetPredicate(
-          (w) => w is Semantics && w.properties.label == 'switch server',
+          (w) => w is Semantics && w.properties.label == 'choose server',
         ),
         findsOneWidget,
       );
@@ -66,7 +66,7 @@ void main() {
       );
       await tester.tap(
         find.byWidgetPredicate(
-          (w) => w is Semantics && w.properties.label == 'switch server',
+          (w) => w is Semantics && w.properties.label == 'choose server',
         ),
       );
       await tester.pumpAndSettle();
@@ -95,7 +95,7 @@ void main() {
 
       await tester.tap(
         find.byWidgetPredicate(
-          (w) => w is Semantics && w.properties.label == 'switch server',
+          (w) => w is Semantics && w.properties.label == 'choose server',
         ),
       );
       await tester.pumpAndSettle();
@@ -113,7 +113,7 @@ void main() {
       );
       await tester.tap(
         find.byWidgetPredicate(
-          (w) => w is Semantics && w.properties.label == 'switch server',
+          (w) => w is Semantics && w.properties.label == 'choose server',
         ),
       );
       await tester.pumpAndSettle();
@@ -135,7 +135,7 @@ void main() {
 
         await tester.tap(
           find.byWidgetPredicate(
-            (w) => w is Semantics && w.properties.label == 'switch server',
+            (w) => w is Semantics && w.properties.label == 'choose server',
           ),
         );
         await tester.pumpAndSettle();
@@ -181,7 +181,7 @@ void main() {
 
       await tester.tap(
         find.byWidgetPredicate(
-          (w) => w is Semantics && w.properties.label == 'switch server',
+          (w) => w is Semantics && w.properties.label == 'choose server',
         ),
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- Promote the chevron-subtitle server picker on login/register screens to a labeled OutlinedButton ("Connect to server: …" with a dns icon). Closes #1183.
- Testers were missing the chevron and landing on the maintainer's prod server.

## Test plan
- [x] Local `flutter analyze --fatal-infos` clean
- [x] 8 `server_subtitle_test.dart` tests updated and passing locally
- [ ] CI passes