### PR TITLE
feat: threads M1 — face stack + last-reply time on reply chip

### DIFF
--- a/apps/client/lib/src/models/chat_message.dart
+++ b/apps/client/lib/src/models/chat_message.dart
@@ -60,6 +60,15 @@ class ChatMessage {
   /// keeps this null and relies on `message_reply_added` to bump the
   /// count. `null` when there are no replies.
   final String? latestReplyPreview;
+
+  /// Timestamp of the most-recent reply. Populated by history loads;
+  /// drives the "Xm ago" label on the thread indicator chip.
+  final DateTime? lastReplyAt;
+
+  /// Usernames of up to 3 distinct most-recent repliers, newest first.
+  /// Populated by history loads so the thread chip can render face stacks
+  /// inline; never larger than 3.
+  final List<String> recentReplierUsernames;
   final String? pinnedById;
   final DateTime? pinnedAt;
   final DateTime? expiresAt;
@@ -111,6 +120,8 @@ class ChatMessage {
     this.replyToUsername,
     this.replyCount = 0,
     this.latestReplyPreview,
+    this.lastReplyAt,
+    this.recentReplierUsernames = const [],
     this.pinnedById,
     this.pinnedAt,
     this.expiresAt,
@@ -176,6 +187,14 @@ class ChatMessage {
       replyToUsername: json['reply_to_username'] as String?,
       replyCount: (json['reply_count'] as int?) ?? 0,
       latestReplyPreview: json['last_reply_snippet'] as String?,
+      lastReplyAt: json['last_reply_at'] != null
+          ? DateTime.tryParse(json['last_reply_at'] as String)
+          : null,
+      recentReplierUsernames:
+          (json['recent_replier_usernames'] as List?)
+              ?.map((e) => e.toString())
+              .toList() ??
+          const [],
       pinnedById: pinnedByIdRaw,
       pinnedAt: pinnedAtRaw != null ? DateTime.tryParse(pinnedAtRaw) : null,
       expiresAt: json['expires_at'] != null
@@ -320,6 +339,8 @@ class ChatMessage {
       'reply_to_username': replyToUsername,
       'reply_count': replyCount,
       'last_reply_snippet': latestReplyPreview,
+      'last_reply_at': lastReplyAt?.toIso8601String(),
+      'recent_replier_usernames': recentReplierUsernames,
       'pinned_by_id': pinnedById,
       'pinned_at': pinnedAt?.toIso8601String(),
       'expires_at': expiresAt?.toIso8601String(),
@@ -346,6 +367,8 @@ class ChatMessage {
     String? replyToUsername,
     int? replyCount,
     Object? latestReplyPreview = _sentinel,
+    Object? lastReplyAt = _sentinel,
+    List<String>? recentReplierUsernames,
     Object? pinnedById = _sentinel,
     Object? pinnedAt = _sentinel,
     Object? expiresAt = _sentinel,
@@ -371,6 +394,11 @@ class ChatMessage {
       latestReplyPreview: latestReplyPreview == _sentinel
           ? this.latestReplyPreview
           : latestReplyPreview as String?,
+      lastReplyAt: lastReplyAt == _sentinel
+          ? this.lastReplyAt
+          : lastReplyAt as DateTime?,
+      recentReplierUsernames:
+          recentReplierUsernames ?? this.recentReplierUsernames,
       pinnedById: pinnedById == _sentinel
           ? this.pinnedById
           : pinnedById as String?,
@@ -405,6 +433,8 @@ class ChatMessage {
             replyToUsername == other.replyToUsername &&
             replyCount == other.replyCount &&
             latestReplyPreview == other.latestReplyPreview &&
+            lastReplyAt == other.lastReplyAt &&
+            _listEquals(recentReplierUsernames, other.recentReplierUsernames) &&
             pinnedById == other.pinnedById &&
             pinnedAt == other.pinnedAt &&
             expiresAt == other.expiresAt &&
@@ -430,6 +460,8 @@ class ChatMessage {
     replyToUsername,
     replyCount,
     latestReplyPreview,
+    lastReplyAt,
+    Object.hashAll(recentReplierUsernames),
     pinnedById,
     pinnedAt,
     expiresAt,

--- a/apps/client/lib/src/widgets/message/reply_count_badge.dart
+++ b/apps/client/lib/src/widgets/message/reply_count_badge.dart
@@ -128,17 +128,24 @@ class ReplyCountBadge extends StatelessWidget {
   }
 
   Widget _buildPillContainer(BuildContext context, String label) {
+    final repliers = message.recentReplierUsernames;
+    final lastReplyAt = message.lastReplyAt;
+    final hasFaces = repliers.isNotEmpty;
+
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      padding: EdgeInsets.fromLTRB(hasFaces ? 4 : 8, 4, 8, 4),
       decoration: BoxDecoration(
         color: context.accent.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(14),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.forum_outlined, size: 12, color: context.accent),
-          const SizedBox(width: 4),
+          if (hasFaces)
+            _FaceStack(usernames: repliers)
+          else
+            Icon(Icons.forum_outlined, size: 12, color: context.accent),
+          const SizedBox(width: 6),
           Text(
             label,
             style: GoogleFonts.inter(
@@ -147,8 +154,86 @@ class ReplyCountBadge extends StatelessWidget {
               fontWeight: FontWeight.w600,
             ),
           ),
+          if (lastReplyAt != null) ...[
+            const SizedBox(width: 6),
+            Text(
+              _formatAgo(lastReplyAt),
+              style: GoogleFonts.inter(fontSize: 11, color: context.textMuted),
+            ),
+          ],
           if (hasUnread) _unreadDot(context),
         ],
+      ),
+    );
+  }
+
+  static String _formatAgo(DateTime when) {
+    final delta = DateTime.now().toUtc().difference(when.toUtc());
+    if (delta.inSeconds < 60) return 'just now';
+    if (delta.inMinutes < 60) return '${delta.inMinutes}m ago';
+    if (delta.inHours < 24) return '${delta.inHours}h ago';
+    if (delta.inDays < 7) return '${delta.inDays}d ago';
+    return '${(delta.inDays / 7).floor()}w ago';
+  }
+}
+
+/// Up to 3 overlapping circular initials of the most-recent repliers.
+/// Used as the leading affordance of the thread chip when reply
+/// metadata is available — falls back to the forum icon otherwise.
+class _FaceStack extends StatelessWidget {
+  const _FaceStack({required this.usernames});
+
+  final List<String> usernames;
+
+  @override
+  Widget build(BuildContext context) {
+    final faces = usernames.take(3).toList();
+    const faceSize = 18.0;
+    const overlap = 6.0;
+    final width = faceSize + (faces.length - 1) * (faceSize - overlap);
+    return SizedBox(
+      width: width,
+      height: faceSize,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          for (int i = 0; i < faces.length; i++)
+            Positioned(
+              left: i * (faceSize - overlap),
+              child: _FaceCircle(name: faces[i], size: faceSize),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FaceCircle extends StatelessWidget {
+  const _FaceCircle({required this.name, required this.size});
+  final String name;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = name.isNotEmpty ? name[0].toUpperCase() : '?';
+    final hue = (name.hashCode % 360).abs().toDouble();
+    final bg = HSLColor.fromAHSL(1.0, hue, 0.55, 0.45).toColor();
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: bg,
+        shape: BoxShape.circle,
+        border: Border.all(color: context.surface, width: 1.5),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        initial,
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: size * 0.55,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }

--- a/apps/client/test/models/chat_message_test.dart
+++ b/apps/client/test/models/chat_message_test.dart
@@ -466,5 +466,42 @@ void main() {
 
       expect(first == second, isFalse);
     });
+
+    test('parses thread indicator fields from server payload', () {
+      final json = {
+        'message_id': 'msg-th',
+        'from_user_id': 'user-abc',
+        'from_username': 'alice',
+        'conversation_id': 'conv-1',
+        'content': 'parent',
+        'timestamp': '2026-05-26T12:00:00Z',
+        'reply_count': 4,
+        'last_reply_at': '2026-05-26T12:03:30Z',
+        'recent_replier_usernames': ['carol', 'bob', 'alice'],
+      };
+
+      final msg = ChatMessage.fromServerJson(json, 'user-abc');
+
+      expect(msg.replyCount, 4);
+      expect(msg.lastReplyAt, DateTime.parse('2026-05-26T12:03:30Z'));
+      expect(msg.recentReplierUsernames, ['carol', 'bob', 'alice']);
+    });
+
+    test('defaults thread indicator fields when absent', () {
+      final json = {
+        'message_id': 'msg-noth',
+        'from_user_id': 'user-abc',
+        'from_username': 'alice',
+        'conversation_id': 'conv-1',
+        'content': 'no replies yet',
+        'timestamp': '2026-05-26T12:00:00Z',
+      };
+
+      final msg = ChatMessage.fromServerJson(json, 'user-abc');
+
+      expect(msg.replyCount, 0);
+      expect(msg.lastReplyAt, isNull);
+      expect(msg.recentReplierUsernames, isEmpty);
+    });
   });
 }

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -42,6 +42,14 @@ pub struct MessageWithSender {
     /// replies. Server truncates to 80 characters so the wire payload is
     /// bounded; clients still render a single line with ellipsis.
     pub last_reply_snippet: Option<String>,
+    /// Timestamp of the most-recent reply, used by the thread indicator
+    /// chip ("3m ago" label). `None` when there are no replies.
+    pub last_reply_at: Option<DateTime<Utc>>,
+    /// Usernames of up to 3 distinct most-recent repliers, newest first.
+    /// Populated by a LATERAL join in `get_messages` so the thread chip
+    /// can render face stacks without a follow-up round-trip.
+    #[serde(default)]
+    pub recent_replier_usernames: Vec<String>,
     /// Reactions aggregated as a JSON array of
     /// `{message_id, user_id, username, emoji}` objects.  Public history
     /// queries (`get_messages`, `get_thread_replies`) populate this with
@@ -237,6 +245,8 @@ pub async fn get_messages(
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 lr.snippet AS last_reply_snippet, \
+                lr.last_reply_at AS last_reply_at, \
+                COALESCE(rru.usernames, ARRAY[]::text[]) AS recent_replier_usernames, \
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
@@ -249,12 +259,26 @@ pub async fn get_messages(
              GROUP BY reply_to_id \
          ) rc ON rc.reply_to_id = m.id \
          LEFT JOIN LATERAL ( \
-             SELECT LEFT(lrm.content, 80) AS snippet \
+             SELECT LEFT(lrm.content, 80) AS snippet, lrm.created_at AS last_reply_at \
              FROM messages lrm \
              WHERE lrm.reply_to_id = m.id AND lrm.deleted_at IS NULL \
              ORDER BY lrm.created_at DESC \
              LIMIT 1 \
          ) lr ON true \
+         LEFT JOIN LATERAL ( \
+             SELECT ARRAY( \
+                 SELECT rru_u.username FROM ( \
+                     SELECT sender_id, MAX(created_at) AS last_at \
+                     FROM messages \
+                     WHERE reply_to_id = m.id AND deleted_at IS NULL \
+                     GROUP BY sender_id \
+                     ORDER BY last_at DESC \
+                     LIMIT 3 \
+                 ) latest \
+                 JOIN users rru_u ON rru_u.id = latest.sender_id \
+                 ORDER BY latest.last_at DESC \
+             ) AS usernames \
+         ) rru ON true \
          LEFT JOIN LATERAL ( \
              SELECT json_agg(json_build_object( \
                  'message_id', r.message_id, \
@@ -347,6 +371,8 @@ pub async fn get_undelivered(
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 NULL::text AS last_reply_snippet, \
+                NULL::timestamptz AS last_reply_at, \
+                ARRAY[]::text[] AS recent_replier_usernames, \
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN batch ON batch.id = m.id \
@@ -607,6 +633,8 @@ pub async fn search_messages(
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 NULL::text AS last_reply_snippet, \
+                NULL::timestamptz AS last_reply_at, \
+                ARRAY[]::text[] AS recent_replier_usernames, \
                 '[]'::json AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \
@@ -980,6 +1008,8 @@ pub async fn get_thread_replies(
                 ru.username AS reply_to_username, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 NULL::text AS last_reply_snippet, \
+                NULL::timestamptz AS last_reply_at, \
+                ARRAY[]::text[] AS recent_replier_usernames, \
                 COALESCE(rx.reactions, '[]'::json) AS reactions \
          FROM messages m \
          JOIN users u ON u.id = m.sender_id \

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -120,6 +120,15 @@ pub struct MessageDto {
     /// queries (`get_messages`) populate it. Server truncates to 80
     /// chars; clients render a single line with ellipsis.
     pub last_reply_snippet: Option<String>,
+    /// Timestamp of the most-recent reply, populated by history queries
+    /// and consumed by the client's thread indicator chip ("3m ago"
+    /// label). `None` on real-time WS frames + when no replies exist.
+    pub last_reply_at: Option<DateTime<Utc>>,
+    /// Usernames of up to 3 distinct most-recent repliers, newest first.
+    /// Surfaces the avatar-face stack on the thread indicator chip
+    /// without an extra round-trip. Always present (possibly empty).
+    #[serde(default)]
+    pub recent_replier_usernames: Vec<String>,
     /// Reactions on this message: array of
     /// `{message_id, user_id, username, emoji}`.  Aggregated by the DB
     /// query so history reloads render reactions immediately instead of
@@ -144,6 +153,8 @@ impl From<db::messages::MessageWithSender> for MessageDto {
             reply_to_username: m.reply_to_username,
             reply_count: m.reply_count,
             last_reply_snippet: m.last_reply_snippet,
+            last_reply_at: m.last_reply_at,
+            recent_replier_usernames: m.recent_replier_usernames,
             reactions: m
                 .reactions
                 .map(|j| j.0)


### PR DESCRIPTION
## Summary
First milestone toward the Slack-style thread indicator from docs/threads-architecture.md and the threads-redesign mockup. The existing **\"X replies\" pill** under threaded messages now carries the **avatar-face stack** and **\"Xm ago\" subtitle** that make threads actually discoverable at a glance.

### Server
- \`MessageWithSender\` + \`MessageDto\` gain \`last_reply_at\` + \`recent_replier_usernames\`.
- \`get_messages\` adds two LATERAL joins to populate them in one round-trip: the last reply's timestamp + up to 3 distinct most-recent repliers' usernames, newest first.
- \`get_thread_replies\` / \`search_messages\` / \`get_undelivered\` fill the new columns with sane defaults so the FromRow contract is still honoured.

### Client
- \`ChatMessage\` gains \`lastReplyAt\` + \`recentReplierUsernames\`; \`copyWith\`, \`toJson\`, \`==\`, \`hashCode\` all updated.
- \`ReplyCountBadge\` now shows up to 3 overlapping initial-circle faces when the new data is present, and a \"Xm / Xh / Xd / Xw ago\" subtitle from \`last_reply_at\`. Falls back to the original forum-icon pill when the server didn't send the new fields so older deployments still work.
- Tap target still fires \`onViewThread\` → existing \`ThreadViewPanel\`. No new wiring needed.

## What's NOT in this PR
Per docs/threads-architecture.md, this is M1 (visual indicator). Still to come:
- \`thread_root_id\` schema migration (the flat-tree, \"replies vanish from main timeline\" model)
- Dedicated \"Reply in thread\" compose action
- Thread inbox / aggregated view
- Per-thread unread state

## Test plan
- [x] \`flutter analyze\` + \`cargo check\` clean
- [x] \`cargo test --lib -p echo-server\` (200 tests) passes
- [x] New \`ChatMessage.fromServerJson\` tests for the new fields + missing-field fallback
- [x] Existing reply/thread tests pass
- [ ] CI passes
- [ ] Manual: open a group with replies → see the new faces row + \"Xm ago\" subtitle
- [ ] Manual: older server (no new fields) → pill falls back to icon + \"X replies\" only