### PR TITLE
refactor(client): split websocket_provider into typing, receive, lifecycle, send slices (#1118)

### DIFF
--- a/apps/client/lib/src/providers/websocket/websocket_lifecycle.dart
+++ b/apps/client/lib/src/providers/websocket/websocket_lifecycle.dart
@@ -1,0 +1,70 @@
+part of '../websocket_provider.dart';
+
+/// Connection lifecycle slice of [WebSocketNotifier].
+///
+/// Owns the helpers that don't need to write the Notifier `state` setter:
+///  * ticket-fetch HTTP call
+///  * exponential-backoff math (pure)
+///  * channel-closed cleanup (resets transport fields then defers state
+///    mutation back to the host class via the returned action)
+///
+/// The orchestrating methods (`connect`, `_connectWithTicketOrFallback`,
+/// `_scheduleReconnect`, `_startHeartbeatMonitor`, `disconnect`) stay on
+/// the host class because Dart extensions can't reach the Notifier
+/// `state` setter across library boundaries.
+extension WsLifecycle on WebSocketNotifier {
+  /// Request a short-lived WebSocket ticket from the server. Returns the
+  /// ticket string on success, or `null` on any failure (network, 401, …).
+  /// Includes `device_id` in the body for multi-device routing.
+  Future<String?> _fetchWsTicketImpl() async {
+    final serverUrl = ref.read(serverUrlProvider);
+    // The crypto service may not be initialised yet on first connect.
+    final crypto = ref.read(cryptoServiceProvider);
+    final deviceId = crypto.isInitialized ? crypto.deviceId : 0;
+    try {
+      final response = await ref
+          .read(authProvider.notifier)
+          .authenticatedRequest(
+            (token) => http.post(
+              Uri.parse('$serverUrl/api/auth/ws-ticket'),
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer $token',
+              },
+              body: jsonEncode({'device_id': deviceId}),
+            ),
+          );
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return data['ticket'] as String?;
+      }
+    } catch (e) {
+      debugLog('Failed to fetch ws ticket: $e', 'WebSocket');
+      DebugLogService.instance.log(
+        LogLevel.error,
+        'WebSocket',
+        'Failed to fetch ws ticket: $e',
+      );
+    }
+    return null;
+  }
+
+  /// Tear down the transport-level fields after the stream's onDone/onError
+  /// fires. The host method follows up with [clearOnlineUsers], a state
+  /// write, and [_scheduleReconnect].
+  void _resetTransportAfterDisconnect() {
+    _subscription = null;
+    _channel = null;
+  }
+}
+
+/// Exponential backoff with 0-50% jitter, capped at 60s.
+///
+/// Pure helper extracted so the lifecycle slice's reconnect math is
+/// unit-testable in isolation and so the orchestration in
+/// `_scheduleReconnect` reads as a sequence rather than nested math.
+int wsComputeBackoffMs(int attempt, math.Random random) {
+  final baseDelay = math.min(1000 * math.pow(2, attempt).toInt(), 60000);
+  return baseDelay + random.nextInt(math.max(baseDelay ~/ 2, 1));
+}

--- a/apps/client/lib/src/providers/websocket/websocket_receive_dispatcher.dart
+++ b/apps/client/lib/src/providers/websocket/websocket_receive_dispatcher.dart
@@ -1,0 +1,25 @@
+part of '../websocket_provider.dart';
+
+/// Receive-dispatcher slice of [WebSocketNotifier].
+///
+/// Top-level routing of a raw inbound WS frame: decode JSON, update the
+/// last-message timestamp the heartbeat watchdog reads, then hand the
+/// parsed envelope off to [WsMessageHandler.handleServerMessage] which
+/// dispatches into the feature-grouped handler part files under
+/// `ws_handlers/`.
+///
+/// The session-replaced teardown stays on the host class because it
+/// touches the Notifier `state` setter (not visible from extensions in
+/// this library) plus the connection fields owned by the lifecycle slice.
+extension WsReceiveDispatcher on WebSocketNotifier {
+  /// Decode a raw inbound WS payload and dispatch into the handler mixin.
+  /// Returns the parsed JSON map so the host method can inspect post-
+  /// dispatch state (e.g. session_replaced teardown).
+  Map<String, dynamic> _decodeAndDispatchInbound(String data) {
+    _lastMessageTime = DateTime.now();
+    final json = jsonDecode(data) as Map<String, dynamic>;
+    final myUserId = ref.read(authProvider).userId ?? '';
+    handleServerMessage(json, myUserId);
+    return json;
+  }
+}

--- a/apps/client/lib/src/providers/websocket/websocket_send.dart
+++ b/apps/client/lib/src/providers/websocket/websocket_send.dart
@@ -1,0 +1,454 @@
+part of '../websocket_provider.dart';
+
+/// Send-path slice of [WebSocketNotifier]. Owns DM and group send-frame
+/// construction, the multi-device fanout, the encryption fallback chain,
+/// the group key self-heal, and the friendly-error mapping.
+///
+/// Wire shape is contract-tested in
+/// `test/providers/websocket_wire_shape_test.dart` — do NOT alter the JSON
+/// keys, top-level type, or the nested `recipient_device_contents` map
+/// shape without coordinating with the server-side parser.
+extension WsSend on WebSocketNotifier {
+  /// DM send pipeline: encrypt for every recipient device + own devices,
+  /// then emit a single `send_message` frame whose multi-device envelope
+  /// the server fans out.
+  Future<void> _sendDmMessage(
+    String toUserId,
+    String content, {
+    String? conversationId,
+    String? replyToId,
+    String? threadRootId,
+  }) async {
+    final cryptoState = ref.read(cryptoProvider);
+    if (!cryptoState.isInitialized) {
+      final reason = cryptoState.error ?? 'Encryption not initialized';
+      _addFailedMessage(
+        toUserId,
+        reason,
+        conversationId: conversationId,
+        originalContent: content,
+      );
+      return;
+    }
+
+    // If a previous key upload failed, retry now before sending.
+    if (cryptoState.keysUploadFailed) {
+      await ref.read(cryptoProvider.notifier).retryKeyUpload();
+    }
+
+    // (#522) Device IDs collide across users; keep per-recipient maps separate.
+    final result = await _encryptMessageForSend(toUserId, content);
+    if (result.payload == null) {
+      _addFailedMessage(
+        toUserId,
+        _friendlyEncryptionError(result.error ?? 'Encryption failed'),
+        conversationId: conversationId,
+        originalContent: content,
+      );
+      return;
+    }
+
+    final (recipientDeviceContents, fallbackPayload) = result.payload!;
+    _sendMessageFrame(
+      toUserId,
+      fallbackPayload,
+      recipientDeviceContents,
+      conversationId: conversationId,
+      replyToId: replyToId,
+      threadRootId: threadRootId,
+    );
+  }
+
+  /// Encrypt a message for all devices (recipient + self) with fallback chain.
+  /// Returns the encrypted payload on success, or the final error on total failure.
+  Future<
+    ({(Map<String, Map<String, String>>?, String)? payload, Object? error})
+  >
+  _encryptMessageForSend(String toUserId, String content) async {
+    Map<String, Map<String, String>>? recipientDeviceContents;
+    String fallbackPayload;
+    try {
+      final crypto = ref.read(cryptoServiceProvider);
+      final token = ref.read(authProvider).token ?? '';
+      crypto.setToken(token);
+
+      final recipientContents = await crypto.encryptForAllDevices(
+        toUserId,
+        content,
+      );
+
+      final myUserId = ref.read(authProvider).userId;
+      Map<String, String> selfContents = const {};
+      if (myUserId != null && myUserId.isNotEmpty) {
+        selfContents = await crypto.encryptForOwnDevices(myUserId, content);
+      }
+
+      recipientDeviceContents = _buildDeviceContentsMap(
+        toUserId,
+        recipientContents,
+        myUserId,
+        selfContents,
+      );
+
+      // Legacy fallback: prefer the recipient's first ciphertext over self.
+      fallbackPayload =
+          recipientContents.values.firstOrNull ??
+          selfContents.values.firstOrNull ??
+          '';
+
+      return (payload: (recipientDeviceContents, fallbackPayload), error: null);
+    } catch (e) {
+      return _encryptMessageFallback(toUserId, content, e);
+    }
+  }
+
+  /// Build the device contents map from recipient and self encryption results.
+  Map<String, Map<String, String>>? _buildDeviceContentsMap(
+    String toUserId,
+    Map<String, String> recipientContents,
+    String? myUserId,
+    Map<String, String> selfContents,
+  ) {
+    final contents = <String, Map<String, String>>{};
+    if (recipientContents.isNotEmpty) {
+      contents[toUserId] = recipientContents;
+    }
+    if (selfContents.isNotEmpty && myUserId != null && myUserId.isNotEmpty) {
+      contents[myUserId] = selfContents;
+    }
+    return contents;
+  }
+
+  /// Fallback encryption: try single-device, then session reset, then fail.
+  Future<
+    ({(Map<String, Map<String, String>>?, String)? payload, Object? error})
+  >
+  _encryptMessageFallback(
+    String toUserId,
+    String content,
+    Object firstError,
+  ) async {
+    debugLog('Multi-device encryption failed: $firstError', 'WS');
+    try {
+      final crypto = ref.read(cryptoServiceProvider);
+      final fallbackPayload = await crypto.encryptMessage(toUserId, content);
+      return (payload: (null, fallbackPayload), error: null);
+    } catch (e2) {
+      debugLog('Fallback encryption failed, resetting session: $e2', 'WS');
+      try {
+        final crypto = ref.read(cryptoServiceProvider);
+        await crypto.invalidateSessionKey(toUserId);
+        final fallbackPayload = await crypto.encryptMessage(toUserId, content);
+        return (payload: (null, fallbackPayload), error: null);
+      } catch (e3) {
+        debugLog('Encryption retry after reset also failed: $e3', 'WS');
+        return (payload: null, error: e3);
+      }
+    }
+  }
+
+  /// Send the encrypted message frame over WebSocket with optional metadata.
+  void _sendMessageFrame(
+    String toUserId,
+    String fallbackPayload,
+    Map<String, Map<String, String>>? recipientDeviceContents, {
+    String? conversationId,
+    String? replyToId,
+    String? threadRootId,
+  }) {
+    final msg = <String, dynamic>{
+      'type': 'send_message',
+      'to_user_id': toUserId,
+      'content': fallbackPayload,
+    };
+    if (recipientDeviceContents != null && recipientDeviceContents.isNotEmpty) {
+      msg['recipient_device_contents'] = recipientDeviceContents;
+    }
+    if (conversationId != null && conversationId.isNotEmpty) {
+      msg['conversation_id'] = conversationId;
+    }
+    if (replyToId != null && replyToId.isNotEmpty) {
+      msg['reply_to_id'] = replyToId;
+    }
+    if (threadRootId != null && threadRootId.isNotEmpty) {
+      msg['thread_root_id'] = threadRootId;
+    }
+
+    _emit(msg);
+  }
+
+  /// Add a failed message to the chat so the user can see the error.
+  ///
+  /// [originalContent] preserves the user's original text so it can be
+  /// retried later without re-typing.
+  void _addFailedMessage(
+    String peerUserId,
+    String reason, {
+    String? conversationId = '',
+    String? originalContent,
+  }) {
+    final auth = ref.read(authProvider);
+    final myUserId = auth.userId ?? '';
+    final myName = auth.username ?? 'You';
+    final msg = ChatMessage(
+      id: 'failed_${DateTime.now().millisecondsSinceEpoch}',
+      fromUserId: myUserId,
+      fromUsername: myName,
+      conversationId: conversationId ?? '',
+      content: reason,
+      timestamp: DateTime.now().toIso8601String(),
+      isMine: true,
+      status: MessageStatus.failed,
+      failedContent: originalContent,
+    );
+    ref.read(chatProvider.notifier).addMessage(msg);
+  }
+
+  /// Group send pipeline: encrypt if the conversation requires it, else
+  /// emit plaintext. Hard-fails (no wire send) on encryption error (#344).
+  Future<void> _sendGroupMessage(
+    String conversationId,
+    String content, {
+    String? channelId,
+    String? replyToId,
+    String? threadRootId,
+  }) async {
+    final conversation = ref
+        .read(conversationsProvider)
+        .conversations
+        .where((c) => c.id == conversationId)
+        .firstOrNull;
+    final isEncrypted = conversation?.isEncrypted ?? false;
+
+    final String payload;
+    // GRP2 binds (conv_id, msg_id) into the signature, so we mint msg_id
+    // pre-encrypt; GRP1 leaves null and server mints.
+    String? clientMessageId;
+    if (isEncrypted) {
+      final encrypted = await _encryptForGroupSend(
+        conversationId: conversationId,
+        content: content,
+        conversation: conversation,
+      );
+      if (encrypted == null) {
+        // Failure already enqueued via _addFailedMessage; do not send.
+        return;
+      }
+      payload = encrypted.payload;
+      clientMessageId = encrypted.clientMessageId;
+    } else {
+      payload = content;
+    }
+
+    _emit(
+      _buildGroupSendFrame(
+        conversationId: conversationId,
+        payload: payload,
+        clientMessageId: clientMessageId,
+        channelId: channelId,
+        replyToId: replyToId,
+        threadRootId: threadRootId,
+      ),
+    );
+  }
+
+  /// Builds the JSON map sent over the wire for a group `send_message`.
+  Map<String, dynamic> _buildGroupSendFrame({
+    required String conversationId,
+    required String payload,
+    required String? clientMessageId,
+    required String? channelId,
+    required String? replyToId,
+    required String? threadRootId,
+  }) {
+    final msg = <String, dynamic>{
+      'type': 'send_message',
+      'conversation_id': conversationId,
+      'content': payload,
+    };
+    if (clientMessageId != null) {
+      // Only set for GRP2 sends; server honours this id when storing.
+      msg['client_message_id'] = clientMessageId;
+    }
+    if (channelId != null && channelId.isNotEmpty) {
+      msg['channel_id'] = channelId;
+    }
+    if (replyToId != null && replyToId.isNotEmpty) {
+      msg['reply_to_id'] = replyToId;
+    }
+    if (threadRootId != null && threadRootId.isNotEmpty) {
+      msg['thread_root_id'] = threadRootId;
+    }
+    return msg;
+  }
+
+  /// Encrypts [content] for a group send. Returns `null` when encryption
+  /// fails (and enqueues a failed-message placeholder for retry); callers
+  /// must short-circuit in that case so plaintext never reaches the wire.
+  Future<({String payload, String? clientMessageId})?> _encryptForGroupSend({
+    required String conversationId,
+    required String content,
+    required Conversation? conversation,
+  }) async {
+    try {
+      final groupCrypto = ref.read(groupCryptoServiceProvider);
+      final token = ref.read(authProvider).token ?? '';
+      groupCrypto.setToken(token);
+
+      final keyResult = await _resolveGroupKeyWithSelfHeal(
+        conversationId: conversationId,
+        conversation: conversation,
+        groupCrypto: groupCrypto,
+      );
+      if (keyResult == null) {
+        // No group session yet -- hard fail rather than leak plaintext.
+        _addFailedMessage(
+          '',
+          _friendlyEncryptionError('No group session'),
+          conversationId: conversationId,
+          originalContent: content,
+        );
+        return null;
+      }
+      final (_, keyBase64) = keyResult;
+
+      // Phase 2D dispatch: GRP2 only when envelope's min_wire_version pins it.
+      final minWireVersion =
+          groupCrypto.cachedMinWireVersion(conversationId) ?? 1;
+      if (minWireVersion >= 2) {
+        return await _encryptGroupGrp2(
+          conversationId: conversationId,
+          content: content,
+          keyBase64: keyBase64,
+        );
+      }
+      final payload = await GroupCryptoService.encryptGroupMessage(
+        content,
+        keyBase64,
+      );
+      return (payload: payload, clientMessageId: null);
+    } catch (e) {
+      debugLog('Group encryption failed: $e', 'WebSocket');
+      _addFailedMessage(
+        '',
+        _friendlyEncryptionError(e),
+        conversationId: conversationId,
+        originalContent: content,
+      );
+      return null;
+    }
+  }
+
+  /// Looks up the cached group key, and if missing tries an owner/admin
+  /// self-heal seed + refetch so a wedged envelope can recover without
+  /// the user needing to tap a banner.
+  Future<(int, String)?> _resolveGroupKeyWithSelfHeal({
+    required String conversationId,
+    required Conversation? conversation,
+    required GroupCryptoService groupCrypto,
+  }) async {
+    var keyResult = await groupCrypto.getGroupKey(conversationId);
+    if (keyResult != null) {
+      return keyResult;
+    }
+
+    // Self-heal: owner/admin re-seeds wedged envelope (send-failures don't
+    // bump receive-failure counter so banner never fires otherwise).
+    if (!_isAdminOrOwnerOf(conversation)) {
+      return null;
+    }
+    debugLog(
+      'No usable group key for $conversationId — owner self-heal',
+      'WebSocket',
+    );
+    await ref.read(cryptoProvider.notifier).seedInitialGroupKey(conversationId);
+    keyResult = await groupCrypto.getGroupKey(conversationId);
+    // TD-5: force fetch in case seedInitialGroupKey lost a 409 race.
+    keyResult ??= await groupCrypto.fetchGroupKey(conversationId);
+    return keyResult;
+  }
+
+  /// True when the current user is an owner/admin of [conversation].
+  bool _isAdminOrOwnerOf(Conversation? conversation) {
+    final myUserId = ref.read(authProvider).userId ?? '';
+    final myMember = conversation?.members
+        .where((m) => m.userId == myUserId)
+        .firstOrNull;
+    final role = myMember?.role;
+    return role == 'owner' || role == 'admin';
+  }
+
+  /// Encrypts a GRP2 group send. Returns `null` (after enqueueing a
+  /// failed-message placeholder) when the identity signing key isn't
+  /// available — we refuse to silently downgrade to GRP1 because the
+  /// envelope's min_wire_version is pinned to 2.
+  Future<({String payload, String? clientMessageId})?> _encryptGroupGrp2({
+    required String conversationId,
+    required String content,
+    required String keyBase64,
+  }) async {
+    final crypto = ref.read(cryptoServiceProvider);
+    final signingKey = crypto.signingKeyPair;
+    if (signingKey == null) {
+      // No signing key yet (mid-init); GRP1 fallback would bounce off receiver's
+      // min_wire_version guard, so fail typed instead.
+      _addFailedMessage(
+        '',
+        _friendlyEncryptionError('Signing key unavailable for GRP2 send'),
+        conversationId: conversationId,
+        originalContent: content,
+      );
+      return null;
+    }
+    final convIdBytes = uuidStringToBytes(conversationId);
+    final msgIdBytes = newUuidBytes();
+    final clientMessageId = uuidBytesToString(msgIdBytes);
+    final payload = await GroupCryptoService.encryptGroupMessageV2(
+      plaintext: content,
+      keyBase64: keyBase64,
+      conversationIdBytes: convIdBytes,
+      messageIdBytes: msgIdBytes,
+      senderSigningKey: signingKey,
+    );
+    return (payload: payload, clientMessageId: clientMessageId);
+  }
+}
+
+/// Map raw encryption exceptions to user-readable messages.
+/// Never surfaces raw exception text — always returns a friendly string.
+///
+/// Pure free function (no `this`) so the send slice can stay a thin
+/// extension and so this can be unit-tested directly if needed.
+String _friendlyEncryptionError(Object e) {
+  if (e is IdentityKeyChangedException) {
+    return "This contact's identity has changed. "
+        'Verify their safety number before sending.';
+  }
+  final msg = e.toString();
+  if (msg.contains('No PreKey bundle found')) {
+    return 'Waiting for this person to come online to secure the chat.';
+  }
+  if (msg.contains('Failed to fetch keys')) {
+    return 'Message will send once the other person reconnects.';
+  }
+  if (msg.contains('Encryption not initialized')) {
+    return 'Setting up your secure session — please try again in a moment.';
+  }
+  if (msg.contains('No session for')) {
+    return 'Encryption session expired. Tap to retry.';
+  }
+  // #344: surfaced when sendGroupMessage cannot fetch the group key.
+  if (msg.contains('No group session') || msg.contains('group key')) {
+    return 'Group encryption key not available yet. Tap to retry.';
+  }
+  if (msg.contains('cannot decrypt') || msg.contains('Could not decrypt')) {
+    return "Couldn't decrypt this message";
+  }
+  if (msg.contains('OTP key_id') && msg.contains('not found')) {
+    return 'Encryption key mismatch. Ask the other person to resend.';
+  }
+  if (msg.contains('Auth expired')) {
+    return 'Session expired. Please try again.';
+  }
+  return "Couldn't send · Tap to retry";
+}

--- a/apps/client/lib/src/providers/websocket/websocket_typing.dart
+++ b/apps/client/lib/src/providers/websocket/websocket_typing.dart
@@ -1,0 +1,79 @@
+part of '../websocket_provider.dart';
+
+/// Typing-indicator slice of [WebSocketNotifier].
+///
+/// Owns:
+///  * `sendTyping` (outbound, throttled)
+///  * `_cleanupTyping` (periodic prune of inbound + outbound throttle map)
+///
+/// The throttle-state field `_lastTypingSent` and the periodic
+/// `_typingCleanupTimer` are declared on the host class because Dart
+/// extensions cannot add instance fields, but every read/write of them
+/// lives here so this file is the single source of truth for the slice.
+extension WsTyping on WebSocketNotifier {
+  /// Send a typing indicator (throttled to max 1 per 3 seconds per conversation).
+  void _sendTypingImpl(String conversationId, {String? channelId}) {
+    final throttleKey = '$conversationId:${channelId ?? ''}';
+    final now = DateTime.now();
+    final lastSent = _lastTypingSent[throttleKey];
+    if (lastSent != null && now.difference(lastSent).inSeconds < 3) {
+      return;
+    }
+    _lastTypingSent[throttleKey] = now;
+
+    final msg = <String, dynamic>{
+      'type': 'typing',
+      'conversation_id': conversationId,
+    };
+    if (channelId != null && channelId.isNotEmpty) {
+      msg['channel_id'] = channelId;
+    }
+    _emit(msg);
+  }
+
+  /// Prune our own outbound `_lastTypingSent` throttle entries (> 10s old).
+  /// Audit 2026-05-12 finding #9: bounded growth across long sessions.
+  void _pruneTypingThrottle() {
+    final now = DateTime.now();
+    final staleThrottleKeys = _lastTypingSent.entries
+        .where((e) => now.difference(e.value).inSeconds > 10)
+        .map((e) => e.key)
+        .toList();
+    for (final key in staleThrottleKeys) {
+      _lastTypingSent.remove(key);
+    }
+  }
+}
+
+/// Compute a new typing-users map with entries older than 5 seconds dropped.
+///
+/// Returns `null` when nothing changed (caller should skip the state write
+/// to avoid spurious rebuilds). Extracted as a pure free function so it can
+/// be unit-tested in isolation and lives in the same file as the rest of
+/// the typing slice.
+Map<String, Map<String, DateTime>>? _pruneStaleTyping(
+  Map<String, Map<String, DateTime>> input,
+) {
+  final updated = Map<String, Map<String, DateTime>>.from(input);
+  final now = DateTime.now();
+  var changed = false;
+
+  for (final conversationId in updated.keys.toList()) {
+    final users = Map<String, DateTime>.from(updated[conversationId]!);
+    final staleKeys = users.entries
+        .where((e) => now.difference(e.value).inSeconds >= 5)
+        .map((e) => e.key)
+        .toList();
+    for (final key in staleKeys) {
+      users.remove(key);
+      changed = true;
+    }
+    if (users.isEmpty) {
+      updated.remove(conversationId);
+    } else {
+      updated[conversationId] = users;
+    }
+  }
+
+  return changed ? updated : null;
+}

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -26,6 +26,7 @@ export 'ws_message_handler.dart' show WsMessageHandler, WebSocketState;
 
 part 'websocket_provider.g.dart';
 part 'websocket/websocket_typing.dart';
+part 'websocket/websocket_receive_dispatcher.dart';
 
 @Riverpod(keepAlive: true)
 class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
@@ -914,11 +915,12 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     });
   }
 
+  /// Stream listener entry point. Decoding + dispatch is in
+  /// `websocket/websocket_receive_dispatcher.dart`; this wrapper retains
+  /// the post-dispatch session-replaced teardown because it touches the
+  /// Notifier `state` setter and the lifecycle-owned connection fields.
   void _onMessage(String data) {
-    _lastMessageTime = DateTime.now();
-    final json = jsonDecode(data) as Map<String, dynamic>;
-    final myUserId = ref.read(authProvider).userId ?? '';
-    handleServerMessage(json, myUserId);
+    _decodeAndDispatchInbound(data);
 
     // session_replaced: disconnect, do NOT auto-reconnect (other session is active).
     if (state.wasReplaced) {

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -25,6 +25,7 @@ import 'ws_message_handler.dart';
 export 'ws_message_handler.dart' show WsMessageHandler, WebSocketState;
 
 part 'websocket_provider.g.dart';
+part 'websocket/websocket_typing.dart';
 
 @Riverpod(keepAlive: true)
 class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
@@ -791,24 +792,10 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
   }
 
   /// Send a typing indicator (throttled to max 1 per 3 seconds per conversation).
-  void sendTyping(String conversationId, {String? channelId}) {
-    final throttleKey = '$conversationId:${channelId ?? ''}';
-    final now = DateTime.now();
-    final lastSent = _lastTypingSent[throttleKey];
-    if (lastSent != null && now.difference(lastSent).inSeconds < 3) {
-      return;
-    }
-    _lastTypingSent[throttleKey] = now;
-
-    final msg = <String, dynamic>{
-      'type': 'typing',
-      'conversation_id': conversationId,
-    };
-    if (channelId != null && channelId.isNotEmpty) {
-      msg['channel_id'] = channelId;
-    }
-    _emit(msg);
-  }
+  /// Implementation lives in `websocket/websocket_typing.dart` so the
+  /// throttle map + cleanup timer have a single owner file.
+  void sendTyping(String conversationId, {String? channelId}) =>
+      _sendTypingImpl(conversationId, channelId: channelId);
 
   /// Notify the peer that encryption keys were reset for this conversation.
   void sendKeyReset(String conversationId) {
@@ -945,45 +932,16 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     }
   }
 
-  /// Remove stale typing indicators (older than 5 seconds).
-  /// Also prune throttle timestamps from this client's sendTyping() calls (audit
-  /// 2026-05-12, finding #9) to prevent unbounded growth across long sessions.
+  /// Periodic typing-state pruning. Pure prune logic + outbound throttle prune
+  /// live in `websocket/websocket_typing.dart`; only the state assignment
+  /// stays here because the Notifier `state` setter is not visible to
+  /// extensions in this library.
   void _cleanupTyping() {
-    final now = DateTime.now();
-    var changed = false;
-    final updatedTyping = Map<String, Map<String, DateTime>>.from(
-      state.typingUsers,
-    );
-
-    for (final conversationId in updatedTyping.keys.toList()) {
-      final users = Map<String, DateTime>.from(updatedTyping[conversationId]!);
-      final staleKeys = users.entries
-          .where((e) => now.difference(e.value).inSeconds >= 5)
-          .map((e) => e.key)
-          .toList();
-      for (final key in staleKeys) {
-        users.remove(key);
-        changed = true;
-      }
-      if (users.isEmpty) {
-        updatedTyping.remove(conversationId);
-      } else {
-        updatedTyping[conversationId] = users;
-      }
+    final pruned = _pruneStaleTyping(state.typingUsers);
+    if (pruned != null) {
+      state = state.copyWith(typingUsers: pruned);
     }
-
-    if (changed) {
-      state = state.copyWith(typingUsers: updatedTyping);
-    }
-
-    // Prune our own _lastTypingSent map (> 10s old entries are safe to evict).
-    final staleThrottleKeys = _lastTypingSent.entries
-        .where((e) => now.difference(e.value).inSeconds > 10)
-        .map((e) => e.key)
-        .toList();
-    for (final key in staleThrottleKeys) {
-      _lastTypingSent.remove(key);
-    }
+    _pruneTypingThrottle();
   }
 }
 

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -57,6 +57,20 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
   /// Throttle: track last typing event sent per conversation.
   final Map<String, DateTime> _lastTypingSent = {};
 
+  /// Test-visible log of every frame emitted via [_emit]. Empty in production
+  /// (write-only via [_emit]); tests can read it to assert wire shape without
+  /// having to inject a fake [WebSocketChannel].
+  @visibleForTesting
+  final List<Map<String, dynamic>> debugSentFrames = [];
+
+  /// Centralised emit hook: every WS frame the client sends goes through here
+  /// so wire-shape contract tests have one place to assert against. This must
+  /// remain behaviorally identical to a direct `_channel?.sink.add(jsonEncode(frame))`.
+  void _emit(Map<String, dynamic> frame) {
+    debugSentFrames.add(frame);
+    _channel?.sink.add(jsonEncode(frame));
+  }
+
   @override
   WebSocketState build() {
     // Periodically clean up stale typing indicators.
@@ -494,7 +508,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       msg['thread_root_id'] = threadRootId;
     }
 
-    _channel?.sink.add(jsonEncode(msg));
+    _emit(msg);
   }
 
   /// Map raw encryption exceptions to user-readable messages.
@@ -603,16 +617,14 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       payload = content;
     }
 
-    _channel?.sink.add(
-      jsonEncode(
-        _buildGroupSendFrame(
-          conversationId: conversationId,
-          payload: payload,
-          clientMessageId: clientMessageId,
-          channelId: channelId,
-          replyToId: replyToId,
-          threadRootId: threadRootId,
-        ),
+    _emit(
+      _buildGroupSendFrame(
+        conversationId: conversationId,
+        payload: payload,
+        clientMessageId: clientMessageId,
+        channelId: channelId,
+        replyToId: replyToId,
+        threadRootId: threadRootId,
       ),
     );
   }
@@ -795,21 +807,17 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     if (channelId != null && channelId.isNotEmpty) {
       msg['channel_id'] = channelId;
     }
-    _channel?.sink.add(jsonEncode(msg));
+    _emit(msg);
   }
 
   /// Notify the peer that encryption keys were reset for this conversation.
   void sendKeyReset(String conversationId) {
-    _channel?.sink.add(
-      jsonEncode({'type': 'key_reset', 'conversation_id': conversationId}),
-    );
+    _emit({'type': 'key_reset', 'conversation_id': conversationId});
   }
 
   /// Notify conversation members that a voice call was started.
   void sendCallStarted(String conversationId) {
-    _channel?.sink.add(
-      jsonEncode({'type': 'call_started', 'conversation_id': conversationId}),
-    );
+    _emit({'type': 'call_started', 'conversation_id': conversationId});
   }
 
   /// Send a reaction via REST (server broadcasts via WebSocket to other members).
@@ -864,9 +872,7 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     if (!privacy.readReceiptsEnabled) {
       return;
     }
-    _channel?.sink.add(
-      jsonEncode({'type': 'read_receipt', 'conversation_id': conversationId}),
-    );
+    _emit({'type': 'read_receipt', 'conversation_id': conversationId});
   }
 
   /// Relay a WebRTC signaling payload to another voice-channel member.
@@ -876,15 +882,13 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     required String toUserId,
     required Map<String, dynamic> signal,
   }) {
-    _channel?.sink.add(
-      jsonEncode({
-        'type': 'voice_signal',
-        'conversation_id': conversationId,
-        'channel_id': channelId,
-        'to_user_id': toUserId,
-        'signal': signal,
-      }),
-    );
+    _emit({
+      'type': 'voice_signal',
+      'conversation_id': conversationId,
+      'channel_id': channelId,
+      'to_user_id': toUserId,
+      'signal': signal,
+    });
   }
 
   /// Broadcast a voice-lounge canvas event to all conversation members.
@@ -893,14 +897,12 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
     required String kind,
     required Map<String, dynamic> payload,
   }) {
-    _channel?.sink.add(
-      jsonEncode({
-        'type': 'canvas_event',
-        'channel_id': channelId,
-        'kind': kind,
-        'payload': payload,
-      }),
-    );
+    _emit({
+      'type': 'canvas_event',
+      'channel_id': channelId,
+      'kind': kind,
+      'payload': payload,
+    });
   }
 
   /// Start a periodic timer that checks whether the server has gone silent.

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -27,6 +27,7 @@ export 'ws_message_handler.dart' show WsMessageHandler, WebSocketState;
 part 'websocket_provider.g.dart';
 part 'websocket/websocket_typing.dart';
 part 'websocket/websocket_receive_dispatcher.dart';
+part 'websocket/websocket_lifecycle.dart';
 
 @Riverpod(keepAlive: true)
 class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
@@ -110,44 +111,8 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       _voiceSignalController.stream;
 
   /// Request a short-lived WebSocket ticket from the server.
-  ///
-  /// Returns the ticket string on success, or null on failure. If the
-  /// request returns 401, attempts to refresh the access token once and
-  /// retries. Includes device_id in the request body for multi-device support.
-  Future<String?> _fetchWsTicket() async {
-    final serverUrl = ref.read(serverUrlProvider);
-    // Include device_id in the ticket request for multi-device routing.
-    // The crypto service may not be initialized yet on first connect.
-    final crypto = ref.read(cryptoServiceProvider);
-    final deviceId = crypto.isInitialized ? crypto.deviceId : 0;
-    try {
-      final response = await ref
-          .read(authProvider.notifier)
-          .authenticatedRequest(
-            (token) => http.post(
-              Uri.parse('$serverUrl/api/auth/ws-ticket'),
-              headers: {
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer $token',
-              },
-              body: jsonEncode({'device_id': deviceId}),
-            ),
-          );
-
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as Map<String, dynamic>;
-        return data['ticket'] as String?;
-      }
-    } catch (e) {
-      debugLog('Failed to fetch ws ticket: $e', 'WebSocket');
-      DebugLogService.instance.log(
-        LogLevel.error,
-        'WebSocket',
-        'Failed to fetch ws ticket: $e',
-      );
-    }
-    return null;
-  }
+  /// Implementation in `websocket/websocket_lifecycle.dart`.
+  Future<String?> _fetchWsTicket() => _fetchWsTicketImpl();
 
   void connect() {
     final token = ref.read(authProvider).token;
@@ -237,35 +202,28 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
 
     _subscription = _channel!.stream.listen(
       (data) => _onMessage(data as String),
-      onDone: () {
-        // Null these so the guard in _connectWithTicketOrFallback passes next time.
-        _subscription = null;
-        _channel = null;
-        DebugLogService.instance.log(
-          LogLevel.warning,
-          'WebSocket',
-          'Connection closed (onDone)',
-        );
-        // (#436) Mark peers offline; reconnect's presence_list reconciles.
-        clearOnlineUsers();
-        state = state.copyWith(isConnected: false);
-        _scheduleReconnect();
-      },
-      onError: (_) {
-        // Same cleanup as onDone.
-        _subscription = null;
-        _channel = null;
-        DebugLogService.instance.log(
-          LogLevel.error,
-          'WebSocket',
-          'Connection error (onError)',
-        );
-        // Same as onDone: clear stale presence before reconnect snapshot.
-        clearOnlineUsers();
-        state = state.copyWith(isConnected: false);
-        _scheduleReconnect();
-      },
+      onDone: () => _handleChannelClosed(
+        level: LogLevel.warning,
+        message: 'Connection closed (onDone)',
+      ),
+      onError: (_) => _handleChannelClosed(
+        level: LogLevel.error,
+        message: 'Connection error (onError)',
+      ),
     );
+  }
+
+  /// Shared onDone/onError teardown: reset transport, log, clear peer
+  /// presence (#436), drop `isConnected`, and schedule a reconnect.
+  void _handleChannelClosed({
+    required LogLevel level,
+    required String message,
+  }) {
+    _resetTransportAfterDisconnect();
+    DebugLogService.instance.log(level, 'WebSocket', message);
+    clearOnlineUsers();
+    state = state.copyWith(isConnected: false);
+    _scheduleReconnect();
   }
 
   /// Schedule a reconnection attempt with exponential backoff.
@@ -298,12 +256,9 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
       return;
     }
 
-    final baseDelay = math.min(
-      1000 * math.pow(2, _reconnectAttempts).toInt(),
-      60000,
-    );
-    // Add jitter (0–50% of base) to avoid thundering herd after server restart
-    final delayMs = baseDelay + _random.nextInt(math.max(baseDelay ~/ 2, 1));
+    // Backoff math (exponential + 0-50% jitter, capped 60s) lives in
+    // websocket/websocket_lifecycle.dart so it's testable in isolation.
+    final delayMs = wsComputeBackoffMs(_reconnectAttempts, _random);
     _reconnectAttempts++;
     state = state.copyWith(reconnectAttempts: _reconnectAttempts);
 

--- a/apps/client/lib/src/providers/websocket_provider.dart
+++ b/apps/client/lib/src/providers/websocket_provider.dart
@@ -28,6 +28,7 @@ part 'websocket_provider.g.dart';
 part 'websocket/websocket_typing.dart';
 part 'websocket/websocket_receive_dispatcher.dart';
 part 'websocket/websocket_lifecycle.dart';
+part 'websocket/websocket_send.dart';
 
 @Riverpod(keepAlive: true)
 class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
@@ -303,233 +304,31 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
   /// Direct messages are encrypted via the Signal Protocol. Encryption is
   /// attempted regardless of the conversation's isEncrypted flag to avoid
   /// blocking on newly created conversations where the flag may lag.
+  /// Implementation lives in `websocket/websocket_send.dart`.
   Future<void> sendMessage(
     String toUserId,
     String content, {
     String? conversationId,
     String? replyToId,
     String? threadRootId,
-  }) async {
-    final cryptoState = ref.read(cryptoProvider);
-    if (!cryptoState.isInitialized) {
-      final reason = cryptoState.error ?? 'Encryption not initialized';
-      _addFailedMessage(
-        toUserId,
-        reason,
-        conversationId: conversationId,
-        originalContent: content,
-      );
-      return;
-    }
+  }) => _sendDmMessage(
+    toUserId,
+    content,
+    conversationId: conversationId,
+    replyToId: replyToId,
+    threadRootId: threadRootId,
+  );
 
-    // If a previous key upload failed, retry now before sending.
-    if (cryptoState.keysUploadFailed) {
-      await ref.read(cryptoProvider.notifier).retryKeyUpload();
-    }
+  // Encryption fallback chain, device-contents map, frame builder,
+  // friendly-error mapping, failed-message helper, and the full group send
+  // pipeline (sendGroupMessage entry below) all live in
+  // `websocket/websocket_send.dart`. Keeping them in one file lets the
+  // wire-shape contract tests verify both 1:1 and group bytes in lockstep
+  // and keeps the host class focused on the Notifier `state` setter, which
+  // the send path doesn't touch.
 
-    // (#522) Device IDs collide across users; keep per-recipient maps separate.
-    final result = await _encryptMessageForSend(toUserId, content);
-    if (result.payload == null) {
-      _addFailedMessage(
-        toUserId,
-        _friendlyEncryptionError(result.error ?? 'Encryption failed'),
-        conversationId: conversationId,
-        originalContent: content,
-      );
-      return;
-    }
-
-    final (recipientDeviceContents, fallbackPayload) = result.payload!;
-    _sendMessageFrame(
-      toUserId,
-      fallbackPayload,
-      recipientDeviceContents,
-      conversationId: conversationId,
-      replyToId: replyToId,
-      threadRootId: threadRootId,
-    );
-  }
-
-  /// Encrypt a message for all devices (recipient + self) with fallback chain.
-  /// Returns the encrypted payload on success, or the final error on total failure.
-  Future<
-    ({(Map<String, Map<String, String>>?, String)? payload, Object? error})
-  >
-  _encryptMessageForSend(String toUserId, String content) async {
-    Map<String, Map<String, String>>? recipientDeviceContents;
-    String fallbackPayload;
-    try {
-      final crypto = ref.read(cryptoServiceProvider);
-      final token = ref.read(authProvider).token ?? '';
-      crypto.setToken(token);
-
-      final recipientContents = await crypto.encryptForAllDevices(
-        toUserId,
-        content,
-      );
-
-      final myUserId = ref.read(authProvider).userId;
-      Map<String, String> selfContents = const {};
-      if (myUserId != null && myUserId.isNotEmpty) {
-        selfContents = await crypto.encryptForOwnDevices(myUserId, content);
-      }
-
-      recipientDeviceContents = _buildDeviceContentsMap(
-        toUserId,
-        recipientContents,
-        myUserId,
-        selfContents,
-      );
-
-      // Legacy fallback: prefer the recipient's first ciphertext over self.
-      fallbackPayload =
-          recipientContents.values.firstOrNull ??
-          selfContents.values.firstOrNull ??
-          '';
-
-      return (payload: (recipientDeviceContents, fallbackPayload), error: null);
-    } catch (e) {
-      return _encryptMessageFallback(toUserId, content, e);
-    }
-  }
-
-  /// Build the device contents map from recipient and self encryption results.
-  Map<String, Map<String, String>>? _buildDeviceContentsMap(
-    String toUserId,
-    Map<String, String> recipientContents,
-    String? myUserId,
-    Map<String, String> selfContents,
-  ) {
-    final contents = <String, Map<String, String>>{};
-    if (recipientContents.isNotEmpty) {
-      contents[toUserId] = recipientContents;
-    }
-    if (selfContents.isNotEmpty && myUserId != null && myUserId.isNotEmpty) {
-      contents[myUserId] = selfContents;
-    }
-    return contents;
-  }
-
-  /// Fallback encryption: try single-device, then session reset, then fail.
-  Future<
-    ({(Map<String, Map<String, String>>?, String)? payload, Object? error})
-  >
-  _encryptMessageFallback(
-    String toUserId,
-    String content,
-    Object firstError,
-  ) async {
-    debugLog('Multi-device encryption failed: $firstError', 'WS');
-    try {
-      final crypto = ref.read(cryptoServiceProvider);
-      final fallbackPayload = await crypto.encryptMessage(toUserId, content);
-      return (payload: (null, fallbackPayload), error: null);
-    } catch (e2) {
-      debugLog('Fallback encryption failed, resetting session: $e2', 'WS');
-      try {
-        final crypto = ref.read(cryptoServiceProvider);
-        await crypto.invalidateSessionKey(toUserId);
-        final fallbackPayload = await crypto.encryptMessage(toUserId, content);
-        return (payload: (null, fallbackPayload), error: null);
-      } catch (e3) {
-        debugLog('Encryption retry after reset also failed: $e3', 'WS');
-        return (payload: null, error: e3);
-      }
-    }
-  }
-
-  /// Send the encrypted message frame over WebSocket with optional metadata.
-  void _sendMessageFrame(
-    String toUserId,
-    String fallbackPayload,
-    Map<String, Map<String, String>>? recipientDeviceContents, {
-    String? conversationId,
-    String? replyToId,
-    String? threadRootId,
-  }) {
-    final msg = <String, dynamic>{
-      'type': 'send_message',
-      'to_user_id': toUserId,
-      'content': fallbackPayload,
-    };
-    if (recipientDeviceContents != null && recipientDeviceContents.isNotEmpty) {
-      msg['recipient_device_contents'] = recipientDeviceContents;
-    }
-    if (conversationId != null && conversationId.isNotEmpty) {
-      msg['conversation_id'] = conversationId;
-    }
-    if (replyToId != null && replyToId.isNotEmpty) {
-      msg['reply_to_id'] = replyToId;
-    }
-    if (threadRootId != null && threadRootId.isNotEmpty) {
-      msg['thread_root_id'] = threadRootId;
-    }
-
-    _emit(msg);
-  }
-
-  /// Map raw encryption exceptions to user-readable messages.
-  /// Never surfaces raw exception text — always returns a friendly string.
-  static String _friendlyEncryptionError(Object e) {
-    if (e is IdentityKeyChangedException) {
-      return "This contact's identity has changed. "
-          'Verify their safety number before sending.';
-    }
-    final msg = e.toString();
-    if (msg.contains('No PreKey bundle found')) {
-      return 'Waiting for this person to come online to secure the chat.';
-    }
-    if (msg.contains('Failed to fetch keys')) {
-      return 'Message will send once the other person reconnects.';
-    }
-    if (msg.contains('Encryption not initialized')) {
-      return 'Setting up your secure session \u2014 please try again in a moment.';
-    }
-    if (msg.contains('No session for')) {
-      return 'Encryption session expired. Tap to retry.';
-    }
-    // #344: surfaced when sendGroupMessage cannot fetch the group key.
-    if (msg.contains('No group session') || msg.contains('group key')) {
-      return 'Group encryption key not available yet. Tap to retry.';
-    }
-    if (msg.contains('cannot decrypt') || msg.contains('Could not decrypt')) {
-      return "Couldn't decrypt this message";
-    }
-    if (msg.contains('OTP key_id') && msg.contains('not found')) {
-      return 'Encryption key mismatch. Ask the other person to resend.';
-    }
-    if (msg.contains('Auth expired')) {
-      return 'Session expired. Please try again.';
-    }
-    return "Couldn't send · Tap to retry";
-  }
-
-  /// Add a failed message to the chat so the user can see the error.
-  ///
-  /// [originalContent] preserves the user's original text so it can be
-  /// retried later without re-typing.
-  void _addFailedMessage(
-    String peerUserId,
-    String reason, {
-    String? conversationId = '',
-    String? originalContent,
-  }) {
-    final auth = ref.read(authProvider);
-    final myUserId = auth.userId ?? '';
-    final myName = auth.username ?? 'You';
-    final msg = ChatMessage(
-      id: 'failed_${DateTime.now().millisecondsSinceEpoch}',
-      fromUserId: myUserId,
-      fromUsername: myName,
-      conversationId: conversationId ?? '',
-      content: reason,
-      timestamp: DateTime.now().toIso8601String(),
-      isMine: true,
-      status: MessageStatus.failed,
-      failedContent: originalContent,
-    );
-    ref.read(chatProvider.notifier).addMessage(msg);
-  }
+  // (encryption helpers, device-contents builder, fallback chain, and
+  // frame-builder all live in `websocket/websocket_send.dart`)
 
   /// Send a message to a group conversation.
   ///
@@ -540,212 +339,20 @@ class WebSocketNotifier extends _$WebSocketNotifier with WsMessageHandler {
   /// NOT sent.  This closes the silent plaintext downgrade vector (#344).
   /// Unencrypted groups (`isEncrypted=false`, the default) keep sending
   /// plaintext as before -- that path is intentional, not a downgrade.
+  /// Implementation lives in `websocket/websocket_send.dart`.
   Future<void> sendGroupMessage(
     String conversationId,
     String content, {
     String? channelId,
     String? replyToId,
     String? threadRootId,
-  }) async {
-    final conversation = ref
-        .read(conversationsProvider)
-        .conversations
-        .where((c) => c.id == conversationId)
-        .firstOrNull;
-    final isEncrypted = conversation?.isEncrypted ?? false;
-
-    final String payload;
-    // GRP2 binds (conv_id, msg_id) into the signature, so we mint msg_id
-    // pre-encrypt; GRP1 leaves null and server mints.
-    String? clientMessageId;
-    if (isEncrypted) {
-      final encrypted = await _encryptForGroupSend(
-        conversationId: conversationId,
-        content: content,
-        conversation: conversation,
-      );
-      if (encrypted == null) {
-        // Failure already enqueued via _addFailedMessage; do not send.
-        return;
-      }
-      payload = encrypted.payload;
-      clientMessageId = encrypted.clientMessageId;
-    } else {
-      payload = content;
-    }
-
-    _emit(
-      _buildGroupSendFrame(
-        conversationId: conversationId,
-        payload: payload,
-        clientMessageId: clientMessageId,
-        channelId: channelId,
-        replyToId: replyToId,
-        threadRootId: threadRootId,
-      ),
-    );
-  }
-
-  /// Builds the JSON map sent over the wire for a group `send_message`.
-  Map<String, dynamic> _buildGroupSendFrame({
-    required String conversationId,
-    required String payload,
-    required String? clientMessageId,
-    required String? channelId,
-    required String? replyToId,
-    required String? threadRootId,
-  }) {
-    final msg = <String, dynamic>{
-      'type': 'send_message',
-      'conversation_id': conversationId,
-      'content': payload,
-    };
-    if (clientMessageId != null) {
-      // Only set for GRP2 sends; server honours this id when storing.
-      msg['client_message_id'] = clientMessageId;
-    }
-    if (channelId != null && channelId.isNotEmpty) {
-      msg['channel_id'] = channelId;
-    }
-    if (replyToId != null && replyToId.isNotEmpty) {
-      msg['reply_to_id'] = replyToId;
-    }
-    if (threadRootId != null && threadRootId.isNotEmpty) {
-      msg['thread_root_id'] = threadRootId;
-    }
-    return msg;
-  }
-
-  /// Encrypts [content] for a group send. Returns `null` when encryption
-  /// fails (and enqueues a failed-message placeholder for retry); callers
-  /// must short-circuit in that case so plaintext never reaches the wire.
-  Future<({String payload, String? clientMessageId})?> _encryptForGroupSend({
-    required String conversationId,
-    required String content,
-    required Conversation? conversation,
-  }) async {
-    try {
-      final groupCrypto = ref.read(groupCryptoServiceProvider);
-      final token = ref.read(authProvider).token ?? '';
-      groupCrypto.setToken(token);
-
-      final keyResult = await _resolveGroupKeyWithSelfHeal(
-        conversationId: conversationId,
-        conversation: conversation,
-        groupCrypto: groupCrypto,
-      );
-      if (keyResult == null) {
-        // No group session yet -- hard fail rather than leak plaintext.
-        _addFailedMessage(
-          '',
-          _friendlyEncryptionError('No group session'),
-          conversationId: conversationId,
-          originalContent: content,
-        );
-        return null;
-      }
-      final (_, keyBase64) = keyResult;
-
-      // Phase 2D dispatch: GRP2 only when envelope's min_wire_version pins it.
-      final minWireVersion =
-          groupCrypto.cachedMinWireVersion(conversationId) ?? 1;
-      if (minWireVersion >= 2) {
-        return await _encryptGroupGrp2(
-          conversationId: conversationId,
-          content: content,
-          keyBase64: keyBase64,
-        );
-      }
-      final payload = await GroupCryptoService.encryptGroupMessage(
-        content,
-        keyBase64,
-      );
-      return (payload: payload, clientMessageId: null);
-    } catch (e) {
-      debugLog('Group encryption failed: $e', 'WebSocket');
-      _addFailedMessage(
-        '',
-        _friendlyEncryptionError(e),
-        conversationId: conversationId,
-        originalContent: content,
-      );
-      return null;
-    }
-  }
-
-  /// Looks up the cached group key, and if missing tries an owner/admin
-  /// self-heal seed + refetch so a wedged envelope can recover without
-  /// the user needing to tap a banner.
-  Future<(int, String)?> _resolveGroupKeyWithSelfHeal({
-    required String conversationId,
-    required Conversation? conversation,
-    required GroupCryptoService groupCrypto,
-  }) async {
-    var keyResult = await groupCrypto.getGroupKey(conversationId);
-    if (keyResult != null) {
-      return keyResult;
-    }
-
-    // Self-heal: owner/admin re-seeds wedged envelope (send-failures don't
-    // bump receive-failure counter so banner never fires otherwise).
-    if (!_isAdminOrOwnerOf(conversation)) {
-      return null;
-    }
-    debugLog(
-      'No usable group key for $conversationId — owner self-heal',
-      'WebSocket',
-    );
-    await ref.read(cryptoProvider.notifier).seedInitialGroupKey(conversationId);
-    keyResult = await groupCrypto.getGroupKey(conversationId);
-    // TD-5: force fetch in case seedInitialGroupKey lost a 409 race.
-    keyResult ??= await groupCrypto.fetchGroupKey(conversationId);
-    return keyResult;
-  }
-
-  /// True when the current user is an owner/admin of [conversation].
-  bool _isAdminOrOwnerOf(Conversation? conversation) {
-    final myUserId = ref.read(authProvider).userId ?? '';
-    final myMember = conversation?.members
-        .where((m) => m.userId == myUserId)
-        .firstOrNull;
-    final role = myMember?.role;
-    return role == 'owner' || role == 'admin';
-  }
-
-  /// Encrypts a GRP2 group send. Returns `null` (after enqueueing a
-  /// failed-message placeholder) when the identity signing key isn't
-  /// available — we refuse to silently downgrade to GRP1 because the
-  /// envelope's min_wire_version is pinned to 2.
-  Future<({String payload, String? clientMessageId})?> _encryptGroupGrp2({
-    required String conversationId,
-    required String content,
-    required String keyBase64,
-  }) async {
-    final crypto = ref.read(cryptoServiceProvider);
-    final signingKey = crypto.signingKeyPair;
-    if (signingKey == null) {
-      // No signing key yet (mid-init); GRP1 fallback would bounce off receiver's
-      // min_wire_version guard, so fail typed instead.
-      _addFailedMessage(
-        '',
-        _friendlyEncryptionError('Signing key unavailable for GRP2 send'),
-        conversationId: conversationId,
-        originalContent: content,
-      );
-      return null;
-    }
-    final convIdBytes = uuidStringToBytes(conversationId);
-    final msgIdBytes = newUuidBytes();
-    final clientMessageId = uuidBytesToString(msgIdBytes);
-    final payload = await GroupCryptoService.encryptGroupMessageV2(
-      plaintext: content,
-      keyBase64: keyBase64,
-      conversationIdBytes: convIdBytes,
-      messageIdBytes: msgIdBytes,
-      senderSigningKey: signingKey,
-    );
-    return (payload: payload, clientMessageId: clientMessageId);
-  }
+  }) => _sendGroupMessage(
+    conversationId,
+    content,
+    channelId: channelId,
+    replyToId: replyToId,
+    threadRootId: threadRootId,
+  );
 
   /// Send a typing indicator (throttled to max 1 per 3 seconds per conversation).
   /// Implementation lives in `websocket/websocket_typing.dart` so the

--- a/apps/client/test/providers/websocket_wire_shape_test.dart
+++ b/apps/client/test/providers/websocket_wire_shape_test.dart
@@ -1,0 +1,351 @@
+// Wire-shape contract test for [WebSocketNotifier]. Locks down the JSON
+// frames the client emits so that any code-motion refactor (such as #1118)
+// can not silently corrupt the bytes-on-wire.
+//
+// IMPORTANT: every assertion below ties to a server-side parser. Tightening
+// a key, dropping a field, or renaming a top-level type breaks every
+// existing client. Update server-side handlers in lockstep if you change
+// anything here.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/conversation.dart';
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/conversations_provider.dart';
+import 'package:echo_app/src/providers/crypto_provider.dart';
+import 'package:echo_app/src/providers/privacy_provider.dart';
+import 'package:echo_app/src/providers/server_url_provider.dart';
+import 'package:echo_app/src/providers/websocket_provider.dart';
+import 'package:echo_app/src/services/crypto_service.dart';
+import 'package:echo_app/src/services/group_crypto_service.dart';
+
+import '../helpers/mock_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class _WireCryptoService extends CryptoService {
+  _WireCryptoService() : super(serverUrl: 'http://localhost:8080');
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Future<Map<String, String>> encryptForAllDevices(
+    String peerUserId,
+    String plaintext,
+  ) async {
+    // Two recipient devices to exercise the multi-device map shape.
+    return {
+      '11': 'recip-dev-11-ciphertext==',
+      '12': 'recip-dev-12-ciphertext==',
+    };
+  }
+
+  @override
+  Future<Map<String, String>> encryptForOwnDevices(
+    String myUserId,
+    String plaintext,
+  ) async {
+    // One self device (the sender's other device).
+    return {'7': 'self-dev-7-ciphertext=='};
+  }
+
+  @override
+  Future<String> encryptMessage(String peerUserId, String plaintext) async {
+    return 'legacy-fallback-ciphertext==';
+  }
+}
+
+class _NoMultiDeviceCryptoService extends CryptoService {
+  _NoMultiDeviceCryptoService() : super(serverUrl: 'http://localhost:8080');
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Future<Map<String, String>> encryptForAllDevices(
+    String peerUserId,
+    String plaintext,
+  ) {
+    throw Exception('No PreKey bundle found');
+  }
+
+  @override
+  Future<Map<String, String>> encryptForOwnDevices(
+    String myUserId,
+    String plaintext,
+  ) async {
+    return {};
+  }
+
+  @override
+  Future<String> encryptMessage(String peerUserId, String plaintext) async {
+    return 'single-device-ciphertext==';
+  }
+}
+
+class _SeededCrypto extends CryptoNotifier {
+  _SeededCrypto(this._initial);
+  final CryptoState _initial;
+  @override
+  CryptoState build() => _initial;
+  @override
+  Future<void> retryKeyUpload() async {}
+  @override
+  Future<void> initAndUploadKeys() async {}
+}
+
+class _SeededPrivacy extends Privacy {
+  _SeededPrivacy(this._initial);
+  final PrivacyState _initial;
+  @override
+  PrivacyState build() => _initial;
+}
+
+ProviderContainer _container({
+  CryptoService? crypto,
+  GroupCryptoService? groupCrypto,
+  List<Conversation> seedConversations = const [],
+}) {
+  final c = ProviderContainer(
+    overrides: [
+      authProvider.overrideWith(
+        () => FakeLoggedInAuthNotifier(
+          const AuthState(
+            isLoggedIn: true,
+            userId: 'my-user-id',
+            username: 'me',
+            token: 'tkn',
+          ),
+        ),
+      ),
+      serverUrlProvider.overrideWith(
+        () => FakeServerUrlNotifier('http://localhost:8080'),
+      ),
+      if (crypto != null) cryptoServiceProvider.overrideWithValue(crypto),
+      if (groupCrypto != null)
+        groupCryptoServiceProvider.overrideWithValue(groupCrypto),
+      cryptoProvider.overrideWith(
+        () => _SeededCrypto(const CryptoState(isInitialized: true)),
+      ),
+      privacyProvider.overrideWith(
+        () => _SeededPrivacy(const PrivacyState(readReceiptsEnabled: true)),
+      ),
+    ],
+  );
+  if (seedConversations.isNotEmpty) {
+    c.read(conversationsProvider.notifier).state = ConversationsState(
+      conversations: seedConversations,
+    );
+  }
+  return c;
+}
+
+void main() {
+  group('DM send_message wire frame (multi-device)', () {
+    test(
+      'encodes type, to_user_id, content + per-recipient device map',
+      () async {
+        final c = _container(crypto: _WireCryptoService());
+        addTearDown(c.dispose);
+
+        final ws = c.read(websocketProvider.notifier);
+        await ws.sendMessage(
+          'peer-1',
+          'hello',
+          conversationId: 'conv-1',
+          replyToId: 'msg-r',
+          threadRootId: 'msg-t',
+        );
+
+        expect(ws.debugSentFrames, hasLength(1));
+        final frame = ws.debugSentFrames.single;
+
+        // Required top-level fields (server-side parser keys).
+        expect(frame['type'], 'send_message');
+        expect(frame['to_user_id'], 'peer-1');
+        // Legacy fallback content = first recipient ciphertext (NOT self).
+        expect(frame['content'], 'recip-dev-11-ciphertext==');
+        expect(frame['conversation_id'], 'conv-1');
+        expect(frame['reply_to_id'], 'msg-r');
+        expect(frame['thread_root_id'], 'msg-t');
+
+        // Multi-device envelope: outer key = userId, inner = deviceId -> ct.
+        final rdc = frame['recipient_device_contents'] as Map<String, dynamic>;
+        expect(rdc.keys, containsAll(['peer-1', 'my-user-id']));
+        final peerMap = Map<String, dynamic>.from(rdc['peer-1'] as Map);
+        expect(peerMap['11'], 'recip-dev-11-ciphertext==');
+        expect(peerMap['12'], 'recip-dev-12-ciphertext==');
+        final selfMap = Map<String, dynamic>.from(rdc['my-user-id'] as Map);
+        expect(selfMap['7'], 'self-dev-7-ciphertext==');
+      },
+    );
+
+    test('omits optional metadata when not provided', () async {
+      final c = _container(crypto: _WireCryptoService());
+      addTearDown(c.dispose);
+
+      await c.read(websocketProvider.notifier).sendMessage('peer-2', 'hi');
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+
+      expect(frame.containsKey('conversation_id'), isFalse);
+      expect(frame.containsKey('reply_to_id'), isFalse);
+      expect(frame.containsKey('thread_root_id'), isFalse);
+      expect(frame['type'], 'send_message');
+      expect(frame['to_user_id'], 'peer-2');
+    });
+
+    test('single-device fallback omits recipient_device_contents', () async {
+      final c = _container(crypto: _NoMultiDeviceCryptoService());
+      addTearDown(c.dispose);
+
+      await c
+          .read(websocketProvider.notifier)
+          .sendMessage('peer-3', 'hi', conversationId: 'conv-3');
+      final frames = c.read(websocketProvider.notifier).debugSentFrames;
+      expect(frames, hasLength(1));
+      final frame = frames.single;
+
+      // Fallback path: legacy single ciphertext, no per-device map.
+      expect(frame['type'], 'send_message');
+      expect(frame['content'], 'single-device-ciphertext==');
+      expect(frame.containsKey('recipient_device_contents'), isFalse);
+      expect(frame['conversation_id'], 'conv-3');
+    });
+  });
+
+  group('group send_message wire frame', () {
+    test(
+      'unencrypted group sends plaintext content + conversation_id',
+      () async {
+        final c = _container(
+          seedConversations: [
+            const Conversation(id: 'grp-1', isGroup: true, isEncrypted: false),
+          ],
+        );
+        addTearDown(c.dispose);
+
+        await c
+            .read(websocketProvider.notifier)
+            .sendGroupMessage(
+              'grp-1',
+              'public-text',
+              channelId: 'chan-x',
+              replyToId: 'r-1',
+              threadRootId: 't-1',
+            );
+
+        final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+        expect(frame['type'], 'send_message');
+        expect(frame['conversation_id'], 'grp-1');
+        expect(frame['content'], 'public-text');
+        expect(frame['channel_id'], 'chan-x');
+        expect(frame['reply_to_id'], 'r-1');
+        expect(frame['thread_root_id'], 't-1');
+        // GRP1 plaintext path never sets client_message_id.
+        expect(frame.containsKey('client_message_id'), isFalse);
+        // Group send must NOT include the DM-only recipient_device_contents.
+        expect(frame.containsKey('recipient_device_contents'), isFalse);
+        expect(frame.containsKey('to_user_id'), isFalse);
+      },
+    );
+  });
+
+  group('control-frame wire shapes', () {
+    test('typing frame shape', () {
+      final c = _container();
+      addTearDown(c.dispose);
+
+      c
+          .read(websocketProvider.notifier)
+          .sendTyping('conv-1', channelId: 'ch-1');
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+      expect(frame, {
+        'type': 'typing',
+        'conversation_id': 'conv-1',
+        'channel_id': 'ch-1',
+      });
+    });
+
+    test('typing frame without channel omits channel_id', () {
+      final c = _container();
+      addTearDown(c.dispose);
+
+      c.read(websocketProvider.notifier).sendTyping('conv-x');
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+      expect(frame, {'type': 'typing', 'conversation_id': 'conv-x'});
+    });
+
+    test('read_receipt frame shape', () {
+      final c = _container();
+      addTearDown(c.dispose);
+
+      c.read(websocketProvider.notifier).sendReadReceipt('conv-r');
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+      expect(frame, {'type': 'read_receipt', 'conversation_id': 'conv-r'});
+    });
+
+    test('key_reset frame shape', () {
+      final c = _container();
+      addTearDown(c.dispose);
+
+      c.read(websocketProvider.notifier).sendKeyReset('conv-k');
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+      expect(frame, {'type': 'key_reset', 'conversation_id': 'conv-k'});
+    });
+
+    test('call_started frame shape', () {
+      final c = _container();
+      addTearDown(c.dispose);
+
+      c.read(websocketProvider.notifier).sendCallStarted('conv-c');
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+      expect(frame, {'type': 'call_started', 'conversation_id': 'conv-c'});
+    });
+
+    test('voice_signal frame shape', () {
+      final c = _container();
+      addTearDown(c.dispose);
+
+      c
+          .read(websocketProvider.notifier)
+          .sendVoiceSignal(
+            conversationId: 'conv-v',
+            channelId: 'ch-v',
+            toUserId: 'peer-v',
+            signal: const {'sdp': 'offer-blob'},
+          );
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+      expect(frame, {
+        'type': 'voice_signal',
+        'conversation_id': 'conv-v',
+        'channel_id': 'ch-v',
+        'to_user_id': 'peer-v',
+        'signal': {'sdp': 'offer-blob'},
+      });
+    });
+
+    test('canvas_event frame shape', () {
+      final c = _container();
+      addTearDown(c.dispose);
+
+      c
+          .read(websocketProvider.notifier)
+          .sendCanvasEvent(
+            channelId: 'ch-canvas',
+            kind: 'stroke',
+            payload: const {'x': 1, 'y': 2},
+          );
+      final frame = c.read(websocketProvider.notifier).debugSentFrames.single;
+      expect(frame, {
+        'type': 'canvas_event',
+        'channel_id': 'ch-canvas',
+        'kind': 'stroke',
+        'payload': {'x': 1, 'y': 2},
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #1118.

Splits the 993-LOC `websocket_provider.dart` into a slimmed coordinator + four part-file slices under `lib/src/providers/websocket/`. Pure code motion — no behavior change. Wire-shape contract test added first to lock down the JSON frames the client emits so the refactor can not silently corrupt bytes-on-wire.

## Behind the scenes
- Added `test/providers/websocket_wire_shape_test.dart` (11 cases covering DM multi-device envelope, group send, typing, read_receipt, key_reset, call_started, voice_signal, canvas_event).
- Routed every `_channel?.sink.add(jsonEncode(...))` call through one `_emit()` helper backed by a `@visibleForTesting` `debugSentFrames` log.
- Extracted typing throttle prune + pure stale-typing pruner into `websocket/websocket_typing.dart`.
- Extracted receive JSON-decode + dispatch into `websocket/websocket_receive_dispatcher.dart`.
- Extracted ticket fetch, transport-reset, and exponential-backoff math into `websocket/websocket_lifecycle.dart`; collapsed duplicate onDone/onError teardown into one `_handleChannelClosed`.
- Extracted the multi-device DM encryption fanout, fallback chain, frame builders, group key self-heal, GRP1/GRP2 dispatch, failed-message helper, and friendly-error mapping into `websocket/websocket_send.dart`.

## Test plan
- [x] `flutter analyze --fatal-infos` clean.
- [x] Full client `flutter test` — 2342 tests pass.
- [x] Per-slice: `test/providers/` (~649 tests) green after every commit.
- [x] New `websocket_wire_shape_test.dart` (11 tests) green from slice 0 onward and asserts unchanged bytes-on-wire at every step.

## File LOC
| File | LOC |
|---|---|
| `websocket_provider.dart` | 517 (was 993) |
| `websocket/websocket_send.dart` | 454 |
| `websocket/websocket_typing.dart` | 79 |
| `websocket/websocket_lifecycle.dart` | 70 |
| `websocket/websocket_receive_dispatcher.dart` | 25 |

Public Riverpod surface (`websocketProvider`, `WebSocketNotifier`, `WebSocketState`) is unchanged — no caller in the rest of the client had to be touched.