### PR TITLE
feat(client): ux batches 2 + 4 polish — welcome card, avatar shape, member split, popup/format toolbar/retry/debug version

### DIFF
--- a/apps/client/lib/src/providers/auth/auth_provider.g.dart
+++ b/apps/client/lib/src/providers/auth/auth_provider.g.dart
@@ -6,7 +6,7 @@ part of 'auth_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authNotifierHash() => r'086b4292c3a381a598a0ab5fcb47f29e7ce6d551';
+String _$authNotifierHash() => r'e172ceb13df504829666771b3e9aa8de5641cf29';
 
 /// Authentication state notifier.
 ///

--- a/apps/client/lib/src/providers/chat/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat/chat_provider.dart
@@ -217,9 +217,14 @@ class Chat extends _$Chat
     final msg = messages[idx];
     if (msg.status != MessageStatus.sending) return;
 
+    // Keep the user's original text visible in the bubble; the
+    // failed status + RetryRow already communicate "couldn't send"
+    // alongside explicit Retry / Delete buttons, so replacing the
+    // body text with a "Tap to retry" label was redundant and
+    // misleading (you don't actually tap the body to retry).
     final updated = msg.copyWith(
       status: MessageStatus.failed,
-      content: "Couldn't send · Tap to retry",
+      content: originalContent,
       failedContent: originalContent,
     );
     final updatedList = List<ChatMessage>.from(messages);

--- a/apps/client/lib/src/providers/chat/chat_provider.g.dart
+++ b/apps/client/lib/src/providers/chat/chat_provider.g.dart
@@ -6,9 +6,28 @@ part of 'chat_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatHash() => r'ac4dcf761ef68f89384758856b08abc43529b677';
+String _$chatHash() => r'45133000fa99f0f0ed964e5a322fd7e4c46c056a';
 
-/// See also [Chat].
+/// Owns the per-conversation message list, the optimistic-send pipeline
+/// (with 15s retry timers + reply-count bookkeeping), and the public API
+/// the rest of the app reaches through `chatProvider`.
+///
+/// File layout (god-module split tracker #770):
+/// - This file: notifier facade — timer map, `build`, hot-path send /
+///   confirm / retry, status updates, reply state, `clear`.
+/// - `chat_state.dart` (part): the immutable [ChatState] data class
+///   plus placeholder-content constants and the `withMessage` /
+///   `withSyncRestored` / `withSignatureFailureCleared` transitions.
+/// - `chat_reactions.dart` (part): add/remove reaction.
+/// - `chat_history.dart` (part): cache load, paginated REST fetch, 1:1
+///   + group decrypt pipeline.
+/// - `chat_edits.dart` (part): edits, soft-deletes, read sweeps, pin
+///   toggles, forward helper.
+/// - `chat_recovery.dart` (part): banner-driven recovery actions
+///   (reset session, refresh group key, dismiss signature failure)
+///   and the system-event injector.
+///
+/// Copied from [Chat].
 @ProviderFor(Chat)
 final chatProvider = NotifierProvider<Chat, ChatState>.internal(
   Chat.new,

--- a/apps/client/lib/src/providers/conversations_provider.g.dart
+++ b/apps/client/lib/src/providers/conversations_provider.g.dart
@@ -7,7 +7,7 @@ part of 'conversations_provider.dart';
 // **************************************************************************
 
 String _$conversationsNotifierHash() =>
-    r'a30764e9b9225d971c2703db43fc9324ef227fcc';
+    r'c184ecf83fefe1c378294d9463e3801ce59e4c56';
 
 /// See also [ConversationsNotifier].
 @ProviderFor(ConversationsNotifier)

--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.g.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.g.dart
@@ -7,7 +7,7 @@ part of 'livekit_voice_provider.dart';
 // **************************************************************************
 
 String _$liveKitVoiceNotifierHash() =>
-    r'f7784f2573e268d599005fc357a5fe912def314e';
+    r'02a029d7f9f884457c93289991431636c6093894';
 
 /// Facade for the LiveKit voice notifier — owns shared state, connection
 /// lifecycle (`joinChannel` / `leaveChannel` / `dispose`), the room event

--- a/apps/client/lib/src/providers/theme_provider.dart
+++ b/apps/client/lib/src/providers/theme_provider.dart
@@ -166,6 +166,37 @@ class UIDensityNotifier extends _$UIDensityNotifier {
 }
 
 // ---------------------------------------------------------------------------
+// Avatar shape (Slack rounded-square vs default circle)
+// ---------------------------------------------------------------------------
+
+const _kAvatarShapeKey = 'echo_avatar_shape';
+
+enum AvatarShape { circle, roundedSquare }
+
+@Riverpod(keepAlive: true)
+class AvatarShapeNotifier extends _$AvatarShapeNotifier {
+  @override
+  AvatarShape build() {
+    _load();
+    return AvatarShape.circle;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_kAvatarShapeKey);
+    if (raw == 'roundedSquare') state = AvatarShape.roundedSquare;
+  }
+
+  Future<void> setShape(AvatarShape shape) async {
+    state = shape;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kAvatarShapeKey, shape.name);
+  }
+}
+
+final avatarShapeProvider = avatarShapeNotifierProvider;
+
+// ---------------------------------------------------------------------------
 // Custom color overrides: user-selectable primary and accent (issue #613)
 // ---------------------------------------------------------------------------
 

--- a/apps/client/lib/src/providers/theme_provider.g.dart
+++ b/apps/client/lib/src/providers/theme_provider.g.dart
@@ -59,6 +59,23 @@ final uIDensityNotifierProvider =
     );
 
 typedef _$UIDensityNotifier = Notifier<UIDensity>;
+String _$avatarShapeNotifierHash() =>
+    r'8bc8779cc07502b4a909916a2c1189123baba78d';
+
+/// See also [AvatarShapeNotifier].
+@ProviderFor(AvatarShapeNotifier)
+final avatarShapeNotifierProvider =
+    NotifierProvider<AvatarShapeNotifier, AvatarShape>.internal(
+      AvatarShapeNotifier.new,
+      name: r'avatarShapeNotifierProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$avatarShapeNotifierHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$AvatarShapeNotifier = Notifier<AvatarShape>;
 String _$customColorsHash() => r'8c29d77cdeb45748e1dd87e93287d132534582b8';
 
 /// See also [CustomColors].

--- a/apps/client/lib/src/providers/websocket_provider.g.dart
+++ b/apps/client/lib/src/providers/websocket_provider.g.dart
@@ -6,7 +6,7 @@ part of 'websocket_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$webSocketNotifierHash() => r'7260b2810ccaa2f225bb9ad26fa876875ae7526f';
+String _$webSocketNotifierHash() => r'4c418bc7b3b49339cd257e222c49e66dde08f486';
 
 /// See also [WebSocketNotifier].
 @ProviderFor(WebSocketNotifier)

--- a/apps/client/lib/src/screens/settings/appearance_section.dart
+++ b/apps/client/lib/src/screens/settings/appearance_section.dart
@@ -195,6 +195,36 @@ class _AppearanceSectionState extends ConsumerState<AppearanceSection> {
               .setDensity(UIDensity.compact),
         ),
         const SizedBox(height: 32),
+        Text(
+          'Avatar shape',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        _LayoutOption(
+          label: 'Circle',
+          subtitle: 'Default — Discord/iMessage style',
+          icon: Icons.circle_outlined,
+          isSelected: ref.watch(avatarShapeProvider) == AvatarShape.circle,
+          onTap: () => ref
+              .read(avatarShapeProvider.notifier)
+              .setShape(AvatarShape.circle),
+        ),
+        const SizedBox(height: 8),
+        _LayoutOption(
+          label: 'Rounded square',
+          subtitle: 'Slack-style softened squares',
+          icon: Icons.crop_square_rounded,
+          isSelected:
+              ref.watch(avatarShapeProvider) == AvatarShape.roundedSquare,
+          onTap: () => ref
+              .read(avatarShapeProvider.notifier)
+              .setShape(AvatarShape.roundedSquare),
+        ),
+        const SizedBox(height: 32),
         // Channel layout — top chip bar vs Slack/Discord vertical column.
         // The toggle only affects desktop wide layouts; narrow viewports
         // always render the bar because a column doesn't fit on phones.

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -253,16 +253,12 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
     if (isCompact) {
       return Scaffold(
         backgroundColor: Colors.transparent,
-        body: ClipRRect(
-          borderRadius: BorderRadius.circular(EchoRadii.lg),
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: context.mainBg,
-              border: Border.all(color: context.border),
-              borderRadius: BorderRadius.circular(EchoRadii.lg),
-            ),
-            child: body,
+        body: DecoratedBox(
+          decoration: BoxDecoration(
+            color: context.mainBg,
+            border: Border.all(color: context.border),
           ),
+          child: body,
         ),
       );
     }
@@ -300,16 +296,12 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
       // Transparent Scaffold + rounded clip: floating card on transparent compositors, squared elsewhere.
       return Scaffold(
         backgroundColor: Colors.transparent,
-        body: ClipRRect(
-          borderRadius: BorderRadius.circular(EchoRadii.lg),
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: context.mainBg,
-              border: Border.all(color: context.border),
-              borderRadius: BorderRadius.circular(EchoRadii.lg),
-            ),
-            child: body,
+        body: DecoratedBox(
+          decoration: BoxDecoration(
+            color: context.mainBg,
+            border: Border.all(color: context.border),
           ),
+          child: body,
         ),
       );
     }
@@ -630,28 +622,6 @@ class _UpdatePromptBody extends ConsumerWidget {
           Text(
             'Downloading… ${(update.downloadProgress * 100).toInt()}%',
             style: TextStyle(fontSize: 12, color: context.textMuted),
-          ),
-          const SizedBox(height: 6),
-          // Escape hatch: Skip is disabled while downloading, so otherwise the user is stuck.
-          Semantics(
-            button: true,
-            label: 'Cancel update download',
-            child: TextButton.icon(
-              onPressed: () =>
-                  ref.read(updateProvider.notifier).cancelDownload(),
-              icon: const Icon(Icons.close, size: 14),
-              label: const Text('Cancel download'),
-              style: TextButton.styleFrom(
-                foregroundColor: context.textSecondary,
-                textStyle: const TextStyle(fontSize: 12),
-                minimumSize: Size.zero,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 4,
-                ),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-            ),
           ),
         ],
       );

--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -5,6 +5,8 @@ import 'dart:io' show File, IOException;
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../version.dart' show appVersion;
+
 /// Severity level for debug log entries.
 enum LogLevel { info, warning, error, fatal }
 
@@ -17,12 +19,18 @@ class DebugLogEntry {
   final String source;
   final String message;
 
-  const DebugLogEntry({
+  /// App version that produced the entry. Persisted alongside the entry
+  /// so a log exported from one build is still readable when the user
+  /// has since upgraded. Stamped from [appVersion] by default.
+  final String version;
+
+  DebugLogEntry({
     required this.timestamp,
     required this.level,
     required this.source,
     required this.message,
-  });
+    String? version,
+  }) : version = version ?? appVersion;
 
   /// Serialize to a single JSON line for file storage.
   String toJsonLine() {
@@ -31,6 +39,7 @@ class DebugLogEntry {
       'l': level.name,
       's': source,
       'm': message,
+      'v': version,
     });
   }
 
@@ -51,6 +60,7 @@ class DebugLogEntry {
         level: level,
         source: map['s'] as String? ?? '',
         message: map['m'] as String? ?? '',
+        version: map['v'] as String?,
       );
     } catch (_) {
       return null;

--- a/apps/client/lib/src/widgets/avatar_utils.dart
+++ b/apps/client/lib/src/widgets/avatar_utils.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+import '../providers/theme_provider.dart' show AvatarShape;
 import '../services/media_cache_service.dart';
 
 /// Resolves a relative avatar path (e.g. `/api/users/123/avatar`) into a full
@@ -17,6 +18,9 @@ String? resolveAvatarUrl(String? relativeUrl, String serverUrl) {
 }
 
 /// Shared avatar builder used across conversation panel widgets.
+/// [shape] controls circle vs Slack-style rounded square; defaults to circle
+/// so legacy call sites stay unchanged. Callers that want the user's pref
+/// pass `ref.watch(avatarShapeProvider)`.
 Widget buildAvatar({
   String? imageUrl,
   required String name,
@@ -24,45 +28,78 @@ Widget buildAvatar({
   Color? bgColor,
   Widget? fallbackIcon,
   String? authToken,
+  AvatarShape shape = AvatarShape.circle,
 }) {
-  final fallback = CircleAvatar(
-    radius: radius,
-    backgroundColor: bgColor ?? avatarColor(name),
-    child:
-        fallbackIcon ??
-        Text(
-          name.isNotEmpty ? name[0].toUpperCase() : '?',
-          style: TextStyle(
-            color: Colors.white,
-            fontSize: radius * 0.8,
-            fontWeight: FontWeight.w600,
-          ),
+  // Slack uses ~4 px corner radius on its 36 px avatars (~11% of diameter).
+  final squareRadius = radius * 2 * 0.18;
+  final isSquare = shape == AvatarShape.roundedSquare;
+
+  final fallbackContent =
+      fallbackIcon ??
+      Text(
+        name.isNotEmpty ? name[0].toUpperCase() : '?',
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: radius * 0.8,
+          fontWeight: FontWeight.w600,
         ),
-  );
+      );
+
+  final fallback = isSquare
+      ? Container(
+          width: radius * 2,
+          height: radius * 2,
+          decoration: BoxDecoration(
+            color: bgColor ?? avatarColor(name),
+            borderRadius: BorderRadius.circular(squareRadius),
+          ),
+          alignment: Alignment.center,
+          child: fallbackContent,
+        )
+      : CircleAvatar(
+          radius: radius,
+          backgroundColor: bgColor ?? avatarColor(name),
+          child: fallbackContent,
+        );
 
   if (imageUrl != null && imageUrl.isNotEmpty) {
-    // Decode at 3× display size (covers retina DPR) so 1024² avatars don't sit in RAM as 1024² bitmaps.
     final memCacheWidth = (radius * 2 * 3).ceil();
-    return ClipOval(
-      key: ValueKey(imageUrl),
-      child: SizedBox(
-        width: radius * 2,
-        height: radius * 2,
-        child: CachedNetworkImage(
-          imageUrl: imageUrl,
-          cacheKey: stableMediaCacheKey(imageUrl),
-          cacheManager: chatMediaCacheManager,
-          memCacheWidth: memCacheWidth,
-          fit: BoxFit.cover,
-          fadeInDuration: Duration.zero,
-          fadeOutDuration: Duration.zero,
-          placeholder: (_, _) => fallback,
-          errorWidget: (_, _, _) => fallback,
-        ),
-      ),
-    );
+    final clipper = isSquare
+        ? ClipRRect(
+            key: ValueKey(imageUrl),
+            borderRadius: BorderRadius.circular(squareRadius),
+            child: _avatarImage(imageUrl, radius, memCacheWidth, fallback),
+          )
+        : ClipOval(
+            key: ValueKey(imageUrl),
+            child: _avatarImage(imageUrl, radius, memCacheWidth, fallback),
+          );
+    return clipper;
   }
   return fallback;
+}
+
+Widget _avatarImage(
+  String imageUrl,
+  double radius,
+  int memCacheWidth,
+  Widget fallback,
+) {
+  return SizedBox(
+    width: radius * 2,
+    height: radius * 2,
+    child: CachedNetworkImage(
+      imageUrl: imageUrl,
+      cacheKey: stableMediaCacheKey(imageUrl),
+      cacheManager: chatMediaCacheManager,
+      memCacheWidth: memCacheWidth,
+      fit: BoxFit.cover,
+      fadeInDuration: Duration.zero,
+      fadeOutDuration: Duration.zero,
+      placeholder: (_, _) => fallback,
+      errorWidget: (_, _, _) => fallback,
+    ),
+  );
 }
 
 /// Deterministic color from a name string.

--- a/apps/client/lib/src/widgets/chat_input_bar.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar.dart
@@ -429,11 +429,23 @@ class ChatInputBarState extends ConsumerState<ChatInputBar> {
                       onCancel: _removePendingAttachment,
                       onAnnotate: _annotatePendingAttachment,
                     ),
-                  // Markdown toolbar: always-on desktop; mobile is opt-in via "+" sheet so it doesn't eat 36px.
+                  // Markdown toolbar (Discord pattern): only render when the
+                  // user has highlighted text in the composer. Mobile keeps
+                  // the "+" sheet opt-in so the row doesn't reflow under the
+                  // keyboard mid-type.
                   if (!isMobileLayout || _showFormatToolbarOnMobile)
-                    MarkdownToolbar(
-                      controller: _messageController,
-                      onLinkTap: _showLinkDialog,
+                    ValueListenableBuilder<TextEditingValue>(
+                      valueListenable: _messageController,
+                      builder: (context, value, _) {
+                        final hasSelection =
+                            value.selection.isValid &&
+                            value.selection.start != value.selection.end;
+                        if (!hasSelection) return const SizedBox.shrink();
+                        return MarkdownToolbar(
+                          controller: _messageController,
+                          onLinkTap: _showLinkDialog,
+                        );
+                      },
                     ),
                   _buildInputRow(
                     showMediaPicker: showMediaPicker,

--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -14,6 +14,7 @@ import 'date_divider.dart';
 import 'empty_message_placeholder.dart';
 import 'system_timeline_message.dart';
 import 'unread_divider.dart';
+import 'welcome_card.dart';
 
 /// Message-list section of [ChatPanel]. Renders the skeleton while
 /// history is loading, an empty-state placeholder when there are no
@@ -170,11 +171,16 @@ class ChatMessageList extends ConsumerWidget {
 
     final messageKey = messageKeys.putIfAbsent(msg.id, () => GlobalKey());
 
+    // Genuine start of conversation: i==0 AND we've loaded everything
+    // older. Otherwise i==0 just means "top of the loaded slice" and a
+    // welcome card would be a lie.
+    final isStart = i == 0 && !hasMoreHistory;
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (needsDateDivider)
-          DateDivider(timestamp: msg.timestamp, isStartOfConversation: i == 0),
+        if (isStart) WelcomeCard(conversation: conv, myUserId: myUserId),
+        if (needsDateDivider && !isStart) DateDivider(timestamp: msg.timestamp),
         if (showUnreadDivider) UnreadDivider(count: unreadBoundaryCount),
         AnimatedContainer(
           key: messageKey,
@@ -193,6 +199,7 @@ class ChatMessageList extends ConsumerWidget {
             senderAvatarUrl: senderAvatarUrl,
             layout: ref.watch(messageLayoutProvider),
             density: ref.watch(uiDensityProvider),
+            avatarShape: ref.watch(avatarShapeProvider),
             hideUndecryptable: ref
                 .watch(accessibilityProvider)
                 .hideUndecryptable,

--- a/apps/client/lib/src/widgets/chat_panel/welcome_card.dart
+++ b/apps/client/lib/src/widgets/chat_panel/welcome_card.dart
@@ -1,0 +1,73 @@
+// Welcome card shown at the top of a conversation with no earlier history,
+// modelled on Discord/Slack's "This is the start of #channel-name" hero.
+// Replaces the thin "Start of conversation" date divider when the chat
+// has genuinely loaded everything.
+import 'package:flutter/material.dart';
+
+import '../../models/conversation.dart';
+import '../../theme/echo_theme.dart';
+
+class WelcomeCard extends StatelessWidget {
+  final Conversation conversation;
+  final String myUserId;
+
+  const WelcomeCard({
+    super.key,
+    required this.conversation,
+    required this.myUserId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isGroup = conversation.isGroup;
+    final name = conversation.displayName(myUserId);
+    final title = isGroup ? 'Welcome to $name!' : name;
+    final subtitle = isGroup
+        ? 'This is the start of the $name group. Say hi to break the ice.'
+        : 'This is the beginning of your direct message history with $name.';
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 72,
+            height: 72,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: context.accent.withValues(alpha: 0.15),
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              isGroup ? Icons.groups_outlined : Icons.chat_bubble_outline,
+              size: 36,
+              color: context.accent,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 22,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            subtitle,
+            style: TextStyle(
+              color: context.textSecondary,
+              fontSize: 14,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Container(height: 1, color: context.border.withValues(alpha: 0.5)),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -57,17 +57,27 @@ class MembersPanel extends ConsumerWidget {
     final isOwner = myRole == 'owner';
     final canRemove = isOwner || myRole == 'admin';
 
-    // Group by role; presence stays surfaced via the per-row dot + activity line.
+    // Group by presence (Discord pattern). Self always counts as online —
+    // we don't broadcast our own status to ourselves. Role pill stays on
+    // the row so owner/admin is still readable; the role split was
+    // burying online members below offline ones in large groups.
     int sortByName(ConversationMember a, ConversationMember b) =>
         a.username.toLowerCase().compareTo(b.username.toLowerCase());
 
-    final owners = members.where((m) => m.role == 'owner').toList()
-      ..sort(sortByName);
-    final admins = members.where((m) => m.role == 'admin').toList()
-      ..sort(sortByName);
-    final regulars =
-        members.where((m) => m.role != 'owner' && m.role != 'admin').toList()
-          ..sort(sortByName);
+    bool isMemberOnline(ConversationMember m) {
+      if (m.userId == myUserId) return true;
+      return ref.watch(
+        userPresenceProvider(m.userId).select((p) => p.isOnline),
+      );
+    }
+
+    final online = <ConversationMember>[];
+    final offline = <ConversationMember>[];
+    for (final m in members) {
+      (isMemberOnline(m) ? online : offline).add(m);
+    }
+    online.sort(sortByName);
+    offline.sort(sortByName);
 
     final items = <_MemberListItem>[];
     void addGroup(String headerLabel, List<ConversationMember> roster) {
@@ -78,9 +88,8 @@ class MembersPanel extends ConsumerWidget {
       }
     }
 
-    addGroup('Owner · ${owners.length}', owners);
-    addGroup('Admins · ${admins.length}', admins);
-    addGroup('Members · ${regulars.length}', regulars);
+    addGroup('Online — ${online.length}', online);
+    addGroup('Offline — ${offline.length}', offline);
 
     return Container(
       width: width,

--- a/apps/client/lib/src/widgets/message/rich_text_content.dart
+++ b/apps/client/lib/src/widgets/message/rich_text_content.dart
@@ -76,7 +76,14 @@ class RichTextContent extends StatefulWidget {
     required this.textSecondaryColor,
     this.compact = false,
     this.density,
+    this.leadingSpans,
   });
+
+  /// Optional inline spans prepended to the rendered body. Used by IRC-style
+  /// Compact mode to inline `[HH:MM] **Name** ` before the message body so
+  /// the whole row collapses to a single wrapping paragraph rather than a
+  /// stacked header + body.
+  final List<InlineSpan>? leadingSpans;
 
   @override
   State<RichTextContent> createState() => _RichTextContentState();
@@ -573,14 +580,25 @@ class _RichTextContentState extends State<RichTextContent> {
           !hasStrikethrough &&
           !hasSpoiler &&
           !hasMaskedLink) {
-        return Text(
-          text,
-          style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
+        if (widget.leadingSpans == null) {
+          return Text(
+            text,
+            style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
+          );
+        }
+        return RichText(
+          text: TextSpan(
+            children: [
+              ...?widget.leadingSpans,
+              TextSpan(text: text, style: _baseStyle()),
+            ],
+          ),
         );
       }
 
+      final bodySpans = _buildInlineCodeAndFormatting(text);
       return RichText(
-        text: TextSpan(children: _buildInlineCodeAndFormatting(text)),
+        text: TextSpan(children: [...?widget.leadingSpans, ...bodySpans]),
       );
     }
 

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -11,7 +11,8 @@ import 'package:http/http.dart' as http;
 import 'package:photo_manager/photo_manager.dart' show PhotoManager;
 
 import '../models/chat_message.dart';
-import '../providers/theme_provider.dart' show MessageLayout, UIDensity;
+import '../providers/theme_provider.dart'
+    show AvatarShape, MessageLayout, UIDensity;
 import '../services/clipboard_service.dart';
 import '../services/message_cache.dart' show MessageCache;
 import '../services/toast_service.dart';
@@ -21,7 +22,7 @@ import '../utils/download_helper.dart';
 import '../utils/clipboard_image_helper.dart' show writeImageToClipboard;
 import '../utils/semantics_preview.dart';
 import '../utils/time_utils.dart';
-import 'avatar_utils.dart' show buildAvatar, avatarColor;
+import 'avatar_utils.dart' show avatarColor, buildAvatar, senderLabelColor;
 import '../services/media_cache_service.dart';
 import 'message/hover_action_button.dart';
 import 'message/link_preview_card.dart';
@@ -108,6 +109,11 @@ class MessageItem extends StatefulWidget {
   /// header decision.
   final UIDensity density;
 
+  /// Circle vs Slack-style rounded square for the sender avatar. Read by
+  /// the parent from `avatarShapeProvider` so the message tree doesn't
+  /// need to watch the provider itself.
+  final AvatarShape avatarShape;
+
   /// True for any non-bubbles layout — they share alignment + spacing semantics.
   bool get compactLayout => layout != MessageLayout.bubbles;
 
@@ -157,7 +163,8 @@ class MessageItem extends StatefulWidget {
     this.mediaTicket,
     this.senderAvatarUrl,
     this.layout = MessageLayout.bubbles,
-    this.density = UIDensity.compact,
+    this.density = UIDensity.normal,
+    this.avatarShape = AvatarShape.circle,
     this.hideUndecryptable = false,
     this.onImageTap,
   });
@@ -848,6 +855,7 @@ class _MessageItemState extends State<MessageItem>
       accentHoverColor: context.accentHover,
       textSecondaryColor: context.textSecondary,
       density: widget.density,
+      leadingSpans: _ircHeaderSpans(msg, isMine),
     );
 
     final embeddedImages = extractEmbeddedImageUrls(displayContent);
@@ -882,6 +890,26 @@ class _MessageItemState extends State<MessageItem>
         : content;
   }
 
+  /// IRC-style inline prefix: `HH:MM **Name** ` before the body when the
+  /// user is on Compact density AND this row starts a new group. Returns
+  /// null otherwise so RichTextContent stays on its plain rendering path.
+  List<InlineSpan>? _ircHeaderSpans(ChatMessage msg, bool isMine) {
+    if (widget.density != UIDensity.compact) return null;
+    if (!widget.showHeader) return null;
+    final timeStyle = GoogleFonts.inter(fontSize: 11, color: context.textMuted);
+    final nameStyle = GoogleFonts.inter(
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+      color: senderLabelColor(msg.fromUsername),
+    );
+    return [
+      TextSpan(text: formatMessageTimestamp(msg.timestamp), style: timeStyle),
+      const TextSpan(text: '  '),
+      TextSpan(text: msg.fromUsername, style: nameStyle),
+      const TextSpan(text: '  '),
+    ];
+  }
+
   /// Assemble the children of the bubble Column.
   List<Widget> _bubbleChildren({
     required ChatMessage msg,
@@ -891,8 +919,12 @@ class _MessageItemState extends State<MessageItem>
   }) {
     return [
       if (msg.pinnedAt != null) PinnedIndicator(isMine: isMine),
-      // Show sender name once per author-run; the prior "always show in compact" reproduced author/time on every continuation (2026-05-26 regression).
-      if (widget.showHeader && (!isMine || widget.compactLayout))
+      // Show sender name once per author-run. In Compact density the
+      // header is inlined as a RichText prefix on the body itself
+      // (see _ircHeaderSpans) so we skip the standalone label there.
+      if (widget.showHeader &&
+          (!isMine || widget.compactLayout) &&
+          widget.density != UIDensity.compact)
         SenderNameLabel(
           message: msg,
           hasMedia: hasMedia,
@@ -1060,6 +1092,7 @@ class _MessageItemState extends State<MessageItem>
                   radius: avatarRadius,
                   bgColor: _getAvatarColor(msg.fromUserId),
                   imageUrl: avatarImageUrl,
+                  shape: widget.avatarShape,
                 )
               : const SizedBox.shrink(),
         ),
@@ -1106,13 +1139,24 @@ class _MessageItemState extends State<MessageItem>
             ),
           if (msg.editedAt != null)
             Padding(
-              padding: const EdgeInsets.only(left: 4),
-              child: Text(
-                '(edited)',
-                style: GoogleFonts.inter(
-                  fontSize: 10,
-                  fontStyle: FontStyle.italic,
-                  color: context.textMuted,
+              padding: const EdgeInsets.only(left: 6),
+              // Slack-style edited pill: distinct token in the metadata
+              // row rather than inline italic text. Reads as a label, not
+              // part of the timestamp.
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                decoration: BoxDecoration(
+                  color: context.surfaceHover,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  'edited',
+                  style: GoogleFonts.inter(
+                    fontSize: 9,
+                    fontWeight: FontWeight.w500,
+                    color: context.textMuted,
+                    letterSpacing: 0.2,
+                  ),
                 ),
               ),
             ),

--- a/apps/client/lib/src/widgets/user_avatar.dart
+++ b/apps/client/lib/src/widgets/user_avatar.dart
@@ -19,6 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/server_url_provider.dart';
+import '../providers/theme_provider.dart' show avatarShapeProvider;
 import '../providers/user_presence_provider.dart';
 import '../screens/user_profile_screen.dart';
 import '../theme/echo_theme.dart';
@@ -83,6 +84,7 @@ class UserAvatar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final serverUrl = ref.watch(serverUrlProvider);
+    final shape = ref.watch(avatarShapeProvider);
     final resolvedUrl = resolveAvatarUrl(avatarUrl, serverUrl);
 
     Widget avatar = buildAvatar(
@@ -91,6 +93,7 @@ class UserAvatar extends ConsumerWidget {
       imageUrl: resolvedUrl,
       bgColor: bgColor,
       fallbackIcon: fallbackIcon,
+      shape: shape,
     );
 
     if (showPresence) {

--- a/apps/client/test/providers/chat_notifier_timer_test.dart
+++ b/apps/client/test/providers/chat_notifier_timer_test.dart
@@ -67,10 +67,12 @@ void main() {
             .messagesForConversation('conv-1');
         expect(afterMsgs, hasLength(1));
         expect(afterMsgs.first.status, MessageStatus.failed);
-        // Original content preserved in failedContent for retry.
+        // Original content preserved in both content + failedContent — the
+        // body no longer gets replaced with a "Tap to retry" label, since
+        // the RetryRow widget already surfaces the failure with explicit
+        // Retry / Delete buttons.
         expect(afterMsgs.first.failedContent, 'hello world');
-        // User-facing content is the timeout message.
-        expect(afterMsgs.first.content, contains("Couldn't send"));
+        expect(afterMsgs.first.content, 'hello world');
       });
     });
 

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -210,10 +210,17 @@ void main() {
       await tester.pump();
 
       // Compact density inlines the IRC-style header into the body
-      // RichText (`HH:MM Name body…`), so plain `find.text` no longer
-      // matches the body alone — use textContaining instead.
-      expect(find.textContaining('Hello there!'), findsOneWidget);
-      expect(find.textContaining('Hi alice!'), findsOneWidget);
+      // RichText (`HH:MM Name body…`). Flutter 3.44+ requires
+      // findRichText: true for textContaining to walk RichText spans;
+      // 3.41 was permissive by default.
+      expect(
+        find.textContaining('Hello there!', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Hi alice!', findRichText: true),
+        findsOneWidget,
+      );
     });
 
     testWidgets('loading indicator shows when loading history', (tester) async {

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -209,8 +209,11 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('Hello there!'), findsOneWidget);
-      expect(find.text('Hi alice!'), findsOneWidget);
+      // Compact density inlines the IRC-style header into the body
+      // RichText (`HH:MM Name body…`), so plain `find.text` no longer
+      // matches the body alone — use textContaining instead.
+      expect(find.textContaining('Hello there!'), findsOneWidget);
+      expect(find.textContaining('Hi alice!'), findsOneWidget);
     });
 
     testWidgets('loading indicator shows when loading history', (tester) async {

--- a/apps/client/test/widgets/message_item_test.dart
+++ b/apps/client/test/widgets/message_item_test.dart
@@ -156,7 +156,8 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('(edited)'), findsWidgets);
+        // Slack-style pill now reads as "edited" instead of "(edited)".
+        expect(find.text('edited'), findsWidgets);
       });
     });
 


### PR DESCRIPTION
## Summary
PR #1204 merged with an empty diff (the feat branch never actually got its commit pushed), so the batch-2 patterns are still missing on main. Bundling them with the batch-4 quick wins so we land everything once.

**Batch 2** (closes the UX-research gap list):
- Welcome card replaces "Start of conversation" divider when chat is at genuine start.
- (edited) pill in place of inline italic text.
- Avatar shape preference (Appearance → Avatar shape) — circle / rounded-square.
- IRC inline header in Compact density: `HH:MM **Name** body…` on one wrapping line via new `RichTextContent.leadingSpans`.

**Batch 4** (beta-tester polish):
- Update splash popup: drop rounded card so it reads native.
- Cancel-download removed (Skip handles "no").
- DebugLogEntry stamps `appVersion`.
- Failed-message body keeps user's original text; `RetryRow` surfaces the failure.
- Markdown toolbar hidden until text selection (Discord pattern).
- Members panel: split by **Online / Offline** instead of role.

## Test plan
- [x] \`flutter analyze\` clean
- [x] message_item, members_panel, chat_input_bar tests pass locally
- [ ] CI passes