### PR TITLE
fix(audit): bound per-click timeout in audit_tour spec

### DIFF
--- a/tests/e2e/audit_tour.spec.ts
+++ b/tests/e2e/audit_tour.spec.ts
@@ -78,15 +78,28 @@ async function tryClickByText(
   label: RegExp,
   timeoutMs = 1500,
 ): Promise<boolean> {
+  // Per-click timeout (5 s) — without it, the click inherits the test
+  // budget (900 s) and a single stuck click (overlay, animation, etc.)
+  // wedges the whole theme. The audit prefers skipping a surface over
+  // hanging — failures land as console warnings in the safe() wrapper.
+  const clickTimeoutMs = 5000;
   const btn = page.getByRole('button', { name: label }).first();
   if (await btn.isVisible({ timeout: timeoutMs }).catch(() => false)) {
-    await btn.click();
-    return true;
+    try {
+      await btn.click({ timeout: clickTimeoutMs });
+      return true;
+    } catch (_) {
+      // fall through to text-locator path
+    }
   }
   const txt = page.getByText(label).first();
   if (await txt.isVisible({ timeout: timeoutMs }).catch(() => false)) {
-    await txt.click();
-    return true;
+    try {
+      await txt.click({ timeout: clickTimeoutMs });
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
   return false;
 }


### PR DESCRIPTION
The last audit run wedged on `indigo/settings/account` when `tryClickByText` tapped the `Profile` tile. The click resolved a locator but never completed — most likely a transient welcome-card or what's-new overlay intercepting pointer events. Because `click()` had no per-call timeout, it inherited the test-level 900 s budget and burned the full 15 minutes on a single tap, leaving paper + ember themes + the AREAS.md regen step to fail with 'browser has been closed'.

## Fix
- Per-click timeout of 5 s.
- Failures now bubble through the existing `safe()` wrapper as a single warning and the next surface continues, rather than wedging the whole theme.

Doesn't address WHY the click is sometimes wedged (separate investigation: the Welcome card / What's New modal may sit over Settings on a freshly-registered audit user). This change just stops one bad surface from killing the whole run.