### PR TITLE
fix(client): drop 'Trouble signing up?' link from register screen

### DIFF
--- a/apps/client/lib/src/screens/register_screen.dart
+++ b/apps/client/lib/src/screens/register_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
@@ -212,22 +211,6 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                             overflow: TextOverflow.visible,
                             softWrap: true,
                           ),
-                        ),
-                        // Escape hatch for testers who can't complete
-                        // signup (#1174). The in-app feedback dialog
-                        // requires a session, so we fall back to mailto.
-                        TextButton(
-                          onPressed: () => launchUrl(
-                            Uri.parse(
-                              'mailto:admin@echo-messenger.us'
-                              '?subject=Echo%20support%3A%20trouble%20signing%20up',
-                            ),
-                          ),
-                          style: TextButton.styleFrom(
-                            foregroundColor: context.textMuted,
-                            textStyle: const TextStyle(fontSize: 12),
-                          ),
-                          child: const Text('Trouble signing up?'),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
Follow-up to #1174 → 9c9d3190. The user reports the "New here?" divider + "Trouble signing in?" link visible on the login screen in v0.0.440 (image #36) and wants them gone.

Login surfaces were already stripped in commit 9c9d3190 ("tighten auth + onboarding for beta launch") — the user is on an older build. This PR removes the matching **"Trouble signing up?"** link from \`register_screen.dart\` for symmetry, and drops the now-unused \`url_launcher\` import.

## Test plan
- [x] \`flutter analyze\` clean
- [x] Existing login + register screen tests pass
- [ ] CI passes
- [ ] After v0.0.441+: user no longer sees either link on either auth screen