### PR TITLE
fix(client): voice dock collapse + clear-board confirm + image button label

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -39,6 +39,7 @@ import '../widgets/global_search_overlay.dart';
 import '../widgets/whats_new_modal.dart';
 import '../widgets/quick_switcher_overlay.dart';
 import '../widgets/system_chrome.dart';
+import '../widgets/voice_dock.dart';
 import '../widgets/voice_footer.dart';
 import '../widgets/window_chrome.dart';
 import 'contacts_screen.dart';

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -163,6 +163,30 @@ mixin _HomeScreenDesktopLayoutMixin
               },
             ),
           ),
+          // Active-voice strip — vertical mic / deafen / hangup column
+          // shown above the settings icon when a call is in progress.
+          // Without this the dock vanishes the moment the user collapses
+          // the sidebar (image #41).
+          Builder(
+            builder: (context) {
+              final voiceLk = ref.watch(livekitVoiceProvider);
+              if (!voiceLk.isActive || voiceLk.channelId == null) {
+                return const SizedBox.shrink();
+              }
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Center(
+                  child: VoiceDock(
+                    collapsed: true,
+                    onNavigateToLounge: () => setState(() {
+                      _self._showingLounge = true;
+                      _self._userDismissedLounge = false;
+                    }),
+                  ),
+                ),
+              );
+            },
+          ),
           // Settings icon at bottom
           Container(
             height: 60,

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -249,43 +249,28 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
       padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
       child: Column(
         children: [
-          Row(
-            children: [
-              Expanded(
-                child: TextButton.icon(
-                  onPressed: () async {
-                    HapticFeedback.lightImpact();
-                    await _pickAndAddImage(context);
-                    if (mounted) widget.onRequestClose?.call();
-                  },
-                  icon: const Icon(
-                    Icons.add_photo_alternate_outlined,
-                    size: 16,
-                  ),
-                  label: const Text('Image'),
-                  style: TextButton.styleFrom(
-                    foregroundColor: context.accent,
-                    textStyle: const TextStyle(fontSize: 12),
-                  ),
+          // Single primary action: "Add image". The destructive Clear
+          // moved out of the drawing menu into a confirmed corner
+          // button on the lounge so a misclick can't wipe everyone's
+          // drawings (image #39 feedback).
+          Tooltip(
+            message: 'Add an image to the canvas',
+            child: SizedBox(
+              width: double.infinity,
+              child: TextButton.icon(
+                onPressed: () async {
+                  HapticFeedback.lightImpact();
+                  await _pickAndAddImage(context);
+                  if (mounted) widget.onRequestClose?.call();
+                },
+                icon: const Icon(Icons.add_photo_alternate_outlined, size: 16),
+                label: const Text('Add image'),
+                style: TextButton.styleFrom(
+                  foregroundColor: context.accent,
+                  textStyle: const TextStyle(fontSize: 12),
                 ),
               ),
-              const SizedBox(width: 4),
-              Expanded(
-                child: TextButton.icon(
-                  onPressed: () {
-                    HapticFeedback.mediumImpact();
-                    ref.read(canvasProvider.notifier).clearDrawing();
-                    widget.onRequestClose?.call();
-                  },
-                  icon: const Icon(Icons.delete_outline, size: 16),
-                  label: const Text('Clear'),
-                  style: TextButton.styleFrom(
-                    foregroundColor: EchoTheme.danger,
-                    textStyle: const TextStyle(fontSize: 12),
-                  ),
-                ),
-              ),
-            ],
+            ),
           ),
           const SizedBox(height: 4),
           // Icon-only export row. Three text labels at this menu width

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import '../providers/auth_provider.dart';
+import '../providers/canvas_provider.dart';
 import '../providers/channels_provider.dart';
 import '../providers/conversations_provider.dart';
 import '../providers/livekit_voice/livekit_voice_provider.dart';
@@ -24,6 +25,7 @@ import '../services/pip_controller.dart';
 import '../services/toast_service.dart';
 import '../theme/echo_theme.dart';
 import '../utils/canvas_utils.dart';
+import '../widgets/confirm_dialog.dart';
 import '../widgets/echo_bottom_sheet.dart';
 import '../widgets/lounge_drawing_canvas.dart';
 import '../widgets/vertex_mesh_background.dart';
@@ -820,6 +822,49 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     );
   }
 
+  /// Top-right "Clear board" affordance with a confirmation dialog.
+  /// Wipes everyone's strokes + images. Lives outside the drawing menu
+  /// because it's a destructive action that shouldn't share neighbours
+  /// with the pen / color / size pickers.
+  Widget _buildClearBoardButton(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: 'Clear the canvas board for everyone',
+      child: Material(
+        color: Colors.black54,
+        shape: const CircleBorder(),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: () => _confirmClearBoard(context),
+          child: const Padding(
+            padding: EdgeInsets.all(8),
+            child: Icon(
+              Icons.delete_sweep_outlined,
+              size: 18,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmClearBoard(BuildContext context) async {
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: 'Clear board?',
+      content: Text(
+        "This removes every drawing and image on the canvas for "
+        'everyone in the call.',
+        style: TextStyle(color: context.textSecondary, fontSize: 14),
+      ),
+      confirmLabel: 'Clear board',
+      destructive: true,
+    );
+    if (!confirmed) return;
+    ref.read(canvasProvider.notifier).clearDrawing();
+  }
+
   /// Small circular icon button that opens the background-picker menu.  This
   /// is the ONE settings entry-point for the customizable voice-lounge
   /// background feature.
@@ -929,6 +974,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
               _buildResetViewButton(context),
               const SizedBox(width: 8),
             ],
+            if (!_spotlightMode) ...[
+              _buildClearBoardButton(context),
+              const SizedBox(width: 8),
+            ],
             _buildBackgroundPickerButton(context),
           ],
         ),
@@ -975,6 +1024,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
             const SizedBox(width: 8),
             if (_viewportTransformed && !_spotlightMode) ...[
               _buildResetViewButton(context),
+              const SizedBox(width: 8),
+            ],
+            if (!_spotlightMode) ...[
+              _buildClearBoardButton(context),
               const SizedBox(width: 8),
             ],
             _buildBackgroundPickerButton(context),

--- a/apps/client/lib/src/widgets/voice_dock.dart
+++ b/apps/client/lib/src/widgets/voice_dock.dart
@@ -147,6 +147,27 @@ class VoiceDock extends ConsumerWidget {
       );
       return _buildCollapsedDock(compactSpec, statusColor);
     }
+
+    // Below this width the full "status + channel name + controls" row
+    // won't fit and the status text wraps letter-by-letter (image #40).
+    // Switch to a tighter horizontal layout — controls only, status dot
+    // for context — that gracefully shrinks down to the collapsed-strip
+    // threshold.
+    const narrowThreshold = 220.0;
+    if (width < narrowThreshold) {
+      final compactSpec = (
+        context: context,
+        ref: ref,
+        voiceLk: voiceLk,
+        voiceSettings: voiceSettings,
+        screenShare: screenShare,
+        conversationId: conversationId,
+        channelId: channelId,
+        m: _DockMetrics.compact,
+      );
+      return _buildNarrowDock(compactSpec, statusColor);
+    }
+
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onTap: onNavigateToLounge,
@@ -178,6 +199,51 @@ class VoiceDock extends ConsumerWidget {
               voiceLk.callStartedAt,
             ),
             ..._buildControlButtons(spec),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Horizontal icon-only dock for sidebars too narrow for the channel
+  /// name but still too wide for the 60-px collapsed-strip layout.
+  /// Status dot anchors the left so the user can still see whether the
+  /// call is connected; the controls row scrolls horizontally if even
+  /// the icons don't fit (e.g. user dragged the rail very narrow).
+  Widget _buildNarrowDock(_DockButtonSpec spec, Color statusColor) {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: onNavigateToLounge,
+      child: Container(
+        width: width,
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+        decoration: BoxDecoration(
+          color: spec.context.surface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: spec.context.border),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Container(
+              width: 8,
+              height: 8,
+              margin: const EdgeInsets.only(left: 4, right: 4),
+              decoration: BoxDecoration(
+                color: statusColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                physics: const ClampingScrollPhysics(),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: _buildControlButtons(spec),
+                ),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
Three voice-lounge polish fixes from image #39 / #40 / #41 inline feedback.

### Voice dock — narrow & collapsed sidebar (#7)
- **Image #40** (narrow): at sidebar widths below 220 px, "Waiting for peers" wrapped letter-by-letter into a vertical column because the inner \`Expanded\` had < 1 ch of horizontal room. New width threshold renders a tighter icon-only horizontal layout — status dot left, scrollable control row right. Above 220 px the full row stays.
- **Image #41** (collapsed): the dock vanished entirely. Insert \`VoiceDock(collapsed: true)\` above the settings tile in the collapsed sidebar so the vertical mic / deafen / hangup column stays visible during a call.

### Clear-board scoping (#5)
Drawing-tools menu's "Clear" used to wipe the whole canvas with no confirmation. Moved to a top-right corner button on the lounge with a confirm dialog ("This removes every drawing and image on the canvas for everyone in the call"). Visible only in canvas (non-spotlight) mode.

A follow-up will add per-user stroke ownership so the in-menu action can become a scoped "Clear my drawings" instead of removed entirely.

### "Add image" button (#4)
Drawing menu's bottom row was an unlabeled "+ Image" half-tile next to the destructive "Clear". With Clear moved out, the primary action is now a single full-width **Add image** \`TextButton.icon\` with a \`Tooltip\` ("Add an image to the canvas").

## Test plan
- [x] \`flutter analyze\` clean
- [x] Voice-dock + voice-lounge widget tests pass
- [ ] CI passes
- [ ] Manual: drag sidebar narrow → dock switches to icon row, no vertical text
- [ ] Manual: collapse sidebar → vertical strip dock appears above settings
- [ ] Manual: drawing menu → "Add image" is the only primary; corner has "Clear board" with confirm

## Follow-ups (separate PRs)
- #1 Compact color/size + arbitrary palette picker
- #2 Canvas text tool
- #3 Highlighter + shape tools
- #6 Canvas background customization (vertex tunables + color picker)