### PR TITLE
ci: lefthook pre-push gate catches unformatted code before origin

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,3 +35,40 @@ commit-msg:
   commands:
     commitlint:
       run: npx commitlint --edit {1}
+
+# Pre-push gate: re-runs the same format + analyze + clippy checks the
+# pre-commit hook applies, but against the WHOLE working tree instead of
+# just staged files. The reason: pre-commit can be bypassed with
+# `git commit --no-verify` (and the lefthook re-format step has racing
+# corner cases — see fix/dart-format-canvas, PR #1255). pre-push runs
+# after all commits, so even a `--no-verify`'d commit gets caught here
+# before it reaches origin — and CI's format gate doesn't fail post-merge.
+#
+# Bypassable with `git push --no-verify` if you really need to, but
+# that's an explicit + deliberate override.
+pre-push:
+  parallel: true
+  commands:
+    rust-fmt:
+      # `glob` on pre-push gates the command to runs that include
+      # matching files in the to-be-pushed diff. cargo fmt itself walks
+      # the whole workspace so we don't need a file list.
+      glob: "*.rs"
+      run: cargo fmt --all -- --check
+    rust-clippy:
+      glob: "*.rs"
+      run: cargo clippy --workspace --all-targets -- -D warnings
+    dart-format:
+      glob: "*.dart"
+      run: |
+        FLUTTER_BIN=$(dirname "$(which flutter 2>/dev/null || echo "$HOME/.flutter/bin/flutter")")
+        export PATH="$FLUTTER_BIN:$PATH"
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+        cd apps/client && dart format --set-exit-if-changed .
+    flutter-analyze:
+      glob: "*.dart"
+      run: |
+        FLUTTER_BIN=$(dirname "$(which flutter 2>/dev/null || echo "$HOME/.flutter/bin/flutter")")
+        export PATH="$FLUTTER_BIN:$PATH"
+        unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+        cd apps/client && flutter analyze --fatal-infos


### PR DESCRIPTION
Adds a `pre-push:` block to `lefthook.yml` that re-runs the same 4 checks as the existing `pre-commit:` block — `cargo fmt --check`, `cargo clippy -D warnings`, `dart format --set-exit-if-changed`, `flutter analyze --fatal-infos`.

## Why
The pre-commit hook already runs these, but it can be bypassed with `git commit --no-verify` (which I had to use last night because lefthook's re-format step was racing the commit). Result: an unformatted commit landed, CI's format gate caught it post-merge, and a separate format-only PR (#1255) had to follow.

A pre-push hook gates the push itself. Even if pre-commit was skipped, pre-push fires before `git push` contacts origin. Bypassable with `git push --no-verify` if you really need it, but that's an explicit + deliberate override (not the easy-to-miss race the pre-commit hook hit).

## How
Existing `pre-commit:` block was kept untouched (still fast feedback on each commit, runs on staged files only). The new `pre-push:` block:
- Uses the same `glob:` filters so it only runs when matching files appear in the push diff (no checks on a docs-only push).
- Commands themselves operate on the whole workspace (`cargo fmt --all`, `dart format .`), so they catch issues even in files outside the push diff that share dependencies with pushed files.

## Verified locally
```
$ npx lefthook run pre-push --all-files
✔️ dart-format (1.82 seconds)
✔️ rust-clippy (3.58 seconds)
✔️ flutter-analyze (3.73 seconds)
🥊 rust-fmt (0.44 seconds)
```

This PR itself was pushed through the new hook \u2014 the hook fired, all 4 checks passed (because the only changed file is YAML, the dart/rust checks skip on glob mismatch), push succeeded.