### PR TITLE
feat: status presets + custom status visible in members panel

### DIFF
--- a/apps/client/lib/src/models/conversation.dart
+++ b/apps/client/lib/src/models/conversation.dart
@@ -212,12 +212,18 @@ class ConversationMember {
   final String? avatarUrl;
   final String? statusText;
 
+  /// Stored presence ('online', 'away', 'dnd', 'invisible'). Null when the
+  /// server build pre-dates the member-row presence join; treat it as
+  /// 'online' downstream.
+  final String? presenceStatus;
+
   const ConversationMember({
     required this.userId,
     required this.username,
     this.role,
     this.avatarUrl,
     this.statusText,
+    this.presenceStatus,
   });
 
   factory ConversationMember.fromJson(Map<String, dynamic> json) {
@@ -227,6 +233,7 @@ class ConversationMember {
       role: json['role'] as String?,
       avatarUrl: json['avatar_url'] as String?,
       statusText: json['status_text'] as String?,
+      presenceStatus: json['presence_status'] as String?,
     );
   }
 
@@ -238,10 +245,17 @@ class ConversationMember {
             username == other.username &&
             role == other.role &&
             avatarUrl == other.avatarUrl &&
-            statusText == other.statusText;
+            statusText == other.statusText &&
+            presenceStatus == other.presenceStatus;
   }
 
   @override
-  int get hashCode =>
-      Object.hash(userId, username, role, avatarUrl, statusText);
+  int get hashCode => Object.hash(
+    userId,
+    username,
+    role,
+    avatarUrl,
+    statusText,
+    presenceStatus,
+  );
 }

--- a/apps/client/lib/src/providers/user_presence_provider.dart
+++ b/apps/client/lib/src/providers/user_presence_provider.dart
@@ -19,11 +19,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../utils/presence.dart';
+import 'auth/auth_provider.dart';
 import 'websocket_provider.dart';
 
 part 'user_presence_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 UserPresence userPresence(Ref ref, String userId) {
+  // The server does not echo presence_update back to the connecting user,
+  // so presenceFor(myUserId) returns offline/empty until a contact triggers
+  // a broadcast. Surface the locally-known presence from authProvider for
+  // self so the user sees their own status dot light up immediately.
+  final myUserId = ref.watch(authProvider.select((s) => s.userId));
+  if (myUserId != null && myUserId == userId) {
+    final myStatus = ref.watch(authProvider.select((s) => s.presenceStatus));
+    return UserPresence(status: myStatus, isOnline: true);
+  }
   return ref.watch(websocketProvider.select((s) => s.presenceFor(userId)));
 }

--- a/apps/client/lib/src/screens/settings/status_section.dart
+++ b/apps/client/lib/src/screens/settings/status_section.dart
@@ -5,12 +5,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/auth_provider.dart';
 import '../../services/toast_service.dart';
 import '../../theme/echo_theme.dart';
+import '../../utils/presence.dart';
 import '../../widgets/settings_panel_scaffold.dart';
 
 /// Maximum characters accepted by `PUT /api/users/me/status-text`.
 /// The server caps at 64; we enforce 80 in the field but show a counter so
 /// users know when they are near the server limit.
 const _kMaxStatusLength = 80;
+
+/// Short, app-curated text statuses surfaced as one-tap presets.
+const _kStatusPresets = <String>[
+  'AFK',
+  'BRB',
+  'In a meeting',
+  'Out to lunch',
+  'Streaming on Twitch',
+  'Heads down',
+];
+
+/// Presence dropdown options. Pairs (status, label) — the colour dot is
+/// resolved by [presenceColor] downstream.
+const _kPresenceOptions = <({String status, String label})>[
+  (status: 'online', label: 'Online'),
+  (status: 'away', label: 'Away'),
+  (status: 'dnd', label: 'Do not disturb'),
+  (status: 'invisible', label: 'Invisible'),
+];
 
 /// Settings section that lets the authenticated user set or clear a short
 /// custom status text.  The text is persisted via
@@ -99,10 +119,35 @@ class _StatusSectionState extends ConsumerState<StatusSection> {
     }
   }
 
+  void _applyPreset(String preset) {
+    _controller
+      ..text = preset
+      ..selection = TextSelection.collapsed(offset: preset.length);
+    _onTextChanged();
+  }
+
+  Future<void> _setPresence(String status) async {
+    final current = ref.read(authProvider).presenceStatus;
+    if (current == status) return;
+    try {
+      await ref.read(authProvider.notifier).setPresenceStatus(status);
+      if (!mounted) return;
+      ToastService.show(context, 'Status set to $status', type: ToastType.info);
+    } catch (e) {
+      if (!mounted) return;
+      ToastService.show(
+        context,
+        'Failed to change status',
+        type: ToastType.error,
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final charCount = _controller.text.length;
     final overLimit = charCount > _kMaxStatusLength;
+    final presence = ref.watch(authProvider.select((s) => s.presenceStatus));
 
     return SettingsPanelScaffold(
       children: [
@@ -124,7 +169,44 @@ class _StatusSectionState extends ConsumerState<StatusSection> {
             height: 1.5,
           ),
         ),
+        const SizedBox(height: 20),
+
+        // Availability picker (online / away / dnd / invisible).
+        Text(
+          'Availability',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final option in _kPresenceOptions)
+              _PresenceChip(
+                label: option.label,
+                color: presenceColor(option.status),
+                selected: presence == option.status,
+                onTap: () => _setPresence(option.status),
+              ),
+          ],
+        ),
+
         const SizedBox(height: 24),
+
+        // Custom status text
+        Text(
+          'Custom message',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
 
         // Text field
         TextField(
@@ -185,6 +267,27 @@ class _StatusSectionState extends ConsumerState<StatusSection> {
           ),
         ),
 
+        const SizedBox(height: 12),
+
+        // One-tap preset chips.
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final preset in _kStatusPresets)
+              ActionChip(
+                label: Text(preset),
+                onPressed: () => _applyPreset(preset),
+                backgroundColor: context.surface,
+                labelStyle: TextStyle(
+                  color: context.textSecondary,
+                  fontSize: 12,
+                ),
+                side: BorderSide(color: context.border),
+              ),
+          ],
+        ),
+
         const SizedBox(height: 20),
 
         // Action buttons
@@ -235,6 +338,58 @@ class _StatusSectionState extends ConsumerState<StatusSection> {
           ],
         ),
       ],
+    );
+  }
+}
+
+/// Selectable pill used in the availability picker. The colour dot sits to
+/// the left of the label; when selected the chip gets an accent outline.
+class _PresenceChip extends StatelessWidget {
+  const _PresenceChip({
+    required this.label,
+    required this.color,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final Color color;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(20),
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: selected
+              ? context.accent.withValues(alpha: 0.15)
+              : context.surface,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: selected ? context.accent : context.border,
+            width: selected ? 1.5 : 1,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: TextStyle(color: context.textPrimary, fontSize: 13),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/client/lib/src/widgets/members_panel.dart
+++ b/apps/client/lib/src/widgets/members_panel.dart
@@ -330,15 +330,32 @@ class _MemberRowState extends ConsumerState<_MemberRow> {
                           ),
                         ],
                       ),
-                      Text(
-                        presenceLabel(
-                          presence.status,
-                          isOnline: presence.isOnline,
-                        ),
-                        style: TextStyle(
-                          color: context.textMuted,
-                          fontSize: 11,
-                        ),
+                      Builder(
+                        builder: (_) {
+                          final selfStatusText = widget.isMe
+                              ? ref.watch(
+                                  authProvider.select((s) => s.statusText),
+                                )
+                              : null;
+                          final memberStatus =
+                              selfStatusText ?? member.statusText;
+                          final label =
+                              (memberStatus != null &&
+                                  memberStatus.trim().isNotEmpty)
+                              ? memberStatus
+                              : presenceLabel(
+                                  presence.status,
+                                  isOnline: presence.isOnline,
+                                );
+                          return Text(
+                            label,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: context.textMuted,
+                              fontSize: 11,
+                            ),
+                          );
+                        },
                       ),
                     ],
                   ),

--- a/apps/client/test/providers/user_presence_provider_test.dart
+++ b/apps/client/test/providers/user_presence_provider_test.dart
@@ -1,0 +1,45 @@
+/// Verify that [userPresenceProvider] surfaces the local user's status from
+/// authProvider as soon as auth lands, even before the server echoes a
+/// presence_update back. Without this override the user sees a missing
+/// status dot on their own avatar in the members panel.
+library;
+
+import 'package:echo_app/src/providers/auth/auth_provider.dart';
+import 'package:echo_app/src/providers/user_presence_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('userPresenceProvider returns online for the local user even when WS '
+      'has not echoed a presence_update yet', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    const myUserId = 'me';
+    container.read(authProvider.notifier).state = const AuthState(
+      userId: myUserId,
+      presenceStatus: 'dnd',
+    );
+
+    final presence = container.read(userPresenceProvider(myUserId));
+    expect(presence.isOnline, isTrue);
+    expect(presence.status, 'dnd');
+  });
+
+  test(
+    'userPresenceProvider still routes other userIds through the WS state',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(authProvider.notifier).state = const AuthState(
+        userId: 'me',
+        presenceStatus: 'online',
+      );
+
+      final presence = container.read(userPresenceProvider('someone-else'));
+      expect(presence.isOnline, isFalse);
+      expect(presence.status, 'offline');
+    },
+  );
+}

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -33,6 +33,8 @@ pub struct GroupMember {
     pub joined_at: DateTime<Utc>,
     pub role: String,
     pub avatar_url: Option<String>,
+    pub status_text: Option<String>,
+    pub presence_status: Option<String>,
 }
 
 /// A row from `group_invite_tokens` (#579).
@@ -297,7 +299,8 @@ pub async fn get_group_members(
     group_id: Uuid,
 ) -> Result<Vec<GroupMember>, sqlx::Error> {
     sqlx::query_as::<_, GroupMember>(
-        "SELECT cm.user_id, u.username, cm.joined_at, cm.role, u.avatar_url \
+        "SELECT cm.user_id, u.username, cm.joined_at, cm.role, u.avatar_url, \
+                u.status_text, u.presence_status \
          FROM conversation_members cm \
          JOIN users u ON u.id = cm.user_id \
          WHERE cm.conversation_id = $1 AND cm.is_removed = false \
@@ -624,7 +627,8 @@ pub async fn get_group_member_previews(
     limit: i64,
 ) -> Result<Vec<GroupMember>, sqlx::Error> {
     sqlx::query_as::<_, GroupMember>(
-        "SELECT cm.user_id, u.username, cm.joined_at, cm.role, u.avatar_url \
+        "SELECT cm.user_id, u.username, cm.joined_at, cm.role, u.avatar_url, \
+                u.status_text, u.presence_status \
          FROM conversation_members cm \
          JOIN users u ON u.id = cm.user_id \
          WHERE cm.conversation_id = $1 AND cm.is_removed = false \


### PR DESCRIPTION
## Summary
Two-part status UX upgrade so the status-text feature is actually surfaced.

### Server
\`get_group_members\` now joins \`status_text\` + \`presence_status\` so the conversation members payload carries them.

### Client
- \`ConversationMember\` gains \`presenceStatus\` (null = back-compat with older servers).
- **Members panel rows** now show \`statusText\` (e.g. "Streaming on Twitch") instead of the generic "online" label whenever the user has a custom message set. For self, this reads from \`authProvider\` directly so changes show up immediately.
- **Settings → Status** now has:
  1. An **Availability picker** — chips for Online / Away / DND / Invisible, wired to the existing \`setPresenceStatus\` action.
  2. **Six one-tap preset chips** for the custom message: AFK, BRB, In a meeting, Out to lunch, Streaming on Twitch, Heads down. Tapping a preset drops the text into the field for review before Save (doesn't auto-save).

## Test plan
- [x] \`flutter analyze\` + \`cargo check\` clean
- [x] Members panel tests pass
- [ ] CI passes
- [ ] Manual: set custom status in settings → see it under your name in the members panel
- [ ] Manual: tap an availability chip → dot colour changes for self and propagates to other clients