### PR TITLE
style(client): close three UX-research gaps (iMessage corners, Today elision, Compact density)

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel/date_divider.dart
+++ b/apps/client/lib/src/widgets/chat_panel/date_divider.dart
@@ -33,13 +33,21 @@ class DateDivider extends ConsumerWidget {
       final dt = DateTime.parse(timestamp).toLocal();
       final now = DateTime.now();
       final yesterday = now.subtract(const Duration(days: 1));
+      final isToday =
+          dt.year == now.year && dt.month == now.month && dt.day == now.day;
+
+      // iMessage convention: skip the "Today" divider — the most recent
+      // messages are assumed to be today. Yesterday + older days still get
+      // labelled so the day boundary is visible when scrolling back. Keep
+      // the divider only for genuine "Start of conversation" callouts on
+      // the very first message.
+      if (isToday && !isStartOfConversation) {
+        return const SizedBox.shrink();
+      }
+
       String label;
       if (isStartOfConversation) {
         label = 'Start of conversation';
-      } else if (dt.year == now.year &&
-          dt.month == now.month &&
-          dt.day == now.day) {
-        label = 'Today';
       } else if (dt.year == yesterday.year &&
           dt.month == yesterday.month &&
           dt.day == yesterday.day) {

--- a/apps/client/lib/src/widgets/message/sender_name_label.dart
+++ b/apps/client/lib/src/widgets/message/sender_name_label.dart
@@ -47,7 +47,12 @@ class SenderNameLabel extends StatelessWidget {
       ),
     );
 
-    final padding = EdgeInsets.only(bottom: 4, left: hasMedia ? 8 : 0);
+    // Compact density gets ~IRC-style chrome: zero bottom gap between
+    // header and body so name+timestamp read as a prefix line, not a
+    // separate paragraph. Bubbles/non-compact keep the small breathing
+    // gap that lets the bold name stand off the body text.
+    final bottomGap = density == UIDensity.compact ? 0.0 : 4.0;
+    final padding = EdgeInsets.only(bottom: bottomGap, left: hasMedia ? 8 : 0);
 
     if (!compactLayout) {
       return Padding(padding: padding, child: nameText);

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -620,18 +620,34 @@ class _MessageItemState extends State<MessageItem>
     return context.recvBubble;
   }
 
-  /// Resolve the bubble border radius with a flat corner on the sender's side.
-  /// In compact mode all messages are left-aligned, so the flat corner is
-  /// always on the bottom-left regardless of sender. Plain mode squares off
-  /// entirely (#564).
+  /// Resolve the bubble border radius with iMessage stacked-pill cornering:
+  /// inside a same-author run the inner-facing corners square to 4px while
+  /// outer corners keep the full 14px radius, so a run of bubbles reads as
+  /// one continuous stack rather than N separate pills. Plain mode squares
+  /// off entirely (#564); compact layout drops the bubble fill so radius
+  /// only matters on the original `bubbles` layout.
   BorderRadius _bubbleBorderRadius({required bool isMine}) {
     if (widget._isPlain) return BorderRadius.zero;
     final isRight = isMine && !widget.compactLayout;
+    const full = Radius.circular(14);
+    const tight = Radius.circular(4);
+    final isFirst = widget.showHeader; // showHeader == first-in-group
+    final isLast = widget.isLastInGroup;
+    if (isRight) {
+      // Bubble sits on the right edge; "inner" = the left-facing corners.
+      return BorderRadius.only(
+        topLeft: full,
+        topRight: isFirst ? full : tight,
+        bottomLeft: full,
+        bottomRight: isLast ? full : tight,
+      );
+    }
+    // Received bubble (left side); "inner" = the right-facing corners.
     return BorderRadius.only(
-      topLeft: const Radius.circular(14),
-      topRight: const Radius.circular(14),
-      bottomLeft: Radius.circular(isRight ? 14 : 4),
-      bottomRight: Radius.circular(isRight ? 4 : 14),
+      topLeft: isFirst ? full : tight,
+      topRight: full,
+      bottomLeft: isLast ? full : tight,
+      bottomRight: full,
     );
   }
 

--- a/scripts/seed_v2_lib.sh
+++ b/scripts/seed_v2_lib.sh
@@ -93,14 +93,30 @@ _seed_curl() {
 #   Populates: SEED_USER_ID, SEED_USER_TOKEN
 seed_user() {
   local username="$1" password="$2" bio="${3:-}" status="${4:-}"
-  local body resp
+  local body resp attempts=0
   body=$(jq -nc --arg u "$username" --arg p "$password" \
     '{username:$u, password:$p}')
-  resp=$(_seed_curl POST /api/auth/register "" "$body" || true)
+
+  # Register-with-backoff: prod's per-IP signup rate-limiter rejects bursts
+  # of registrations even with the 5s pause; retry the register up to 4
+  # times with growing pauses before falling through to login (which only
+  # helps if the username already exists).
+  while [ $attempts -lt 4 ]; do
+    resp=$(_seed_curl POST /api/auth/register "" "$body" || true)
+    if [ -n "$(jq -r '.access_token // empty' <<<"$resp" 2>/dev/null)" ]; then
+      break
+    fi
+    attempts=$((attempts + 1))
+    sleep $((15 * attempts))
+  done
+
   if [ -z "$(jq -r '.access_token // empty' <<<"$resp" 2>/dev/null)" ]; then
-    # Username already exists (or registration rate-limited): fall back to login.
+    # Username already exists (or rate-limit never cleared): fall back to login.
     resp=$(_seed_curl POST /api/auth/login "" "$body")
   fi
+  # Short delay between users so the next register doesn't immediately trip
+  # the per-IP burst limit. Tunable via SEED_REGISTER_PAUSE (defaults 5s).
+  sleep "${SEED_REGISTER_PAUSE:-5}"
   SEED_USER_ID=$(jq -r '.user_id // empty' <<<"$resp")
   SEED_USER_TOKEN=$(jq -r '.access_token // empty' <<<"$resp")
   if [ -z "$SEED_USER_ID" ] || [ -z "$SEED_USER_TOKEN" ]; then


### PR DESCRIPTION
## Summary
Three patterns from \`docs/ux-research/{imessage,discord,slack}-message-ui.md\` that Echo wasn't matching:

- **Gap B — iMessage stacked-pill corners**: inner-facing bubble corners square to 4 px inside same-author runs; outer corners keep 14 px so the run reads as one continuous pill stack.
- **Gap C — "Today" elision**: skip the date divider when the label is "Today" (~32 px saved at the top of every active channel). Yesterday + older dates still labelled.
- **Gap A — Compact density chrome tighten**: drop the 4 px bottom gap under \`SenderNameLabel\` in Compact density so the header reads as an inline prefix rather than a separate paragraph above the body. Real RichText inline (Discord IRC-style) is a larger refactor; this delivers the bulk of the visual win.

Plus: \`scripts/seed_v2_lib.sh\` gets register-with-backoff retry so a prod seed run survives the per-IP signup rate-limiter — successfully created 6 users on prod just now (\`riley_/morgan_/taylor_/jordan_/casey_/quinn_1779820576\`, password \`seedv2pass\`).

## Test plan
- [x] \`flutter analyze\` clean
- [x] 41 message_item + 4 date_divider tests pass locally
- [ ] CI passes