### PR TITLE
feat(client): infinite-style canvas (100k surface, auto-fit on join)

### DIFF
--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -4,23 +4,38 @@ import 'dart:ui' show Color;
 // Canvas geometry helpers
 // ---------------------------------------------------------------------------
 
-/// Fixed virtual canvas size shared by every participant regardless of their
-/// screen size or orientation. The InteractiveViewer in the voice lounge
-/// scrolls + zooms inside this 4096×4096 logical surface so a circle drawn
-/// on a phone reads as a circle on a desktop. See
-/// `apps/client/lib/src/screens/voice_lounge_screen.dart` for the
-/// viewport-fit math (minScale = min(viewportW, viewportH) / kCanvasWidth).
-const double kCanvasWidth = 4096;
-const double kCanvasHeight = 4096;
+/// Virtual canvas size. 100k×100k is large enough to feel infinite for any
+/// realistic call (at default 1× zoom you'd have to drag your finger across
+/// the screen ~250 times to cross it) while staying inside the range where
+/// Flutter's transformation math and floating-point precision behave well.
+/// Treat the lounge as a Figma-style pannable surface where the user lands
+/// in a default region (origin, or the bbox of existing content on
+/// rejoin) and can zoom out repeatedly to see more.
+///
+/// Old call-sites of `kCanvasWidth` from the 4096-era still work as a
+/// "clamp coords to the canvas" guard, but the value is now so large the
+/// clamp is effectively a no-op for any realistic input.
+const double kCanvasWidth = 100000;
+const double kCanvasHeight = 100000;
 
-/// Migrates legacy [0, 1] normalized coordinates persisted before the fixed
-/// 4096-px space landed. The heuristic is "value ≤ 1.0 means legacy
-/// normalized" — safe because the new pixel range starts at 0 and crosses 1
-/// instantly (4096 / 4096 ≈ 1.0 is at the bottom-right corner; any other
-/// real-world stroke point is far above 1.0). Without this old persisted
-/// canvases would collapse into the top-left pixel after upgrade.
+/// Legacy 4096-px canvas size, used by [_migrateLegacyCoord] so old
+/// persisted strokes land where they were drawn (in the top-left 4% of
+/// the new 100k space) instead of being rescaled to fill the new range.
+/// Auto-fit-to-content on join zooms the user to that region naturally,
+/// so users never notice the canvas got bigger underneath them.
+const double _kLegacyNormalisedScale = 4096;
+
+/// Migrates very old (pre-4096) coordinates persisted as normalized 0..1
+/// fractions of the viewport. Returns absolute canvas-space pixels.
+///
+/// Heuristic: a `value <= 1.0` is interpreted as normalised and multiplied
+/// by [_kLegacyNormalisedScale] (NOT by [kCanvasWidth] — multiplying by
+/// 100k would scatter old drawings across the entire new space, breaking
+/// their relative positions). 4096-era and 100k-era coords (anything > 1)
+/// pass through unchanged. The `axisExtent` parameter is now unused but
+/// kept for call-site compatibility; remove on the next sweep.
 double _migrateLegacyCoord(double value, double axisExtent) {
-  if (value <= 1.0) return value * axisExtent;
+  if (value <= 1.0) return value * _kLegacyNormalisedScale;
   return value;
 }
 

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -12,7 +12,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import '../models/canvas_models.dart'
-    show CanvasTool, kCanvasHeight, kCanvasWidth;
+    show CanvasState, CanvasTool, kCanvasHeight, kCanvasWidth;
 import '../providers/auth_provider.dart';
 import '../providers/canvas_provider.dart';
 import '../providers/channels_provider.dart';
@@ -156,68 +156,111 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   }
 
   void _onViewportChanged() {
-    // The reset-view button only needs to appear when the user has actively
-    // panned or zoomed away from the initial fit-to-screen pose. The fit
-    // pose itself isn't identity (it's a uniform scale), so use the matrix
-    // translation + a tolerance check on scale instead.
-    final m = _viewport.value;
+    // Show the reset-view affordance whenever the user is no longer at
+    // the auto-fit pose (either scale or translation differs by more
+    // than a tolerance). Computing the fit pose here is cheap because
+    // _computeInitialPose is O(strokes + images) and runs only on
+    // transform changes (1× per pan/zoom frame, throttled by Flutter).
     final size = MediaQuery.maybeSizeOf(context) ?? Size.zero;
-    final fit = size.width <= 0 || size.height <= 0
-        ? 1.0
-        : math.min(size.width / kCanvasWidth, size.height / kCanvasHeight);
-    final scaleDiff = (m.getMaxScaleOnAxis() - fit).abs();
-    final translated = m.getTranslation().length > 0.5;
-    final transformed = scaleDiff > 1e-3 || translated;
+    if (size.width <= 0 || size.height <= 0) return;
+    final fitPose = _computeInitialPose(ref.read(canvasProvider), size);
+    final fitScale = fitPose.getMaxScaleOnAxis();
+    final fitTranslation = fitPose.getTranslation();
+    final cur = _viewport.value;
+    final scaleDiff = (cur.getMaxScaleOnAxis() - fitScale).abs();
+    final translationDiff =
+        (cur.getTranslation() - fitTranslation).length;
+    // Tolerances: scale within 0.1% of fit, translation within 0.5 px.
+    final transformed = scaleDiff > fitScale * 1e-3 || translationDiff > 0.5;
     if (transformed != _viewportTransformed) {
       setState(() => _viewportTransformed = transformed);
     }
   }
 
   void _resetViewport() {
-    // Reset to the same starting pose used on first mount: canvas top-left
-    // at viewport top-left, scaled so the entire 4096-px surface fits.
+    // Recompute the same auto-fit pose used on first mount so the user
+    // can always get back to "looking at the existing content".
     final size = MediaQuery.sizeOf(context);
     if (size.width <= 0 || size.height <= 0) {
       _viewport.value = Matrix4.identity();
       return;
     }
-    final fit = math.min(
-      size.width / kCanvasWidth,
-      size.height / kCanvasHeight,
-    );
-    _viewport.value = Matrix4.identity()..scaleByDouble(fit, fit, fit, 1);
+    _viewport.value = _computeInitialPose(ref.read(canvasProvider), size);
   }
 
-  /// Toggle between fit-to-screen and a 2× zoom centred on the tap point.
-  /// `tapPoint` is in viewport-local pixels (where the user touched);
-  /// `minScale` is the fit-to-screen scale for the current viewport.
-  ///
-  /// This is the recommended mobile UX: pinch is fiddly with one hand,
-  /// and the gesture arena gets noisy with a drawing tool in hand. A
-  /// double-tap is unambiguous and works in either drawing or idle mode.
-  void _toggleDoubleTapZoom(Offset tapPoint, double minScale) {
+  /// Compute the matrix that frames the existing canvas content inside
+  /// [viewport]. Auto-fit semantics:
+  ///   - Bounding box of every stroke point + image rect (NOT avatars —
+  ///     they jitter every audio tick).
+  ///   - +10% padding so content doesn't touch the edges.
+  ///   - Empty canvas → identity at origin (user can pan to find their
+  ///     own drawing space).
+  Matrix4 _computeInitialPose(CanvasState canvas, Size viewport) {
+    // Walk strokes + images for the bbox.
+    double minX = double.infinity, minY = double.infinity;
+    double maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+    for (final s in canvas.strokes) {
+      for (final p in s.points) {
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y > maxY) maxY = p.y;
+      }
+    }
+    for (final img in canvas.images) {
+      if (img.x < minX) minX = img.x;
+      if (img.y < minY) minY = img.y;
+      if (img.x + img.width > maxX) maxX = img.x + img.width;
+      if (img.y + img.height > maxY) maxY = img.y + img.height;
+    }
+    final hasContent =
+        minX != double.infinity && (maxX > minX) && (maxY > minY);
+    if (!hasContent) {
+      // Empty canvas — identity at origin. User starts at (0,0) at 1×,
+      // pans to wherever they want to draw.
+      return Matrix4.identity();
+    }
+    final contentW = maxX - minX;
+    final contentH = maxY - minY;
+    // 10% padding around the bbox so strokes don't kiss the edges.
+    final pad = math.max(contentW, contentH) * 0.1;
+    final paddedW = contentW + pad * 2;
+    final paddedH = contentH + pad * 2;
+    final fit = math.min(
+      viewport.width / paddedW,
+      viewport.height / paddedH,
+    );
+    // Anchor: bbox top-left lands at (-pad, -pad) of the visible region
+    // so the padding shows on every side.
+    return Matrix4.identity()
+      ..scaleByDouble(fit, fit, fit, 1)
+      ..setTranslationRaw(-(minX - pad) * fit, -(minY - pad) * fit, 0);
+  }
+
+  /// Toggle between auto-fit and a 2× zoom centred on the tap point.
+  /// `tapPoint` is viewport-local pixels.
+  void _toggleDoubleTapZoom(Offset tapPoint) {
     final current = _viewport.value.getMaxScaleOnAxis();
-    final isFit = (current - minScale).abs() < 1e-3;
-    if (isFit) {
+    final size = MediaQuery.maybeSizeOf(context) ?? Size.zero;
+    final fitPose = _computeInitialPose(ref.read(canvasProvider), size);
+    final fitScale = fitPose.getMaxScaleOnAxis();
+    final isAtFit = (current - fitScale).abs() < 1e-3;
+    if (isAtFit) {
       // Zoom in. The transform's scale * canvasPoint + translate = tap,
-      // so translate = tap - scale * canvasPoint. We want the tap point
-      // to stay anchored on the same pixel of the canvas under the
-      // finger as it zooms in.
+      // so translate = tap - scale * canvasPoint, anchoring the tap on
+      // the same canvas pixel.
       const targetScale = 2.0;
       final inverse = Matrix4.copy(_viewport.value)..invert();
       final canvasPoint = MatrixUtils.transformPoint(inverse, tapPoint);
-      final m = Matrix4.identity()
+      _viewport.value = Matrix4.identity()
         ..scaleByDouble(targetScale, targetScale, targetScale, 1)
         ..setTranslationRaw(
           tapPoint.dx - canvasPoint.dx * targetScale,
           tapPoint.dy - canvasPoint.dy * targetScale,
           0,
         );
-      _viewport.value = m;
     } else {
-      // Snap back to fit-to-screen.
-      _viewport.value = Matrix4.identity()
-        ..scaleByDouble(minScale, minScale, minScale, 1);
+      _viewport.value = fitPose;
     }
   }
 
@@ -1290,6 +1333,13 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     // Background sits in a separate scaffold layer behind this widget
     // so it never moves with the canvas.
     const maxScale = 4.0;
+    // Floor on how far the user can keep pinching out. Below this scale
+    // the 100k canvas would render under one logical pixel and the math
+    // collapses; in practice a user pinches to fit-content + a couple
+    // more outs and stops. Picked an order of magnitude past
+    // viewport/canvas so the Figma "zoom out forever" feel survives
+    // without giving Flutter a degenerate transform to deal with.
+    const minScaleFloor = 0.0001;
 
     final viewportContent = _spotlightMode
         ? mergedContent
@@ -1297,37 +1347,29 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
             builder: (ctx, constraints) {
               final viewportW = constraints.maxWidth;
               final viewportH = constraints.maxHeight;
-              final minScale = viewportW <= 0 || viewportH <= 0
-                  ? 0.1
-                  : math.min(
-                      viewportW / kCanvasWidth,
-                      viewportH / kCanvasHeight,
-                    );
-
-              // Initial pose: canvas top-left at the viewport top-left,
-              // scaled to fit. Re-applied if the viewport size changes
-              // (rotation, sidebar toggle, etc.) so the user never gets
-              // stuck off-canvas.
+              // Initial pose: auto-fit to the bbox of existing strokes +
+              // images so a late joiner doesn't have to hunt for the
+              // content. Falls back to identity-at-origin when the
+              // canvas is empty.
               if (!_viewportInitialised && viewportW > 0 && viewportH > 0) {
                 _viewportInitialised = true;
+                final canvas = ref.read(canvasProvider);
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   if (!mounted) return;
-                  _viewport.value = Matrix4.identity()
-                    ..scaleByDouble(minScale, minScale, minScale, 1);
+                  _viewport.value = _computeInitialPose(
+                    canvas,
+                    Size(viewportW, viewportH),
+                  );
                 });
               }
 
               return GestureDetector(
-                // Double-tap to toggle zoom — single-finger UX that
-                // doesn't fight the gesture arena. Tap once at fit-to-
-                // screen to jump to 2x at the tap point; tap again to
-                // return to fit.
                 behavior: HitTestBehavior.translucent,
                 onDoubleTapDown: (details) =>
-                    _toggleDoubleTapZoom(details.localPosition, minScale),
+                    _toggleDoubleTapZoom(details.localPosition),
                 child: InteractiveViewer(
                   transformationController: _viewport,
-                  minScale: minScale,
+                  minScale: minScaleFloor,
                   maxScale: maxScale,
                   panEnabled: !_isDrawing,
                   scaleEnabled: true,

--- a/apps/client/test/models/canvas_models_test.dart
+++ b/apps/client/test/models/canvas_models_test.dart
@@ -4,9 +4,13 @@ import 'package:echo_app/src/models/canvas_models.dart';
 
 void main() {
   group('CanvasPoint', () {
-    test('canvas dimensions are the agreed 4096 px square', () {
-      expect(kCanvasWidth, 4096);
-      expect(kCanvasHeight, 4096);
+    test('canvas dimensions are the 100k-px figma-style surface', () {
+      // The 100k value is the "feels infinite" virtual canvas; in 2026-05
+      // we bumped from the original 4096 to give users true Figma-style
+      // pan/zoom. The auto-fit-on-join logic frames the bbox of existing
+      // content so users never have to find the corner.
+      expect(kCanvasWidth, 100000);
+      expect(kCanvasHeight, 100000);
     });
 
     test('round-trips through JSON in canvas-space pixels', () {
@@ -24,12 +28,13 @@ void main() {
       expect(p.y, 200.0);
     });
 
-    test('legacy 0..1 normalized coords migrate to canvas-space pixels', () {
+    test('legacy 0..1 normalized coords migrate to legacy-4096 space', () {
       // Strokes persisted before the fixed-size canvas migration stored
-      // x/y as fractions of the participant's viewport. The fromJson
-      // heuristic (value ≤ 1.0 = legacy) rescales them to the shared
-      // 4096-px space so circles drawn on a phone display as circles on
-      // desktop after the upgrade.
+      // x/y as fractions of the participant's viewport. After the 100k
+      // bump, those are rescaled by 4096 (NOT by kCanvasWidth) so the
+      // old drawings stay in their original spatial relationships in
+      // the top-left 4% of the new 100k space. Auto-fit-to-content on
+      // join zooms users to that region naturally.
       final p = CanvasPoint.fromJson({'x': 0.5, 'y': 0.25});
       expect(p.x, closeTo(2048.0, 1e-9));
       expect(p.y, closeTo(1024.0, 1e-9));
@@ -103,7 +108,11 @@ void main() {
       expect(restored.height, closeTo(800, 1e-9));
     });
 
-    test('legacy 0..1 image coords migrate to canvas-space pixels', () {
+    test('legacy 0..1 image coords migrate to legacy-4096 space', () {
+      // Same rationale as the stroke-point test: legacy normalised
+      // values rescale by 4096 (not 100k) so old persisted images keep
+      // their relative positions in the top-left of the new space.
+      const legacyExtent = 4096.0;
       final restored = CanvasImage.fromJson({
         'id': 'img-legacy',
         'url': 'https://example.com/old.png',
@@ -112,10 +121,10 @@ void main() {
         'width': 0.5,
         'height': 0.25,
       });
-      expect(restored.x, closeTo(kCanvasWidth * 0.1, 1e-9));
-      expect(restored.y, closeTo(kCanvasHeight * 0.2, 1e-9));
-      expect(restored.width, closeTo(kCanvasWidth * 0.5, 1e-9));
-      expect(restored.height, closeTo(kCanvasHeight * 0.25, 1e-9));
+      expect(restored.x, closeTo(legacyExtent * 0.1, 1e-9));
+      expect(restored.y, closeTo(legacyExtent * 0.2, 1e-9));
+      expect(restored.width, closeTo(legacyExtent * 0.5, 1e-9));
+      expect(restored.height, closeTo(legacyExtent * 0.25, 1e-9));
     });
 
     test('copyWith updates only specified fields', () {


### PR DESCRIPTION
Re-grounded the canvas after user feedback. Previously: hard-fixed 4096×4096 with minScale = fit. User testing showed the canvas felt small and only the top-left was drawable when zoomed out beyond fit. Original intent (from the day-one brief) was Figma-style infinite.

## Design (decided with the user, 4 questions)

| Q | Answer |
|---|---|
| Canvas size | Truly infinite — Figma-style, no bounds |
| Min zoom | Zoom out forever — canvas keeps shrinking |
| Initial pose for new joiners | Auto-pan/zoom to fit existing content |
| Mesh background behaviour | Stays fixed to the screen (unchanged) |

## Implementation

- `kCanvasWidth` / `kCanvasHeight` bumped from 4096 → 100,000. Large enough to feel infinite for any realistic call (~250 phone-widths across) while staying within Flutter math safe ranges.
- `minScale` set to a tiny floor (0.0001) — pinch out 'forever' without giving InteractiveViewer a degenerate transform.
- Auto-fit pose: walks strokes + images for a bbox, computes a fit-with-10%-padding scale + translation. Empty canvas → identity at origin. Hooked into both first-mount AND reset-view-button so the user can always snap back to 'what everyone else sees'.
- Double-tap-zoom: toggles between the auto-fit pose and 2× anchored on the tap point.
- Reset-view button visibility: was comparing scale-to-fit only; now compares scale AND translation against the auto-fit pose with tolerance, so any pan or zoom shows the button.

## Backward compatibility

Legacy migration heuristic in `_migrateLegacyCoord` was `value <= 1.0 ⇒ value * axisExtent`. Now `value <= 1.0 ⇒ value * 4096` (the legacy canvas size), NOT `value * 100000`. Old pre-4096 normalised drawings rescale to their original 4096-era positions; they land in the top-left 4% of the new 100k space. Auto-fit-to-content zooms users to that region naturally so the canvas just feels bigger underneath them. 4096-era and 100k-era coords (anything > 1) pass through unchanged.

## Validation

- [x] `flutter analyze --fatal-infos` clean
- [x] `cargo check -p echo-server` clean
- [x] **2,331 / 2,331** Flutter tests pass
- [x] Old persisted strokes (pre-4096 normalised AND 4096-era pixel) round-trip + render in the same relative positions; new strokes work at any coordinate in the 100k space

## Test plan
- [ ] Pinch out past `minScaleFloor` — canvas keeps shrinking, no clamp glitch
- [ ] Join a lounge with existing drawings → auto-fits to the content bbox
- [ ] Join an empty lounge → lands at (0,0) at 1× zoom
- [ ] Pan to (50000, 50000), draw a stroke → renders there; rejoin → still there
- [ ] Reset-view button appears whenever pose differs from auto-fit; disappears at auto-fit
- [ ] Double-tap: zooms to 2× at tap point; double-tap again → snaps back to auto-fit