### PR TITLE
feat: threads M3 — per-thread unread state + cross-group inbox

### DIFF
--- a/apps/client/lib/src/models/thread_inbox_entry.dart
+++ b/apps/client/lib/src/models/thread_inbox_entry.dart
@@ -1,0 +1,64 @@
+/// One row of the cross-group threads inbox.
+///
+/// Mirrors the server's `ThreadInboxEntry` (apps/server/src/db/threads.rs)
+/// and is returned from `GET /api/threads/inbox` sorted newest-reply-first.
+library;
+
+import 'package:flutter/foundation.dart' show immutable;
+
+@immutable
+class ThreadInboxEntry {
+  final String threadRootId;
+  final String conversationId;
+  final String? channelId;
+  final String parentSenderUsername;
+  final String parentExcerpt;
+  final DateTime lastReplyAt;
+  final String lastReplyExcerpt;
+  final String lastReplySenderUsername;
+  final int replyCount;
+  final int unreadCount;
+
+  bool get isUnread => unreadCount > 0;
+
+  const ThreadInboxEntry({
+    required this.threadRootId,
+    required this.conversationId,
+    required this.channelId,
+    required this.parentSenderUsername,
+    required this.parentExcerpt,
+    required this.lastReplyAt,
+    required this.lastReplyExcerpt,
+    required this.lastReplySenderUsername,
+    required this.replyCount,
+    required this.unreadCount,
+  });
+
+  factory ThreadInboxEntry.fromJson(Map<String, dynamic> json) {
+    return ThreadInboxEntry(
+      threadRootId: json['thread_root_id'] as String,
+      conversationId: json['conversation_id'] as String,
+      channelId: json['channel_id'] as String?,
+      parentSenderUsername: json['parent_sender_username'] as String,
+      parentExcerpt: json['parent_excerpt'] as String,
+      lastReplyAt: DateTime.parse(json['last_reply_at'] as String),
+      lastReplyExcerpt: json['last_reply_excerpt'] as String,
+      lastReplySenderUsername: json['last_reply_sender_username'] as String,
+      replyCount: (json['reply_count'] as num).toInt(),
+      unreadCount: (json['unread_count'] as num).toInt(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ThreadInboxEntry &&
+          threadRootId == other.threadRootId &&
+          lastReplyAt == other.lastReplyAt &&
+          replyCount == other.replyCount &&
+          unreadCount == other.unreadCount;
+
+  @override
+  int get hashCode =>
+      Object.hash(threadRootId, lastReplyAt, replyCount, unreadCount);
+}

--- a/apps/client/lib/src/providers/threads_inbox_provider.dart
+++ b/apps/client/lib/src/providers/threads_inbox_provider.dart
@@ -1,0 +1,160 @@
+/// Cross-group threads inbox state + mark-read + nav-rail unread count.
+///
+/// Backed by three REST endpoints landed in threads M3:
+///   GET  /api/threads/inbox         → ThreadInboxEntry[]
+///   POST /api/messages/:id/thread/read
+///   GET  /api/threads/unread-count  → { count }
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../models/thread_inbox_entry.dart';
+import 'auth_provider.dart';
+import 'server_url_provider.dart';
+
+part 'threads_inbox_provider.g.dart';
+
+/// Snapshot of the threads-inbox screen.
+@immutable
+class ThreadsInboxState {
+  final List<ThreadInboxEntry> entries;
+  final bool loading;
+  final String? error;
+
+  const ThreadsInboxState({
+    this.entries = const [],
+    this.loading = false,
+    this.error,
+  });
+
+  ThreadsInboxState copyWith({
+    List<ThreadInboxEntry>? entries,
+    bool? loading,
+    Object? error = _sentinel,
+  }) {
+    return ThreadsInboxState(
+      entries: entries ?? this.entries,
+      loading: loading ?? this.loading,
+      error: error == _sentinel ? this.error : error as String?,
+    );
+  }
+}
+
+const _sentinel = Object();
+
+@Riverpod(keepAlive: true)
+class ThreadsInbox extends _$ThreadsInbox {
+  @override
+  ThreadsInboxState build() => const ThreadsInboxState();
+
+  /// Pull fresh inbox rows. Called on first sidebar-Threads click and
+  /// whenever the user pulls to refresh.
+  Future<void> load() async {
+    state = state.copyWith(loading: true, error: null);
+    try {
+      final serverUrl = ref.read(serverUrlProvider);
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.get(
+              Uri.parse('$serverUrl/api/threads/inbox'),
+              headers: {'Authorization': 'Bearer $token'},
+            ),
+          );
+      if (response.statusCode != 200) {
+        state = state.copyWith(
+          loading: false,
+          error: 'Server returned ${response.statusCode}',
+        );
+        return;
+      }
+      final raw = jsonDecode(response.body) as List;
+      final entries = raw
+          .map((e) => ThreadInboxEntry.fromJson(e as Map<String, dynamic>))
+          .toList();
+      state = state.copyWith(loading: false, entries: entries, error: null);
+    } catch (e) {
+      state = state.copyWith(loading: false, error: e.toString());
+    }
+  }
+
+  /// Mark a thread read on the server AND in the local cache so the
+  /// inbox row + chip badge update immediately (don't wait for a
+  /// refetch).
+  Future<void> markRead(String threadRootId) async {
+    // Optimistic local update.
+    final updated = state.entries.map((e) {
+      if (e.threadRootId != threadRootId) return e;
+      return ThreadInboxEntry(
+        threadRootId: e.threadRootId,
+        conversationId: e.conversationId,
+        channelId: e.channelId,
+        parentSenderUsername: e.parentSenderUsername,
+        parentExcerpt: e.parentExcerpt,
+        lastReplyAt: e.lastReplyAt,
+        lastReplyExcerpt: e.lastReplyExcerpt,
+        lastReplySenderUsername: e.lastReplySenderUsername,
+        replyCount: e.replyCount,
+        unreadCount: 0,
+      );
+    }).toList();
+    state = state.copyWith(entries: updated);
+
+    try {
+      final serverUrl = ref.read(serverUrlProvider);
+      await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.post(
+              Uri.parse('$serverUrl/api/messages/$threadRootId/thread/read'),
+              headers: {'Authorization': 'Bearer $token'},
+            ),
+          );
+    } catch (_) {
+      // Best-effort: a failed POST leaves the optimistic state. Next
+      // inbox refresh will re-derive the truth from the server.
+    }
+
+    // Refresh the nav-rail badge.
+    unawaited(ref.read(unreadThreadCountProvider.notifier).refresh());
+  }
+}
+
+/// Aggregated unread-threads number for the nav-rail badge. Polled on
+/// app focus + after each markRead.
+@Riverpod(keepAlive: true)
+class UnreadThreadCount extends _$UnreadThreadCount {
+  @override
+  int build() {
+    // Initial fetch is fire-and-forget; UI renders 0 until it lands.
+    Future.microtask(refresh);
+    return 0;
+  }
+
+  Future<void> refresh() async {
+    try {
+      final serverUrl = ref.read(serverUrlProvider);
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.get(
+              Uri.parse('$serverUrl/api/threads/unread-count'),
+              headers: {'Authorization': 'Bearer $token'},
+            ),
+          );
+      if (response.statusCode != 200) return;
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      state = (body['count'] as num?)?.toInt() ?? 0;
+    } catch (_) {
+      // Best-effort badge; silent failure is acceptable.
+    }
+  }
+}
+
+// Generated symbols (`threadsInboxProvider` + `unreadThreadCountProvider`)
+// are exported directly from the `.g.dart` part; no manual aliases here.

--- a/apps/client/lib/src/providers/threads_inbox_provider.g.dart
+++ b/apps/client/lib/src/providers/threads_inbox_provider.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'threads_inbox_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$threadsInboxHash() => r'1af78c14b9077d9faafc265edd8edb0535088eac';
+
+/// See also [ThreadsInbox].
+@ProviderFor(ThreadsInbox)
+final threadsInboxProvider =
+    NotifierProvider<ThreadsInbox, ThreadsInboxState>.internal(
+      ThreadsInbox.new,
+      name: r'threadsInboxProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$threadsInboxHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ThreadsInbox = Notifier<ThreadsInboxState>;
+String _$unreadThreadCountHash() => r'abb352917474884c76b879a6e964dda44a2ff326';
+
+/// Aggregated unread-threads number for the nav-rail badge. Polled on
+/// app focus + after each markRead.
+///
+/// Copied from [UnreadThreadCount].
+@ProviderFor(UnreadThreadCount)
+final unreadThreadCountProvider =
+    NotifierProvider<UnreadThreadCount, int>.internal(
+      UnreadThreadCount.new,
+      name: r'unreadThreadCountProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$unreadThreadCountHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$UnreadThreadCount = Notifier<int>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/client/lib/src/router/app_router.dart
+++ b/apps/client/lib/src/router/app_router.dart
@@ -22,6 +22,7 @@ import '../screens/safety_number_screen.dart';
 import '../screens/saved_messages_screen.dart';
 import '../screens/settings_screen.dart';
 import '../screens/splash_screen.dart';
+import '../screens/threads_inbox_screen.dart';
 import '../screens/username_invite_screen.dart';
 import '../screens/user_profile_screen.dart';
 
@@ -236,6 +237,11 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/contacts',
         pageBuilder: (context, state) =>
             _fadePage(key: state.pageKey, child: const ContactsScreen()),
+      ),
+      GoRoute(
+        path: '/threads',
+        pageBuilder: (context, state) =>
+            _fadePage(key: state.pageKey, child: const ThreadsInboxScreen()),
       ),
       GoRoute(
         path: '/create-group',

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -23,6 +23,7 @@ mixin _HomeScreenDesktopLayoutMixin
       onNewGroup: _openCreateGroup,
       onDiscover: _openDiscoverGroups,
       onSavedMessages: _openSavedMessages,
+      onThreads: () => context.push('/threads'),
       onCollapseSidebar: onCollapseSidebar,
       onSettings: _openSettings,
       onShowContacts: _openContacts,

--- a/apps/client/lib/src/screens/threads_inbox_screen.dart
+++ b/apps/client/lib/src/screens/threads_inbox_screen.dart
@@ -1,0 +1,304 @@
+/// Cross-group threads inbox (Slack-style).
+///
+/// Lists every thread the user can see, newest reply first, with
+/// per-row unread counts. Tapping a row routes to the parent
+/// conversation and opens the thread panel anchored at the root.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../models/thread_inbox_entry.dart';
+import '../providers/threads_inbox_provider.dart';
+import '../theme/echo_theme.dart';
+import '../widgets/window_chrome.dart';
+
+class ThreadsInboxScreen extends ConsumerStatefulWidget {
+  const ThreadsInboxScreen({super.key});
+
+  @override
+  ConsumerState<ThreadsInboxScreen> createState() => _ThreadsInboxScreenState();
+}
+
+class _ThreadsInboxScreenState extends ConsumerState<ThreadsInboxScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Fire-and-forget initial fetch. State is keep-alive so a return
+    // visit doesn't refetch unless the user pulls to refresh.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(threadsInboxProvider.notifier).load();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final inbox = ref.watch(threadsInboxProvider);
+    return Scaffold(
+      backgroundColor: context.mainBg,
+      body: Column(
+        children: [
+          const AppTitleBar(title: 'Threads'),
+          _buildHeader(context),
+          Expanded(child: _buildBody(context, inbox)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: context.border)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.forum_outlined, color: context.textPrimary, size: 22),
+          const SizedBox(width: 10),
+          Text(
+            'Threads',
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const Spacer(),
+          IconButton(
+            tooltip: 'Refresh',
+            icon: Icon(Icons.refresh, color: context.textSecondary, size: 18),
+            onPressed: () => ref.read(threadsInboxProvider.notifier).load(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, ThreadsInboxState inbox) {
+    if (inbox.loading && inbox.entries.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (inbox.error != null && inbox.entries.isEmpty) {
+      return _buildErrorState(context, inbox.error!);
+    }
+    if (inbox.entries.isEmpty) {
+      return _buildEmptyState(context);
+    }
+    return RefreshIndicator(
+      onRefresh: () => ref.read(threadsInboxProvider.notifier).load(),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: inbox.entries.length,
+        itemBuilder: (context, index) {
+          final entry = inbox.entries[index];
+          return _ThreadInboxRow(
+            entry: entry,
+            onTap: () => _openThread(context, entry),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(40),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.forum_outlined, size: 48, color: context.textMuted),
+            const SizedBox(height: 16),
+            Text(
+              'No threads yet',
+              style: TextStyle(
+                color: context.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Reply to a message in thread and it will show up here.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: context.textSecondary, fontSize: 13),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context, String error) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(40),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: context.textMuted),
+            const SizedBox(height: 16),
+            Text(
+              "Couldn't load threads",
+              style: TextStyle(
+                color: context.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              error,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: context.textSecondary, fontSize: 13),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () => ref.read(threadsInboxProvider.notifier).load(),
+              child: const Text('Try again'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openThread(BuildContext context, ThreadInboxEntry entry) {
+    // Mark read locally + on the server before routing so the badge
+    // updates immediately.
+    ref.read(threadsInboxProvider.notifier).markRead(entry.threadRootId);
+    // Route the user to the parent conversation; the thread panel is
+    // surfaced from the message itself. Deep-link via a query param so
+    // HomeScreen can auto-open the thread on land.
+    context.go(
+      '/home'
+      '?conversation=${entry.conversationId}'
+      '&thread=${entry.threadRootId}',
+    );
+  }
+}
+
+class _ThreadInboxRow extends StatelessWidget {
+  const _ThreadInboxRow({required this.entry, required this.onTap});
+
+  final ThreadInboxEntry entry;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        hoverColor: context.surfaceHover,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                Icons.forum_outlined,
+                size: 20,
+                color: entry.isUnread ? context.accent : context.textMuted,
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            entry.parentSenderUsername,
+                            style: TextStyle(
+                              color: context.textPrimary,
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Text(
+                          _formatAgo(entry.lastReplyAt),
+                          style: TextStyle(
+                            color: context.textMuted,
+                            fontSize: 11,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      entry.parentExcerpt,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: context.textSecondary,
+                        fontSize: 13,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '${entry.lastReplySenderUsername}: '
+                      '${entry.lastReplyExcerpt}',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(color: context.textMuted, fontSize: 12),
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      children: [
+                        Text(
+                          '${entry.replyCount} '
+                          '${entry.replyCount == 1 ? "reply" : "replies"}',
+                          style: TextStyle(
+                            color: context.textMuted,
+                            fontSize: 11,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        if (entry.isUnread) ...[
+                          const SizedBox(width: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 6,
+                              vertical: 2,
+                            ),
+                            decoration: BoxDecoration(
+                              color: context.accent,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Text(
+                              '${entry.unreadCount} new',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 10,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _formatAgo(DateTime when) {
+    final delta = DateTime.now().toUtc().difference(when.toUtc());
+    if (delta.inSeconds < 60) return 'just now';
+    if (delta.inMinutes < 60) return '${delta.inMinutes}m ago';
+    if (delta.inHours < 24) return '${delta.inHours}h ago';
+    if (delta.inDays < 7) return '${delta.inDays}d ago';
+    return '${(delta.inDays / 7).floor()}w ago';
+  }
+}

--- a/apps/client/lib/src/widgets/conversation_panel.dart
+++ b/apps/client/lib/src/widgets/conversation_panel.dart
@@ -60,6 +60,10 @@ class ConversationPanel extends ConsumerStatefulWidget {
   final VoidCallback? onGlobalSearch;
   final VoidCallback? onSavedMessages;
 
+  /// Opens the cross-group threads inbox. Surfaced from the "+" menu
+  /// next to Saved Messages.
+  final VoidCallback? onThreads;
+
   /// Opens the keyboard-shortcuts overlay (also bindable to Ctrl+/).
   /// When null, the help icon in the header is hidden.
   final VoidCallback? onShowKeyboardShortcuts;
@@ -90,6 +94,7 @@ class ConversationPanel extends ConsumerStatefulWidget {
     this.onShowContacts,
     this.onGlobalSearch,
     this.onSavedMessages,
+    this.onThreads,
     this.onShowKeyboardShortcuts,
     this.onScanQr,
     this.onMessageContact,

--- a/apps/client/lib/src/widgets/conversation_panel/parts/header.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/header.dart
@@ -141,6 +141,8 @@ mixin _ConversationPanelHeaderMixin
                   widget.onDiscover?.call();
                 case 'saved':
                   widget.onSavedMessages?.call();
+                case 'threads':
+                  widget.onThreads?.call();
               }
             },
             itemBuilder: (context) => const [
@@ -215,6 +217,22 @@ mixin _ConversationPanelHeaderMixin
                           'Saved Messages',
                           overflow: TextOverflow.ellipsis,
                         ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              PopupMenuItem(
+                value: 'threads',
+                child: SizedBox(
+                  width: 200,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.forum_outlined, size: 18),
+                      SizedBox(width: 10),
+                      Flexible(
+                        child: Text('Threads', overflow: TextOverflow.ellipsis),
                       ),
                     ],
                   ),

--- a/apps/client/lib/src/widgets/thread_view_panel.dart
+++ b/apps/client/lib/src/widgets/thread_view_panel.dart
@@ -8,6 +8,7 @@ import '../models/chat_message.dart';
 import '../providers/auth_provider.dart';
 import '../providers/chat_provider.dart';
 import '../providers/server_url_provider.dart';
+import '../providers/threads_inbox_provider.dart';
 import '../theme/echo_theme.dart';
 import '../theme/motion_tokens.dart';
 import 'message/rich_text_content.dart';
@@ -53,6 +54,13 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
   void initState() {
     super.initState();
     _loadReplies();
+    // Threads M3: opening the panel implicitly marks this thread as
+    // read. Fire-and-forget on the inbox provider — fails silently if
+    // offline; the next inbox refresh re-derives the truth.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(threadsInboxProvider.notifier).markRead(widget.parentMessage.id);
+    });
   }
 
   @override

--- a/apps/server/migrations/20260527090000_thread_read_state.sql
+++ b/apps/server/migrations/20260527090000_thread_read_state.sql
@@ -1,0 +1,24 @@
+-- Threads M3 (docs/threads-architecture.md §4: per-thread unread state).
+--
+-- One row per (user, thread_root_id) recording when the user last viewed
+-- that thread. The threads-inbox + per-thread badges compare
+-- last_read_at to the thread's most-recent reply (m.created_at) to
+-- compute the unread count.
+--
+-- Schema is intentionally narrow: no follower/subscriber concept yet —
+-- visibility comes from membership in the parent's conversation. A
+-- thread is "visible" if the user is in the conversation; it shows in
+-- the inbox if it has at least one reply AND the user has visibility.
+CREATE TABLE thread_read_state (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    thread_root_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    last_read_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, thread_root_id)
+);
+
+-- Hot path: the inbox query walks every thread root the user can see
+-- (in conversations they're a member of) and joins thread_read_state to
+-- compute unread counts. Index by (user_id) for that join + (thread_
+-- root_id) for the mark-read upsert.
+CREATE INDEX idx_thread_read_state_user
+  ON thread_read_state (user_id);

--- a/apps/server/src/db/mod.rs
+++ b/apps/server/src/db/mod.rs
@@ -11,6 +11,7 @@ pub mod password_reset;
 pub mod polls;
 pub mod push_tokens;
 pub mod reactions;
+pub mod threads;
 pub mod tokens;
 pub mod upload_sessions;
 pub mod users;

--- a/apps/server/src/db/threads.rs
+++ b/apps/server/src/db/threads.rs
@@ -1,0 +1,167 @@
+//! Thread read-state + inbox queries (M3).
+//!
+//! Tracks the last time a user viewed each thread so the client can
+//! render per-thread unread counts and an aggregated cross-group
+//! threads inbox.
+//!
+//! Visibility is implicit — a user "sees" a thread iff they're a
+//! member of the parent message's conversation. No follow/subscribe
+//! table yet; follow-then-mute work belongs to a later milestone.
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// One row of the threads-inbox response. Carries enough metadata for
+/// the client to render the inbox list (parent excerpt, last reply
+/// time, unread count, conversation context).
+#[derive(Debug, sqlx::FromRow, serde::Serialize)]
+pub struct ThreadInboxEntry {
+    /// Root message id (also the thread's stable id).
+    pub thread_root_id: Uuid,
+    /// Conversation the thread lives in. Used by the client to
+    /// route the user back to the right place when they tap.
+    pub conversation_id: Uuid,
+    /// Channel id (when the parent lived in a channel — null for DMs
+    /// and group conversations without channels).
+    pub channel_id: Option<Uuid>,
+    /// Parent author + content excerpt for the list-row preview. The
+    /// excerpt is truncated to 120 chars server-side so the response
+    /// stays bounded.
+    pub parent_sender_username: String,
+    pub parent_excerpt: String,
+    /// Newest reply timestamp; drives the inbox's "X minutes ago" label
+    /// and is also used for the sort.
+    pub last_reply_at: DateTime<Utc>,
+    /// Snippet of the most-recent reply (also truncated to 120).
+    pub last_reply_excerpt: String,
+    pub last_reply_sender_username: String,
+    /// Total replies on this thread.
+    pub reply_count: i64,
+    /// Count of replies after the caller's `last_read_at` (0 when caller
+    /// has no row in `thread_read_state` is replaced by reply_count —
+    /// see the COALESCE in the SQL).
+    pub unread_count: i64,
+}
+
+/// Inbox listing for [user_id]: every thread the user can see, with
+/// unread counts. Sorted newest-reply-first.
+pub async fn get_threads_inbox(
+    pool: &sqlx::PgPool,
+    user_id: Uuid,
+    limit: i64,
+) -> Result<Vec<ThreadInboxEntry>, sqlx::Error> {
+    // - root: every message that has at least one reply (joined via
+    //   replies.thread_root_id or replies.reply_to_id for back-compat
+    //   with pre-M2 inline replies).
+    // - thread_read_state: optional join. NULL last_read_at means the
+    //   caller never opened the thread, so every reply is unread.
+    // - Visibility: caller must be a non-removed member of the parent's
+    //   conversation.
+    sqlx::query_as::<_, ThreadInboxEntry>(
+        "WITH replies AS ( \
+             SELECT \
+                 COALESCE(m.thread_root_id, m.reply_to_id) AS root_id, \
+                 m.created_at, \
+                 m.content, \
+                 m.sender_id \
+             FROM messages m \
+             WHERE (m.thread_root_id IS NOT NULL OR m.reply_to_id IS NOT NULL) \
+               AND m.deleted_at IS NULL \
+         ), latest AS ( \
+             SELECT \
+                 r.root_id, \
+                 COUNT(*) AS reply_count, \
+                 MAX(r.created_at) AS last_reply_at \
+             FROM replies r \
+             GROUP BY r.root_id \
+         ), latest_msg AS ( \
+             SELECT DISTINCT ON (r.root_id) \
+                 r.root_id, \
+                 LEFT(r.content, 120) AS last_reply_excerpt, \
+                 r.sender_id AS last_reply_sender_id \
+             FROM replies r \
+             ORDER BY r.root_id, r.created_at DESC \
+         ) \
+         SELECT \
+             root.id AS thread_root_id, \
+             root.conversation_id, \
+             root.channel_id, \
+             ru.username AS parent_sender_username, \
+             LEFT(root.content, 120) AS parent_excerpt, \
+             latest.last_reply_at, \
+             latest_msg.last_reply_excerpt, \
+             lru.username AS last_reply_sender_username, \
+             latest.reply_count, \
+             COALESCE(( \
+                 SELECT COUNT(*) FROM replies r2 \
+                 WHERE r2.root_id = root.id \
+                   AND r2.created_at > COALESCE(trs.last_read_at, 'epoch'::timestamptz) \
+             ), latest.reply_count) AS unread_count \
+         FROM latest \
+         JOIN messages root ON root.id = latest.root_id AND root.deleted_at IS NULL \
+         JOIN users ru ON ru.id = root.sender_id \
+         JOIN latest_msg ON latest_msg.root_id = root.id \
+         JOIN users lru ON lru.id = latest_msg.last_reply_sender_id \
+         JOIN conversation_members cm \
+              ON cm.conversation_id = root.conversation_id \
+             AND cm.user_id = $1 \
+             AND cm.is_removed = false \
+         LEFT JOIN thread_read_state trs \
+              ON trs.user_id = $1 AND trs.thread_root_id = root.id \
+         ORDER BY latest.last_reply_at DESC \
+         LIMIT $2",
+    )
+    .bind(user_id)
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+
+/// Bump (or insert) the read marker so future inbox calls treat replies
+/// newer than `at` as unread and earlier replies as read.
+pub async fn mark_thread_read(
+    pool: &sqlx::PgPool,
+    user_id: Uuid,
+    thread_root_id: Uuid,
+    at: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO thread_read_state (user_id, thread_root_id, last_read_at) \
+         VALUES ($1, $2, $3) \
+         ON CONFLICT (user_id, thread_root_id) \
+         DO UPDATE SET last_read_at = GREATEST(thread_read_state.last_read_at, EXCLUDED.last_read_at)",
+    )
+    .bind(user_id)
+    .bind(thread_root_id)
+    .bind(at)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Count of distinct threads the user has unread replies in. Powers the
+/// nav-rail badge.
+pub async fn unread_thread_count(pool: &sqlx::PgPool, user_id: Uuid) -> Result<i64, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(DISTINCT root_id) FROM ( \
+             SELECT \
+                 COALESCE(m.thread_root_id, m.reply_to_id) AS root_id, \
+                 m.created_at, \
+                 m.conversation_id \
+             FROM messages m \
+             WHERE (m.thread_root_id IS NOT NULL OR m.reply_to_id IS NOT NULL) \
+               AND m.deleted_at IS NULL \
+         ) r \
+         JOIN conversation_members cm \
+              ON cm.conversation_id = r.conversation_id \
+             AND cm.user_id = $1 \
+             AND cm.is_removed = false \
+         LEFT JOIN thread_read_state trs \
+              ON trs.user_id = $1 AND trs.thread_root_id = r.root_id \
+         WHERE r.created_at > COALESCE(trs.last_read_at, 'epoch'::timestamptz)",
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
+}

--- a/apps/server/src/routes/messages.rs
+++ b/apps/server/src/routes/messages.rs
@@ -1000,3 +1000,75 @@ pub async fn unpin_conversation(
         .db_ctx("unpin_conversation")?;
     Ok(StatusCode::NO_CONTENT)
 }
+
+// ---------------------------------------------------------------------------
+// Threads inbox + read state (M3)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct ThreadsInboxQuery {
+    /// Soft cap. Server clamps to [1, 100]; default 50 keeps the
+    /// payload bounded for the initial inbox render.
+    pub limit: Option<i64>,
+}
+
+/// GET /api/threads/inbox — every thread the caller can see, sorted
+/// newest-reply-first, with per-row unread counts.
+pub async fn get_threads_inbox(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ThreadsInboxQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let limit = params.limit.unwrap_or(50).clamp(1, 100);
+    let entries = db::threads::get_threads_inbox(&state.pool, auth.user_id, limit)
+        .await
+        .db_ctx("get_threads_inbox")?;
+    Ok(Json(entries))
+}
+
+/// POST /api/messages/:thread_root_id/thread/read — bump the read marker
+/// for the caller's view of this thread. The client calls this when the
+/// user opens the thread panel (and again on each new reply they see).
+pub async fn mark_thread_read(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path(thread_root_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    // Verify the user has visibility into the thread's conversation
+    // before recording a read marker. Otherwise a malicious caller could
+    // observe whether a root id exists by probing the endpoint.
+    let parent: Option<(Uuid,)> =
+        sqlx::query_as("SELECT conversation_id FROM messages WHERE id = $1 AND deleted_at IS NULL")
+            .bind(thread_root_id)
+            .fetch_optional(&state.pool)
+            .await
+            .db_ctx("mark_thread_read/lookup")?;
+    let conversation_id = parent
+        .map(|(cid,)| cid)
+        .ok_or_else(|| AppError::not_found("Thread not found"))?;
+    let is_member = db::groups::is_member(&state.pool, conversation_id, auth.user_id)
+        .await
+        .db_ctx("mark_thread_read/is_member")?;
+    if !is_member {
+        return Err(AppError::with_code(
+            ErrorCode::NotMember,
+            "Not a member of this conversation",
+        ));
+    }
+    db::threads::mark_thread_read(&state.pool, auth.user_id, thread_root_id, Utc::now())
+        .await
+        .db_ctx("mark_thread_read")?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// GET /api/threads/unread-count — single integer for the nav-rail
+/// badge. Cheap query; safe to poll on focus.
+pub async fn get_unread_thread_count(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
+    let count = db::threads::unread_thread_count(&state.pool, auth.user_id)
+        .await
+        .db_ctx("unread_thread_count")?;
+    Ok(Json(serde_json::json!({ "count": count })))
+}

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -262,6 +262,15 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
                 .layer(middleware::from_fn(edit_message_limit)),
         )
         .route("/messages/{id}/replies", get(messages::get_thread_replies))
+        .route(
+            "/messages/{id}/thread/read",
+            post(messages::mark_thread_read),
+        )
+        .route("/threads/inbox", get(messages::get_threads_inbox))
+        .route(
+            "/threads/unread-count",
+            get(messages::get_unread_thread_count),
+        )
         .route("/messages/{id}/reactions", post(reactions::add_reaction))
         .route(
             "/messages/{message_id}/reactions/{emoji}",


### PR DESCRIPTION
## Summary
Slack-style threads, milestone 3. Adds per-thread read markers, the cross-group **Threads** inbox the user navigates to from the sidebar "+" menu, and auto-mark-read when the thread panel opens.

### Server
- New migration \`20260527090000_thread_read_state.sql\` — \`thread_read_state(user_id, thread_root_id, last_read_at)\` with a \`(user_id)\` index for the inbox join.
- New \`db::threads\` module with three queries:
  - \`get_threads_inbox\` — every thread the caller can see, sorted newest-reply-first, with per-row unread counts. Visibility is implicit (caller must be a non-removed member of the parent's conversation). NULL \`last_read_at\` → every reply is unread.
  - \`mark_thread_read\` — INSERT ... ON CONFLICT upsert with \`GREATEST\` so out-of-order requests don't roll back the marker.
  - \`unread_thread_count\` — single integer for the nav-rail badge.
- Three new routes:
  - \`GET /api/threads/inbox\`
  - \`POST /api/messages/:id/thread/read\`
  - \`GET /api/threads/unread-count\`

Both write endpoints verify the caller's membership in the parent's conversation before responding so probe responses can't be used as an existence oracle.

### Client
- New \`ThreadInboxEntry\` model + \`threadsInboxProvider\` notifier (load, optimistically mark read, refresh badge).
- \`unreadThreadCountProvider\` keep-alive notifier for the badge.
- \`ThreadsInboxScreen\` — list view sorted newest-reply-first; parent excerpt + last-reply excerpt + sender + "X new" badge for unread threads. Tap → routes to \`/home?conversation=…&thread=…\`.
- New "Threads" entry in the \`ConversationPanel\` "+" menu next to Saved Messages, wired through \`onThreads\` callback in the desktop layout.
- \`ThreadViewPanel\` calls \`markRead\` on \`initState\` so the unread badge clears as soon as the panel opens.

### What's deferred to M4
- Inline "Reply in thread" item on the message context menu (today only the thread panel's Reply button uses the asThread flag).
- "Also send to channel" toggle in the composer.
- Push-notification dampening via \`thread_subscriptions\`.

## Test plan
- [x] \`cargo check\` + \`cargo build --tests\` clean (200 unit tests pass)
- [x] \`flutter analyze\` clean across all touched files
- [ ] CI passes
- [ ] Manual: send a reply in a thread → "Threads" inbox in the + menu shows that thread with a "1 new" pill
- [ ] Manual: open the thread panel from the inbox → row's pill clears, nav-rail count refreshes