### PR TITLE
feat(client): hide unused themes, mark defaults, familiarity preset step

### DIFF
--- a/apps/client/lib/src/screens/register_screen.dart
+++ b/apps/client/lib/src/screens/register_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
@@ -212,22 +211,6 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                             overflow: TextOverflow.visible,
                             softWrap: true,
                           ),
-                        ),
-                        // Escape hatch for testers who can't complete
-                        // signup (#1174). The in-app feedback dialog
-                        // requires a session, so we fall back to mailto.
-                        TextButton(
-                          onPressed: () => launchUrl(
-                            Uri.parse(
-                              'mailto:admin@echo-messenger.us'
-                              '?subject=Echo%20support%3A%20trouble%20signing%20up',
-                            ),
-                          ),
-                          style: TextButton.styleFrom(
-                            foregroundColor: context.textMuted,
-                            textStyle: const TextStyle(fontSize: 12),
-                          ),
-                          child: const Text('Trouble signing up?'),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
Three appearance changes from inline feedback on image #37.

### 1. Hide all themes except System + Ember from the picker
The themeOptions list now only renders **System** and **Ember** cards. The remaining ThemeData factories (indigo, paper, graphite, sakura, highContrast) stay wired up inside the enum + \`app.dart\` dispatch tables, so a user who picked one before it was hidden keeps using it — they just can't switch back via the picker until we re-expose it.

### 2. Default badges in the appearance settings
Tiny accent "Default" pill rendered on the option that matches a fresh install:
- **Theme**: System
- **Message layout**: Discord (matches \`MessageLayout.compact\` default)
- **Density**: Compact (matches \`UIDensity.compact\` default)
- **Avatar shape**: Circle (matches \`AvatarShape.circle\` default)

The misleading "Default" label on the Bubbles message-layout row also got renamed to **Bubbles**, with the actual Default badge moved to the correct (Discord) row.

### 3. New "Familiarity" step in the onboarding wizard
A new page inserted between Welcome and Choose your look asks "Which chat app are you used to?" and offers three cards:

| Preset | Theme | Layout | Density | Avatar |
|---|---|---|---|---|
| **iMessage** | System | Bubbles | Normal | Circle |
| **Discord** | Ember | Compact | Compact | Circle |
| **Slack** | System | Plain | Normal | Rounded square |

Each card has a small \`CustomPainter\` mockup that doesn't depend on the active theme so the preview always reads the same. Tap a card → preset is applied + wizard auto-advances. Users can still hand-tune any setting on later wizard pages or in Settings.

## Test plan
- [x] \`flutter analyze\` clean
- [x] Existing settings + wizard tests pass
- [ ] CI passes
- [ ] Manual: Settings → App → Appearance shows 2 theme cards with "Default" pill on System
- [ ] Manual: every group (layout/density/avatar) has exactly one "Default" pill on the value the provider returns from \`build()\`
- [ ] Manual: new signup → wizard step 2 = familiarity → tap Discord → theme + density + layout + avatar flip together, then advance