### PR TITLE
fix(client): spawn canvas images and screen-share at viewport centre

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -3,8 +3,6 @@ library;
 
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math' as math;
-
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -51,8 +49,6 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   CanvasTool _selectedTool = CanvasTool.pen;
   Color _selectedColor = Colors.white;
   double _selectedSize = 4.0;
-
-  static final _rng = math.Random();
 
   static const _penColors = [
     Colors.white,
@@ -527,13 +523,17 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   void _addImageByUrl(String url) {
     if (!mounted) return;
     // Broadcast via canvasProvider only — local _canvas?.addImageFromUrl caused a "stuck twin" (#752).
+    // Spawn dead-centre: the user just confirmed an image; they shouldn't
+    // have to hunt for it in a random off-centre quadrant.
+    const w = 0.25;
+    const h = 0.25;
     final img = CanvasImage(
       id: newCanvasId(),
       url: url,
-      x: 0.2 + _rng.nextDouble() * 0.3,
-      y: 0.2 + _rng.nextDouble() * 0.3,
-      width: 0.25,
-      height: 0.25,
+      x: 0.5 - w / 2,
+      y: 0.5 - h / 2,
+      width: w,
+      height: h,
     );
     ref.read(canvasProvider.notifier).addImage(img);
   }

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -117,16 +117,20 @@ class ScreenShareViewer extends ConsumerWidget {
 // ---------------------------------------------------------------------------
 
 class DraggableScreenShareWindow extends StatefulWidget {
-  final double initialTop;
-  final double initialRight;
+  /// Optional initial top offset from the canvas top edge. When null the
+  /// window spawns centred in the visible canvas area instead of
+  /// anchoring to a corner — matches user expectation that "starting a
+  /// screen share" puts the window where they're already looking.
+  final double? initialTop;
+  final double? initialRight;
   final String label;
   final bool isLocal;
   final Widget child;
 
   const DraggableScreenShareWindow({
     super.key,
-    this.initialTop = 16,
-    this.initialRight = 16,
+    this.initialTop,
+    this.initialRight,
     required this.label,
     this.isLocal = false,
     required this.child,
@@ -157,8 +161,8 @@ class _DraggableScreenShareWindowState
   @override
   void initState() {
     super.initState();
-    _top = widget.initialTop;
-    _left = 0; // Will be calculated in build
+    _top = widget.initialTop ?? 0; // overridden in build when null
+    _left = 0; // overridden in build
   }
 
   @override
@@ -168,7 +172,12 @@ class _DraggableScreenShareWindowState
       child: LayoutBuilder(
         builder: (ctx, constraints) {
           if (!_positioned) {
-            _left = constraints.maxWidth - widget.initialRight - _width;
+            // initialTop/initialRight null → centre. Otherwise anchor to
+            // the requested top-right offset (legacy callers).
+            _top = widget.initialTop ?? (constraints.maxHeight - _height) / 2;
+            _left = widget.initialRight != null
+                ? constraints.maxWidth - widget.initialRight! - _width
+                : (constraints.maxWidth - _width) / 2;
             _positioned = true;
           }
           // Clamp position within bounds

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -451,14 +451,18 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
   }
 
   void _addImageFromUrl(String url) {
-    final rng = math.Random();
+    // Spawn dead-centre. The drag-and-drop or paste action that lands here
+    // already represents intent — the user shouldn't have to chase a
+    // random off-centre placement to start working with the image.
+    const w = 0.25;
+    const h = 0.25;
     final img = CanvasImage(
       id: newCanvasId(),
       url: url,
-      x: 0.2 + rng.nextDouble() * 0.3,
-      y: 0.2 + rng.nextDouble() * 0.3,
-      width: 0.25,
-      height: 0.25,
+      x: 0.5 - w / 2,
+      y: 0.5 - h / 2,
+      width: w,
+      height: h,
     );
     ref.read(canvasProvider.notifier).addImage(img);
   }


### PR DESCRIPTION
Images dropped on the canvas (drag-and-drop, paste-URL, drawing-menu upload) and the screen-share window now spawn dead-centre in the visible canvas instead of a random off-centre quadrant / top-right corner.

User intent for 'add this thing to the canvas' is 'put it where I'm looking' — chasing a randomly-placed image to recentre adds friction. The screen-share window now takes nullable initialTop/initialRight; null → centre.

## Test plan
- [x] flutter analyze clean
- [ ] Manual: paste image URL → image lands centred
- [ ] Manual: drop image from filesystem → centred
- [ ] Manual: start screen share → window opens centred (not pinned to top-right)

Follow-ups: avatar resize-feel + fast-drag detach are still in the queue.