### PR TITLE
fix(server,voice): nonce livekit identity to prevent rejoin timeout

### DIFF
--- a/apps/server/src/routes/voice.rs
+++ b/apps/server/src/routes/voice.rs
@@ -77,10 +77,31 @@ pub async fn generate_token(
         .ok_or_else(|| AppError::not_found("User not found"))?;
 
     let username = user.username;
-    let identity = body.identity.unwrap_or_else(|| username.clone());
 
-    // Identity must be the username or user_id — prevents impersonation.
-    if identity != username && identity != auth.user_id.to_string() {
+    // Identity collision fix: when the client doesn't supply an explicit
+    // identity we append a per-issuance nonce so successive join attempts
+    // present as distinct participants to the LiveKit SFU. Without this,
+    // a rejoin within the SFU's ~15-second participant-idle window collides
+    // with the previous (still-tracked) participant of the same identity
+    // and publish requests time out (LiveKit `TimeoutException` after 10s
+    // on `setMicrophoneEnabled`). The display name is set separately via
+    // `setName(username)` on the client, so the nonce never reaches the UI.
+    //
+    // Identity max length on LiveKit is 64; an 8-char nonce keeps the
+    // composite well under that even with a 30-char max username.
+    let nonce = uuid::Uuid::new_v4().simple().to_string();
+    let nonce = &nonce[..8];
+    let default_identity = format!("{username}#{nonce}");
+    let identity = body.identity.unwrap_or(default_identity);
+
+    // Identity must be the username, the nonced default, or the user_id —
+    // prevents impersonation while permitting the new `username#nonce` form.
+    let is_valid_identity = identity == username
+        || identity == auth.user_id.to_string()
+        || identity
+            .strip_prefix(&format!("{username}#"))
+            .is_some_and(|tail| tail.len() == 8 && tail.chars().all(|c| c.is_ascii_hexdigit()));
+    if !is_valid_identity {
         return Err(AppError::bad_request(
             "Identity must match authenticated user",
         ));


### PR DESCRIPTION
## Summary

Rejoining a voice channel within ~15s of leaving consistently failed with:
```
[FTL] LiveKit Exception: [TimeoutException] Signal request timed out
[ERR] LiveKitVoice: joinChannel: setMicrophoneEnabled threw: [TrackPublishException] Failed to publish track
[ERR] UI: Failed to join voice channel
```

Root cause: the LiveKit token's `sub` (identity) was the bare username. Inside the SFU's participant-idle window (~15s), the prior participant of the same identity was still tracked. When the new client connected and tried to publish the mic track, the SFU silently dropped the publish request — `setMicrophoneEnabled` then timed out after LiveKit's hardcoded 10s ack window.

## Fix

When no explicit identity is supplied, append an 8-char nonce: `username#a1b2c3d4`. Each token issuance now presents as a fresh participant to the SFU, so the rejoin no longer collides.

- Identity max length on LiveKit is 64; `max-30 username + # + 8 hex` stays well under.
- Display name is unaffected — the client still calls `setName(username)` on connect, so other participants see `npc`, not the nonced identity.
- Impersonation guard preserved: the validator accepts `username`, `user_id`, or the new `username#NNNNNNNN` form.

## Test plan

- [x] `cargo test -p echo-server --lib routes::voice` (4 tests pass)
- [ ] Manual: join lounge → leave → rejoin within 10s → confirm no TrackPublishException
- [ ] Manual: confirm participant name on remote side is still the username, not nonced form

Headlining iOS bug from production logs (user quote: "im still having issues safely joining and leaving and joining back with voice calls").