### PR TITLE
Quiet prod log spam and fix two crash paths from iOS log review

### DIFF
--- a/apps/client/lib/main.dart
+++ b/apps/client/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Directory, Platform;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show SemanticsBinding;
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -52,6 +53,15 @@ void main() {
   // viewer — framework errors almost always indicate a crash or a broken
   // widget tree.
   FlutterError.onError = (details) {
+    if (_isBenignNoActiveStream(details.exception)) {
+      DebugLogService.instance.log(
+        LogLevel.fine,
+        'flutter',
+        'Swallowed benign EventChannel "No active stream to cancel": '
+            '${details.exception}',
+      );
+      return;
+    }
     DebugLogService.instance.log(
       LogLevel.fatal,
       'flutter',
@@ -68,6 +78,14 @@ void main() {
   // Returns true to signal that the error was handled and should not be
   // re-thrown by the engine.
   PlatformDispatcher.instance.onError = (error, stack) {
+    if (_isBenignNoActiveStream(error)) {
+      DebugLogService.instance.log(
+        LogLevel.fine,
+        'platform',
+        'Swallowed benign EventChannel "No active stream to cancel": $error',
+      );
+      return true;
+    }
     DebugLogService.instance.log(LogLevel.fatal, 'platform', '$error\n$stack');
     DebugLogService.instance.forceFlushSync();
     return true;
@@ -81,6 +99,14 @@ void main() {
       await _initAndRun();
     },
     (error, stack) {
+      if (_isBenignNoActiveStream(error)) {
+        DebugLogService.instance.log(
+          LogLevel.fine,
+          'platform',
+          'Swallowed benign EventChannel "No active stream to cancel": $error',
+        );
+        return;
+      }
       debugPrint('[Unhandled] $error\n$stack');
       DebugLogService.instance.log(
         LogLevel.fatal,
@@ -90,6 +116,22 @@ void main() {
       DebugLogService.instance.forceFlushSync();
     },
   );
+}
+
+/// True when [error] is the harmless LiveKit/EventChannel teardown race:
+/// `PlatformException(error, No active stream to cancel, null, null)`.
+///
+/// The LiveKit SDK opens an EventChannel broadcast stream for screen-share
+/// and other platform tracks. On Linux + iOS, cancelling that stream when
+/// nothing is currently active throws this PlatformException from the
+/// platform side. Our `setScreenShareEnabled(false)` already swallows it at
+/// the call site, but the SDK also rethrows it from an internal stream
+/// callback that escapes our try/catch and surfaces as [FTL] in the log
+/// viewer. Demote it to FINE so prod logs aren't dominated by this noise.
+bool _isBenignNoActiveStream(Object error) {
+  if (error is! PlatformException) return false;
+  final msg = error.message;
+  return msg != null && msg.contains('No active stream');
 }
 
 /// Initialize Hive with a sane storage location.

--- a/apps/client/lib/src/providers/crypto_provider.dart
+++ b/apps/client/lib/src/providers/crypto_provider.dart
@@ -138,7 +138,7 @@ class CryptoNotifier extends _$CryptoNotifier {
       try {
         await crypto.uploadKeys();
         DebugLogService.instance.log(
-          LogLevel.info,
+          LogLevel.fine,
           'Crypto',
           'Keys uploaded to server (attempt $attempt)',
         );
@@ -214,7 +214,7 @@ class CryptoNotifier extends _$CryptoNotifier {
         );
       } else {
         DebugLogService.instance.log(
-          LogLevel.info,
+          LogLevel.fine,
           'Crypto',
           'Initialized successfully',
         );

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -689,6 +689,7 @@ class _DebugLogsSubpageState extends State<_DebugLogsSubpage> {
       final m = e.timestamp.minute.toString().padLeft(2, '0');
       final s = e.timestamp.second.toString().padLeft(2, '0');
       final level = switch (e.level) {
+        LogLevel.fine => 'FIN',
         LogLevel.info => 'INF',
         LogLevel.warning => 'WRN',
         LogLevel.error => 'ERR',
@@ -839,6 +840,7 @@ class _DebugLogEntryTileState extends State<_DebugLogEntryTile> {
     final m = entry.timestamp.minute.toString().padLeft(2, '0');
     final s = entry.timestamp.second.toString().padLeft(2, '0');
     final level = switch (entry.level) {
+      LogLevel.fine => 'FIN',
       LogLevel.info => 'INF',
       LogLevel.warning => 'WRN',
       LogLevel.error => 'ERR',
@@ -937,6 +939,7 @@ class _DebugLevelBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final (String label, Color color) = switch (level) {
+      LogLevel.fine => ('FIN', EchoTheme.textMuted),
       LogLevel.info => ('INF', EchoTheme.online),
       LogLevel.warning => ('WRN', EchoTheme.warning),
       LogLevel.error => ('ERR', EchoTheme.danger),

--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -555,22 +556,27 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
           subtitle: 'Verifies the URL before adding it to your list.',
           onTap: _showAddServerDialog,
         ),
-        const SizedBox(height: 16),
-        Divider(color: context.border),
-        const SizedBox(height: 16),
-        // Debug logs entry (absorbed from former Debug section).
-        SettingsListTile(
-          icon: Icons.bug_report_outlined,
-          title: 'Debug Logs',
-          subtitle: 'View recent in-app log entries.',
-          onTap: () {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => const _DebugLogsSubpage(),
-              ),
-            );
-          },
-        ),
+        // Debug logs entry (absorbed from former Debug section). Hidden in
+        // release builds — users were complaining about the technical log
+        // viewer being reachable from settings (2026-05-27 prod feedback).
+        // Still available in debug builds for developer triage.
+        if (kDebugMode) ...[
+          const SizedBox(height: 16),
+          Divider(color: context.border),
+          const SizedBox(height: 16),
+          SettingsListTile(
+            icon: Icons.bug_report_outlined,
+            title: 'Debug Logs',
+            subtitle: 'View recent in-app log entries.',
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const _DebugLogsSubpage(),
+                ),
+              );
+            },
+          ),
+        ],
         const SizedBox(height: 8),
         // Beta-prep #4c: surface the feedback dialog from About so testers
         // have a one-tap path to report issues without leaving the app.

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -105,10 +105,17 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   /// transform differs from identity (any zoom or pan applied).
   bool _viewportTransformed = false;
 
+  /// Captured at initState so dispose() can clear fullscreen without
+  /// touching `ref` (which becomes invalid the moment the element is
+  /// unmounted, even before super.dispose runs). Riverpod's
+  /// StateController survives across rebuilds and is safe to retain.
+  late final StateController<bool> _fullscreenNotifier;
+
   @override
   void initState() {
     super.initState();
     _viewport = TransformationController()..addListener(_onViewportChanged);
+    _fullscreenNotifier = ref.read(voiceLoungeFullscreenProvider.notifier);
     // Breadcrumb fires post-joinChannel: missing = crash in joinChannel; present-but-alone = crash in build.
     final voiceLk = ref.read(livekitVoiceProvider);
     DebugLogService.instance.log(
@@ -127,19 +134,9 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       ..removeListener(_onViewportChanged)
       ..dispose();
     // Clear fullscreen so the user doesn't return to an immersive
-    // HomeScreen (no sidebar / no title bar) the next time they open
-    // the lounge. Read the provider's notifier synchronously now —
-    // ConsumerState's `ref` is invalidated the moment `super.dispose`
-    // runs, so a deferred `Future.microtask(() => ref.read(...))`
-    // crashes with "Cannot use 'ref' after the widget was disposed".
-    try {
-      final notifier = ref.read(voiceLoungeFullscreenProvider.notifier);
-      if (notifier.state) notifier.state = false;
-    } catch (_) {
-      // Ref may already be invalid in narrow edge cases (route swap
-      // during teardown). Silently skip — the next mount will pick up
-      // whatever value the provider holds.
-    }
+    // HomeScreen the next time they open the lounge. Uses the notifier
+    // captured at initState — ref is unsafe in dispose().
+    if (_fullscreenNotifier.state) _fullscreenNotifier.state = false;
     DebugLogService.instance.log(
       LogLevel.info,
       'VoiceLoungeUI',

--- a/apps/client/lib/src/services/app_lifecycle_logger.dart
+++ b/apps/client/lib/src/services/app_lifecycle_logger.dart
@@ -12,8 +12,10 @@ import 'debug_log_service.dart';
 /// occur during app startup and voice-channel entry on iOS, where the audio
 /// session activation can trigger lifecycle events before the first frame.
 ///
-/// Each lifecycle event is logged at [LogLevel.info]. For states that are
-/// close to the process going away (paused, detached, hidden) the write is
+/// Each lifecycle event is logged at [LogLevel.fine] — these breadcrumbs are
+/// useful when triaging a specific issue but are far too noisy to keep at
+/// INF in production (every backgrounding event fires one). For states close
+/// to the process going away (paused, detached, hidden) the write is
 /// force-flushed immediately so the breadcrumb survives even if the OS kills
 /// the process within milliseconds.
 ///
@@ -38,7 +40,7 @@ class AppLifecycleLogger with WidgetsBindingObserver {
     if (!needsImmediateFlush) return;
 
     DebugLogService.instance.log(
-      LogLevel.info,
+      LogLevel.fine,
       'Lifecycle',
       'state=${state.name}',
     );

--- a/apps/client/lib/src/services/crypto_service.dart
+++ b/apps/client/lib/src/services/crypto_service.dart
@@ -246,7 +246,7 @@ class CryptoService {
       }
     }
     DebugLogService.instance.log(
-      LogLevel.info,
+      LogLevel.fine,
       'Crypto',
       'Loaded ${_sessions.length} session(s) from storage on init',
     );

--- a/apps/client/lib/src/services/debug_log_service.dart
+++ b/apps/client/lib/src/services/debug_log_service.dart
@@ -8,7 +8,14 @@ import 'package:path_provider/path_provider.dart';
 import '../version.dart' show appVersion;
 
 /// Severity level for debug log entries.
-enum LogLevel { info, warning, error, fatal }
+///
+/// Ordered low-to-high: `fine` is the most verbose (trace-style breadcrumbs
+/// that are useful when debugging but shouldn't dominate production logs);
+/// `fatal` is reserved for unrecoverable errors that immediately precede a
+/// crash. Production-noise breadcrumbs (lifecycle transitions, routine
+/// crypto init, swallowed benign errors) should log at `fine` so they stay
+/// in the on-disk ring buffer for triage without spamming the in-app viewer.
+enum LogLevel { fine, info, warning, error, fatal }
 
 /// A single timestamped log entry captured by [DebugLogService].
 class DebugLogEntry {
@@ -297,6 +304,7 @@ class DebugLogService with ChangeNotifier {
       final m = e.timestamp.minute.toString().padLeft(2, '0');
       final s = e.timestamp.second.toString().padLeft(2, '0');
       final level = switch (e.level) {
+        LogLevel.fine => 'FIN',
         LogLevel.info => 'INF',
         LogLevel.warning => 'WRN',
         LogLevel.error => 'ERR',


### PR DESCRIPTION
## Summary

Five small fixes from the latest iOS prod-log triage. Four still needed a code change in this branch; #1 was already fixed on main by #1224, so it isn't included here.

## New / Improved

- **Settings**: the Debug Logs viewer is now hidden in release builds. Users reported the technical log screen reachable from Settings -> About wasn't something they should see (2026-05-27 prod feedback). The dev build still has it for triage.

## Fixed

- **Voice lounge teardown** no longer prints `[FTL] Cannot use "ref" after the widget was disposed.` when leaving a call. The fullscreen-clearing notifier is now captured at `initState` and used in `dispose` without touching `ref`.
- **iOS / Linux screen-share teardown** no longer prints `[FTL] PlatformException: No active stream to cancel`. The underlying LiveKit EventChannel race is benign; we now demote it to a `fine` breadcrumb at the global Flutter / PlatformDispatcher / runZonedGuarded error handlers instead of letting it fly past as fatal.

## Behind the scenes

- New `LogLevel.fine` level added to `DebugLogService`. Routine `Lifecycle: state=...`, `Crypto: Loaded N session(s)`, `Crypto: Keys uploaded`, and `Crypto: Initialized successfully` breadcrumbs all moved from `info` to `fine` so they still land in the on-disk ring buffer for triage but stop dominating the in-app viewer.
- All three debug-log viewer switches updated to render the new level as `FIN`.

## Test plan

- [x] `flutter analyze --fatal-infos` clean.
- [x] `flutter test` for `services/debug_log_service`, `utils/debug_log`, `providers/crypto_provider`, `widgets/settings/about_section`, and `screens/voice_lounge/` all green.
- [ ] On a debug build, confirm Debug Logs is still reachable; on a release build, confirm it is gone.
- [ ] In a voice call, leave the lounge while screen-sharing on Linux/iOS and confirm no `FTL` lines for ref-after-dispose or "No active stream to cancel" appear in Debug Logs.

Not touched (separate PRs):
- voice rejoin TrackPublishException
- mobile screen-share UX / orientation