### PR TITLE
Fix mobile screen-share retry loop, portrait-share aspect, and lounge touch targets

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
+++ b/apps/client/lib/src/screens/voice_lounge/participant_grid.dart
@@ -21,6 +21,7 @@ import '../../widgets/voice/participant_attention.dart';
 import '../../widgets/voice_speaking_ring.dart';
 import '../user_profile_screen.dart';
 import 'participant_volume_controller.dart';
+import 'screen_share.dart' show AspectAwareVideoTrack;
 
 class ParticipantGrid extends StatelessWidget {
   final lk.Room? room;
@@ -689,7 +690,14 @@ class AvatarCircle extends StatelessWidget {
 /// retries on a short timer until the track appears or the widget is disposed.
 class LocalScreenShareTrack extends StatefulWidget {
   final WidgetRef ref;
-  const LocalScreenShareTrack({super.key, required this.ref});
+
+  /// Optional aspect-ratio sink. When provided, the rendered track
+  /// reports its source dimensions here so a parent
+  /// [DraggableScreenShareWindow] can reshape itself to match (e.g.
+  /// portrait phone share renders portrait, not letterboxed 16:9).
+  final ValueNotifier<double?>? aspectRatio;
+
+  const LocalScreenShareTrack({super.key, required this.ref, this.aspectRatio});
 
   @override
   State<LocalScreenShareTrack> createState() => _LocalScreenShareTrackState();
@@ -758,6 +766,14 @@ class _LocalScreenShareTrackState extends State<LocalScreenShareTrack> {
             ),
           ),
         ),
+      );
+    }
+    final aspect = widget.aspectRatio;
+    if (aspect != null) {
+      return AspectAwareVideoTrack(
+        track: _track!,
+        aspectRatio: aspect,
+        fit: lk.VideoViewFit.contain,
       );
     }
     return lk.VideoTrackRenderer(_track!, fit: lk.VideoViewFit.contain);

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -12,6 +12,7 @@ import 'package:livekit_client/livekit_client.dart' as lk;
 import '../../providers/livekit_voice/livekit_voice_provider.dart';
 import '../../providers/screen_share_provider.dart';
 import '../../theme/echo_theme.dart';
+import 'screen_share_actions.dart' show toggleScreenShare;
 
 // ---------------------------------------------------------------------------
 // Aspect-aware track renderer
@@ -217,14 +218,12 @@ class _ScreenShareViewerState extends ConsumerState<ScreenShareViewer> {
             child: IconButton(
               icon: const Icon(Icons.close, size: 18, color: Colors.white),
               tooltip: 'Stop sharing',
-              onPressed: () async {
-                await ref
-                    .read(livekitVoiceProvider.notifier)
-                    .setScreenShareEnabled(false);
-                ref
-                    .read(screenShareProvider.notifier)
-                    .setLiveKitScreenShareActive(false);
-              },
+              // Route through the shared toggle so the in-flight
+              // guard + iOS broadcast settle delay applies here too —
+              // tapping Close + then Share in quick succession was the
+              // exact pattern that triggered the iOS "Recording
+              // interrupted by another application" loop (#mobile-voice).
+              onPressed: () => toggleScreenShare(context, ref),
               style: IconButton.styleFrom(
                 backgroundColor: EchoTheme.danger.withValues(alpha: 0.7),
                 padding: const EdgeInsets.all(10),

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart'
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:livekit_client/livekit_client.dart' as lk;
 
 import '../../providers/livekit_voice/livekit_voice_provider.dart';
@@ -13,16 +14,135 @@ import '../../providers/screen_share_provider.dart';
 import '../../theme/echo_theme.dart';
 
 // ---------------------------------------------------------------------------
+// Aspect-aware track renderer
+// ---------------------------------------------------------------------------
+
+/// Renders a [lk.VideoTrack] and continuously reports the source video's
+/// aspect ratio via [aspectRatio]. This lets a portrait-source screen
+/// share (e.g. an iPhone) drive a portrait-shaped viewer window instead
+/// of being letterboxed inside a hard-coded 16:9 frame.
+///
+/// Owns its own [rtc.RTCVideoRenderer] so it can listen for dimension
+/// updates (the LiveKit-managed renderer inside [lk.VideoTrackRenderer]
+/// doesn't expose those). The renderer is shared with the LiveKit
+/// widget via the `cachedRenderer` parameter so we don't pay for two
+/// textures.
+class AspectAwareVideoTrack extends StatefulWidget {
+  final lk.VideoTrack track;
+  final lk.VideoViewFit fit;
+  final lk.VideoViewMirrorMode mirrorMode;
+
+  /// Output: receives the source video's width / height each time the
+  /// underlying renderer reports new dimensions. Stays `null` until the
+  /// first frame arrives. Callers can `addListener` to react.
+  final ValueNotifier<double?> aspectRatio;
+
+  const AspectAwareVideoTrack({
+    super.key,
+    required this.track,
+    required this.aspectRatio,
+    this.fit = lk.VideoViewFit.contain,
+    this.mirrorMode = lk.VideoViewMirrorMode.off,
+  });
+
+  @override
+  State<AspectAwareVideoTrack> createState() => _AspectAwareVideoTrackState();
+}
+
+class _AspectAwareVideoTrackState extends State<AspectAwareVideoTrack> {
+  rtc.RTCVideoRenderer? _renderer;
+
+  @override
+  void initState() {
+    super.initState();
+    _initRenderer();
+  }
+
+  Future<void> _initRenderer() async {
+    final renderer = rtc.RTCVideoRenderer();
+    await renderer.initialize();
+    if (!mounted) {
+      // Disposed during async init; drop the renderer to avoid leaking.
+      // ignore: unawaited_futures
+      renderer.dispose();
+      return;
+    }
+    renderer.addListener(_onRendererValue);
+    setState(() => _renderer = renderer);
+  }
+
+  void _onRendererValue() {
+    final r = _renderer;
+    if (r == null) return;
+    final w = r.value.width;
+    final h = r.value.height;
+    if (w <= 0 || h <= 0) return;
+    final aspect = w / h;
+    if (widget.aspectRatio.value != aspect) {
+      widget.aspectRatio.value = aspect;
+    }
+  }
+
+  @override
+  void dispose() {
+    final renderer = _renderer;
+    _renderer = null;
+    if (renderer != null) {
+      renderer.removeListener(_onRendererValue);
+      // VideoTrackRenderer was constructed with autoDisposeRenderer:
+      // false so we own the lifecycle here.
+      // ignore: unawaited_futures
+      renderer.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final renderer = _renderer;
+    if (renderer == null) {
+      // While the renderer is initializing, render nothing. The first
+      // valid frame triggers a rebuild via setState in _initRenderer.
+      return const SizedBox.shrink();
+    }
+    return lk.VideoTrackRenderer(
+      widget.track,
+      fit: widget.fit,
+      mirrorMode: widget.mirrorMode,
+      cachedRenderer: renderer,
+      autoDisposeRenderer: false,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Screen share viewer (local)
 // ---------------------------------------------------------------------------
 
-class ScreenShareViewer extends ConsumerWidget {
+class ScreenShareViewer extends ConsumerStatefulWidget {
   const ScreenShareViewer({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Watch only isScreenSharing so the widget rebuilds when the screen share
-    // track becomes available, without rebuilding on every audio level tick.
+  ConsumerState<ScreenShareViewer> createState() => _ScreenShareViewerState();
+}
+
+class _ScreenShareViewerState extends ConsumerState<ScreenShareViewer> {
+  // Lives for the widget's lifetime so the same notifier is reused
+  // across rebuilds. AspectAwareVideoTrack writes into it as new
+  // frames arrive; the ValueListenableBuilder below reads it.
+  final ValueNotifier<double?> _aspectRatio = ValueNotifier<double?>(null);
+
+  @override
+  void dispose() {
+    _aspectRatio.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Watch only isScreenSharing so the widget rebuilds when the
+    // screen-share track becomes available, without rebuilding on
+    // every audio-level tick.
     ref.watch(screenShareProvider.select((s) => s.isScreenSharing));
     final room = ref.read(livekitVoiceProvider.notifier).room;
     final localParticipant = room?.localParticipant;
@@ -51,10 +171,16 @@ class ScreenShareViewer extends ConsumerWidget {
       child: Stack(
         children: [
           Center(
-            child: AspectRatio(
-              aspectRatio: 16 / 9,
-              child: lk.VideoTrackRenderer(
-                screenTrack,
+            child: ValueListenableBuilder<double?>(
+              valueListenable: _aspectRatio,
+              // Fall back to 16:9 until the first frame arrives. After
+              // that, the viewer matches the source so a portrait phone
+              // share renders vertically.
+              builder: (_, ratio, child) =>
+                  AspectRatio(aspectRatio: ratio ?? 16 / 9, child: child),
+              child: AspectAwareVideoTrack(
+                track: screenTrack,
+                aspectRatio: _aspectRatio,
                 fit: lk.VideoViewFit.contain,
               ),
             ),
@@ -116,6 +242,13 @@ class ScreenShareViewer extends ConsumerWidget {
 // Draggable + resizable screen share window on the canvas
 // ---------------------------------------------------------------------------
 
+/// Builder signature for [DraggableScreenShareWindow.childBuilder]. The
+/// [aspectRatio] notifier is owned by the window and lives for the
+/// widget's lifetime — pass it into an [AspectAwareVideoTrack] so the
+/// window's aspect ratio reshapes when the source's dimensions change.
+typedef ScreenShareChildBuilder =
+    Widget Function(BuildContext context, ValueNotifier<double?> aspectRatio);
+
 class DraggableScreenShareWindow extends StatefulWidget {
   /// Optional initial top offset from the canvas top edge. When null the
   /// window spawns centred in the visible canvas area instead of
@@ -125,7 +258,14 @@ class DraggableScreenShareWindow extends StatefulWidget {
   final double? initialRight;
   final String label;
   final bool isLocal;
-  final Widget child;
+
+  /// Either a static [child] or a [childBuilder] that consumes the
+  /// window's own aspect-ratio notifier. Exactly one must be provided.
+  /// Use [childBuilder] when the child renders a live video track so
+  /// the window can reshape itself to match the source (a phone share
+  /// arrives portrait, not 16:9).
+  final Widget? child;
+  final ScreenShareChildBuilder? childBuilder;
 
   const DraggableScreenShareWindow({
     super.key,
@@ -133,8 +273,12 @@ class DraggableScreenShareWindow extends StatefulWidget {
     this.initialRight,
     required this.label,
     this.isLocal = false,
-    required this.child,
-  });
+    this.child,
+    this.childBuilder,
+  }) : assert(
+         (child == null) != (childBuilder == null),
+         'Provide exactly one of child or childBuilder',
+       );
 
   @override
   State<DraggableScreenShareWindow> createState() =>
@@ -150,19 +294,56 @@ class _DraggableScreenShareWindowState
   bool _positioned = false;
   bool _hovered = false;
 
+  /// Owned by this widget; lives for the State's lifetime. Fed into the
+  /// [ScreenShareChildBuilder] so the child (an [AspectAwareVideoTrack])
+  /// can push the source video's true aspect ratio up to us as frames
+  /// arrive. Stays at the default landscape value until the first
+  /// frame reports a different shape.
+  final ValueNotifier<double?> _sourceAspect = ValueNotifier<double?>(null);
+
+  /// Locked aspect ratio for the window. Defaults to landscape; updated
+  /// from [_sourceAspect] when the underlying video reports its first
+  /// frame. Locking the window to the source ratio means the resize
+  /// gesture scales the window proportionally and the underlying
+  /// content never deforms regardless of source orientation.
+  double _aspectRatio = 16.0 / 9.0;
+
   static const double _minWidth = 160;
   static const double _minHeight = 90;
-  // 16:9 — the source shared-screen content is always rendered with
-  // BoxFit.contain inside the window, so locking the window itself to
-  // the same aspect ratio means the resize gesture scales the window
-  // proportionally and the underlying content never deforms.
-  static const double _aspectRatio = 16.0 / 9.0;
+  // Cap so a 9:19.5 phone share doesn't produce a window so narrow
+  // it's unreadable, and so an ultrawide source can't grow wider than
+  // the canvas typically affords.
+  static const double _maxAspectRatio = 21.0 / 9.0;
+  static const double _minAspectRatio = 9.0 / 21.0;
 
   @override
   void initState() {
     super.initState();
     _top = widget.initialTop ?? 0; // overridden in build when null
     _left = 0; // overridden in build
+    _sourceAspect.addListener(_onAspectRatioChanged);
+  }
+
+  @override
+  void dispose() {
+    _sourceAspect.removeListener(_onAspectRatioChanged);
+    _sourceAspect.dispose();
+    super.dispose();
+  }
+
+  /// Adopt a new source aspect ratio. Preserves the user's current
+  /// width as a mental anchor and recomputes height. Clamped so a
+  /// degenerate stream can't collapse the window.
+  void _onAspectRatioChanged() {
+    final reported = _sourceAspect.value;
+    if (reported == null || reported <= 0) return;
+    final clamped = reported.clamp(_minAspectRatio, _maxAspectRatio);
+    if ((clamped - _aspectRatio).abs() < 0.01) return;
+    if (!mounted) return;
+    setState(() {
+      _aspectRatio = clamped;
+      _height = (_width / _aspectRatio).clamp(_minHeight, double.infinity);
+    });
   }
 
   @override
@@ -229,7 +410,11 @@ class _DraggableScreenShareWindowState
                       clipBehavior: Clip.antiAlias,
                       child: Stack(
                         children: [
-                          Positioned.fill(child: widget.child),
+                          Positioned.fill(
+                            child:
+                                widget.child ??
+                                widget.childBuilder!(context, _sourceAspect),
+                          ),
                           // Label badge — hover-only. The rounded chip used
                           // to overhang the (rounded) window corner; only
                           // showing it on hover keeps the screen view clean

--- a/apps/client/lib/src/screens/voice_lounge/screen_share_actions.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share_actions.dart
@@ -3,6 +3,7 @@
 /// entry points behavior-identical (#911).
 library;
 
+import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -20,6 +21,25 @@ bool _useLiveKitPicker() {
   if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) return true;
   return false;
 }
+
+/// In-flight guard for [toggleScreenShare]. The iOS broadcast picker
+/// is asynchronous: the user taps Share, the picker appears, they tap
+/// "Start Broadcast", and only then does ReplayKit fire
+/// `broadcastStarted`. If the user (or a jittery tap) fires a second
+/// toggle while the first is mid-flight, ReplayKit reports
+/// "Recording interrupted by another application" and the user has
+/// to tap 2-3 times before a share actually sticks (#mobile-voice).
+///
+/// Library-level so the guard is shared across both entry points
+/// (sidebar voice dock + lounge floating dock).
+bool _toggleInFlight = false;
+
+/// Settle delay between stopping a share and accepting the next
+/// toggle. On iOS, ReplayKit needs a moment for `broadcastFinished`
+/// to fully tear down the extension before a new
+/// `RPSystemBroadcastPickerView` press won't collide with the
+/// previous session.
+const Duration _iosBroadcastSettle = Duration(milliseconds: 600);
 
 /// Unpublish, stop, and dispose every screen-share publication on [local].
 ///
@@ -110,6 +130,13 @@ Future<void> _startScreenShareNative(
   final ok = await lkNotifier.setScreenShareEnabled(true);
   if (ok) {
     ssNotifier.setLiveKitScreenShareActive(true);
+  } else {
+    // Defensive: if the SDK reports failure (broadcast picker dismissed,
+    // permission denied, ReplayKit interrupted), make sure provider state
+    // doesn't drift to "sharing" — otherwise the next tap would hit the
+    // stop path instead of the start path and the user would have to
+    // tap a third time to recover. (#mobile-voice)
+    ssNotifier.setLiveKitScreenShareActive(false);
   }
 }
 
@@ -121,20 +148,43 @@ Future<void> _startScreenShareNative(
 /// publish (no simulcast). On mobile / web the LiveKit notifier handles source
 /// selection internally via the platform's native picker.
 ///
+/// Guarded against rapid re-entry: if a previous toggle is still in flight
+/// the second call is ignored. This is what fixed the "3-taps-to-share"
+/// behaviour on iOS — every tap before ReplayKit settled was issuing a
+/// fresh `setScreenShareEnabled` that ReplayKit then treated as an
+/// "interrupting application" (#mobile-voice).
+///
 /// No-op when not in a voice channel (no room available).
 Future<void> toggleScreenShare(BuildContext context, WidgetRef ref) async {
-  final screenShare = ref.read(screenShareProvider);
-  final lkNotifier = ref.read(livekitVoiceProvider.notifier);
-  final ssNotifier = ref.read(screenShareProvider.notifier);
-
-  if (screenShare.isScreenSharing) {
-    await _stopScreenShare(lkNotifier, ssNotifier);
+  if (_toggleInFlight) {
+    debugPrint('[ScreenShare] toggle ignored: previous toggle still in flight');
     return;
   }
+  _toggleInFlight = true;
+  try {
+    final screenShare = ref.read(screenShareProvider);
+    final lkNotifier = ref.read(livekitVoiceProvider.notifier);
+    final ssNotifier = ref.read(screenShareProvider.notifier);
 
-  if (_useLiveKitPicker()) {
-    await _startScreenShareWithPicker(context, lkNotifier, ssNotifier);
-  } else {
-    await _startScreenShareNative(lkNotifier, ssNotifier);
+    if (screenShare.isScreenSharing) {
+      await _stopScreenShare(lkNotifier, ssNotifier);
+      // On iOS, give ReplayKit a moment to fully tear the broadcast
+      // extension down before this method returns. Without the settle,
+      // a "start" tap immediately after a "stop" tap collides with the
+      // outgoing extension and surfaces as "Recording interrupted by
+      // another application".
+      if (!kIsWeb && Platform.isIOS) {
+        await Future<void>.delayed(_iosBroadcastSettle);
+      }
+      return;
+    }
+
+    if (_useLiveKitPicker()) {
+      await _startScreenShareWithPicker(context, lkNotifier, ssNotifier);
+    } else {
+      await _startScreenShareNative(lkNotifier, ssNotifier);
+    }
+  } finally {
+    _toggleInFlight = false;
   }
 }

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -262,11 +262,15 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
               initialTop: 16.0 + idx * 30,
               label: "$name's screen",
               isLocal: false,
-              child: GestureDetector(
+              // Builder form so the window reshapes itself to match the
+              // remote source — a phone share comes in portrait, not
+              // 16:9.
+              childBuilder: (ctx, aspect) => GestureDetector(
                 onDoubleTap: () =>
                     setState(() => _focusedTileKey = 'screenshare-$sid'),
-                child: lk.VideoTrackRenderer(
-                  track,
+                child: AspectAwareVideoTrack(
+                  track: track,
+                  aspectRatio: aspect,
                   fit: lk.VideoViewFit.contain,
                 ),
               ),
@@ -399,10 +403,12 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
               initialTop: 16,
               label: 'Your screen',
               isLocal: true,
-              child: GestureDetector(
+              // Builder form so the window matches a portrait phone
+              // share instead of letterboxing it into landscape.
+              childBuilder: (ctx, aspect) => GestureDetector(
                 onDoubleTap: () =>
                     setState(() => _focusedTileKey = kScreenshareLocal),
-                child: LocalScreenShareTrack(ref: ref),
+                child: LocalScreenShareTrack(ref: ref, aspectRatio: aspect),
               ),
             ),
         ],

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -774,28 +774,39 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     );
   }
 
-  /// Fullscreen-immersive toggle. Pressing this hides the HomeScreen
-  /// sidebar / members panel / title bar and the lounge's own header,
-  /// leaving only the canvas + dock. Pressing again restores them.
-  Widget _buildFullscreenButton(BuildContext context) {
-    final isFull = ref.watch(voiceLoungeFullscreenProvider);
+  /// True on iOS / Android — the touch-friendly platforms where the
+  /// corner controls need a 44pt minimum hit target instead of the
+  /// 34pt that's fine for desktop mouse pointers.
+  bool get _isTouchPlatform =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.android);
+
+  /// Wraps an icon button payload in a tappable circle. On touch
+  /// platforms the hit target is bumped to 44×44 (Apple HIG / Material
+  /// minimum); desktop keeps the compact 34×34 size that the design
+  /// originally shipped with.
+  Widget _buildCornerControl({
+    required String semanticLabel,
+    required IconData icon,
+    required VoidCallback onTap,
+  }) {
+    final double size = _isTouchPlatform ? 44 : 34;
+    final double iconSize = _isTouchPlatform ? 22 : 18;
     return Semantics(
       button: true,
-      label: isFull ? 'Exit fullscreen lounge' : 'Enter fullscreen lounge',
+      label: semanticLabel,
       child: Material(
         color: Colors.black54,
         shape: const CircleBorder(),
         child: InkWell(
           customBorder: const CircleBorder(),
-          onTap: () => ref
-              .read(voiceLoungeFullscreenProvider.notifier)
-              .update((v) => !v),
-          child: Padding(
-            padding: const EdgeInsets.all(8),
-            child: Icon(
-              isFull ? Icons.fullscreen_exit : Icons.fullscreen,
-              size: 18,
-              color: Colors.white,
+          onTap: onTap,
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: Center(
+              child: Icon(icon, size: iconSize, color: Colors.white),
             ),
           ),
         ),
@@ -803,28 +814,28 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     );
   }
 
+  /// Fullscreen-immersive toggle. Pressing this hides the HomeScreen
+  /// sidebar / members panel / title bar and the lounge's own header,
+  /// leaving only the canvas + dock. Pressing again restores them.
+  Widget _buildFullscreenButton(BuildContext context) {
+    final isFull = ref.watch(voiceLoungeFullscreenProvider);
+    return _buildCornerControl(
+      semanticLabel: isFull
+          ? 'Exit fullscreen lounge'
+          : 'Enter fullscreen lounge',
+      icon: isFull ? Icons.fullscreen_exit : Icons.fullscreen,
+      onTap: () =>
+          ref.read(voiceLoungeFullscreenProvider.notifier).update((v) => !v),
+    );
+  }
+
   /// Reset-view affordance shown only when the canvas is zoomed or panned.
   /// Returns the canvas transform to identity (1x, no offset).
   Widget _buildResetViewButton(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: 'Reset canvas zoom',
-      child: Material(
-        color: Colors.black54,
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: _resetViewport,
-          child: const Padding(
-            padding: EdgeInsets.all(8),
-            child: Icon(
-              Icons.fit_screen_outlined,
-              size: 18,
-              color: Colors.white,
-            ),
-          ),
-        ),
-      ),
+    return _buildCornerControl(
+      semanticLabel: 'Reset canvas zoom',
+      icon: Icons.fit_screen_outlined,
+      onTap: _resetViewport,
     );
   }
 
@@ -833,25 +844,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   /// because it's a destructive action that shouldn't share neighbours
   /// with the pen / color / size pickers.
   Widget _buildClearBoardButton(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: 'Clear the canvas board for everyone',
-      child: Material(
-        color: Colors.black54,
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: () => _confirmClearBoard(context),
-          child: const Padding(
-            padding: EdgeInsets.all(8),
-            child: Icon(
-              Icons.delete_sweep_outlined,
-              size: 18,
-              color: Colors.white,
-            ),
-          ),
-        ),
-      ),
+    return _buildCornerControl(
+      semanticLabel: 'Clear the canvas board for everyone',
+      icon: Icons.delete_sweep_outlined,
+      onTap: () => _confirmClearBoard(context),
     );
   }
 
@@ -875,21 +871,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   /// is the ONE settings entry-point for the customizable voice-lounge
   /// background feature.
   Widget _buildBackgroundPickerButton(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: 'Voice lounge background settings',
-      child: Material(
-        color: Colors.black54,
-        shape: const CircleBorder(),
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: () => _openBackgroundMenu(context),
-          child: const Padding(
-            padding: EdgeInsets.all(8),
-            child: Icon(Icons.wallpaper, size: 18, color: Colors.white),
-          ),
-        ),
-      ),
+    return _buildCornerControl(
+      semanticLabel: 'Voice lounge background settings',
+      icon: Icons.wallpaper,
+      onTap: () => _openBackgroundMenu(context),
     );
   }
 
@@ -1021,7 +1006,11 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       ..._buildSubmenuFollowers(conversationId),
       Positioned(bottom: 16, left: 0, right: 0, child: dock),
       Positioned(
-        top: isFull ? 16 : 60,
+        // When fullscreen-immersive, clear the iOS notch / Android
+        // status bar with viewPadding.top so the corner controls
+        // (including Fullscreen Exit) aren't hidden under the camera
+        // cutout. When not fullscreen, sit below LoungeHeader.
+        top: isFull ? (MediaQuery.viewPaddingOf(context).top + 8) : 60,
         right: 12,
         child: Row(
           mainAxisSize: MainAxisSize.min,

--- a/apps/client/test/screens/voice_lounge/screen_share_actions_test.dart
+++ b/apps/client/test/screens/voice_lounge/screen_share_actions_test.dart
@@ -180,4 +180,88 @@ void main() {
       );
     });
   });
+
+  group('screen_share_actions.dart re-entrancy guard (#mobile-voice)', () {
+    test('toggleScreenShare gates on a library-level in-flight flag', () {
+      // The 3-taps-to-share regression on iOS was caused by repeated
+      // setScreenShareEnabled calls landing while ReplayKit was still
+      // settling. Removing the in-flight guard re-enables the
+      // regression.
+      expect(
+        source,
+        contains('_toggleInFlight'),
+        reason:
+            'toggleScreenShare must keep a library-level in-flight flag so '
+            'rapid taps cannot stack setScreenShareEnabled calls '
+            '(#mobile-voice).',
+      );
+      expect(
+        source,
+        contains('if (_toggleInFlight)'),
+        reason:
+            'toggleScreenShare must early-return when a previous toggle is '
+            'still running.',
+      );
+    });
+
+    test(
+      'toggleScreenShare yields after stop on iOS so ReplayKit can settle',
+      () {
+        // Without the post-stop delay the next start tap collides with
+        // the outgoing broadcast extension and the user gets
+        // "Recording interrupted by another application".
+        expect(
+          source,
+          contains('_iosBroadcastSettle'),
+          reason:
+              'toggleScreenShare must await an iOS settle delay between '
+              'stop and accepting the next toggle (#mobile-voice).',
+        );
+        expect(
+          source,
+          contains('Platform.isIOS'),
+          reason:
+              'The settle delay must be gated on iOS so other platforms '
+              'do not pay the cost.',
+        );
+      },
+    );
+
+    test('_startScreenShareNative resets provider state when start fails', () {
+      // If setScreenShareEnabled returns false (picker dismissed,
+      // permission denied, ReplayKit interrupted) the provider's
+      // isScreenSharing flag must stay false — otherwise the next
+      // tap hits the stop path instead of retrying, and the user has
+      // to tap a third time.
+      //
+      // Locate the function body to keep the assertion narrowly
+      // scoped instead of matching the substring anywhere in the
+      // file.
+      final fnStart = source.indexOf('Future<void> _startScreenShareNative(');
+      expect(fnStart, isNot(-1), reason: '_startScreenShareNative not found');
+      final braceStart = source.indexOf('{', fnStart);
+      var depth = 0;
+      var fnEnd = -1;
+      for (var i = braceStart; i < source.length; i++) {
+        if (source[i] == '{') {
+          depth++;
+        } else if (source[i] == '}') {
+          depth--;
+          if (depth == 0) {
+            fnEnd = i;
+            break;
+          }
+        }
+      }
+      expect(fnEnd, isNot(-1));
+      final fn = source.substring(fnStart, fnEnd + 1);
+      expect(
+        fn,
+        contains('setLiveKitScreenShareActive(false)'),
+        reason:
+            '_startScreenShareNative must clear the provider when the '
+            'SDK reports start failure (#mobile-voice).',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Bundles three iOS lounge UX fixes uncovered during real-device testing.

- **Stop the 3-tap screen-share retry on mobile.** Rapid taps on Share were stacking `setScreenShareEnabled` calls while ReplayKit was mid-teardown, which surfaced as iOS's "Recording interrupted by another application" alert. A library-level in-flight guard now ignores repeat taps until the previous toggle resolves, a short iOS settle delay runs after stop so the broadcast extension finishes tearing down before the next press, and the start path resets provider state when the SDK reports failure so a dismissed picker doesn't strand the UI in "sharing".
- **Render portrait phone shares vertical, not letterboxed 16:9.** The draggable share window and the inline share viewer were hard-coded to 16:9, so an iPhone share came in horizontal with grey bars top/bottom. They now subscribe to the source's true dimensions via a small `AspectAwareVideoTrack` helper (own `RTCVideoRenderer`, shared with the LiveKit widget) and reshape themselves the first time a frame reports its width/height. Clamped 9:21 ... 21:9 so a degenerate stream can't collapse the window.
- **Make the lounge corner controls reachable on touch.** Fullscreen / reset-zoom / clear-board / background-picker were all 34×34, below the 44pt minimum hit target on iOS/Android. They're now 44×44 on touch platforms and stay 34×34 on desktop. The fullscreen control in immersive mode also clears the iOS notch via `viewPadding.top` so users can find Exit Fullscreen on a notched device.

Closely related items being shipped separately (not touched here): the voice-rejoin TimeoutException and the production log cleanup.

## Test plan
- [x] `flutter analyze --fatal-infos` on all touched files (clean)
- [x] `flutter test test/screens/voice_lounge/ test/providers/screen_share_provider_test.dart` (38/38 passing)
- [x] Added 3 source-text regression assertions for the in-flight guard, the iOS settle delay, and the start-failure reset
- [ ] **Manual on iOS device:**
  - [ ] Tap Share once → ReplayKit picker appears → tap "Start Broadcast" → share starts on the first try (no Recording-interrupted alert, no triple-tap)
  - [ ] Stop share → immediately tap Share again → second start works on the first try
  - [ ] Cancel the broadcast picker → tap Share again → it re-prompts cleanly (no stuck "sharing" UI state)
  - [ ] iPhone shares screen → remote viewer sees portrait orientation (not letterboxed 16:9)
  - [ ] iPhone shares screen → local "Your screen" preview also displays portrait
- [ ] **Manual on iPhone receiver:**
  - [ ] Open voice lounge in portrait → all four corner buttons (fullscreen, reset zoom when zoomed, clear board, background) are tappable on first try
  - [ ] Enter fullscreen mode → exit-fullscreen button is visible below the notch, not hidden behind it
  - [ ] Pinch-zoom canvas works; single-finger drag-pan works from empty canvas areas
- [ ] **Manual on Android device:** same checklist as iOS minus the ReplayKit-specific bits