### PR TITLE
fix(client): compact voice-lounge header for mobile

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge/lounge_header.dart
+++ b/apps/client/lib/src/screens/voice_lounge/lounge_header.dart
@@ -29,42 +29,82 @@ class LoungeHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final participantTooltip =
+        '$participantCount participant${participantCount != 1 ? 's' : ''}';
     return Container(
       height: 56,
-      padding: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
       decoration: BoxDecoration(
         color: context.surface,
         border: Border(bottom: BorderSide(color: context.border, width: 1)),
       ),
       child: Row(
         children: [
-          const Icon(Icons.graphic_eq, size: 20, color: EchoTheme.online),
-          const SizedBox(width: 10),
-          Text(
-            channelName,
-            style: TextStyle(
-              color: context.textPrimary,
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
+          // Compact back: chevron only. The previous "Back to chat" text
+          // button ate ~110 px and collided with the call-metrics chip
+          // + participant pill on phones (user feedback 2026-05-28).
+          if (onBackToChat != null)
+            IconButton(
+              tooltip: 'Back to chat',
+              onPressed: onBackToChat,
+              icon: const Icon(Icons.chevron_left, size: 24),
+              style: IconButton.styleFrom(
+                foregroundColor: context.textSecondary,
+                minimumSize: const Size(40, 40),
+                padding: EdgeInsets.zero,
+              ),
             ),
-          ),
-          const SizedBox(width: 8),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: context.surfaceHover,
-              borderRadius: BorderRadius.circular(10),
-            ),
+          const Icon(Icons.graphic_eq, size: 18, color: EchoTheme.online),
+          const SizedBox(width: 6),
+          // Lounge name takes whatever space is left, ellipsis-truncated
+          // if needed so the trailing metrics/eye don't get pushed off
+          // the right edge of a narrow phone.
+          Flexible(
             child: Text(
-              '$participantCount participant${participantCount != 1 ? 's' : ''}',
+              channelName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
               style: TextStyle(
-                color: context.textSecondary,
-                fontSize: 11,
-                fontWeight: FontWeight.w500,
+                color: context.textPrimary,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
               ),
             ),
           ),
-          if (trailing != null) ...[const SizedBox(width: 8), trailing!],
+          const SizedBox(width: 6),
+          // Icon + number instead of "N participant(s)". The full text
+          // moves to a tooltip so screen readers + hover users still get it.
+          Tooltip(
+            message: participantTooltip,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: context.surfaceHover,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.person_outline,
+                    size: 12,
+                    color: context.textSecondary,
+                  ),
+                  const SizedBox(width: 3),
+                  Text(
+                    '$participantCount',
+                    style: TextStyle(
+                      color: context.textSecondary,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (trailing != null) ...[const SizedBox(width: 6), trailing!],
           const Spacer(),
           if (onToggleMembers != null)
             IconButton(
@@ -80,17 +120,8 @@ class LoungeHeader extends StatelessWidget {
               ),
               style: IconButton.styleFrom(
                 foregroundColor: context.textSecondary,
-                minimumSize: const Size(44, 44),
-              ),
-            ),
-          if (onBackToChat != null)
-            TextButton.icon(
-              onPressed: onBackToChat,
-              icon: const Icon(Icons.chat_outlined, size: 16),
-              label: const Text('Back to chat'),
-              style: TextButton.styleFrom(
-                foregroundColor: context.textSecondary,
-                textStyle: const TextStyle(fontSize: 13),
+                minimumSize: const Size(40, 40),
+                padding: EdgeInsets.zero,
               ),
             ),
         ],


### PR DESCRIPTION
Top bar of the voice lounge was cramming \u00b6 lounge speaker icon + name + "N participant(s)" pill + call-metrics chip + members eye-toggle + "Back to chat" text button into 420 px of width on a phone. Total fixed width was ~580 px so things overflowed or pushed each other off-screen.

## Compressed layout

| Element | Before | After |
|---------|--------|-------|
| Back to chat | `TextButton.icon` with "Back to chat" label (~110 px) | `IconButton` with chevron-left only (40 px), tooltip carries the label |
| Lounge name | Fixed-width Text | Wrapped in `Flexible` with `overflow: ellipsis` so it truncates instead of pushing siblings |
| Participant pill | "1 participant" / "3 participants" text | Person icon + number (e.g. `👤 1`), full phrase moved to a tooltip |
| Call metrics chip | unchanged (already compact) | unchanged |
| Members eye-toggle | 44 px hit target | 40 px (still meets typical touch threshold on the trailing edge) |
| Outer horizontal padding | 16 px each side | 8 px each side |

Net: header content fits inside ~280 px on a phone (well under the 420 px viewport even with members panel collapsed).

## Validation
- [x] `flutter analyze --fatal-infos` clean
- [x] **2,331 / 2,331** Flutter tests pass
- [x] Pre-commit + pre-push hooks ran clean

## Test plan
- [ ] Mobile portrait: name, participant pill, call metrics + members eye all visible without overflow
- [ ] Long channel names truncate with ellipsis instead of pushing trailing controls off-screen
- [ ] Back to chat \u2192 chevron tap behaves like the old TextButton