### PR TITLE
fix(client): unlock pinch zoom + clean deselect path on mobile canvas

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -184,6 +184,22 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     }
   }
 
+  /// Toggle drawing mode from the dock's pencil button. When turning OFF,
+  /// also resets `selectedTool` to `CanvasTool.none` — otherwise the
+  /// auto-enable watch in `build()` (which flips `_isDrawing = true`
+  /// whenever a non-none tool is selected) immediately re-enables
+  /// drawing, leaving the user with no way to exit drawing mode (user
+  /// feedback 2026-05-28).
+  void _toggleDrawingMode() {
+    final wasDrawing = _isDrawing;
+    setState(() => _isDrawing = !wasDrawing);
+    if (wasDrawing) {
+      // Exiting drawing mode — clear the tool so the build watch doesn't
+      // immediately auto-re-enable on the next frame.
+      ref.read(canvasProvider.notifier).setTool(CanvasTool.none);
+    }
+  }
+
   void _resetViewport() {
     // Recompute the same auto-fit pose used on first mount so the user
     // can always get back to "looking at the existing content". Uses
@@ -1190,7 +1206,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       case DockSubmenu.draw:
         link = _drawingToolsLayerLink;
         content = DrawingToolsMenu(
-          onToggleDrawing: () => setState(() => _isDrawing = !_isDrawing),
+          onToggleDrawing: _toggleDrawingMode,
           isDrawing: _isDrawing,
           conversationId: conversationId,
           onRequestClose: _closeSubmenu,
@@ -1267,7 +1283,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       conversationId: conversationId,
       channelId: channelId,
       isDrawing: _isDrawing,
-      onToggleDrawing: () => setState(() => _isDrawing = !_isDrawing),
+      onToggleDrawing: _toggleDrawingMode,
       activeSubmenu: _activeSubmenu,
       onToggleSubmenu: (submenu) {
         setState(() {

--- a/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
+++ b/apps/client/lib/src/widgets/lounge_drawing_canvas.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -42,10 +41,14 @@ class LoungeDrawingCanvasState extends ConsumerState<LoungeDrawingCanvas> {
     if (!widget.isActive) return const SizedBox.shrink();
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      // DragStartBehavior.down so the inner pan claims the gesture arena
-      // immediately on pointer-down instead of waiting for slop —
-      // otherwise a fast first stroke can get reclassified.
-      dragStartBehavior: DragStartBehavior.down,
+      // Default `DragStartBehavior.start` (NOT `.down`) — `.down` claimed
+      // the gesture arena immediately on first-pointer-down, which
+      // blocked the parent InteractiveViewer's ScaleGestureRecognizer
+      // from ever taking over a two-finger pinch. With `.start`, the pan
+      // recogniser waits for a few pixels of slop before claiming, which
+      // gives the multi-touch path a window to assert ownership. Strokes
+      // have a tiny startup delay (kPanSlop ≈ 18 px) but pinch-to-zoom
+      // works on mobile again — see user feedback 2026-05-28.
       onPanStart: (details) {
         ref
             .read(canvasProvider.notifier)


### PR DESCRIPTION
Two real bugs from user feedback (screenshots showed mobile lounge with tools selected but no way to zoom, pan, or deselect):

## 1. Pinch-to-zoom didn't work on mobile

`LoungeDrawingCanvas` set `dragStartBehavior: DragStartBehavior.down`, which makes `PanGestureRecognizer` claim the gesture arena IMMEDIATELY on first-pointer-down — before any movement. Once claimed, no competing recogniser can take over the gesture. So when the user touched a second finger for pinch, the parent InteractiveViewer's `ScaleGestureRecognizer` couldn't claim the multi-touch sequence.

Fixed by switching back to the default `DragStartBehavior.start` — the pan recogniser waits for a few pixels of slop (~kPanSlop = 18) before claiming, which gives ScaleGestureRecognizer a window to assert ownership over a multi-touch gesture. The trade-off: stroke start has a tiny startup delay until the cursor has moved 18 px. Worth it for pinch.

## 2. No way to deselect a tool on mobile

The dock's pencil button (`onToggleDrawing`) just flipped `_isDrawing`. But the auto-enable watch in `build()` (which flips `_isDrawing = true` whenever `selectedTool != none`) immediately re-enabled drawing on the next frame. User got stuck with a tool in hand and no escape.

Fixed via new `_toggleDrawingMode()` helper: when turning OFF, also resets `selectedTool = CanvasTool.none` so the auto-enable watch doesn't re-fire.

## Validation

- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` — **2,331 / 2,331** pass
- [x] Pre-commit + pre-push hooks ran clean (no `--no-verify`)

## Test plan

- [ ] Mobile: select pen, pinch with two fingers → canvas zooms (was blocked)
- [ ] Mobile: select rect, tap pencil-button on dock → exits drawing mode (was stuck)
- [ ] Mobile: with no tool selected, single-finger drag → pans the canvas
- [ ] Mobile: with tool selected, single-finger drag → draws (with ~18 px slop before stroke starts)
- [ ] Desktop: no regression in mouse-driven flows