### PR TITLE
fix(client): voice rejoin crash + ref-after-dispose

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -121,13 +121,20 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     _viewport
       ..removeListener(_onViewportChanged)
       ..dispose();
-    // Clear fullscreen so the user doesn't return to an immersive HomeScreen
-    // (no sidebar / no title bar) the next time they open the lounge.
-    Future.microtask(() {
-      if (ref.read(voiceLoungeFullscreenProvider)) {
-        ref.read(voiceLoungeFullscreenProvider.notifier).state = false;
-      }
-    });
+    // Clear fullscreen so the user doesn't return to an immersive
+    // HomeScreen (no sidebar / no title bar) the next time they open
+    // the lounge. Read the provider's notifier synchronously now —
+    // ConsumerState's `ref` is invalidated the moment `super.dispose`
+    // runs, so a deferred `Future.microtask(() => ref.read(...))`
+    // crashes with "Cannot use 'ref' after the widget was disposed".
+    try {
+      final notifier = ref.read(voiceLoungeFullscreenProvider.notifier);
+      if (notifier.state) notifier.state = false;
+    } catch (_) {
+      // Ref may already be invalid in narrow edge cases (route swap
+      // during teardown). Silently skip — the next mount will pick up
+      // whatever value the provider holds.
+    }
     DebugLogService.instance.log(
       LogLevel.info,
       'VoiceLoungeUI',

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -67,7 +67,11 @@ class _ChannelColumnState extends ConsumerState<ChannelColumn> {
   @override
   Widget build(BuildContext context) {
     final channelsState = ref.watch(channelsProvider);
-    final channels = channelsState.channelsFor(widget.conversation.id)
+    // channelsFor() can return an unmodifiable view backed by the state's
+    // internal map (e.g. when the conversation has no channels yet, an
+    // empty const list comes back). Sorting in-place crashes with
+    // "Cannot modify an unmodifiable list" on the next build. Copy first.
+    final channels = List.of(channelsState.channelsFor(widget.conversation.id))
       ..sort((a, b) => a.position.compareTo(b.position));
     final textChannels = channels.where((c) => c.isText).toList();
     final voiceChannels = channels.where((c) => c.isVoice).toList();


### PR DESCRIPTION
## Summary
Two crashes from a single rejoin-call session.

### \`channel_column.dart:71\` — Cannot modify an unmodifiable list
\`ChannelsState.channelsFor()\` can return an unmodifiable view (a const empty list when the conversation has no channels yet, or a cached view downstream). The build was calling \`.sort()\` in-place, which throws on the very next build.

Fix: copy into a fresh list before sorting.

### \`voice_lounge_screen.dart\` dispose — ref-after-dispose
The cleanup hook that resets \`voiceLoungeFullscreenProvider\` was deferred via \`Future.microtask\`, but a \`ConsumerState\`'s ref is invalidated as soon as \`super.dispose\` runs — the microtask then fired after teardown and crashed with "Bad state: Cannot use 'ref' after the widget was disposed".

Fix: read the notifier synchronously before \`super.dispose\`, wrapped in try/catch for the narrow route-swap-mid-teardown edge case.

## Test plan
- [x] \`flutter analyze\` clean
- [x] Channel column tests pass
- [ ] CI passes
- [ ] Manual: leave a voice call, rejoin → no crash on rebuild