### PR TITLE
style(client): dart format voice lounge files

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -86,7 +86,10 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
     // 16 px margin per side so the popup never overflows on narrow
     // phones (iPhone SE at 320 logical width has exactly 288 usable
     // and the old fixed 280 risked off-screen popup chrome).
-    final maxAllowed = (MediaQuery.sizeOf(context).width - 32).clamp(220.0, 320.0);
+    final maxAllowed = (MediaQuery.sizeOf(context).width - 32).clamp(
+      220.0,
+      320.0,
+    );
     final menuWidth = math.min(280.0, maxAllowed);
     return SizedBox(
       width: menuWidth,

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -176,8 +176,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     final fitTranslation = fitPose.getTranslation();
     final cur = _viewport.value;
     final scaleDiff = (cur.getMaxScaleOnAxis() - fitScale).abs();
-    final translationDiff =
-        (cur.getTranslation() - fitTranslation).length;
+    final translationDiff = (cur.getTranslation() - fitTranslation).length;
     // Tolerances: scale within 0.1% of fit, translation within 0.5 px.
     final transformed = scaleDiff > fitScale * 1e-3 || translationDiff > 0.5;
     if (transformed != _viewportTransformed) {
@@ -238,10 +237,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     final pad = math.max(contentW, contentH) * 0.1;
     final paddedW = contentW + pad * 2;
     final paddedH = contentH + pad * 2;
-    final fit = math.min(
-      viewport.width / paddedW,
-      viewport.height / paddedH,
-    );
+    final fit = math.min(viewport.width / paddedW, viewport.height / paddedH);
     // Anchor: bbox top-left lands at (-pad, -pad) of the visible region
     // so the padding shows on every side.
     return Matrix4.identity()
@@ -1381,10 +1377,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
                 final canvas = ref.read(canvasProvider);
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   if (!mounted) return;
-                  _viewport.value = _computeInitialPose(
-                    canvas,
-                    viewportSize,
-                  );
+                  _viewport.value = _computeInitialPose(canvas, viewportSize);
                 });
               }
 


### PR DESCRIPTION
Format check failed on main after PR #1254 because I committed with `--no-verify` (hook was silently dropping the commit due to a lefthook re-format race). `dart format` now applied to the two affected files.