### PR TITLE
fix(client): screen-share quality applies + participant volume context menu

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_av_controls.dart
@@ -181,11 +181,18 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
         final track = await LocalVideoTrack.createScreenShareTrack(
           captureOptions,
         );
+        // (#910) Single-layer VP8 + the user's current bitrate/fps so the
+        // quality picker (dock_submenus.ScreenShareSubmenu) actually takes
+        // effect on the screen-share track instead of silently defaulting.
         await room.localParticipant?.publishVideoTrack(
           track,
-          publishOptions: const VideoPublishOptions(
+          publishOptions: VideoPublishOptions(
             simulcast: false,
             videoCodec: 'vp8',
+            videoEncoding: VideoEncoding(
+              maxBitrate: state.videoBitrate,
+              maxFramerate: state.videoFps,
+            ),
           ),
         );
       }
@@ -233,33 +240,72 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
     }
   }
 
-  /// Apply the current videoBitrate / videoFps to the active camera track.
+  /// Apply the current videoBitrate / videoFps to BOTH the active camera
+  /// track AND the active screen-share track.
   ///
   /// LiveKit 2.7.x throws TrackPublishException when publishVideoTrack is
   /// called on an already-published track, so we unpublish first and then
-  /// republish with the new encoding options via a fresh camera track.
+  /// republish with the new encoding options via a fresh track.
+  ///
+  /// Screen-share's quality picker (dock_submenus.ScreenShareSubmenu) was
+  /// previously a no-op because this method only touched camera publications.
   Future<void> _applyVideoEncoding() async {
     final room = _room;
-    if (room == null || !state.isVideoEnabled || state.autoQuality) return;
+    if (room == null || state.autoQuality) return;
 
     final localParticipant = room.localParticipant;
     if (localParticipant == null) return;
 
-    final cameraPub = localParticipant.videoTrackPublications
-        .where((pub) => pub.source == TrackSource.camera && pub.track != null)
-        .firstOrNull;
+    // Camera leg — only republish when video is actually enabled.
+    if (state.isVideoEnabled) {
+      final cameraPub = localParticipant.videoTrackPublications
+          .where((pub) => pub.source == TrackSource.camera && pub.track != null)
+          .firstOrNull;
+      if (cameraPub != null) {
+        try {
+          await localParticipant.removePublishedTrack(cameraPub.sid);
+          final newTrack = await LocalVideoTrack.createCameraTrack(
+            room.roomOptions.defaultCameraCaptureOptions,
+          );
+          await localParticipant.publishVideoTrack(
+            newTrack,
+            publishOptions: VideoPublishOptions(
+              videoEncoding: VideoEncoding(
+                maxBitrate: state.videoBitrate,
+                maxFramerate: state.videoFps,
+              ),
+            ),
+          );
+        } catch (e) {
+          debugPrint('[LiveKitVoice] setVideoParams (camera) failed: $e');
+          DebugLogService.instance.log(
+            LogLevel.warning,
+            'LiveKitVoice',
+            'Video params change (camera) failed: $e',
+          );
+        }
+      }
+    }
 
-    if (cameraPub != null) {
+    // Screen-share leg — republish if currently sharing so the new bitrate
+    // / fps takes effect on the active stream.
+    final screenPub = localParticipant.videoTrackPublications
+        .where(
+          (pub) =>
+              pub.source == TrackSource.screenShareVideo && pub.track != null,
+        )
+        .firstOrNull;
+    if (screenPub != null) {
       try {
-        // Unpublish the existing track; re-publishing the same track object
-        // throws TrackPublishException('track already exists') in SDK 2.7.x.
-        await localParticipant.removePublishedTrack(cameraPub.sid);
-        final newTrack = await LocalVideoTrack.createCameraTrack(
-          room.roomOptions.defaultCameraCaptureOptions,
+        await localParticipant.removePublishedTrack(screenPub.sid);
+        final newTrack = await LocalVideoTrack.createScreenShareTrack(
+          room.roomOptions.defaultScreenShareCaptureOptions,
         );
         await localParticipant.publishVideoTrack(
           newTrack,
           publishOptions: VideoPublishOptions(
+            simulcast: false,
+            videoCodec: 'vp8',
             videoEncoding: VideoEncoding(
               maxBitrate: state.videoBitrate,
               maxFramerate: state.videoFps,
@@ -267,11 +313,11 @@ mixin LiveKitVoiceAvControlsMixin on Notifier<LiveKitVoiceState> {
           ),
         );
       } catch (e) {
-        debugPrint('[LiveKitVoice] setVideoParams failed: $e');
+        debugPrint('[LiveKitVoice] setVideoParams (screen) failed: $e');
         DebugLogService.instance.log(
           LogLevel.warning,
           'LiveKitVoice',
-          'Video params change failed: $e',
+          'Video params change (screen) failed: $e',
         );
       }
     }

--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -7,15 +7,19 @@ import 'dart:ui' show ImageFilter;
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:livekit_client/livekit_client.dart' as lk;
 
 import '../../providers/livekit_voice/livekit_voice_provider.dart';
+import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
 import '../../theme/motion_tokens.dart';
 import '../../utils/canvas_utils.dart';
+import '../../widgets/context_menu/echo_context_menu.dart';
 import '../../widgets/voice/participant_attention.dart';
 import '../../widgets/voice_speaking_ring.dart';
+import '../user_profile_screen.dart';
 import 'participant_volume_controller.dart';
 
 class ParticipantGrid extends StatelessWidget {
@@ -250,7 +254,7 @@ class ParticipantGrid extends StatelessWidget {
 // Single participant tile
 // ---------------------------------------------------------------------------
 
-class ParticipantTile extends StatefulWidget {
+class ParticipantTile extends ConsumerStatefulWidget {
   final String name;
   final String? avatarUrl;
   final bool hasVideo;
@@ -305,10 +309,10 @@ class ParticipantTile extends StatefulWidget {
   });
 
   @override
-  State<ParticipantTile> createState() => _ParticipantTileState();
+  ConsumerState<ParticipantTile> createState() => _ParticipantTileState();
 }
 
-class _ParticipantTileState extends State<ParticipantTile> {
+class _ParticipantTileState extends ConsumerState<ParticipantTile> {
   /// Grace period that keeps `isSpeaking` true for a brief window after the
   /// last above-threshold sample, so the ring doesn't flicker during natural
   /// pauses mid-sentence (#907).
@@ -535,212 +539,70 @@ class _ParticipantTileState extends State<ParticipantTile> {
     final participant = widget.remoteParticipant;
     if (participant == null) return;
 
-    final overlay =
-        Overlay.of(context, rootOverlay: true).context.findRenderObject()
-            as RenderBox?;
-    final overlaySize = overlay?.size ?? MediaQuery.of(context).size;
-
-    showMenu<void>(
+    final identity = participant.identity.isNotEmpty
+        ? participant.identity
+        : participant.sid.toString();
+    final initialVolume = ParticipantVolumeController.instance.volumeFor(
+      identity,
+    );
+    final perUserVolumeSupported =
+        kIsWeb || defaultTargetPlatform != TargetPlatform.windows;
+    // Capture a stable, mounted-safe reference to the menu's context so the
+    // slider callbacks can fire after EchoContextMenu's overlay disposes.
+    EchoContextMenu.open(
       context: context,
-      position: RelativeRect.fromLTRB(
-        position.dx,
-        position.dy,
-        overlaySize.width - position.dx,
-        overlaySize.height - position.dy,
-      ),
-      color: context.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(10),
-        side: BorderSide(color: context.border),
-      ),
-      items: [
-        PopupMenuItem<void>(
-          // enabled: true (default) keeps the slider track + thumb rendered in
-          // their normal theme colors. We override [onTap] to null so tapping
-          // the slider doesn't dismiss the menu — the popover handles its own
-          // dismissal via the "Toggle mute for me" row.
-          onTap: null,
-          padding: EdgeInsets.zero,
-          child: _ParticipantVolumePopover(
-            participant: participant,
-            name: widget.name,
-            onToggleMute: widget.onMuteForMe,
-          ),
+      target: DebugTarget('voice-member:$identity'),
+      anchor: position,
+      model: ContextMenuModel(
+        header: VolumeSliderHeader(
+          title: widget.name,
+          initialValue: initialVolume,
+          enabled: perUserVolumeSupported,
+          disabledTooltip: perUserVolumeSupported
+              ? null
+              : 'Per-user volume isn’t supported on Windows yet.',
+          onChanged: (_) {},
+          onChangeEnd: (next) {
+            unawaited(
+              ParticipantVolumeController.instance.setVolume(participant, next),
+            );
+          },
         ),
-      ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Volume slider popover (per-participant)
-// ---------------------------------------------------------------------------
-
-class _ParticipantVolumePopover extends StatefulWidget {
-  final lk.RemoteParticipant participant;
-  final String name;
-  final VoidCallback? onToggleMute;
-
-  const _ParticipantVolumePopover({
-    required this.participant,
-    required this.name,
-    this.onToggleMute,
-  });
-
-  @override
-  State<_ParticipantVolumePopover> createState() =>
-      _ParticipantVolumePopoverState();
-}
-
-class _ParticipantVolumePopoverState extends State<_ParticipantVolumePopover> {
-  late double _volume;
-
-  /// `flutter_webrtc`'s `Helper.setVolume` is a no-op on the Windows native
-  /// backend (#909). We keep the slider visible so users can see the control
-  /// exists, but render it disabled with a tooltip explaining why.
-  bool get _perUserVolumeSupported {
-    if (kIsWeb) return true;
-    return defaultTargetPlatform != TargetPlatform.windows;
-  }
-
-  static const String _windowsTooltip =
-      'Per-user volume is not supported on Windows yet (flutter_webrtc limitation)';
-
-  @override
-  void initState() {
-    super.initState();
-    final identity = widget.participant.identity.isNotEmpty
-        ? widget.participant.identity
-        : widget.participant.sid.toString();
-    _volume = ParticipantVolumeController.instance.volumeFor(identity);
-  }
-
-  /// Visual-only update while the user is dragging. We deliberately do NOT
-  /// call [ParticipantVolumeController.setVolume] from here — overlapping
-  /// async slider events can resolve out of order and leave the WebRTC track
-  /// gain at a stale value. The commit happens once on [_onChangeEnd].
-  void _onChanged(double next) {
-    setState(() => _volume = next);
-  }
-
-  Future<void> _onChangeEnd(double next) async {
-    await ParticipantVolumeController.instance.setVolume(
-      widget.participant,
-      next,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final percent = (_volume * 100).round();
-    final sliderTheme = SliderTheme.of(context).copyWith(
-      trackHeight: 4,
-      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
-      overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
-      activeTrackColor: context.accent,
-      inactiveTrackColor: context.border,
-      thumbColor: context.accent,
-      overlayColor: context.accent.withValues(alpha: 0.18),
-    );
-
-    // Vertical slider: rotate a horizontal Slider 90° counter-clockwise so
-    // the high end sits at the top. SfSlider isn't a project dep, and a
-    // hand-rolled GestureDetector slider would skip a11y/keyboard support
-    // — rotating the framework Slider keeps semantics intact.
-    final supported = _perUserVolumeSupported;
-    Widget verticalSlider = SizedBox(
-      width: 36,
-      height: 140,
-      child: RotatedBox(
-        quarterTurns: 3,
-        child: SliderTheme(
-          data: sliderTheme,
-          child: Slider(
-            value: _volume,
-            min: 0,
-            max: 1,
-            onChanged: supported ? _onChanged : null,
-            onChangeEnd: supported ? _onChangeEnd : null,
-          ),
-        ),
-      ),
-    );
-    if (!supported) {
-      verticalSlider = Tooltip(message: _windowsTooltip, child: verticalSlider);
-    }
-
-    return SizedBox(
-      width: 180,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(14, 10, 14, 10),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            SizedBox(
-              width: double.infinity,
-              child: Text(
-                widget.name,
-                style: TextStyle(
-                  color: context.textPrimary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                ),
-                overflow: TextOverflow.ellipsis,
-                textAlign: TextAlign.center,
+        sections: [
+          ContextMenuSection(
+            actions: [
+              ContextMenuAction(
+                label: 'Profile',
+                icon: Icons.person_outline,
+                onTap: () => UserProfileScreen.show(context, ref, identity),
               ),
-            ),
-            const SizedBox(height: 2),
-            Text(
-              '$percent%',
-              style: TextStyle(color: context.textMuted, fontSize: 11),
-            ),
-            const SizedBox(height: 4),
-            Icon(Icons.volume_up, size: 16, color: context.textMuted),
-            verticalSlider,
-            Icon(
-              _volume <= 0.001 ? Icons.volume_off : Icons.volume_down,
-              size: 16,
-              color: context.textMuted,
-            ),
-            if (widget.onToggleMute != null) ...[
-              const SizedBox(height: 6),
-              const Divider(height: 1),
-              const SizedBox(height: 4),
-              InkWell(
+              ContextMenuAction(
+                label: 'Mention',
+                icon: Icons.alternate_email,
                 onTap: () {
-                  Navigator.of(context).pop();
-                  widget.onToggleMute?.call();
+                  // Mention is wired by the chat composer; until that hook
+                  // lands here, copy a "@name" handle to the clipboard so
+                  // the user can paste it.
+                  Clipboard.setData(ClipboardData(text: '@${widget.name}'));
+                  ToastService.show(
+                    context,
+                    'Copied @${widget.name} to clipboard',
+                    type: ToastType.info,
+                  );
                 },
-                borderRadius: BorderRadius.circular(6),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 8,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        Icons.volume_off,
-                        size: 16,
-                        color: context.textSecondary,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Toggle mute for me',
-                        style: TextStyle(
-                          color: context.textPrimary,
-                          fontSize: 13,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
               ),
             ],
-          ],
-        ),
+          ),
+          ContextMenuSection(
+            actions: [
+              ContextMenuAction(
+                label: 'Mute for me',
+                icon: Icons.volume_off_outlined,
+                onTap: widget.onMuteForMe ?? () {},
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/apps/client/lib/src/widgets/context_menu/context_menu_overlay.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_overlay.dart
@@ -158,11 +158,14 @@ class _ContextMenuOverlayState extends State<_ContextMenuOverlay> {
     // Rough lower bound used only for viewport clamping. Real
     // intrinsic size handles itself once painted.
     const headerRow = 56.0;
+    const volumeHeaderRow = 92.0;
     const itemRow = 36.0;
     const divider = 13.0;
     const padding = 12.0;
     var h = padding * 2;
-    if (model.header != null) h += headerRow;
+    if (model.header != null) {
+      h += model.header is VolumeSliderHeader ? volumeHeaderRow : headerRow;
+    }
     if (model.title != null) h += 32;
     for (var i = 0; i < model.sections.length; i++) {
       if (i > 0) h += divider;
@@ -282,7 +285,87 @@ class _MenuContents extends StatelessWidget {
   Widget _renderHeader(BuildContext context, ContextMenuHeader header) {
     return switch (header) {
       InlineReactionsHeader h => _InlineReactionsRow(header: h),
+      VolumeSliderHeader h => _VolumeSliderRow(header: h),
     };
+  }
+}
+
+class _VolumeSliderRow extends StatefulWidget {
+  const _VolumeSliderRow({required this.header});
+  final VolumeSliderHeader header;
+
+  @override
+  State<_VolumeSliderRow> createState() => _VolumeSliderRowState();
+}
+
+class _VolumeSliderRowState extends State<_VolumeSliderRow> {
+  late double _value = widget.header.initialValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final percent = (_value * 100).round();
+    final disabled = !widget.header.enabled;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.header.title,
+                  style: TextStyle(
+                    color: context.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Text(
+                '$percent%',
+                style: TextStyle(
+                  color: disabled ? context.textMuted : context.textSecondary,
+                  fontSize: 12,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ],
+          ),
+          SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 3,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+              overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
+              activeTrackColor: context.accent,
+              inactiveTrackColor: context.border,
+            ),
+            child: Slider(
+              value: _value.clamp(0.0, 2.0),
+              min: 0,
+              max: 2,
+              onChanged: disabled
+                  ? null
+                  : (v) {
+                      setState(() => _value = v);
+                      widget.header.onChanged(v);
+                    },
+              onChangeEnd: disabled ? null : widget.header.onChangeEnd,
+            ),
+          ),
+          if (disabled && widget.header.disabledTooltip != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                widget.header.disabledTooltip!,
+                style: TextStyle(color: context.textMuted, fontSize: 11),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/client/lib/src/widgets/context_menu/context_menu_sheet.dart
+++ b/apps/client/lib/src/widgets/context_menu/context_menu_sheet.dart
@@ -107,7 +107,75 @@ class _ContextMenuSheetState extends State<_ContextMenuSheet> {
   Widget _renderHeader(BuildContext context, ContextMenuHeader header) {
     return switch (header) {
       InlineReactionsHeader h => _InlineReactionsRow(header: h),
+      VolumeSliderHeader h => _SheetVolumeSliderRow(header: h),
     };
+  }
+}
+
+class _SheetVolumeSliderRow extends StatefulWidget {
+  const _SheetVolumeSliderRow({required this.header});
+  final VolumeSliderHeader header;
+
+  @override
+  State<_SheetVolumeSliderRow> createState() => _SheetVolumeSliderRowState();
+}
+
+class _SheetVolumeSliderRowState extends State<_SheetVolumeSliderRow> {
+  late double _value = widget.header.initialValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final percent = (_value * 100).round();
+    final disabled = !widget.header.enabled;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.header.title,
+                  style: TextStyle(
+                    color: context.textPrimary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              Text(
+                '$percent%',
+                style: TextStyle(
+                  color: disabled ? context.textMuted : context.textSecondary,
+                  fontSize: 13,
+                ),
+              ),
+            ],
+          ),
+          Slider(
+            value: _value.clamp(0.0, 2.0),
+            min: 0,
+            max: 2,
+            activeColor: context.accent,
+            inactiveColor: context.border,
+            onChanged: disabled
+                ? null
+                : (v) {
+                    setState(() => _value = v);
+                    widget.header.onChanged(v);
+                  },
+            onChangeEnd: disabled ? null : widget.header.onChangeEnd,
+          ),
+          if (disabled && widget.header.disabledTooltip != null)
+            Text(
+              widget.header.disabledTooltip!,
+              style: TextStyle(color: context.textMuted, fontSize: 12),
+            ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -102,6 +102,37 @@ class InlineReactionsHeader extends ContextMenuHeader {
   final VoidCallback onOpenFullPicker;
 }
 
+/// Per-participant volume slider header used by the voice-lounge member
+/// context menu. Shows the participant's display name, current percent,
+/// and a draggable 0–200% slider. `onChanged` fires on drag (cheap UI
+/// update); `onChangeEnd` commits the value to the WebRTC track.
+class VolumeSliderHeader extends ContextMenuHeader {
+  const VolumeSliderHeader({
+    required this.title,
+    required this.initialValue,
+    required this.onChanged,
+    required this.onChangeEnd,
+    this.enabled = true,
+    this.disabledTooltip,
+  });
+
+  /// Display name shown above the slider.
+  final String title;
+
+  /// Initial value in [0.0, 2.0] — 1.0 is 100% (system default).
+  final double initialValue;
+
+  /// Called continuously while dragging. Visual-only.
+  final ValueChanged<double> onChanged;
+
+  /// Called once when the user releases the thumb. Commit point.
+  final ValueChanged<double> onChangeEnd;
+
+  /// When false the slider greys out and shows [disabledTooltip].
+  final bool enabled;
+  final String? disabledTooltip;
+}
+
 /// Resolved menu tree for one target. Built from a target by the
 /// per-target registries (see `actions/*_actions_registry.dart`,
 /// added in PRs 2-4).


### PR DESCRIPTION
## Summary
Two fixes from beta-tester feedback:

1. **Screen-share quality picker was silent.** \`_applyVideoEncoding\` only touched camera publications, and \`setScreenShareEnabled(true)\` published without bitrate/fps. The Low / Balanced / High preset never reached the screen-share track. Now both publish + republish paths thread \`state.videoBitrate\` and \`state.videoFps\` so the picker actually changes the stream.

2. **Per-participant volume popover** migrated to \`EchoContextMenu\` so it matches the standard dark menu look: Profile · Mention · Mute as ContextMenuActions, with a new \`VolumeSliderHeader\` rendering the slider above. The old \`PopupMenuItem\` + standalone \`_ParticipantVolumePopover\` are deleted. \`VolumeSliderHeader\` is wired into both desktop overlay and mobile sheet.

## Test plan
- [x] \`flutter analyze\` clean on changed files
- [x] context_menu_overlay + livekit_voice_provider tests pass locally
- [ ] CI passes
- [ ] Manual: right-click a participant, see Profile/Mention/Mute + volume slider; change Low/Balanced/High while screen-sharing and see remote stream adapt