### PR TITLE
feat(client): Figma-style infinite canvas + softer screen-share frame

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -188,11 +188,15 @@ class _DraggableScreenShareWindowState
                     decoration: BoxDecoration(
                       color: Colors.black.withValues(alpha: 0.85),
                       borderRadius: BorderRadius.circular(12),
+                      // Softer accent ring (alpha .25, hairline) so the
+                      // window sits in the canvas without reading as a
+                      // hard frame the user mistakes for the canvas
+                      // boundary.
                       border: Border.all(
                         color:
                             (widget.isLocal ? EchoTheme.danger : context.accent)
-                                .withValues(alpha: 0.6),
-                        width: 1.5,
+                                .withValues(alpha: 0.25),
+                        width: 0.5,
                       ),
                       boxShadow: [
                         BoxShadow(

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -1094,26 +1094,27 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       ],
     );
 
-    // Figma-style zoom + pan. Bg stays fixed because _buildBackground sits in
-    // a separate scaffold layer underneath this widget. Pan is disabled while
-    // drawing so single-pointer drags become strokes, not viewport pans.
-    // Pinch + ctrl-scroll still zoom regardless.
+    // Figma-style zoom + pan: the canvas reads as an effectively-infinite
+    // workspace. Background sits in a separate scaffold layer behind this
+    // widget so panning the canvas never reveals "outside" — the bg
+    // image stays put. boundaryMargin is intentionally infinite so the
+    // user is never wall-stopped while exploring.
     //
-    // boundaryMargin: a finite-but-generous extent gives users room to
-    // arrange tiles past the visible viewport without ever scrolling into
-    // the void past the canvas edge. Infinity here meant the bordered
-    // canvas rectangle could be panned far off-screen, exposing the
-    // background and making the boundary line jarringly obvious.
+    // Pan is disabled while drawing so single-pointer drags become
+    // strokes, not viewport pans. Pinch + ctrl/trackpad-scroll still
+    // zoom regardless.
+    //
+    // Scale range matches Figma's broad envelope: 20% to 800%.
     final viewportContent = _spotlightMode
         ? mergedContent
         : InteractiveViewer(
             transformationController: _viewport,
-            minScale: 0.6,
-            maxScale: 4.0,
+            minScale: 0.2,
+            maxScale: 8.0,
             panEnabled: !_isDrawing,
             scaleEnabled: true,
             trackpadScrollCausesScale: true,
-            boundaryMargin: const EdgeInsets.all(600),
+            boundaryMargin: const EdgeInsets.all(double.infinity),
             child: mergedContent,
           );
 


### PR DESCRIPTION
## Summary
Aligns the voice-lounge canvas with how Figma manages its workspace, and removes the misread "canvas frame" the user reported in feedback.

### InteractiveViewer
- \`boundaryMargin: EdgeInsets.all(600)\` → \`EdgeInsets.all(double.infinity)\`. Figma's workspace has no wall; you can roam forever. The lounge background image lives in a separate scaffold layer underneath the InteractiveViewer, so panning the canvas never reveals "outside" — the bg stays put behind everything.
- \`minScale: 0.6 → 0.2\`, \`maxScale: 4.0 → 8.0\` to match Figma's 20%–800% envelope.

### Screen-share window
The accent / danger \`1.5 px @ alpha 0.6\` border on \`DraggableScreenShareWindow\` is what the user pointed at in the "obvious canvas border" feedback — it framed the screen-share rectangle in the canvas but at scene level it reads like a hard canvas boundary. Softened to \`0.5 px @ alpha 0.25\` so the window sits inside the canvas without trying to be the canvas edge.

## Test plan
- [x] \`flutter analyze\` clean
- [ ] CI passes
- [ ] Manual: pan + zoom in canvas mode → no wall stop, no visible canvas frame, just background everywhere
- [ ] Manual: with screen-share active → window has a subtle hairline, not the previous accent ring