### PR TITLE
fix(client): lounge polish — boundary scale, hover labels, resize ring, drop cancel

### DIFF
--- a/apps/client/lib/src/providers/voice_lounge_view_mode_provider.dart
+++ b/apps/client/lib/src/providers/voice_lounge_view_mode_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Which top-level view the voice lounge is in. Persisted at the
+/// provider level so toggling fullscreen (which rebuilds the
+/// HomeScreen layout column and remounts VoiceLoungeScreen at a
+/// different Row index) doesn't snap the lounge back to spotlight.
+enum VoiceLoungeView { spotlight, canvas }
+
+final voiceLoungeViewModeProvider = StateProvider<VoiceLoungeView>(
+  (ref) => VoiceLoungeView.spotlight,
+);

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -144,9 +144,15 @@ class _DraggableScreenShareWindowState
   double _width = 320;
   double _height = 180;
   bool _positioned = false;
+  bool _hovered = false;
 
   static const double _minWidth = 160;
   static const double _minHeight = 90;
+  // 16:9 — the source shared-screen content is always rendered with
+  // BoxFit.contain inside the window, so locking the window itself to
+  // the same aspect ratio means the resize gesture scales the window
+  // proportionally and the underlying content never deforms.
+  static const double _aspectRatio = 16.0 / 9.0;
 
   @override
   void initState() {
@@ -175,105 +181,125 @@ class _DraggableScreenShareWindowState
               Positioned(
                 left: _left,
                 top: _top,
-                child: GestureDetector(
-                  onPanUpdate: (d) {
-                    setState(() {
-                      _left += d.delta.dx;
-                      _top += d.delta.dy;
-                    });
-                  },
-                  child: Container(
-                    width: _width,
-                    height: _height,
-                    decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.85),
-                      borderRadius: BorderRadius.circular(12),
-                      // Softer accent ring (alpha .25, hairline) so the
-                      // window sits in the canvas without reading as a
-                      // hard frame the user mistakes for the canvas
-                      // boundary.
-                      border: Border.all(
-                        color:
-                            (widget.isLocal ? EchoTheme.danger : context.accent)
-                                .withValues(alpha: 0.25),
-                        width: 0.5,
-                      ),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.5),
-                          blurRadius: 16,
-                          offset: const Offset(0, 4),
+                child: MouseRegion(
+                  onEnter: (_) => setState(() => _hovered = true),
+                  onExit: (_) => setState(() => _hovered = false),
+                  child: GestureDetector(
+                    onPanUpdate: (d) {
+                      setState(() {
+                        _left += d.delta.dx;
+                        _top += d.delta.dy;
+                      });
+                    },
+                    child: Container(
+                      width: _width,
+                      height: _height,
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: 0.85),
+                        borderRadius: BorderRadius.circular(12),
+                        // Softer accent ring (alpha .25, hairline) so the
+                        // window sits in the canvas without reading as a
+                        // hard frame the user mistakes for the canvas
+                        // boundary.
+                        border: Border.all(
+                          color:
+                              (widget.isLocal
+                                      ? EchoTheme.danger
+                                      : context.accent)
+                                  .withValues(alpha: 0.25),
+                          width: 0.5,
                         ),
-                      ],
-                    ),
-                    clipBehavior: Clip.antiAlias,
-                    child: Stack(
-                      children: [
-                        Positioned.fill(child: widget.child),
-                        // Label badge
-                        Positioned(
-                          top: 6,
-                          left: 8,
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 6,
-                              vertical: 3,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Colors.black.withValues(alpha: 0.6),
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const Icon(
-                                  Icons.screen_share,
-                                  size: 11,
-                                  color: Colors.white70,
-                                ),
-                                const SizedBox(width: 4),
-                                Text(
-                                  widget.label,
-                                  style: const TextStyle(
-                                    color: Colors.white70,
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.w500,
-                                  ),
-                                ),
-                              ],
-                            ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.5),
+                            blurRadius: 16,
+                            offset: const Offset(0, 4),
                           ),
-                        ),
-                        // Resize handle (bottom-right corner)
-                        Positioned(
-                          right: 0,
-                          bottom: 0,
-                          child: GestureDetector(
-                            onPanUpdate: (d) {
-                              setState(() {
-                                _width = (_width + d.delta.dx).clamp(
-                                  _minWidth,
-                                  constraints.maxWidth - _left,
-                                );
-                                _height = (_height + d.delta.dy).clamp(
-                                  _minHeight,
-                                  constraints.maxHeight - _top,
-                                );
-                              });
-                            },
-                            child: Container(
-                              width: 20,
-                              height: 20,
-                              alignment: Alignment.bottomRight,
-                              child: Icon(
-                                Icons.open_in_full,
-                                size: 12,
-                                color: Colors.white.withValues(alpha: 0.4),
+                        ],
+                      ),
+                      clipBehavior: Clip.antiAlias,
+                      child: Stack(
+                        children: [
+                          Positioned.fill(child: widget.child),
+                          // Label badge — hover-only. The rounded chip used
+                          // to overhang the (rounded) window corner; only
+                          // showing it on hover keeps the screen view clean
+                          // and avoids the corner-collision visual.
+                          if (_hovered)
+                            Positioned(
+                              top: 8,
+                              left: 8,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 6,
+                                  vertical: 3,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: Colors.black.withValues(alpha: 0.6),
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(
+                                      Icons.screen_share,
+                                      size: 11,
+                                      color: Colors.white70,
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Text(
+                                      widget.label,
+                                      style: const TextStyle(
+                                        color: Colors.white70,
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
-                          ),
-                        ),
-                      ],
+                          // Resize handle (bottom-right corner). Locked to
+                          // _aspectRatio so the underlying screen content
+                          // never deforms — only the bounding window
+                          // scales proportionally.
+                          if (_hovered)
+                            Positioned(
+                              right: 0,
+                              bottom: 0,
+                              child: GestureDetector(
+                                onPanUpdate: (d) {
+                                  setState(() {
+                                    // Use the larger of dx/dy so the gesture
+                                    // feels uniform; derive height from the
+                                    // locked aspect ratio.
+                                    final nextW = (_width + d.delta.dx).clamp(
+                                      _minWidth,
+                                      constraints.maxWidth - _left,
+                                    );
+                                    final aspectH = nextW / _aspectRatio;
+                                    final nextH = aspectH.clamp(
+                                      _minHeight,
+                                      constraints.maxHeight - _top,
+                                    );
+                                    _width = nextH * _aspectRatio;
+                                    _height = nextH;
+                                  });
+                                },
+                                child: Container(
+                                  width: 20,
+                                  height: 20,
+                                  alignment: Alignment.bottomRight,
+                                  child: Icon(
+                                    Icons.open_in_full,
+                                    size: 12,
+                                    color: Colors.white.withValues(alpha: 0.4),
+                                  ),
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -17,6 +17,7 @@ import '../providers/screen_share_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/voice_lounge_background_provider.dart';
 import '../providers/voice_lounge_fullscreen_provider.dart';
+import '../providers/voice_lounge_view_mode_provider.dart';
 import '../providers/voice_settings_provider.dart';
 import '../services/debug_log_service.dart';
 import '../services/pip_controller.dart';
@@ -86,10 +87,12 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   /// Which dock submenu is currently open (null = none).
   DockSubmenu? _activeSubmenu;
 
-  /// When true, force the spotlight/participant grid instead of the canvas.
-  /// Defaults to true so users land in the familiar grid view; the canvas
-  /// (vertex mesh + draggable pucks) is opt-in via the dock toggle.
-  bool _spotlightMode = true;
+  // Spotlight vs canvas selection lives in voiceLoungeViewModeProvider
+  // so toggling fullscreen (which remounts this widget at a different
+  // Row index in HomeScreen's layout) doesn't snap us back to spotlight.
+  // See lib/src/providers/voice_lounge_view_mode_provider.dart.
+  bool get _spotlightMode =>
+      ref.watch(voiceLoungeViewModeProvider) == VoiceLoungeView.spotlight;
 
   /// Pan + zoom controller for the canvas. Identity = 1x, no offset.
   /// The lounge background sits OUTSIDE this transform so zoom/pan only
@@ -1075,13 +1078,17 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       drawingToolsLayerLink: _drawingToolsLayerLink,
       spotlightMode: _spotlightMode,
       onToggleSpotlight: () {
-        setState(() {
-          _spotlightMode = !_spotlightMode;
-          if (_spotlightMode) {
+        final notifier = ref.read(voiceLoungeViewModeProvider.notifier);
+        final next = _spotlightMode
+            ? VoiceLoungeView.canvas
+            : VoiceLoungeView.spotlight;
+        notifier.state = next;
+        if (next == VoiceLoungeView.spotlight) {
+          setState(() {
             _isDrawing = false;
             _activeSubmenu = null;
-          }
-        });
+          });
+        }
       },
     );
 
@@ -1101,27 +1108,39 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       ],
     );
 
-    // Figma-style zoom + pan: the canvas reads as an effectively-infinite
-    // workspace. Background sits in a separate scaffold layer behind this
-    // widget so panning the canvas never reveals "outside" — the bg
-    // image stays put. boundaryMargin is intentionally infinite so the
-    // user is never wall-stopped while exploring.
+    // Figma-style zoom + pan with a finite canvas. The boundaryMargin
+    // is sized so that at minScale the user sees the full workspace —
+    // boundary then doubles as the visible "page edge" + a scale
+    // reference, instead of either a hard wall mid-pan or an infinite
+    // void with no anchor.
+    //
+    // Background sits in a separate scaffold layer behind this widget
+    // so the bg never moves with the canvas.
     //
     // Pan is disabled while drawing so single-pointer drags become
     // strokes, not viewport pans. Pinch + ctrl/trackpad-scroll still
     // zoom regardless.
-    //
-    // Scale range matches Figma's broad envelope: 20% to 800%.
+    const minScale = 0.25;
+    const maxScale = 4.0;
+    final size = MediaQuery.sizeOf(context);
+    // (1 / minScale - 1) / 2 → margin per side that, at minScale, fits
+    // the full workspace into the viewport. With minScale=0.25 the
+    // margin is 1.5× viewport per side, so total canvas = 4× viewport.
+    final marginX = size.width * ((1 / minScale - 1) / 2);
+    final marginY = size.height * ((1 / minScale - 1) / 2);
     final viewportContent = _spotlightMode
         ? mergedContent
         : InteractiveViewer(
             transformationController: _viewport,
-            minScale: 0.2,
-            maxScale: 8.0,
+            minScale: minScale,
+            maxScale: maxScale,
             panEnabled: !_isDrawing,
             scaleEnabled: true,
             trackpadScrollCausesScale: true,
-            boundaryMargin: const EdgeInsets.all(double.infinity),
+            boundaryMargin: EdgeInsets.symmetric(
+              horizontal: marginX,
+              vertical: marginY,
+            ),
             child: mergedContent,
           );
 

--- a/apps/client/lib/src/widgets/conversation_panel/parts/banners.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/banners.dart
@@ -117,18 +117,10 @@ mixin _ConversationPanelBannersMixin on ConsumerState<ConversationPanel> {
         final pct = (update.downloadProgress * 100).toInt();
         return (
           label: 'Downloading update... $pct%',
-          action: TextButton(
-            onPressed: () => ref.read(updateProvider.notifier).cancelDownload(),
-            style: TextButton.styleFrom(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              minimumSize: Size.zero,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-            child: Text(
-              'Cancel',
-              style: TextStyle(color: context.textMuted, fontSize: 11),
-            ),
-          ),
+          // Cancel removed — users were aborting downloads halfway, leaving
+          // half-fetched payloads on disk that the next launch had to clean
+          // up. Updates are quick; no in-flight cancel surface.
+          action: null,
           showDismiss: false,
           progress: LinearProgressIndicator(
             value: update.downloadProgress,

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -881,7 +881,8 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   }
 
   Widget _buildAvatarWithTrail(Widget avatar) {
-    if (_reduceMotion) return avatar;
+    final withRing = _wrapInResizeRing(avatar);
+    if (_reduceMotion) return withRing;
 
     // Keep trail layer mounted (idle painter returns early) to avoid CustomPaint remount when buffer flips empty/non-empty.
     return Stack(
@@ -903,31 +904,91 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
             ),
           ),
         ),
-        avatar,
+        withRing,
       ],
     );
   }
 
+  /// Wraps the avatar tile in a circular click-and-drag resize ring.
+  /// When [onResize] is null (callers that don't want resize, e.g. tests)
+  /// this is a no-op so the avatar renders unwrapped. On hover the ring
+  /// becomes visible and PanUpdate gestures on its 10 px perimeter drive
+  /// the resize callback — clicks dead-center still pass through to the
+  /// avatar's move-drag wrapper.
+  Widget _wrapInResizeRing(Widget avatar) {
+    if (widget.onResize == null) return avatar;
+    const ringThickness = 6.0;
+    final ringSize = _effectiveAvatarSize + ringThickness * 2;
+    return SizedBox(
+      width: ringSize,
+      height: ringSize,
+      child: Stack(
+        clipBehavior: Clip.none,
+        alignment: Alignment.center,
+        children: [
+          // Bottom layer: perimeter gesture catcher + visible ring on
+          // hover. HitTestBehavior.opaque on the full square, but a
+          // smaller centered IgnorePointer hole lets the inner move
+          // drag through (next layer).
+          MouseRegion(
+            cursor: SystemMouseCursors.resizeUpRightDownLeft,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onPanUpdate: (d) => widget.onResize!(d.delta.dx, d.delta.dy),
+              onPanEnd: (_) => widget.onResizeEnd?.call(),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                width: ringSize,
+                height: ringSize,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: _hovered
+                        ? context.accent.withValues(alpha: 0.6)
+                        : Colors.transparent,
+                    width: 2,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          // Top layer: actual avatar tile. Sized to the original
+          // _effectiveAvatarSize so the surrounding ring stays clickable
+          // for resize.
+          avatar,
+        ],
+      ),
+    );
+  }
+
   Widget _buildContent(_ParticipantInfo info, Widget avatarWithTrail) {
+    // Username label appears only on hover — keeps the canvas clean when
+    // there are many participants. The label sits beneath the puck and
+    // is reserved as a 16 px slot at all times so neighbour avatars
+    // don't jump on hover.
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         avatarWithTrail,
         const SizedBox(height: 4),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-          decoration: BoxDecoration(
-            color: context.surface.withValues(alpha: 0.54),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Text(
-            info.name,
-            style: TextStyle(
-              color: context.textPrimary,
-              fontSize: 11,
-              fontWeight: FontWeight.w500,
+        AnimatedOpacity(
+          duration: const Duration(milliseconds: 120),
+          opacity: _hovered ? 1.0 : 0.0,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: context.surface.withValues(alpha: 0.7),
+              borderRadius: BorderRadius.circular(8),
             ),
-            overflow: TextOverflow.ellipsis,
+            child: Text(
+              info.name,
+              style: TextStyle(
+                color: context.textPrimary,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ),
       ],
@@ -965,33 +1026,8 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
             },
             child: content,
           ),
-          if (_hovered && widget.onResize != null)
-            Positioned(
-              right: -2,
-              bottom: -2,
-              child: MouseRegion(
-                cursor: SystemMouseCursors.resizeDownRight,
-                child: GestureDetector(
-                  onPanUpdate: (d) => widget.onResize!(d.delta.dx, d.delta.dy),
-                  onPanEnd: (_) => widget.onResizeEnd?.call(),
-                  child: Container(
-                    width: 22,
-                    height: 22,
-                    decoration: BoxDecoration(
-                      color: context.surface.withValues(alpha: 0.85),
-                      shape: BoxShape.circle,
-                      border: Border.all(color: context.border),
-                    ),
-                    alignment: Alignment.center,
-                    child: Icon(
-                      Icons.open_in_full,
-                      size: 12,
-                      color: context.textPrimary,
-                    ),
-                  ),
-                ),
-              ),
-            ),
+          // Resize ring lives inside _wrapInResizeRing (avatar-tile
+          // sibling), so no corner button is needed here.
         ],
       ),
     );

--- a/apps/client/test/widgets/conversation_panel_test.dart
+++ b/apps/client/test/widgets/conversation_panel_test.dart
@@ -717,29 +717,32 @@ void main() {
       },
     );
 
-    testWidgets('downloading update banner shows percentage and Cancel', (
-      tester,
-    ) async {
-      await tester.pumpApp(
-        ConversationPanel(onConversationTap: (_) {}),
-        overrides: [
-          ...standardOverrides(conversations: const []),
-          updateProvider.overrideWith(
-            () => _FakeUpdateNotifier(
-              const UpdateState(
-                status: UpdateStatus.downloading,
-                latestVersion: '9.9.9',
-                downloadProgress: 0.42,
+    testWidgets(
+      'downloading update banner shows percentage without a cancel button',
+      (tester) async {
+        await tester.pumpApp(
+          ConversationPanel(onConversationTap: (_) {}),
+          overrides: [
+            ...standardOverrides(conversations: const []),
+            updateProvider.overrideWith(
+              () => _FakeUpdateNotifier(
+                const UpdateState(
+                  status: UpdateStatus.downloading,
+                  latestVersion: '9.9.9',
+                  downloadProgress: 0.42,
+                ),
               ),
             ),
-          ),
-        ],
-      );
-      await tester.pump();
+          ],
+        );
+        await tester.pump();
 
-      expect(find.text('Downloading update... 42%'), findsOneWidget);
-      expect(find.text('Cancel'), findsOneWidget);
-    });
+        expect(find.text('Downloading update... 42%'), findsOneWidget);
+        // Cancel button was removed — abort flows left half-fetched
+        // payloads on disk that the next launch had to clean up.
+        expect(find.text('Cancel'), findsNothing);
+      },
+    );
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Six fixes from inline feedback (image refs #29-32).

### #1 Canvas boundary scales with min zoom
InteractiveViewer's infinite boundaryMargin gave the user no anchor and an obvious frame appeared mid-pan. Switch to a finite margin computed from viewport size + minScale so the workspace edges align exactly with what's visible at the most-zoomed-out level. \`minScale 0.25\`, \`maxScale 4.0\` → 4× viewport canvas.

### #2 Remove cancel-download from inline update banner
Cancel button + tap handler removed. Aborts mid-download left partial payloads on disk that the next launch had to clean up. \`cancelDownload\` stays on the provider but no UI surface invokes it.

### #3 Lock screen-share aspect ratio on resize
Resize handle now derives height from \`width / 16:9\`, so the underlying screen content never deforms — only the bounding box scales proportionally.

### #4 "Your screen" label hover-only
Screen-share window label + resize handle now only render on pointer hover. Removes the overhanging rounded chip in the corner when the user isn't interacting.

### #6 Avatar resize ring
Replaces the small bottom-right corner icon with a hover-only circular ring AROUND the avatar — clicking anywhere on the ring's perimeter drags to resize, clicking the avatar centre still drags to move.

### #7 Username hover-only on avatar
Avatar name label fades in only on hover. Permanent labels under every puck made the canvas noisy with many participants.

### #8 Fullscreen preserves canvas vs spotlight view
Move spotlight mode out of widget state into a new \`voiceLoungeViewModeProvider\`. Toggling fullscreen rebuilds the HomeScreen layout column, which was remounting \`VoiceLoungeScreen\` at a different Row position and resetting local state to spotlight. Provider-backed state survives the remount.

## Test plan
- [x] \`flutter analyze\` clean
- [x] All affected tests pass (chat panel banner test updated)
- [ ] CI passes
- [ ] Manual: pan canvas → finite extent at minScale, no obvious wall mid-pan
- [ ] Manual: hover avatar → name fades in, ring becomes draggable on perimeter
- [ ] Manual: hover screen-share → label appears, drag corner → aspect locked
- [ ] Manual: toggle fullscreen while in canvas mode → stays in canvas