### PR TITLE
fix(client): show status dot on own avatar in members panel

### DIFF
--- a/apps/client/lib/src/providers/user_presence_provider.dart
+++ b/apps/client/lib/src/providers/user_presence_provider.dart
@@ -19,11 +19,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../utils/presence.dart';
+import 'auth/auth_provider.dart';
 import 'websocket_provider.dart';
 
 part 'user_presence_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 UserPresence userPresence(Ref ref, String userId) {
+  // The server does not echo presence_update back to the connecting user,
+  // so presenceFor(myUserId) returns offline/empty until a contact triggers
+  // a broadcast. Surface the locally-known presence from authProvider for
+  // self so the user sees their own status dot light up immediately.
+  final myUserId = ref.watch(authProvider.select((s) => s.userId));
+  if (myUserId != null && myUserId == userId) {
+    final myStatus = ref.watch(authProvider.select((s) => s.presenceStatus));
+    return UserPresence(status: myStatus, isOnline: true);
+  }
   return ref.watch(websocketProvider.select((s) => s.presenceFor(userId)));
 }

--- a/apps/client/test/providers/user_presence_provider_test.dart
+++ b/apps/client/test/providers/user_presence_provider_test.dart
@@ -1,0 +1,45 @@
+/// Verify that [userPresenceProvider] surfaces the local user's status from
+/// authProvider as soon as auth lands, even before the server echoes a
+/// presence_update back. Without this override the user sees a missing
+/// status dot on their own avatar in the members panel.
+library;
+
+import 'package:echo_app/src/providers/auth/auth_provider.dart';
+import 'package:echo_app/src/providers/user_presence_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('userPresenceProvider returns online for the local user even when WS '
+      'has not echoed a presence_update yet', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    const myUserId = 'me';
+    container.read(authProvider.notifier).state = const AuthState(
+      userId: myUserId,
+      presenceStatus: 'dnd',
+    );
+
+    final presence = container.read(userPresenceProvider(myUserId));
+    expect(presence.isOnline, isTrue);
+    expect(presence.status, 'dnd');
+  });
+
+  test(
+    'userPresenceProvider still routes other userIds through the WS state',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(authProvider.notifier).state = const AuthState(
+        userId: 'me',
+        presenceStatus: 'online',
+      );
+
+      final presence = container.read(userPresenceProvider('someone-else'));
+      expect(presence.isOnline, isFalse);
+      expect(presence.status, 'offline');
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Fixes the bug shown in the screenshot — \`nnpc\` in the Online — 1 section is missing a green dot on their avatar, even though the row label reads "online".

## Root cause
The server only broadcasts \`presence_update\` to a user's contacts; it never echoes it back to the connecting user. So \`userPresenceProvider(myUserId)\` returned offline / empty until somebody else's status change happened to load self into the WS state too.

The members-panel row label special-cases self by reading \`authProvider.presenceStatus\` directly (so it says "online"), but \`UserAvatar(showPresence: true)\` reads \`userPresenceProvider\` and was getting the stale offline state — hence the missing dot.

## Fix
Override \`userPresenceProvider\` for self at the source: if the requested userId matches \`authProvider.userId\`, return \`UserPresence(status: authState.presenceStatus, isOnline: true)\`. Other users still route through the WS state.

## Test plan
- [x] New unit test confirms self gets isOnline=true + the auth state's status
- [x] New unit test confirms other userIds still route through WS state (no regression)
- [x] \`flutter analyze\` clean
- [ ] Manual: green dot now visible on own avatar in members panel