### PR TITLE
fix(client): bound canvas pan + tighten drawing tools menu

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -83,7 +83,7 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 240,
+      width: 280,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -287,42 +287,29 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
               ),
             ],
           ),
+          const SizedBox(height: 4),
+          // Icon-only export row. Three text labels at this menu width
+          // wrapped onto two lines ("PN G", "Sav e", "Loa d") — tooltips
+          // carry the affordance instead.
           Row(
+            mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Expanded(
-                child: TextButton.icon(
-                  onPressed: () => _exportPng(context),
-                  icon: const Icon(Icons.image_outlined, size: 16),
-                  label: const Text('PNG'),
-                  style: TextButton.styleFrom(
-                    foregroundColor: context.textSecondary,
-                    textStyle: const TextStyle(fontSize: 12),
-                  ),
-                ),
+              _ExportIconButton(
+                icon: Icons.image_outlined,
+                tooltip: 'Export canvas as PNG',
+                onTap: () => _exportPng(context),
               ),
-              const SizedBox(width: 4),
-              Expanded(
-                child: TextButton.icon(
-                  onPressed: () => _exportJson(context),
-                  icon: const Icon(Icons.save_alt_outlined, size: 16),
-                  label: const Text('Save'),
-                  style: TextButton.styleFrom(
-                    foregroundColor: context.textSecondary,
-                    textStyle: const TextStyle(fontSize: 12),
-                  ),
-                ),
+              const SizedBox(width: 12),
+              _ExportIconButton(
+                icon: Icons.save_alt_outlined,
+                tooltip: 'Save snapshot to JSON',
+                onTap: () => _exportJson(context),
               ),
-              const SizedBox(width: 4),
-              Expanded(
-                child: TextButton.icon(
-                  onPressed: () => _importJson(context),
-                  icon: const Icon(Icons.upload_file_outlined, size: 16),
-                  label: const Text('Load'),
-                  style: TextButton.styleFrom(
-                    foregroundColor: context.textSecondary,
-                    textStyle: const TextStyle(fontSize: 12),
-                  ),
-                ),
+              const SizedBox(width: 12),
+              _ExportIconButton(
+                icon: Icons.upload_file_outlined,
+                tooltip: 'Load snapshot from JSON',
+                onTap: () => _importJson(context),
               ),
             ],
           ),
@@ -624,6 +611,39 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Compact icon-only button used for the canvas snapshot row. Carries the
+/// affordance label as a tooltip so the menu doesn't have to grow wider to
+/// fit "Save / Load / PNG" text on every locale + density combo.
+class _ExportIconButton extends StatelessWidget {
+  const _ExportIconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: InkResponse(
+        onTap: () {
+          HapticFeedback.lightImpact();
+          onTap();
+        },
+        radius: 22,
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Icon(icon, size: 18, color: context.textSecondary),
         ),
       ),
     );

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -1088,16 +1088,22 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     // a separate scaffold layer underneath this widget. Pan is disabled while
     // drawing so single-pointer drags become strokes, not viewport pans.
     // Pinch + ctrl-scroll still zoom regardless.
+    //
+    // boundaryMargin: a finite-but-generous extent gives users room to
+    // arrange tiles past the visible viewport without ever scrolling into
+    // the void past the canvas edge. Infinity here meant the bordered
+    // canvas rectangle could be panned far off-screen, exposing the
+    // background and making the boundary line jarringly obvious.
     final viewportContent = _spotlightMode
         ? mergedContent
         : InteractiveViewer(
             transformationController: _viewport,
-            minScale: 0.5,
+            minScale: 0.6,
             maxScale: 4.0,
             panEnabled: !_isDrawing,
             scaleEnabled: true,
             trackpadScrollCausesScale: true,
-            boundaryMargin: const EdgeInsets.all(double.infinity),
+            boundaryMargin: const EdgeInsets.all(600),
             child: mergedContent,
           );
 


### PR DESCRIPTION
## Summary
Two voice-lounge polish fixes from inline feedback on top of the M2 thread work.

### 1. Bounded canvas pan/zoom
Replace \`InteractiveViewer\`'s infinite \`boundaryMargin\` with a generous-but-finite \`EdgeInsets.all(600)\`. Users still get plenty of room to arrange tiles past the visible viewport, but can no longer drag deep into the void past the canvas edge (the screenshot showed a single hairline edge visible while panned far out). \`minScale\` bumps from 0.5 → 0.6 so the canvas can't shrink below readable. Strokes remain clamped to the canvas via normalized [0,1] coords.

### 2. Tighter drawing tools menu
The bottom row of export buttons had been wrapping labels onto two lines ("PN G", "Sav e", "Loa d") because the menu was only 240px wide. Two changes:
- Widen menu to 280px.
- Replace the bottom-row \`TextButton.icon\` labels with three compact icon-only buttons. Tooltips carry the affordance ("Export canvas as PNG" / "Save snapshot to JSON" / "Load snapshot from JSON").

The Image + Clear row stays intact at full text-and-icon since those are the primary actions.

## Test plan
- [x] \`flutter analyze\` clean
- [x] Existing voice-lounge tests pass
- [ ] CI passes
- [ ] Manual: open lounge in fullscreen → pan with cursor → finite boundary now prevents scrolling deep into bg
- [ ] Manual: tap draw → see icon-only PNG/Save/Load row instead of wrapped labels