### PR TITLE
feat(client): resize handles for participant video tiles

### DIFF
--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -161,14 +161,29 @@ class AvatarPosition {
   final double x;
   final double y;
 
+  /// Scale factor applied to the rendered avatar / video tile. 1.0 = the
+  /// historical default size; bounded by [minScale] / [maxScale] in the
+  /// canvas controller. Broadcast over the same `avatar_move` WS event so
+  /// the server does not need a new event kind.
+  final double scale;
+
+  static const double minScale = 0.5;
+  static const double maxScale = 5.0;
+
   const AvatarPosition({
     required this.userId,
     required this.x,
     required this.y,
+    this.scale = 1.0,
   });
 
-  AvatarPosition copyWith({double? x, double? y}) =>
-      AvatarPosition(userId: userId, x: x ?? this.x, y: y ?? this.y);
+  AvatarPosition copyWith({double? x, double? y, double? scale}) =>
+      AvatarPosition(
+        userId: userId,
+        x: x ?? this.x,
+        y: y ?? this.y,
+        scale: scale ?? this.scale,
+      );
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -321,10 +321,18 @@ class CanvasController extends _$CanvasController {
   // -------------------------------------------------------------------------
 
   /// Called while the user is dragging their avatar.  Updates local state
-  /// immediately and queues a throttled WS broadcast.
+  /// immediately and queues a throttled WS broadcast. The current scale is
+  /// preserved.
   void moveLocalAvatar(String userId, CanvasPoint pos) {
+    final existing = state.avatarPositions[userId];
+    final scale = existing?.scale ?? 1.0;
     final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
-    updated[userId] = AvatarPosition(userId: userId, x: pos.x, y: pos.y);
+    updated[userId] = AvatarPosition(
+      userId: userId,
+      x: pos.x,
+      y: pos.y,
+      scale: scale,
+    );
     state = state.copyWith(avatarPositions: updated);
 
     _pendingAvatar = (userId: userId, pos: pos);
@@ -342,10 +350,57 @@ class CanvasController extends _$CanvasController {
       return;
     }
     _pendingAvatar = null;
+    final existing = state.avatarPositions[pending.userId];
     _sendCanvasEvent('avatar_move', {
       'user_id': pending.userId,
       'x': pending.pos.x,
       'y': pending.pos.y,
+      'scale': existing?.scale ?? 1.0,
+    });
+  }
+
+  /// Called while the user is dragging an avatar's resize handle. Same
+  /// throttling as [moveLocalAvatar] — broadcasts ride the existing
+  /// `avatar_move` channel, server is passthrough.
+  void resizeAvatar(String userId, double scale) {
+    final clamped = scale.clamp(
+      AvatarPosition.minScale,
+      AvatarPosition.maxScale,
+    );
+    final existing = state.avatarPositions[userId];
+    final pos = existing != null
+        ? CanvasPoint(x: existing.x, y: existing.y)
+        : const CanvasPoint(x: 0.5, y: 0.5);
+    final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
+    updated[userId] = AvatarPosition(
+      userId: userId,
+      x: pos.x,
+      y: pos.y,
+      scale: clamped,
+    );
+    state = state.copyWith(avatarPositions: updated);
+
+    _pendingAvatar = (userId: userId, pos: pos);
+    _avatarThrottle ??= Timer.periodic(
+      const Duration(milliseconds: 50),
+      (_) => _flushAvatarMove(),
+    );
+  }
+
+  /// Flushes the pending avatar resize immediately on pointer-up.
+  void commitAvatarResize(String userId) {
+    _avatarThrottle?.cancel();
+    _avatarThrottle = null;
+    _pendingAvatar = null;
+
+    if (_channelId == null) return;
+    final existing = state.avatarPositions[userId];
+    if (existing == null) return;
+    _sendCanvasEvent('avatar_move', {
+      'user_id': userId,
+      'x': existing.x,
+      'y': existing.y,
+      'scale': existing.scale,
     });
   }
 
@@ -355,13 +410,21 @@ class CanvasController extends _$CanvasController {
     _avatarThrottle = null;
     _pendingAvatar = null;
 
+    final existing = state.avatarPositions[userId];
+    final scale = existing?.scale ?? 1.0;
     final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
-    updated[userId] = AvatarPosition(userId: userId, x: pos.x, y: pos.y);
+    updated[userId] = AvatarPosition(
+      userId: userId,
+      x: pos.x,
+      y: pos.y,
+      scale: scale,
+    );
     state = state.copyWith(avatarPositions: updated);
     _sendCanvasEvent('avatar_move', {
       'user_id': userId,
       'x': pos.x,
       'y': pos.y,
+      'scale': scale,
     });
   }
 
@@ -465,11 +528,21 @@ class CanvasController extends _$CanvasController {
       case 'avatar_move':
         final x = (payload['x'] as num?)?.toDouble() ?? 0.5;
         final y = (payload['y'] as num?)?.toDouble() ?? 0.5;
+        // Older clients won't send `scale`; preserve the prior value (or
+        // default to 1.0) so a move from an old build doesn't reset the
+        // size that a newer participant just resized.
+        final existing = state.avatarPositions[fromUserId];
+        final rawScale = (payload['scale'] as num?)?.toDouble();
+        final scale = (rawScale ?? existing?.scale ?? 1.0).clamp(
+          AvatarPosition.minScale,
+          AvatarPosition.maxScale,
+        );
         final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
         updated[fromUserId] = AvatarPosition(
           userId: fromUserId,
           x: x.clamp(0.0, 1.0),
           y: y.clamp(0.0, 1.0),
+          scale: scale,
         );
         state = state.copyWith(avatarPositions: updated);
     }

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -20,7 +20,6 @@ import 'voice/participant_attention.dart';
 import 'voice_speaking_ring.dart';
 
 const double _kAvatarSize = 48.0;
-const double _kAvatarHalfSize = _kAvatarSize / 2;
 
 /// Interactive voice-lounge canvas.
 ///
@@ -281,15 +280,20 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
       index,
     );
     final normalized = pos ?? defaultPos;
+    final scale = normalized.scale;
     final offset = _toLocal(CanvasPoint(x: normalized.x, y: normalized.y));
 
-    final left = (offset.dx - _kAvatarHalfSize).clamp(
+    final effectiveSize = _kAvatarSize * scale;
+    final effectiveHalf = effectiveSize / 2;
+    final left = (offset.dx - effectiveHalf).clamp(
       0.0,
-      canvasSize.width > _kAvatarSize ? canvasSize.width - _kAvatarSize : 0.0,
+      canvasSize.width > effectiveSize ? canvasSize.width - effectiveSize : 0.0,
     );
-    final top = (offset.dy - _kAvatarHalfSize).clamp(
+    final top = (offset.dy - effectiveHalf).clamp(
       0.0,
-      canvasSize.height > _kAvatarSize ? canvasSize.height - _kAvatarSize : 0.0,
+      canvasSize.height > effectiveSize
+          ? canvasSize.height - effectiveSize
+          : 0.0,
     );
 
     final attention = attentionFor(
@@ -305,6 +309,7 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
         participant: participant,
         canvasSize: canvasSize,
         currentPos: CanvasPoint(x: normalized.x, y: normalized.y),
+        scale: scale,
         attention: attention,
         httpHeaders: authState.token != null
             ? {'Authorization': 'Bearer ${authState.token}'}
@@ -319,6 +324,20 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
               .read(canvasProvider.notifier)
               .commitLocalAvatarMove(participant.userId, norm);
         },
+        onResize: (dx, dy) {
+          // Diagonal grip — use the larger of dx + dy so the user feels
+          // a uniform resize regardless of which axis they pull. Pixel
+          // delta over the base 48 px tile sets the per-frame scale step.
+          final delta = (dx + dy) / 2.0;
+          final current = normalized.scale;
+          final next = current + delta / _kAvatarSize;
+          ref
+              .read(canvasProvider.notifier)
+              .resizeAvatar(participant.userId, next);
+        },
+        onResizeEnd: () => ref
+            .read(canvasProvider.notifier)
+            .commitAvatarResize(participant.userId),
         draggable: true,
         onDoubleTap: participant.videoTrack != null
             ? () => widget.onVideoDoubleTap?.call(
@@ -621,8 +640,19 @@ class _DraggableAvatar extends StatefulWidget {
 
   /// Current normalized position [0,1] on the canvas.
   final CanvasPoint currentPos;
+
+  /// User-controlled size multiplier on top of [_kAvatarSize]. 1.0 = the
+  /// historical default 48 px puck.
+  final double scale;
+
   final void Function(CanvasPoint norm) onDrag;
   final void Function(CanvasPoint norm) onDragEnd;
+
+  /// Called while the user drags the bottom-right resize handle. [dx], [dy]
+  /// are pixel deltas; the parent translates them to a new scale factor.
+  final void Function(double dx, double dy)? onResize;
+  final VoidCallback? onResizeEnd;
+
   final bool draggable;
   final VoidCallback? onDoubleTap;
 
@@ -640,6 +670,9 @@ class _DraggableAvatar extends StatefulWidget {
     required this.currentPos,
     required this.onDrag,
     required this.onDragEnd,
+    this.scale = 1.0,
+    this.onResize,
+    this.onResizeEnd,
     this.attention = ParticipantAttention.idle,
     this.draggable = false,
     this.onDoubleTap,
@@ -653,6 +686,7 @@ class _DraggableAvatar extends StatefulWidget {
 class _DraggableAvatarState extends State<_DraggableAvatar>
     with SingleTickerProviderStateMixin {
   CanvasPoint? _localPos;
+  bool _hovered = false;
 
   /// Buffer of recent positions used to paint the presence trail
   /// (Phase 3a sub-slice 2 of `docs/ux-roadmap.md`).
@@ -779,6 +813,8 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
     return _initialsWidget(initial);
   }
 
+  double get _effectiveAvatarSize => _kAvatarSize * widget.scale;
+
   Widget _buildAvatarTile(
     _ParticipantInfo info,
     Widget innerContent,
@@ -788,8 +824,8 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
     final avatarColor = HSLColor.fromAHSL(1.0, hue, 0.5, 0.35).toColor();
 
     return Container(
-      width: _kAvatarSize,
-      height: _kAvatarSize,
+      width: _effectiveAvatarSize,
+      height: _effectiveAvatarSize,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         color: hasVideo
@@ -825,8 +861,8 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
         child: VoiceSpeakingRing(
           audioLevel: info.audioLevel,
           child: Container(
-            width: _kAvatarSize,
-            height: _kAvatarSize,
+            width: _effectiveAvatarSize,
+            height: _effectiveAvatarSize,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
               boxShadow: [
@@ -855,13 +891,13 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
         IgnorePointer(
           child: RepaintBoundary(
             child: CustomPaint(
-              size: const Size(_kAvatarSize, _kAvatarSize),
+              size: Size(_effectiveAvatarSize, _effectiveAvatarSize),
               painter: _TrailPainter(
                 trail: _trail,
                 currentPos: _localPos ?? widget.currentPos,
                 canvasSize: widget.canvasSize,
                 color: EchoTheme.online,
-                radius: _kAvatarHalfSize * 0.45,
+                radius: _effectiveAvatarSize * 0.225,
                 tick: _trailTick,
               ),
             ),
@@ -901,28 +937,62 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   Widget _buildDraggableWrapper(Widget content) {
     return MouseRegion(
       cursor: SystemMouseCursors.grab,
-      child: GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onDoubleTap: widget.onDoubleTap,
-        onPanUpdate: (details) {
-          final s = widget.canvasSize;
-          if (s.width <= 0 || s.height <= 0) return;
-          final dx = details.delta.dx / s.width;
-          final dy = details.delta.dy / s.height;
-          final base = _localPos ?? widget.currentPos;
-          final newPos = CanvasPoint(
-            x: (base.x + dx).clamp(0.0, 1.0),
-            y: (base.y + dy).clamp(0.0, 1.0),
-          );
-          _pushTrailSample(base);
-          _localPos = newPos;
-          widget.onDrag(newPos);
-        },
-        onPanEnd: (_) {
-          widget.onDragEnd(_localPos ?? widget.currentPos);
-          _localPos = null;
-        },
-        child: content,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onDoubleTap: widget.onDoubleTap,
+            onPanUpdate: (details) {
+              final s = widget.canvasSize;
+              if (s.width <= 0 || s.height <= 0) return;
+              final dx = details.delta.dx / s.width;
+              final dy = details.delta.dy / s.height;
+              final base = _localPos ?? widget.currentPos;
+              final newPos = CanvasPoint(
+                x: (base.x + dx).clamp(0.0, 1.0),
+                y: (base.y + dy).clamp(0.0, 1.0),
+              );
+              _pushTrailSample(base);
+              _localPos = newPos;
+              widget.onDrag(newPos);
+            },
+            onPanEnd: (_) {
+              widget.onDragEnd(_localPos ?? widget.currentPos);
+              _localPos = null;
+            },
+            child: content,
+          ),
+          if (_hovered && widget.onResize != null)
+            Positioned(
+              right: -2,
+              bottom: -2,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.resizeDownRight,
+                child: GestureDetector(
+                  onPanUpdate: (d) => widget.onResize!(d.delta.dx, d.delta.dy),
+                  onPanEnd: (_) => widget.onResizeEnd?.call(),
+                  child: Container(
+                    width: 22,
+                    height: 22,
+                    decoration: BoxDecoration(
+                      color: context.surface.withValues(alpha: 0.85),
+                      shape: BoxShape.circle,
+                      border: Border.all(color: context.border),
+                    ),
+                    alignment: Alignment.center,
+                    child: Icon(
+                      Icons.open_in_full,
+                      size: 12,
+                      color: context.textPrimary,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/apps/client/test/providers/canvas_provider_test.dart
+++ b/apps/client/test/providers/canvas_provider_test.dart
@@ -195,6 +195,27 @@ void main() {
       expect(x, 1.0);
       expect(y, 0.0);
     });
+
+    test('AvatarPosition.scale defaults to 1.0 and survives copyWith', () {
+      const a = AvatarPosition(userId: 'u', x: 0.3, y: 0.6);
+      expect(a.scale, 1.0);
+      final moved = a.copyWith(x: 0.4);
+      expect(moved.scale, 1.0);
+      final resized = moved.copyWith(scale: 2.5);
+      expect(resized.scale, 2.5);
+      expect(resized.x, 0.4);
+    });
+
+    test('AvatarPosition.scale honours min/max constants', () {
+      expect(AvatarPosition.minScale, lessThan(1.0));
+      expect(AvatarPosition.maxScale, greaterThan(1.0));
+      // Clamping happens inside the controller; verify constants are wired so
+      // a future refactor does not silently drop the bound.
+      expect(
+        AvatarPosition.minScale,
+        lessThanOrEqualTo(AvatarPosition.maxScale),
+      );
+    });
   });
 
   group('CanvasState.copyWith', () {


### PR DESCRIPTION
## Summary
Finishes the second half of canvas item #2 — participant avatars / video tiles now have the same hover-only resize grip as canvas images.

- \`AvatarPosition\` gains \`scale\` (default 1.0, bounded 0.5–5.0); \`copyWith\` preserves it across moves.
- \`canvasProvider\` gets \`resizeAvatar\` + \`commitAvatarResize\`, reusing the existing \`avatar_move\` WS event with a new \`scale\` field. Older clients just ignore the extra key, so **no server migration needed**.
- The \`avatar_move\` handler reads \`scale\` (back-compat: missing field preserves the previous value), clamps to the model's min/max.
- \`_DraggableAvatar\` render size becomes \`_kAvatarSize * scale\`; speaking ring + presence trail follow. Positioning math uses the scaled half-size so resized tiles still snap to canvas edges.
- Hover-only resize grip in the bottom-right drives the new callbacks. The diagonal pan delta is averaged across axes for a uniform feel.

## Test plan
- [x] \`flutter analyze\` clean
- [x] Existing + new canvas-provider tests pass (\`AvatarPosition.scale\` defaults + survives copyWith)
- [ ] CI passes
- [ ] Manual: drag the bottom-right grip on a participant tile → the tile resizes locally + on the other client
- [ ] Manual: a stale build sending plain \`avatar_move\` without \`scale\` does NOT zero out a resized peer