### PR TITLE
feat: threads M4 — reply-in-thread menu, unread chip, header rework, push dampening

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_message_list.dart
@@ -62,6 +62,11 @@ class ChatMessageList extends ConsumerWidget {
   final void Function(ChatMessage message) onEnterEditMode;
   final void Function(ChatMessage message) onReply;
   final void Function(ChatMessage message) onOpenThread;
+
+  /// Slack-style "Reply in thread" entry on the message context menu.
+  /// Sets the active reply to the message with the thread flag, then
+  /// opens the panel anchored on the parent. null = hide the row.
+  final void Function(ChatMessage message)? onReplyInThread;
   final void Function(ChatMessage message) onPin;
   final void Function(ChatMessage message) onUnpin;
   final void Function(ChatMessage message) onForward;
@@ -111,6 +116,7 @@ class ChatMessageList extends ConsumerWidget {
     required this.onEnterEditMode,
     required this.onReply,
     required this.onOpenThread,
+    this.onReplyInThread,
     required this.onPin,
     required this.onUnpin,
     required this.onForward,
@@ -218,6 +224,7 @@ class ChatMessageList extends ConsumerWidget {
             // #582: suppress edit on encrypted convs — would broadcast plaintext until per-device edit fanout ships.
             onEdit: conv.isEncrypted ? null : onEnterEditMode,
             onReply: onReply,
+            onReplyInThread: onReplyInThread,
             onViewThread: onOpenThread,
             onPin: onPin,
             onUnpin: onUnpin,

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -296,6 +296,17 @@ Widget buildChatContentBox(
                         ref.read(chatProvider.notifier).setReplyTo(msg);
                         p.chatInputBarKey.currentState?.requestInputFocus();
                       },
+                      onReplyInThread: (msg) {
+                        // Stamp the reply with the thread root so the
+                        // outbound message lands in the thread panel,
+                        // not the main timeline.
+                        ref
+                            .read(chatProvider.notifier)
+                            .setReplyTo(msg, asThread: true);
+                        // Open the thread panel so the user sees the
+                        // active conversation context while typing.
+                        p.onOpenThread(msg);
+                      },
                       onOpenThread: p.onOpenThread,
                       onPin: p.onPinMessage,
                       onUnpin: p.onUnpinMessage,

--- a/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
+++ b/apps/client/lib/src/widgets/context_menu/actions/message_actions_registry.dart
@@ -49,6 +49,12 @@ ContextMenuSection _primarySection(MessageTarget t) {
         icon: Icons.reply_outlined,
         onTap: t.onReply,
       ),
+    if (t.onReplyInThread != null)
+      ContextMenuAction(
+        label: 'Reply in thread',
+        icon: Icons.forum_outlined,
+        onTap: t.onReplyInThread,
+      ),
     if (t.onForward != null)
       ContextMenuAction(
         label: 'Forward',

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -191,6 +191,7 @@ class MessageTarget extends ContextMenuTarget {
     required this.mediaUrl,
     required this.isImageMedia,
     this.onReply,
+    this.onReplyInThread,
     this.onForward,
     this.onRetry,
     this.onCopyText,
@@ -217,6 +218,11 @@ class MessageTarget extends ContextMenuTarget {
 
   // Action handlers — null = row hidden.
   final VoidCallback? onReply;
+
+  /// Distinct from [onReply]: anchors the new reply to the thread root
+  /// so it filters out of the main timeline (Slack-style). null = row
+  /// hidden (e.g. failed-message bubbles).
+  final VoidCallback? onReplyInThread;
   final VoidCallback? onForward;
   final VoidCallback? onRetry;
   final VoidCallback? onCopyText;

--- a/apps/client/lib/src/widgets/message/reply_count_badge.dart
+++ b/apps/client/lib/src/widgets/message/reply_count_badge.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import '../../models/chat_message.dart';
+import '../../providers/threads_inbox_provider.dart';
 import '../../theme/echo_theme.dart';
 
 /// Tappable "X replies" pill shown beneath a message that has at least
 /// one threaded reply.  Aligns to the bubble's own side (right for
 /// "my" messages in bubbles layout, left otherwise).  Tapping fires
 /// [onTap] -- typically opens the thread view.
-class ReplyCountBadge extends StatelessWidget {
+///
+/// Unread state comes from the threads inbox provider (M3): when the
+/// most recent inbox snapshot has a matching entry with unreadCount > 0,
+/// the badge renders an accent dot inline. Caller can still hard-force
+/// the state via the [hasUnread] override prop for tests.
+class ReplyCountBadge extends ConsumerWidget {
   final ChatMessage message;
   final bool isMine;
   final ValueChanged<ChatMessage>? onTap;
@@ -18,15 +25,10 @@ class ReplyCountBadge extends StatelessWidget {
   /// chrome of a pill clashes with the surrounding text-only treatment.
   final bool inlineStyle;
 
-  /// Whether the local user has unread replies on this thread. When true,
-  /// a small accent-coloured dot renders on the badge so the user can
-  /// spot fresh activity without opening the thread (#449-3).
-  ///
-  /// Today no call site wires this — the unread-tracking state path
-  /// (last-viewed-reply timestamp, per-thread, persisted) is deferred
-  /// to a separate change. The prop is plumbed now so the visual
-  /// affordance is in place and a follow-up only has to flip the bool.
-  final bool hasUnread;
+  /// Forces the unread dot on regardless of inbox state. Default is to
+  /// derive from the threads-inbox provider snapshot. Tests + the
+  /// thread panel (where the parent is always "read") can override.
+  final bool? hasUnread;
 
   const ReplyCountBadge({
     super.key,
@@ -34,7 +36,7 @@ class ReplyCountBadge extends StatelessWidget {
     required this.isMine,
     this.onTap,
     this.inlineStyle = false,
-    this.hasUnread = false,
+    this.hasUnread,
   });
 
   Widget _unreadDot(BuildContext context) {
@@ -52,12 +54,26 @@ class ReplyCountBadge extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final count = message.replyCount;
     final label = count == 1 ? '1 reply' : '$count replies';
+    final unread = hasUnread ?? _isUnreadFromInbox(ref);
     return inlineStyle
-        ? _buildInline(context, label)
-        : _buildPill(context, label);
+        ? _buildInline(context, label, unread)
+        : _buildPill(context, label, unread);
+  }
+
+  /// True when the threads-inbox snapshot has a matching entry with
+  /// unreadCount > 0. Falls back to false when the inbox hasn't been
+  /// loaded yet (so we never falsely advertise unread state).
+  bool _isUnreadFromInbox(WidgetRef ref) {
+    final inbox = ref.watch(threadsInboxProvider);
+    for (final entry in inbox.entries) {
+      if (entry.threadRootId == message.id) {
+        return entry.unreadCount > 0;
+      }
+    }
+    return false;
   }
 
   EdgeInsets _topPadding(double topInset) =>
@@ -69,25 +85,25 @@ class ReplyCountBadge extends StatelessWidget {
   VoidCallback? get _onTapCallback =>
       onTap == null ? null : () => onTap!(message);
 
-  Widget _buildInline(BuildContext context, String label) {
+  Widget _buildInline(BuildContext context, String label, bool unread) {
     return Padding(
       padding: _topPadding(2),
       child: Align(
         alignment: _alignment,
         child: Semantics(
-          label: hasUnread ? 'View $label (new replies)' : 'View $label',
+          label: unread ? 'View $label (new replies)' : 'View $label',
           button: true,
           child: InkWell(
             borderRadius: BorderRadius.circular(2),
             onTap: _onTapCallback,
-            child: _buildInlineRow(context, label),
+            child: _buildInlineRow(context, label, unread),
           ),
         ),
       ),
     );
   }
 
-  Widget _buildInlineRow(BuildContext context, String label) {
+  Widget _buildInlineRow(BuildContext context, String label, bool unread) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -101,12 +117,12 @@ class ReplyCountBadge extends StatelessWidget {
             decorationColor: context.accent.withValues(alpha: 0.4),
           ),
         ),
-        if (hasUnread) _unreadDot(context),
+        if (unread) _unreadDot(context),
       ],
     );
   }
 
-  Widget _buildPill(BuildContext context, String label) {
+  Widget _buildPill(BuildContext context, String label, bool unread) {
     return Padding(
       padding: _topPadding(4),
       child: Align(
@@ -119,7 +135,7 @@ class ReplyCountBadge extends StatelessWidget {
             child: InkWell(
               borderRadius: BorderRadius.circular(12),
               onTap: _onTapCallback,
-              child: _buildPillContainer(context, label),
+              child: _buildPillContainer(context, label, unread),
             ),
           ),
         ),
@@ -127,7 +143,7 @@ class ReplyCountBadge extends StatelessWidget {
     );
   }
 
-  Widget _buildPillContainer(BuildContext context, String label) {
+  Widget _buildPillContainer(BuildContext context, String label, bool unread) {
     final repliers = message.recentReplierUsernames;
     final lastReplyAt = message.lastReplyAt;
     final hasFaces = repliers.isNotEmpty;
@@ -161,7 +177,7 @@ class ReplyCountBadge extends StatelessWidget {
               style: GoogleFonts.inter(fontSize: 11, color: context.textMuted),
             ),
           ],
-          if (hasUnread) _unreadDot(context),
+          if (unread) _unreadDot(context),
         ],
       ),
     );

--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -69,6 +69,11 @@ class MessageItem extends StatefulWidget {
   final void Function(ChatMessage message)? onDelete;
   final void Function(ChatMessage message)? onEdit;
   final void Function(ChatMessage message)? onReply;
+
+  /// Distinct from [onReply]: stamps the reply with the thread root so
+  /// the message vanishes from the main timeline and only shows in the
+  /// thread panel (Slack-style "Reply in thread").
+  final void Function(ChatMessage message)? onReplyInThread;
   final void Function(ChatMessage message)? onViewThread;
   final void Function(String userId)? onAvatarTap;
   final void Function(ChatMessage message)? onPin;
@@ -147,6 +152,7 @@ class MessageItem extends StatefulWidget {
     this.onDelete,
     this.onEdit,
     this.onReply,
+    this.onReplyInThread,
     this.onViewThread,
     this.onAvatarTap,
     this.onPin,
@@ -1402,6 +1408,7 @@ class _MessageItemState extends State<MessageItem>
       mediaUrl: mediaUrl,
       isImageMedia: isImage,
       onReply: _wrapMsgCallback(widget.onReply, msg),
+      onReplyInThread: _wrapMsgCallback(widget.onReplyInThread, msg),
       onForward: _wrapMsgCallback(widget.onForward, msg),
       onRetry: _resolveRetryCallback(msg),
       onCopyText: () => _copyMessageText(msg, mediaUrl),

--- a/apps/client/lib/src/widgets/thread_view_panel.dart
+++ b/apps/client/lib/src/widgets/thread_view_panel.dart
@@ -186,8 +186,7 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
       ),
       child: Column(
         children: [
-          _buildHeader(context),
-          Divider(height: 1, color: context.border),
+          _buildHeader(context, replies.length),
           _buildParentMessage(context, parent, replies),
           Divider(height: 1, color: context.border),
           Expanded(child: _buildRepliesList(context, replies)),
@@ -197,23 +196,48 @@ class _ThreadViewPanelState extends ConsumerState<ThreadViewPanel> {
     );
   }
 
-  Widget _buildHeader(BuildContext context) {
+  Widget _buildHeader(BuildContext context, int replyCount) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: context.border)),
+      ),
       child: Row(
         children: [
           Icon(Icons.forum_outlined, size: 18, color: context.accent),
-          const SizedBox(width: 8),
+          const SizedBox(width: 10),
           Expanded(
-            child: Text(
-              'Thread',
-              style: TextStyle(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                color: context.textPrimary,
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Thread',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: context.textPrimary,
+                    height: 1.1,
+                  ),
+                ),
+                if (replyCount > 0) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    '$replyCount '
+                    '${replyCount == 1 ? "reply" : "replies"} · '
+                    'started by ${widget.parentMessage.fromUsername}',
+                    style: TextStyle(fontSize: 11, color: context.textMuted),
+                  ),
+                ],
+              ],
             ),
           ),
+          if (widget.parentMessage.recentReplierUsernames.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: _ReplierFaceStack(
+                usernames: widget.parentMessage.recentReplierUsernames,
+              ),
+            ),
           Semantics(
             label: 'Close thread',
             button: true,
@@ -482,4 +506,65 @@ void showThreadBottomSheet({
       ),
     ),
   );
+}
+
+/// Up to 3 overlapping initial-circles for recent repliers, rendered in
+/// the thread header so the user can see at a glance who's been
+/// chatting. Smaller cousin of the reply-chip face stack.
+class _ReplierFaceStack extends StatelessWidget {
+  const _ReplierFaceStack({required this.usernames});
+  final List<String> usernames;
+
+  @override
+  Widget build(BuildContext context) {
+    final faces = usernames.take(3).toList();
+    const faceSize = 18.0;
+    const overlap = 6.0;
+    final width = faceSize + (faces.length - 1) * (faceSize - overlap);
+    return SizedBox(
+      width: width,
+      height: faceSize,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          for (var i = 0; i < faces.length; i++)
+            Positioned(
+              left: i * (faceSize - overlap),
+              child: _SmallInitialCircle(name: faces[i], size: faceSize),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SmallInitialCircle extends StatelessWidget {
+  const _SmallInitialCircle({required this.name, required this.size});
+  final String name;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final initial = name.isNotEmpty ? name[0].toUpperCase() : '?';
+    final hue = (name.hashCode % 360).abs().toDouble();
+    final bg = HSLColor.fromAHSL(1.0, hue, 0.55, 0.45).toColor();
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: bg,
+        shape: BoxShape.circle,
+        border: Border.all(color: context.surface, width: 1.5),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        initial,
+        style: TextStyle(
+          color: Colors.white,
+          fontSize: size * 0.55,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
 }

--- a/apps/server/src/db/mentions.rs
+++ b/apps/server/src/db/mentions.rs
@@ -212,6 +212,21 @@ async fn resolve_mention_targets(
 }
 
 /// Bulk-insert one row per target into `mentions` with `ON CONFLICT DO
+/// Look up the user ids @-mentioned in a single message. Used by the
+/// thread-push dampening path (M4): a reply notifies non-subscribers
+/// only when they're explicitly named.
+pub async fn get_mentioned_user_ids(
+    pool: &PgPool,
+    message_id: Uuid,
+) -> Result<Vec<Uuid>, sqlx::Error> {
+    let rows: Vec<(Uuid,)> =
+        sqlx::query_as("SELECT mentioned_user_id FROM mentions WHERE message_id = $1")
+            .bind(message_id)
+            .fetch_all(pool)
+            .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
 /// NOTHING` so a redelivery is a no-op.  Uses `UNNEST` to bind a single
 /// array parameter rather than building a variadic `VALUES` clause.
 async fn insert_mention_rows(

--- a/apps/server/src/db/threads.rs
+++ b/apps/server/src/db/threads.rs
@@ -139,6 +139,29 @@ pub async fn mark_thread_read(
     Ok(())
 }
 
+/// Users who are "subscribed" to push notifications for replies in
+/// [thread_root_id]. Subscription is implicit: the thread root's
+/// author + everyone who's ever replied in the thread. Used by the
+/// fanout path to dampen pushes — non-subscribers only get a push
+/// when explicitly @mentioned in the new reply.
+pub async fn get_thread_subscribers(
+    pool: &sqlx::PgPool,
+    thread_root_id: Uuid,
+) -> Result<Vec<Uuid>, sqlx::Error> {
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT sender_id FROM messages \
+         WHERE id = $1 AND deleted_at IS NULL \
+         UNION \
+         SELECT DISTINCT sender_id FROM messages \
+         WHERE (thread_root_id = $1 OR reply_to_id = $1) \
+           AND deleted_at IS NULL",
+    )
+    .bind(thread_root_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
 /// Count of distinct threads the user has unread replies in. Powers the
 /// nav-rail badge.
 pub async fn unread_thread_count(pool: &sqlx::PgPool, user_id: Uuid) -> Result<i64, sqlx::Error> {

--- a/apps/server/src/ws/message_service/fanout.rs
+++ b/apps/server/src/ws/message_service/fanout.rs
@@ -451,6 +451,18 @@ pub(in crate::ws::message_service) async fn fanout_message(
         );
     }
 
+    // Threads M4: dampen push for thread replies. Only the thread
+    // root's author + previous repliers (auto-subscribers) and anyone
+    // @mentioned in this new reply get a push; everyone else in the
+    // conversation stays silent until they explicitly open the thread.
+    if let Some(thread_root_id) = fields.thread_root_id
+        && !offline_user_ids.is_empty()
+    {
+        offline_user_ids =
+            filter_thread_push_recipients(&state.pool, offline_user_ids, thread_root_id, stored_id)
+                .await;
+    }
+
     if !offline_user_ids.is_empty() && !suppress_offline_push {
         spawn_push_notifications(
             state.pool.clone(),
@@ -462,4 +474,43 @@ pub(in crate::ws::message_service) async fn fanout_message(
             stored_id,
         );
     }
+}
+
+/// Threads M4 dampening: trim [offline_user_ids] to only the users
+/// who are subscribed to the thread (root author + prior repliers) or
+/// who got @mentioned in the new reply. Anyone else stays silent.
+///
+/// Failures are non-fatal — on any DB error we fall back to the
+/// undampened recipient list so a flaky DB doesn't accidentally
+/// silence the whole conversation.
+async fn filter_thread_push_recipients(
+    pool: &sqlx::PgPool,
+    offline_user_ids: Vec<Uuid>,
+    thread_root_id: Uuid,
+    new_message_id: Uuid,
+) -> Vec<Uuid> {
+    let subscribers = match db::threads::get_thread_subscribers(pool, thread_root_id).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(
+                "thread push filter: subscriber lookup failed: {e:?}; using full recipient list"
+            );
+            return offline_user_ids;
+        }
+    };
+    let mentioned = match db::mentions::get_mentioned_user_ids(pool, new_message_id).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(
+                "thread push filter: mention lookup failed: {e:?}; using full recipient list"
+            );
+            return offline_user_ids;
+        }
+    };
+    let allowed: std::collections::HashSet<Uuid> =
+        subscribers.into_iter().chain(mentioned).collect();
+    offline_user_ids
+        .into_iter()
+        .filter(|id| allowed.contains(id))
+        .collect()
 }


### PR DESCRIPTION
## Summary
Four polish items on top of M3 to bring threads close to Slack parity.

### 1. Inline "Reply in thread" context-menu item
\`MessageTarget\` gains an \`onReplyInThread\` slot; the message-actions registry renders a new row labeled **"Reply in thread"** alongside **"Reply"**. \`MessageItem\` widget exposes a matching callback. Wired in \`chat_panel_body.dart\` to:
1. \`setReplyTo(msg, asThread: true)\` (so the next send carries \`thread_root_id\`)
2. Open the thread panel anchored on the parent

### 3. Wire \`hasUnread\` on \`ReplyCountBadge\`
\`ReplyCountBadge\` is now a \`ConsumerWidget\` that reads the threads-inbox snapshot. When an inbox entry matches the parent id with \`unreadCount > 0\`, the chip renders the existing unread dot. The \`hasUnread\` prop becomes a nullable override so tests + the thread panel can still hard-force the state.

### 4. Better thread-panel header
- "Thread" title is bolder + carries a subtitle ("3 replies · started by alice").
- Recent-replier face stack rendered to the right of the title.
- Header gets a bottom border + the duplicate divider above the parent message removed.

### 5. Push-notification dampening (Slack-style)
Thread replies no longer ping everyone in the conversation. New \`db::threads::get_thread_subscribers\` returns the root author + every previous replier; \`db::mentions::get_mentioned_user_ids\` exposes the per-message mention set. In \`fanout::fanout_message\`, when \`thread_root_id\` is set we intersect the offline-user-id list with \`subscribers ∪ mentioned\` before spawning push. DB failures fall back to the undampened list so a flaky DB never accidentally silences a whole conversation.

## Test plan
- [x] \`flutter analyze\` + \`cargo check\` + \`cargo test --lib\` (200 tests) clean
- [x] Existing chat-panel widget tests still pass
- [ ] CI passes
- [ ] Manual: right-click a message → see "Reply in thread" → tap → composer stamped with thread context + panel opens
- [ ] Manual: reply chip on a parent with unread replies shows the dot
- [ ] Manual: thread reply does NOT push notify a member who hasn't participated in the thread and wasn't @mentioned