### PR TITLE
feat(client): canvas tool polish (palette, shapes, text, mesh bg) + drag-feel fix

### DIFF
--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -41,7 +41,54 @@ class CanvasPoint {
 // Drawing strokes
 // ---------------------------------------------------------------------------
 
-enum StrokeKind { pen, eraser }
+/// Brush type. `pen` and `eraser` are the original freehand modes;
+/// `highlighter` is a thick translucent pen; `line`, `rect`, `ellipse`
+/// are two-point shapes recorded as `[first, last]` and rendered as
+/// straight geometry by the painter.
+enum StrokeKind { pen, eraser, highlighter, line, rect, ellipse }
+
+/// `true` if the kind is a two-point geometric shape rather than a freehand
+/// stroke. Shape kinds always store exactly two points: the gesture's start
+/// and end positions; intermediate samples are discarded.
+bool isShapeKind(StrokeKind kind) =>
+    kind == StrokeKind.line ||
+    kind == StrokeKind.rect ||
+    kind == StrokeKind.ellipse;
+
+StrokeKind _strokeKindFromString(String? raw) {
+  switch (raw) {
+    case 'eraser':
+      return StrokeKind.eraser;
+    case 'highlighter':
+      return StrokeKind.highlighter;
+    case 'line':
+      return StrokeKind.line;
+    case 'rect':
+      return StrokeKind.rect;
+    case 'ellipse':
+      return StrokeKind.ellipse;
+    case 'pen':
+    default:
+      return StrokeKind.pen;
+  }
+}
+
+String _strokeKindToString(StrokeKind kind) {
+  switch (kind) {
+    case StrokeKind.eraser:
+      return 'eraser';
+    case StrokeKind.highlighter:
+      return 'highlighter';
+    case StrokeKind.line:
+      return 'line';
+    case StrokeKind.rect:
+      return 'rect';
+    case StrokeKind.ellipse:
+      return 'ellipse';
+    case StrokeKind.pen:
+      return 'pen';
+  }
+}
 
 /// A single freehand stroke drawn on the canvas.
 class CanvasStroke {
@@ -66,9 +113,7 @@ class CanvasStroke {
     points: (json['points'] as List)
         .map((p) => CanvasPoint.fromJson(p as Map<String, dynamic>))
         .toList(),
-    kind: (json['kind'] as String?) == 'eraser'
-        ? StrokeKind.eraser
-        : StrokeKind.pen,
+    kind: _strokeKindFromString(json['kind'] as String?),
   );
 
   Map<String, dynamic> toJson() => {
@@ -76,7 +121,7 @@ class CanvasStroke {
     'color': color,
     'width': width,
     'points': points.map((p) => p.toJson()).toList(),
-    'kind': kind == StrokeKind.eraser ? 'eraser' : 'pen',
+    'kind': _strokeKindToString(kind),
   };
 
   CanvasStroke copyWith({
@@ -190,7 +235,36 @@ class AvatarPosition {
 // Drawing tools
 // ---------------------------------------------------------------------------
 
-enum CanvasTool { none, pen, eraser }
+enum CanvasTool { none, pen, eraser, highlighter, line, rect, ellipse }
+
+/// `true` for any tool that records a freehand or shape stroke (i.e. the
+/// drawing-layer should grab pointer events for it).
+bool isDrawingTool(CanvasTool tool) =>
+    tool == CanvasTool.pen ||
+    tool == CanvasTool.eraser ||
+    tool == CanvasTool.highlighter ||
+    tool == CanvasTool.line ||
+    tool == CanvasTool.rect ||
+    tool == CanvasTool.ellipse;
+
+/// Map the currently-selected [CanvasTool] to the [StrokeKind] it produces.
+StrokeKind strokeKindForTool(CanvasTool tool) {
+  switch (tool) {
+    case CanvasTool.eraser:
+      return StrokeKind.eraser;
+    case CanvasTool.highlighter:
+      return StrokeKind.highlighter;
+    case CanvasTool.line:
+      return StrokeKind.line;
+    case CanvasTool.rect:
+      return StrokeKind.rect;
+    case CanvasTool.ellipse:
+      return StrokeKind.ellipse;
+    case CanvasTool.pen:
+    case CanvasTool.none:
+      return StrokeKind.pen;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Full canvas state

--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -44,8 +44,11 @@ class CanvasPoint {
 /// Brush type. `pen` and `eraser` are the original freehand modes;
 /// `highlighter` is a thick translucent pen; `line`, `rect`, `ellipse`
 /// are two-point shapes recorded as `[first, last]` and rendered as
-/// straight geometry by the painter.
-enum StrokeKind { pen, eraser, highlighter, line, rect, ellipse }
+/// straight geometry by the painter. `text` is a single-anchor text label;
+/// `points[0]` is the top-left anchor, `width` is the font size in
+/// logical pixels, and the optional `text` field on [CanvasStroke] holds
+/// the label content.
+enum StrokeKind { pen, eraser, highlighter, line, rect, ellipse, text }
 
 /// `true` if the kind is a two-point geometric shape rather than a freehand
 /// stroke. Shape kinds always store exactly two points: the gesture's start
@@ -67,6 +70,8 @@ StrokeKind _strokeKindFromString(String? raw) {
       return StrokeKind.rect;
     case 'ellipse':
       return StrokeKind.ellipse;
+    case 'text':
+      return StrokeKind.text;
     case 'pen':
     default:
       return StrokeKind.pen;
@@ -85,6 +90,8 @@ String _strokeKindToString(StrokeKind kind) {
       return 'rect';
     case StrokeKind.ellipse:
       return 'ellipse';
+    case StrokeKind.text:
+      return 'text';
     case StrokeKind.pen:
       return 'pen';
   }
@@ -98,12 +105,18 @@ class CanvasStroke {
   final List<CanvasPoint> points;
   final StrokeKind kind;
 
+  /// Only set for `kind == StrokeKind.text`; otherwise `null`. Stored on the
+  /// stroke so text labels round-trip through the existing strokes JSONB
+  /// without needing a new server-side column.
+  final String? text;
+
   const CanvasStroke({
     required this.id,
     required this.color,
     required this.width,
     required this.points,
     this.kind = StrokeKind.pen,
+    this.text,
   });
 
   factory CanvasStroke.fromJson(Map<String, dynamic> json) => CanvasStroke(
@@ -114,6 +127,7 @@ class CanvasStroke {
         .map((p) => CanvasPoint.fromJson(p as Map<String, dynamic>))
         .toList(),
     kind: _strokeKindFromString(json['kind'] as String?),
+    text: json['text'] as String?,
   );
 
   Map<String, dynamic> toJson() => {
@@ -122,6 +136,7 @@ class CanvasStroke {
     'width': width,
     'points': points.map((p) => p.toJson()).toList(),
     'kind': _strokeKindToString(kind),
+    if (text != null) 'text': text,
   };
 
   CanvasStroke copyWith({
@@ -130,12 +145,14 @@ class CanvasStroke {
     double? width,
     List<CanvasPoint>? points,
     StrokeKind? kind,
+    String? text,
   }) => CanvasStroke(
     id: id ?? this.id,
     color: color ?? this.color,
     width: width ?? this.width,
     points: points ?? this.points,
     kind: kind ?? this.kind,
+    text: text ?? this.text,
   );
 }
 
@@ -235,10 +252,11 @@ class AvatarPosition {
 // Drawing tools
 // ---------------------------------------------------------------------------
 
-enum CanvasTool { none, pen, eraser, highlighter, line, rect, ellipse }
+enum CanvasTool { none, pen, eraser, highlighter, line, rect, ellipse, text }
 
 /// `true` for any tool that records a freehand or shape stroke (i.e. the
-/// drawing-layer should grab pointer events for it).
+/// drawing-layer should grab pointer events for it). Text is excluded —
+/// it uses a tap-to-place flow handled separately in the canvas widget.
 bool isDrawingTool(CanvasTool tool) =>
     tool == CanvasTool.pen ||
     tool == CanvasTool.eraser ||
@@ -260,6 +278,8 @@ StrokeKind strokeKindForTool(CanvasTool tool) {
       return StrokeKind.rect;
     case CanvasTool.ellipse:
       return StrokeKind.ellipse;
+    case CanvasTool.text:
+      return StrokeKind.text;
     case CanvasTool.pen:
     case CanvasTool.none:
       return StrokeKind.pen;

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -200,9 +200,35 @@ class CanvasController extends _$CanvasController {
         return 'rect';
       case StrokeKind.ellipse:
         return 'ellipse';
+      case StrokeKind.text:
+        return 'text';
       case StrokeKind.pen:
         return 'pen';
     }
+  }
+
+  /// Commit a text label at [anchor]. Persisted as a stroke (kind=text) so
+  /// it round-trips through the existing canvas tables — no schema change.
+  void addTextLabel({
+    required CanvasPoint anchor,
+    required String text,
+    required double fontSize,
+    required Color color,
+  }) {
+    if (_channelId == null) return;
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    final stroke = CanvasStroke(
+      id: newCanvasId(),
+      color: colorToHex(color),
+      width: fontSize,
+      points: [anchor],
+      kind: StrokeKind.text,
+      text: trimmed,
+    );
+    final newStrokes = List<CanvasStroke>.from(state.strokes)..add(stroke);
+    state = state.copyWith(strokes: newStrokes);
+    _sendCanvasEvent('stroke', stroke.toJson());
   }
 
   /// Eraser is rendered 3× the selected width so the user can wipe a

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -140,18 +140,30 @@ class CanvasController extends _$CanvasController {
   }
 
   void continueStroke(CanvasPoint point) {
-    final pts = List<CanvasPoint>.from(state.activePoints)..add(point);
+    final tool = state.selectedTool;
+    List<CanvasPoint> pts;
+    if (isShapeKind(strokeKindForTool(tool))) {
+      // Shape tools (line/rect/ellipse) only need first + last point.
+      // Replace the trailing point on every move so the preview rubberbands
+      // without bloating the points list.
+      pts = state.activePoints.isEmpty
+          ? [point]
+          : [state.activePoints.first, point];
+    } else {
+      pts = List<CanvasPoint>.from(state.activePoints)..add(point);
+    }
     state = state.copyWith(activePoints: pts);
 
-    // Buffer the new point for throttled broadcast.
-    _pendingStrokePoints ??= [];
-    _pendingStrokePoints!.add(point);
-
-    // Start throttle timer if not already running.
-    _strokeThrottle ??= Timer.periodic(
-      const Duration(milliseconds: 33), // ~30 fps
-      (_) => _flushStrokePoints(),
-    );
+    // Shapes don't need streaming WS partials — the final stroke at endStroke
+    // is enough. Freehand keeps the 30 Hz partial broadcast.
+    if (!isShapeKind(strokeKindForTool(tool))) {
+      _pendingStrokePoints ??= [];
+      _pendingStrokePoints!.add(point);
+      _strokeThrottle ??= Timer.periodic(
+        const Duration(milliseconds: 33), // ~30 fps
+        (_) => _flushStrokePoints(),
+      );
+    }
   }
 
   void _flushStrokePoints() {
@@ -162,13 +174,42 @@ class CanvasController extends _$CanvasController {
       return;
     }
     _pendingStrokePoints = null;
-    final isEraser = state.selectedTool == CanvasTool.eraser;
+    final tool = state.selectedTool;
+    final kind = strokeKindForTool(tool);
+    final isEraser = kind == StrokeKind.eraser;
     _sendCanvasEvent('stroke_partial', {
       'points': pending.map((p) => {'x': p.x, 'y': p.y}).toList(),
       'color': isEraser ? '#00000000' : colorToHex(state.currentColor),
-      'width': isEraser ? state.strokeWidth * 3 : state.strokeWidth,
-      'kind': isEraser ? 'eraser' : 'pen',
+      'width': _effectiveStrokeWidth(kind),
+      'kind': _strokeKindWire(kind),
     });
+  }
+
+  /// Wire `kind` string per protocol — falls back to "pen" for unknown.
+  /// Mirrors the mapping in [CanvasStroke.toJson] but kept independent so
+  /// stroke_partial events don't need to construct a full stroke.
+  String _strokeKindWire(StrokeKind kind) {
+    switch (kind) {
+      case StrokeKind.eraser:
+        return 'eraser';
+      case StrokeKind.highlighter:
+        return 'highlighter';
+      case StrokeKind.line:
+        return 'line';
+      case StrokeKind.rect:
+        return 'rect';
+      case StrokeKind.ellipse:
+        return 'ellipse';
+      case StrokeKind.pen:
+        return 'pen';
+    }
+  }
+
+  /// Eraser is rendered 3× the selected width so the user can wipe a
+  /// reasonable area without dialing the size slider up.
+  double _effectiveStrokeWidth(StrokeKind kind) {
+    if (kind == StrokeKind.eraser) return state.strokeWidth * 3;
+    return state.strokeWidth;
   }
 
   void endStroke() {
@@ -180,13 +221,15 @@ class CanvasController extends _$CanvasController {
     _strokeThrottle = null;
     _pendingStrokePoints = null;
 
-    final isEraser = state.selectedTool == CanvasTool.eraser;
+    final tool = state.selectedTool;
+    final kind = strokeKindForTool(tool);
+    final isEraser = kind == StrokeKind.eraser;
     final stroke = CanvasStroke(
       id: newCanvasId(),
       color: isEraser ? '#00000000' : colorToHex(state.currentColor),
-      width: isEraser ? state.strokeWidth * 3 : state.strokeWidth,
+      width: _effectiveStrokeWidth(kind),
       points: List.from(state.activePoints),
-      kind: isEraser ? StrokeKind.eraser : StrokeKind.pen,
+      kind: kind,
     );
 
     // Append locally.

--- a/apps/client/lib/src/providers/voice_lounge_background_provider.dart
+++ b/apps/client/lib/src/providers/voice_lounge_background_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui' show Color;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,23 +8,55 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// SharedPreferences key for the custom voice-lounge background path.
 const kVoiceLoungeBgPathKey = 'voice_lounge_bg_path';
 
+/// SharedPreferences key for the optional custom vertex colour (32-bit ARGB).
+const kVoiceLoungeVertexColorKey = 'voice_lounge_vertex_color';
+const kVoiceLoungeVertexCountKey = 'voice_lounge_vertex_count';
+const kVoiceLoungeConnectionDistanceKey = 'voice_lounge_connection_distance';
+
+/// Defaults applied when the user hasn't customised the vertex-mesh.
+/// Mirror `VertexMeshBackground`'s built-in defaults.
+const int kDefaultVertexCount = 40;
+const double kDefaultConnectionDistance = 120;
+
 /// Immutable state for the voice-lounge background.
 ///
 /// `customBackgroundPath` is `null` when the user hasn't picked a custom
 /// background (the lounge falls back to the built-in vertex-mesh).  When set,
 /// it points to a file on disk (typically copied into the app's document
 /// directory so it survives reinstall-safe storage migrations).
+///
+/// `vertexColor`, `vertexCount`, `connectionDistance` tune the built-in
+/// vertex-mesh when no custom image is in use. `null` on `vertexColor` means
+/// "use the theme accent". Counts and distances persist across sessions.
 @immutable
 class VoiceLoungeBackgroundState {
   final String? customBackgroundPath;
+  final Color? vertexColor;
+  final int vertexCount;
+  final double connectionDistance;
 
-  const VoiceLoungeBackgroundState({this.customBackgroundPath});
+  const VoiceLoungeBackgroundState({
+    this.customBackgroundPath,
+    this.vertexColor,
+    this.vertexCount = kDefaultVertexCount,
+    this.connectionDistance = kDefaultConnectionDistance,
+  });
 
-  VoiceLoungeBackgroundState copyWith({Object? customBackgroundPath = _unset}) {
+  VoiceLoungeBackgroundState copyWith({
+    Object? customBackgroundPath = _unset,
+    Object? vertexColor = _unset,
+    int? vertexCount,
+    double? connectionDistance,
+  }) {
     return VoiceLoungeBackgroundState(
       customBackgroundPath: identical(customBackgroundPath, _unset)
           ? this.customBackgroundPath
           : customBackgroundPath as String?,
+      vertexColor: identical(vertexColor, _unset)
+          ? this.vertexColor
+          : vertexColor as Color?,
+      vertexCount: vertexCount ?? this.vertexCount,
+      connectionDistance: connectionDistance ?? this.connectionDistance,
     );
   }
 
@@ -52,9 +85,15 @@ class VoiceLoungeBackground extends Notifier<VoiceLoungeBackgroundState> {
     try {
       final prefs = await SharedPreferences.getInstance();
       final path = prefs.getString(kVoiceLoungeBgPathKey);
-      if (path != null && path.isNotEmpty) {
-        state = state.copyWith(customBackgroundPath: path);
-      }
+      final argb = prefs.getInt(kVoiceLoungeVertexColorKey);
+      final count = prefs.getInt(kVoiceLoungeVertexCountKey);
+      final dist = prefs.getDouble(kVoiceLoungeConnectionDistanceKey);
+      state = state.copyWith(
+        customBackgroundPath: (path != null && path.isNotEmpty) ? path : null,
+        vertexColor: argb != null ? Color(argb) : null,
+        vertexCount: count?.clamp(10, 120),
+        connectionDistance: dist?.clamp(40.0, 240.0),
+      );
     } catch (e) {
       debugPrint('[VoiceLoungeBackground] load failed: $e');
     }
@@ -76,8 +115,63 @@ class VoiceLoungeBackground extends Notifier<VoiceLoungeBackgroundState> {
     }
   }
 
-  /// Convenience: clear the custom background.
+  Future<void> setVertexColor(Color? color) async {
+    state = state.copyWith(vertexColor: color);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (color == null) {
+        await prefs.remove(kVoiceLoungeVertexColorKey);
+      } else {
+        await prefs.setInt(kVoiceLoungeVertexColorKey, color.toARGB32());
+      }
+    } catch (e) {
+      debugPrint('[VoiceLoungeBackground] persist vertexColor failed: $e');
+    }
+  }
+
+  Future<void> setVertexCount(int count) async {
+    final clamped = count.clamp(10, 120);
+    state = state.copyWith(vertexCount: clamped);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(kVoiceLoungeVertexCountKey, clamped);
+    } catch (e) {
+      debugPrint('[VoiceLoungeBackground] persist vertexCount failed: $e');
+    }
+  }
+
+  Future<void> setConnectionDistance(double distance) async {
+    final clamped = distance.clamp(40.0, 240.0);
+    state = state.copyWith(connectionDistance: clamped);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setDouble(kVoiceLoungeConnectionDistanceKey, clamped);
+    } catch (e) {
+      debugPrint(
+        '[VoiceLoungeBackground] persist connectionDistance failed: $e',
+      );
+    }
+  }
+
+  /// Clears the custom image background. Vertex tunables are preserved.
   Future<void> clear() => setCustomBackgroundPath(null);
+
+  /// Resets every vertex tunable back to the defaults.
+  Future<void> resetVertexDefaults() async {
+    state = state.copyWith(
+      vertexColor: null,
+      vertexCount: kDefaultVertexCount,
+      connectionDistance: kDefaultConnectionDistance,
+    );
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(kVoiceLoungeVertexColorKey);
+      await prefs.remove(kVoiceLoungeVertexCountKey);
+      await prefs.remove(kVoiceLoungeConnectionDistanceKey);
+    } catch (e) {
+      debugPrint('[VoiceLoungeBackground] resetVertexDefaults failed: $e');
+    }
+  }
 }
 
 /// Returns `true` when [path] is a non-empty filesystem path that points to

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -123,6 +123,7 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
             'Ellipse',
             CanvasTool.ellipse,
           ),
+          _toolChip(context, Icons.text_fields, 'Text', CanvasTool.text),
           _toolChip(context, Icons.auto_fix_high, 'Erase', CanvasTool.eraser),
         ],
       ),

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -67,10 +67,13 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   void initState() {
     super.initState();
     // Hydrate from the provider so the menu opens with the current selection.
+    // `none` means the drawing layer is off; show "pen" as the default
+    // selected tool, but don't push it back into the provider — that would
+    // arm the drawing layer just by opening the menu.
     final canvas = ref.read(canvasProvider);
-    _selectedTool = canvas.selectedTool == CanvasTool.eraser
-        ? CanvasTool.eraser
-        : CanvasTool.pen;
+    _selectedTool = canvas.selectedTool == CanvasTool.none
+        ? CanvasTool.pen
+        : canvas.selectedTool;
     _selectedColor = canvas.currentColor;
     _selectedSize = canvas.strokeWidth;
   }
@@ -84,10 +87,15 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _buildToolSelector(context),
-          if (_selectedTool == CanvasTool.pen) ...[
+          // Eraser strips colour + ignores the colour picker, but every
+          // other tool (pen, highlighter, shapes) is colour + size aware.
+          if (_selectedTool != CanvasTool.eraser) ...[
             const Divider(height: 1),
             _buildColorPicker(context),
             const SizedBox(height: 4),
+            const Divider(height: 1),
+            _buildSizePicker(context),
+          ] else ...[
             const Divider(height: 1),
             _buildSizePicker(context),
           ],
@@ -101,10 +109,20 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   Widget _buildToolSelector(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-      child: Row(
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
         children: [
-          _toolChip(context, Icons.edit, 'Draw', CanvasTool.pen),
-          const SizedBox(width: 8),
+          _toolChip(context, Icons.edit, 'Pen', CanvasTool.pen),
+          _toolChip(context, Icons.brush, 'Highlight', CanvasTool.highlighter),
+          _toolChip(context, Icons.show_chart, 'Line', CanvasTool.line),
+          _toolChip(context, Icons.crop_square, 'Rectangle', CanvasTool.rect),
+          _toolChip(
+            context,
+            Icons.circle_outlined,
+            'Ellipse',
+            CanvasTool.ellipse,
+          ),
           _toolChip(context, Icons.auto_fix_high, 'Erase', CanvasTool.eraser),
         ],
       ),
@@ -631,43 +649,43 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
     CanvasTool tool,
   ) {
     final isSelected = _selectedTool == tool;
-    return Expanded(
-      child: GestureDetector(
-        onTap: () {
-          HapticFeedback.selectionClick();
-          setState(() => _selectedTool = tool);
-          ref.read(canvasProvider.notifier).setTool(tool);
-        },
-        child: Container(
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          decoration: BoxDecoration(
-            color: isSelected
-                ? context.accent.withValues(alpha: 0.12)
-                : Colors.transparent,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: isSelected ? context.accent : context.border,
+    // Wrap-friendly: no Expanded. Width auto-sizes to icon + short label so
+    // 6 tools fit two rows of three on the 280px menu.
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        setState(() => _selectedTool = tool);
+        ref.read(canvasProvider.notifier).setTool(tool);
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? context.accent.withValues(alpha: 0.12)
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: isSelected ? context.accent : context.border,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 16,
+              color: isSelected ? context.accent : context.textSecondary,
             ),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                icon,
-                size: 16,
-                color: isSelected ? context.accent : context.textSecondary,
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: TextStyle(
+                color: isSelected ? context.accent : context.textPrimary,
+                fontSize: 12,
+                fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
               ),
-              const SizedBox(width: 4),
-              Text(
-                label,
-                style: TextStyle(
-                  color: isSelected ? context.accent : context.textPrimary,
-                  fontSize: 12,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -7,6 +7,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../models/canvas_models.dart';
@@ -62,8 +63,6 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
     Colors.pink,
   ];
 
-  static const _penSizes = [2.0, 4.0, 6.0, 10.0, 16.0];
-
   @override
   void initState() {
     super.initState();
@@ -113,129 +112,202 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   }
 
   Widget _buildColorPicker(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-          child: Text(
-            'Color',
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Colour',
             style: TextStyle(
               color: context.textMuted,
               fontSize: 11,
               fontWeight: FontWeight.w600,
             ),
           ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          child: GridView.count(
-            crossAxisCount: 5,
-            mainAxisSpacing: 2,
-            crossAxisSpacing: 2,
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            childAspectRatio: 1.0,
-            children: _penColors.map((c) => _colorSwatch(context, c)).toList(),
+          const SizedBox(height: 6),
+          // Single compact row: 9 quick presets + a custom-colour disk that
+          // opens an HSV picker. Wraps if it doesn't fit (palette grows when
+          // recent custom colours are added).
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              for (final c in _penColors) _colorSwatch(context, c),
+              _customColorTile(context),
+            ],
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
   Widget _colorSwatch(BuildContext context, Color c) {
-    final isSelected = _selectedColor == c;
+    final isSelected = _selectedColor.toARGB32() == c.toARGB32();
     return GestureDetector(
       onTap: () {
         HapticFeedback.selectionClick();
         setState(() => _selectedColor = c);
         ref.read(canvasProvider.notifier).setColor(c);
       },
-      child: SizedBox(
-        width: 44,
-        height: 44,
-        child: Center(
-          child: AnimatedContainer(
-            duration: MotionDurations.quick,
-            width: isSelected ? 24 : 20,
-            height: isSelected ? 24 : 20,
-            decoration: BoxDecoration(
-              color: c,
-              shape: BoxShape.circle,
-              border: Border.all(
-                color: isSelected ? context.accent : context.border,
-                width: isSelected ? 2.5 : 1,
-              ),
-              boxShadow: isSelected
-                  ? [BoxShadow(color: c.withValues(alpha: 0.5), blurRadius: 6)]
-                  : null,
-            ),
+      child: AnimatedContainer(
+        duration: MotionDurations.quick,
+        width: 22,
+        height: 22,
+        decoration: BoxDecoration(
+          color: c,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: isSelected ? context.accent : context.border,
+            width: isSelected ? 2.5 : 1,
           ),
+          boxShadow: isSelected
+              ? [BoxShadow(color: c.withValues(alpha: 0.5), blurRadius: 6)]
+              : null,
         ),
       ),
     );
   }
 
-  Widget _buildSizePicker(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-          child: Text(
-            'Size',
-            style: TextStyle(
-              color: context.textMuted,
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-            ),
+  /// "+" tile that pops an HSV / hex colour picker dialog. The selected
+  /// custom colour is committed to the canvas provider just like any preset.
+  Widget _customColorTile(BuildContext context) {
+    final isCustom = !_penColors.any(
+      (p) => p.toARGB32() == _selectedColor.toARGB32(),
+    );
+    return GestureDetector(
+      onTap: _openCustomColorPicker,
+      child: Container(
+        width: 22,
+        height: 22,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          // Conic gradient hint that this is the "choose anything" tile.
+          gradient: isCustom
+              ? null
+              : const SweepGradient(
+                  colors: [
+                    Colors.red,
+                    Colors.yellow,
+                    Colors.green,
+                    Colors.cyan,
+                    Colors.blue,
+                    Colors.purple,
+                    Colors.red,
+                  ],
+                ),
+          color: isCustom ? _selectedColor : null,
+          border: Border.all(
+            color: isCustom ? context.accent : context.border,
+            width: isCustom ? 2.5 : 1,
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Row(
-            children: _penSizes.map((s) => _sizeChip(context, s)).toList(),
-          ),
-        ),
-      ],
+        child: isCustom
+            ? null
+            : Icon(Icons.add, size: 14, color: context.textPrimary),
+      ),
     );
   }
 
-  Widget _sizeChip(BuildContext context, double s) {
-    final isSelected = _selectedSize == s;
-    return Padding(
-      padding: const EdgeInsets.only(right: 8),
-      child: GestureDetector(
-        onTap: () {
-          HapticFeedback.selectionClick();
-          setState(() => _selectedSize = s);
-          ref.read(canvasProvider.notifier).setStrokeWidth(s);
-        },
-        child: AnimatedContainer(
-          duration: MotionDurations.quick,
-          width: 28,
-          height: 28,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: isSelected
-                ? context.accent.withValues(alpha: 0.12)
-                : Colors.transparent,
-            border: Border.all(
-              color: isSelected ? context.accent : context.border,
-              width: isSelected ? 2 : 1,
-            ),
-          ),
-          child: Center(
-            child: Container(
-              width: s.clamp(4.0, 16.0),
-              height: s.clamp(4.0, 16.0),
-              decoration: BoxDecoration(
-                color: isSelected ? context.accent : context.textPrimary,
-                shape: BoxShape.circle,
-              ),
-            ),
+  Future<void> _openCustomColorPicker() async {
+    HapticFeedback.selectionClick();
+    Color picked = _selectedColor;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: ctx.surface,
+        contentPadding: const EdgeInsets.all(12),
+        content: SingleChildScrollView(
+          child: ColorPicker(
+            pickerColor: _selectedColor,
+            onColorChanged: (c) => picked = c,
+            enableAlpha: false,
+            labelTypes: const [],
+            pickerAreaHeightPercent: 0.65,
+            displayThumbColor: true,
+            paletteType: PaletteType.hsvWithHue,
           ),
         ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Use colour'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    if (confirmed == true) {
+      setState(() => _selectedColor = picked);
+      ref.read(canvasProvider.notifier).setColor(picked);
+    }
+  }
+
+  Widget _buildSizePicker(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Size',
+                style: TextStyle(
+                  color: context.textMuted,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '${_selectedSize.toStringAsFixed(0)} px',
+                style: TextStyle(
+                  color: context.textPrimary,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              // Live preview dot tracks the slider value so users can eyeball
+              // the brush thickness without dragging in mid-air.
+              SizedBox(
+                width: 28,
+                height: 28,
+                child: Center(
+                  child: Container(
+                    width: _selectedSize.clamp(2.0, 24.0),
+                    height: _selectedSize.clamp(2.0, 24.0),
+                    decoration: BoxDecoration(
+                      color: _selectedColor,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Slider(
+                  value: _selectedSize.clamp(1.0, 48.0),
+                  min: 1,
+                  max: 48,
+                  divisions: 47,
+                  onChanged: (v) {
+                    setState(() => _selectedSize = v);
+                    ref.read(canvasProvider.notifier).setStrokeWidth(v);
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
+import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -374,6 +375,9 @@ class _DraggableScreenShareWindowState
                   onEnter: (_) => setState(() => _hovered = true),
                   onExit: (_) => setState(() => _hovered = false),
                   child: GestureDetector(
+                    // Win the arena on pointer-down so InteractiveViewer's
+                    // pan recognizer can't steal a fast drag mid-gesture.
+                    dragStartBehavior: DragStartBehavior.down,
                     onPanUpdate: (d) {
                       setState(() {
                         _left += d.delta.dx;
@@ -461,6 +465,7 @@ class _DraggableScreenShareWindowState
                               right: 0,
                               bottom: 0,
                               child: GestureDetector(
+                                dragStartBehavior: DragStartBehavior.down,
                                 onPanUpdate: (d) {
                                   setState(() {
                                     // Use the larger of dx/dy so the gesture

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:flutter/gestures.dart' show kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -672,37 +673,36 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
           ),
           content: SizedBox(
             width: MediaQuery.sizeOf(dialogCtx).width.clamp(320.0, 440.0),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  'Choose a custom image',
-                  style: TextStyle(
-                    color: dialogCtx.textSecondary,
-                    fontSize: 13,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                FilledButton.icon(
-                  icon: const Icon(Icons.image_outlined),
-                  label: const Text('Browse files'),
-                  onPressed: () {
-                    Navigator.of(dialogCtx).pop();
-                    _pickBackground();
-                  },
-                ),
-                if (hasCustom) ...[
-                  const SizedBox(height: 16),
-                  TextButton.icon(
-                    icon: const Icon(Icons.restore),
-                    label: const Text('Reset to default'),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  FilledButton.icon(
+                    icon: const Icon(Icons.image_outlined),
+                    label: const Text('Custom image'),
                     onPressed: () {
                       Navigator.of(dialogCtx).pop();
-                      _clearBackground();
+                      _pickBackground();
                     },
                   ),
+                  if (hasCustom) ...[
+                    const SizedBox(height: 8),
+                    TextButton.icon(
+                      icon: const Icon(Icons.restore),
+                      label: const Text('Remove image'),
+                      onPressed: () {
+                        Navigator.of(dialogCtx).pop();
+                        _clearBackground();
+                      },
+                    ),
+                  ],
+                  const SizedBox(height: 12),
+                  Divider(height: 1, color: dialogCtx.border),
+                  const SizedBox(height: 12),
+                  const _VertexTunableControls(),
                 ],
-              ],
+              ),
             ),
           ),
           shape: RoundedRectangleBorder(
@@ -715,27 +715,34 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       await showEchoBottomSheet<void>(
         ctx,
         builder: (sheetCtx) {
-          return Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ListTile(
-                leading: const Icon(Icons.image_outlined),
-                title: const Text('Choose voice lounge background'),
-                onTap: () {
-                  Navigator.of(sheetCtx).pop();
-                  _pickBackground();
-                },
-              ),
-              if (hasCustom)
+          return SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
                 ListTile(
-                  leading: const Icon(Icons.restore),
-                  title: const Text('Reset to default'),
+                  leading: const Icon(Icons.image_outlined),
+                  title: const Text('Choose voice lounge background'),
                   onTap: () {
                     Navigator.of(sheetCtx).pop();
-                    _clearBackground();
+                    _pickBackground();
                   },
                 ),
-            ],
+                if (hasCustom)
+                  ListTile(
+                    leading: const Icon(Icons.restore),
+                    title: const Text('Remove image'),
+                    onTap: () {
+                      Navigator.of(sheetCtx).pop();
+                      _clearBackground();
+                    },
+                  ),
+                const Divider(height: 1),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: _VertexTunableControls(),
+                ),
+              ],
+            ),
           );
         },
       );
@@ -749,6 +756,9 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   Widget _buildBackground(BuildContext context) {
     final bg = ref.watch(voiceLoungeBackgroundProvider);
     final path = bg.customBackgroundPath;
+    final vertexColor = bg.vertexColor ?? context.accent;
+    final vertexCount = bg.vertexCount;
+    final connectionDistance = bg.connectionDistance;
     if (customBackgroundFileExists(path)) {
       return Stack(
         fit: StackFit.expand,
@@ -757,8 +767,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
             File(path!),
             fit: BoxFit.cover,
             errorBuilder: (_, _, _) => VertexMeshBackground(
-              accentColor: context.accent,
+              accentColor: vertexColor,
               backgroundColor: context.mainBg,
+              vertexCount: vertexCount,
+              connectionDistance: connectionDistance,
             ),
           ),
           const ColoredBox(color: Color(0x80000000)),
@@ -766,8 +778,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       );
     }
     return VertexMeshBackground(
-      accentColor: context.accent,
+      accentColor: vertexColor,
       backgroundColor: context.mainBg,
+      vertexCount: vertexCount,
+      connectionDistance: connectionDistance,
     );
   }
 
@@ -1210,6 +1224,156 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
           totalParticipants,
         );
       },
+    );
+  }
+}
+
+/// Sliders + colour disk for the built-in vertex-mesh background.
+/// Lives in this file because the parent dialog is owned here; lifting it
+/// to its own file would force exporting private theme accessors.
+class _VertexTunableControls extends ConsumerWidget {
+  const _VertexTunableControls();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bg = ref.watch(voiceLoungeBackgroundProvider);
+    final notifier = ref.read(voiceLoungeBackgroundProvider.notifier);
+    final dotColor = bg.vertexColor ?? context.accent;
+    final isCustomColor = bg.vertexColor != null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Mesh',
+          style: TextStyle(
+            color: context.textSecondary,
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Text(
+              'Dot colour',
+              style: TextStyle(color: context.textPrimary, fontSize: 13),
+            ),
+            const Spacer(),
+            GestureDetector(
+              onTap: () async {
+                Color picked = dotColor;
+                final confirmed = await showDialog<bool>(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    backgroundColor: ctx.surface,
+                    content: SingleChildScrollView(
+                      child: ColorPicker(
+                        pickerColor: dotColor,
+                        onColorChanged: (c) => picked = c,
+                        enableAlpha: false,
+                        labelTypes: const [],
+                        pickerAreaHeightPercent: 0.6,
+                      ),
+                    ),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(ctx).pop(false),
+                        child: const Text('Cancel'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.of(ctx).pop(true),
+                        child: const Text('Use colour'),
+                      ),
+                    ],
+                  ),
+                );
+                if (confirmed == true) {
+                  await notifier.setVertexColor(picked);
+                }
+              },
+              child: Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: dotColor,
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: isCustomColor ? context.accent : context.border,
+                    width: isCustomColor ? 2 : 1,
+                  ),
+                ),
+              ),
+            ),
+            if (isCustomColor)
+              IconButton(
+                tooltip: 'Reset dot colour',
+                icon: Icon(
+                  Icons.refresh,
+                  size: 16,
+                  color: context.textSecondary,
+                ),
+                onPressed: () => notifier.setVertexColor(null),
+              ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Row(
+          children: [
+            Expanded(
+              flex: 2,
+              child: Text(
+                'Density',
+                style: TextStyle(color: context.textPrimary, fontSize: 13),
+              ),
+            ),
+            Expanded(
+              flex: 5,
+              child: Slider(
+                value: bg.vertexCount.toDouble(),
+                min: 10,
+                max: 120,
+                divisions: 22,
+                label: '${bg.vertexCount}',
+                onChanged: (v) => notifier.setVertexCount(v.round()),
+              ),
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            Expanded(
+              flex: 2,
+              child: Text(
+                'Reach',
+                style: TextStyle(color: context.textPrimary, fontSize: 13),
+              ),
+            ),
+            Expanded(
+              flex: 5,
+              child: Slider(
+                value: bg.connectionDistance,
+                min: 40,
+                max: 240,
+                divisions: 20,
+                label: '${bg.connectionDistance.round()}',
+                onChanged: notifier.setConnectionDistance,
+              ),
+            ),
+          ],
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton.icon(
+            icon: Icon(Icons.restore, size: 16, color: context.textSecondary),
+            label: Text(
+              'Reset mesh',
+              style: TextStyle(color: context.textSecondary, fontSize: 12),
+            ),
+            onPressed: notifier.resetVertexDefaults,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/client/lib/src/widgets/vertex_mesh_background.dart
+++ b/apps/client/lib/src/widgets/vertex_mesh_background.dart
@@ -54,6 +54,17 @@ class _VertexMeshBackgroundState extends State<VertexMeshBackground>
   }
 
   @override
+  void didUpdateWidget(VertexMeshBackground oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Tunable changes from the customisation dialog: re-seed the vertex
+    // list so density slider changes are visible without a restart.
+    if (oldWidget.vertexCount != widget.vertexCount && _lastSize != Size.zero) {
+      _initVertices(_lastSize);
+      _repaint.value++;
+    }
+  }
+
+  @override
   void dispose() {
     _ticker.dispose();
     _repaint.dispose();

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -692,6 +692,12 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   CanvasPoint? _localPos;
   bool _hovered = false;
 
+  /// Distance from the ring centre at the start of a resize pan, in local
+  /// (ring-relative) pixels. Used to translate radial pointer motion into
+  /// per-frame scale deltas, so the gesture feels uniform regardless of
+  /// which side of the ring the user grabbed.
+  double? _resizeStartRadius;
+
   /// Buffer of recent positions used to paint the presence trail
   /// (Phase 3a sub-slice 2 of `docs/ux-roadmap.md`).
   final PuckTrail _trail = PuckTrail();
@@ -916,13 +922,18 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
   /// Wraps the avatar tile in a circular click-and-drag resize ring.
   /// When [onResize] is null (callers that don't want resize, e.g. tests)
   /// this is a no-op so the avatar renders unwrapped. On hover the ring
-  /// becomes visible and PanUpdate gestures on its 10 px perimeter drive
-  /// the resize callback — clicks dead-center still pass through to the
-  /// avatar's move-drag wrapper.
+  /// becomes visible. The gesture is radial: pulling the cursor away from
+  /// the avatar centre grows it, pushing toward the centre shrinks it —
+  /// regardless of which side of the ring the user grabbed. Previously
+  /// the code averaged `(dx + dy) / 2` of the per-frame delta, which felt
+  /// inverted on the left and top quadrants of the ring (dragging
+  /// outward in those directions returned negative deltas and shrank
+  /// the avatar).
   Widget _wrapInResizeRing(Widget avatar) {
     if (widget.onResize == null) return avatar;
     const ringThickness = 6.0;
     final ringSize = _effectiveAvatarSize + ringThickness * 2;
+    final ringCenter = Offset(ringSize / 2, ringSize / 2);
     return SizedBox(
       width: ringSize,
       height: ringSize,
@@ -938,8 +949,27 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
             cursor: SystemMouseCursors.resizeUpRightDownLeft,
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
-              onPanUpdate: (d) => widget.onResize!(d.delta.dx, d.delta.dy),
-              onPanEnd: (_) => widget.onResizeEnd?.call(),
+              dragStartBehavior: DragStartBehavior.down,
+              onPanStart: (d) {
+                _resizeStartRadius = (d.localPosition - ringCenter).distance;
+              },
+              onPanUpdate: (d) {
+                final start = _resizeStartRadius;
+                if (start == null || start <= 0) return;
+                final currentRadius = (d.localPosition - ringCenter).distance;
+                // Per-frame radial delta. Positive when the pointer moved
+                // away from centre, negative when toward — true to user
+                // intuition regardless of which quadrant the gesture
+                // started in.
+                final delta = currentRadius - start;
+                _resizeStartRadius = currentRadius;
+                widget.onResize!(delta, delta);
+              },
+              onPanEnd: (_) {
+                _resizeStartRadius = null;
+                widget.onResizeEnd?.call();
+              },
+              onPanCancel: () => _resizeStartRadius = null,
               child: AnimatedContainer(
                 duration: const Duration(milliseconds: 120),
                 width: ringSize,
@@ -1009,6 +1039,11 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
         children: [
           GestureDetector(
             behavior: HitTestBehavior.translucent,
+            // Win the gesture arena on pointer-down (see _CanvasImageWidget
+            // for full rationale). Avatars are smaller targets and a brief
+            // moment of arena-fight with InteractiveViewer can detach them
+            // mid-drag.
+            dragStartBehavior: DragStartBehavior.down,
             onDoubleTap: widget.onDoubleTap,
             onPanUpdate: (details) {
               final s = widget.canvasSize;
@@ -1090,6 +1125,13 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
       onEnter: (_) => setState(() => _hovered = true),
       onExit: (_) => setState(() => _hovered = false),
       child: GestureDetector(
+        // DragStartBehavior.down: the inner image's pan recognizer wins
+        // the gesture arena on pointer-down instead of waiting for
+        // kPanSlop. Without this, a fast drag occasionally lost
+        // arbitration to the parent InteractiveViewer's PanGestureRecognizer
+        // mid-gesture and detached, forcing the user to click and start
+        // the drag over (user-reported 2026-05-27).
+        dragStartBehavior: DragStartBehavior.down,
         onPanUpdate: (d) => widget.onMove(d.delta.dx, d.delta.dy),
         onPanEnd: (_) => widget.onMoveEnd(),
         child: Stack(
@@ -1169,6 +1211,7 @@ class _CanvasImageWidgetState extends State<_CanvasImageWidget> {
                 child: MouseRegion(
                   cursor: SystemMouseCursors.resizeDownRight,
                   child: GestureDetector(
+                    dragStartBehavior: DragStartBehavior.down,
                     onPanUpdate: (d) => widget.onResize(d.delta.dx, d.delta.dy),
                     onPanEnd: (_) => widget.onResizeEnd(),
                     child: Container(

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -141,24 +141,21 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
                         child: _DrawingLayer(
                           canvas: canvas,
                           onPointerDown: (offset) {
-                            if (tool == CanvasTool.pen ||
-                                tool == CanvasTool.eraser) {
+                            if (isDrawingTool(tool)) {
                               ref
                                   .read(canvasProvider.notifier)
                                   .startStroke(_toNormalized(offset));
                             }
                           },
                           onPointerMove: (offset) {
-                            if (tool == CanvasTool.pen ||
-                                tool == CanvasTool.eraser) {
+                            if (isDrawingTool(tool)) {
                               ref
                                   .read(canvasProvider.notifier)
                                   .continueStroke(_toNormalized(offset));
                             }
                           },
                           onPointerUp: () {
-                            if (tool == CanvasTool.pen ||
-                                tool == CanvasTool.eraser) {
+                            if (isDrawingTool(tool)) {
                               ref.read(canvasProvider.notifier).endStroke();
                             }
                           },
@@ -536,13 +533,14 @@ class _CanvasPainter extends CustomPainter {
 
     if (canvas.activePoints.isNotEmpty) {
       final tool = canvas.selectedTool;
-      final isEraser = tool == CanvasTool.eraser;
+      final kind = strokeKindForTool(tool);
+      final isEraser = kind == StrokeKind.eraser;
       final activeStroke = CanvasStroke(
         id: '__active__',
         color: isEraser ? '#000000' : colorToHex(canvas.currentColor),
         width: isEraser ? canvas.strokeWidth * 3 : canvas.strokeWidth,
         points: canvas.activePoints,
-        kind: isEraser ? StrokeKind.eraser : StrokeKind.pen,
+        kind: kind,
       );
       _paintStroke(c, size, activeStroke);
     }
@@ -563,6 +561,13 @@ class _CanvasPainter extends CustomPainter {
       paint
         ..blendMode = BlendMode.clear
         ..color = const Color(0x00000000);
+    } else if (stroke.kind == StrokeKind.highlighter) {
+      // Translucent + multiply blend: stacks underneath dark UI without
+      // washing out the canvas, and double-passes deepen the colour the
+      // way a real highlighter does.
+      paint
+        ..blendMode = BlendMode.srcOver
+        ..color = _parseColor(stroke.color).withValues(alpha: 0.35);
     } else {
       paint
         ..blendMode = BlendMode.srcOver
@@ -571,13 +576,34 @@ class _CanvasPainter extends CustomPainter {
 
     final first = stroke.points.first;
 
-    if (stroke.points.length == 1) {
+    // Single-point freehand stroke: a dot.
+    if (stroke.points.length == 1 && !isShapeKind(stroke.kind)) {
       c.drawCircle(
         Offset(first.x * size.width, first.y * size.height),
         stroke.width / 2,
         paint..style = PaintingStyle.fill,
       );
       return;
+    }
+
+    // Two-point shape kinds — straight geometry from first to last.
+    if (isShapeKind(stroke.kind) && stroke.points.length >= 2) {
+      final last = stroke.points.last;
+      final p1 = Offset(first.x * size.width, first.y * size.height);
+      final p2 = Offset(last.x * size.width, last.y * size.height);
+      switch (stroke.kind) {
+        case StrokeKind.line:
+          c.drawLine(p1, p2, paint);
+          return;
+        case StrokeKind.rect:
+          c.drawRect(Rect.fromPoints(p1, p2), paint);
+          return;
+        case StrokeKind.ellipse:
+          c.drawOval(Rect.fromPoints(p1, p2), paint);
+          return;
+        default:
+          break;
+      }
     }
 
     final path = Path();

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -115,6 +115,50 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
     return Offset(norm.x * size.width, norm.y * size.height);
   }
 
+  /// Opens a small text-entry dialog and commits the result as a text label
+  /// at [anchor]. Returns immediately when the canvas isn't usable (no
+  /// channel id yet) so the user doesn't see a no-op dialog.
+  Future<void> _promptTextLabel(CanvasPoint anchor) async {
+    final controller = TextEditingController();
+    final canvas = ref.read(canvasProvider);
+    // Cache the values so the closure doesn't re-read provider mid-dialog.
+    final fontSize = canvas.strokeWidth.clamp(10.0, 64.0);
+    final color = canvas.currentColor;
+    final committed = await showDialog<String?>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Add text'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          maxLength: 200,
+          decoration: const InputDecoration(hintText: 'Type a label…'),
+          onSubmitted: (v) => Navigator.of(ctx).pop(v),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(null),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(controller.text),
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (committed == null || committed.trim().isEmpty) return;
+    ref
+        .read(canvasProvider.notifier)
+        .addTextLabel(
+          anchor: anchor,
+          text: committed,
+          fontSize: fontSize,
+          color: color,
+        );
+  }
+
   @override
   Widget build(BuildContext context) {
     final canvas = ref.watch(canvasProvider);
@@ -145,6 +189,8 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
                               ref
                                   .read(canvasProvider.notifier)
                                   .startStroke(_toNormalized(offset));
+                            } else if (tool == CanvasTool.text) {
+                              _promptTextLabel(_toNormalized(offset));
                             }
                           },
                           onPointerMove: (offset) {
@@ -550,6 +596,29 @@ class _CanvasPainter extends CustomPainter {
 
   void _paintStroke(Canvas c, Size size, CanvasStroke stroke) {
     if (stroke.points.isEmpty) return;
+
+    // Text label: render its content at the anchor and bail out before
+    // freehand-stroke logic gets a chance to draw a stray dot.
+    if (stroke.kind == StrokeKind.text) {
+      final label = stroke.text;
+      if (label == null || label.isEmpty) return;
+      final anchor = stroke.points.first;
+      final tp = TextPainter(
+        text: TextSpan(
+          text: label,
+          style: TextStyle(
+            color: _parseColor(stroke.color),
+            fontSize: stroke.width,
+            fontWeight: FontWeight.w500,
+            shadows: const [Shadow(color: Color(0xAA000000), blurRadius: 2)],
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+        textAlign: TextAlign.left,
+      )..layout(maxWidth: size.width);
+      tp.paint(c, Offset(anchor.x * size.width, anchor.y * size.height));
+      return;
+    }
 
     final paint = Paint()
       ..strokeCap = StrokeCap.round


### PR DESCRIPTION
Finishes the remaining 5 items from the canvas polish batch. All on `dev`, opened against `main` as one PR per request.

## Commits

| Commit | What |
|--------|------|
| `a8f672f1` | **#113 drag/resize feel** — avatar resize ring now tracks radial pointer distance instead of averaging `(dx+dy)/2`. Pull-away grows; push-toward shrinks, regardless of which quadrant you grabbed. Image / avatar / screen-share gesture detectors now use `DragStartBehavior.down` so fast drags don't lose arbitration to `InteractiveViewer` mid-gesture. |
| `7ca00526` | **#108 compact colour + size** — palette is now a single wrap-row of 9 presets + a `+` tile that opens a full HSV / hex picker (uses the existing `flutter_colorpicker` dep). Size chips replaced with a 1–48 px slider that shows live numeric readout + brush preview. |
| `74453f92` | **#111 mesh background tunables** — new `Mesh` section in the background customisation dialog (desktop) and bottom sheet (mobile): dot colour (picker), density (10–120 nodes), reach (40–240 px). All persisted in `SharedPreferences`; `Reset mesh` clears to defaults. `VertexMeshBackground` re-seeds on `vertexCount` change so density updates are live. |
| `5309141e` | **#110 highlighter + shape tools** — `StrokeKind` and `CanvasTool` enums extended with `highlighter` (translucent thick pen, α 0.35), `line`, `rect`, `ellipse`. Shapes record only `[first, last]` so the painter renders straight geometry and the WS partial-stroke channel skips intermediate samples. Tool selector is now a 7-chip wrap row. |
| `94548934` | **#109 text tool** — new `CanvasTool.text` + `StrokeKind.text` (the text content piggybacks on the existing strokes JSONB via an optional `text` field on `CanvasStroke` — **no server schema change**). Selecting Text + tapping the canvas opens an inline `Add text` dialog; on submit the label commits at the tap anchor and broadcasts via the existing `stroke` WS event. Painter renders text labels via `TextPainter` with the current colour, font size from the size slider (clamped 10–64 pt), and a 2 px black drop shadow for legibility on busy backgrounds. |

## Validation

- `flutter analyze --fatal-infos` clean (full client)
- `flutter test` — **2316 / 2316 passing**, 9 intentionally skipped (matches main baseline)
- `cargo test -p echo-server --lib` clean (server integration tests need TEST_DATABASE_URL and only run under CI)
- 62/62 canvas + lounge widget tests pass

## Test plan (manual)

- [ ] Pen still draws as before — no regression in freehand
- [ ] Highlighter draws translucent thick stroke
- [ ] Line / Rectangle / Ellipse: drag from one corner to the other; release commits the shape
- [ ] Text: tap on empty canvas → dialog appears → type label → label renders at tap location and remote participants see it
- [ ] Size slider: live preview dot tracks slider, brush thickness matches
- [ ] Custom colour: `+` tile opens HSV picker; selected colour persists across reopening menu
- [ ] Mesh background dialog: density slider visibly changes node count immediately; reach slider tightens / loosens connection lines; reset button returns to theme defaults
- [ ] Avatar resize: pulling away from centre grows, pushing toward shrinks — works on all four quadrants
- [ ] Image / screen-share fast drag: rapid mouse motion doesn't detach the drag mid-gesture