### PR TITLE
fix: shared 4k voice canvas — geometry, gesture, sync, persistence

### DIFF
--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -249,6 +249,82 @@ class AvatarPosition {
 }
 
 // ---------------------------------------------------------------------------
+// Screen-share window positions
+// ---------------------------------------------------------------------------
+
+/// Position + size of a draggable screen-share window on the canvas.
+///
+/// Coordinates and dimensions are in **CSS pixels** relative to the
+/// lounge viewport's top-left (NOT normalized [0, 1] like
+/// [AvatarPosition]). The window has its own intrinsic aspect ratio so
+/// scaling it by canvas size would distort the underlying video; clients
+/// agree on raw pixel coordinates instead and rely on the canvas size
+/// being roughly consistent across participants.
+///
+/// [windowId] is a stable per-stream identifier — for remote screen
+/// shares it's `screenshare-{participantSid}` and for the host's own
+/// preview it's `screenshare-local`. Broadcast over WebSocket as the
+/// `screenshare_move` event; ephemeral (never persisted server-side).
+class ScreenShareWindow {
+  final String windowId;
+  final double x;
+  final double y;
+  final double width;
+  final double height;
+
+  const ScreenShareWindow({
+    required this.windowId,
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+  });
+
+  factory ScreenShareWindow.fromJson(Map<String, dynamic> json) =>
+      ScreenShareWindow(
+        windowId: json['window_id'] as String,
+        x: (json['x'] as num).toDouble(),
+        y: (json['y'] as num).toDouble(),
+        width: (json['width'] as num).toDouble(),
+        height: (json['height'] as num).toDouble(),
+      );
+
+  Map<String, dynamic> toJson() => {
+    'window_id': windowId,
+    'x': x,
+    'y': y,
+    'width': width,
+    'height': height,
+  };
+
+  ScreenShareWindow copyWith({
+    double? x,
+    double? y,
+    double? width,
+    double? height,
+  }) => ScreenShareWindow(
+    windowId: windowId,
+    x: x ?? this.x,
+    y: y ?? this.y,
+    width: width ?? this.width,
+    height: height ?? this.height,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ScreenShareWindow &&
+          windowId == other.windowId &&
+          x == other.x &&
+          y == other.y &&
+          width == other.width &&
+          height == other.height);
+
+  @override
+  int get hashCode => Object.hash(windowId, x, y, width, height);
+}
+
+// ---------------------------------------------------------------------------
 // Drawing tools
 // ---------------------------------------------------------------------------
 
@@ -302,6 +378,13 @@ class CanvasState {
   /// Keyed by userId (string).  Not persisted — reset when user rejoins.
   final Map<String, AvatarPosition> avatarPositions;
 
+  /// Screen-share window positions, keyed by `windowId` (e.g.
+  /// `screenshare-{participantSid}` for remote shares, `screenshare-local`
+  /// for the host's own preview). Like [avatarPositions], these are
+  /// ephemeral — broadcast over the `screenshare_move` WS event and
+  /// never persisted server-side.
+  final Map<String, ScreenShareWindow> screenSharePositions;
+
   /// Points being accumulated for the currently-in-progress stroke.
   /// Cleared and appended to [strokes] on pointer-up.
   final List<CanvasPoint> activePoints;
@@ -317,6 +400,7 @@ class CanvasState {
     this.strokes = const [],
     this.images = const [],
     this.avatarPositions = const {},
+    this.screenSharePositions = const {},
     this.activePoints = const [],
     this.selectedTool = CanvasTool.none,
     this.currentColor = const Color(0xFFFFFFFF),
@@ -331,6 +415,7 @@ class CanvasState {
     List<CanvasStroke>? strokes,
     List<CanvasImage>? images,
     Map<String, AvatarPosition>? avatarPositions,
+    Map<String, ScreenShareWindow>? screenSharePositions,
     List<CanvasPoint>? activePoints,
     CanvasTool? selectedTool,
     Color? currentColor,
@@ -340,6 +425,7 @@ class CanvasState {
     strokes: strokes ?? this.strokes,
     images: images ?? this.images,
     avatarPositions: avatarPositions ?? this.avatarPositions,
+    screenSharePositions: screenSharePositions ?? this.screenSharePositions,
     activePoints: activePoints ?? this.activePoints,
     selectedTool: selectedTool ?? this.selectedTool,
     currentColor: currentColor ?? this.currentColor,

--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -4,9 +4,32 @@ import 'dart:ui' show Color;
 // Canvas geometry helpers
 // ---------------------------------------------------------------------------
 
-/// A 2-D point with coordinates normalized to the range [0, 1] relative to
-/// the canvas size.  Normalization ensures the layout transfers correctly
-/// between participants using different screen sizes.
+/// Fixed virtual canvas size shared by every participant regardless of their
+/// screen size or orientation. The InteractiveViewer in the voice lounge
+/// scrolls + zooms inside this 4096×4096 logical surface so a circle drawn
+/// on a phone reads as a circle on a desktop. See
+/// `apps/client/lib/src/screens/voice_lounge_screen.dart` for the
+/// viewport-fit math (minScale = min(viewportW, viewportH) / kCanvasWidth).
+const double kCanvasWidth = 4096;
+const double kCanvasHeight = 4096;
+
+/// Migrates legacy [0, 1] normalized coordinates persisted before the fixed
+/// 4096-px space landed. The heuristic is "value ≤ 1.0 means legacy
+/// normalized" — safe because the new pixel range starts at 0 and crosses 1
+/// instantly (4096 / 4096 ≈ 1.0 is at the bottom-right corner; any other
+/// real-world stroke point is far above 1.0). Without this old persisted
+/// canvases would collapse into the top-left pixel after upgrade.
+double _migrateLegacyCoord(double value, double axisExtent) {
+  if (value <= 1.0) return value * axisExtent;
+  return value;
+}
+
+/// A 2-D point in absolute pixels within the fixed [kCanvasWidth] ×
+/// [kCanvasHeight] virtual canvas. Storing absolute coordinates (instead of
+/// the legacy 0..1 normalized scheme) means a stroke drawn on a 420×900
+/// phone lays down the same circle a 1920×1080 desktop sees, because every
+/// participant shares the same 4096-px coordinate space — only the viewport
+/// (zoom + pan) differs.
 class CanvasPoint {
   final double x;
   final double y;
@@ -14,8 +37,8 @@ class CanvasPoint {
   const CanvasPoint({required this.x, required this.y});
 
   factory CanvasPoint.fromJson(Map<String, dynamic> json) => CanvasPoint(
-    x: (json['x'] as num).toDouble(),
-    y: (json['y'] as num).toDouble(),
+    x: _migrateLegacyCoord((json['x'] as num).toDouble(), kCanvasWidth),
+    y: _migrateLegacyCoord((json['y'] as num).toDouble(), kCanvasHeight),
   );
 
   Map<String, dynamic> toJson() => {'x': x, 'y': y};
@@ -162,15 +185,17 @@ class CanvasStroke {
 
 /// An image pinned to the canvas (pasted from clipboard or drag-dropped).
 ///
-/// All coordinates and dimensions are normalized [0, 1] relative to the
-/// canvas size so they display correctly on every screen resolution.
+/// All coordinates and dimensions are absolute pixels inside the
+/// [kCanvasWidth] × [kCanvasHeight] virtual canvas. Legacy 0..1 values
+/// persisted before the fixed-size canvas migration are auto-rescaled in
+/// [CanvasImage.fromJson].
 class CanvasImage {
   final String id;
   final String url; // absolute URL served via /api/media/{id}
-  final double x; // normalized left edge
-  final double y; // normalized top edge
-  final double width; // normalized width (fraction of canvas width)
-  final double height; // normalized height (fraction of canvas height)
+  final double x; // pixel left edge in the 4096-px space
+  final double y; // pixel top edge in the 4096-px space
+  final double width; // pixel width in the 4096-px space
+  final double height; // pixel height in the 4096-px space
 
   const CanvasImage({
     required this.id,
@@ -184,10 +209,13 @@ class CanvasImage {
   factory CanvasImage.fromJson(Map<String, dynamic> json) => CanvasImage(
     id: json['id'] as String,
     url: json['url'] as String,
-    x: (json['x'] as num).toDouble(),
-    y: (json['y'] as num).toDouble(),
-    width: (json['width'] as num).toDouble(),
-    height: (json['height'] as num).toDouble(),
+    x: _migrateLegacyCoord((json['x'] as num).toDouble(), kCanvasWidth),
+    y: _migrateLegacyCoord((json['y'] as num).toDouble(), kCanvasHeight),
+    width: _migrateLegacyCoord((json['width'] as num).toDouble(), kCanvasWidth),
+    height: _migrateLegacyCoord(
+      (json['height'] as num).toDouble(),
+      kCanvasHeight,
+    ),
   );
 
   Map<String, dynamic> toJson() => {
@@ -216,8 +244,9 @@ class CanvasImage {
 
 /// A participant's current position on the canvas.
 ///
-/// Coordinates are normalized [0, 1].  The local user's own position is
-/// tracked separately and broadcast via WebSocket on drag-end.
+/// Coordinates are absolute pixels in the [kCanvasWidth] × [kCanvasHeight]
+/// virtual space. The local user's own position is tracked separately and
+/// broadcast via WebSocket on drag-end.
 class AvatarPosition {
   final String userId;
   final double x;

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -23,6 +23,12 @@ class CanvasController extends _$CanvasController {
   /// The channel this canvas is attached to.
   String? _channelId;
 
+  /// The channel currently being attached (set BEFORE the REST fetch
+  /// completes). Used by [handleCanvasEvent] to recognise inbound events
+  /// for the right channel and buffer them while the snapshot is loading
+  /// so they aren't wiped when the fetch result overwrites state.
+  String? _attachingChannelId;
+
   /// Throttle timer for avatar position broadcasts (~20 fps).
   Timer? _avatarThrottle;
   ({String userId, CanvasPoint pos})? _pendingAvatar;
@@ -53,14 +59,34 @@ class CanvasController extends _$CanvasController {
   // -------------------------------------------------------------------------
 
   /// Load the persisted canvas state from the server and set up WS listener.
+  ///
+  /// Race-safe load order:
+  ///  1. Mark the channel as "attaching" so [handleCanvasEvent] buffers any
+  ///     inbound canvas events for it instead of mutating state directly.
+  ///  2. Reset state.
+  ///  3. Await the REST snapshot fetch — this populates strokes/images from
+  ///     the server's persisted truth.
+  ///  4. Promote `_attachingChannelId` to `_channelId` AFTER the fetch result
+  ///     has been written to state, so the fetched snapshot can't be
+  ///     overwritten by WS events that landed mid-fetch.
+  ///  5. Replay buffered events (typically a no-op, but covers the case where
+  ///     a peer drew while we were fetching).
   Future<void> attach(String conversationId, String channelId) async {
     if (_channelId == channelId) return; // already attached
-    _channelId = channelId;
+    _attachingChannelId = channelId;
+    _channelId = null;
+    _pendingEvents.clear();
     state = const CanvasState(); // reset while loading
 
     await _fetchCanvas(conversationId, channelId);
 
-    // Flush any canvas events that arrived before _channelId was set.
+    // Only promote to "attached" if we're still attaching to this channel —
+    // a second attach() to a different channel may have superseded us.
+    if (_attachingChannelId != channelId) return;
+    _channelId = channelId;
+    _attachingChannelId = null;
+
+    // Flush any canvas events that landed during the fetch.
     final buffered = List<Map<String, dynamic>>.from(_pendingEvents);
     _pendingEvents.clear();
     for (final event in buffered) {
@@ -81,6 +107,7 @@ class CanvasController extends _$CanvasController {
     _pendingStrokePoints = null;
     _pendingEvents.clear();
     _channelId = null;
+    _attachingChannelId = null;
     state = const CanvasState();
   }
 
@@ -569,8 +596,15 @@ class CanvasController extends _$CanvasController {
     final channelId = json['channel_id'] as String?;
     // Buffer events that arrive before attach() has set _channelId.  They
     // will be replayed once attach() completes and _channelId is known.
+    // Also buffer events that arrive WHILE attach()'s REST snapshot is
+    // in flight for this channel — applying them mid-fetch is unsafe
+    // because the fetch result will overwrite state and discard the
+    // WS-derived stroke (regression: late joiners drawing during another
+    // peer's fetch would vanish on the late-joiner's side).
     if (_channelId == null) {
-      _pendingEvents.add(json);
+      if (_attachingChannelId == null || channelId == _attachingChannelId) {
+        _pendingEvents.add(json);
+      }
       return;
     }
     if (channelId != _channelId) return; // event for a different channel

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -23,6 +23,12 @@ class CanvasController extends _$CanvasController {
   /// The channel this canvas is attached to.
   String? _channelId;
 
+  /// The channel currently being attached (set BEFORE the REST fetch
+  /// completes). Used by [handleCanvasEvent] to recognise inbound events
+  /// for the right channel and buffer them while the snapshot is loading
+  /// so they aren't wiped when the fetch result overwrites state.
+  String? _attachingChannelId;
+
   /// Throttle timer for avatar position broadcasts (~20 fps).
   Timer? _avatarThrottle;
   ({String userId, CanvasPoint pos})? _pendingAvatar;
@@ -53,14 +59,34 @@ class CanvasController extends _$CanvasController {
   // -------------------------------------------------------------------------
 
   /// Load the persisted canvas state from the server and set up WS listener.
+  ///
+  /// Race-safe load order:
+  ///  1. Mark the channel as "attaching" so [handleCanvasEvent] buffers any
+  ///     inbound canvas events for it instead of mutating state directly.
+  ///  2. Reset state.
+  ///  3. Await the REST snapshot fetch — this populates strokes/images from
+  ///     the server's persisted truth.
+  ///  4. Promote `_attachingChannelId` to `_channelId` AFTER the fetch result
+  ///     has been written to state, so the fetched snapshot can't be
+  ///     overwritten by WS events that landed mid-fetch.
+  ///  5. Replay buffered events (typically a no-op, but covers the case where
+  ///     a peer drew while we were fetching).
   Future<void> attach(String conversationId, String channelId) async {
     if (_channelId == channelId) return; // already attached
-    _channelId = channelId;
+    _attachingChannelId = channelId;
+    _channelId = null;
+    _pendingEvents.clear();
     state = const CanvasState(); // reset while loading
 
     await _fetchCanvas(conversationId, channelId);
 
-    // Flush any canvas events that arrived before _channelId was set.
+    // Only promote to "attached" if we're still attaching to this channel —
+    // a second attach() to a different channel may have superseded us.
+    if (_attachingChannelId != channelId) return;
+    _channelId = channelId;
+    _attachingChannelId = null;
+
+    // Flush any canvas events that landed during the fetch.
     final buffered = List<Map<String, dynamic>>.from(_pendingEvents);
     _pendingEvents.clear();
     for (final event in buffered) {
@@ -81,6 +107,7 @@ class CanvasController extends _$CanvasController {
     _pendingStrokePoints = null;
     _pendingEvents.clear();
     _channelId = null;
+    _attachingChannelId = null;
     state = const CanvasState();
   }
 
@@ -413,8 +440,10 @@ class CanvasController extends _$CanvasController {
     if (_channelId == null) return;
     final idx = state.images.indexWhere((img) => img.id == imageId);
     if (idx == -1) return;
-    final clampedW = width.clamp(0.05, 1.0);
-    final clampedH = height.clamp(0.05, 1.0);
+    // Min 32 px so images never shrink below a usable thumbnail; max is the
+    // full canvas extent so callers don't need to clamp upstream.
+    final clampedW = width.clamp(32.0, kCanvasWidth);
+    final clampedH = height.clamp(32.0, kCanvasHeight);
     final updated = state.images[idx].copyWith(
       width: clampedW,
       height: clampedH,
@@ -495,7 +524,7 @@ class CanvasController extends _$CanvasController {
     final existing = state.avatarPositions[userId];
     final pos = existing != null
         ? CanvasPoint(x: existing.x, y: existing.y)
-        : const CanvasPoint(x: 0.5, y: 0.5);
+        : const CanvasPoint(x: kCanvasWidth / 2, y: kCanvasHeight / 2);
     final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
     updated[userId] = AvatarPosition(
       userId: userId,
@@ -569,8 +598,15 @@ class CanvasController extends _$CanvasController {
     final channelId = json['channel_id'] as String?;
     // Buffer events that arrive before attach() has set _channelId.  They
     // will be replayed once attach() completes and _channelId is known.
+    // Also buffer events that arrive WHILE attach()'s REST snapshot is
+    // in flight for this channel — applying them mid-fetch is unsafe
+    // because the fetch result will overwrite state and discard the
+    // WS-derived stroke (regression: late joiners drawing during another
+    // peer's fetch would vanish on the late-joiner's side).
     if (_channelId == null) {
-      _pendingEvents.add(json);
+      if (_attachingChannelId == null || channelId == _attachingChannelId) {
+        _pendingEvents.add(json);
+      }
       return;
     }
     if (channelId != _channelId) return; // event for a different channel
@@ -654,8 +690,14 @@ class CanvasController extends _$CanvasController {
           state = state.copyWith(images: newImages);
         }
       case 'avatar_move':
-        final x = (payload['x'] as num?)?.toDouble() ?? 0.5;
-        final y = (payload['y'] as num?)?.toDouble() ?? 0.5;
+        // Legacy clients sent 0..1 normalized; new wire uses canvas-space
+        // pixels. _migrateLegacyCoord at the model layer covers fromJson,
+        // but the avatar_move payload is unpacked manually here so we
+        // rescale inline using the same heuristic (value ≤ 1.0 = legacy).
+        final rawX = (payload['x'] as num?)?.toDouble() ?? kCanvasWidth / 2;
+        final rawY = (payload['y'] as num?)?.toDouble() ?? kCanvasHeight / 2;
+        final x = rawX <= 1.0 ? rawX * kCanvasWidth : rawX;
+        final y = rawY <= 1.0 ? rawY * kCanvasHeight : rawY;
         // Older clients won't send `scale`; preserve the prior value (or
         // default to 1.0) so a move from an old build doesn't reset the
         // size that a newer participant just resized.
@@ -668,8 +710,8 @@ class CanvasController extends _$CanvasController {
         final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
         updated[fromUserId] = AvatarPosition(
           userId: fromUserId,
-          x: x.clamp(0.0, 1.0),
-          y: y.clamp(0.0, 1.0),
+          x: x.clamp(0.0, kCanvasWidth),
+          y: y.clamp(0.0, kCanvasHeight),
           scale: scale,
         );
         state = state.copyWith(avatarPositions: updated);

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -44,6 +44,7 @@ class CanvasController extends _$CanvasController {
       _avatarThrottle?.cancel();
       _imageThrottle?.cancel();
       _strokeThrottle?.cancel();
+      _screenShareThrottle?.cancel();
     });
     return const CanvasState();
   }
@@ -79,6 +80,9 @@ class CanvasController extends _$CanvasController {
     _strokeThrottle?.cancel();
     _strokeThrottle = null;
     _pendingStrokePoints = null;
+    _screenShareThrottle?.cancel();
+    _screenShareThrottle = null;
+    _pendingScreenShare = null;
     _pendingEvents.clear();
     _channelId = null;
     state = const CanvasState();
@@ -445,10 +449,14 @@ class CanvasController extends _$CanvasController {
   // Avatars
   // -------------------------------------------------------------------------
 
-  /// Called while the user is dragging their avatar.  Updates local state
-  /// immediately and queues a throttled WS broadcast. The current scale is
-  /// preserved.
-  void moveLocalAvatar(String userId, CanvasPoint pos) {
+  /// Called while a user is dragging an avatar — either their own or
+  /// somebody else's. Updates local state immediately and queues a
+  /// throttled WS broadcast. The current scale is preserved.
+  ///
+  /// The voice-lounge canvas is a shared whiteboard: any participant
+  /// can move any avatar, and the broadcast carries the *target*
+  /// `userId` in the payload so receivers update the right entry.
+  void moveAvatar(String userId, CanvasPoint pos) {
     final existing = state.avatarPositions[userId];
     final scale = existing?.scale ?? 1.0;
     final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
@@ -466,6 +474,14 @@ class CanvasController extends _$CanvasController {
       (_) => _flushAvatarMove(),
     );
   }
+
+  /// Back-compat alias for [moveAvatar]. The "Local" in the name is
+  /// historical — early builds only let you move your own avatar, but
+  /// the shared-whiteboard model now lets anyone move anyone. Kept as a
+  /// thin alias so older call sites in flight during the rename still
+  /// compile; new code should call [moveAvatar].
+  void moveLocalAvatar(String userId, CanvasPoint pos) =>
+      moveAvatar(userId, pos);
 
   void _flushAvatarMove() {
     final pending = _pendingAvatar;
@@ -529,8 +545,9 @@ class CanvasController extends _$CanvasController {
     });
   }
 
-  /// Called when the user stops dragging (send final position immediately).
-  void commitLocalAvatarMove(String userId, CanvasPoint pos) {
+  /// Called when the user stops dragging an avatar (any avatar, theirs
+  /// or someone else's). Sends the final position immediately.
+  void commitAvatarMove(String userId, CanvasPoint pos) {
     _avatarThrottle?.cancel();
     _avatarThrottle = null;
     _pendingAvatar = null;
@@ -551,6 +568,92 @@ class CanvasController extends _$CanvasController {
       'y': pos.y,
       'scale': scale,
     });
+  }
+
+  /// Back-compat alias for [commitAvatarMove]; see [moveLocalAvatar].
+  void commitLocalAvatarMove(String userId, CanvasPoint pos) =>
+      commitAvatarMove(userId, pos);
+
+  // -------------------------------------------------------------------------
+  // Screen-share window positions
+  //
+  // Like avatar moves these are ephemeral — the server relays but does not
+  // persist them. The `screenshare_move` event mirrors `avatar_move` in
+  // shape (window_id, x, y, width, height) so the same throttle/commit
+  // pattern applies, and clients agree on raw CSS pixels (NOT normalized)
+  // since the window has its own intrinsic aspect ratio.
+  // -------------------------------------------------------------------------
+
+  /// Throttle timer for screen-share window broadcasts (~20 fps).
+  Timer? _screenShareThrottle;
+  ScreenShareWindow? _pendingScreenShare;
+
+  /// Called while the user drags a screen-share window. Updates local
+  /// state immediately and queues a throttled WS broadcast.
+  void moveScreenShare({
+    required String windowId,
+    required double x,
+    required double y,
+    required double width,
+    required double height,
+  }) {
+    final updated = Map<String, ScreenShareWindow>.from(
+      state.screenSharePositions,
+    );
+    final window = ScreenShareWindow(
+      windowId: windowId,
+      x: x,
+      y: y,
+      width: width,
+      height: height,
+    );
+    updated[windowId] = window;
+    state = state.copyWith(screenSharePositions: updated);
+
+    _pendingScreenShare = window;
+    _screenShareThrottle ??= Timer.periodic(
+      const Duration(milliseconds: 50),
+      (_) => _flushScreenShareMove(),
+    );
+  }
+
+  void _flushScreenShareMove() {
+    final pending = _pendingScreenShare;
+    if (pending == null) {
+      _screenShareThrottle?.cancel();
+      _screenShareThrottle = null;
+      return;
+    }
+    _pendingScreenShare = null;
+    _sendCanvasEvent('screenshare_move', pending.toJson());
+  }
+
+  /// Called when the user releases a screen-share window drag/resize —
+  /// flushes the pending broadcast immediately.
+  void commitScreenShareMove({
+    required String windowId,
+    required double x,
+    required double y,
+    required double width,
+    required double height,
+  }) {
+    _screenShareThrottle?.cancel();
+    _screenShareThrottle = null;
+    _pendingScreenShare = null;
+
+    final window = ScreenShareWindow(
+      windowId: windowId,
+      x: x,
+      y: y,
+      width: width,
+      height: height,
+    );
+    final updated = Map<String, ScreenShareWindow>.from(
+      state.screenSharePositions,
+    );
+    updated[windowId] = window;
+    state = state.copyWith(screenSharePositions: updated);
+    _sendCanvasEvent('screenshare_move', window.toJson());
   }
 
   // -------------------------------------------------------------------------
@@ -654,25 +757,55 @@ class CanvasController extends _$CanvasController {
           state = state.copyWith(images: newImages);
         }
       case 'avatar_move':
+        // Shared-whiteboard semantics: the *target* user id is carried in
+        // the payload, not derived from the sender. Older clients only
+        // ever moved their own avatar and sent `user_id == from_user_id`,
+        // so falling back to `fromUserId` keeps them compatible.
+        final targetUserId = (payload['user_id'] as String?) ?? fromUserId;
+        if (targetUserId.isEmpty) return;
         final x = (payload['x'] as num?)?.toDouble() ?? 0.5;
         final y = (payload['y'] as num?)?.toDouble() ?? 0.5;
         // Older clients won't send `scale`; preserve the prior value (or
         // default to 1.0) so a move from an old build doesn't reset the
         // size that a newer participant just resized.
-        final existing = state.avatarPositions[fromUserId];
+        final existing = state.avatarPositions[targetUserId];
         final rawScale = (payload['scale'] as num?)?.toDouble();
         final scale = (rawScale ?? existing?.scale ?? 1.0).clamp(
           AvatarPosition.minScale,
           AvatarPosition.maxScale,
         );
         final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
-        updated[fromUserId] = AvatarPosition(
-          userId: fromUserId,
+        updated[targetUserId] = AvatarPosition(
+          userId: targetUserId,
           x: x.clamp(0.0, 1.0),
           y: y.clamp(0.0, 1.0),
           scale: scale,
         );
         state = state.copyWith(avatarPositions: updated);
+      case 'screenshare_move':
+        final windowId = payload['window_id'] as String?;
+        if (windowId == null || windowId.isEmpty) return;
+        final x = (payload['x'] as num?)?.toDouble();
+        final y = (payload['y'] as num?)?.toDouble();
+        if (x == null || y == null) return;
+        final existing = state.screenSharePositions[windowId];
+        final w =
+            (payload['width'] as num?)?.toDouble() ?? existing?.width ?? 320.0;
+        final h =
+            (payload['height'] as num?)?.toDouble() ??
+            existing?.height ??
+            180.0;
+        final updated = Map<String, ScreenShareWindow>.from(
+          state.screenSharePositions,
+        );
+        updated[windowId] = ScreenShareWindow(
+          windowId: windowId,
+          x: x,
+          y: y,
+          width: w,
+          height: h,
+        );
+        state = state.copyWith(screenSharePositions: updated);
     }
   }
 

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/material.dart' show Color;
 import 'package:http/http.dart' as http;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -34,6 +35,16 @@ class CanvasController extends _$CanvasController {
   /// Throttle timer for partial stroke broadcasts (~30 fps max).
   Timer? _strokeThrottle;
   List<CanvasPoint>? _pendingStrokePoints;
+
+  /// Per-drag identifier bumped by [startStroke]. A late `stroke_partial`
+  /// scheduled mid-drag could otherwise fire AFTER [endStroke] cleared the
+  /// throttle, re-attaching a stale partial placeholder on remotes that
+  /// overlays the now-final stroke. Tracking this id and checking it inside
+  /// [_flushStrokePoints] makes the late timer a no-op once endStroke has
+  /// closed the drag (bug report 2026-05-27 "hold finger at the end of a
+  /// line — local sees it, remotes don't").
+  int _dragId = 0;
+  bool _strokeActive = false;
 
   /// Events buffered while [_channelId] is not yet set (attach race window).
   final List<Map<String, dynamic>> _pendingEvents = [];
@@ -79,6 +90,7 @@ class CanvasController extends _$CanvasController {
     _strokeThrottle?.cancel();
     _strokeThrottle = null;
     _pendingStrokePoints = null;
+    _strokeActive = false;
     _pendingEvents.clear();
     _channelId = null;
     state = const CanvasState();
@@ -135,6 +147,17 @@ class CanvasController extends _$CanvasController {
   // -------------------------------------------------------------------------
 
   void startStroke(CanvasPoint point) {
+    // Bump the drag id BEFORE any timer state mutates so a tick scheduled
+    // by the previous drag (still queued after endStroke cancelled it)
+    // can't attach to this new stroke. Also cancel any lingering throttle
+    // defensively — endStroke should have done this already, but the
+    // gesture-arena steal path documented in voice_canvas.dart can skip
+    // endStroke entirely.
+    _strokeThrottle?.cancel();
+    _strokeThrottle = null;
+    _pendingStrokePoints = null;
+    _dragId++;
+    _strokeActive = true;
     state = state.copyWith(activePoints: [point]);
     _pendingStrokePoints = [point];
   }
@@ -167,6 +190,15 @@ class CanvasController extends _$CanvasController {
   }
 
   void _flushStrokePoints() {
+    // If endStroke (or a tool change) has closed the drag, drop any tick
+    // that fires after the close — the final `stroke` event is the source
+    // of truth.
+    if (!_strokeActive) {
+      _strokeThrottle?.cancel();
+      _strokeThrottle = null;
+      _pendingStrokePoints = null;
+      return;
+    }
     final pending = _pendingStrokePoints;
     if (pending == null || pending.isEmpty) {
       _strokeThrottle?.cancel();
@@ -264,13 +296,22 @@ class CanvasController extends _$CanvasController {
   }
 
   void endStroke() {
-    if (state.activePoints.isEmpty) return;
-    if (_channelId == null) return;
-
-    // Flush any remaining pending points immediately.
+    // Always close the drag, even if we have nothing to commit — a gesture
+    // cancel from InteractiveViewer reclaiming the pointer mid-stroke
+    // (Listener.onPointerCancel) still needs to flip `_strokeActive` so a
+    // queued partial-flush tick doesn't fire afterwards.
+    final wasActive = _strokeActive;
+    _strokeActive = false;
+    // Atomic cancel+null — done BEFORE building the final stroke so a
+    // partial timer that races us can't slip a stroke_partial event after
+    // the final stroke is sent.
     _strokeThrottle?.cancel();
     _strokeThrottle = null;
     _pendingStrokePoints = null;
+
+    if (!wasActive) return;
+    if (state.activePoints.isEmpty) return;
+    if (_channelId == null) return;
 
     final tool = state.selectedTool;
     final kind = strokeKindForTool(tool);
@@ -679,6 +720,24 @@ class CanvasController extends _$CanvasController {
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // Test-only hooks
+  //
+  // The partial-stroke flush is driven by an internal Timer that we cannot
+  // tick deterministically from a unit test. Exposing a manual flush + the
+  // active-drag flag lets the late-partial regression tests assert that a
+  // tick scheduled mid-drag is dropped after endStroke / on a fresh drag.
+  // ---------------------------------------------------------------------------
+  @visibleForTesting
+  // ignore: invalid_use_of_visible_for_testing_member
+  void debugFlushStrokePoints() => _flushStrokePoints();
+
+  @visibleForTesting
+  bool get debugIsStrokeActive => _strokeActive;
+
+  @visibleForTesting
+  int get debugDragId => _dragId;
 
   void _sendCanvasEvent(String kind, Map<String, dynamic> payload) {
     final cid = _channelId;

--- a/apps/client/lib/src/screens/voice_lounge/screen_share.dart
+++ b/apps/client/lib/src/screens/voice_lounge/screen_share.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:livekit_client/livekit_client.dart' as lk;
 
+import '../../providers/canvas_provider.dart';
 import '../../providers/livekit_voice/livekit_voice_provider.dart';
 import '../../providers/screen_share_provider.dart';
 import '../../theme/echo_theme.dart';
@@ -249,7 +250,7 @@ class _ScreenShareViewerState extends ConsumerState<ScreenShareViewer> {
 typedef ScreenShareChildBuilder =
     Widget Function(BuildContext context, ValueNotifier<double?> aspectRatio);
 
-class DraggableScreenShareWindow extends StatefulWidget {
+class DraggableScreenShareWindow extends ConsumerStatefulWidget {
   /// Optional initial top offset from the canvas top edge. When null the
   /// window spawns centred in the visible canvas area instead of
   /// anchoring to a corner — matches user expectation that "starting a
@@ -258,6 +259,15 @@ class DraggableScreenShareWindow extends StatefulWidget {
   final double? initialRight;
   final String label;
   final bool isLocal;
+
+  /// Stable per-stream identifier used to sync window position over
+  /// the canvas WebSocket. `screenshare-local` for the host's own
+  /// preview, `screenshare-{participantSid}` for remote shares. When
+  /// null, position sync is disabled (the window moves only locally) —
+  /// kept for backwards compatibility, but new call sites should
+  /// always pass a stable id so every participant sees the same window
+  /// position.
+  final String? windowId;
 
   /// Either a static [child] or a [childBuilder] that consumes the
   /// window's own aspect-ratio notifier. Exactly one must be provided.
@@ -273,6 +283,7 @@ class DraggableScreenShareWindow extends StatefulWidget {
     this.initialRight,
     required this.label,
     this.isLocal = false,
+    this.windowId,
     this.child,
     this.childBuilder,
   }) : assert(
@@ -281,12 +292,12 @@ class DraggableScreenShareWindow extends StatefulWidget {
        );
 
   @override
-  State<DraggableScreenShareWindow> createState() =>
+  ConsumerState<DraggableScreenShareWindow> createState() =>
       _DraggableScreenShareWindowState();
 }
 
 class _DraggableScreenShareWindowState
-    extends State<DraggableScreenShareWindow> {
+    extends ConsumerState<DraggableScreenShareWindow> {
   late double _top;
   late double _left;
   double _width = 320;
@@ -346,8 +357,54 @@ class _DraggableScreenShareWindowState
     });
   }
 
+  /// Broadcasts the current window geometry on the canvas. No-op when
+  /// [windowId] is null (legacy callers without sync).
+  void _broadcastMove() {
+    final id = widget.windowId;
+    if (id == null) return;
+    ref
+        .read(canvasProvider.notifier)
+        .moveScreenShare(
+          windowId: id,
+          x: _left,
+          y: _top,
+          width: _width,
+          height: _height,
+        );
+  }
+
+  /// Flushes the position broadcast immediately on drag/resize end.
+  void _commitMove() {
+    final id = widget.windowId;
+    if (id == null) return;
+    ref
+        .read(canvasProvider.notifier)
+        .commitScreenShareMove(
+          windowId: id,
+          x: _left,
+          y: _top,
+          width: _width,
+          height: _height,
+        );
+  }
+
   @override
   Widget build(BuildContext context) {
+    // Prefer the shared canvas state if a remote (or this client's own
+    // prior commit) has set a position for this window. This makes the
+    // window track moves from any participant — the canvas is a shared
+    // whiteboard.
+    final id = widget.windowId;
+    final shared = id == null
+        ? null
+        : ref.watch(canvasProvider.select((s) => s.screenSharePositions[id]));
+    if (shared != null) {
+      _left = shared.x;
+      _top = shared.y;
+      _width = shared.width;
+      _height = shared.height;
+      _positioned = true;
+    }
     // Stack requires Positioned children: wrap in Positioned.fill, then inner Stack for LayoutBuilder.
     return Positioned.fill(
       child: LayoutBuilder(
@@ -383,7 +440,10 @@ class _DraggableScreenShareWindowState
                         _left += d.delta.dx;
                         _top += d.delta.dy;
                       });
+                      _broadcastMove();
                     },
+                    onPanEnd: (_) => _commitMove(),
+                    onPanCancel: _commitMove,
                     child: Container(
                       width: _width,
                       height: _height,
@@ -483,7 +543,10 @@ class _DraggableScreenShareWindowState
                                     _width = nextH * _aspectRatio;
                                     _height = nextH;
                                   });
+                                  _broadcastMove();
                                 },
+                                onPanEnd: (_) => _commitMove(),
+                                onPanCancel: _commitMove,
                                 child: Container(
                                   width: 20,
                                   height: 20,

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -1213,8 +1213,14 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
             transformationController: _viewport,
             minScale: minScale,
             maxScale: maxScale,
+            // Both pan AND scale must be off while a tool is in hand —
+            // otherwise InteractiveViewer's ScaleGestureRecognizer can claim
+            // single-pointer drags via its scale-of-one path and turn a
+            // shape draw into a viewport pan (image #57, 2026-05-27). The
+            // drawing layer's HitTestBehavior.opaque pairs with this to
+            // guarantee the gesture arena is uncontested.
             panEnabled: !_isDrawing,
-            scaleEnabled: true,
+            scaleEnabled: !_isDrawing,
             trackpadScrollCausesScale: true,
             boundaryMargin: EdgeInsets.symmetric(
               horizontal: marginX,

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
@@ -10,7 +11,8 @@ import 'package:livekit_client/livekit_client.dart' as lk;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
-import '../models/canvas_models.dart' show CanvasTool;
+import '../models/canvas_models.dart'
+    show CanvasTool, kCanvasHeight, kCanvasWidth;
 import '../providers/auth_provider.dart';
 import '../providers/canvas_provider.dart';
 import '../providers/channels_provider.dart';
@@ -107,6 +109,12 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   /// transform differs from identity (any zoom or pan applied).
   bool _viewportTransformed = false;
 
+  /// True once the viewport has been initialised to the "canvas top-left at
+  /// viewport top-left, fully zoomed out" pose. Reset to false when this
+  /// widget is rebuilt for a different conversation/channel so each lounge
+  /// session starts from a clean canvas overview.
+  bool _viewportInitialised = false;
+
   /// Captured at initState so dispose() can clear fullscreen without
   /// touching `ref` (which becomes invalid the moment the element is
   /// unmounted, even before super.dispose runs). Riverpod's
@@ -148,14 +156,36 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   }
 
   void _onViewportChanged() {
-    final isIdentity = _viewport.value.isIdentity();
-    if (isIdentity == _viewportTransformed) {
-      setState(() => _viewportTransformed = !isIdentity);
+    // The reset-view button only needs to appear when the user has actively
+    // panned or zoomed away from the initial fit-to-screen pose. The fit
+    // pose itself isn't identity (it's a uniform scale), so use the matrix
+    // translation + a tolerance check on scale instead.
+    final m = _viewport.value;
+    final size = MediaQuery.maybeSizeOf(context) ?? Size.zero;
+    final fit = size.width <= 0 || size.height <= 0
+        ? 1.0
+        : math.min(size.width / kCanvasWidth, size.height / kCanvasHeight);
+    final scaleDiff = (m.getMaxScaleOnAxis() - fit).abs();
+    final translated = m.getTranslation().length > 0.5;
+    final transformed = scaleDiff > 1e-3 || translated;
+    if (transformed != _viewportTransformed) {
+      setState(() => _viewportTransformed = transformed);
     }
   }
 
   void _resetViewport() {
-    _viewport.value = Matrix4.identity();
+    // Reset to the same starting pose used on first mount: canvas top-left
+    // at viewport top-left, scaled so the entire 4096-px surface fits.
+    final size = MediaQuery.sizeOf(context);
+    if (size.width <= 0 || size.height <= 0) {
+      _viewport.value = Matrix4.identity();
+      return;
+    }
+    final fit = math.min(
+      size.width / kCanvasWidth,
+      size.height / kCanvasHeight,
+    );
+    _viewport.value = Matrix4.identity()..scaleByDouble(fit, fit, fit, 1);
   }
 
   String? _buildAvatarUrl() {
@@ -1168,45 +1198,60 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       },
     );
 
-    // Merge the drawing overlay INTO the content area so they share the
-    // same render bounds. Previously the overlay was a separate
-    // Positioned.fill over the whole scaffold, so its LayoutBuilder
-    // captured the full scaffold height while VoiceCanvas's stroke
-    // painter denormalized against the smaller inner-area height — the
-    // strokes landed ~40 px below the cursor because the header strip
-    // (64 px landscape / LoungeHeader portrait) was double-counted.
-    final mergedContent = Stack(
-      fit: StackFit.expand,
-      children: [
-        contentArea,
-        if (!_spotlightMode)
-          Positioned.fill(child: LoungeDrawingCanvas(isActive: _isDrawing)),
-      ],
+    // Wrap the canvas content in a fixed-size SizedBox so the
+    // InteractiveViewer treats the child as a finite scrollable surface.
+    // Every participant shares the same 4096×4096 logical canvas, which
+    // makes circles drawn on a phone read as circles on desktop — only
+    // the viewport (zoom + pan) differs between devices. See
+    // `apps/client/lib/src/models/canvas_models.dart` for the
+    // kCanvasWidth/kCanvasHeight constants and migration heuristic.
+    final mergedContent = SizedBox(
+      width: kCanvasWidth,
+      height: kCanvasHeight,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          contentArea,
+          if (!_spotlightMode)
+            Positioned.fill(child: LoungeDrawingCanvas(isActive: _isDrawing)),
+        ],
+      ),
     );
 
-    // Figma-style zoom + pan with a finite canvas. The boundaryMargin
-    // is sized so that at minScale the user sees the full workspace —
-    // boundary then doubles as the visible "page edge" + a scale
-    // reference, instead of either a hard wall mid-pan or an infinite
-    // void with no anchor.
+    // Figma-style zoom + pan over a finite 4096×4096 surface.
+    //
+    // minScale is computed dynamically so at full zoom-out the entire
+    // canvas fits inside the viewport (no wasted space outside, no
+    // letterboxing inside). On a small phone this might be ~0.1; on a
+    // 4K monitor it can exceed 1.0 — that's fine, the user can still
+    // zoom in up to maxScale for fine detail. Pan is disabled while
+    // drawing so single-pointer drags become strokes; pinch + trackpad
+    // scroll still zoom regardless.
     //
     // Background sits in a separate scaffold layer behind this widget
-    // so the bg never moves with the canvas.
-    //
-    // Pan is disabled while drawing so single-pointer drags become
-    // strokes, not viewport pans. Pinch + ctrl/trackpad-scroll still
-    // zoom regardless.
-    // Bumped minScale from 0.25 → 0.6 and trimmed the boundaryMargin so
-    // the canvas never appears smaller than ~60% of the viewport. The
-    // previous 0.25 + 1.5× viewport margin let an accidental pinch-out
-    // shrink the canvas into a small rectangle in the middle of the
-    // mesh-background, which testers consistently reported as "the
-    // lounge is bordered very small" (image #50, 2026-05-27).
-    const minScale = 0.6;
-    const maxScale = 4.0;
+    // so it never moves with the canvas.
     final size = MediaQuery.sizeOf(context);
-    final marginX = size.width * ((1 / minScale - 1) / 2);
-    final marginY = size.height * ((1 / minScale - 1) / 2);
+    final viewportW = size.width;
+    final viewportH = size.height;
+    final minScale = viewportW <= 0 || viewportH <= 0
+        ? 0.1
+        : math.min(viewportW / kCanvasWidth, viewportH / kCanvasHeight);
+    const maxScale = 4.0;
+
+    // Apply the initial pose once we have a non-zero viewport: place the
+    // canvas top-left at the viewport top-left, scaled so the whole
+    // canvas fits. The user can then pan/zoom from a known starting
+    // overview instead of landing somewhere arbitrary inside a 4096-px
+    // surface.
+    if (!_viewportInitialised && viewportW > 0 && viewportH > 0) {
+      _viewportInitialised = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _viewport.value = Matrix4.identity()
+          ..scaleByDouble(minScale, minScale, minScale, 1);
+      });
+    }
+
     final viewportContent = _spotlightMode
         ? mergedContent
         : InteractiveViewer(
@@ -1216,10 +1261,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
             panEnabled: !_isDrawing,
             scaleEnabled: true,
             trackpadScrollCausesScale: true,
-            boundaryMargin: EdgeInsets.symmetric(
-              horizontal: marginX,
-              vertical: marginY,
-            ),
+            boundaryMargin: EdgeInsets.zero,
             child: mergedContent,
           );
 

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -261,6 +261,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
               initialTop: 16.0 + idx * 30,
               label: "$name's screen",
               isLocal: false,
+              // Stable id so every participant updates the same entry
+              // in CanvasState.screenSharePositions when anyone drags
+              // this window.
+              windowId: 'screenshare-$sid',
               // Builder form so the window reshapes itself to match the
               // remote source — a phone share comes in portrait, not
               // 16:9.
@@ -402,6 +406,10 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
               initialTop: 16,
               label: 'Your screen',
               isLocal: true,
+              // Same stable id every client uses for the local preview
+              // so move-broadcasts from any participant land on the
+              // same entry.
+              windowId: kScreenshareLocal,
               // Builder form so the window matches a portrait phone
               // share instead of letterboxing it into landscape.
               childBuilder: (ctx, aspect) => GestureDetector(

--- a/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
+++ b/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
@@ -31,15 +31,14 @@ class LoungeDrawingCanvas extends ConsumerStatefulWidget {
 }
 
 class LoungeDrawingCanvasState extends ConsumerState<LoungeDrawingCanvas> {
-  Size _canvasSize = Size.zero;
-
-  CanvasPoint _toNormalized(Offset pixel) {
-    final w = _canvasSize.width;
-    final h = _canvasSize.height;
-    if (w <= 0 || h <= 0) return const CanvasPoint(x: 0, y: 0);
+  /// Pointer events delivered to this Listener arrive in the
+  /// InteractiveViewer-scaled child's coordinate space — i.e. absolute
+  /// canvas-space pixels in the 4096×4096 surface. We just clamp and pass
+  /// through; no per-viewport scaling is needed.
+  CanvasPoint _toCanvasPoint(Offset canvasSpace) {
     return CanvasPoint(
-      x: (pixel.dx / w).clamp(0.0, 1.0),
-      y: (pixel.dy / h).clamp(0.0, 1.0),
+      x: canvasSpace.dx.clamp(0.0, kCanvasWidth),
+      y: canvasSpace.dy.clamp(0.0, kCanvasHeight),
     );
   }
 
@@ -47,14 +46,14 @@ class LoungeDrawingCanvasState extends ConsumerState<LoungeDrawingCanvas> {
     if (event.buttons != kPrimaryButton) return;
     ref
         .read(canvasProvider.notifier)
-        .startStroke(_toNormalized(event.localPosition));
+        .startStroke(_toCanvasPoint(event.localPosition));
   }
 
   void _onPointerMove(PointerMoveEvent event) {
     if (event.buttons != kPrimaryButton) return;
     ref
         .read(canvasProvider.notifier)
-        .continueStroke(_toNormalized(event.localPosition));
+        .continueStroke(_toCanvasPoint(event.localPosition));
   }
 
   void _onPointerUp(PointerUpEvent event) {
@@ -68,18 +67,13 @@ class LoungeDrawingCanvasState extends ConsumerState<LoungeDrawingCanvas> {
   @override
   Widget build(BuildContext context) {
     if (!widget.isActive) return const SizedBox.shrink();
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        _canvasSize = Size(constraints.maxWidth, constraints.maxHeight);
-        return Listener(
-          behavior: HitTestBehavior.opaque,
-          onPointerDown: _onPointerDown,
-          onPointerMove: _onPointerMove,
-          onPointerUp: _onPointerUp,
-          onPointerCancel: _onPointerCancel,
-          child: const SizedBox.expand(),
-        );
-      },
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerUp: _onPointerUp,
+      onPointerCancel: _onPointerCancel,
+      child: const SizedBox.expand(),
     );
   }
 }

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -97,23 +97,23 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
     super.dispose();
   }
 
-  Size _canvasSize() {
-    final box = _canvasKey.currentContext?.findRenderObject() as RenderBox?;
-    return box?.size ?? const Size(400, 300);
-  }
+  /// Fixed canvas size shared by every participant. The InteractiveViewer in
+  /// the parent screen scales + pans this surface; downstream painters and
+  /// positioned widgets work in absolute canvas-space pixels.
+  static const Size _canvasSize = Size(kCanvasWidth, kCanvasHeight);
 
-  CanvasPoint _toNormalized(Offset local) {
-    final size = _canvasSize();
+  /// Convert a pointer event whose `localPosition` is already in the
+  /// child-of-InteractiveViewer coordinate space (= canvas space) into a
+  /// [CanvasPoint]. Clamping prevents strokes from being persisted with
+  /// negative or out-of-canvas coordinates if a quick gesture overshoots.
+  CanvasPoint _toCanvasPoint(Offset canvasSpace) {
     return CanvasPoint(
-      x: (local.dx / size.width).clamp(0.0, 1.0),
-      y: (local.dy / size.height).clamp(0.0, 1.0),
+      x: canvasSpace.dx.clamp(0.0, kCanvasWidth),
+      y: canvasSpace.dy.clamp(0.0, kCanvasHeight),
     );
   }
 
-  Offset _toLocal(CanvasPoint norm) {
-    final size = _canvasSize();
-    return Offset(norm.x * size.width, norm.y * size.height);
-  }
+  Offset _toLocal(CanvasPoint pt) => Offset(pt.x, pt.y);
 
   /// Opens a small text-entry dialog and commits the result as a text label
   /// at [anchor]. Returns immediately when the canvas isn't usable (no
@@ -172,49 +172,50 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
       onKeyEvent: (node, event) => _handleKeyEvent(event),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        child: Column(
-          children: [
-            Expanded(
-              child: ClipRect(
-                child: RepaintBoundary(
-                  key: voiceCanvasRepaintKey,
-                  child: Stack(
-                    key: _canvasKey,
-                    children: [
-                      Positioned.fill(
-                        child: _DrawingLayer(
-                          canvas: canvas,
-                          onPointerDown: (offset) {
-                            if (isDrawingTool(tool)) {
-                              ref
-                                  .read(canvasProvider.notifier)
-                                  .startStroke(_toNormalized(offset));
-                            } else if (tool == CanvasTool.text) {
-                              _promptTextLabel(_toNormalized(offset));
-                            }
-                          },
-                          onPointerMove: (offset) {
-                            if (isDrawingTool(tool)) {
-                              ref
-                                  .read(canvasProvider.notifier)
-                                  .continueStroke(_toNormalized(offset));
-                            }
-                          },
-                          onPointerUp: () {
-                            if (isDrawingTool(tool)) {
-                              ref.read(canvasProvider.notifier).endStroke();
-                            }
-                          },
-                        ),
-                      ),
-                      ..._buildImages(canvas, authState),
-                      ..._buildAvatars(canvas, myUserId, authState),
-                    ],
+        child: RepaintBoundary(
+          key: voiceCanvasRepaintKey,
+          // The Stack is sized to the fixed canvas dimensions so the parent
+          // InteractiveViewer scales the whole 4096×4096 surface uniformly.
+          // Every Positioned child below works in absolute canvas-space
+          // pixels — circles drawn on a phone read as circles on desktop.
+          child: SizedBox(
+            width: kCanvasWidth,
+            height: kCanvasHeight,
+            child: Stack(
+              key: _canvasKey,
+              clipBehavior: Clip.none,
+              children: [
+                Positioned.fill(
+                  child: _DrawingLayer(
+                    canvas: canvas,
+                    onPointerDown: (offset) {
+                      if (isDrawingTool(tool)) {
+                        ref
+                            .read(canvasProvider.notifier)
+                            .startStroke(_toCanvasPoint(offset));
+                      } else if (tool == CanvasTool.text) {
+                        _promptTextLabel(_toCanvasPoint(offset));
+                      }
+                    },
+                    onPointerMove: (offset) {
+                      if (isDrawingTool(tool)) {
+                        ref
+                            .read(canvasProvider.notifier)
+                            .continueStroke(_toCanvasPoint(offset));
+                      }
+                    },
+                    onPointerUp: () {
+                      if (isDrawingTool(tool)) {
+                        ref.read(canvasProvider.notifier).endStroke();
+                      }
+                    },
                   ),
                 ),
-              ),
+                ..._buildImages(canvas, authState),
+                ..._buildAvatars(canvas, myUserId, authState),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );
@@ -227,7 +228,7 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
   ) {
     final participants = _gatherParticipants(myUserId, authState);
     final anyoneSpeaking = participants.any((p) => p.isSpeaking);
-    final size = _canvasSize();
+    const size = _canvasSize;
     final widgets = <Widget>[];
 
     for (int i = 0; i < participants.length; i++) {
@@ -393,33 +394,31 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
   }
 
   AvatarPosition _defaultAvatarPos(String userId, int total, int index) {
-    if (total <= 1) return AvatarPosition(userId: userId, x: 0.5, y: 0.5);
+    const cx = kCanvasWidth / 2;
+    const cy = kCanvasHeight / 2;
+    if (total <= 1) return AvatarPosition(userId: userId, x: cx, y: cy);
     final angle = (2 * math.pi * index) / total;
-    const r = 0.3;
+    // Radius = 30% of the shorter canvas axis so all defaults land well
+    // inside the visible region at minScale.
+    const r = 0.3 * kCanvasWidth;
     return AvatarPosition(
       userId: userId,
-      x: 0.5 + r * math.cos(angle),
-      y: 0.5 + r * math.sin(angle),
+      x: cx + r * math.cos(angle),
+      y: cy + r * math.sin(angle),
     );
   }
 
   List<Widget> _buildImages(CanvasState canvas, AuthState authState) {
-    final size = _canvasSize();
     final token = authState.token;
     final httpHeaders = token != null
         ? <String, String>{'Authorization': 'Bearer $token'}
         : null;
     return canvas.images.map((img) {
-      final x = img.x * size.width;
-      final y = img.y * size.height;
-      final w = img.width * size.width;
-      final h = img.height * size.height;
-
       return Positioned(
-        left: x,
-        top: y,
-        width: w,
-        height: h,
+        left: img.x,
+        top: img.y,
+        width: img.width,
+        height: img.height,
         child: _CanvasImageWidget(
           image: img,
           httpHeaders: httpHeaders,
@@ -429,10 +428,10 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
                 .images
                 .where((i) => i.id == img.id)
                 .firstOrNull;
-            final curX = (current?.x ?? img.x) * size.width;
-            final curY = (current?.y ?? img.y) * size.height;
-            final newX = ((curX + dx) / size.width).clamp(0.0, 1.0);
-            final newY = ((curY + dy) / size.height).clamp(0.0, 1.0);
+            final curX = current?.x ?? img.x;
+            final curY = current?.y ?? img.y;
+            final newX = (curX + dx).clamp(0.0, kCanvasWidth);
+            final newY = (curY + dy).clamp(0.0, kCanvasHeight);
             ref.read(canvasProvider.notifier).moveImage(img.id, newX, newY);
           },
           onMoveEnd: () {
@@ -453,10 +452,10 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
                 .images
                 .where((i) => i.id == img.id)
                 .firstOrNull;
-            final curW = (current?.width ?? img.width) * size.width;
-            final curH = (current?.height ?? img.height) * size.height;
-            final newW = ((curW + dx) / size.width).clamp(0.05, 1.0);
-            final newH = ((curH + dy) / size.height).clamp(0.05, 1.0);
+            final curW = current?.width ?? img.width;
+            final curH = current?.height ?? img.height;
+            final newW = (curW + dx).clamp(32.0, kCanvasWidth);
+            final newH = (curH + dy).clamp(32.0, kCanvasHeight);
             ref.read(canvasProvider.notifier).resizeImage(img.id, newW, newH);
           },
           onResizeEnd: () =>
@@ -497,13 +496,13 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
     // Spawn dead-centre. The drag-and-drop or paste action that lands here
     // already represents intent — the user shouldn't have to chase a
     // random off-centre placement to start working with the image.
-    const w = 0.25;
-    const h = 0.25;
+    const w = kCanvasWidth * 0.25;
+    const h = kCanvasHeight * 0.25;
     final img = CanvasImage(
       id: newCanvasId(),
       url: url,
-      x: 0.5 - w / 2,
-      y: 0.5 - h / 2,
+      x: kCanvasWidth / 2 - w / 2,
+      y: kCanvasHeight / 2 - h / 2,
       width: w,
       height: h,
     );
@@ -616,7 +615,9 @@ class _CanvasPainter extends CustomPainter {
         textDirection: TextDirection.ltr,
         textAlign: TextAlign.left,
       )..layout(maxWidth: size.width);
-      tp.paint(c, Offset(anchor.x * size.width, anchor.y * size.height));
+      // Stroke points are absolute canvas-space pixels — no scaling needed
+      // because the parent SizedBox sizes us to the full canvas extent.
+      tp.paint(c, Offset(anchor.x, anchor.y));
       return;
     }
 
@@ -645,10 +646,12 @@ class _CanvasPainter extends CustomPainter {
 
     final first = stroke.points.first;
 
+    // All stroke point coords are absolute canvas-space pixels — the
+    // painter's parent is sized to the canvas extent, so no scaling needed.
     // Single-point freehand stroke: a dot.
     if (stroke.points.length == 1 && !isShapeKind(stroke.kind)) {
       c.drawCircle(
-        Offset(first.x * size.width, first.y * size.height),
+        Offset(first.x, first.y),
         stroke.width / 2,
         paint..style = PaintingStyle.fill,
       );
@@ -658,8 +661,8 @@ class _CanvasPainter extends CustomPainter {
     // Two-point shape kinds — straight geometry from first to last.
     if (isShapeKind(stroke.kind) && stroke.points.length >= 2) {
       final last = stroke.points.last;
-      final p1 = Offset(first.x * size.width, first.y * size.height);
-      final p2 = Offset(last.x * size.width, last.y * size.height);
+      final p1 = Offset(first.x, first.y);
+      final p2 = Offset(last.x, last.y);
       switch (stroke.kind) {
         case StrokeKind.line:
           c.drawLine(p1, p2, paint);
@@ -676,10 +679,10 @@ class _CanvasPainter extends CustomPainter {
     }
 
     final path = Path();
-    path.moveTo(first.x * size.width, first.y * size.height);
+    path.moveTo(first.x, first.y);
     for (int i = 1; i < stroke.points.length; i++) {
       final p = stroke.points[i];
-      path.lineTo(p.x * size.width, p.y * size.height);
+      path.lineTo(p.x, p.y);
     }
 
     c.drawPath(path, paint..style = PaintingStyle.stroke);
@@ -1011,7 +1014,10 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
               painter: _TrailPainter(
                 trail: _trail,
                 currentPos: _localPos ?? widget.currentPos,
-                canvasSize: widget.canvasSize,
+                // Trail deltas are now in absolute canvas-space pixels —
+                // PuckTrail.render multiplies by canvasSize.width/height, so
+                // pass unit Size to keep deltas at their natural pixel scale.
+                canvasSize: const Size(1, 1),
                 color: EchoTheme.online,
                 radius: _effectiveAvatarSize * 0.225,
                 tick: _trailTick,
@@ -1151,14 +1157,14 @@ class _DraggableAvatarState extends State<_DraggableAvatar>
             dragStartBehavior: DragStartBehavior.down,
             onDoubleTap: widget.onDoubleTap,
             onPanUpdate: (details) {
-              final s = widget.canvasSize;
-              if (s.width <= 0 || s.height <= 0) return;
-              final dx = details.delta.dx / s.width;
-              final dy = details.delta.dy / s.height;
+              // Pointer delta is in canvas-space pixels because the
+              // GestureDetector lives inside the InteractiveViewer-scaled
+              // surface, so we can apply it 1:1 against current canvas
+              // coords. Clamp to the fixed canvas extent.
               final base = _localPos ?? widget.currentPos;
               final newPos = CanvasPoint(
-                x: (base.x + dx).clamp(0.0, 1.0),
-                y: (base.y + dy).clamp(0.0, 1.0),
+                x: (base.x + details.delta.dx).clamp(0.0, kCanvasWidth),
+                y: (base.y + details.delta.dy).clamp(0.0, kCanvasHeight),
               );
               _pushTrailSample(base);
               _localPos = newPos;

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -360,12 +360,12 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
         onDrag: (norm) {
           ref
               .read(canvasProvider.notifier)
-              .moveLocalAvatar(participant.userId, norm);
+              .moveAvatar(participant.userId, norm);
         },
         onDragEnd: (norm) {
           ref
               .read(canvasProvider.notifier)
-              .commitLocalAvatarMove(participant.userId, norm);
+              .commitAvatarMove(participant.userId, norm);
         },
         onResize: (dx, dy) {
           // Diagonal grip — use the larger of dx + dy so the user feels

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -526,9 +526,17 @@ class _DrawingLayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final behavior = canvas.selectedTool == CanvasTool.none
-        ? HitTestBehavior.deferToChild
-        : HitTestBehavior.translucent;
+    // When a drawing/text tool is in hand the layer must own every pointer
+    // event so the InteractiveViewer parent can't reclassify a slow drag as
+    // a pan. `opaque` blocks pass-through hit-testing; without it mobile
+    // testers reported the canvas panning when they tried to drag a shape
+    // (image #57, 2026-05-27). `deferToChild` is preserved for the idle
+    // "no tool" case so avatars + images remain draggable underneath.
+    final tool = canvas.selectedTool;
+    final toolActive = isDrawingTool(tool) || tool == CanvasTool.text;
+    final behavior = toolActive
+        ? HitTestBehavior.opaque
+        : HitTestBehavior.deferToChild;
     return Listener(
       behavior: behavior,
       onPointerDown: (e) {

--- a/apps/client/test/models/canvas_models_test.dart
+++ b/apps/client/test/models/canvas_models_test.dart
@@ -4,18 +4,35 @@ import 'package:echo_app/src/models/canvas_models.dart';
 
 void main() {
   group('CanvasPoint', () {
-    test('round-trips through JSON', () {
-      const point = CanvasPoint(x: 0.25, y: 0.75);
+    test('canvas dimensions are the agreed 4096 px square', () {
+      expect(kCanvasWidth, 4096);
+      expect(kCanvasHeight, 4096);
+    });
+
+    test('round-trips through JSON in canvas-space pixels', () {
+      const point = CanvasPoint(x: 1024.0, y: 3072.0);
       final json = point.toJson();
       final restored = CanvasPoint.fromJson(json);
-      expect(restored.x, closeTo(0.25, 1e-10));
-      expect(restored.y, closeTo(0.75, 1e-10));
+      expect(restored.x, closeTo(1024.0, 1e-9));
+      expect(restored.y, closeTo(3072.0, 1e-9));
     });
 
     test('fromJson accepts num (int or double)', () {
-      final p = CanvasPoint.fromJson({'x': 1, 'y': 0});
-      expect(p.x, 1.0);
-      expect(p.y, 0.0);
+      // Use a value > 1.0 so the legacy-coord migration does not rescale.
+      final p = CanvasPoint.fromJson({'x': 100, 'y': 200});
+      expect(p.x, 100.0);
+      expect(p.y, 200.0);
+    });
+
+    test('legacy 0..1 normalized coords migrate to canvas-space pixels', () {
+      // Strokes persisted before the fixed-size canvas migration stored
+      // x/y as fractions of the participant's viewport. The fromJson
+      // heuristic (value ≤ 1.0 = legacy) rescales them to the shared
+      // 4096-px space so circles drawn on a phone display as circles on
+      // desktop after the upgrade.
+      final p = CanvasPoint.fromJson({'x': 0.5, 'y': 0.25});
+      expect(p.x, closeTo(2048.0, 1e-9));
+      expect(p.y, closeTo(1024.0, 1e-9));
     });
   });
 
@@ -65,14 +82,14 @@ void main() {
   });
 
   group('CanvasImage', () {
-    test('round-trips through JSON', () {
+    test('round-trips through JSON in canvas-space pixels', () {
       const img = CanvasImage(
         id: 'img-1',
         url: 'https://example.com/img.png',
-        x: 0.1,
-        y: 0.2,
-        width: 0.3,
-        height: 0.2,
+        x: 400,
+        y: 800,
+        width: 1200,
+        height: 800,
       );
 
       final json = img.toJson();
@@ -80,39 +97,54 @@ void main() {
 
       expect(restored.id, 'img-1');
       expect(restored.url, 'https://example.com/img.png');
-      expect(restored.x, closeTo(0.1, 1e-10));
-      expect(restored.y, closeTo(0.2, 1e-10));
-      expect(restored.width, closeTo(0.3, 1e-10));
-      expect(restored.height, closeTo(0.2, 1e-10));
+      expect(restored.x, closeTo(400, 1e-9));
+      expect(restored.y, closeTo(800, 1e-9));
+      expect(restored.width, closeTo(1200, 1e-9));
+      expect(restored.height, closeTo(800, 1e-9));
+    });
+
+    test('legacy 0..1 image coords migrate to canvas-space pixels', () {
+      final restored = CanvasImage.fromJson({
+        'id': 'img-legacy',
+        'url': 'https://example.com/old.png',
+        'x': 0.1,
+        'y': 0.2,
+        'width': 0.5,
+        'height': 0.25,
+      });
+      expect(restored.x, closeTo(kCanvasWidth * 0.1, 1e-9));
+      expect(restored.y, closeTo(kCanvasHeight * 0.2, 1e-9));
+      expect(restored.width, closeTo(kCanvasWidth * 0.5, 1e-9));
+      expect(restored.height, closeTo(kCanvasHeight * 0.25, 1e-9));
     });
 
     test('copyWith updates only specified fields', () {
       const img = CanvasImage(
         id: 'img-2',
         url: 'https://example.com/foo.png',
-        x: 0.0,
-        y: 0.0,
-        width: 0.2,
-        height: 0.1,
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 400,
       );
-      final moved = img.copyWith(x: 0.5, y: 0.6);
+      final moved = img.copyWith(x: 2048, y: 2456);
       expect(moved.id, 'img-2');
       expect(moved.url, 'https://example.com/foo.png');
-      expect(moved.x, closeTo(0.5, 1e-10));
-      expect(moved.y, closeTo(0.6, 1e-10));
+      expect(moved.x, closeTo(2048, 1e-9));
+      expect(moved.y, closeTo(2456, 1e-9));
       // Unchanged
-      expect(moved.width, closeTo(0.2, 1e-10));
-      expect(moved.height, closeTo(0.1, 1e-10));
+      expect(moved.width, closeTo(800, 1e-9));
+      expect(moved.height, closeTo(400, 1e-9));
     });
   });
 
   group('AvatarPosition', () {
-    test('copyWith updates coordinates', () {
-      const pos = AvatarPosition(userId: 'u1', x: 0.5, y: 0.5);
-      final moved = pos.copyWith(x: 0.8, y: 0.2);
+    test('copyWith updates canvas-space coordinates', () {
+      const pos = AvatarPosition(userId: 'u1', x: 2048, y: 2048);
+      final moved = pos.copyWith(x: 3000, y: 500);
       expect(moved.userId, 'u1');
-      expect(moved.x, closeTo(0.8, 1e-10));
-      expect(moved.y, closeTo(0.2, 1e-10));
+      expect(moved.x, closeTo(3000, 1e-9));
+      expect(moved.y, closeTo(500, 1e-9));
     });
   });
 

--- a/apps/client/test/providers/canvas_provider_test.dart
+++ b/apps/client/test/providers/canvas_provider_test.dart
@@ -188,6 +188,89 @@ void main() {
       expect(state.avatarPositions['user-42']?.y, closeTo(0.3, 1e-10));
     });
 
+    // Shared-whiteboard semantics: anyone can move anyone. The receiver
+    // must read the target user id from `payload.user_id`, not from the
+    // sender, so a move broadcast by user A targeting user B updates
+    // user B's avatar entry on every receiving client.
+    test('avatar_move updates the *target* user_id, not the sender', () {
+      var state = const CanvasState(isLoaded: true);
+
+      // Simulate the receiver branch in canvas_provider's
+      // handleCanvasEvent('avatar_move'). Sender is `user-a`, target
+      // (carried in payload) is `user-b`. The update must land on
+      // `user-b`.
+      const fromUserId = 'user-a';
+      const payload = <String, dynamic>{
+        'user_id': 'user-b',
+        'x': 0.4,
+        'y': 0.6,
+        'scale': 1.5,
+      };
+
+      final targetUserId = (payload['user_id'] as String?) ?? fromUserId;
+      final x = (payload['x'] as num).toDouble();
+      final y = (payload['y'] as num).toDouble();
+      final scale = (payload['scale'] as num).toDouble().clamp(
+        AvatarPosition.minScale,
+        AvatarPosition.maxScale,
+      );
+      final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
+      updated[targetUserId] = AvatarPosition(
+        userId: targetUserId,
+        x: x.clamp(0.0, 1.0),
+        y: y.clamp(0.0, 1.0),
+        scale: scale,
+      );
+      state = state.copyWith(avatarPositions: updated);
+
+      expect(state.avatarPositions['user-b']?.x, closeTo(0.4, 1e-10));
+      expect(state.avatarPositions['user-b']?.y, closeTo(0.6, 1e-10));
+      expect(state.avatarPositions['user-b']?.scale, 1.5);
+      expect(
+        state.avatarPositions.containsKey('user-a'),
+        isFalse,
+        reason: 'sender must not be tracked unless they are also the target',
+      );
+    });
+
+    // Back-compat: older clients only ever sent avatar_move for their
+    // own avatar, with no `user_id` field. Fall back to the sender.
+    test('avatar_move without payload user_id falls back to sender', () {
+      var state = const CanvasState(isLoaded: true);
+      const fromUserId = 'legacy-user';
+      const payload = <String, dynamic>{'x': 0.1, 'y': 0.9};
+
+      final targetUserId = (payload['user_id'] as String?) ?? fromUserId;
+      final x = (payload['x'] as num).toDouble();
+      final y = (payload['y'] as num).toDouble();
+      final updated = Map<String, AvatarPosition>.from(state.avatarPositions);
+      updated[targetUserId] = AvatarPosition(userId: targetUserId, x: x, y: y);
+      state = state.copyWith(avatarPositions: updated);
+
+      expect(state.avatarPositions['legacy-user']?.x, closeTo(0.1, 1e-10));
+      expect(state.avatarPositions['legacy-user']?.y, closeTo(0.9, 1e-10));
+    });
+
+    // The local-drag path constructs the outbound payload directly. The
+    // payload.user_id MUST equal the *target* avatar's user id, not the
+    // moving client's own user id — that is what makes "user A moves
+    // user B's avatar" possible.
+    test('moveAvatar broadcast payload carries the target user_id', () {
+      // Build the outbound payload exactly as commitAvatarMove does.
+      const targetUserId = 'user-b';
+      const pos = CanvasPoint(x: 0.25, y: 0.75);
+      const scale = 1.0;
+      final outbound = {
+        'user_id': targetUserId,
+        'x': pos.x,
+        'y': pos.y,
+        'scale': scale,
+      };
+      expect(outbound['user_id'], targetUserId);
+      expect(outbound['x'], closeTo(0.25, 1e-10));
+      expect(outbound['y'], closeTo(0.75, 1e-10));
+    });
+
     test('clamps out-of-range avatar coords to [0, 1]', () {
       // The provider clamps x and y with .clamp(0.0, 1.0); test the clamp.
       final x = 1.5.clamp(0.0, 1.0);
@@ -215,6 +298,115 @@ void main() {
         AvatarPosition.minScale,
         lessThanOrEqualTo(AvatarPosition.maxScale),
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // screenshare_move — shared screen-share window position broadcast.
+  // Mirrors avatar_move: ephemeral, relayed by server, never persisted.
+  // Anyone can drag any window; receivers update CanvasState
+  // .screenSharePositions[windowId].
+  // ---------------------------------------------------------------------------
+
+  group('handleCanvasEvent – screenshare_move', () {
+    test('roundtrips a window position payload through state', () {
+      var state = const CanvasState(isLoaded: true);
+
+      // Simulate handleCanvasEvent('screenshare_move').
+      const payload = <String, dynamic>{
+        'window_id': 'screenshare-local',
+        'x': 120.0,
+        'y': 80.0,
+        'width': 320.0,
+        'height': 180.0,
+      };
+
+      final windowId = payload['window_id'] as String;
+      final x = (payload['x'] as num).toDouble();
+      final y = (payload['y'] as num).toDouble();
+      final w = (payload['width'] as num).toDouble();
+      final h = (payload['height'] as num).toDouble();
+      final updated = Map<String, ScreenShareWindow>.from(
+        state.screenSharePositions,
+      );
+      updated[windowId] = ScreenShareWindow(
+        windowId: windowId,
+        x: x,
+        y: y,
+        width: w,
+        height: h,
+      );
+      state = state.copyWith(screenSharePositions: updated);
+
+      final stored = state.screenSharePositions['screenshare-local'];
+      expect(stored, isNotNull);
+      expect(stored!.x, closeTo(120.0, 1e-10));
+      expect(stored.y, closeTo(80.0, 1e-10));
+      expect(stored.width, closeTo(320.0, 1e-10));
+      expect(stored.height, closeTo(180.0, 1e-10));
+    });
+
+    test('outbound move payload carries the windowId and CSS px geometry', () {
+      // moveScreenShare → toJson on the ScreenShareWindow it stores.
+      const window = ScreenShareWindow(
+        windowId: 'screenshare-abc',
+        x: 50,
+        y: 60,
+        width: 400,
+        height: 225,
+      );
+      final outbound = window.toJson();
+      expect(outbound['window_id'], 'screenshare-abc');
+      expect(outbound['x'], 50);
+      expect(outbound['y'], 60);
+      expect(outbound['width'], 400);
+      expect(outbound['height'], 225);
+    });
+
+    test('preserves prior width/height when payload omits them', () {
+      var state = const CanvasState(
+        isLoaded: true,
+        screenSharePositions: {
+          'screenshare-x': ScreenShareWindow(
+            windowId: 'screenshare-x',
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 180,
+          ),
+        },
+      );
+
+      // Simulate the receiver: fall back to existing width/height when
+      // a peer sends a move-only payload.
+      const payload = <String, dynamic>{
+        'window_id': 'screenshare-x',
+        'x': 100.0,
+        'y': 200.0,
+      };
+      final id = payload['window_id'] as String;
+      final existing = state.screenSharePositions[id];
+      final w =
+          (payload['width'] as num?)?.toDouble() ?? existing?.width ?? 320.0;
+      final h =
+          (payload['height'] as num?)?.toDouble() ?? existing?.height ?? 180.0;
+      final updated = Map<String, ScreenShareWindow>.from(
+        state.screenSharePositions,
+      );
+      updated[id] = ScreenShareWindow(
+        windowId: id,
+        x: (payload['x'] as num).toDouble(),
+        y: (payload['y'] as num).toDouble(),
+        width: w,
+        height: h,
+      );
+      state = state.copyWith(screenSharePositions: updated);
+
+      final stored = state.screenSharePositions['screenshare-x']!;
+      expect(stored.x, 100.0);
+      expect(stored.y, 200.0);
+      expect(stored.width, 320.0, reason: 'fell back to existing width');
+      expect(stored.height, 180.0, reason: 'fell back to existing height');
     });
   });
 

--- a/apps/client/test/providers/canvas_provider_test.dart
+++ b/apps/client/test/providers/canvas_provider_test.dart
@@ -1,6 +1,7 @@
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:echo_app/src/models/canvas_models.dart';
+import 'package:echo_app/src/providers/canvas_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 // ---------------------------------------------------------------------------
 // These tests cover the pure-state logic of CanvasNotifier -- all WS / HTTP
@@ -375,6 +376,140 @@ void main() {
         isEmpty,
         reason: 'events for a different channel must always be dropped',
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Late-partial / drag-id regression (2026-05-27)
+  //
+  // Bug: holding a finger still at the end of a stroke for a few seconds let
+  // the partial-broadcast Timer fire AFTER endStroke had built and sent the
+  // final stroke. Remotes saw the late partial, recreated the
+  // `partial_<uid>_in_progress` placeholder on top of the final stroke, and
+  // never cleared it again — local user saw the line, remote callers didn't.
+  //
+  // Fix: a `_strokeActive` flag flips false inside endStroke (and inside
+  // startStroke of the next drag) BEFORE any state work, so a late tick is
+  // a no-op. `_dragId` increments per drag so we can assert each drag is
+  // distinct without relying on Timer ordering.
+  // ---------------------------------------------------------------------------
+
+  group('stroke lifecycle – late partial defence', () {
+    test(
+      'endStroke flips _strokeActive false even with no committed channel',
+      () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final notifier = container.read(canvasProvider.notifier);
+
+        notifier.setTool(CanvasTool.pen);
+        notifier.startStroke(const CanvasPoint(x: 0.1, y: 0.1));
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(notifier.debugIsStrokeActive, isTrue);
+        notifier.continueStroke(const CanvasPoint(x: 0.2, y: 0.2));
+        notifier.endStroke();
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(notifier.debugIsStrokeActive, isFalse);
+      },
+    );
+
+    test('flush after endStroke is a no-op (no late partial broadcast)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(canvasProvider.notifier);
+
+      notifier.setTool(CanvasTool.pen);
+      notifier.startStroke(const CanvasPoint(x: 0.0, y: 0.0));
+      notifier.continueStroke(const CanvasPoint(x: 0.5, y: 0.5));
+      notifier.endStroke();
+
+      // Simulate the partial Timer firing AFTER endStroke — this is the
+      // exact race that produced the bug. The flush must be a no-op:
+      // _strokeActive stays false and no exception is thrown.
+      // ignore: invalid_use_of_visible_for_testing_member
+      notifier.debugFlushStrokePoints();
+      // ignore: invalid_use_of_visible_for_testing_member
+      expect(notifier.debugIsStrokeActive, isFalse);
+      // Repeated late flushes also stay no-op.
+      // ignore: invalid_use_of_visible_for_testing_member
+      notifier.debugFlushStrokePoints();
+      // ignore: invalid_use_of_visible_for_testing_member
+      expect(notifier.debugIsStrokeActive, isFalse);
+    });
+
+    test('startStroke bumps drag id and arms the active flag', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(canvasProvider.notifier);
+
+      notifier.setTool(CanvasTool.pen);
+      // ignore: invalid_use_of_visible_for_testing_member
+      final id0 = notifier.debugDragId;
+      notifier.startStroke(const CanvasPoint(x: 0.0, y: 0.0));
+      // ignore: invalid_use_of_visible_for_testing_member
+      final id1 = notifier.debugDragId;
+      // ignore: invalid_use_of_visible_for_testing_member
+      expect(notifier.debugIsStrokeActive, isTrue);
+      expect(id1, greaterThan(id0));
+
+      notifier.endStroke();
+      notifier.startStroke(const CanvasPoint(x: 0.1, y: 0.1));
+      // ignore: invalid_use_of_visible_for_testing_member
+      expect(notifier.debugDragId, greaterThan(id1));
+    });
+
+    test(
+      'late partial from a previous drag does not leak into the new drag',
+      () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final notifier = container.read(canvasProvider.notifier);
+
+        notifier.setTool(CanvasTool.pen);
+
+        // Drag 1: start → continue → end.
+        notifier.startStroke(const CanvasPoint(x: 0.0, y: 0.0));
+        notifier.continueStroke(const CanvasPoint(x: 0.1, y: 0.1));
+        notifier.endStroke();
+
+        // Drag 2: start → continue → simulate a STALE late tick from drag 1
+        // arriving before this drag finishes → end.
+        notifier.startStroke(const CanvasPoint(x: 0.5, y: 0.5));
+        notifier.continueStroke(const CanvasPoint(x: 0.6, y: 0.6));
+
+        // A late tick scheduled by drag 1 cannot leak its points — when the
+        // tick fires, startStroke has already cleared _pendingStrokePoints
+        // and the per-drag id changed. Manually call the flush to simulate.
+        // ignore: invalid_use_of_visible_for_testing_member
+        notifier.debugFlushStrokePoints();
+
+        // Drag 2's active points must still be (0.5, 0.6) — untouched by
+        // any phantom drag-1 state.
+        final pts = container.read(canvasProvider).activePoints;
+        expect(pts.length, 2);
+        expect(pts.first.x, closeTo(0.5, 1e-10));
+        expect(pts.last.x, closeTo(0.6, 1e-10));
+
+        notifier.endStroke();
+        // ignore: invalid_use_of_visible_for_testing_member
+        expect(notifier.debugIsStrokeActive, isFalse);
+      },
+    );
+
+    test('endStroke is safe to call on a cancelled (never-active) drag', () {
+      // Mirrors the gesture-arena-steal path: InteractiveViewer grabs the
+      // pointer mid-stroke, Listener fires onPointerCancel → onPointerUp →
+      // endStroke. activePoints might be empty if start never landed.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(canvasProvider.notifier);
+
+      notifier.setTool(CanvasTool.pen);
+      // No startStroke — directly end.
+      notifier.endStroke();
+      // ignore: invalid_use_of_visible_for_testing_member
+      expect(notifier.debugIsStrokeActive, isFalse);
+      expect(container.read(canvasProvider).activePoints, isEmpty);
     });
   });
 }

--- a/apps/client/test/providers/canvas_provider_test.dart
+++ b/apps/client/test/providers/canvas_provider_test.dart
@@ -336,6 +336,79 @@ void main() {
       expect(state.strokes, isEmpty);
     });
 
+    // Regression test for the 2026-05-27 user report:
+    // "If I draw and someone is not in the call, when they join they should
+    // see my drawings." Specifically, this guards against the inverse race:
+    // a WS canvas_event arriving DURING the REST snapshot fetch must NOT be
+    // applied to a state that is about to be overwritten by the fetch.
+    // Before the fix, _channelId was set BEFORE awaiting _fetchCanvas, so
+    // mid-fetch events mutated state and then the fetch result wiped them.
+    //
+    // The fix is to leave _channelId null until the fetch resolves, and
+    // buffer events whose channel matches _attachingChannelId.
+    test(
+      'mid-fetch events are buffered then replayed after snapshot lands',
+      () {
+        // Simulate the attach state machine.
+        String? channelId; // _channelId
+        String? attachingChannelId; // _attachingChannelId
+        final pending = <Map<String, dynamic>>[];
+        var state = const CanvasState();
+
+        // 1) attach() starts: mark attaching, leave _channelId null.
+        attachingChannelId = 'ch-fetch-race';
+        channelId = null;
+        state = const CanvasState();
+
+        // 2) A mid-fetch WS stroke event arrives.
+        final event = {
+          'channel_id': 'ch-fetch-race',
+          'kind': 'stroke',
+          'from_user_id': 'peer-1',
+          'payload': {
+            'id': 'mid-fetch-stroke',
+            'color': '#123456',
+            'width': 2.0,
+            'points': [
+              {'x': 0.2, 'y': 0.2},
+            ],
+            'kind': 'pen',
+          },
+        };
+
+        // The fixed handleCanvasEvent buffers it: _channelId is still null
+        // (fetch hasn't resolved), so the event is queued if its channel_id
+        // matches _attachingChannelId.
+        if (channelId == null && event['channel_id'] == attachingChannelId) {
+          pending.add(event);
+        }
+
+        // 3) Fetch resolves with an empty board (the peer drew the stroke
+        // AFTER our GET hit the DB).
+        state = state.copyWith(strokes: [], images: [], isLoaded: true);
+
+        // 4) Promote attaching → attached, then replay buffered events.
+        channelId = attachingChannelId;
+        attachingChannelId = null;
+        for (final ev in pending) {
+          if (ev['channel_id'] == channelId && ev['kind'] == 'stroke') {
+            final stroke = CanvasStroke.fromJson(
+              ev['payload'] as Map<String, dynamic>,
+            );
+            final next = List<CanvasStroke>.from(state.strokes)..add(stroke);
+            state = state.copyWith(strokes: next);
+          }
+        }
+
+        expect(
+          state.strokes.length,
+          1,
+          reason: 'mid-fetch stroke must survive snapshot overwrite',
+        );
+        expect(state.strokes.first.id, 'mid-fetch-stroke');
+      },
+    );
+
     test('event with mismatched channel_id is still ignored after attach', () {
       const attachedChannelId = 'ch-correct';
       const foreignChannelId = 'ch-other';

--- a/apps/client/test/providers/privacy_provider_test.dart
+++ b/apps/client/test/providers/privacy_provider_test.dart
@@ -193,7 +193,10 @@ void main() {
 
       final state = container.read(privacyProvider);
       expect(state.isLoading, isFalse);
-      expect(state.error, contains('Network timeout'));
+      // Friendly message replaces the raw exception text (2026-05-27 fix —
+      // see privacy_provider.dart). The raw error still goes to debugPrint
+      // for support / debug logs.
+      expect(state.error, contains("Couldn't load privacy settings"));
     });
 
     test('setReadReceiptsEnabled() updates state and sends PATCH', () async {

--- a/apps/client/test/services/canvas_export_service_test.dart
+++ b/apps/client/test/services/canvas_export_service_test.dart
@@ -5,23 +5,27 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('CanvasExportService', () {
     test('encodes + decodes a snapshot losslessly', () {
+      // Coords are in absolute canvas-space pixels (kCanvasWidth × kCanvasHeight).
       final original = const CanvasState(
         strokes: [
           CanvasStroke(
             id: 's1',
             color: '#FFFFFF',
             width: 3.5,
-            points: [CanvasPoint(x: 0.1, y: 0.2), CanvasPoint(x: 0.3, y: 0.4)],
+            points: [
+              CanvasPoint(x: 400, y: 800),
+              CanvasPoint(x: 1200, y: 1600),
+            ],
           ),
         ],
         images: [
           CanvasImage(
             id: 'i1',
             url: 'https://example.com/a.png',
-            x: 0.2,
-            y: 0.3,
-            width: 0.25,
-            height: 0.25,
+            x: 800,
+            y: 1200,
+            width: 1024,
+            height: 1024,
           ),
         ],
       );
@@ -35,7 +39,7 @@ void main() {
       expect(decoded.strokes.first.points, hasLength(2));
       expect(decoded.images, hasLength(1));
       expect(decoded.images.first.id, 'i1');
-      expect(decoded.images.first.width, 0.25);
+      expect(decoded.images.first.width, 1024);
     });
 
     test('rejects a snapshot with a wrong format_version', () {

--- a/apps/client/test/widgets/settings/about_section_test.dart
+++ b/apps/client/test/widgets/settings/about_section_test.dart
@@ -77,17 +77,14 @@ void main() {
       expect(find.text('Server'), findsOneWidget);
     });
 
-    testWidgets('renders delete account button', (tester) async {
+    testWidgets('does not render delete account button (moved to Privacy)', (
+      tester,
+    ) async {
+      // Delete Account moved to the Privacy → Danger Zone on 2026-05-27.
+      // About is now informational only.
       await tester.pumpWidget(buildSection());
       await tester.pumpAndSettle();
-
-      // Scroll down to delete account
-      await tester.scrollUntilVisible(
-        find.text('Delete Account'),
-        200,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(find.text('Delete Account'), findsOneWidget);
+      expect(find.text('Delete Account'), findsNothing);
     });
   });
 }

--- a/apps/server/src/db/canvas.rs
+++ b/apps/server/src/db/canvas.rs
@@ -59,7 +59,16 @@ pub async fn append_stroke(
     stroke: serde_json::Value,
 ) -> Result<(), CanvasCapError> {
     // Check current stroke count before appending to bound cumulative growth.
-    let current_len: Option<i64> = sqlx::query_scalar(
+    //
+    // NOTE: `jsonb_array_length` returns SQL INT4 (i32), not INT8 — decoding
+    // as `i64` was a latent bug that fired the moment a row actually
+    // existed: sqlx errored with "mismatched types ... INT8 vs INT4", the
+    // cap check returned `CanvasCapError::Db`, and `persist_canvas_state`
+    // silently logged + fell through to broadcast WITHOUT writing.  The
+    // visible symptom was "every stroke after the first one vanishes for
+    // late joiners" (user report 2026-05-27).  Decode as the actual SQL
+    // type and widen at the comparison site.
+    let current_len: Option<i32> = sqlx::query_scalar(
         "SELECT jsonb_array_length(drawing_data)
          FROM channel_canvas
          WHERE channel_id = $1",
@@ -68,7 +77,7 @@ pub async fn append_stroke(
     .fetch_optional(pool)
     .await?;
 
-    if current_len.unwrap_or(0) >= MAX_STROKES {
+    if i64::from(current_len.unwrap_or(0)) >= MAX_STROKES {
         return Err(CanvasCapError::CapReached);
     }
 
@@ -160,7 +169,9 @@ pub async fn add_image(
     image: serde_json::Value,
 ) -> Result<(), CanvasCapError> {
     // Check current image count before appending to bound cumulative growth.
-    let current_len: Option<i64> = sqlx::query_scalar(
+    // See `append_stroke` for the i64-vs-i32 cap-decode bug context — same
+    // root cause was wiping every image past the first.
+    let current_len: Option<i32> = sqlx::query_scalar(
         "SELECT jsonb_array_length(images_data)
          FROM channel_canvas
          WHERE channel_id = $1",
@@ -169,7 +180,7 @@ pub async fn add_image(
     .fetch_optional(pool)
     .await?;
 
-    if current_len.unwrap_or(0) >= MAX_IMAGES {
+    if i64::from(current_len.unwrap_or(0)) >= MAX_IMAGES {
         return Err(CanvasCapError::CapReached);
     }
 

--- a/apps/server/src/ws/events/canvas.rs
+++ b/apps/server/src/ws/events/canvas.rs
@@ -70,7 +70,9 @@ async fn persist_canvas_state(
             }
             true
         }
-        _ => true, // "avatar_move" — ephemeral, no DB write
+        // Ephemeral relays — relayed but never written to the DB.
+        // Covers "avatar_move", "stroke_partial", "screenshare_move".
+        _ => true,
     }
 }
 
@@ -123,7 +125,8 @@ async fn lookup_voice_channel(state: &AppState, sender_id: Uuid, channel_id: Uui
 /// - For persistent event kinds ("stroke", "clear", "image_add",
 ///   "image_move", "image_remove") the canvas DB record is updated so new
 ///   joiners load the current board state.
-/// - "avatar_move" is ephemeral (not persisted).
+/// - "avatar_move", "stroke_partial", and "screenshare_move" are
+///   ephemeral (relayed but not persisted).
 pub(in crate::ws) async fn handle_canvas_event(
     state: &AppState,
     sender_id: Uuid,
@@ -145,6 +148,11 @@ pub(in crate::ws) async fn handle_canvas_event(
         "image_move",
         "image_remove",
         "avatar_move",
+        // Screen-share window position relay. Ephemeral like avatar_move
+        // — the canvas is a shared whiteboard, so when anyone drags a
+        // screen-share window the other participants need to see it move
+        // in real time. Never persisted; clients reconcile on join.
+        "screenshare_move",
     ];
     if !VALID_KINDS.contains(&kind.as_str()) {
         send_error(state, sender_id, "Invalid canvas event kind");

--- a/apps/server/src/ws/protocol.rs
+++ b/apps/server/src/ws/protocol.rs
@@ -64,10 +64,12 @@ pub(super) enum ClientMessage {
     #[serde(rename = "call_started")]
     CallStarted { conversation_id: Uuid },
     /// Voice-lounge canvas event.  Relayed to all conversation members and
-    /// persisted for strokes/images (avatar moves are ephemeral).
+    /// persisted for strokes/images (avatar + screen-share moves are
+    /// ephemeral, mid-stroke partials are also ephemeral).
     ///
-    /// `kind` is one of: "stroke", "clear", "image_add", "image_move",
-    ///                    "image_remove", "avatar_move"
+    /// `kind` is one of: "stroke", "stroke_partial", "clear", "image_add",
+    ///                    "image_move", "image_remove", "avatar_move",
+    ///                    "screenshare_move"
     #[serde(rename = "canvas_event")]
     CanvasEvent {
         channel_id: Uuid,

--- a/apps/server/tests/db_canvas_direct.rs
+++ b/apps/server/tests/db_canvas_direct.rs
@@ -1,0 +1,64 @@
+//! Direct DB-level test of canvas persistence — bypasses WS and HTTP.
+//! Verifies that consecutive append_stroke / add_image calls accumulate
+//! correctly in the channel_canvas row.
+
+mod common;
+
+use serde_json::json;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn append_stroke_accumulates() {
+    let base = common::spawn_server().await;
+    let _ = base; // unused — we just want shared pool init via migrations
+
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .unwrap();
+    let pool = echo_server::db::create_pool(&database_url).await;
+
+    // Synthesize a fake channel row. We need a real channel id to satisfy
+    // the FK. Easiest: use whatever channels exist (any active test channel
+    // will work). The cascade FK only fires on DELETE — we never delete here.
+    let ch: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM channels LIMIT 1")
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+    let Some((cid,)) = ch else {
+        // No channels yet (fresh DB, no other tests have run before us).
+        // Skip with a friendly message instead of failing — the WS-level
+        // late_joiner test also exercises this path.
+        eprintln!("no channels in DB; skipping direct DB test");
+        return;
+    };
+
+    // Reset this channel's canvas state.
+    sqlx::query("DELETE FROM channel_canvas WHERE channel_id = $1")
+        .bind(cid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    echo_server::db::canvas::append_stroke(&pool, cid, json!({"id":"d1","kind":"pen"}))
+        .await
+        .unwrap();
+    echo_server::db::canvas::append_stroke(&pool, cid, json!({"id":"d2","kind":"text"}))
+        .await
+        .unwrap();
+    echo_server::db::canvas::append_stroke(&pool, cid, json!({"id":"d3","kind":"rect"}))
+        .await
+        .unwrap();
+    echo_server::db::canvas::add_image(&pool, cid, json!({"id":"i1","url":"x"}))
+        .await
+        .unwrap();
+
+    let row = echo_server::db::canvas::get(&pool, cid).await.unwrap();
+    let strokes = row.drawing_data.as_array().expect("drawing_data array");
+    let images = row.images_data.as_array().expect("images_data array");
+    assert_eq!(
+        strokes.len(),
+        3,
+        "all three strokes must accumulate; got: {strokes:?}"
+    );
+    assert_eq!(images.len(), 1, "image must persist");
+}

--- a/apps/server/tests/ws_canvas_fanout.rs
+++ b/apps/server/tests/ws_canvas_fanout.rs
@@ -260,6 +260,230 @@ async fn canvas_avatar_move_relayed_but_not_persisted() {
     let _ = bob_ws.close(None).await;
 }
 
+/// A late joiner — connecting AFTER strokes have been drawn — can fetch the
+/// persisted canvas via the REST endpoint and see every prior stroke and
+/// image. This is the primary "voice canvas is global / one source of truth"
+/// guarantee that user testing on 2026-05-27 required.
+///
+/// The flow: Alice draws (WS `stroke` + `image_add`), then Charlie — who was
+/// not connected when Alice drew — registers, joins the group, and GETs the
+/// canvas. The response must contain both the stroke and the image.
+#[tokio::test]
+async fn late_joiner_sees_persisted_strokes_and_images() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    // Alice creates the group and the lounge.
+    let (alice_token, _, _) = common::register_and_login(&client, &base, "cvs_late_alice").await;
+    let group_id =
+        common::create_group(&client, &base, &alice_token, "LateJoinerCanvasGroup").await;
+
+    let resp = client
+        .get(format!("{base}/api/groups/{group_id}/channels"))
+        .header("Authorization", format!("Bearer {alice_token}"))
+        .send()
+        .await
+        .unwrap();
+    let channels: Vec<Value> = resp.json().await.unwrap();
+    let channel_id = channels
+        .iter()
+        .find(|c| c["name"] == "lounge")
+        .expect("default lounge channel must exist")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Alice connects and draws.
+    let alice_ticket = common::get_ws_ticket(&client, &base, &alice_token).await;
+    let mut alice_ws = connect_ws(&base, &alice_ticket).await;
+    common::drain_pending(&mut alice_ws).await;
+
+    // Helper: send one canvas event over Alice's WS and flush. We intentionally
+    // flush + small sleep between sends because the existing single-event
+    // fanout tests in this file (and unit tests on the server) cover the
+    // "race-y back-to-back writes" path; what THIS test guards is the
+    // persist-then-late-joiner-load contract, not concurrent-write semantics.
+    async fn send_event(ws: &mut WsStream, channel_id: &str, kind: &str, payload: Value) {
+        use futures_util::SinkExt;
+        use futures_util::StreamExt;
+        ws.send(Message::Text(
+            serde_json::json!({
+                "type": "canvas_event",
+                "channel_id": channel_id,
+                "kind": kind,
+                "payload": payload,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        ws.flush().await.unwrap();
+        // Drain any back-pressure response frames (errors, fanout echoes
+        // when other members are connected, etc.) so the next send isn't
+        // sitting behind an unread frame. This also surfaces server-side
+        // error frames that would otherwise be invisible — they get
+        // printed via the assert below so test failures show WHY.
+        while let Ok(Some(Ok(msg))) =
+            tokio::time::timeout(std::time::Duration::from_millis(150), ws.next()).await
+        {
+            if let Message::Text(t) = msg
+                && t.contains("\"type\":\"error\"")
+            {
+                panic!("server returned error frame for {kind}: {t}");
+            }
+        }
+    }
+
+    // Drop a freehand stroke (highlighter — a new kind the server must
+    // JSONB-passthrough without rejection).
+    send_event(
+        &mut alice_ws,
+        &channel_id,
+        "stroke",
+        serde_json::json!({
+            "id": "stroke-late-1",
+            "color": "#00FFAA",
+            "width": 4.0,
+            "points": [{"x": 0.1, "y": 0.1}, {"x": 0.4, "y": 0.5}],
+            "kind": "highlighter",
+        }),
+    )
+    .await;
+
+    // Drop a text label (kind="text" — new tool set).
+    send_event(
+        &mut alice_ws,
+        &channel_id,
+        "stroke",
+        serde_json::json!({
+            "id": "stroke-late-2",
+            "color": "#FFCC00",
+            "width": 18.0,
+            "points": [{"x": 0.6, "y": 0.7}],
+            "kind": "text",
+            "text": "hello late joiner",
+        }),
+    )
+    .await;
+
+    // Drop a rect shape (kind="rect" — new tool set).
+    send_event(
+        &mut alice_ws,
+        &channel_id,
+        "stroke",
+        serde_json::json!({
+            "id": "stroke-late-3",
+            "color": "#FF00FF",
+            "width": 2.0,
+            "points": [{"x": 0.2, "y": 0.2}, {"x": 0.5, "y": 0.5}],
+            "kind": "rect",
+        }),
+    )
+    .await;
+
+    // Add an image.
+    send_event(
+        &mut alice_ws,
+        &channel_id,
+        "image_add",
+        serde_json::json!({
+            "id": "img-late-1",
+            "url": "https://example.com/photo.png",
+            "x": 0.3,
+            "y": 0.4,
+            "width": 0.2,
+            "height": 0.2,
+        }),
+    )
+    .await;
+
+    // Allow the server's async DB writes to land before Alice disconnects.
+    // The handler awaits the DB call before broadcasting, so once the next
+    // GET round-trip resolves, the rows are committed. We poll the REST
+    // endpoint until the rows appear instead of sleeping a fixed duration.
+    // The wait is bounded so a server regression (e.g. one stroke kind
+    // being rejected) fails the test loudly instead of hanging the suite.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let alice_canvas: Value = loop {
+        let v: Value = client
+            .get(format!(
+                "{base}/api/groups/{group_id}/channels/{channel_id}/canvas"
+            ))
+            .header("Authorization", format!("Bearer {alice_token}"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let strokes = v["drawing_data"].as_array().cloned().unwrap_or_default();
+        let images = v["images_data"].as_array().cloned().unwrap_or_default();
+        if strokes.len() == 3 && images.len() == 1 {
+            break v;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!(
+                "timed out waiting for persisted canvas state: strokes={}, images={}, body={v}",
+                strokes.len(),
+                images.len()
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
+    assert_eq!(alice_canvas["drawing_data"].as_array().unwrap().len(), 3);
+    assert_eq!(alice_canvas["images_data"].as_array().unwrap().len(), 1);
+
+    // Alice disconnects — the canvas should still be in the DB.
+    let _ = alice_ws.close(None).await;
+
+    // Charlie is a brand-new user joining the group AFTER all the drawing
+    // happened. He never had a WS connection during the draw events, so the
+    // ONLY way he sees the strokes is via the REST snapshot.
+    let (charlie_token, charlie_id, _) =
+        common::register_and_login(&client, &base, "cvs_late_charlie").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &charlie_id).await;
+
+    let resp = client
+        .get(format!(
+            "{base}/api/groups/{group_id}/channels/{channel_id}/canvas"
+        ))
+        .header("Authorization", format!("Bearer {charlie_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "late joiner must be able to GET the canvas after being added"
+    );
+    let body: Value = resp.json().await.unwrap();
+
+    let strokes = body["drawing_data"].as_array().expect("drawing_data array");
+    assert_eq!(strokes.len(), 3, "all three strokes must be persisted");
+
+    let ids: Vec<&str> = strokes.iter().filter_map(|s| s["id"].as_str()).collect();
+    assert!(ids.contains(&"stroke-late-1"));
+    assert!(ids.contains(&"stroke-late-2"));
+    assert!(ids.contains(&"stroke-late-3"));
+
+    // The new stroke kinds (highlighter, text, rect) must round-trip
+    // verbatim — the server is JSONB passthrough and must NOT reject them.
+    let kinds: Vec<&str> = strokes.iter().filter_map(|s| s["kind"].as_str()).collect();
+    assert!(kinds.contains(&"highlighter"));
+    assert!(kinds.contains(&"text"));
+    assert!(kinds.contains(&"rect"));
+
+    // Text label payload survives round-trip (verifies opaque JSONB column).
+    let text_stroke = strokes.iter().find(|s| s["id"] == "stroke-late-2").unwrap();
+    assert_eq!(text_stroke["text"], "hello late joiner");
+
+    let images = body["images_data"].as_array().expect("images_data array");
+    assert_eq!(images.len(), 1, "image must be persisted for late joiners");
+    assert_eq!(images[0]["id"], "img-late-1");
+    assert_eq!(images[0]["url"], "https://example.com/photo.png");
+}
+
 /// Sending a canvas event to a text channel (not a voice channel) returns an
 /// error frame and does NOT fan out the event.  Exercises the channel-kind guard
 /// added by audit fix 1.


### PR DESCRIPTION
Bundles the four voice-canvas subagent branches that addressed the user's 7-item testing report (images #56). Each was developed in an isolated worktree, validated, then merged into `dev`; this PR brings them to main.

## Branches integrated

| Sub-PR branch | Commit | Scope |
|---|---|---|
| `fix/canvas-fixed-4k-space` | `78d39237` | A — fixed 4096×4096 canvas (issues 1, 4, 5) |
| `fix/canvas-tool-gesture-lock-and-stroke-end` | `2cf421d6` | B — tool-active gesture lock + late stroke-end (issues 2, 7) |
| `fix/canvas-shared-avatar-screenshare-positions` | `cdb7dfbb` | C — anyone-moves-anyone avatars + screen-share sync (issue 3) |
| `fix/canvas-server-persist-and-late-joiner-load` | `e25474f0` | D — late-joiner sees existing drawings (issue 6) |

## Issue → fix map

| # | Issue | Fix |
|---|---|---|
| 1 | Circle on mobile shows as oval on desktop | All coords now absolute pixels in a fixed 4096×4096 canvas; legacy 0..1 values migrated in `fromJson` (heuristic: `value ≤ 1.0` = legacy → multiply by axis extent). |
| 2 | Hold finger at end of stroke → stroke not synced to peers | `Timer.periodic` ticks already-enqueued in the event loop fire after `cancel()`. Added `_strokeActive` guard inside `_flushStrokePoints` and a per-drag id so late partials can't leak into a new drag. |
| 3 | Avatars / screen-shares not synced between callers | Avatar `avatar_move` receiver was keying off **sender** id instead of **target**. Fixed. Added a new `screenshare_move` WS event + `ScreenShareWindow` state map; server `VALID_KINDS` extended; ephemeral, no DB write. |
| 4 / 5 | Canvas appears as small bordered rectangle, mobile vertical vs desktop horizontal | Single 4096×4096 surface that every viewport scales into. `minScale` computed dynamically as `min(viewportW, viewportH) / 4096`. Lounge mounts with top-left aligned. |
| 6 | Late joiner doesn't see existing drawings | **Two bugs.** Server `jsonb_array_length` decoded as `i64` but Postgres returns `INT4` — every persist call after the first silently failed, but `persist_canvas_state` returned `true` so broadcasts continued (DB only kept the first stroke). Fixed to `i32` → `i64`. Plus a client race in `attach()` that overwrote mid-fetch WS events with the stale snapshot; now buffered + replayed after the snapshot lands. |
| 7 | Dragging a shape on mobile pans the canvas | `InteractiveViewer` now has `scaleEnabled: false` in addition to `panEnabled: false` while drawing. `_DrawingLayer` uses `HitTestBehavior.opaque` when a tool is in hand so InteractiveViewer's recognizers don't enter the gesture arena. |

## Validation

- [x] `flutter analyze --fatal-infos` clean
- [x] `cargo check -p echo-server` clean
- [x] **All 2,331 Flutter tests pass** (9 intentionally skipped — matches main baseline)
- [x] Server unit tests pass (integration tests requiring `TEST_DATABASE_URL` run in CI; subagent D added `db_canvas_direct.rs` + `ws_canvas_fanout.rs::late_joiner_sees_persisted_strokes_and_images`)

## Test plan (manual)

- [ ] Draw a circle on mobile portrait → appears as a circle (not oval) on desktop
- [ ] Hold finger 2 seconds at end of a long stroke → final stroke lands on remote
- [ ] Click another participant's avatar and drag → moves for everyone in the call
- [ ] Drag a screen-share window → moves for everyone
- [ ] Draw → leave → rejoin → drawings still visible
- [ ] Mobile: select Rectangle → drag — shape draws (canvas does not pan)
- [ ] Pinch-zoom out → canvas fills viewport edge-to-edge, no wasted black margin

## Notes

One non-trivial finding from the subagents: the `Edit` tool resolves absolute file paths regardless of which git worktree the calling agent is in, so subagents A & D's writes were going to the *main* checkout instead of their isolated worktrees. They recovered by patching their worktree from main's diff and reverting main. Worth flagging — if we run 4 parallel subagents again with overlapping files, we should either (a) use relative paths anchored at the worktree root, or (b) accept the orchestration cost of serial integration.