### PR TITLE
feat: profile background colour (#5)

### DIFF
--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -81,6 +81,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
   final _phoneDigitsController = TextEditingController();
   _CountryCode _selectedCountry = _countries.first; // US +1
   bool _profileLoaded = false;
+  String? _backgroundColor;
   bool _saving = false;
 
   // Password change
@@ -141,6 +142,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
           _emailController.text = data['email'] as String? ?? '';
           _phoneController.text = data['phone'] as String? ?? '';
           _parsePhoneIntoComponents(data['phone'] as String? ?? '');
+          _backgroundColor = data['background_color'] as String?;
           _profileLoaded = true;
           _profileError = false;
         });
@@ -172,6 +174,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
         'website': _websiteController.text,
         'email': _emailController.text,
         'phone': phoneValue,
+        'background_color': _backgroundColor ?? '',
       };
 
       final resp = await ref
@@ -664,6 +667,8 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
           const SizedBox(height: 12),
           _buildPronounsField(),
           const SizedBox(height: 12),
+          _buildBackgroundColorPicker(),
+          const SizedBox(height: 12),
           _profileField(
             controller: _bioController,
             label: 'Bio',
@@ -764,6 +769,55 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
   bool get _isCustomPronoun =>
       _pronounsController.text.isNotEmpty &&
       !_pronounOptions.contains(_pronounsController.text);
+
+  /// Curated profile-banner palette. Each entry shows behind the avatar
+  /// on the user-profile sheet. Validated server-side as #RRGGBB so we
+  /// just send the hex string; tap an already-selected swatch to clear.
+  static const List<({String label, String hex})> _bgPalette = [
+    (label: 'Indigo', hex: '#4F46E5'),
+    (label: 'Sky', hex: '#0EA5E9'),
+    (label: 'Emerald', hex: '#10B981'),
+    (label: 'Amber', hex: '#F59E0B'),
+    (label: 'Rose', hex: '#F43F5E'),
+    (label: 'Fuchsia', hex: '#D946EF'),
+    (label: 'Slate', hex: '#475569'),
+  ];
+
+  Widget _buildBackgroundColorPicker() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6, left: 4),
+          child: Text(
+            'Profile background',
+            style: TextStyle(
+              color: context.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final entry in _bgPalette)
+              _BgSwatch(
+                hex: entry.hex,
+                label: entry.label,
+                selected: _backgroundColor == entry.hex,
+                onTap: () => setState(() {
+                  _backgroundColor = _backgroundColor == entry.hex
+                      ? null
+                      : entry.hex;
+                }),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
 
   Widget _buildPronounsField() {
     final currentValue = _pronounsController.text;
@@ -1174,6 +1228,49 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
         contentPadding: const EdgeInsets.symmetric(
           horizontal: 12,
           vertical: 10,
+        ),
+      ),
+    );
+  }
+}
+
+class _BgSwatch extends StatelessWidget {
+  final String hex;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _BgSwatch({
+    required this.hex,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final value = int.tryParse(hex.substring(1), radix: 16);
+    final color = value == null ? Colors.grey : Color(0xFF000000 | value);
+    return Semantics(
+      label: '$label background${selected ? " (selected)" : ""}',
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: selected ? context.textPrimary : Colors.transparent,
+              width: 2,
+            ),
+          ),
+          child: selected
+              ? const Icon(Icons.check, size: 18, color: Colors.white)
+              : null,
         ),
       ),
     );

--- a/apps/client/lib/src/screens/user_profile_screen.dart
+++ b/apps/client/lib/src/screens/user_profile_screen.dart
@@ -52,6 +52,7 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
   String? _website;
   String? _email;
   String? _phone;
+  String? _backgroundColor;
   bool _isContact = false;
 
   @override
@@ -92,6 +93,7 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
           _website = data['website'] as String?;
           _email = data['email'] as String?;
           _phone = data['phone'] as String?;
+          _backgroundColor = data['background_color'] as String?;
           _isLoading = false;
         });
       } else {
@@ -302,34 +304,68 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
       isOnline: presence.isOnline,
     );
 
+    // Discord/Slack-style banner: a thin colored band behind the top of
+    // the profile sheet that the avatar overlaps. Uses the user's
+    // background_color when set (validated server-side as #RRGGBB);
+    // otherwise reads as transparent and looks like a normal sheet.
+    final bannerColor = _parseHexColor(_backgroundColor);
+
     return SingleChildScrollView(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      padding: EdgeInsets.zero,
       child: Column(
         children: [
-          Container(
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              border: Border.all(color: ringColor, width: 3),
-            ),
-            padding: const EdgeInsets.all(3),
-            child: buildAvatar(
-              name: _username,
-              radius: 52,
-              imageUrl: fullAvatarUrl,
+          if (bannerColor != null)
+            Container(height: 96, color: bannerColor)
+          else
+            const SizedBox(height: 32),
+          Transform.translate(
+            offset: Offset(0, bannerColor != null ? -52 : 0),
+            child: Container(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: ringColor, width: 3),
+                color: context.surface,
+              ),
+              padding: const EdgeInsets.all(3),
+              child: buildAvatar(
+                name: _username,
+                radius: 52,
+                imageUrl: fullAvatarUrl,
+              ),
             ),
           ),
-          const SizedBox(height: 16),
-          _buildNameSection(),
-          _buildStatusSection(),
-          const SizedBox(height: 12),
-          _buildBioSection(),
-          ..._buildContactDetailRows(),
-          _buildMemberSinceRow(),
-          const SizedBox(height: 28),
-          _buildActionButton(),
+          // Pull the rest of the content up so it doesn't gap-out under
+          // the negative-offset avatar.
+          Transform.translate(
+            offset: Offset(0, bannerColor != null ? -36 : 0),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                children: [
+                  const SizedBox(height: 16),
+                  _buildNameSection(),
+                  _buildStatusSection(),
+                  const SizedBox(height: 12),
+                  _buildBioSection(),
+                  ..._buildContactDetailRows(),
+                  _buildMemberSinceRow(),
+                  const SizedBox(height: 28),
+                  _buildActionButton(),
+                ],
+              ),
+            ),
+          ),
         ],
       ),
     );
+  }
+
+  /// Parse a #RRGGBB hex string into a Color, returning null on any
+  /// parse failure so a bad backend value can't crash the sheet.
+  Color? _parseHexColor(String? hex) {
+    if (hex == null || hex.length != 7 || !hex.startsWith('#')) return null;
+    final v = int.tryParse(hex.substring(1), radix: 16);
+    return v == null ? null : Color(0xFF000000 | v);
   }
 
   /// Display name + username + pronouns header section.

--- a/apps/server/migrations/20260526190000_profile_background_color.sql
+++ b/apps/server/migrations/20260526190000_profile_background_color.sql
@@ -1,0 +1,4 @@
+-- Profile background colour: hex string in #RRGGBB form (e.g. #4F46E5).
+-- Stored as TEXT for forward-compat with future "preset name" values; client
+-- validates against a known palette before persisting.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS background_color TEXT;

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -125,6 +125,7 @@ pub struct UserProfileRow {
     pub website: Option<String>,
     pub email: Option<String>,
     pub phone: Option<String>,
+    pub background_color: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -170,7 +171,7 @@ pub async fn search_users(
          timezone, pronouns, website, \
          CASE WHEN email_visible THEN email ELSE NULL END AS email, \
          CASE WHEN phone_visible THEN phone ELSE NULL END AS phone, \
-         created_at \
+         background_color, created_at \
          FROM users \
          WHERE id != $2 AND searchable = true AND ( \
            username ILIKE $1 ESCAPE '\\' \
@@ -256,7 +257,7 @@ pub async fn find_public_profile(
          timezone, pronouns, website, \
          CASE WHEN email_visible THEN email ELSE NULL END AS email, \
          CASE WHEN phone_visible THEN phone ELSE NULL END AS phone, \
-         created_at \
+         background_color, created_at \
          FROM users WHERE id = $1",
     )
     .bind(user_id)
@@ -274,6 +275,7 @@ pub struct ProfileUpdate<'a> {
     pub website: Option<&'a str>,
     pub email: Option<&'a str>,
     pub phone: Option<&'a str>,
+    pub background_color: Option<&'a str>,
 }
 
 /// Update profile fields for a user. Only non-null fields are updated.
@@ -292,10 +294,11 @@ pub async fn update_profile(
          pronouns = CASE WHEN $6 IS NULL THEN pronouns ELSE NULLIF($6, '') END, \
          website = CASE WHEN $7 IS NULL THEN website ELSE NULLIF($7, '') END, \
          email = CASE WHEN $8 IS NULL THEN email ELSE NULLIF($8, '') END, \
-         phone = CASE WHEN $9 IS NULL THEN phone ELSE NULLIF($9, '') END \
+         phone = CASE WHEN $9 IS NULL THEN phone ELSE NULLIF($9, '') END, \
+         background_color = CASE WHEN $10 IS NULL THEN background_color ELSE NULLIF($10, '') END \
          WHERE id = $1 \
          RETURNING id, username, display_name, avatar_url, bio, status_message, \
-                  timezone, pronouns, website, email, phone, created_at",
+                  timezone, pronouns, website, email, phone, background_color, created_at",
     )
     .bind(user_id)
     .bind(fields.display_name)
@@ -306,6 +309,7 @@ pub async fn update_profile(
     .bind(fields.website)
     .bind(fields.email)
     .bind(fields.phone)
+    .bind(fields.background_color)
     .fetch_one(pool)
     .await
 }

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -34,6 +34,7 @@ pub struct UserProfile {
     pub website: Option<String>,
     pub email: Option<String>,
     pub phone: Option<String>,
+    pub background_color: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -47,6 +48,7 @@ pub struct UpdateProfileRequest {
     pub website: Option<String>,
     pub email: Option<String>,
     pub phone: Option<String>,
+    pub background_color: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -156,6 +158,7 @@ pub async fn get_profile(
         website: profile.website,
         email: profile.email,
         phone: profile.phone,
+        background_color: profile.background_color,
         created_at: profile.created_at,
     }))
 }
@@ -231,6 +234,20 @@ pub async fn update_profile(
     {
         return Err(AppError::bad_request("Phone must be 30 characters or less"));
     }
+    if let Some(ref color) = body.background_color
+        && !color.is_empty()
+    {
+        // Strict #RRGGBB. Front-end constrains to a preset palette, but
+        // we re-validate so callers using the raw API can't inject CSS.
+        let valid = color.len() == 7
+            && color.starts_with('#')
+            && color[1..].chars().all(|c| c.is_ascii_hexdigit());
+        if !valid {
+            return Err(AppError::bad_request(
+                "background_color must be a #RRGGBB hex string",
+            ));
+        }
+    }
 
     // Normalize phone to E.164: strip all non-digit chars except leading +.
     let normalized_phone = body.phone.as_deref().map(|p| {
@@ -252,6 +269,7 @@ pub async fn update_profile(
         website: body.website.as_deref(),
         email: body.email.as_deref(),
         phone: normalized_phone.as_deref(),
+        background_color: body.background_color.as_deref(),
     };
     let profile = db::users::update_profile(&state.pool, auth.user_id, &fields)
         .await
@@ -269,6 +287,7 @@ pub async fn update_profile(
         website: profile.website,
         email: profile.email,
         phone: profile.phone,
+        background_color: profile.background_color,
         created_at: profile.created_at,
     }))
 }


### PR DESCRIPTION
## Summary
Per-user accent colour shown as a banner band behind the avatar on the profile sheet. Closes the colour-only first step of #5; banner image upload is a follow-up.

- **Server**: new migration adds \`users.background_color TEXT\`. GET / PATCH /api/users/me/profile carry the field. Strict \`#RRGGBB\` validation server-side (clients are also constrained to a curated 7-hue palette).
- **Client**: Settings → Profile gets a colour-swatch picker (7 hues + clear). UserProfileScreen renders a 96 px band with the avatar overlapping by 52 px when a colour is set; falls back to the existing flat layout when null.

## Test plan
- [x] \`cargo check -p echo-server\` clean
- [x] \`flutter analyze\` clean on changed files
- [x] account_section tests pass locally
- [ ] CI passes
- [ ] Manual: pick + save a colour, reload, verify it persists and shows on the sheet