### PR TITLE
fix(client): use Material for about-section server card (CI test fix)

### DIFF
--- a/apps/client/lib/src/screens/settings/about_section.dart
+++ b/apps/client/lib/src/screens/settings/about_section.dart
@@ -430,10 +430,15 @@ class _AboutSectionState extends ConsumerState<AboutSection> {
           ),
         ),
         const SizedBox(height: 12),
-        Container(
-          decoration: BoxDecoration(
-            color: context.surface,
-            border: Border.all(color: context.border),
+        // Material (not Container w/ BoxDecoration) — Material's `color`
+        // sits BELOW the InkResponse layer so ListTile ripples stay
+        // visible. The previous Container-with-decoration triggered the
+        // "ListTile background color may be invisible" debug assertion
+        // in test (failing CI on #1247).
+        Material(
+          color: context.surface,
+          shape: RoundedRectangleBorder(
+            side: BorderSide(color: context.border),
             borderRadius: BorderRadius.circular(12),
           ),
           clipBehavior: Clip.antiAlias,


### PR DESCRIPTION
## Cause

PR #1242 wrapped the server list in:

```dart
Container(
  decoration: BoxDecoration(color: context.surface, ...),
  child: Column(... SettingsListTile ...),
)
```

Flutter's debug assertion catches this: a `DecoratedBox` (Container with decoration) sits ABOVE the `InkResponse` layer of the contained `ListTile`, so ListTile background + ink splashes get hidden. The assertion only fires in test runs, not at runtime, so my local `flutter test test/screens/settings/` (different path) missed it — only the full Flutter CI surfaced it via `test/widgets/settings/about_section_test.dart`.

CI run #26545378031 reported `2327 passed, 4 failed` — all 4 the about_section tests.

## Fix

Swap `Container` → `Material` with the same colour + border + radius. Material's `color` sits BELOW the InkResponse layer, so ListTile ripples render correctly.

```dart
Material(
  color: context.surface,
  shape: RoundedRectangleBorder(
    side: BorderSide(color: context.border),
    borderRadius: BorderRadius.circular(12),
  ),
  ...
)
```

Visually identical card. Tests now pass locally: `flutter test test/widgets/settings/about_section_test.dart` → 4/4.

## Test plan
- [x] `flutter analyze --fatal-infos` clean
- [x] All 4 about_section widget tests pass locally
- [ ] Flutter CI on main is green after merge