### PR TITLE
ci: fix sigpipe in release tag-reserve loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,14 @@ jobs:
           trap 'rm -f "$PUSH_ERR"' EXIT
 
           for attempt in 1 2 3 4 5; do
-            LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1)
+            # for-each-ref --count=1 writes exactly one line and exits
+            # cleanly. The previous `git tag -l | head -1` was racy under
+            # `set -o pipefail`: once the tag list grew past ~450 entries,
+            # `head` closed the pipe before `git tag` finished writing,
+            # `git tag` got SIGPIPE, and the pipeline exited 141 on the
+            # first loop iteration — masking the actual reserve logic.
+            LATEST=$(git for-each-ref --count=1 --sort=-v:refname \
+              --format='%(refname:short)' 'refs/tags/v*')
             if [ -z "$LATEST" ]; then
               LATEST="v0.0.0"
             fi


### PR DESCRIPTION
`Release / Calculate Version` has been failing all evening (since PR #1239) with exit code 141 (SIGPIPE), 470 ms into the step. Each run today reproduced it.

## Root cause

The atomic-tag-reserve loop starts with:

```bash
LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1)
```

Tag count crossed ~450 today (`git tag -l 'v*' | wc -l` → 468). `head -1` closes the pipe after reading one line; `git tag` keeps trying to write the remaining ~467 lines and gets SIGPIPE. Under `set -o pipefail` (line 1 of the script), that becomes the pipeline's exit code → 141 → `set -e` exits the entire step before any tag-reserve logic runs.

## Fix

Replace with `git for-each-ref --count=1 ...`, which writes exactly one line by design — no truncation, no SIGPIPE possible. Verified locally:

```
$ git for-each-ref --count=1 --sort=-v:refname --format='%(refname:short)' 'refs/tags/v*'
v0.0.468
```

## Test plan
- [ ] CI Release workflow re-runs on this branch (it's a push-to-main workflow, won't run on the PR itself, but merging this fixes the next push to main)

Note: SonarCloud has a separate pre-existing failure (chunked-media-upload finalize returning 500) — not addressed here, not introduced by today's changes.