### PR TITLE
fix(client): Hive flush on paused + truthful logout copy + remembered-accounts quick-switch

### DIFF
--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -187,6 +187,15 @@ void _performCleanup(ProviderContainer container) {
     WindowStateService.save().ignore();
   } catch (_) {}
   try {
+    // #1182: kick a fire-and-forget flush on the message-cache boxes
+    // before the close. SIGTERM gives systemd ~5s to clean up; even a
+    // partial flush is better than zero, and the no-await-required
+    // ShutdownHandler.paused path will already have flushed in most
+    // graceful shutdown sequences. This catches the SIGKILL-after-no-
+    // -paused (web exit, IDE force-quit) case.
+    MessageCache.flushAll().ignore();
+  } catch (_) {}
+  try {
     // Hive.close() is async; starting it before exit(0) gives Hive a chance
     // to begin flushing buffered writes, which prevents box-file corruption
     // on graceful SIGTERM paths.

--- a/apps/client/lib/src/services/message_cache.dart
+++ b/apps/client/lib/src/services/message_cache.dart
@@ -300,6 +300,27 @@ class MessageCache {
     _convBoxes.clear();
   }
 
+  /// Await `box.flush()` on every currently-open conversation box.
+  ///
+  /// Called from [ShutdownHandler] when the OS signals `AppLifecycleState
+  /// .paused` (one beat before `detached`, where async work is no longer
+  /// awaitable). With this, the fire-and-forget `Hive.close()` on
+  /// `detached` has minimal in-flight data left to lose if the process
+  /// is hard-killed before close completes (#1182).
+  ///
+  /// Errors are swallowed per-box — the cache is a performance optimisation,
+  /// not a source of truth, and we never want flush to block teardown.
+  static Future<void> flushAll() async {
+    for (final box in _convBoxes.values) {
+      if (!box.isOpen) continue;
+      try {
+        await box.flush();
+      } catch (_) {
+        // Per-box best-effort; keep flushing the rest.
+      }
+    }
+  }
+
   /// Retrieve the Hive encryption key from secure storage, or null if
   /// secure storage is not available yet (e.g. before first login).
   static Future<List<int>?> _getEncryptionKey() async {

--- a/apps/client/lib/src/widgets/shutdown_handler.dart
+++ b/apps/client/lib/src/widgets/shutdown_handler.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../providers/websocket_provider.dart';
+import '../services/message_cache.dart';
 
 /// Wraps the widget tree with a lifecycle observer that performs a graceful
 /// shutdown when the OS requests app termination.
@@ -48,8 +51,20 @@ class _ShutdownHandlerState extends ConsumerState<ShutdownHandler>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState lifecycleState) {
-    if (lifecycleState == AppLifecycleState.detached) {
-      _handleShutdown();
+    switch (lifecycleState) {
+      case AppLifecycleState.paused:
+        // `paused` is the OS warning that we're about to be backgrounded /
+        // terminated, but we can still safely await. Use the breathing room
+        // to flush message-cache writes to disk — once `detached` fires we
+        // can only fire-and-forget Hive.close(), and a hard kill mid-write
+        // would otherwise corrupt the cache box (#1182).
+        unawaited(MessageCache.flushAll());
+      case AppLifecycleState.detached:
+        _handleShutdown();
+      case AppLifecycleState.resumed:
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
+        break;
     }
   }
 
@@ -62,7 +77,9 @@ class _ShutdownHandlerState extends ConsumerState<ShutdownHandler>
       // Provider may already be disposed during forced teardown — ignore.
     }
 
-    // 2. Fire-and-forget Hive.close (sync callback can't await); starting close beats mid-write kill.
+    // 2. Fire-and-forget Hive.close (sync callback can't await); the
+    //    `paused` branch above already flushed pending writes, so the
+    //    in-flight close window is minimal.
     Hive.close().ignore();
   }
 


### PR DESCRIPTION
## Summary
Three pre-beta fixes bundled in this branch.

### 1. Hive flush on paused lifecycle ([#1182](https://github.com/NC1107/echo-messenger/issues/1182))
\`Hive.close()\` is async; \`ShutdownHandler.didChangeAppLifecycleState\` is synchronous. On a fast SIGTERM the cache box can be left mid-write and become unreadable on next launch.

- New \`MessageCache.flushAll()\` awaits \`box.flush()\` on every open box (per-box best-effort).
- \`ShutdownHandler\` now switches on the lifecycle state; calls \`flushAll()\` on \`paused\` (which IS async-safe — one beat before detached) so the fire-and-forget close has minimal in-flight data left to lose.
- Mirrored on the SIGTERM path in \`main.dart\`.

### 2. Truthful logout copy
Old dialog said "Your local encryption keys will be cleared. Old encrypted messages on this device may become unreadable." in danger red.

Reality check (verified in this PR):
- \`SecureKeyStore.clearUserScope()\` only clears the in-memory \`_userPrefix\` — Signal identity + session keys stay on disk.
- \`UserDataDir.clearUser()\` only clears the in-memory user reference — files stay.
- \`CryptoNotifier.resetState()\` explicitly documents that it preserves stored keys ("avoiding the key-loss bug where deletion of stored keys caused init() to regenerate a new identity and make all prior encrypted messages permanently unreadable").

New copy: "Log out of this account? Your messages and encryption keys stay on this device — they'll be ready when you sign back in." \`destructive: false\` since nothing is being destroyed.

### 3. Remembered-accounts quick-switch (Chrome-style)
A "Continue as" row appears above the username field on the login screen when previous accounts have signed in on this device. Each tile shows the avatar + username; tap pre-fills the username field, long-press surfaces a "Forget this account" sheet that drops the tile but leaves the on-disk data untouched.

- New \`rememberedAccountsProvider\` (keep-alive Notifier) persists \`[ { userId, username, serverUrl, avatarUrl, lastUsedAt } ]\` to SharedPreferences. **No passwords or tokens stored**, just identity hints.
- Hooked from \`AuthNotifier.login\` and \`AuthNotifier.register\` so successful sign-ins refresh the list.
- Scoped to the active server URL — switching servers hides tiles for accounts that lived on the other origin.
- Cap of 8 entries; oldest falls off when a new one is added.

## Test plan
- [x] \`flutter analyze\` clean across all touched files
- [x] Settings + login screen tests still pass
- [ ] CI passes
- [ ] Manual: log in → log out → username pre-fills via tile + password field is empty
- [ ] Manual: long-press tile → "Forget" sheet → tile disappears; re-login still works (on-disk data intact)
- [ ] Manual: SIGTERM after a flurry of writes → next launch opens the cache without "failed to open box" warnings