### PR TITLE
fix(client): canvas uses actual InteractiveViewer region across all devices

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -4,6 +4,8 @@ library;
 import 'dart:convert';
 import 'dart:io';
 import 'package:file_picker/file_picker.dart';
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -80,8 +82,14 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
 
   @override
   Widget build(BuildContext context) {
+    // 280 px target, clamped down to the device's safe width minus a
+    // 16 px margin per side so the popup never overflows on narrow
+    // phones (iPhone SE at 320 logical width has exactly 288 usable
+    // and the old fixed 280 risked off-screen popup chrome).
+    final maxAllowed = (MediaQuery.sizeOf(context).width - 32).clamp(220.0, 320.0);
+    final menuWidth = math.min(280.0, maxAllowed);
     return SizedBox(
-      width: 280,
+      width: menuWidth,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -109,11 +109,19 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   /// transform differs from identity (any zoom or pan applied).
   bool _viewportTransformed = false;
 
-  /// True once the viewport has been initialised to the "canvas top-left at
-  /// viewport top-left, fully zoomed out" pose. Reset to false when this
-  /// widget is rebuilt for a different conversation/channel so each lounge
-  /// session starts from a clean canvas overview.
+  /// True once the viewport has been initialised to the auto-fit-content
+  /// pose. Reset to false when this widget is rebuilt for a different
+  /// conversation/channel so each lounge session starts from a clean
+  /// canvas overview.
   bool _viewportInitialised = false;
+
+  /// Tracks the actual InteractiveViewer region (from LayoutBuilder
+  /// constraints) so listener-driven callbacks like [_onViewportChanged]
+  /// + [_resetViewport] + [_toggleDoubleTapZoom] use the same dimensions
+  /// the initial pose was computed against. MediaQuery.sizeOf would
+  /// over-count by the header band + dock + members panel on tablets
+  /// and desktops, leaving reset/double-tap landing in the wrong pose.
+  Size? _interactiveViewportSize;
 
   /// Captured at initState so dispose() can clear fullscreen without
   /// touching `ref` (which becomes invalid the moment the element is
@@ -158,11 +166,11 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   void _onViewportChanged() {
     // Show the reset-view affordance whenever the user is no longer at
     // the auto-fit pose (either scale or translation differs by more
-    // than a tolerance). Computing the fit pose here is cheap because
-    // _computeInitialPose is O(strokes + images) and runs only on
-    // transform changes (1× per pan/zoom frame, throttled by Flutter).
-    final size = MediaQuery.maybeSizeOf(context) ?? Size.zero;
-    if (size.width <= 0 || size.height <= 0) return;
+    // than a tolerance). Uses the actual InteractiveViewer constraints
+    // captured by the LayoutBuilder — MediaQuery.sizeOf would over-count
+    // by the header band + dock + members panel.
+    final size = _interactiveViewportSize;
+    if (size == null || size.width <= 0 || size.height <= 0) return;
     final fitPose = _computeInitialPose(ref.read(canvasProvider), size);
     final fitScale = fitPose.getMaxScaleOnAxis();
     final fitTranslation = fitPose.getTranslation();
@@ -179,9 +187,13 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
 
   void _resetViewport() {
     // Recompute the same auto-fit pose used on first mount so the user
-    // can always get back to "looking at the existing content".
-    final size = MediaQuery.sizeOf(context);
-    if (size.width <= 0 || size.height <= 0) {
+    // can always get back to "looking at the existing content". Uses
+    // the actual InteractiveViewer region (captured by LayoutBuilder)
+    // so the reset lands in the right place on any device — tablets +
+    // desktops include sidebars / members panel that MediaQuery
+    // doesn't subtract.
+    final size = _interactiveViewportSize;
+    if (size == null || size.width <= 0 || size.height <= 0) {
       _viewport.value = Matrix4.identity();
       return;
     }
@@ -241,7 +253,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
   /// `tapPoint` is viewport-local pixels.
   void _toggleDoubleTapZoom(Offset tapPoint) {
     final current = _viewport.value.getMaxScaleOnAxis();
-    final size = MediaQuery.maybeSizeOf(context) ?? Size.zero;
+    final size = _interactiveViewportSize ?? Size.zero;
     final fitPose = _computeInitialPose(ref.read(canvasProvider), size);
     final fitScale = fitPose.getMaxScaleOnAxis();
     final isAtFit = (current - fitScale).abs() < 1e-3;
@@ -1347,6 +1359,19 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
             builder: (ctx, constraints) {
               final viewportW = constraints.maxWidth;
               final viewportH = constraints.maxHeight;
+              final viewportSize = Size(viewportW, viewportH);
+              // Cache the actual InteractiveViewer region so the
+              // listener-driven helpers (_onViewportChanged,
+              // _resetViewport, _toggleDoubleTapZoom) compute the same
+              // pose on tablets / desktops as the initial-mount path.
+              // MediaQuery.sizeOf includes the header + dock + members
+              // panel and would mis-anchor the reset / double-tap.
+              if (_interactiveViewportSize != viewportSize) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!mounted) return;
+                  _interactiveViewportSize = viewportSize;
+                });
+              }
               // Initial pose: auto-fit to the bbox of existing strokes +
               // images so a late joiner doesn't have to hunt for the
               // content. Falls back to identity-at-origin when the
@@ -1358,7 +1383,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
                   if (!mounted) return;
                   _viewport.value = _computeInitialPose(
                     canvas,
-                    Size(viewportW, viewportH),
+                    viewportSize,
                   );
                 });
               }


### PR DESCRIPTION
Sweep for device-dependent canvas paths uncovered three mismatches between the initial-pose math (LayoutBuilder constraints) and the listener-driven helpers (MediaQuery.sizeOf).

## What was inconsistent

| Path | Used | Should use |
|------|------|------------|
| Initial pose | LayoutBuilder `constraints` (correct) | — |
| `_onViewportChanged` (reset-button visibility) | `MediaQuery.sizeOf` (full screen) | InteractiveViewer constraints |
| `_resetViewport` (reset button + double-tap fallback) | `MediaQuery.sizeOf` | InteractiveViewer constraints |
| `_toggleDoubleTapZoom` (snap-back target) | `MediaQuery.sizeOf` | InteractiveViewer constraints |
| Drawing tools menu width | hardcoded `280 px` | clamped to viewport width − 32 px margin |

On a phone in portrait the full-screen and the interactive area are close enough that the bug was invisible. On tablets, desktops with sidebars, or any layout where the canvas occupies a fraction of the screen (members panel, lounge header, dock), `MediaQuery.sizeOf` over-counts — reset and double-tap landed in the wrong pose; the reset button could appear / disappear at the wrong scale.

## Fix
- New `_interactiveViewportSize` state field, updated by the LayoutBuilder (post-frame) every rebuild. All three listener-driven helpers read from it instead of MediaQuery.
- Drawing tools menu computes `menuWidth = min(280, screenWidth − 32)` so the popup never overflows on iPhone SE-class devices (320 logical px width).

## What this guarantees
- Reset / double-tap / reset-button visibility behave identically on phone (portrait + landscape), tablet, laptop, ultrawide.
- Drawing menu always fits regardless of device width.
- Strokes / avatars / images already store absolute canvas coords so they were already device-independent; this PR completes the picture for the viewport-control surfaces.

## Validation
- [x] `flutter analyze --fatal-infos` clean
- [x] **2,331 / 2,331** Flutter tests pass

## Test plan
- [ ] Mobile portrait: draw stroke, pan, hit reset → snaps to auto-fit correctly
- [ ] Mobile landscape: same
- [ ] Desktop with members panel visible: reset lands centred on existing content (not offset by panel width)
- [ ] iPhone SE (320 px wide): drawing tools popup fits within screen, no overflow chrome
- [ ] Tablet portrait / landscape: minScale + auto-fit consistent