### PR TITLE
Voice-lounge canvas interaction contract (canvas redesign PR A)

### DIFF
--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -37,7 +37,7 @@ Voice lounges include a shared canvas — drawings, screen-share window position
 
 The pickup plan for closing this gap is tracked at [#1268](https://github.com/NC1107/echo-messenger/issues/1268); it requires the group-message E2E protocol (GRP2) to ship first. Until then, treat anything you draw or any window you reposition in a lounge as visible to the server operator.
 
-If a lounge belongs to an encrypted group, the app shows a one-line notice the first time you enter that lounge so this gap is surfaced at the right moment, not just in this document.
+The first time you enter a voice lounge in an encrypted group on a given device, the app shows a one-time popup acknowledging this gap so it's surfaced at the right moment, not just buried in this document. The popup is dismissible and does not return.
 
 ## Where the data lives
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -29,6 +29,16 @@ your own Echo server, you are the operator and you control all data stored on it
 - **Third-party analytics or trackers.** No Mixpanel, no Segment, no Google Analytics, no Sentry.
 - **Your private keys.** They're generated on-device and stored in your platform keystore (Keychain on iOS/macOS, Credential Manager on Android, libsecret on Linux, etc.).
 
+## Voice-lounge canvas
+
+Voice lounges include a shared canvas — drawings, screen-share window positions, and avatar positions are synchronized to everyone in the lounge in real time.
+
+**Canvas content is server-readable. It is not end-to-end encrypted, even in groups where messages are.** When you draw a stroke, drag your avatar, or move a screen-share window in a voice lounge, the coordinates and stroke data pass through the server in plaintext, and persistent kinds (strokes, image references, board clears) are stored in the Echo database as plaintext JSON.
+
+The pickup plan for closing this gap is tracked at [#1268](https://github.com/NC1107/echo-messenger/issues/1268); it requires the group-message E2E protocol (GRP2) to ship first. Until then, treat anything you draw or any window you reposition in a lounge as visible to the server operator.
+
+If a lounge belongs to an encrypted group, the app shows a one-line notice the first time you enter that lounge so this gap is surfaced at the right moment, not just in this document.
+
 ## Where the data lives
 
 PostgreSQL on the server at `echo-messenger.us`. Access is restricted to the operator (GitHub user `NC1107`).

--- a/docs/voice-lounge/01-coordinate-policy.md
+++ b/docs/voice-lounge/01-coordinate-policy.md
@@ -60,4 +60,8 @@ The stroke coord migration heuristic (`_migrateLegacyCoord`) is **not** revisite
 ## Open questions
 
 - **Per-aspect-ratio refinement for screen-share overlay placement** — the normalization treats a 16:9 desktop and a 9:19 phone identically, which is good enough for v1 but may want a future "anchor + offset" model (`{anchor: 'top-right', x_offset_norm: 0.05}`). Pickup trigger: tester reports that proportional placement looks wrong on a particular device class.
-- **Whether resize sync uses the same normalization or stays in absolute pixels** — current implementation syncs `w_norm` and `h_norm` per this decision. Open to revisit if windows end up at unreadable sizes on small screens; the simple fix would be to clamp `w_min_px` / `h_min_px` on the receive side.
+
+## Confirmed by review (2026-05-28)
+
+- **Resize sync uses the same viewport-normalization as position.** `w_norm` and `h_norm` ride in 0..1 of the sender's viewport. The receiver multiplies by its own viewport size **and** clamps to a `w_min_px` / `h_min_px` floor (120 px) so phone-side windows don't shrink below readable size. This preserves "looks proportional across devices" while preventing the worst-case "tiny window on a phone" outcome.
+- **Strokes, shapes, avatars are unchanged.** They live in canvas-world (100k) coordinates and zoom/pan with the InteractiveViewer transform, so they already appear in the same logical position on every device. The resize-sync change only affects the screen-share window overlay, not whiteboard content.

--- a/docs/voice-lounge/01-coordinate-policy.md
+++ b/docs/voice-lounge/01-coordinate-policy.md
@@ -1,0 +1,63 @@
+# 01 — Coordinate policy
+
+## Status quo
+
+Three canvas entity classes, **three different coordinate models**:
+
+| Entity | Coordinate space | Wire format | Code |
+|---|---|---|---|
+| **Strokes** (freehand, shapes, text) | Canvas-world, absolute pixels in 100 000 × 100 000 surface | Absolute pixels, with `_migrateLegacyCoord` heuristic accepting ≤ 1.0 as legacy 0..1 normalized (multiplied by **4096**, not 100k) | `canvas_models.dart:37`, `apps/server/src/db/canvas.rs` |
+| **Avatars** | Canvas-world, absolute pixels in 100 000 × 100 000 surface, default ring radius `0.3 × kCanvasWidth ≈ 30 000 px` | Same as strokes; keyed by `user_id` | `voice_canvas.dart:385`, `canvas_provider.dart:534` |
+| **Screen-share windows** | **Viewport-relative CSS pixels** (clamped against the receiving InteractiveViewer's `LayoutBuilder` constraints) | Raw CSS pixels `{window_id, x, y, width, height}` — explicitly NOT normalized, comment in `canvas_provider.dart:646` | `screen_share.dart:402-422`, `canvas_provider.dart:691,719` |
+
+### The cross-device divergence bug this creates
+
+Sender on a 1920×1080 desktop drags a screen-share window to `x = 1500, y = 200`. The `screenshare_move` payload broadcasts those raw values. A receiver on a 390×844 phone reads `_left = shared.x = 1500`, then `LayoutBuilder` immediately clamps to `min(constraints.maxWidth - 60) = 330`. The window snaps to the right edge of the phone, nowhere near where the sender intended it.
+
+This is a coordinate-space leak: sender's local viewport pixels are being treated as a universal coordinate, but only the receiver's viewport gives them meaning.
+
+Avatars and strokes don't have this bug because they live in canvas-world coordinates, and every device renders the same 100k surface through its own InteractiveViewer transform.
+
+## Options
+
+### Option A — Unify everything to canvas-world
+
+Screen-share windows become canvas objects in 100k space.
+
+- **Pro:** one coord model; cross-device parity for free.
+- **Con:** screen-share windows are conceptually a UI overlay, not a whiteboard primitive. Putting them in the 100k surface means they zoom and pan with the canvas — a participant zooming into a stroke would zoom out of the screen share. That's bad UX. It also means we lose the ability to keep screen share visible during a stroke focus.
+
+### Option B — Normalize the screen-share wire format
+
+Screen-share windows stay viewport overlays *locally*, but the wire format is normalized 0..1 of "lounge interactive viewport". Sender divides by their `_interactiveViewportSize`; receiver multiplies by their own `_interactiveViewportSize`.
+
+- **Pro:** cross-device parity. Screen-share keeps overlay semantics (no zoom-with-canvas). Minimal new code — a translation layer in `canvas_provider.dart` send/receive paths plus a viewport-size sentinel on each end.
+- **Con:** the receiver might have a wildly different aspect ratio. A window pinned to the top-right on a 1920×1080 desktop will appear top-right on a phone too — but proportionally taller/narrower. Acceptable for overlay UX; can be refined per-aspect-ratio later if needed.
+
+### Option C — Keep hybrid; document the divergence as deliberate
+
+Each device's screen-share window position is intentionally local. Wire format goes away entirely; positions are not synchronized.
+
+- **Pro:** simplest. Each user arranges their own view.
+- **Con:** kills shared-pointing UX ("look at this thing in the upper-left of your screen share"). The current `screenshare_move` synchronization exists because that UX was wanted.
+
+## Decision
+
+**Option B**, dated 2026-05-28.
+
+Wire format for `screenshare_move` becomes `{window_id, x_norm, y_norm, w_norm, h_norm}` with values in `[0.0, 1.0]` of the sender's interactive viewport. Receiver multiplies by its own `_interactiveViewportSize` before applying. A `coord_v` field on the event distinguishes the new format from legacy CSS-pixel payloads (legacy continues to be accepted via a translation shim until Phase 4's sunset gate fires).
+
+Avatars and strokes stay in canvas-world coordinates with no changes.
+
+The stroke coord migration heuristic (`_migrateLegacyCoord`) is **not** revisited here; Phase 4 (legacy migration sunset) owns that decision.
+
+## Acceptance criteria
+
+- Any PR that introduces a new canvas entity must place it in one of the two documented coord spaces (canvas-world for whiteboard-like content, normalized-viewport for overlay-like content) and state which in the PR description.
+- Any change to `screenshare_move` payload shape must bump `coord_v` and provide a translation shim for the previous version.
+- No PR may reintroduce raw-CSS-pixel coordinates as a wire format for any entity that synchronizes across devices.
+
+## Open questions
+
+- **Per-aspect-ratio refinement for screen-share overlay placement** — the normalization treats a 16:9 desktop and a 9:19 phone identically, which is good enough for v1 but may want a future "anchor + offset" model (`{anchor: 'top-right', x_offset_norm: 0.05}`). Pickup trigger: tester reports that proportional placement looks wrong on a particular device class.
+- **Whether resize sync uses the same normalization or stays in absolute pixels** — current implementation syncs `w_norm` and `h_norm` per this decision. Open to revisit if windows end up at unreadable sizes on small screens; the simple fix would be to clamp `w_min_px` / `h_min_px` on the receive side.

--- a/docs/voice-lounge/02-input-matrix.md
+++ b/docs/voice-lounge/02-input-matrix.md
@@ -69,6 +69,9 @@ These apply across all device classes; they exist to make gesture-arena behavior
 
 ## Open questions
 
-- **Right-click context menu** — the matrix lists right-click as "tool-cancel / Escape" today, but a real context menu (Cut / Copy / Paste / Bring forward / Send back) would be useful for canvas objects. Pickup trigger: first feature request for canvas-object reordering or copy-paste.
 - **Pen / stylus support** — currently treated as touch. iPad pencil / Wacom may want pressure-sensitive stroke width. Pickup trigger: tester with a stylus reports unsatisfying stroke quality.
-- **Trackpad scroll-wheel zoom without modifier** — some apps treat unmodified trackpad scroll as zoom (Figma) vs pan (most browsers). Today we use modifier-required. Pickup trigger: user feedback prefers unmodified zoom.
+
+## Confirmed by review (2026-05-28)
+
+- **Right-click on canvas = cancel draw / clear selection** (same as Escape). No full context menu in v1; defer Cut/Copy/Paste/z-order until first feature request.
+- **Trackpad scroll-wheel zoom stays modifier-required** (Ctrl/Cmd + scroll). Unmodified two-finger scroll pans. Predictable across web + desktop; revisit if testers report friction.

--- a/docs/voice-lounge/02-input-matrix.md
+++ b/docs/voice-lounge/02-input-matrix.md
@@ -1,0 +1,74 @@
+# 02 — Input matrix
+
+## Status quo
+
+The lounge canvas uses an `InteractiveViewer` for pan/zoom and a `LoungeDrawingCanvas` `GestureDetector` overlay for stroke capture. Recent fixes (#1247, #1257, #1266) tuned gesture-arena handoff but no written contract exists for how each input device class should behave. Implementation decisions have been ad-hoc per-bug.
+
+## Decision matrix
+
+Per device class, per action. Conflict rules at the bottom.
+
+### Touch (phone, tablet)
+
+| Action | Gesture | Notes |
+|---|---|---|
+| Pan | One-finger drag | Only when `selectedTool == CanvasTool.none` (no active draw tool) |
+| Zoom | Pinch (two fingers) | Always available — pinch wins arena over draw via the slop-based `PanGestureRecognizer` handoff (`lounge_drawing_canvas.dart:42`) |
+| Draw | One-finger drag | Only when a draw tool is selected; ~18 px slop before claim |
+| Select an object (avatar, image) | Tap | Tool-agnostic |
+| Double-tap zoom (zoom in 2× at point) | Two quick taps | Only when `selectedTool == CanvasTool.none`. Disabled while a draw tool is active (#1266) |
+| Tool-cancel / exit draw mode | Tap the active tool button again | Currently routed through `_toggleDrawingMode()`; deselects + clears `selectedTool` |
+
+### Mouse (Linux/Windows/macOS desktop, web with mouse)
+
+| Action | Gesture | Notes |
+|---|---|---|
+| Pan | Middle-click drag, OR left-click drag with no tool selected | Same `selectedTool == none` gate as touch |
+| Zoom | `Ctrl/Cmd + scroll wheel` | Wheel without modifier scrolls page / nothing |
+| Draw | Left-click drag | Same slop-based handoff as touch |
+| Select an object | Left-click | |
+| Double-tap zoom | Double-click | Same `selectedTool == none` gate. Double-click while drawing is **explicitly suppressed** (#1266 fix) |
+| Tool-cancel | Right-click OR Escape | Right-click currently has no canvas handler; this is a future addition |
+
+### Trackpad (laptop touchpad)
+
+| Action | Gesture | Notes |
+|---|---|---|
+| Pan | Two-finger drag | Same as scroll; no modifier |
+| Zoom | Pinch-to-zoom (built-in trackpad gesture) OR `Ctrl/Cmd + scroll` | Trackpad pinches arrive as scale events |
+| Draw | One-finger drag | Click-and-drag; same slop handoff |
+| Select | One-finger tap | |
+| Double-tap zoom | Double-tap (one finger) | Same gate |
+
+### Keyboard (all devices with hardware keyboard)
+
+| Action | Keys | Notes |
+|---|---|---|
+| Reset view (fit-to-content) | `0` or `Cmd/Ctrl+0` | Resets to `_centeredPose` |
+| Zoom in | `Cmd/Ctrl + +` | 1.25× current scale |
+| Zoom out | `Cmd/Ctrl + -` | 0.8× current scale |
+| Pan | Arrow keys | 100 canvas-pixels per press; `Shift+Arrow` = 500 |
+| Cancel draw / clear selection | `Escape` | Same as right-click |
+| Cycle tools | `B` (brush) / `E` (eraser) / `T` (text) / `Escape` (none) | Single-letter, no modifier; only active when canvas has focus |
+
+## Conflict rules
+
+These apply across all device classes; they exist to make gesture-arena behavior predictable instead of emergent.
+
+1. **A draw stroke in progress wins all other gestures** — pinch, double-tap, double-click, scroll-wheel zoom are all suppressed for the duration of the stroke (from `onPanStart` to `onPanEnd` / `onPanCancel`). This is the rule that today's #1266 fix encodes.
+2. **A second simultaneous pointer cancels a draw stroke and yields to the pinch/scale recognizer.** Implemented today via the slop-based `PanGestureRecognizer` losing the arena to `ScaleGestureRecognizer` once it sees the second pointer (`lounge_drawing_canvas.dart:42`). This is the rule that today's #1257 fix encodes.
+3. **`selectedTool == CanvasTool.none` means pan/zoom is unrestricted; any tool selected means pan/zoom are still possible but require the gesture to *not* trigger a draw first.** Practically: pinch always pans/zooms; single-pointer drag draws only if a tool is active.
+4. **Tool switching is destructive** — switching from brush to eraser mid-stroke cancels the in-flight stroke (no half-finished strokes get committed). Already implemented via `endStroke` on tool change.
+5. **Focus is required for keyboard shortcuts** — the canvas must have keyboard focus (clicked into) before `B`/`E`/`T`/`Escape` cycle tools. Same model as Figma. Single-letter shortcuts must not fire while the chat input has focus.
+
+## Acceptance criteria
+
+- A PR that adds a new gesture (or changes an existing one) must update the matrix above before the behavior change merges.
+- Any new gesture must declare its arena precedence relative to draw, pinch-zoom, and double-tap. "It just works in testing" is not a precedence declaration.
+- The keyboard shortcuts column is the contract for `Shortcuts`/`Actions` widget keymaps; new shortcuts must not collide with existing single-letter keys without a written justification.
+
+## Open questions
+
+- **Right-click context menu** — the matrix lists right-click as "tool-cancel / Escape" today, but a real context menu (Cut / Copy / Paste / Bring forward / Send back) would be useful for canvas objects. Pickup trigger: first feature request for canvas-object reordering or copy-paste.
+- **Pen / stylus support** — currently treated as touch. iPad pencil / Wacom may want pressure-sensitive stroke width. Pickup trigger: tester with a stylus reports unsatisfying stroke quality.
+- **Trackpad scroll-wheel zoom without modifier** — some apps treat unmodified trackpad scroll as zoom (Figma) vs pan (most browsers). Today we use modifier-required. Pickup trigger: user feedback prefers unmodified zoom.

--- a/docs/voice-lounge/03-multi-device.md
+++ b/docs/voice-lounge/03-multi-device.md
@@ -1,0 +1,78 @@
+# 03 — Multi-device per user
+
+## Status quo
+
+Canvas avatar entries are keyed by `user_id`, **not** by `(user_id, device_id)`. Every device for a user shares one avatar slot.
+
+Citations:
+- `voice_canvas.dart:341` — `key: ValueKey('avatar-${participant.userId}')`
+- `voice_canvas.dart:353` — `.moveAvatar(participant.userId, norm)`
+- `canvas_provider.dart:534` — `void moveAvatar(String userId, CanvasPoint pos)`
+- `canvas_provider.dart:868-870` — incoming `avatar_move` payload keyed by `userId`
+
+### What happens today with two devices
+
+A user on desktop + phone simultaneously in the same lounge:
+
+1. Both devices receive `lounge.join` and add the user's avatar.
+2. Each device computes its own `_defaultAvatarPos` from its local view of `total participants + index`. Because the same user appears once in the participant list (server dedupes by user_id), the position calculation is consistent.
+3. Either device can drag the avatar. The drag broadcasts `avatar_move` with the user_id. Both devices apply it — including the device that **didn't** initiate it.
+4. If both devices drag simultaneously, the two `avatar_move` streams interleave at the server; the receiving canvas state is last-write-wins. The user's avatar visibly fights itself.
+5. Both devices show the same single avatar, even though there are two real call participants associated with this user_id.
+
+### The interactions this breaks
+
+- Simultaneous edits from two of the user's own devices cause avatar jitter.
+- Other participants can't visually distinguish "Nick on desktop" from "Nick on phone" — relevant for voice attribution if one device is muted and the other isn't.
+- A user joining their second device gets dropped into a position calculated as if they were one participant; the avatar position is shared and nothing new gets placed.
+
+This is a latent bug. It hasn't surfaced as a user report yet because multi-device-in-the-same-call is rare in beta.
+
+## Options
+
+### Option A — Keep user_id keying; accept LWW
+
+No change. Document the limitation. Two devices fight; users learn to use one device per call.
+
+- **Pro:** zero work.
+- **Con:** real LWW jitter when a user actually uses two devices. Doesn't scale with adoption.
+
+### Option B — Switch to (user_id, device_id) keying
+
+Each device gets its own avatar slot. Display name shows `username` for the first one and `username (device 2)` for the second.
+
+- **Pro:** clean model; matches the underlying reality.
+- **Con:** confusing — most users don't think of themselves as multiple avatars. Two avatars with the same picture and name might look broken. Also requires server-side multi-device coordination (each device needs a unique session id that survives reconnects).
+
+### Option C — Single avatar slot per user; one device is the "canvas authority"
+
+User_id keying stays. When a user has 2+ devices in a lounge, the **most-recently-active** device is the only one allowed to send canvas events for that user. Other devices are read-only on canvas (they still see and render, just can't send `avatar_move` / `stroke` / `image_*`).
+
+The "most-recently-active" device is whichever sent the most recent canvas event from this user_id, with a fallback rule of "first to join the lounge" on cold start.
+
+- **Pro:** fixes the LWW bug without introducing duplicate-avatar UX. Failure mode (a tester's old device sometimes can't draw) is recoverable by tapping the canvas on the device they want to use.
+- **Con:** silent — a user dragging on phone while desktop is "canvas authority" sees no effect and might think the canvas is broken. Needs a small UI indicator ("Drawing from desktop") to make the state visible.
+
+## Decision
+
+**Option C**, dated 2026-05-28.
+
+Single avatar slot per user. The most-recently-active device is the canvas authority. Other devices are read-only and show a small "Drawing from <device name>" pill in the canvas top-bar so the user understands why their input is ignored. Tapping the canvas on a non-authority device sends a `canvas_authority_claim` event that flips authority to that device after a 1s grace period (the grace stops mash-tapping causing rapid handoff oscillation).
+
+Server-side: `canvas_authority_claim` is a new event kind alongside `avatar_move`. The server tracks `(user_id, voice_channel_id) → device_id` in memory (no DB persistence — the state resets when the user leaves the lounge). All `avatar_move` / `stroke` / `image_*` events from a non-authority device are silently dropped at the server with no error response (drop-not-reject so the rogue device doesn't repeatedly retry).
+
+This is **not** a multi-device E2E protocol change — it's a single-writer-per-lounge policy on top of existing infrastructure.
+
+## Acceptance criteria
+
+- Two devices for the same user join the same lounge. Only one device's gestures move the avatar.
+- The non-authority device displays an indicator naming the authority device.
+- Tapping the canvas on the non-authority device transfers authority within 1-2 seconds.
+- A user with one device sees no behavioral change from today.
+- A user joining their second device sees their existing avatar, not a duplicate.
+
+## Open questions
+
+- **Device-name display** — how do we surface the device name? `device_name` is collected during key upload (per the device-aware server work). Need to confirm it propagates into the lounge presence payload. Pickup: during implementation, if not present, decide between adding to presence vs. inline lookup via `/api/devices/<id>`.
+- **Cross-lounge authority** — does the authority device for lounge A automatically also become authority for lounge B if the user joins B? Default answer: no, authority is per-lounge. Open to revisit if testers find that confusing.
+- **Voice-attribution UX** — currently muting on one device doesn't visually distinguish which device is muted on the avatar. That's a voice-system issue, not a canvas one, and is out of scope here. Captured for future routing to the voice surface.

--- a/docs/voice-lounge/03-multi-device.md
+++ b/docs/voice-lounge/03-multi-device.md
@@ -74,5 +74,8 @@ This is **not** a multi-device E2E protocol change — it's a single-writer-per-
 ## Open questions
 
 - **Device-name display** — how do we surface the device name? `device_name` is collected during key upload (per the device-aware server work). Need to confirm it propagates into the lounge presence payload. Pickup: during implementation, if not present, decide between adding to presence vs. inline lookup via `/api/devices/<id>`.
-- **Cross-lounge authority** — does the authority device for lounge A automatically also become authority for lounge B if the user joins B? Default answer: no, authority is per-lounge. Open to revisit if testers find that confusing.
 - **Voice-attribution UX** — currently muting on one device doesn't visually distinguish which device is muted on the avatar. That's a voice-system issue, not a canvas one, and is out of scope here. Captured for future routing to the voice surface.
+
+## Confirmed by review (2026-05-28)
+
+- **Authority is per-lounge.** Joining lounge B with a desktop that was authority in lounge A starts fresh — whoever draws first in B becomes B's authority. No cross-lounge state to track.

--- a/docs/voice-lounge/04-encrypted-canvas.md
+++ b/docs/voice-lounge/04-encrypted-canvas.md
@@ -50,7 +50,7 @@ Flip canvas off in `is_encrypted == true` groups. Plaintext groups keep the feat
 
 Short-term action (this Phase 1 PR's scope, or a fast follow-up):
 - Add a `Canvas content is not encrypted` section to `docs/PRIVACY.md`.
-- Add a non-blocking notice in the lounge UI for encrypted groups: a small text under the lounge header like "Canvas drawings and shared positions are visible to the server." Dismissible-per-lounge but reappears on each new lounge.
+- Show a **one-time-ever** popup the first time the user enters a voice lounge in an encrypted group: "Canvas drawings and shared positions are currently visible to the server — end-to-end encryption for canvas is tracked at #1268." Dismiss button stores `seen_encrypted_canvas_notice_v1 = true` in SharedPreferences; the popup never appears again for that user (per-device, since SharedPreferences is per-install). Updated 2026-05-28 per review: previous draft called for a per-lounge dismissible notice; reduced to a single global acknowledgement to avoid notice fatigue.
 
 Medium-term action (scheduled after GRP2 message E2E lands):
 - Tracked as #1268 (filed 2026-05-28), linked to the GRP2 design and this doc.
@@ -61,7 +61,7 @@ Option C is rejected because the feature is too useful to remove and the gap is 
 ## Acceptance criteria
 
 - `docs/PRIVACY.md` contains a section titled "Voice-lounge canvas" that states canvas data is server-readable.
-- An encrypted-group lounge displays a one-line privacy notice on first entry.
+- A one-time popup appears the first time the user enters any encrypted-group lounge; after dismissal the popup never appears again on that device.
 - A tracked follow-up issue exists for the GRP2-canvas-encryption work with the documented pickup trigger: "GRP2 message E2E shipped to prod (not just merged)."
 - No PR that adds new canvas event kinds may merge without explicitly stating which side (plaintext or encrypted) it lives on. If plaintext, the PR must also add the kind to the privacy-doc list.
 

--- a/docs/voice-lounge/04-encrypted-canvas.md
+++ b/docs/voice-lounge/04-encrypted-canvas.md
@@ -1,0 +1,72 @@
+# 04 — Encrypted-group canvas
+
+## Status quo
+
+**Canvas events are plaintext on the wire and on disk, regardless of whether the lounge belongs to an encrypted group.**
+
+Citations:
+- `apps/server/src/ws/events/canvas.rs:137` — `handle_canvas_event` takes JWT-authenticated `sender_id`, calls `verify_membership(sender_id, conversation_id)`, then accepts the payload. No encryption check, no per-event signing.
+- `apps/server/src/db/canvas.rs` — persistent kinds (`stroke`, `image_add`, `image_move`, `image_remove`, `clear`) are written to the database as JSON. Server reads them on join to send the current board state to new arrivals.
+- `apps/client/lib/src/providers/canvas_provider.dart` — sender does not consult `is_encrypted` on the group; the payload goes through `_sendCanvasEvent` regardless.
+
+This means: in an encrypted group, where 1:1 and group **messages** are E2E encrypted (per #1131 / GRP2 design), canvas content is still **server-readable**.
+
+This is a real privacy gap. Today it is undocumented. `docs/PRIVACY.md` does not call it out.
+
+## Why this is the way it is
+
+Canvas was added before GRP2 message E2E was specified. The fast path was "WS relay using existing JWT auth"; that worked for plaintext groups (where messages also go plaintext via the relay) and was never revisited when GRP2 was scoped. GRP2 design (`docs/group-e2e-design/`) targets **messages** specifically — canvas isn't in its scope.
+
+## Options
+
+### Option A — Accept the gap; document it explicitly
+
+Update `docs/PRIVACY.md` to call out:
+- Canvas drawings, screen-share window positions, and avatar positions are **not** E2E encrypted, even in groups where messages are.
+- Treat canvas content as visible to the server operator (us, today; the self-hoster when self-hosted).
+
+Keep behavior unchanged.
+
+- **Pro:** zero engineering work. Honest privacy posture.
+- **Con:** users in encrypted groups may incorrectly assume "encrypted" applies to the whole lounge experience. Privacy debt grows the longer it stays.
+
+### Option B — Encrypt canvas payloads with the group's GRP2 sender key (when GRP2 ships)
+
+Once GRP2's sender-key infrastructure is live for messages, reuse the same per-group symmetric key to encrypt canvas event payloads. Server still relays + persists, but the payloads it sees are ciphertext blobs.
+
+- **Pro:** matches the message-encryption posture; no separate trust model.
+- **Con:** depends on GRP2 message E2E landing first. The canvas DB schema needs to accept opaque blobs (it does — JSON columns can hold ciphertext-strings, but server-side replay-from-snapshot semantics change because the server can't introspect). Persisted strokes for late joiners need to be re-encrypted on every key rotation, which is non-trivial state to manage.
+
+### Option C — Disable canvas in encrypted groups until Option B ships
+
+Flip canvas off in `is_encrypted == true` groups. Plaintext groups keep the feature.
+
+- **Pro:** closes the gap immediately. No trust mismatch.
+- **Con:** removes a feature from the group type that's about to become the default (#1131 flipped new groups to encrypted-by-default). Users would lose access to the lounge canvas in most of their groups.
+
+## Decision
+
+**Option A short-term, Option B medium-term.** Dated 2026-05-28.
+
+Short-term action (this Phase 1 PR's scope, or a fast follow-up):
+- Add a `Canvas content is not encrypted` section to `docs/PRIVACY.md`.
+- Add a non-blocking notice in the lounge UI for encrypted groups: a small text under the lounge header like "Canvas drawings and shared positions are visible to the server." Dismissible-per-lounge but reappears on each new lounge.
+
+Medium-term action (scheduled after GRP2 message E2E lands):
+- File a tracked issue with the title "Encrypt canvas events with GRP2 sender key" linked to the GRP2 design and to this doc.
+- Acceptance: server logs no longer contain plaintext canvas payloads in `is_encrypted == true` groups.
+
+Option C is rejected because the feature is too useful to remove and the gap is small enough to disclose-and-defer.
+
+## Acceptance criteria
+
+- `docs/PRIVACY.md` contains a section titled "Voice-lounge canvas" that states canvas data is server-readable.
+- An encrypted-group lounge displays a one-line privacy notice on first entry.
+- A tracked follow-up issue exists for the GRP2-canvas-encryption work with the documented pickup trigger: "GRP2 message E2E shipped to prod (not just merged)."
+- No PR that adds new canvas event kinds may merge without explicitly stating which side (plaintext or encrypted) it lives on. If plaintext, the PR must also add the kind to the privacy-doc list.
+
+## Open questions
+
+- **Server-side metadata even after Option B** — group_id, sender_user_id, timestamp, and event_kind remain visible to the server post-Option-B. That's the metadata floor for any relay-based architecture. Open question for a future doc: do we want a P2P-mesh alternative for canvas that hides metadata too? Unlikely in this product but worth naming.
+- **Existing persisted plaintext strokes after Option B lands** — when GRP2 encryption gets retrofitted to canvas, what happens to drawings already in the DB? Three options: leave them plaintext and let them age out; encrypt-in-place during a one-shot migration; just drop them at cutover. Pickup: during Option B implementation, decide based on how many groups have meaningful canvas content at that time.
+- **Image uploads** — `image_add` events reference media URLs that resolve to files in `./uploads/`. Even with payload encryption (Option B), the image bytes themselves are stored unencrypted. Closing that gap is its own design (likely requires per-group media keys + ciphertext-at-rest, which the existing media pipeline doesn't do). Pickup: same trigger as Option B.

--- a/docs/voice-lounge/04-encrypted-canvas.md
+++ b/docs/voice-lounge/04-encrypted-canvas.md
@@ -53,7 +53,7 @@ Short-term action (this Phase 1 PR's scope, or a fast follow-up):
 - Add a non-blocking notice in the lounge UI for encrypted groups: a small text under the lounge header like "Canvas drawings and shared positions are visible to the server." Dismissible-per-lounge but reappears on each new lounge.
 
 Medium-term action (scheduled after GRP2 message E2E lands):
-- File a tracked issue with the title "Encrypt canvas events with GRP2 sender key" linked to the GRP2 design and to this doc.
+- Tracked as #1268 (filed 2026-05-28), linked to the GRP2 design and this doc.
 - Acceptance: server logs no longer contain plaintext canvas payloads in `is_encrypted == true` groups.
 
 Option C is rejected because the feature is too useful to remove and the gap is small enough to disclose-and-defer.

--- a/docs/voice-lounge/README.md
+++ b/docs/voice-lounge/README.md
@@ -1,0 +1,29 @@
+# Voice-lounge canvas interaction contract
+
+This folder is the **decision-of-record** for how the voice-lounge canvas, its inputs, and its synchronization model behave. It exists because the implementation has acquired enough device-class assumptions, gesture-arena tradeoffs, and per-event wire formats that informal-knowledge approaches were producing avoidable regressions (see PRs #1247 through #1266 for the trail).
+
+Every canvas-behavior PR from this point forward must:
+
+1. Cite the relevant section of these docs in the PR description.
+2. If the PR proposes a change that contradicts a documented decision, the doc gets updated **first**, in its own PR, with the new rationale.
+
+## Contents
+
+- **[01 — Coordinate policy](01-coordinate-policy.md)** — what coordinate space each canvas entity lives in, how those spaces are wire-encoded, and the rule for cross-device translation.
+- **[02 — Input matrix](02-input-matrix.md)** — per-device-class mapping for pan, zoom, draw, select, and double-tap; gesture-arena precedence; conflict rules.
+- **[03 — Multi-device per user](03-multi-device.md)** — how a user with 2+ devices in the same lounge is represented on the canvas, and what's read-only vs write.
+- **[04 — Encrypted-group canvas](04-encrypted-canvas.md)** — current trust posture for canvas events in encrypted groups, the documented gap, and the path to closing it.
+
+## Plan that this contract serves
+
+The contract is **Phase 1 / PR A** of the canvas redesign plan in `canvas_redesign.md`. Phases 2-5 (server geometry validation, gesture + integration tests, legacy-coord sunset, perf budget) all depend on the decisions captured here.
+
+## How decisions are recorded
+
+Each doc follows the same shape:
+
+- **Status quo** — what the code does today, with file:line citations.
+- **Options** — the alternatives considered, each with cost + benefit.
+- **Decision** — the option we picked and **why**, dated.
+- **Acceptance criteria** — the testable rule any future PR must honor.
+- **Open questions** — things deferred to a later decision, with their pickup trigger.


### PR DESCRIPTION
PR A of the canvas redesign plan (`canvas_redesign.md` v2). **Doc-only — no behavior changes.**

Four decision documents under `docs/voice-lounge/` plus an index. Each doc states status quo with file:line citations, lays out the options considered, names a decision dated 2026-05-28, and lists acceptance criteria future behavior PRs must honor.

## Decisions captured

| Doc | Decision in one line |
|---|---|
| **[01 — Coordinate policy](docs/voice-lounge/01-coordinate-policy.md)** | Avatars + strokes stay canvas-world (100k); screen-share wire format switches to normalized-of-viewport with a `coord_v` shim for the legacy CSS-pixel payload. Fixes the cross-device divergence bug where a 1500 px window from a 1920px desktop snaps to the right edge of a 390 px phone. |
| **[02 — Input matrix](docs/voice-lounge/02-input-matrix.md)** | Per-device matrix for pan / zoom / draw / select / double-tap across touch, mouse, trackpad, keyboard, plus five gesture-arena conflict rules that today's #1247/#1257/#1266 fixes encode but were never documented. |
| **[03 — Multi-device per user](docs/voice-lounge/03-multi-device.md)** | Single avatar slot per user; the most-recently-active device is the canvas-authority. Non-authority devices are read-only and show a "Drawing from <device>" pill. Tap-to-claim with 1s grace period. |
| **[04 — Encrypted-group canvas](docs/voice-lounge/04-encrypted-canvas.md)** | Disclose the gap now (update `docs/PRIVACY.md` + a one-line lounge notice); encrypt with GRP2 sender key once GRP2 message E2E lands. Rejects the "disable canvas in encrypted groups" alternative. |

## Why this exists

Five PRs over the last week have tuned canvas gesture-arena handoff (#1247, #1257, #1266) and the cross-device coord drift (still open) without a written contract. The plan in `canvas_redesign.md` v2 makes PR A doc-only specifically because the next four PRs (server geometry validation, gesture tests, legacy-coord sunset, perf budget) need shared decisions to reference. This PR is that reference.

## What gets locked in

After this PR merges, every canvas-behavior PR must:
1. Cite the relevant section in its description.
2. If the PR contradicts a documented decision, the doc gets updated **first**, in its own PR, with the new rationale.

The first PR to do this will be the server-side geometry validation work (Phase 2 / PR B).

## Out of scope here

- Behavior changes (next PRs in the plan).
- Stroke-coord legacy migration sunset (Phase 4 / PR E owns the trigger thresholds).
- Performance budget specifics (Phase 5 / PR F owns the measurement design).

## Review focus

Each doc has a **Decision** section dated today and an **Open questions** section. If any decision is wrong for your product intent, flag it now — once this lands, future PRs will cite these and changing direction gets more expensive. Open questions are deferrable; decisions are the load-bearing part.

## Test plan

- [ ] Read each doc end-to-end; confirm decisions match your product intent.
- [ ] Flag any open question you want answered before merge (vs. left as a pickup-trigger item).
- [ ] No CI gates beyond format/commit-lint apply to a doc-only PR.