### PR TITLE
feat: profile status pill, voice button, joined location line

### DIFF
--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -75,6 +75,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
   final _bioController = TextEditingController();
   final _pronounsController = TextEditingController();
   final _timezoneController = TextEditingController();
+  final _locationController = TextEditingController();
   final _websiteController = TextEditingController();
   final _emailController = TextEditingController();
   final _phoneController = TextEditingController();
@@ -103,6 +104,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     _currentPasswordController.dispose();
     _newPasswordController.dispose();
     _timezoneController.dispose();
+    _locationController.dispose();
     _websiteController.dispose();
     _emailController.dispose();
     _phoneController.dispose();
@@ -143,6 +145,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
           _phoneController.text = data['phone'] as String? ?? '';
           _parsePhoneIntoComponents(data['phone'] as String? ?? '');
           _backgroundColor = data['background_color'] as String?;
+          _locationController.text = data['location'] as String? ?? '';
           _profileLoaded = true;
           _profileError = false;
         });
@@ -175,6 +178,7 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
         'email': _emailController.text,
         'phone': phoneValue,
         'background_color': _backgroundColor ?? '',
+        'location': _locationController.text,
       };
 
       final resp = await ref
@@ -678,6 +682,13 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
           ),
           const SizedBox(height: 12),
           _buildTimezoneDropdown(),
+          const SizedBox(height: 12),
+          _profileField(
+            controller: _locationController,
+            label: 'Location',
+            hint: 'City, region — shown on your profile',
+            maxLength: 80,
+          ),
           const SizedBox(height: 12),
           _profileField(
             controller: _websiteController,

--- a/apps/client/lib/src/screens/user_profile_screen.dart
+++ b/apps/client/lib/src/screens/user_profile_screen.dart
@@ -7,10 +7,13 @@ import 'package:http/http.dart' as http;
 import 'package:qr_flutter/qr_flutter.dart';
 
 import '../providers/auth_provider.dart';
+import '../providers/chat_provider.dart';
 import '../providers/contacts_provider.dart';
 import '../providers/conversations_provider.dart';
+import '../providers/livekit_voice/livekit_voice_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/user_presence_provider.dart';
+import '../providers/websocket_provider.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/presence.dart';
@@ -53,6 +56,7 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
   String? _email;
   String? _phone;
   String? _backgroundColor;
+  String? _location;
   bool _isContact = false;
 
   @override
@@ -94,6 +98,7 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
           _email = data['email'] as String?;
           _phone = data['phone'] as String?;
           _backgroundColor = data['background_color'] as String?;
+          _location = data['location'] as String?;
           _isLoading = false;
         });
       } else {
@@ -413,19 +418,61 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
     );
   }
 
-  /// Status message line (if set).
+  /// Status pill: `● Online · {status text}`. Driven by the user's
+  /// presence (from userPresenceProvider) and the optional status_text
+  /// the user can set. Renders as a small chip below the identity block
+  /// regardless of whether status_text is set — the presence label
+  /// alone is informative.
   Widget _buildStatusSection() {
-    if (_statusMessage == null || _statusMessage!.isEmpty) {
-      return const SizedBox.shrink();
+    final isSelf = widget.userId == ref.read(authProvider).userId;
+    final UserPresence presence;
+    if (isSelf) {
+      final myStatus = ref.watch(authProvider.select((s) => s.presenceStatus));
+      presence = UserPresence(status: myStatus, isOnline: true);
+    } else {
+      presence = ref.watch(userPresenceProvider(widget.userId));
     }
+    final dotColor = presenceColor(
+      presence.status,
+      isOnline: presence.isOnline,
+    );
+    final label = presenceLabel(presence.status, isOnline: presence.isOnline);
+    final hasStatus =
+        _statusMessage != null && _statusMessage!.trim().isNotEmpty;
+    final pillText = hasStatus ? '$label · ${_statusMessage!.trim()}' : label;
     return Padding(
-      padding: const EdgeInsets.only(top: 6),
-      child: Text(
-        _statusMessage!,
-        style: TextStyle(
-          color: context.textSecondary,
-          fontSize: 13,
-          fontStyle: FontStyle.italic,
+      padding: const EdgeInsets.only(top: 8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: context.surfaceHover,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: context.border),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: dotColor,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                pillText,
+                style: TextStyle(
+                  color: context.textSecondary,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -482,16 +529,41 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
         ),
         const SizedBox(height: 8),
       ],
-      if (_timezone != null && _timezone!.isNotEmpty) ...[
+      // Joined location row: "🌐 Berlin · UTC+1 · 09:47 local". Each
+      // half is optional; we render the row as long as at least one of
+      // location / timezone is present, joined with " · ".
+      if (_buildLocationLine() != null) ...[
         _iconRow(
-          icon: Icons.schedule,
+          icon: Icons.public,
           iconColor: context.textMuted,
-          text: 'Local time: ${_formatLocalTime(_timezone!)} ($_timezone)',
+          text: _buildLocationLine()!,
           textColor: context.textMuted,
         ),
         const SizedBox(height: 8),
       ],
     ];
+  }
+
+  /// Compose the location/timezone/local-time line. Returns null when
+  /// neither `location` nor `timezone` is set so the row is skipped.
+  String? _buildLocationLine() {
+    final parts = <String>[];
+    if (_location != null && _location!.trim().isNotEmpty) {
+      parts.add(_location!.trim());
+    }
+    if (_timezone != null && _timezone!.isNotEmpty) {
+      final offsetMin = _ianaOffsetMinutes[_timezone!];
+      if (offsetMin != null) {
+        final h = offsetMin ~/ 60;
+        final m = (offsetMin % 60).abs();
+        final sign = h >= 0 ? '+' : '';
+        parts.add(
+          m == 0 ? 'UTC$sign$h' : 'UTC$sign$h:${m.toString().padLeft(2, '0')}',
+        );
+      }
+      parts.add('${_formatLocalTime(_timezone!)} local');
+    }
+    return parts.isEmpty ? null : parts.join(' · ');
   }
 
   Widget _iconRow({
@@ -585,9 +657,9 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
               const SizedBox(width: 8),
               Expanded(
                 child: OutlinedButton.icon(
-                  onPressed: _openSafetyNumber,
-                  icon: const Icon(Icons.security_outlined, size: 18),
-                  label: const Text('Safety Number'),
+                  onPressed: _isStartingDm ? null : _startVoiceFromProfile,
+                  icon: const Icon(Icons.call_outlined, size: 18),
+                  label: const Text('Voice'),
                   style: OutlinedButton.styleFrom(
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),
@@ -597,6 +669,21 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
                 ),
               ),
             ],
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: _openSafetyNumber,
+              icon: const Icon(Icons.security_outlined, size: 18),
+              label: const Text('Safety Number'),
+              style: OutlinedButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
           ),
           const SizedBox(height: 8),
           SizedBox(
@@ -658,6 +745,52 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
       ToastService.show(
         context,
         'Could not start conversation',
+        type: ToastType.error,
+      );
+    } finally {
+      if (mounted) setState(() => _isStartingDm = false);
+    }
+  }
+
+  /// Get-or-create the DM with this user, then start a LiveKit voice
+  /// call against it. Reuses the conv.id as both conversationId and
+  /// channelId — the DM convention used by chat_header_bar's voice
+  /// affordance.
+  Future<void> _startVoiceFromProfile() async {
+    if (_isStartingDm) return;
+    final voiceState = ref.read(livekitVoiceProvider);
+    if (voiceState.isActive) {
+      ToastService.show(
+        context,
+        'Already in a voice call.',
+        type: ToastType.info,
+      );
+      return;
+    }
+    setState(() => _isStartingDm = true);
+    try {
+      final conv = await ref
+          .read(conversationsProvider.notifier)
+          .getOrCreateDm(widget.userId, _username);
+      if (!mounted) return;
+      await ref
+          .read(livekitVoiceProvider.notifier)
+          .joinChannel(conversationId: conv.id, channelId: conv.id);
+      ref.read(websocketProvider.notifier).sendCallStarted(conv.id);
+      ref
+          .read(chatProvider.notifier)
+          .addSystemEvent(conv.id, 'Voice call started');
+      if (!mounted) return;
+      if (Navigator.canPop(context)) Navigator.pop(context);
+      context.go('/home?conversation=${conv.id}');
+    } on DmException catch (e) {
+      if (!mounted) return;
+      ToastService.show(context, e.message, type: ToastType.error);
+    } catch (e) {
+      if (!mounted) return;
+      ToastService.show(
+        context,
+        'Could not start voice call',
         type: ToastType.error,
       );
     } finally {

--- a/apps/client/test/widgets/chat_panel_test.dart
+++ b/apps/client/test/widgets/chat_panel_test.dart
@@ -209,8 +209,17 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('Hello there!'), findsOneWidget);
-      expect(find.text('Hi alice!'), findsOneWidget);
+      // Compact density inlines the IRC-style header into the body
+      // RichText (`HH:MM Name body…`). Flutter 3.44+ requires
+      // findRichText: true for textContaining to walk RichText spans.
+      expect(
+        find.textContaining('Hello there!', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Hi alice!', findRichText: true),
+        findsOneWidget,
+      );
     });
 
     testWidgets('loading indicator shows when loading history', (tester) async {

--- a/apps/server/migrations/20260526200000_profile_location.sql
+++ b/apps/server/migrations/20260526200000_profile_location.sql
@@ -1,0 +1,5 @@
+-- Profile location text (city, region, country — free-form). Pairs with the
+-- existing timezone column so the profile sheet can render "Berlin · UTC+1
+-- · 09:47 local" on a single line. 80-char cap to leave headroom for
+-- "Tokyo, Japan" but reject prose.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS location TEXT;

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -126,6 +126,7 @@ pub struct UserProfileRow {
     pub email: Option<String>,
     pub phone: Option<String>,
     pub background_color: Option<String>,
+    pub location: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -171,7 +172,7 @@ pub async fn search_users(
          timezone, pronouns, website, \
          CASE WHEN email_visible THEN email ELSE NULL END AS email, \
          CASE WHEN phone_visible THEN phone ELSE NULL END AS phone, \
-         background_color, created_at \
+         background_color, location, created_at \
          FROM users \
          WHERE id != $2 AND searchable = true AND ( \
            username ILIKE $1 ESCAPE '\\' \
@@ -257,7 +258,7 @@ pub async fn find_public_profile(
          timezone, pronouns, website, \
          CASE WHEN email_visible THEN email ELSE NULL END AS email, \
          CASE WHEN phone_visible THEN phone ELSE NULL END AS phone, \
-         background_color, created_at \
+         background_color, location, created_at \
          FROM users WHERE id = $1",
     )
     .bind(user_id)
@@ -276,6 +277,7 @@ pub struct ProfileUpdate<'a> {
     pub email: Option<&'a str>,
     pub phone: Option<&'a str>,
     pub background_color: Option<&'a str>,
+    pub location: Option<&'a str>,
 }
 
 /// Update profile fields for a user. Only non-null fields are updated.
@@ -295,10 +297,11 @@ pub async fn update_profile(
          website = CASE WHEN $7 IS NULL THEN website ELSE NULLIF($7, '') END, \
          email = CASE WHEN $8 IS NULL THEN email ELSE NULLIF($8, '') END, \
          phone = CASE WHEN $9 IS NULL THEN phone ELSE NULLIF($9, '') END, \
-         background_color = CASE WHEN $10 IS NULL THEN background_color ELSE NULLIF($10, '') END \
+         background_color = CASE WHEN $10 IS NULL THEN background_color ELSE NULLIF($10, '') END, \
+         location = CASE WHEN $11 IS NULL THEN location ELSE NULLIF($11, '') END \
          WHERE id = $1 \
          RETURNING id, username, display_name, avatar_url, bio, status_message, \
-                  timezone, pronouns, website, email, phone, background_color, created_at",
+                  timezone, pronouns, website, email, phone, background_color, location, created_at",
     )
     .bind(user_id)
     .bind(fields.display_name)
@@ -310,6 +313,7 @@ pub async fn update_profile(
     .bind(fields.email)
     .bind(fields.phone)
     .bind(fields.background_color)
+    .bind(fields.location)
     .fetch_one(pool)
     .await
 }

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -35,6 +35,7 @@ pub struct UserProfile {
     pub email: Option<String>,
     pub phone: Option<String>,
     pub background_color: Option<String>,
+    pub location: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -49,6 +50,7 @@ pub struct UpdateProfileRequest {
     pub email: Option<String>,
     pub phone: Option<String>,
     pub background_color: Option<String>,
+    pub location: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -159,6 +161,7 @@ pub async fn get_profile(
         email: profile.email,
         phone: profile.phone,
         background_color: profile.background_color,
+        location: profile.location,
         created_at: profile.created_at,
     }))
 }
@@ -248,6 +251,13 @@ pub async fn update_profile(
             ));
         }
     }
+    if let Some(ref loc) = body.location
+        && loc.len() > 80
+    {
+        return Err(AppError::bad_request(
+            "Location must be 80 characters or less",
+        ));
+    }
 
     // Normalize phone to E.164: strip all non-digit chars except leading +.
     let normalized_phone = body.phone.as_deref().map(|p| {
@@ -270,6 +280,7 @@ pub async fn update_profile(
         email: body.email.as_deref(),
         phone: normalized_phone.as_deref(),
         background_color: body.background_color.as_deref(),
+        location: body.location.as_deref(),
     };
     let profile = db::users::update_profile(&state.pool, auth.user_id, &fields)
         .await
@@ -288,6 +299,7 @@ pub async fn update_profile(
         email: profile.email,
         phone: profile.phone,
         background_color: profile.background_color,
+        location: profile.location,
         created_at: profile.created_at,
     }))
 }


### PR DESCRIPTION
## Summary
Three follow-ups from the unfinished profile-sheet design (image shared 2026-05-26):

- **Status pill**: \`● Online · {status text}\` — small chip under the identity block driven by \`userPresenceProvider\` + the existing \`status_text\` field. Always renders the presence label even when no custom status is set.
- **Voice button**: paired with Message in a 2-up Row. Reuses the DM-id-as-channel-id convention from \`chat_header_bar\` so the existing voice fanout / LiveKit flow handles it. Tapping it opens the DM and joins voice in one step.
- **Joined location line**: \`🌐 Berlin · UTC+1 · 09:47 local\` — folds new \`location\` text column + UTC offset + computed local time onto one row. Standalone "Local time: …" row goes away.

## Server
- Migration adds \`users.location TEXT\` (validated ≤80 chars)
- GET / PATCH /api/users/me/profile carry the field
- \`ProfileUpdate\` and \`UserProfileRow\` extended

## Client
- Settings → Profile: new Location text field next to Timezone
- UserProfileScreen renders the joined location line + replaces the standalone status section with the pill + adds Voice button next to Message

## Test plan
- [x] \`cargo check -p echo-server\` clean
- [x] \`flutter analyze\` clean on changed files
- [x] account_section tests pass locally
- [ ] CI passes