### PR TITLE
feat(client): export voice lounge canvas as PNG + import/export JSON (#6)

### DIFF
--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -203,6 +203,25 @@ class CanvasController extends _$CanvasController {
     _sendCanvasEvent('clear', {});
   }
 
+  /// Replace the local canvas state with a previously-exported snapshot and
+  /// broadcast it to the rest of the participants. Used by the JSON import
+  /// affordance — sends a `clear`, then `image_add` for every image, then
+  /// `stroke` for every stroke, so remote clients converge.
+  void importSnapshot({
+    required List<CanvasStroke> strokes,
+    required List<CanvasImage> images,
+  }) {
+    state = state.copyWith(strokes: strokes, images: images);
+    if (_channelId == null) return;
+    _sendCanvasEvent('clear', {});
+    for (final img in images) {
+      _sendCanvasEvent('image_add', img.toJson());
+    }
+    for (final stroke in strokes) {
+      _sendCanvasEvent('stroke', stroke.toJson());
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Images
   // -------------------------------------------------------------------------

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -1,9 +1,12 @@
 /// Drawing tools popup menu used by the floating dock's draw submenu.
 library;
 
+import 'dart:convert';
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,12 +15,14 @@ import '../../models/canvas_models.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/canvas_provider.dart';
 import '../../providers/server_url_provider.dart';
+import '../../services/canvas_export_service.dart';
 import '../../services/chunked_upload_client.dart';
 import '../../services/toast_service.dart';
 import '../../services/upload_client.dart';
 import '../../theme/echo_theme.dart';
 import '../../theme/motion_tokens.dart';
 import '../../utils/canvas_utils.dart';
+import '../../widgets/voice_canvas.dart' show voiceCanvasRepaintKey;
 
 /// Popup content for the drawing tools menu.
 class DrawingToolsMenu extends ConsumerStatefulWidget {
@@ -242,42 +247,202 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   Widget _buildActionButtons(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-      child: Row(
+      child: Column(
         children: [
-          Expanded(
-            child: TextButton.icon(
-              onPressed: () async {
-                HapticFeedback.lightImpact();
-                await _pickAndAddImage(context);
-                if (mounted) widget.onRequestClose?.call();
-              },
-              icon: const Icon(Icons.add_photo_alternate_outlined, size: 16),
-              label: const Text('Image'),
-              style: TextButton.styleFrom(
-                foregroundColor: context.accent,
-                textStyle: const TextStyle(fontSize: 12),
+          Row(
+            children: [
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () async {
+                    HapticFeedback.lightImpact();
+                    await _pickAndAddImage(context);
+                    if (mounted) widget.onRequestClose?.call();
+                  },
+                  icon: const Icon(
+                    Icons.add_photo_alternate_outlined,
+                    size: 16,
+                  ),
+                  label: const Text('Image'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: context.accent,
+                    textStyle: const TextStyle(fontSize: 12),
+                  ),
+                ),
               ),
-            ),
+              const SizedBox(width: 4),
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () {
+                    HapticFeedback.mediumImpact();
+                    ref.read(canvasProvider.notifier).clearDrawing();
+                    widget.onRequestClose?.call();
+                  },
+                  icon: const Icon(Icons.delete_outline, size: 16),
+                  label: const Text('Clear'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: EchoTheme.danger,
+                    textStyle: const TextStyle(fontSize: 12),
+                  ),
+                ),
+              ),
+            ],
           ),
-          const SizedBox(width: 4),
-          Expanded(
-            child: TextButton.icon(
-              onPressed: () {
-                HapticFeedback.mediumImpact();
-                ref.read(canvasProvider.notifier).clearDrawing();
-                widget.onRequestClose?.call();
-              },
-              icon: const Icon(Icons.delete_outline, size: 16),
-              label: const Text('Clear'),
-              style: TextButton.styleFrom(
-                foregroundColor: EchoTheme.danger,
-                textStyle: const TextStyle(fontSize: 12),
+          Row(
+            children: [
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () => _exportPng(context),
+                  icon: const Icon(Icons.image_outlined, size: 16),
+                  label: const Text('PNG'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: context.textSecondary,
+                    textStyle: const TextStyle(fontSize: 12),
+                  ),
+                ),
               ),
-            ),
+              const SizedBox(width: 4),
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () => _exportJson(context),
+                  icon: const Icon(Icons.save_alt_outlined, size: 16),
+                  label: const Text('Save'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: context.textSecondary,
+                    textStyle: const TextStyle(fontSize: 12),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+              Expanded(
+                child: TextButton.icon(
+                  onPressed: () => _importJson(context),
+                  icon: const Icon(Icons.upload_file_outlined, size: 16),
+                  label: const Text('Load'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: context.textSecondary,
+                    textStyle: const TextStyle(fontSize: 12),
+                  ),
+                ),
+              ),
+            ],
           ),
         ],
       ),
     );
+  }
+
+  /// Save [bytes] under [suggestedName]. On web, file_picker writes the file
+  /// itself via a browser download; on native it only returns a path and we
+  /// write the bytes ourselves (see services/export_service.dart #740).
+  Future<String?> _saveBytes({
+    required Uint8List bytes,
+    required String suggestedName,
+    required String dialogTitle,
+    required List<String> allowedExtensions,
+  }) async {
+    if (kIsWeb) {
+      return FilePicker.saveFile(
+        dialogTitle: dialogTitle,
+        fileName: suggestedName,
+        type: FileType.custom,
+        allowedExtensions: allowedExtensions,
+        bytes: bytes,
+      );
+    }
+    final path = await FilePicker.saveFile(
+      dialogTitle: dialogTitle,
+      fileName: suggestedName,
+      type: FileType.custom,
+      allowedExtensions: allowedExtensions,
+    );
+    if (path == null) return null;
+    await File(path).writeAsBytes(bytes, flush: true);
+    return path;
+  }
+
+  Future<void> _exportPng(BuildContext ctx) async {
+    HapticFeedback.lightImpact();
+    try {
+      final bytes = await CanvasExportService.capturePng(voiceCanvasRepaintKey);
+      final path = await _saveBytes(
+        bytes: bytes,
+        suggestedName:
+            'voice-canvas-${DateTime.now().millisecondsSinceEpoch}.png',
+        dialogTitle: 'Export canvas as PNG',
+        allowedExtensions: const ['png'],
+      );
+      if (!ctx.mounted) return;
+      ToastService.show(
+        ctx,
+        path == null ? 'Export cancelled.' : 'Canvas exported.',
+        type: path == null ? ToastType.info : ToastType.success,
+      );
+    } catch (e) {
+      if (!ctx.mounted) return;
+      ToastService.show(ctx, 'PNG export failed: $e', type: ToastType.error);
+    }
+    if (mounted) widget.onRequestClose?.call();
+  }
+
+  Future<void> _exportJson(BuildContext ctx) async {
+    HapticFeedback.lightImpact();
+    try {
+      final json = CanvasExportService.encodeJson(ref.read(canvasProvider));
+      final bytes = Uint8List.fromList(utf8.encode(json));
+      final path = await _saveBytes(
+        bytes: bytes,
+        suggestedName:
+            'voice-canvas-${DateTime.now().millisecondsSinceEpoch}.json',
+        dialogTitle: 'Save canvas snapshot',
+        allowedExtensions: const ['json'],
+      );
+      if (!ctx.mounted) return;
+      ToastService.show(
+        ctx,
+        path == null ? 'Save cancelled.' : 'Snapshot saved.',
+        type: path == null ? ToastType.info : ToastType.success,
+      );
+    } catch (e) {
+      if (!ctx.mounted) return;
+      ToastService.show(ctx, 'Save failed: $e', type: ToastType.error);
+    }
+    if (mounted) widget.onRequestClose?.call();
+  }
+
+  Future<void> _importJson(BuildContext ctx) async {
+    HapticFeedback.lightImpact();
+    try {
+      final result = await FilePicker.pickFiles(
+        dialogTitle: 'Load canvas snapshot',
+        type: FileType.custom,
+        allowedExtensions: const ['json'],
+        withData: true,
+      );
+      if (result == null || result.files.isEmpty) {
+        if (mounted) widget.onRequestClose?.call();
+        return;
+      }
+      final bytes = result.files.first.bytes;
+      if (bytes == null) {
+        if (!ctx.mounted) return;
+        ToastService.show(
+          ctx,
+          'Could not read the snapshot file.',
+          type: ToastType.error,
+        );
+        return;
+      }
+      final decoded = CanvasExportService.decodeJson(utf8.decode(bytes));
+      ref
+          .read(canvasProvider.notifier)
+          .importSnapshot(strokes: decoded.strokes, images: decoded.images);
+      if (!ctx.mounted) return;
+      ToastService.show(ctx, 'Snapshot loaded.', type: ToastType.success);
+    } catch (e) {
+      if (!ctx.mounted) return;
+      ToastService.show(ctx, 'Load failed: $e', type: ToastType.error);
+    }
+    if (mounted) widget.onRequestClose?.call();
   }
 
   /// Open the system file picker to select an image and add it to the canvas.

--- a/apps/client/lib/src/services/canvas_export_service.dart
+++ b/apps/client/lib/src/services/canvas_export_service.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+import '../models/canvas_models.dart';
+
+/// Helpers for importing / exporting the shared voice-lounge canvas.
+///
+/// The canvas is rendered inside a [RepaintBoundary] keyed by
+/// `voiceCanvasRepaintKey` (see `widgets/voice_canvas.dart`). PNG capture
+/// walks that boundary's render tree; JSON capture round-trips through the
+/// existing `CanvasStroke.toJson` / `CanvasImage.toJson` model helpers.
+class CanvasExportService {
+  CanvasExportService._();
+
+  /// Snapshot version surfaced on disk so a future import can tell when
+  /// it's reading an incompatible payload.
+  static const int snapshotFormatVersion = 1;
+
+  /// Capture the active canvas as a PNG. Returns the PNG bytes ready to be
+  /// written to disk. Caller is responsible for picking a destination path
+  /// — most surfaces will use `file_picker.saveFile`.
+  static Future<Uint8List> capturePng(
+    GlobalKey repaintKey, {
+    double pixelRatio = 2.0,
+  }) async {
+    final object = repaintKey.currentContext?.findRenderObject();
+    if (object is! RenderRepaintBoundary) {
+      throw StateError('Voice canvas repaint boundary is not mounted yet.');
+    }
+    final image = await object.toImage(pixelRatio: pixelRatio);
+    try {
+      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+      if (byteData == null) {
+        throw StateError('Failed to encode canvas image to PNG.');
+      }
+      return byteData.buffer.asUint8List();
+    } finally {
+      image.dispose();
+    }
+  }
+
+  /// Serialize the persistent parts of [state] (strokes + images) to a
+  /// JSON string. Avatar positions and in-progress drawing state are
+  /// excluded — they're ephemeral and would clash with the live
+  /// participants on import.
+  static String encodeJson(CanvasState state) {
+    final payload = {
+      'format_version': snapshotFormatVersion,
+      'strokes': state.strokes.map((s) => s.toJson()).toList(),
+      'images': state.images.map((i) => i.toJson()).toList(),
+    };
+    return const JsonEncoder.withIndent('  ').convert(payload);
+  }
+
+  /// Parse a JSON snapshot previously produced by [encodeJson]. Throws
+  /// [FormatException] on a malformed payload so callers can surface an
+  /// error toast without leaving the canvas in a partial state.
+  static ({List<CanvasStroke> strokes, List<CanvasImage> images}) decodeJson(
+    String json,
+  ) {
+    final dynamic root = jsonDecode(json);
+    if (root is! Map<String, dynamic>) {
+      throw const FormatException(
+        'Canvas snapshot root must be a JSON object.',
+      );
+    }
+    final version = root['format_version'];
+    if (version is! int || version != snapshotFormatVersion) {
+      throw FormatException(
+        'Unsupported canvas snapshot format_version: $version. '
+        'Expected $snapshotFormatVersion.',
+      );
+    }
+    final strokesRaw = root['strokes'];
+    final imagesRaw = root['images'];
+    if (strokesRaw is! List || imagesRaw is! List) {
+      throw const FormatException(
+        'Canvas snapshot is missing strokes / images arrays.',
+      );
+    }
+    final strokes = <CanvasStroke>[];
+    for (final raw in strokesRaw) {
+      if (raw is Map<String, dynamic>) {
+        strokes.add(CanvasStroke.fromJson(raw));
+      }
+    }
+    final images = <CanvasImage>[];
+    for (final raw in imagesRaw) {
+      if (raw is Map<String, dynamic>) {
+        images.add(CanvasImage.fromJson(raw));
+      }
+    }
+    return (strokes: strokes, images: images);
+  }
+}

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -52,6 +52,14 @@ class VoiceCanvas extends ConsumerStatefulWidget {
   ConsumerState<VoiceCanvas> createState() => _VoiceCanvasState();
 }
 
+/// Globally-accessible key used to capture the active voice-lounge canvas
+/// as a PNG. The Stack inside this RepaintBoundary holds the strokes,
+/// images, and avatar tiles. Reset whenever the canvas widget rebuilds so
+/// the key always points at the currently mounted instance.
+final GlobalKey voiceCanvasRepaintKey = GlobalKey(
+  debugLabel: 'voice-canvas-repaint',
+);
+
 class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
   final _canvasKey = GlobalKey();
 
@@ -125,39 +133,42 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
           children: [
             Expanded(
               child: ClipRect(
-                child: Stack(
-                  key: _canvasKey,
-                  children: [
-                    Positioned.fill(
-                      child: _DrawingLayer(
-                        canvas: canvas,
-                        onPointerDown: (offset) {
-                          if (tool == CanvasTool.pen ||
-                              tool == CanvasTool.eraser) {
-                            ref
-                                .read(canvasProvider.notifier)
-                                .startStroke(_toNormalized(offset));
-                          }
-                        },
-                        onPointerMove: (offset) {
-                          if (tool == CanvasTool.pen ||
-                              tool == CanvasTool.eraser) {
-                            ref
-                                .read(canvasProvider.notifier)
-                                .continueStroke(_toNormalized(offset));
-                          }
-                        },
-                        onPointerUp: () {
-                          if (tool == CanvasTool.pen ||
-                              tool == CanvasTool.eraser) {
-                            ref.read(canvasProvider.notifier).endStroke();
-                          }
-                        },
+                child: RepaintBoundary(
+                  key: voiceCanvasRepaintKey,
+                  child: Stack(
+                    key: _canvasKey,
+                    children: [
+                      Positioned.fill(
+                        child: _DrawingLayer(
+                          canvas: canvas,
+                          onPointerDown: (offset) {
+                            if (tool == CanvasTool.pen ||
+                                tool == CanvasTool.eraser) {
+                              ref
+                                  .read(canvasProvider.notifier)
+                                  .startStroke(_toNormalized(offset));
+                            }
+                          },
+                          onPointerMove: (offset) {
+                            if (tool == CanvasTool.pen ||
+                                tool == CanvasTool.eraser) {
+                              ref
+                                  .read(canvasProvider.notifier)
+                                  .continueStroke(_toNormalized(offset));
+                            }
+                          },
+                          onPointerUp: () {
+                            if (tool == CanvasTool.pen ||
+                                tool == CanvasTool.eraser) {
+                              ref.read(canvasProvider.notifier).endStroke();
+                            }
+                          },
+                        ),
                       ),
-                    ),
-                    ..._buildImages(canvas, authState),
-                    ..._buildAvatars(canvas, myUserId, authState),
-                  ],
+                      ..._buildImages(canvas, authState),
+                      ..._buildAvatars(canvas, myUserId, authState),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/apps/client/test/services/canvas_export_service_test.dart
+++ b/apps/client/test/services/canvas_export_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:echo_app/src/models/canvas_models.dart';
+import 'package:echo_app/src/services/canvas_export_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CanvasExportService', () {
+    test('encodes + decodes a snapshot losslessly', () {
+      final original = const CanvasState(
+        strokes: [
+          CanvasStroke(
+            id: 's1',
+            color: '#FFFFFF',
+            width: 3.5,
+            points: [CanvasPoint(x: 0.1, y: 0.2), CanvasPoint(x: 0.3, y: 0.4)],
+          ),
+        ],
+        images: [
+          CanvasImage(
+            id: 'i1',
+            url: 'https://example.com/a.png',
+            x: 0.2,
+            y: 0.3,
+            width: 0.25,
+            height: 0.25,
+          ),
+        ],
+      );
+
+      final json = CanvasExportService.encodeJson(original);
+      final decoded = CanvasExportService.decodeJson(json);
+
+      expect(decoded.strokes, hasLength(1));
+      expect(decoded.strokes.first.id, 's1');
+      expect(decoded.strokes.first.color, '#FFFFFF');
+      expect(decoded.strokes.first.points, hasLength(2));
+      expect(decoded.images, hasLength(1));
+      expect(decoded.images.first.id, 'i1');
+      expect(decoded.images.first.width, 0.25);
+    });
+
+    test('rejects a snapshot with a wrong format_version', () {
+      const payload = '{"format_version": 999, "strokes": [], "images": []}';
+      expect(
+        () => CanvasExportService.decodeJson(payload),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects missing arrays', () {
+      const payload = '{"format_version": 1}';
+      expect(
+        () => CanvasExportService.decodeJson(payload),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects non-object root', () {
+      expect(
+        () => CanvasExportService.decodeJson('"hello"'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Three new buttons in the drawing-tools menu give users full control over a voice-lounge canvas snapshot.

- **PNG** — captures the canvas \`RepaintBoundary\` at 2x and writes the bytes via file_picker. On web the browser handles the download; on native we get a path back and write the bytes ourselves (matches the existing chat-export flow in services/export_service.dart).
- **Save** — serializes the persistent strokes + images to a JSON snapshot with a \`format_version\` field, saved the same way.
- **Load** — picks a JSON snapshot, parses it, replaces the local canvas state, and **rebroadcasts** the contents over the existing canvas WS events (\`clear\`, then \`image_add\` + \`stroke\` for each entry) so other participants converge on the imported board.

Capture / encode / decode lives in \`services/canvas_export_service.dart\` so it's testable without spinning up a widget tree. A new \`voiceCanvasRepaintKey\` (GlobalKey) anchors the RepaintBoundary inside \`VoiceCanvas\`.

## Test plan
- [x] \`flutter analyze\` clean
- [x] New unit tests for JSON round-trip + format-version rejection + malformed input
- [x] Existing canvas-provider tests still pass
- [ ] CI passes
- [ ] Manual: draw + paste a few things → PNG → file saves with expected content
- [ ] Manual: Save → Clear → Load → the strokes + images come back, and other participants in the room see the same state