### PR TITLE
refactor(client): regroup settings list into 4 clear buckets

### DIFF
--- a/apps/client/lib/src/screens/settings_screen.dart
+++ b/apps/client/lib/src/screens/settings_screen.dart
@@ -157,7 +157,9 @@ class SettingsRootView extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           UserHeaderCard(onTap: () => onTap(SettingsSection.profile)),
-          const SectionHeader('Account preferences'),
+          // Account: identity, presence, who-can-reach-you. Stuff that
+          // travels with the user across devices.
+          const SectionHeader('Account'),
           _CardGroup(
             children: [
               if (onSavedMessages != null)
@@ -167,6 +169,31 @@ class SettingsRootView extends ConsumerWidget {
                   label: 'Saved Messages',
                   onTap: onSavedMessages!,
                 ),
+              _row(
+                context,
+                icon: Icons.mood_outlined,
+                iconColor: context.settingsIconPalette.info,
+                section: SettingsSection.status,
+              ),
+              _row(
+                context,
+                icon: Icons.devices_outlined,
+                iconColor: context.settingsIconPalette.devices,
+                section: SettingsSection.devices,
+              ),
+              _row(
+                context,
+                icon: Icons.lock_outline,
+                iconColor: context.settingsIconPalette.privacy,
+                section: SettingsSection.privacy,
+              ),
+            ],
+          ),
+          // App: visual + input + locale + assistive prefs. Per-install
+          // rather than per-identity.
+          const SectionHeader('App'),
+          _CardGroup(
+            children: [
               _row(
                 context,
                 icon: Icons.palette_outlined,
@@ -183,6 +210,18 @@ class SettingsRootView extends ConsumerWidget {
               ),
               _row(
                 context,
+                icon: Icons.accessibility_outlined,
+                iconColor: context.settingsIconPalette.accessibility,
+                section: SettingsSection.accessibility,
+              ),
+            ],
+          ),
+          // Communication: chat / voice routing + alerting.
+          const SectionHeader('Communication'),
+          _CardGroup(
+            children: [
+              _row(
+                context,
                 icon: Icons.notifications_outlined,
                 iconColor: context.settingsIconPalette.notifications,
                 section: SettingsSection.notifications,
@@ -193,29 +232,17 @@ class SettingsRootView extends ConsumerWidget {
                 iconColor: context.settingsIconPalette.voiceVideo,
                 section: SettingsSection.voiceVideo,
               ),
-              _row(
-                context,
-                icon: Icons.lock_outline,
-                iconColor: context.settingsIconPalette.privacy,
-                section: SettingsSection.privacy,
-              ),
-              _row(
-                context,
-                icon: Icons.devices_outlined,
-                iconColor: context.settingsIconPalette.devices,
-                section: SettingsSection.devices,
-              ),
+            ],
+          ),
+          // Data: caches, exports, on-device footprint.
+          const SectionHeader('Data'),
+          _CardGroup(
+            children: [
               _row(
                 context,
                 icon: Icons.sd_storage_outlined,
                 iconColor: context.textPrimary,
                 section: SettingsSection.dataStorage,
-              ),
-              _row(
-                context,
-                icon: Icons.accessibility_outlined,
-                iconColor: context.settingsIconPalette.accessibility,
-                section: SettingsSection.accessibility,
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
Audit response: the settings root view dumped every section under a single "Account preferences" header — ten flat rows mixing appearance, language, notifications, voice/video, privacy, devices, storage, and accessibility. Hard to scan and inconsistent with how Discord / Slack / iMessage organize settings.

### New grouping
- **Account** — Saved Messages, Status, Devices, Privacy. Identity + who-can-reach-you. Travels with the user across installs.
- **App** — Appearance, Language, Accessibility. Visual + locale + assistive prefs. Per-install rather than per-identity.
- **Communication** — Notifications, Voice & Video. Chat / voice routing + alerting.
- **Data** — Storage. On-device footprint + exports.

Echo / About / Log out stay in their own card groups (unchanged).

### Behavioral changes
- **Status moves out of "buried in Settings"** into the Account list itself so users find it without going through the avatar pill. (Previous status pill UX hint applied.)
- All other sections keep their current widget, route, and behavior.

### Audit notes — what stayed where
| Section | Bucket | Why |
|---|---|---|
| Profile (header card) | top of root | Already separate by design |
| Status | Account | Identity-level presence + custom text |
| Devices | Account | "Where am I logged in" maps to identity |
| Privacy | Account | "Who can DM me / blocked users" maps to identity |
| Appearance | App | Per-install theme + colors |
| Language | App | Per-install locale |
| Accessibility | App | Per-install motion / font scale |
| Notifications | Communication | Alerts on incoming chat / voice |
| Voice & Video | Communication | Mic / camera / push-to-talk |
| Storage | Data | Cache + exports |
| Admin dashboard | Echo | Server-side admin |
| About | Echo | Version / changelog / license |

## Not changed
- \`SettingsSection\` enum values
- \`SettingsContent\` dispatch
- Routes / deep links
- Section widget implementations

## Test plan
- [x] \`flutter analyze\` clean
- [x] Existing settings tests pass
- [ ] CI passes
- [ ] Manual: scroll through Settings → four headed groups, sensible ordering