### PR TITLE
feat(client): resize handles for canvas images (#2 partial)

### DIFF
--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -262,6 +262,41 @@ class CanvasController extends _$CanvasController {
     _sendCanvasEvent('image_remove', {'id': imageId});
   }
 
+  /// Live-resize throttle: piggybacks on the existing image_move WS event so
+  /// the server's update_image upserts the new size without any server-side
+  /// changes (CanvasImage.toJson includes width + height).
+  void resizeImage(String imageId, double width, double height) {
+    if (_channelId == null) return;
+    final idx = state.images.indexWhere((img) => img.id == imageId);
+    if (idx == -1) return;
+    final clampedW = width.clamp(0.05, 1.0);
+    final clampedH = height.clamp(0.05, 1.0);
+    final updated = state.images[idx].copyWith(
+      width: clampedW,
+      height: clampedH,
+    );
+    final newImages = List<CanvasImage>.from(state.images)..[idx] = updated;
+    state = state.copyWith(images: newImages);
+
+    _pendingImageMove = updated.toJson();
+    _imageThrottle ??= Timer.periodic(
+      const Duration(milliseconds: 100),
+      (_) => _flushImageMove(),
+    );
+  }
+
+  /// Flushes the pending resize state immediately on pointer-up.
+  void commitImageResize(String imageId) {
+    _imageThrottle?.cancel();
+    _imageThrottle = null;
+    _pendingImageMove = null;
+
+    if (_channelId == null) return;
+    final idx = state.images.indexWhere((img) => img.id == imageId);
+    if (idx == -1) return;
+    _sendCanvasEvent('image_move', state.images[idx].toJson());
+  }
+
   // -------------------------------------------------------------------------
   // Avatars
   // -------------------------------------------------------------------------

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -374,6 +374,20 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
                   .commitImageMove(img.id, currentImg.x, currentImg.y);
             }
           },
+          onResize: (dx, dy) {
+            final current = ref
+                .read(canvasProvider)
+                .images
+                .where((i) => i.id == img.id)
+                .firstOrNull;
+            final curW = (current?.width ?? img.width) * size.width;
+            final curH = (current?.height ?? img.height) * size.height;
+            final newW = ((curW + dx) / size.width).clamp(0.05, 1.0);
+            final newH = ((curH + dy) / size.height).clamp(0.05, 1.0);
+            ref.read(canvasProvider.notifier).resizeImage(img.id, newW, newH);
+          },
+          onResizeEnd: () =>
+              ref.read(canvasProvider.notifier).commitImageResize(img.id),
           onRemove: () => ref.read(canvasProvider.notifier).removeImage(img.id),
         ),
       );
@@ -919,6 +933,8 @@ class _CanvasImageWidget extends StatefulWidget {
   final Map<String, String>? httpHeaders;
   final void Function(double dx, double dy) onMove;
   final VoidCallback onMoveEnd;
+  final void Function(double dx, double dy) onResize;
+  final VoidCallback onResizeEnd;
   final VoidCallback onRemove;
 
   const _CanvasImageWidget({
@@ -926,6 +942,8 @@ class _CanvasImageWidget extends StatefulWidget {
     this.httpHeaders,
     required this.onMove,
     required this.onMoveEnd,
+    required this.onResize,
+    required this.onResizeEnd,
     required this.onRemove,
   });
 
@@ -990,6 +1008,35 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                       Icons.close,
                       size: 16,
                       color: context.textPrimary,
+                    ),
+                  ),
+                ),
+              ),
+            if (_hovered)
+              Positioned(
+                bottom: 0,
+                right: 0,
+                child: MouseRegion(
+                  cursor: SystemMouseCursors.resizeDownRight,
+                  child: GestureDetector(
+                    onPanUpdate: (d) => widget.onResize(d.delta.dx, d.delta.dy),
+                    onPanEnd: (_) => widget.onResizeEnd(),
+                    child: Container(
+                      width: 24,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        color: context.surface.withValues(alpha: 0.7),
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(8),
+                          bottomRight: Radius.circular(4),
+                        ),
+                      ),
+                      alignment: Alignment.center,
+                      child: Icon(
+                        Icons.open_in_full,
+                        size: 14,
+                        color: context.textPrimary,
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
Phase 3b of the voice-lounge canvas batch — drag-to-resize for images.

- Bottom-right resize grip appears on image hover (mirrors the top-right close button).
- Drag the grip → live local resize + throttled WS broadcast.
- Pointer-up flushes the final size to the server.
- Reuses the existing \`image_move\` WS event because \`CanvasImage.toJson\` already round-trips width + height — \`update_image\` on the server upserts the full row, no server changes needed.
- Clamps min 5% / max 100% of canvas dimension on each axis. Aspect ratio is free.

## What's NOT in this PR
**Video-tile (participant) resize.** \`AvatarPosition\` carries only x/y today; per-tile sizing needs a new column + WS schema update + drag rewrite, which belongs in its own slice. The image-resize half ships now to unblock day-to-day immersion use.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`canvas_provider_test.dart\` passes
- [ ] CI passes
- [ ] Manual: paste an image into the canvas, hover → see the bottom-right grip, drag to resize, drop → other participants see the new size