### PR TITLE
perf(client): Firefox-profile follow-ups — image cache cap, dock blur, list keep-alive

### DIFF
--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -30,11 +30,14 @@ void main() {
   // has no implementation (#727).
   MediaKit.ensureInitialized();
 
-  // Cap Flutter's in-memory decoded-image cache: 500 images / 100 MB.
-  // The default (1000 images, no byte cap) is too generous for a chat app
-  // that can display hundreds of unique images in one session.
-  PaintingBinding.instance.imageCache.maximumSize = 500;
-  PaintingBinding.instance.imageCache.maximumSizeBytes = 100 * 1024 * 1024;
+  // Cap Flutter's in-memory decoded-image cache.
+  // Web holds decoded bitmaps in the JS heap, so 100 MB risks browser OOM
+  // under memory pressure — drop to 30 MB / 200 images there (#1117).
+  // Native keeps the original 500 / 100 MB.
+  PaintingBinding.instance.imageCache.maximumSize = kIsWeb ? 200 : 500;
+  PaintingBinding.instance.imageCache.maximumSizeBytes = kIsWeb
+      ? 30 * 1024 * 1024
+      : 100 * 1024 * 1024;
 
   // Register lifecycle observer early — before runApp — so it captures state
   // changes that happen during voice-channel entry on iOS (audio session

--- a/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
+++ b/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
@@ -3,6 +3,7 @@ library;
 
 import 'dart:ui' show ImageFilter;
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -56,15 +57,14 @@ class FloatingDock extends ConsumerWidget {
     return Center(
       child: ClipRRect(
         borderRadius: BorderRadius.circular(32),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+        // 24x24 BackdropFilter is one of CanvasKit/Firefox's worst hot
+        // paths. Skip the blur on web; surface tint at 0.88 alpha already
+        // reads as glass without the per-frame offscreen rasterise.
+        child: _MaybeBlur(
+          sigma: 24,
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             decoration: BoxDecoration(
-              // Was hard-coded `Color(0xE01C1C1E)` — the same RGB as
-              // `EchoTheme.surface` with an 0xE0 (≈88%) alpha for the
-              // backdrop-blurred glass effect. Pull from the token so light
-              // theme and any future surface re-skin pick this up.
               color: context.surface.withValues(alpha: 0.88),
               borderRadius: BorderRadius.circular(32),
               border: Border.all(color: context.border),
@@ -401,6 +401,24 @@ class DrawingToolsPanel extends StatelessWidget {
         ],
       ),
       clipBehavior: Clip.antiAlias,
+      child: child,
+    );
+  }
+}
+
+/// BackdropFilter wrapper that skips the blur on web. CanvasKit's
+/// Gaussian blur composites an offscreen GPU buffer per frame; on
+/// Firefox/NVIDIA EGL that's enough to stall the lounge.
+class _MaybeBlur extends StatelessWidget {
+  final double sigma;
+  final Widget child;
+  const _MaybeBlur({required this.sigma, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    if (kIsWeb) return child;
+    return BackdropFilter(
+      filter: ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
       child: child,
     );
   }

--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -239,6 +239,10 @@ class ChatMessageList extends ConsumerWidget {
         // Flutter 3.41+ renames to scrollCacheExtent; drop ignore when .flutter-version > 3.41.9.
         // ignore: deprecated_member_use
         cacheExtent: 600,
+        // Default true leaks Slivers in long histories (10k+ msgs). Message
+        // rows don't hold per-tile state that needs keep-alive (reaction
+        // overlays are anchored to widget keys, not state). #1117
+        addAutomaticKeepAlives: false,
         itemCount: messages.length + 1,
         itemBuilder: (context, index) {
           if (index == 0) {


### PR DESCRIPTION
## Summary
Three follow-up wins from the Firefox-profile audit (#1117 items 1-2 + an extra BackdropFilter sweep):

1. **Image cache web cap** — drop from 100 MB / 500 to 30 MB / 200 on web; native unchanged.
2. **Floating dock blur** — skip 24×24 BackdropFilter on web (same `kIsWeb` guard as the participant tiles fix).
3. **Chat list keep-alives** — `addAutomaticKeepAlives: false` so 10k+ histories don't leak Slivers.

## Test plan
- [x] `flutter analyze --fatal-infos` clean on changed files
- [x] Chat panel widget tests pass locally
- [ ] CI passes