### PR TITLE
feat(client): show call duration + ping in voice lounge

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/call_metrics_chip.dart
+++ b/apps/client/lib/src/screens/voice_lounge/call_metrics_chip.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/livekit_voice/livekit_voice_provider.dart';
+import '../../theme/echo_theme.dart';
+
+/// Pill that shows elapsed call duration (MM:SS) and round-trip ping for the
+/// active voice session. State comes from [livekitVoiceProvider] —
+/// [LiveKitVoiceState.callStartedAt] is stamped when the user joins a
+/// channel, and [LiveKitVoiceState.rttMs] is polled by `RtcStatsPoll`
+/// every 2 seconds. Duration ticks locally at 1 Hz so we don't have to
+/// rebroadcast clock state from the provider.
+class CallMetricsChip extends ConsumerStatefulWidget {
+  const CallMetricsChip({super.key});
+
+  @override
+  ConsumerState<CallMetricsChip> createState() => _CallMetricsChipState();
+}
+
+class _CallMetricsChipState extends ConsumerState<CallMetricsChip> {
+  Timer? _tick;
+
+  @override
+  void initState() {
+    super.initState();
+    _tick = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _tick?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final voice = ref.watch(livekitVoiceProvider);
+    final startedAt = voice.callStartedAt;
+    if (startedAt == null) return const SizedBox.shrink();
+
+    final elapsed = DateTime.now().difference(startedAt);
+    final duration = _formatDuration(elapsed);
+    final rtt = voice.rttMs;
+    final pingColor = _pingColor(rtt);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: Colors.black54,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.timer_outlined, size: 13, color: Colors.white70),
+          const SizedBox(width: 4),
+          Text(
+            duration,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontFeatures: [FontFeature.tabularFigures()],
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (rtt > 0) ...[
+            Container(
+              width: 1,
+              height: 12,
+              color: Colors.white24,
+              margin: const EdgeInsets.symmetric(horizontal: 8),
+            ),
+            Container(
+              width: 6,
+              height: 6,
+              decoration: BoxDecoration(
+                color: pingColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 5),
+            Text(
+              '${rtt.round()} ms',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+                fontFeatures: [FontFeature.tabularFigures()],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  static String _formatDuration(Duration d) {
+    final hours = d.inHours;
+    final minutes = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return hours > 0 ? '$hours:$minutes:$seconds' : '$minutes:$seconds';
+  }
+
+  static Color _pingColor(double rtt) {
+    if (rtt <= 100) return EchoTheme.online;
+    if (rtt <= 250) return EchoTheme.warning;
+    return EchoTheme.danger;
+  }
+}

--- a/apps/client/lib/src/screens/voice_lounge/lounge_header.dart
+++ b/apps/client/lib/src/screens/voice_lounge/lounge_header.dart
@@ -12,6 +12,11 @@ class LoungeHeader extends StatelessWidget {
   final bool membersSidebarCollapsed;
   final VoidCallback? onToggleMembers;
 
+  /// Optional metrics chip (call duration + ping). Rendered to the right
+  /// of the participant count when present so it sits at eye-level with
+  /// the channel name. Null in tests / when metrics aren't ready.
+  final Widget? trailing;
+
   const LoungeHeader({
     super.key,
     required this.channelName,
@@ -19,6 +24,7 @@ class LoungeHeader extends StatelessWidget {
     this.onBackToChat,
     this.membersSidebarCollapsed = false,
     this.onToggleMembers,
+    this.trailing,
   });
 
   @override
@@ -58,6 +64,7 @@ class LoungeHeader extends StatelessWidget {
               ),
             ),
           ),
+          if (trailing != null) ...[const SizedBox(width: 8), trailing!],
           const Spacer(),
           if (onToggleMembers != null)
             IconButton(

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -27,6 +27,7 @@ import '../widgets/echo_bottom_sheet.dart';
 import '../widgets/lounge_drawing_canvas.dart';
 import '../widgets/vertex_mesh_background.dart';
 import '../widgets/voice_canvas.dart';
+import 'voice_lounge/call_metrics_chip.dart';
 import 'voice_lounge/dock_submenus.dart';
 import 'voice_lounge/drawing_tools_menu.dart';
 import 'voice_lounge/floating_dock.dart';
@@ -896,8 +897,16 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         Positioned(
           top: 16,
           left: 60,
-          child: _buildHeaderBadge(context, channelName, totalParticipants),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildHeaderBadge(context, channelName, totalParticipants),
+              const SizedBox(width: 8),
+              const CallMetricsChip(),
+            ],
+          ),
         ),
+      if (isFull) const Positioned(top: 16, left: 60, child: CallMetricsChip()),
       Positioned(
         top: 16,
         right: 16,
@@ -938,6 +947,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
               onBackToChat: widget.onBackToChat,
               membersSidebarCollapsed: !widget.membersPanelVisible,
               onToggleMembers: widget.onToggleMembersPanel,
+              trailing: const CallMetricsChip(),
             ),
           Expanded(child: contentArea),
           const SizedBox(height: 80),


### PR DESCRIPTION
## Summary
The state already tracked \`callStartedAt\` (when the user joined) and \`rttMs\` (RTC stats polled every 2s) but neither was displayed anywhere — the lounge gave you mic / camera state in the dock and nothing else, so you couldn't tell how long the call had run or whether the connection was healthy.

Adds a new \`CallMetricsChip\` — a compact \`black54\` pill that shows:
- **MM:SS** elapsed since join (or H:MM:SS for long calls). Ticks locally at 1 Hz.
- A small color dot + \`### ms\` ping. Color tiers: green ≤100 ms, amber ≤250 ms, red beyond.

Placement:
- **Portrait** — new \`trailing\` slot in \`LoungeHeader\`, sitting just after the participant-count badge.
- **Landscape** — in the floating top-left badge row, immediately right of the channel name. When fullscreen mode hides the badge, the chip renders standalone at the same anchor.

## Test plan
- [x] \`flutter analyze\` clean
- [x] Existing voice-lounge tests pass
- [ ] CI passes
- [ ] Manual: join a voice channel → see duration tick + ping update every couple seconds; color flips green/amber/red as ping changes