### PR TITLE
feat(client): animate GIFs in voice lounge canvas (#3)

### DIFF
--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -928,6 +928,14 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   );
 }
 
+/// Returns true when a URL points at an animated GIF asset. We only check
+/// the path's extension because the server already vets MIME type on
+/// upload and query strings on .gif (CDN cache busters) are common.
+bool _isGif(String url) {
+  final lower = url.split('?').first.toLowerCase();
+  return lower.endsWith('.gif');
+}
+
 class _CanvasImageWidget extends StatefulWidget {
   final CanvasImage image;
   final Map<String, String>? httpHeaders;
@@ -979,15 +987,36 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
               ),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(4),
-                child: CachedNetworkImage(
-                  imageUrl: widget.image.url,
-                  httpHeaders: widget.httpHeaders ?? const {},
-                  fit: BoxFit.cover,
-                  errorWidget: (_, _, _) => Container(
-                    color: context.surfaceHover,
-                    child: Icon(Icons.broken_image, color: context.textMuted),
-                  ),
-                ),
+                // GIFs need Image.network for multi-frame animation;
+                // CachedNetworkImage decodes a single frame so animated
+                // GIFs render as a static first frame. Detect the .gif
+                // extension and pick the right widget per image.
+                child: _isGif(widget.image.url)
+                    ? Image.network(
+                        widget.image.url,
+                        headers: widget.httpHeaders ?? const {},
+                        fit: BoxFit.cover,
+                        gaplessPlayback: true,
+                        errorBuilder: (_, _, _) => Container(
+                          color: context.surfaceHover,
+                          child: Icon(
+                            Icons.broken_image,
+                            color: context.textMuted,
+                          ),
+                        ),
+                      )
+                    : CachedNetworkImage(
+                        imageUrl: widget.image.url,
+                        httpHeaders: widget.httpHeaders ?? const {},
+                        fit: BoxFit.cover,
+                        errorWidget: (_, _, _) => Container(
+                          color: context.surfaceHover,
+                          child: Icon(
+                            Icons.broken_image,
+                            color: context.textMuted,
+                          ),
+                        ),
+                      ),
               ),
             ),
             if (_hovered)

--- a/apps/client/test/widgets/voice_canvas_gif_test.dart
+++ b/apps/client/test/widgets/voice_canvas_gif_test.dart
@@ -1,0 +1,39 @@
+/// `_isGif` heuristic — URLs ending in `.gif` route through `Image.network`
+/// so animation plays; everything else still goes through `CachedNetworkImage`.
+/// The helper is private so we exercise it through a small re-implementation
+/// that mirrors the production logic.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+bool isGifLikeForTesting(String url) {
+  final lower = url.split('?').first.toLowerCase();
+  return lower.endsWith('.gif');
+}
+
+void main() {
+  test('detects .gif extension', () {
+    expect(isGifLikeForTesting('https://example.com/sticker.gif'), isTrue);
+  });
+
+  test('detects .GIF (case-insensitive)', () {
+    expect(isGifLikeForTesting('https://example.com/STICKER.GIF'), isTrue);
+  });
+
+  test('strips query strings before checking extension', () {
+    expect(
+      isGifLikeForTesting('https://cdn.example/foo.gif?v=123&x=y'),
+      isTrue,
+    );
+  });
+
+  test('returns false for static formats', () {
+    expect(isGifLikeForTesting('https://example.com/foo.png'), isFalse);
+    expect(isGifLikeForTesting('https://example.com/foo.jpg'), isFalse);
+    expect(isGifLikeForTesting('https://example.com/foo.webp'), isFalse);
+  });
+
+  test('returns false when a path has gif in the middle but no extension', () {
+    expect(isGifLikeForTesting('https://example.com/gifs/animation'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
GIFs already round-tripped through the canvas — file_picker accepted them, the server preserved \`image/gif\` MIME, and the URL came back fine — but they rendered as a **static first frame** because \`CachedNetworkImage\` decodes once and reuses the buffer.

Switch the canvas image renderer to detect \`.gif\` URLs (extension only, after stripping query strings) and render those through \`Image.network\` with \`gaplessPlayback: true\`. That uses Flutter's multi-frame codec, so GIFs actually animate now. PNG / JPG / WebP stay on \`CachedNetworkImage\` so they keep the cross-session disk cache.

## Test plan
- [x] \`flutter analyze\` clean
- [x] New unit tests for the \`isGif\` heuristic (extension, case, query strings, false positives)
- [ ] Manual: paste / upload a GIF into the canvas → it animates