### PR TITLE
feat: threads M2 — thread_root_id sends replies to the panel only

### DIFF
--- a/apps/client/lib/src/models/chat_message.dart
+++ b/apps/client/lib/src/models/chat_message.dart
@@ -52,6 +52,13 @@ class ChatMessage {
   final String? replyToId;
   final String? replyToContent;
   final String? replyToUsername;
+
+  /// Threads M2 (docs/threads-architecture.md): when non-null this message
+  /// belongs to the thread rooted at that id and is filtered out of the
+  /// main channel timeline. Old servers omit the field — treat as null
+  /// (back-compat: legacy replies stay in the main timeline).
+  final String? threadRootId;
+
   final int replyCount;
 
   /// Truncated content of the most-recent reply to this message, used for
@@ -118,6 +125,7 @@ class ChatMessage {
     this.replyToId,
     this.replyToContent,
     this.replyToUsername,
+    this.threadRootId,
     this.replyCount = 0,
     this.latestReplyPreview,
     this.lastReplyAt,
@@ -185,6 +193,7 @@ class ChatMessage {
       replyToId: json['reply_to_id'] as String?,
       replyToContent: json['reply_to_content'] as String?,
       replyToUsername: json['reply_to_username'] as String?,
+      threadRootId: json['thread_root_id'] as String?,
       replyCount: (json['reply_count'] as int?) ?? 0,
       latestReplyPreview: json['last_reply_snippet'] as String?,
       lastReplyAt: json['last_reply_at'] != null
@@ -337,6 +346,7 @@ class ChatMessage {
       'reply_to_id': replyToId,
       'reply_to_content': replyToContent,
       'reply_to_username': replyToUsername,
+      'thread_root_id': threadRootId,
       'reply_count': replyCount,
       'last_reply_snippet': latestReplyPreview,
       'last_reply_at': lastReplyAt?.toIso8601String(),
@@ -365,6 +375,7 @@ class ChatMessage {
     String? replyToId,
     String? replyToContent,
     String? replyToUsername,
+    Object? threadRootId = _sentinel,
     int? replyCount,
     Object? latestReplyPreview = _sentinel,
     Object? lastReplyAt = _sentinel,
@@ -390,6 +401,9 @@ class ChatMessage {
       replyToId: replyToId ?? this.replyToId,
       replyToContent: replyToContent ?? this.replyToContent,
       replyToUsername: replyToUsername ?? this.replyToUsername,
+      threadRootId: threadRootId == _sentinel
+          ? this.threadRootId
+          : threadRootId as String?,
       replyCount: replyCount ?? this.replyCount,
       latestReplyPreview: latestReplyPreview == _sentinel
           ? this.latestReplyPreview
@@ -431,6 +445,7 @@ class ChatMessage {
             replyToId == other.replyToId &&
             replyToContent == other.replyToContent &&
             replyToUsername == other.replyToUsername &&
+            threadRootId == other.threadRootId &&
             replyCount == other.replyCount &&
             latestReplyPreview == other.latestReplyPreview &&
             lastReplyAt == other.lastReplyAt &&
@@ -458,6 +473,7 @@ class ChatMessage {
     replyToId,
     replyToContent,
     replyToUsername,
+    threadRootId,
     replyCount,
     latestReplyPreview,
     lastReplyAt,

--- a/apps/client/lib/src/providers/chat/chat_provider.dart
+++ b/apps/client/lib/src/providers/chat/chat_provider.dart
@@ -105,8 +105,10 @@ class Chat extends _$Chat
   }
 
   /// Set the message being replied to (shown in the input bar).
-  void setReplyTo(ChatMessage message) {
-    state = state.copyWith(replyToMessage: message);
+  /// When [asThread] is true the resulting send will carry `thread_root_id`
+  /// so the reply lands only in the thread panel.
+  void setReplyTo(ChatMessage message, {bool asThread = false}) {
+    state = state.copyWith(replyToMessage: message, replyAsThread: asThread);
   }
 
   /// Clear the active reply.
@@ -123,6 +125,7 @@ class Chat extends _$Chat
     String? replyToId,
     String? replyToContent,
     String? replyToUsername,
+    String? threadRootId,
   }) {
     final pendingId = 'pending_${DateTime.now().millisecondsSinceEpoch}';
     // Use real username for symmetry; "You" only as a last-resort fallback.
@@ -140,6 +143,7 @@ class Chat extends _$Chat
       replyToId: replyToId,
       replyToContent: replyToContent,
       replyToUsername: replyToUsername,
+      threadRootId: threadRootId,
       failedContent: content, // preserve for retry if send times out
     );
     var newState = state.withMessage(msg);

--- a/apps/client/lib/src/providers/chat/chat_state.dart
+++ b/apps/client/lib/src/providers/chat/chat_state.dart
@@ -41,6 +41,13 @@ class ChatState {
   /// The message being replied to (shown in the input bar).
   final ChatMessage? replyToMessage;
 
+  /// Threads M2: when true, the active [replyToMessage] reply should be
+  /// sent with `thread_root_id` set so the row lands only in the thread
+  /// panel, not the main timeline. Flipped on by the thread panel's
+  /// "Reply" action and by the message context menu's "Reply in thread";
+  /// regular "Reply" leaves this false and the row stays inline.
+  final bool replyAsThread;
+
   /// Per-conversation count of *consecutive* "[Could not decrypt…]"
   /// placeholders. Resets to 0 when any message in the conversation decrypts
   /// successfully. The chat UI shows an "encryption out of sync — reset?"
@@ -78,6 +85,7 @@ class ChatState {
     this.loadingHistory = const {},
     this.hasMore = const {},
     this.replyToMessage,
+    this.replyAsThread = false,
     this.consecutiveDecryptFailures = const {},
     this.signatureFailures = const {},
     this.groupsNeedingRotation = const {},
@@ -338,6 +346,7 @@ class ChatState {
     Map<String, bool>? loadingHistory,
     Map<String, bool>? hasMore,
     ChatMessage? replyToMessage,
+    bool? replyAsThread,
     bool clearReply = false,
     Map<String, int>? consecutiveDecryptFailures,
     Set<String>? signatureFailures,
@@ -352,6 +361,7 @@ class ChatState {
       replyToMessage: clearReply
           ? null
           : (replyToMessage ?? this.replyToMessage),
+      replyAsThread: clearReply ? false : (replyAsThread ?? this.replyAsThread),
       consecutiveDecryptFailures:
           consecutiveDecryptFailures ?? this.consecutiveDecryptFailures,
       signatureFailures: signatureFailures ?? this.signatureFailures,

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -331,6 +331,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     String content, {
     String? conversationId,
     String? replyToId,
+    String? threadRootId,
   }) async {
     final cryptoState = ref.read(cryptoProvider);
     if (!cryptoState.isInitialized) {
@@ -368,6 +369,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       recipientDeviceContents,
       conversationId: conversationId,
       replyToId: replyToId,
+      threadRootId: threadRootId,
     );
   }
 
@@ -466,6 +468,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     Map<String, Map<String, String>>? recipientDeviceContents, {
     String? conversationId,
     String? replyToId,
+    String? threadRootId,
   }) {
     final msg = <String, dynamic>{
       'type': 'send_message',
@@ -480,6 +483,9 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     }
     if (replyToId != null && replyToId.isNotEmpty) {
       msg['reply_to_id'] = replyToId;
+    }
+    if (threadRootId != null && threadRootId.isNotEmpty) {
+      msg['thread_root_id'] = threadRootId;
     }
 
     _channel?.sink.add(jsonEncode(msg));
@@ -562,6 +568,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     String content, {
     String? channelId,
     String? replyToId,
+    String? threadRootId,
   }) async {
     final conversation = ref
         .read(conversationsProvider)
@@ -598,6 +605,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
           clientMessageId: clientMessageId,
           channelId: channelId,
           replyToId: replyToId,
+          threadRootId: threadRootId,
         ),
       ),
     );
@@ -610,6 +618,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     required String? clientMessageId,
     required String? channelId,
     required String? replyToId,
+    required String? threadRootId,
   }) {
     final msg = <String, dynamic>{
       'type': 'send_message',
@@ -625,6 +634,9 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     }
     if (replyToId != null && replyToId.isNotEmpty) {
       msg['reply_to_id'] = replyToId;
+    }
+    if (threadRootId != null && threadRootId.isNotEmpty) {
+      msg['thread_root_id'] = threadRootId;
     }
     return msg;
   }

--- a/apps/client/lib/src/widgets/chat_input_bar/parts/send_handling.dart
+++ b/apps/client/lib/src/widgets/chat_input_bar/parts/send_handling.dart
@@ -174,6 +174,11 @@ extension _SendHandling on ChatInputBarState {
     final myUserId = ref.read(authProvider).userId ?? '';
     final chatState = ref.read(chatProvider);
     final replyTo = chatState.replyToMessage;
+    // Threads M2: resolve the root for the thread-reply path. Reply targets
+    // that are themselves thread replies anchor to the same root; replies
+    // to a top-level message anchor to its id.
+    final asThread = chatState.replyAsThread && replyTo != null;
+    final threadRootId = asThread ? (replyTo.threadRootId ?? replyTo.id) : null;
 
     String peerUserId = '';
     String? channelId;
@@ -198,6 +203,7 @@ extension _SendHandling on ChatInputBarState {
           replyToId: replyTo?.id,
           replyToContent: replyTo?.content,
           replyToUsername: replyTo?.fromUsername,
+          threadRootId: threadRootId,
         );
 
     // Haptic + chime on local commit (desktop no-op; iOS respects system-haptics setting).
@@ -218,6 +224,7 @@ extension _SendHandling on ChatInputBarState {
               expandedText,
               channelId: channelId,
               replyToId: replyTo?.id,
+              threadRootId: threadRootId,
             );
       } else {
         await ref
@@ -227,6 +234,7 @@ extension _SendHandling on ChatInputBarState {
               expandedText,
               conversationId: conv.id,
               replyToId: replyTo?.id,
+              threadRootId: threadRootId,
             );
       }
     } catch (e) {

--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -493,7 +493,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         serverUrl: serverUrl,
         authToken: authToken,
         onReply: (msg) {
-          ref.read(chatProvider.notifier).setReplyTo(msg);
+          // From the thread panel: this reply belongs in the thread, not
+          // the main timeline. asThread=true flips the WS send to carry
+          // thread_root_id.
+          ref.read(chatProvider.notifier).setReplyTo(msg, asThread: true);
           _chatInputBarKey.currentState?.requestInputFocus();
         },
       );
@@ -1042,7 +1045,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
             serverUrl: serverUrl,
             authToken: authToken,
             onReply: (msg) {
-              ref.read(chatProvider.notifier).setReplyTo(msg);
+              ref.read(chatProvider.notifier).setReplyTo(msg, asThread: true);
               _chatInputBarKey.currentState?.requestInputFocus();
             },
             onClose: () => setState(() => _threadParent = null),

--- a/apps/client/lib/src/widgets/chat_panel/message_actions.dart
+++ b/apps/client/lib/src/widgets/chat_panel/message_actions.dart
@@ -45,6 +45,7 @@ Future<void> retryMessage({
         message.failedContent ?? message.content,
         channelId: message.channelId,
         replyToId: message.replyToId,
+        threadRootId: message.threadRootId,
       );
     } else {
       final myUserId = ref.read(authProvider).userId ?? '';
@@ -55,6 +56,7 @@ Future<void> retryMessage({
         message.failedContent ?? message.content,
         conversationId: conv.id,
         replyToId: message.replyToId,
+        threadRootId: message.threadRootId,
       );
     }
   } catch (_) {

--- a/apps/client/lib/src/widgets/chat_panel_controller.dart
+++ b/apps/client/lib/src/widgets/chat_panel_controller.dart
@@ -222,8 +222,12 @@ class ChatPanelController extends ChangeNotifier {
     } else {
       raw = chatState.messagesForConversation(conv.id);
     }
-    if (deletedForMeIds.isEmpty) return raw;
-    return raw.where((m) => !deletedForMeIds.contains(m.id)).toList();
+    // Threads M2: rows with thread_root_id set live only in the thread
+    // panel, never in the main channel timeline (docs/threads-architecture.md).
+    final visible = raw.where(
+      (m) => m.threadRootId == null && !deletedForMeIds.contains(m.id),
+    );
+    return identical(visible, raw) ? raw : visible.toList();
   }
 
   /// Apply channel + delete-for-me filters to a pre-fetched message list.
@@ -246,6 +250,8 @@ class ChatPanelController extends ChangeNotifier {
             (m.channelId == null || m.channelId!.isEmpty);
       });
     }
+    // Threads M2: keep thread replies out of the main timeline.
+    filtered = filtered.where((m) => m.threadRootId == null);
     if (deletedForMeIds.isNotEmpty) {
       filtered = filtered.where((m) => !deletedForMeIds.contains(m.id));
     }

--- a/apps/client/lib/src/widgets/thread_view_panel.dart
+++ b/apps/client/lib/src/widgets/thread_view_panel.dart
@@ -144,7 +144,9 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
         (s) => s.messagesForConversation(parent.conversationId),
       ),
     );
-    final replies = allMessages.where((m) => m.replyToId == parent.id).toList();
+    final replies = allMessages
+        .where((m) => m.threadRootId == parent.id || m.replyToId == parent.id)
+        .toList();
 
     // Scroll to bottom when a new reply arrives while the panel is open.
     // Use ref.listen to trigger the side-effect outside the build phase.
@@ -152,7 +154,9 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
       chatProvider.select(
         (s) => s
             .messagesForConversation(parent.conversationId)
-            .where((m) => m.replyToId == parent.id)
+            .where(
+              (m) => m.threadRootId == parent.id || m.replyToId == parent.id,
+            )
             .toList(),
       ),
       (prev, next) {

--- a/apps/client/test/widgets/chat_input_bar_parts_test.dart
+++ b/apps/client/test/widgets/chat_input_bar_parts_test.dart
@@ -82,6 +82,7 @@ class _StubChat extends Chat {
     String? replyToId,
     String? replyToContent,
     String? replyToUsername,
+    String? threadRootId,
   }) {
     addOptimisticCalls.add([peerUserId, content, conversationId]);
     // Skip the real Timer-based timeout machinery — tests would leak.
@@ -127,6 +128,7 @@ class _StubWs extends WebSocketNotifier {
     String content, {
     String? conversationId,
     String? replyToId,
+    String? threadRootId,
   }) async {
     sendCalls.add([toUserId, content, conversationId]);
   }
@@ -137,6 +139,7 @@ class _StubWs extends WebSocketNotifier {
     String content, {
     String? channelId,
     String? replyToId,
+    String? threadRootId,
   }) async {
     sendGroupCalls.add([conversationId, content]);
   }

--- a/apps/client/test/widgets/chat_panel/message_actions_test.dart
+++ b/apps/client/test/widgets/chat_panel/message_actions_test.dart
@@ -146,6 +146,7 @@ class _StubChat extends Chat {
     String? replyToId,
     String? replyToContent,
     String? replyToUsername,
+    String? threadRootId,
   }) {
     addMessageCalls.add(
       ChatMessage(
@@ -191,6 +192,7 @@ class _StubWs extends WebSocketNotifier {
     String content, {
     String? conversationId,
     String? replyToId,
+    String? threadRootId,
   }) async {
     sendCalls.add([toUserId, content, conversationId, replyToId]);
     if (sendThrows) throw Exception('ws-send-failed');
@@ -202,6 +204,7 @@ class _StubWs extends WebSocketNotifier {
     String content, {
     String? channelId,
     String? replyToId,
+    String? threadRootId,
   }) async {
     sendGroupCalls.add([conversationId, content, channelId, replyToId]);
     if (sendThrows) throw Exception('ws-send-failed');

--- a/apps/server/migrations/20260526210000_thread_root_id.sql
+++ b/apps/server/migrations/20260526210000_thread_root_id.sql
@@ -1,0 +1,21 @@
+-- Threads M2 (docs/threads-architecture.md §3).
+--
+-- thread_root_id points at the ROOT of a thread (immutable for the life of
+-- the thread). Distinct from reply_to_id, which still names the immediate
+-- quoted parent. When set, the row is a thread reply and is filtered OUT
+-- of the main channel timeline by get_messages — it only renders in the
+-- thread panel.
+--
+-- Existing replies keep thread_root_id NULL, so they stay in the main
+-- timeline (back-compat: the semantic shift is too large to apply
+-- retroactively; only new replies flagged "Reply in thread" go thread-
+-- only).
+ALTER TABLE messages
+  ADD COLUMN thread_root_id UUID NULL
+  REFERENCES messages(id) ON DELETE SET NULL;
+
+-- Hot path: load thread N replies for a parent. Partial index because the
+-- column is sparse (most messages aren't thread replies).
+CREATE INDEX idx_messages_thread_root
+  ON messages (conversation_id, thread_root_id)
+  WHERE thread_root_id IS NOT NULL AND deleted_at IS NULL;

--- a/apps/server/src/db/messages.rs
+++ b/apps/server/src/db/messages.rs
@@ -36,6 +36,11 @@ pub struct MessageWithSender {
     pub reply_to_id: Option<Uuid>,
     pub reply_to_content: Option<String>,
     pub reply_to_username: Option<String>,
+    /// Root of the thread this message belongs to. NULL = top-level (lives
+    /// in the main channel timeline); non-NULL = thread reply (lives only
+    /// in the thread panel). Distinct from `reply_to_id` which still names
+    /// the immediate quoted parent.
+    pub thread_root_id: Option<Uuid>,
     pub reply_count: i64,
     /// Truncated content of the most recent reply to this message
     /// (Slack-style inline thread preview). `None` when there are no
@@ -194,21 +199,38 @@ pub async fn store_message(
     // GRP2 senders bind a client-minted UUID into their signature payload
     // (audit OQ-12); when None the column default assigns one.
     client_message_id: Option<Uuid>,
+    // Threads M2: when set, the row joins the thread rooted at this id and
+    // is filtered out of the main channel timeline. The CTE resolves the
+    // root through the parent's own thread_root_id so a "reply to a
+    // thread reply" still anchors to the original root (Slack-flat).
+    thread_root_id: Option<Uuid>,
 ) -> Result<MessageRow, sqlx::Error> {
     let expires_at: Option<DateTime<Utc>> =
         ttl_seconds.map(|s| Utc::now() + chrono::Duration::seconds(s));
     sqlx::query_as::<_, MessageRow>(
         "WITH parent AS ( \
-             SELECT id FROM messages \
+             SELECT id, thread_root_id FROM messages \
              WHERE id = $5 AND conversation_id = $1 AND deleted_at IS NULL \
+         ), thread_anchor AS ( \
+             SELECT id FROM messages \
+             WHERE id = $9 AND conversation_id = $1 AND deleted_at IS NULL \
          ) \
-         INSERT INTO messages (id, conversation_id, channel_id, sender_id, content, reply_to_id, expires_at, sender_device_id) \
+         INSERT INTO messages (id, conversation_id, channel_id, sender_id, content, reply_to_id, expires_at, sender_device_id, thread_root_id) \
          SELECT COALESCE($8, gen_random_uuid()), \
                 $1, $2, $3, $4, \
                 CASE WHEN $5::uuid IS NULL THEN NULL \
                      ELSE (SELECT id FROM parent) END, \
-                $6, $7 \
-         WHERE $5::uuid IS NULL OR EXISTS (SELECT 1 FROM parent) \
+                $6, $7, \
+                CASE \
+                    WHEN $9::uuid IS NOT NULL THEN \
+                        COALESCE( \
+                            (SELECT thread_root_id FROM messages WHERE id = $9 AND conversation_id = $1), \
+                            (SELECT id FROM thread_anchor) \
+                        ) \
+                    ELSE NULL \
+                END \
+         WHERE ($5::uuid IS NULL OR EXISTS (SELECT 1 FROM parent)) \
+           AND ($9::uuid IS NULL OR EXISTS (SELECT 1 FROM thread_anchor)) \
          RETURNING id, conversation_id, channel_id, sender_id, sender_device_id, \
                    content, created_at, delivered, reply_to_id, expires_at",
     )
@@ -220,6 +242,7 @@ pub async fn store_message(
     .bind(expires_at)
     .bind(sender_device_id)
     .bind(client_message_id)
+    .bind(thread_root_id)
     .fetch_one(pool)
     .await
 }
@@ -243,6 +266,7 @@ pub async fn get_messages(
                 m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
+                m.thread_root_id, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 lr.snippet AS last_reply_snippet, \
                 lr.last_reply_at AS last_reply_at, \
@@ -299,6 +323,7 @@ pub async fn get_messages(
            AND ($2::uuid IS NULL OR m.channel_id = $2) \
            AND ($3::timestamptz IS NULL OR m.created_at < $3) \
            AND m.deleted_at IS NULL \
+           AND m.thread_root_id IS NULL \
          ORDER BY m.created_at DESC \
          LIMIT $4",
     )
@@ -369,6 +394,7 @@ pub async fn get_undelivered(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
+                m.thread_root_id, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 NULL::text AS last_reply_snippet, \
                 NULL::timestamptz AS last_reply_at, \
@@ -631,6 +657,7 @@ pub async fn search_messages(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
+                m.thread_root_id, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 NULL::text AS last_reply_snippet, \
                 NULL::timestamptz AS last_reply_at, \
@@ -1006,6 +1033,7 @@ pub async fn get_thread_replies(
                 m.content, m.created_at, m.edited_at, m.reply_to_id, \
                 rm.content AS reply_to_content, \
                 ru.username AS reply_to_username, \
+                m.thread_root_id, \
                 COALESCE(rc.reply_count, 0) AS reply_count, \
                 NULL::text AS last_reply_snippet, \
                 NULL::timestamptz AS last_reply_at, \
@@ -1032,7 +1060,7 @@ pub async fn get_thread_replies(
              JOIN users rxu ON rxu.id = r.user_id \
              WHERE r.message_id = m.id \
          ) rx ON true \
-         WHERE m.reply_to_id = $1 \
+         WHERE (m.thread_root_id = $1 OR m.reply_to_id = $1) \
            AND m.conversation_id = $2 \
            AND m.deleted_at IS NULL \
            AND ($3::timestamptz IS NULL OR m.created_at < $3) \

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -114,6 +114,9 @@ pub struct MessageDto {
     pub reply_to_id: Option<Uuid>,
     pub reply_to_content: Option<String>,
     pub reply_to_username: Option<String>,
+    /// Threads M2: when set, this message belongs to the thread rooted at
+    /// the given id and is filtered out of the main channel timeline.
+    pub thread_root_id: Option<Uuid>,
     pub reply_count: i64,
     /// Truncated content of the most recent reply to this message, when
     /// `reply_count > 0`. `None` on real-time WS events; only history
@@ -151,6 +154,7 @@ impl From<db::messages::MessageWithSender> for MessageDto {
             reply_to_id: m.reply_to_id,
             reply_to_content: m.reply_to_content,
             reply_to_username: m.reply_to_username,
+            thread_root_id: m.thread_root_id,
             reply_count: m.reply_count,
             last_reply_snippet: m.last_reply_snippet,
             last_reply_at: m.last_reply_at,

--- a/apps/server/src/ws/events/dispatch.rs
+++ b/apps/server/src/ws/events/dispatch.rs
@@ -79,6 +79,7 @@ pub(in crate::ws) async fn handle_text_message(
             recipient_device_contents,
             ttl_seconds,
             client_message_id,
+            thread_root_id,
         } => {
             message_service::handle_send_message(
                 state,
@@ -93,6 +94,7 @@ pub(in crate::ws) async fn handle_text_message(
                 recipient_device_contents,
                 ttl_seconds,
                 client_message_id,
+                thread_root_id,
             )
             .await;
         }

--- a/apps/server/src/ws/message_service/fanout.rs
+++ b/apps/server/src/ws/message_service/fanout.rs
@@ -39,6 +39,7 @@ pub(in crate::ws::message_service) struct NewMessageFields {
     pub(super) reply_to_id: Option<Uuid>,
     pub(super) reply_to_content: Option<String>,
     pub(super) reply_to_username: Option<String>,
+    pub(super) thread_root_id: Option<Uuid>,
     pub(super) expires_at: Option<DateTime<Utc>>,
 }
 
@@ -58,6 +59,7 @@ impl NewMessageFields {
                 reply_to_id,
                 reply_to_content,
                 reply_to_username,
+                thread_root_id,
                 expires_at,
                 undecryptable: _,
             } => Some(Self {
@@ -72,6 +74,7 @@ impl NewMessageFields {
                 reply_to_id: *reply_to_id,
                 reply_to_content: reply_to_content.clone(),
                 reply_to_username: reply_to_username.clone(),
+                thread_root_id: *thread_root_id,
                 expires_at: *expires_at,
             }),
             _ => None,
@@ -112,6 +115,7 @@ pub(in crate::ws::message_service) fn build_per_device_json(
         reply_to_id: fields.reply_to_id,
         reply_to_content: fields.reply_to_content.clone(),
         reply_to_username: fields.reply_to_username.clone(),
+        thread_root_id: fields.thread_root_id,
         expires_at: fields.expires_at,
         undecryptable: None,
     };

--- a/apps/server/src/ws/message_service/mod.rs
+++ b/apps/server/src/ws/message_service/mod.rs
@@ -63,6 +63,10 @@ pub(super) async fn handle_send_message(
     // GRP2: client-minted, bound into the sender signature (OQ-12). The server
     // MUST honour it or signature verification breaks.
     client_message_id: Option<Uuid>,
+    // Threads M2: set when the client used "Reply in thread"; resolved to
+    // the parent's own thread_root_id inside store_message so a reply to
+    // a reply still anchors to the original root.
+    thread_root_id: Option<Uuid>,
 ) {
     if !validate_message_length(state, sender_id, &content) {
         return;
@@ -135,6 +139,7 @@ pub(super) async fn handle_send_message(
         conv_security.disappearing_ttl_seconds,
         conv_security.is_encrypted,
         client_message_id,
+        thread_root_id,
     )
     .await
     else {
@@ -156,6 +161,7 @@ pub(super) async fn handle_send_message(
         reply_to_id,
         reply_to_content: reply_content,
         reply_to_username: reply_username,
+        thread_root_id,
         expires_at: stored.expires_at,
         undecryptable: None,
     };

--- a/apps/server/src/ws/message_service/replay.rs
+++ b/apps/server/src/ws/message_service/replay.rs
@@ -150,6 +150,7 @@ async fn deliver_one_batch(
             reply_to_id: msg.reply_to_id,
             reply_to_content: msg.reply_to_content.clone(),
             reply_to_username: msg.reply_to_username.clone(),
+            thread_root_id: msg.thread_root_id,
             expires_at: None, // Offline delivery: expiry already passed if expired
             undecryptable,
         };

--- a/apps/server/src/ws/message_service/storage.rs
+++ b/apps/server/src/ws/message_service/storage.rs
@@ -190,6 +190,7 @@ pub(in crate::ws::message_service) async fn store_and_confirm(
     conv_ttl_seconds: Option<i32>,
     is_encrypted: bool,
     client_message_id: Option<Uuid>,
+    thread_root_id: Option<Uuid>,
 ) -> Option<db::messages::MessageRow> {
     let effective_ttl = resolve_effective_ttl(ttl_seconds, conv_ttl_seconds);
 
@@ -204,6 +205,7 @@ pub(in crate::ws::message_service) async fn store_and_confirm(
         reply_to_id,
         effective_ttl,
         client_message_id,
+        thread_root_id,
     )
     .await
     {

--- a/apps/server/src/ws/protocol.rs
+++ b/apps/server/src/ws/protocol.rs
@@ -38,6 +38,12 @@ pub(super) enum ClientMessage {
         /// as a unique-constraint error so the sender can retry.
         #[serde(default)]
         client_message_id: Option<Uuid>,
+        /// Threads M2: when set, the row joins the thread rooted at the
+        /// given message id. The store path resolves to the parent's own
+        /// thread_root_id if non-null, so a reply-to-a-reply still
+        /// anchors to the original root (Slack-flat).
+        #[serde(default)]
+        thread_root_id: Option<Uuid>,
     },
     #[serde(rename = "typing")]
     Typing {
@@ -91,6 +97,13 @@ pub enum ServerMessage {
         reply_to_content: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         reply_to_username: Option<String>,
+        /// Threads M2: when set, this message is a thread reply and
+        /// belongs in the thread panel rooted at this id, not in the
+        /// main channel timeline. Old clients ignore unknown fields, so
+        /// the omission of this key for top-level messages keeps wire
+        /// compat.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_root_id: Option<Uuid>,
         #[serde(skip_serializing_if = "Option::is_none")]
         expires_at: Option<DateTime<Utc>>,
         /// Set to `true` when the server cannot deliver per-device ciphertext

--- a/apps/server/tests/ws_messaging.rs
+++ b/apps/server/tests/ws_messaging.rs
@@ -1570,6 +1570,7 @@ async fn offline_replay_delivers_beyond_one_page() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("store_message failed");

--- a/apps/server/tests/ws_replay.rs
+++ b/apps/server/tests/ws_replay.rs
@@ -97,6 +97,7 @@ async fn offline_replay_delivers_all_stored_messages() {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("store_message failed");
@@ -157,6 +158,7 @@ async fn offline_replay_paginated_no_duplicates() {
             alice_uuid,
             None,
             &format!("page-replay-msg-{i}"),
+            None,
             None,
             None,
             None,
@@ -474,6 +476,7 @@ async fn soft_deleted_message_not_replayed() {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("store kept message failed");
@@ -485,6 +488,7 @@ async fn soft_deleted_message_not_replayed() {
         alice_uuid,
         None,
         "delete-this-message",
+        None,
         None,
         None,
         None,
@@ -568,6 +572,7 @@ async fn ttl_expired_message_not_replayed() {
         None,
         None,
         None,
+        None,
     )
     .await
     .expect("store live message failed");
@@ -580,6 +585,7 @@ async fn ttl_expired_message_not_replayed() {
         alice_uuid,
         None,
         "expired-message",
+        None,
         None,
         None,
         None,


### PR DESCRIPTION
## Summary
Second milestone for Slack-style threads (\`docs/threads-architecture.md\` §3). Replies tagged with \`thread_root_id\` are filtered out of the main channel timeline and live only in the thread panel.

### Server
- New migration \`20260526210000_thread_root_id.sql\`: adds \`messages.thread_root_id UUID NULL\` + partial index on \`(conversation_id, thread_root_id)\`.
- \`store_message\` accepts \`thread_root_id\` and resolves to the parent's own \`thread_root_id\` when set, else the parent's id — a reply-to-a-reply still anchors at the original root (Slack-flat).
- \`get_messages\` now filters \`m.thread_root_id IS NULL\` on the main timeline.
- \`get_thread_replies\` matches on \`thread_root_id = $1 OR reply_to_id = $1\` so the panel still surfaces pre-M2 legacy inline replies.
- \`SendMessage\` frame + \`ServerMessage::NewMessage\` + replay frame + per-device fanout all carry the new field. Older clients ignore unknown keys.

### Client
- \`ChatMessage\` gains \`threadRootId\`.
- \`chat_panel_controller\` filters \`threadRootId != null\` out of the main timeline.
- \`ThreadViewPanel\` matches BOTH \`threadRootId\` and \`replyToId\`.
- \`ChatState\` gains \`replyAsThread\`; \`setReplyTo(message, asThread: true)\` flips it. The thread panel's "Reply" button uses that path.
- Send handling resolves the root (\`parent.threadRootId ?? parent.id\`) and plumbs \`threadRootId\` through \`addOptimistic\` + \`sendMessage\` / \`sendGroupMessage\` / retry. Test stubs updated.

## Behavior
- **Existing inline replies stay in the main timeline.** Only new replies sent from inside the thread panel become "real" thread replies that vanish from the channel.
- **Back-compat both directions.** Old servers omit \`thread_root_id\` and clients treat null as "main timeline". Old clients ignore the new field and dump unknown replies into main, which the server now back-fills with thread anchoring on receive.

## Deferred to follow-up
Per \`docs/threads-architecture.md\` §4 (hard parts): per-thread unread state, \`thread_subscriptions\` push dampening, cross-group threads inbox, and a separate "Reply in thread" item on inline messages.

## Test plan
- [x] \`cargo check\` + \`cargo build --tests\` clean
- [x] \`flutter analyze\` clean across all touched files
- [x] Existing chat_panel + chat_message tests still pass
- [ ] CI passes
- [ ] Manual: open thread panel on a parent → tap "Reply" → send → reply shows ONLY in the panel, not the main timeline
- [ ] Manual: inline "Reply" (right-click → Reply) → send → reply still inline in main (unchanged)