### PR TITLE
fix(client): mobile canvas pinch + double-tap zoom + fit to actual region

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -188,6 +188,39 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     _viewport.value = Matrix4.identity()..scaleByDouble(fit, fit, fit, 1);
   }
 
+  /// Toggle between fit-to-screen and a 2× zoom centred on the tap point.
+  /// `tapPoint` is in viewport-local pixels (where the user touched);
+  /// `minScale` is the fit-to-screen scale for the current viewport.
+  ///
+  /// This is the recommended mobile UX: pinch is fiddly with one hand,
+  /// and the gesture arena gets noisy with a drawing tool in hand. A
+  /// double-tap is unambiguous and works in either drawing or idle mode.
+  void _toggleDoubleTapZoom(Offset tapPoint, double minScale) {
+    final current = _viewport.value.getMaxScaleOnAxis();
+    final isFit = (current - minScale).abs() < 1e-3;
+    if (isFit) {
+      // Zoom in. The transform's scale * canvasPoint + translate = tap,
+      // so translate = tap - scale * canvasPoint. We want the tap point
+      // to stay anchored on the same pixel of the canvas under the
+      // finger as it zooms in.
+      const targetScale = 2.0;
+      final inverse = Matrix4.copy(_viewport.value)..invert();
+      final canvasPoint = MatrixUtils.transformPoint(inverse, tapPoint);
+      final m = Matrix4.identity()
+        ..scaleByDouble(targetScale, targetScale, targetScale, 1)
+        ..setTranslationRaw(
+          tapPoint.dx - canvasPoint.dx * targetScale,
+          tapPoint.dy - canvasPoint.dy * targetScale,
+          0,
+        );
+      _viewport.value = m;
+    } else {
+      // Snap back to fit-to-screen.
+      _viewport.value = Matrix4.identity()
+        ..scaleByDouble(minScale, minScale, minScale, 1);
+    }
+  }
+
   String? _buildAvatarUrl() {
     final avatarPath = ref.read(authProvider).avatarUrl;
     if (avatarPath == null || avatarPath.isEmpty) return null;
@@ -1228,55 +1261,68 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
 
     // Figma-style zoom + pan over a finite 4096×4096 surface.
     //
-    // minScale is computed dynamically so at full zoom-out the entire
-    // canvas fits inside the viewport (no wasted space outside, no
-    // letterboxing inside). On a small phone this might be ~0.1; on a
-    // 4K monitor it can exceed 1.0 — that's fine, the user can still
-    // zoom in up to maxScale for fine detail. Pan is disabled while
-    // drawing so single-pointer drags become strokes; pinch + trackpad
-    // scroll still zoom regardless.
+    // minScale uses the InteractiveViewer's ACTUAL region (via
+    // LayoutBuilder below), not the full screen — the previous
+    // MediaQuery-based calc included the header band + dock so the canvas
+    // rendered smaller than the available area and only the top-left
+    // corner was touchable (user feedback, 2026-05-27).
+    //
+    // Pan is disabled while drawing so single-pointer drags become
+    // strokes. **Scale stays enabled**: pinch needs two fingers and
+    // doesn't conflict with single-finger drawing — the drawing layer's
+    // PanGestureRecognizer cancels when a second pointer arrives,
+    // handing the pinch off to InteractiveViewer's ScaleGestureRecognizer.
     //
     // Background sits in a separate scaffold layer behind this widget
     // so it never moves with the canvas.
-    final size = MediaQuery.sizeOf(context);
-    final viewportW = size.width;
-    final viewportH = size.height;
-    final minScale = viewportW <= 0 || viewportH <= 0
-        ? 0.1
-        : math.min(viewportW / kCanvasWidth, viewportH / kCanvasHeight);
     const maxScale = 4.0;
-
-    // Apply the initial pose once we have a non-zero viewport: place the
-    // canvas top-left at the viewport top-left, scaled so the whole
-    // canvas fits. The user can then pan/zoom from a known starting
-    // overview instead of landing somewhere arbitrary inside a 4096-px
-    // surface.
-    if (!_viewportInitialised && viewportW > 0 && viewportH > 0) {
-      _viewportInitialised = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        _viewport.value = Matrix4.identity()
-          ..scaleByDouble(minScale, minScale, minScale, 1);
-      });
-    }
 
     final viewportContent = _spotlightMode
         ? mergedContent
-        : InteractiveViewer(
-            transformationController: _viewport,
-            minScale: minScale,
-            maxScale: maxScale,
-            // Both pan AND scale must be off while a tool is in hand —
-            // otherwise InteractiveViewer's ScaleGestureRecognizer can claim
-            // single-pointer drags via its scale-of-one path and turn a
-            // shape draw into a viewport pan (image #57, 2026-05-27). The
-            // drawing layer's HitTestBehavior.opaque pairs with this to
-            // guarantee the gesture arena is uncontested.
-            panEnabled: !_isDrawing,
-            scaleEnabled: !_isDrawing,
-            trackpadScrollCausesScale: true,
-            boundaryMargin: EdgeInsets.zero,
-            child: mergedContent,
+        : LayoutBuilder(
+            builder: (ctx, constraints) {
+              final viewportW = constraints.maxWidth;
+              final viewportH = constraints.maxHeight;
+              final minScale = viewportW <= 0 || viewportH <= 0
+                  ? 0.1
+                  : math.min(
+                      viewportW / kCanvasWidth,
+                      viewportH / kCanvasHeight,
+                    );
+
+              // Initial pose: canvas top-left at the viewport top-left,
+              // scaled to fit. Re-applied if the viewport size changes
+              // (rotation, sidebar toggle, etc.) so the user never gets
+              // stuck off-canvas.
+              if (!_viewportInitialised && viewportW > 0 && viewportH > 0) {
+                _viewportInitialised = true;
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!mounted) return;
+                  _viewport.value = Matrix4.identity()
+                    ..scaleByDouble(minScale, minScale, minScale, 1);
+                });
+              }
+
+              return GestureDetector(
+                // Double-tap to toggle zoom — single-finger UX that
+                // doesn't fight the gesture arena. Tap once at fit-to-
+                // screen to jump to 2x at the tap point; tap again to
+                // return to fit.
+                behavior: HitTestBehavior.translucent,
+                onDoubleTapDown: (details) =>
+                    _toggleDoubleTapZoom(details.localPosition, minScale),
+                child: InteractiveViewer(
+                  transformationController: _viewport,
+                  minScale: minScale,
+                  maxScale: maxScale,
+                  panEnabled: !_isDrawing,
+                  scaleEnabled: true,
+                  trackpadScrollCausesScale: true,
+                  boundaryMargin: EdgeInsets.zero,
+                  child: mergedContent,
+                ),
+              );
+            },
           );
 
     return OrientationBuilder(

--- a/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
+++ b/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
@@ -5,21 +5,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/canvas_models.dart';
 import '../providers/canvas_provider.dart';
 
-/// Transparent pointer-capture overlay for freehand drawing in the voice
-/// lounge.
+/// Single-pointer drawing overlay for the voice lounge canvas.
 ///
-/// All stroke state (in-progress + committed) is owned by [canvasProvider]
-/// so it broadcasts to other participants and persists.  This widget is
-/// purely a pointer router: when [isActive] is true it sits above the voice
-/// canvas, captures pointer events that would otherwise hit avatars or
-/// shared-screen tiles, and forwards them to the provider as normalized
-/// `CanvasPoint`s.
+/// Previously used [Listener] with [HitTestBehavior.opaque] which ate ALL
+/// pointer events — including the second finger of a pinch — before the
+/// parent [InteractiveViewer]'s `ScaleGestureRecognizer` could claim them.
+/// That killed pinch-to-zoom on mobile (user feedback, 2026-05-27).
 ///
-/// Rendering of strokes (committed and in-progress) happens in
-/// `widgets/voice_canvas.dart`'s `_DrawingLayer`, which subscribes to the
-/// same provider state.  Without this overlay, drawing-mode pointer events
-/// would race with avatar drag handlers and stroke broadcast was previously
-/// not happening at all (#752).
+/// Now uses [GestureDetector]'s `onPan*` callbacks. Flutter's
+/// `PanGestureRecognizer` accepts exactly one pointer; a second touch
+/// causes the pan to lose the gesture arena, letting InteractiveViewer's
+/// scale recogniser take over so pinch-to-zoom works.
 class LoungeDrawingCanvas extends ConsumerStatefulWidget {
   final bool isActive;
 
@@ -31,10 +27,9 @@ class LoungeDrawingCanvas extends ConsumerStatefulWidget {
 }
 
 class LoungeDrawingCanvasState extends ConsumerState<LoungeDrawingCanvas> {
-  /// Pointer events delivered to this Listener arrive in the
-  /// InteractiveViewer-scaled child's coordinate space — i.e. absolute
-  /// canvas-space pixels in the 4096×4096 surface. We just clamp and pass
-  /// through; no per-viewport scaling is needed.
+  /// Pointer events arrive in the InteractiveViewer-scaled child's
+  /// coordinate space — absolute pixels in the 4096×4096 surface. We
+  /// clamp and pass through; no per-viewport scaling is needed.
   CanvasPoint _toCanvasPoint(Offset canvasSpace) {
     return CanvasPoint(
       x: canvasSpace.dx.clamp(0.0, kCanvasWidth),
@@ -42,37 +37,31 @@ class LoungeDrawingCanvasState extends ConsumerState<LoungeDrawingCanvas> {
     );
   }
 
-  void _onPointerDown(PointerDownEvent event) {
-    if (event.buttons != kPrimaryButton) return;
-    ref
-        .read(canvasProvider.notifier)
-        .startStroke(_toCanvasPoint(event.localPosition));
-  }
-
-  void _onPointerMove(PointerMoveEvent event) {
-    if (event.buttons != kPrimaryButton) return;
-    ref
-        .read(canvasProvider.notifier)
-        .continueStroke(_toCanvasPoint(event.localPosition));
-  }
-
-  void _onPointerUp(PointerUpEvent event) {
-    ref.read(canvasProvider.notifier).endStroke();
-  }
-
-  void _onPointerCancel(PointerCancelEvent event) {
-    ref.read(canvasProvider.notifier).endStroke();
-  }
-
   @override
   Widget build(BuildContext context) {
     if (!widget.isActive) return const SizedBox.shrink();
-    return Listener(
+    return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onPointerDown: _onPointerDown,
-      onPointerMove: _onPointerMove,
-      onPointerUp: _onPointerUp,
-      onPointerCancel: _onPointerCancel,
+      // DragStartBehavior.down so the inner pan claims the gesture arena
+      // immediately on pointer-down instead of waiting for slop —
+      // otherwise a fast first stroke can get reclassified.
+      dragStartBehavior: DragStartBehavior.down,
+      onPanStart: (details) {
+        ref
+            .read(canvasProvider.notifier)
+            .startStroke(_toCanvasPoint(details.localPosition));
+      },
+      onPanUpdate: (details) {
+        ref
+            .read(canvasProvider.notifier)
+            .continueStroke(_toCanvasPoint(details.localPosition));
+      },
+      onPanEnd: (_) {
+        ref.read(canvasProvider.notifier).endStroke();
+      },
+      onPanCancel: () {
+        ref.read(canvasProvider.notifier).endStroke();
+      },
       child: const SizedBox.expand(),
     );
   }


### PR DESCRIPTION
Three mobile canvas issues from real testing:

| Issue | Cause | Fix |
|-------|-------|-----|
| Pinch-to-zoom doesn't work | LoungeDrawingCanvas used `Listener(HitTestBehavior.opaque)` which ate ALL pointer events including the second finger of a pinch — InteractiveViewer's `ScaleGestureRecognizer` never saw them. | Switched to `GestureDetector` with `onPan*` callbacks. Flutter's `PanGestureRecognizer` accepts exactly one pointer; a second touch loses the gesture arena and InteractiveViewer takes over. |
| Canvas shows in a small square only | `minScale` used `MediaQuery.sizeOf(context)` (full screen including 64 px header + ~80 px dock) but InteractiveViewer is inside an `Expanded` that's smaller. Canvas rendered scaled for a bigger region than it actually had, so only part of the viewport was canvas. | Wrap InteractiveViewer in `LayoutBuilder`, compute `minScale` from the actual constraint dimensions. Canvas now fills its real area edge-to-edge. |
| No reliable zoom on mobile | Pinch was broken (above); `scaleEnabled: false` while drawing further locked it out. | `scaleEnabled: true` always (PanGestureRecognizer in the drawing layer cancels on multi-touch so pinch reaches InteractiveViewer). Plus a **double-tap to zoom**: tap once at fit → 2× centred on the tap point, tap again → fit. Single-finger UX that works in drawing mode too. |

## Test plan
- [ ] Mobile: pinch out → canvas zooms in, anchored on the centre of the pinch
- [ ] Mobile: pinch in → canvas zooms back out
- [ ] Mobile: double-tap empty space → zooms to 2× at that point
- [ ] Mobile: double-tap again → returns to fit-to-screen
- [ ] Mobile: with a tool in hand, single-finger drag draws (does NOT pan canvas)
- [ ] Mobile: canvas fills the actual lounge area (no wasted black margin below)
- [ ] Desktop: pinch + trackpad scroll still work, no regression in existing UX