### PR TITLE
Canvas redesign PR B: server geometry validation + encrypted-canvas one-time popup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@ RUST_LOG=echo_server=debug
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080
 
+# Voice-lounge canvas geometry/schema validation phase.
+# log_only (default): warn-log invalid payloads, keep relaying.
+# enforce: drop invalid payloads with canvas.validation.* error code.
+# off: skip validation entirely (escape hatch).
+# CANVAS_VALIDATION_MODE=log_only
+
 # iOS Push Notifications (APNs) -- optional, leave unset to disable
 # See docs/ios-push-setup.md for setup instructions.
 # APNS_AUTH_KEY_BASE64=   # base64-encoded .p8 key (preferred over file path)

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -32,6 +32,7 @@ import '../utils/canvas_utils.dart';
 import '../widgets/confirm_dialog.dart';
 import '../widgets/echo_bottom_sheet.dart';
 import '../widgets/lounge_drawing_canvas.dart';
+import '../widgets/voice_lounge/encrypted_canvas_notice.dart';
 import '../widgets/vertex_mesh_background.dart';
 import '../widgets/voice_canvas.dart';
 import 'voice_lounge/call_metrics_chip.dart';
@@ -195,6 +196,18 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
           'conversationId=${voiceLk.conversationId ?? "none"}',
     );
     DebugLogService.instance.forceFlush().ignore();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final convId = ref.read(livekitVoiceProvider).conversationId;
+      if (convId == null || convId.isEmpty) return;
+      final conv = ref
+          .read(conversationsProvider)
+          .conversations
+          .where((c) => c.id == convId)
+          .firstOrNull;
+      if (conv == null) return;
+      EncryptedCanvasNotice.maybeShow(context, isEncrypted: conv.isEncrypted);
+    });
   }
 
   @override

--- a/apps/client/lib/src/widgets/voice_lounge/encrypted_canvas_notice.dart
+++ b/apps/client/lib/src/widgets/voice_lounge/encrypted_canvas_notice.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// One-time disclosure that voice-lounge canvas content is not end-to-end
+/// encrypted, even in encrypted conversations.
+///
+/// See `docs/voice-lounge/04-encrypted-canvas.md` for the contract that
+/// motivates this notice and the pickup plan tracked at #1268.
+class EncryptedCanvasNotice {
+  /// SharedPreferences key. `_v1` so a future content rewrite can re-prompt
+  /// by bumping to `_v2` without losing the historical signal.
+  static const String prefsKey = 'seen_encrypted_canvas_notice_v1';
+
+  /// Shows the popup once per device. No-op when:
+  ///   * `isEncrypted` is false, or
+  ///   * the user has already dismissed the popup on this install.
+  ///
+  /// Safe to call from `addPostFrameCallback` in a lounge screen's
+  /// `initState`. Awaits internally; callers can ignore the future.
+  static Future<void> maybeShow(
+    BuildContext context, {
+    required bool isEncrypted,
+  }) async {
+    if (!isEncrypted) return;
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(prefsKey) ?? false) return;
+    if (!context.mounted) return;
+
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (ctx) => AlertDialog(
+        title: const Text("Canvas isn't encrypted yet"),
+        content: const Text(
+          'Drawings, screen-share positions, and avatar moves in voice '
+          'lounges are currently visible to the server, even in encrypted '
+          'conversations. End-to-end encryption for the canvas is on the '
+          'way (tracked at #1268). This message will not appear again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Got it'),
+          ),
+        ],
+      ),
+    );
+
+    await prefs.setBool(prefsKey, true);
+  }
+}

--- a/apps/client/test/widgets/voice_lounge/encrypted_canvas_notice_test.dart
+++ b/apps/client/test/widgets/voice_lounge/encrypted_canvas_notice_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/widgets/voice_lounge/encrypted_canvas_notice.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> pumpHost(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                key: const Key('trigger-encrypted'),
+                onPressed: () =>
+                    EncryptedCanvasNotice.maybeShow(context, isEncrypted: true),
+                child: const Text('open-encrypted'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows dialog on first call when isEncrypted is true', (
+    tester,
+  ) async {
+    await pumpHost(tester);
+    await tester.tap(find.byKey(const Key('trigger-encrypted')));
+    await tester.pumpAndSettle();
+    expect(find.text("Canvas isn't encrypted yet"), findsOneWidget);
+    expect(find.text('Got it'), findsOneWidget);
+  });
+
+  testWidgets('does NOT show when isEncrypted is false', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              key: const Key('trigger-plain'),
+              onPressed: () =>
+                  EncryptedCanvasNotice.maybeShow(context, isEncrypted: false),
+              child: const Text('open-plain'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('trigger-plain')));
+    await tester.pumpAndSettle();
+    expect(find.text("Canvas isn't encrypted yet"), findsNothing);
+  });
+
+  testWidgets('sets the seen flag after dismiss + does not show again', (
+    tester,
+  ) async {
+    await pumpHost(tester);
+    await tester.tap(find.byKey(const Key('trigger-encrypted')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Got it'));
+    await tester.pumpAndSettle();
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool(EncryptedCanvasNotice.prefsKey), isTrue);
+
+    await tester.tap(find.byKey(const Key('trigger-encrypted')));
+    await tester.pumpAndSettle();
+    expect(find.text("Canvas isn't encrypted yet"), findsNothing);
+  });
+
+  testWidgets('skips when seen flag is already true', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      EncryptedCanvasNotice.prefsKey: true,
+    });
+    await pumpHost(tester);
+    await tester.tap(find.byKey(const Key('trigger-encrypted')));
+    await tester.pumpAndSettle();
+    expect(find.text("Canvas isn't encrypted yet"), findsNothing);
+  });
+}

--- a/apps/server/src/ws/events/canvas.rs
+++ b/apps/server/src/ws/events/canvas.rs
@@ -1,12 +1,104 @@
 //! Voice-lounge canvas event handling: validate, persist, relay.
 
+use std::sync::OnceLock;
+
 use uuid::Uuid;
 
 use crate::db;
 use crate::routes::AppState;
 use crate::ws::error::send_error;
+use crate::ws::events::canvas_validation::{self, ValidationError};
 use crate::ws::protocol::ServerMessage;
 use crate::ws::typing_service;
+
+/// Rollout phase for the per-kind geometry/schema validators.
+///
+/// `LogOnly` runs the validators but never blocks the event — the canvas
+/// behavior is unchanged from before validation existed, and mismatches
+/// emit a structured `warn!` we can grep production logs for. After we've
+/// observed `log_only` for ~2 weeks and confirmed legitimate clients pass,
+/// the env flips to `enforce` and rejections start dropping events.
+///
+/// `Off` is an escape hatch in case of a false-positive incident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValidationMode {
+    Off,
+    LogOnly,
+    Enforce,
+}
+
+impl ValidationMode {
+    fn from_env_str(raw: Option<&str>) -> Self {
+        match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+            Some("off") => Self::Off,
+            Some("enforce") => Self::Enforce,
+            // Default + any unrecognized value: log_only. Unrecognized
+            // values fall through to log_only so a typo doesn't accidentally
+            // disable validation entirely.
+            _ => Self::LogOnly,
+        }
+    }
+}
+
+fn validation_mode() -> ValidationMode {
+    // Read once per process. Env changes require a server restart, which
+    // matches every other env-driven knob in `config.rs`.
+    static MODE: OnceLock<ValidationMode> = OnceLock::new();
+    *MODE.get_or_init(|| {
+        let mode =
+            ValidationMode::from_env_str(std::env::var("CANVAS_VALIDATION_MODE").ok().as_deref());
+        tracing::info!("CANVAS_VALIDATION_MODE = {:?}", mode);
+        mode
+    })
+}
+
+/// Apply per-kind validation per the active `CANVAS_VALIDATION_MODE`.
+///
+/// Returns `false` if the caller should stop processing the event (only
+/// happens in `Enforce` mode on validation failure).  In `LogOnly` mode a
+/// rejection is logged and the event continues through the pipeline.
+fn apply_validation(
+    state: &AppState,
+    sender_id: Uuid,
+    channel_id: Uuid,
+    kind: &str,
+    payload: &serde_json::Value,
+) -> bool {
+    let mode = validation_mode();
+    if matches!(mode, ValidationMode::Off) {
+        return true;
+    }
+    let Err(err) = canvas_validation::validate(kind, payload) else {
+        return true;
+    };
+    log_validation_failure(sender_id, channel_id, kind, payload, &err);
+    if matches!(mode, ValidationMode::Enforce) {
+        send_error(state, sender_id, &err.code);
+        return false;
+    }
+    true
+}
+
+fn log_validation_failure(
+    sender_id: Uuid,
+    channel_id: Uuid,
+    kind: &str,
+    payload: &serde_json::Value,
+    err: &ValidationError,
+) {
+    // Truncate payload to 256 bytes so a misbehaving client can't flood
+    // disk via the log pipeline.
+    let snippet = serde_json::to_string(payload).unwrap_or_default();
+    let truncated: String = snippet.chars().take(256).collect();
+    tracing::warn!(
+        sender_id = %sender_id,
+        channel_id = %channel_id,
+        kind = %kind,
+        reason = %err.code,
+        payload_snippet = %truncated,
+        "canvas validation rejected payload",
+    );
+}
 
 /// Persist canvas state for non-ephemeral event kinds.
 /// Returns early if a hard error (cap reached) prevents broadcast.
@@ -166,6 +258,14 @@ pub(in crate::ws) async fn handle_canvas_event(
         return;
     }
 
+    // Per-kind schema/geometry validation. In the default `log_only` mode
+    // mismatches emit a `warn!` and the event continues unchanged; once
+    // `CANVAS_VALIDATION_MODE=enforce` is set, mismatches return a
+    // `canvas.validation.*` error code and drop the event.
+    if !apply_validation(state, sender_id, channel_id, &kind, &payload) {
+        return;
+    }
+
     let conversation_id = match lookup_voice_channel(state, sender_id, channel_id).await {
         Some(cid) => cid,
         None => return,
@@ -196,5 +296,51 @@ pub(in crate::ws) async fn handle_canvas_event(
         state
             .hub
             .broadcast_json(&member_ids, &json, Some(sender_id));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_mode_defaults_to_log_only_when_unset() {
+        assert_eq!(ValidationMode::from_env_str(None), ValidationMode::LogOnly);
+    }
+
+    #[test]
+    fn validation_mode_parses_enforce() {
+        assert_eq!(
+            ValidationMode::from_env_str(Some("enforce")),
+            ValidationMode::Enforce
+        );
+    }
+
+    #[test]
+    fn validation_mode_parses_off() {
+        assert_eq!(
+            ValidationMode::from_env_str(Some("off")),
+            ValidationMode::Off
+        );
+    }
+
+    #[test]
+    fn validation_mode_is_case_insensitive() {
+        assert_eq!(
+            ValidationMode::from_env_str(Some("ENFORCE")),
+            ValidationMode::Enforce
+        );
+        assert_eq!(
+            ValidationMode::from_env_str(Some("  Off  ")),
+            ValidationMode::Off
+        );
+    }
+
+    #[test]
+    fn validation_mode_unknown_falls_back_to_log_only() {
+        assert_eq!(
+            ValidationMode::from_env_str(Some("strict")),
+            ValidationMode::LogOnly
+        );
     }
 }

--- a/apps/server/src/ws/events/canvas_validation.rs
+++ b/apps/server/src/ws/events/canvas_validation.rs
@@ -1,0 +1,799 @@
+//! Per-event-kind schema validation for voice-lounge canvas events.
+//!
+//! Every validator is a pure function: it inspects a `serde_json::Value`
+//! payload and returns either `Ok(())` (payload passes the kind's schema)
+//! or `Err(ValidationError)` carrying a stable, log-greppable code.
+//!
+//! The validators here are the *floor* of safety — paired with the existing
+//! byte-size cap (`MAX_CANVAS_PAYLOAD_BYTES`) and the event-kind allowlist,
+//! they reject pathological geometry (`NaN`, `Infinity`, 1e30, negative
+//! widths, point arrays of length 1_000_000 within the byte budget) before
+//! it reaches persistence or relay.
+//!
+//! Error codes follow `canvas.validation.<kind>.<field>.<reason>` so future
+//! log analysis stays sane (see PR B of the canvas redesign plan).
+
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+/// Bound for coordinates in the 100 000 × 100 000 canvas-world surface.
+/// `kCanvasWidth = 100_000` on the client; we accept a small slack window
+/// past that for legacy 0..1 migration helpers + clamps.
+pub const CANVAS_COORD_MIN: f64 = -1_000.0;
+pub const CANVAS_COORD_MAX: f64 = 110_000.0;
+/// Hard limit on the canvas surface itself. Width/height for image entities
+/// cannot exceed this — anything larger is almost certainly garbage.
+pub const CANVAS_SURFACE_MAX: f64 = 100_000.0;
+
+/// Caps for stroke point arrays.
+pub const MAX_STROKE_POINTS: usize = 5_000;
+pub const MAX_STROKE_PARTIAL_POINTS: usize = 200;
+
+/// Stroke width sanity bound. 200 px is well beyond any practical brush.
+pub const MAX_STROKE_WIDTH: f64 = 200.0;
+
+/// Lenient bound for legacy screen-share CSS-pixel coords. Real viewports
+/// are 0..3840, but we leave a generous fudge for unusual DPI scaling.
+pub const LEGACY_SCREENSHARE_MIN: f64 = -10_000.0;
+pub const LEGACY_SCREENSHARE_MAX: f64 = 10_000.0;
+
+/// Max length of the `window_id` string in screenshare events.
+pub const MAX_WINDOW_ID_LEN: usize = 64;
+
+/// Tools mirrored from the Dart `CanvasTool` enum.
+pub const VALID_TOOLS: &[&str] = &[
+    "freehand",
+    "highlighter",
+    "eraser",
+    "rectangle",
+    "ellipse",
+    "arrow",
+    "line",
+    "text",
+];
+
+/// Stable, log-greppable code for a rejected payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    pub code: String,
+}
+
+impl ValidationError {
+    fn new(code: impl Into<String>) -> Self {
+        Self { code: code.into() }
+    }
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.code)
+    }
+}
+
+/// Validate a canvas event payload against the schema for its `kind`.
+///
+/// Unknown kinds are not rejected here — the caller already enforces the
+/// kind allowlist. This function returns `Ok(())` for any kind it does not
+/// have a validator for so future kinds aren't accidentally blocked when
+/// added to the allowlist before a schema lands.
+pub fn validate(kind: &str, payload: &Value) -> Result<(), ValidationError> {
+    match kind {
+        "stroke" => validate_stroke(payload),
+        "stroke_partial" => validate_stroke_partial(payload),
+        "clear" => validate_clear(payload),
+        "image_add" => validate_image_add(payload),
+        "image_move" => validate_image_move(payload),
+        "image_remove" => validate_image_remove(payload),
+        "avatar_move" => validate_avatar_move(payload),
+        "screenshare_move" => validate_screenshare_move(payload),
+        _ => Ok(()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-field helpers (kept tiny so each validator stays inside the cognitive
+// complexity budget).
+// ---------------------------------------------------------------------------
+
+fn finite_f64(payload: &Value, field: &str) -> Result<f64, ValidationError> {
+    let v = payload.get(field).and_then(Value::as_f64).ok_or_else(|| {
+        ValidationError::new(format!(
+            "canvas.validation.field.{field}.missing_or_not_number"
+        ))
+    })?;
+    if !v.is_finite() {
+        return Err(ValidationError::new(format!(
+            "canvas.validation.field.{field}.not_finite"
+        )));
+    }
+    Ok(v)
+}
+
+fn finite_f64_in(payload: &Value, field: &str, min: f64, max: f64) -> Result<f64, ValidationError> {
+    let v = finite_f64(payload, field)?;
+    if v < min || v > max {
+        return Err(ValidationError::new(format!(
+            "canvas.validation.field.{field}.out_of_range"
+        )));
+    }
+    Ok(v)
+}
+
+fn canvas_coord(payload: &Value, field: &str) -> Result<f64, ValidationError> {
+    finite_f64_in(payload, field, CANVAS_COORD_MIN, CANVAS_COORD_MAX)
+}
+
+fn is_uuid_shaped(s: &str) -> bool {
+    if s.len() != 36 {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    for (i, b) in bytes.iter().enumerate() {
+        let is_dash = matches!(i, 8 | 13 | 18 | 23);
+        if is_dash {
+            if *b != b'-' {
+                return false;
+            }
+        } else if !b.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    true
+}
+
+fn require_uuid(payload: &Value, field: &str) -> Result<(), ValidationError> {
+    let s = payload
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| ValidationError::new(format!("canvas.validation.field.{field}.missing")))?;
+    if !is_uuid_shaped(s) {
+        return Err(ValidationError::new(format!(
+            "canvas.validation.field.{field}.not_uuid"
+        )));
+    }
+    Ok(())
+}
+
+fn is_hex_color(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'#') {
+        return false;
+    }
+    if bytes.len() != 7 && bytes.len() != 9 {
+        return false;
+    }
+    bytes[1..].iter().all(u8::is_ascii_hexdigit)
+}
+
+// ---------------------------------------------------------------------------
+// stroke / stroke_partial
+// ---------------------------------------------------------------------------
+
+fn validate_point(point: &Value, idx: usize) -> Result<(), ValidationError> {
+    let x = point.get("x").and_then(Value::as_f64).ok_or_else(|| {
+        ValidationError::new(format!("canvas.validation.stroke.points[{idx}].x.missing"))
+    })?;
+    let y = point.get("y").and_then(Value::as_f64).ok_or_else(|| {
+        ValidationError::new(format!("canvas.validation.stroke.points[{idx}].y.missing"))
+    })?;
+    if !x.is_finite() || !y.is_finite() {
+        return Err(ValidationError::new(format!(
+            "canvas.validation.stroke.points[{idx}].not_finite"
+        )));
+    }
+    if !(CANVAS_COORD_MIN..=CANVAS_COORD_MAX).contains(&x)
+        || !(CANVAS_COORD_MIN..=CANVAS_COORD_MAX).contains(&y)
+    {
+        return Err(ValidationError::new(format!(
+            "canvas.validation.stroke.points[{idx}].out_of_range"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_points_array(payload: &Value, max_len: usize) -> Result<(), ValidationError> {
+    let points = payload
+        .get("points")
+        .and_then(Value::as_array)
+        .ok_or_else(|| ValidationError::new("canvas.validation.stroke.points.missing"))?;
+    if points.is_empty() {
+        return Err(ValidationError::new(
+            "canvas.validation.stroke.points.empty",
+        ));
+    }
+    if points.len() > max_len {
+        return Err(ValidationError::new(
+            "canvas.validation.stroke.points.too_many",
+        ));
+    }
+    for (i, p) in points.iter().enumerate() {
+        validate_point(p, i)?;
+    }
+    Ok(())
+}
+
+fn validate_optional_stroke_meta(payload: &Value) -> Result<(), ValidationError> {
+    if let Some(color) = payload.get("color") {
+        let s = color
+            .as_str()
+            .ok_or_else(|| ValidationError::new("canvas.validation.stroke.color.not_string"))?;
+        if !is_hex_color(s) {
+            return Err(ValidationError::new(
+                "canvas.validation.stroke.color.not_hex",
+            ));
+        }
+    }
+    if let Some(width) = payload.get("width") {
+        let w = width
+            .as_f64()
+            .ok_or_else(|| ValidationError::new("canvas.validation.stroke.width.not_number"))?;
+        if !w.is_finite() || w <= 0.0 || w > MAX_STROKE_WIDTH {
+            return Err(ValidationError::new(
+                "canvas.validation.stroke.width.out_of_range",
+            ));
+        }
+    }
+    if let Some(tool) = payload.get("tool") {
+        let s = tool
+            .as_str()
+            .ok_or_else(|| ValidationError::new("canvas.validation.stroke.tool.not_string"))?;
+        if !VALID_TOOLS.contains(&s) {
+            return Err(ValidationError::new(
+                "canvas.validation.stroke.tool.unknown",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_stroke(payload: &Value) -> Result<(), ValidationError> {
+    validate_points_array(payload, MAX_STROKE_POINTS)?;
+    validate_optional_stroke_meta(payload)
+}
+
+fn validate_stroke_partial(payload: &Value) -> Result<(), ValidationError> {
+    // stroke_partial is just a live-preview frame; per-point bounds still
+    // apply, but optional meta fields are ignored.
+    validate_points_array(payload, MAX_STROKE_PARTIAL_POINTS)
+}
+
+// ---------------------------------------------------------------------------
+// clear
+// ---------------------------------------------------------------------------
+
+fn validate_clear(payload: &Value) -> Result<(), ValidationError> {
+    // Empty payload (object or null) is fine.
+    match payload {
+        Value::Null => Ok(()),
+        Value::Object(map) if map.is_empty() => Ok(()),
+        Value::Object(map) => {
+            // Only `scope` is allowed, and its value is one of two literals.
+            for k in map.keys() {
+                if k != "scope" {
+                    return Err(ValidationError::new(format!(
+                        "canvas.validation.clear.{k}.unknown_field"
+                    )));
+                }
+            }
+            if let Some(scope) = map.get("scope") {
+                let s = scope.as_str().ok_or_else(|| {
+                    ValidationError::new("canvas.validation.clear.scope.not_string")
+                })?;
+                if s != "all" && s != "mine" {
+                    return Err(ValidationError::new(
+                        "canvas.validation.clear.scope.unknown_value",
+                    ));
+                }
+            }
+            Ok(())
+        }
+        _ => Err(ValidationError::new("canvas.validation.clear.not_object")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// image_add / image_move / image_remove
+// ---------------------------------------------------------------------------
+
+fn validate_image_dims(payload: &Value) -> Result<(), ValidationError> {
+    let w = finite_f64(payload, "width")?;
+    let h = finite_f64(payload, "height")?;
+    if w <= 0.0 || w > CANVAS_SURFACE_MAX {
+        return Err(ValidationError::new(
+            "canvas.validation.image.width.out_of_range",
+        ));
+    }
+    if h <= 0.0 || h > CANVAS_SURFACE_MAX {
+        return Err(ValidationError::new(
+            "canvas.validation.image.height.out_of_range",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_image_url(payload: &Value) -> Result<(), ValidationError> {
+    let url = payload
+        .get("url")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ValidationError::new("canvas.validation.image_add.url.missing"))?;
+    if !url.starts_with("/api/media/") {
+        return Err(ValidationError::new(
+            "canvas.validation.image_add.url.not_relative",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_image_add(payload: &Value) -> Result<(), ValidationError> {
+    require_uuid(payload, "id")?;
+    validate_image_url(payload)?;
+    canvas_coord(payload, "x")?;
+    canvas_coord(payload, "y")?;
+    validate_image_dims(payload)
+}
+
+fn validate_image_move(payload: &Value) -> Result<(), ValidationError> {
+    require_uuid(payload, "id")?;
+    canvas_coord(payload, "x")?;
+    canvas_coord(payload, "y")?;
+    let has_w = payload.get("width").is_some();
+    let has_h = payload.get("height").is_some();
+    match (has_w, has_h) {
+        (false, false) => Ok(()),
+        (true, true) => validate_image_dims(payload),
+        _ => Err(ValidationError::new(
+            "canvas.validation.image_move.dims.partial",
+        )),
+    }
+}
+
+fn validate_image_remove(payload: &Value) -> Result<(), ValidationError> {
+    require_uuid(payload, "id")
+}
+
+// ---------------------------------------------------------------------------
+// avatar_move
+// ---------------------------------------------------------------------------
+
+fn validate_avatar_move(payload: &Value) -> Result<(), ValidationError> {
+    require_uuid(payload, "user_id")?;
+    canvas_coord(payload, "x")?;
+    canvas_coord(payload, "y")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// screenshare_move (dual format during the coord_v=1 → coord_v=2 transition)
+// ---------------------------------------------------------------------------
+
+fn validate_window_id(payload: &Value) -> Result<(), ValidationError> {
+    let s = payload
+        .get("window_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ValidationError::new("canvas.validation.screenshare_move.window_id.missing")
+        })?;
+    if s.is_empty() {
+        return Err(ValidationError::new(
+            "canvas.validation.screenshare_move.window_id.empty",
+        ));
+    }
+    if s.len() > MAX_WINDOW_ID_LEN {
+        return Err(ValidationError::new(
+            "canvas.validation.screenshare_move.window_id.too_long",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_screenshare_v2(payload: &Value) -> Result<(), ValidationError> {
+    for field in ["x_norm", "y_norm", "w_norm", "h_norm"] {
+        finite_f64_in(payload, field, 0.0, 1.0)?;
+    }
+    Ok(())
+}
+
+fn validate_screenshare_legacy(payload: &Value) -> Result<(), ValidationError> {
+    for field in ["x", "y", "width", "height"] {
+        finite_f64_in(
+            payload,
+            field,
+            LEGACY_SCREENSHARE_MIN,
+            LEGACY_SCREENSHARE_MAX,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_screenshare_move(payload: &Value) -> Result<(), ValidationError> {
+    validate_window_id(payload)?;
+    let coord_v = payload.get("coord_v").and_then(Value::as_i64);
+    match coord_v {
+        None | Some(1) => validate_screenshare_legacy(payload),
+        Some(2) => validate_screenshare_v2(payload),
+        Some(_) => Err(ValidationError::new(
+            "canvas.validation.screenshare_move.coord_v.unsupported",
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn err_code(kind: &str, payload: Value) -> String {
+        validate(kind, &payload).expect_err("should reject").code
+    }
+
+    // -- stroke ------------------------------------------------------------
+
+    #[test]
+    fn stroke_valid_payload_passes() {
+        let payload = json!({
+            "points": [{"x": 0.0, "y": 0.0}, {"x": 100.0, "y": 50.0}],
+            "color": "#ff00aa",
+            "width": 4.0,
+            "tool": "freehand"
+        });
+        assert!(validate("stroke", &payload).is_ok());
+    }
+
+    #[test]
+    fn stroke_rejects_non_numeric_x() {
+        // `serde_json::json!` cannot encode NaN/Infinity (invalid JSON), so
+        // simulate the on-the-wire equivalent: a non-number where x is
+        // expected. The validator must still reject it.
+        let payload = json!({"points": [{"x": "nope", "y": 0.0}]});
+        assert!(err_code("stroke", payload).contains("missing"));
+    }
+
+    #[test]
+    fn stroke_rejects_missing_y() {
+        let payload = json!({"points": [{"x": 0.0}]});
+        assert!(err_code("stroke", payload).contains("y.missing"));
+    }
+
+    #[test]
+    fn stroke_rejects_out_of_range_x() {
+        let payload = json!({"points": [{"x": 1.0e9, "y": 0.0}]});
+        assert!(err_code("stroke", payload).contains("out_of_range"));
+    }
+
+    #[test]
+    fn stroke_rejects_too_many_points() {
+        let pts: Vec<_> = (0..6000).map(|_| json!({"x": 1.0, "y": 1.0})).collect();
+        let payload = json!({"points": pts});
+        assert!(err_code("stroke", payload).contains("too_many"));
+    }
+
+    #[test]
+    fn stroke_rejects_empty_points() {
+        let payload = json!({"points": []});
+        assert!(err_code("stroke", payload).contains("empty"));
+    }
+
+    #[test]
+    fn stroke_rejects_missing_points() {
+        let payload = json!({});
+        assert!(err_code("stroke", payload).contains("missing"));
+    }
+
+    #[test]
+    fn stroke_rejects_bad_hex_color() {
+        let payload = json!({"points": [{"x": 0.0, "y": 0.0}], "color": "red"});
+        assert!(err_code("stroke", payload).contains("color.not_hex"));
+    }
+
+    #[test]
+    fn stroke_accepts_rgba_hex() {
+        let payload = json!({"points": [{"x": 0.0, "y": 0.0}], "color": "#ff00aaff"});
+        assert!(validate("stroke", &payload).is_ok());
+    }
+
+    #[test]
+    fn stroke_rejects_negative_width() {
+        let payload = json!({"points": [{"x": 0.0, "y": 0.0}], "width": -1.0});
+        assert!(err_code("stroke", payload).contains("width.out_of_range"));
+    }
+
+    #[test]
+    fn stroke_rejects_huge_width() {
+        let payload = json!({"points": [{"x": 0.0, "y": 0.0}], "width": 500.0});
+        assert!(err_code("stroke", payload).contains("width.out_of_range"));
+    }
+
+    #[test]
+    fn stroke_rejects_unknown_tool() {
+        let payload = json!({"points": [{"x": 0.0, "y": 0.0}], "tool": "lightsaber"});
+        assert!(err_code("stroke", payload).contains("tool.unknown"));
+    }
+
+    // -- stroke_partial ---------------------------------------------------
+
+    #[test]
+    fn stroke_partial_caps_at_200_points() {
+        let pts: Vec<_> = (0..201).map(|_| json!({"x": 1.0, "y": 1.0})).collect();
+        let payload = json!({"points": pts});
+        assert!(err_code("stroke_partial", payload).contains("too_many"));
+    }
+
+    #[test]
+    fn stroke_partial_ignores_optional_meta() {
+        // 'tool: chainsaw' would fail validate_stroke but stroke_partial ignores it.
+        let payload = json!({
+            "points": [{"x": 0.0, "y": 0.0}],
+            "tool": "chainsaw"
+        });
+        assert!(validate("stroke_partial", &payload).is_ok());
+    }
+
+    // -- clear -------------------------------------------------------------
+
+    #[test]
+    fn clear_accepts_empty_object() {
+        assert!(validate("clear", &json!({})).is_ok());
+    }
+
+    #[test]
+    fn clear_accepts_scope_all() {
+        assert!(validate("clear", &json!({"scope": "all"})).is_ok());
+    }
+
+    #[test]
+    fn clear_accepts_scope_mine() {
+        assert!(validate("clear", &json!({"scope": "mine"})).is_ok());
+    }
+
+    #[test]
+    fn clear_rejects_unknown_scope() {
+        let payload = json!({"scope": "everything-please"});
+        assert!(err_code("clear", payload).contains("scope.unknown_value"));
+    }
+
+    #[test]
+    fn clear_rejects_unknown_field() {
+        let payload = json!({"haha": "gotcha"});
+        assert!(err_code("clear", payload).contains("unknown_field"));
+    }
+
+    // -- image_add --------------------------------------------------------
+
+    fn good_image_add() -> Value {
+        json!({
+            "id": "11111111-1111-1111-1111-111111111111",
+            "url": "/api/media/abc.png",
+            "x": 100.0,
+            "y": 200.0,
+            "width": 400.0,
+            "height": 300.0
+        })
+    }
+
+    #[test]
+    fn image_add_valid_passes() {
+        assert!(validate("image_add", &good_image_add()).is_ok());
+    }
+
+    #[test]
+    fn image_add_rejects_non_uuid() {
+        let mut p = good_image_add();
+        p["id"] = json!("not-a-uuid");
+        assert!(err_code("image_add", p).contains("id.not_uuid"));
+    }
+
+    #[test]
+    fn image_add_rejects_absolute_url() {
+        let mut p = good_image_add();
+        p["url"] = json!("https://evil.example.com/x.png");
+        assert!(err_code("image_add", p).contains("url.not_relative"));
+    }
+
+    #[test]
+    fn image_add_rejects_negative_width() {
+        let mut p = good_image_add();
+        p["width"] = json!(-50.0);
+        assert!(err_code("image_add", p).contains("width.out_of_range"));
+    }
+
+    #[test]
+    fn image_add_rejects_huge_width() {
+        let mut p = good_image_add();
+        p["width"] = json!(1.0e9);
+        assert!(err_code("image_add", p).contains("width.out_of_range"));
+    }
+
+    #[test]
+    fn image_add_rejects_non_numeric_x() {
+        let mut p = good_image_add();
+        p["x"] = json!("oops");
+        assert!(err_code("image_add", p).contains("x.missing_or_not_number"));
+    }
+
+    // -- image_move -------------------------------------------------------
+
+    #[test]
+    fn image_move_no_dims_is_ok() {
+        let p = json!({
+            "id": "22222222-2222-2222-2222-222222222222",
+            "x": 0.0, "y": 0.0
+        });
+        assert!(validate("image_move", &p).is_ok());
+    }
+
+    #[test]
+    fn image_move_both_dims_present_is_ok() {
+        let p = json!({
+            "id": "22222222-2222-2222-2222-222222222222",
+            "x": 0.0, "y": 0.0,
+            "width": 100.0, "height": 50.0
+        });
+        assert!(validate("image_move", &p).is_ok());
+    }
+
+    #[test]
+    fn image_move_partial_dims_rejected() {
+        let p = json!({
+            "id": "22222222-2222-2222-2222-222222222222",
+            "x": 0.0, "y": 0.0,
+            "width": 100.0
+        });
+        assert!(err_code("image_move", p).contains("dims.partial"));
+    }
+
+    // -- image_remove -----------------------------------------------------
+
+    #[test]
+    fn image_remove_valid_uuid_passes() {
+        let p = json!({"id": "33333333-3333-3333-3333-333333333333"});
+        assert!(validate("image_remove", &p).is_ok());
+    }
+
+    #[test]
+    fn image_remove_bad_uuid_rejected() {
+        let p = json!({"id": "junk"});
+        assert!(err_code("image_remove", p).contains("id.not_uuid"));
+    }
+
+    // -- avatar_move ------------------------------------------------------
+
+    #[test]
+    fn avatar_move_valid_passes() {
+        let p = json!({
+            "user_id": "44444444-4444-4444-4444-444444444444",
+            "x": 1000.0, "y": 2000.0
+        });
+        assert!(validate("avatar_move", &p).is_ok());
+    }
+
+    #[test]
+    fn avatar_move_rejects_out_of_range_y() {
+        let p = json!({
+            "user_id": "44444444-4444-4444-4444-444444444444",
+            "x": 0.0, "y": 1.0e10
+        });
+        assert!(err_code("avatar_move", p).contains("out_of_range"));
+    }
+
+    #[test]
+    fn avatar_move_rejects_missing_user_id() {
+        let p = json!({"x": 0.0, "y": 0.0});
+        assert!(err_code("avatar_move", p).contains("user_id.missing"));
+    }
+
+    // -- screenshare_move -------------------------------------------------
+
+    #[test]
+    fn screenshare_legacy_format_passes_without_coord_v() {
+        let p = json!({
+            "window_id": "win-1",
+            "x": 100.0, "y": 50.0, "width": 800.0, "height": 600.0
+        });
+        assert!(validate("screenshare_move", &p).is_ok());
+    }
+
+    #[test]
+    fn screenshare_legacy_format_passes_with_coord_v1() {
+        let p = json!({
+            "window_id": "win-1",
+            "coord_v": 1,
+            "x": 100.0, "y": 50.0, "width": 800.0, "height": 600.0
+        });
+        assert!(validate("screenshare_move", &p).is_ok());
+    }
+
+    #[test]
+    fn screenshare_v2_format_passes() {
+        let p = json!({
+            "window_id": "win-2",
+            "coord_v": 2,
+            "x_norm": 0.25, "y_norm": 0.5, "w_norm": 0.4, "h_norm": 0.3
+        });
+        assert!(validate("screenshare_move", &p).is_ok());
+    }
+
+    #[test]
+    fn screenshare_v2_rejects_x_norm_above_one() {
+        let p = json!({
+            "window_id": "win-2",
+            "coord_v": 2,
+            "x_norm": 1.5, "y_norm": 0.5, "w_norm": 0.4, "h_norm": 0.3
+        });
+        assert!(err_code("screenshare_move", p).contains("x_norm.out_of_range"));
+    }
+
+    #[test]
+    fn screenshare_v2_rejects_negative_y_norm() {
+        let p = json!({
+            "window_id": "win-2",
+            "coord_v": 2,
+            "x_norm": 0.5, "y_norm": -0.1, "w_norm": 0.4, "h_norm": 0.3
+        });
+        assert!(err_code("screenshare_move", p).contains("y_norm.out_of_range"));
+    }
+
+    #[test]
+    fn screenshare_rejects_unknown_coord_v() {
+        let p = json!({
+            "window_id": "win-2",
+            "coord_v": 99,
+            "x_norm": 0.5, "y_norm": 0.5, "w_norm": 0.4, "h_norm": 0.3
+        });
+        assert!(err_code("screenshare_move", p).contains("coord_v.unsupported"));
+    }
+
+    #[test]
+    fn screenshare_rejects_empty_window_id() {
+        let p = json!({
+            "window_id": "",
+            "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0
+        });
+        assert!(err_code("screenshare_move", p).contains("window_id.empty"));
+    }
+
+    #[test]
+    fn screenshare_rejects_too_long_window_id() {
+        let long = "a".repeat(MAX_WINDOW_ID_LEN + 1);
+        let p = json!({
+            "window_id": long,
+            "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0
+        });
+        assert!(err_code("screenshare_move", p).contains("window_id.too_long"));
+    }
+
+    #[test]
+    fn screenshare_legacy_rejects_non_numeric() {
+        let p = json!({
+            "window_id": "win",
+            "x": "boom", "y": 0.0, "width": 100.0, "height": 100.0
+        });
+        assert!(err_code("screenshare_move", p).contains("missing_or_not_number"));
+    }
+
+    #[test]
+    fn screenshare_legacy_rejects_out_of_range() {
+        let p = json!({
+            "window_id": "win",
+            "x": 1.0e9, "y": 0.0, "width": 100.0, "height": 100.0
+        });
+        assert!(err_code("screenshare_move", p).contains("x.out_of_range"));
+    }
+
+    // -- unknown kind -----------------------------------------------------
+
+    #[test]
+    fn unknown_kind_is_passthrough_ok() {
+        // Future kinds added to the allowlist before a schema lands must not
+        // be accidentally blocked here.
+        assert!(validate("future_kind", &json!({"whatever": 1})).is_ok());
+    }
+
+    // -- ValidationMode parsing covered alongside the mode enum (see canvas.rs).
+}

--- a/apps/server/src/ws/events/mod.rs
+++ b/apps/server/src/ws/events/mod.rs
@@ -2,5 +2,6 @@
 
 pub(super) mod broadcast;
 pub(super) mod canvas;
+pub(super) mod canvas_validation;
 pub(super) mod dispatch;
 pub(super) mod voice;

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -37,7 +37,7 @@ Voice lounges include a shared canvas — drawings, screen-share window position
 
 The pickup plan for closing this gap is tracked at [#1268](https://github.com/NC1107/echo-messenger/issues/1268); it requires the group-message E2E protocol (GRP2) to ship first. Until then, treat anything you draw or any window you reposition in a lounge as visible to the server operator.
 
-If a lounge belongs to an encrypted group, the app shows a one-line notice the first time you enter that lounge so this gap is surfaced at the right moment, not just in this document.
+The first time you enter a voice lounge in an encrypted group on a given device, the app shows a one-time popup acknowledging this gap so it's surfaced at the right moment, not just buried in this document. The popup is dismissible and does not return.
 
 ## Where the data lives
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -29,6 +29,16 @@ your own Echo server, you are the operator and you control all data stored on it
 - **Third-party analytics or trackers.** No Mixpanel, no Segment, no Google Analytics, no Sentry.
 - **Your private keys.** They're generated on-device and stored in your platform keystore (Keychain on iOS/macOS, Credential Manager on Android, libsecret on Linux, etc.).
 
+## Voice-lounge canvas
+
+Voice lounges include a shared canvas — drawings, screen-share window positions, and avatar positions are synchronized to everyone in the lounge in real time.
+
+**Canvas content is server-readable. It is not end-to-end encrypted, even in groups where messages are.** When you draw a stroke, drag your avatar, or move a screen-share window in a voice lounge, the coordinates and stroke data pass through the server in plaintext, and persistent kinds (strokes, image references, board clears) are stored in the Echo database as plaintext JSON.
+
+The pickup plan for closing this gap is tracked at [#1268](https://github.com/NC1107/echo-messenger/issues/1268); it requires the group-message E2E protocol (GRP2) to ship first. Until then, treat anything you draw or any window you reposition in a lounge as visible to the server operator.
+
+If a lounge belongs to an encrypted group, the app shows a one-line notice the first time you enter that lounge so this gap is surfaced at the right moment, not just in this document.
+
 ## Where the data lives
 
 PostgreSQL on the server at `echo-messenger.us`. Access is restricted to the operator (GitHub user `NC1107`).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -139,6 +139,30 @@ scrape_configs:
 - Wrong token → `401 Unauthorized`
 - Correct token → `200` with Prometheus text body
 
+## Voice-lounge canvas validation
+
+The voice-lounge canvas server runs per-event-kind schema and geometry
+validation on every incoming `canvas_event` (stroke points, image coords,
+screen-share window position, etc.). The rollout phase is controlled by the
+`CANVAS_VALIDATION_MODE` environment variable on the server container:
+
+| Value | Behavior |
+|-------|----------|
+| `log_only` (default) | Validators run; mismatches emit a structured `warn!` with the reason code and a 256-byte payload snippet, but the event is **relayed and persisted unchanged**. Use this to watch logs for legitimate clients that might be sending unexpected payloads before tightening. |
+| `enforce` | Validators run; mismatches return a `canvas.validation.<kind>.<field>.<reason>` error to the sender and the event is **dropped** (not relayed, not persisted). |
+| `off` | Validators do not run. Escape hatch for false-positive incidents. |
+
+Add it to your `.env` file and pass it through in `docker-compose.prod.yml`:
+
+```yaml
+server:
+  environment:
+    CANVAS_VALIDATION_MODE: log_only
+```
+
+Unset or unrecognized values fall through to `log_only`, so a typo cannot
+accidentally disable validation entirely.
+
 ## Backups
 
 ### Database backup

--- a/docs/voice-lounge/01-coordinate-policy.md
+++ b/docs/voice-lounge/01-coordinate-policy.md
@@ -60,4 +60,8 @@ The stroke coord migration heuristic (`_migrateLegacyCoord`) is **not** revisite
 ## Open questions
 
 - **Per-aspect-ratio refinement for screen-share overlay placement** — the normalization treats a 16:9 desktop and a 9:19 phone identically, which is good enough for v1 but may want a future "anchor + offset" model (`{anchor: 'top-right', x_offset_norm: 0.05}`). Pickup trigger: tester reports that proportional placement looks wrong on a particular device class.
-- **Whether resize sync uses the same normalization or stays in absolute pixels** — current implementation syncs `w_norm` and `h_norm` per this decision. Open to revisit if windows end up at unreadable sizes on small screens; the simple fix would be to clamp `w_min_px` / `h_min_px` on the receive side.
+
+## Confirmed by review (2026-05-28)
+
+- **Resize sync uses the same viewport-normalization as position.** `w_norm` and `h_norm` ride in 0..1 of the sender's viewport. The receiver multiplies by its own viewport size **and** clamps to a `w_min_px` / `h_min_px` floor (120 px) so phone-side windows don't shrink below readable size. This preserves "looks proportional across devices" while preventing the worst-case "tiny window on a phone" outcome.
+- **Strokes, shapes, avatars are unchanged.** They live in canvas-world (100k) coordinates and zoom/pan with the InteractiveViewer transform, so they already appear in the same logical position on every device. The resize-sync change only affects the screen-share window overlay, not whiteboard content.

--- a/docs/voice-lounge/01-coordinate-policy.md
+++ b/docs/voice-lounge/01-coordinate-policy.md
@@ -1,0 +1,63 @@
+# 01 — Coordinate policy
+
+## Status quo
+
+Three canvas entity classes, **three different coordinate models**:
+
+| Entity | Coordinate space | Wire format | Code |
+|---|---|---|---|
+| **Strokes** (freehand, shapes, text) | Canvas-world, absolute pixels in 100 000 × 100 000 surface | Absolute pixels, with `_migrateLegacyCoord` heuristic accepting ≤ 1.0 as legacy 0..1 normalized (multiplied by **4096**, not 100k) | `canvas_models.dart:37`, `apps/server/src/db/canvas.rs` |
+| **Avatars** | Canvas-world, absolute pixels in 100 000 × 100 000 surface, default ring radius `0.3 × kCanvasWidth ≈ 30 000 px` | Same as strokes; keyed by `user_id` | `voice_canvas.dart:385`, `canvas_provider.dart:534` |
+| **Screen-share windows** | **Viewport-relative CSS pixels** (clamped against the receiving InteractiveViewer's `LayoutBuilder` constraints) | Raw CSS pixels `{window_id, x, y, width, height}` — explicitly NOT normalized, comment in `canvas_provider.dart:646` | `screen_share.dart:402-422`, `canvas_provider.dart:691,719` |
+
+### The cross-device divergence bug this creates
+
+Sender on a 1920×1080 desktop drags a screen-share window to `x = 1500, y = 200`. The `screenshare_move` payload broadcasts those raw values. A receiver on a 390×844 phone reads `_left = shared.x = 1500`, then `LayoutBuilder` immediately clamps to `min(constraints.maxWidth - 60) = 330`. The window snaps to the right edge of the phone, nowhere near where the sender intended it.
+
+This is a coordinate-space leak: sender's local viewport pixels are being treated as a universal coordinate, but only the receiver's viewport gives them meaning.
+
+Avatars and strokes don't have this bug because they live in canvas-world coordinates, and every device renders the same 100k surface through its own InteractiveViewer transform.
+
+## Options
+
+### Option A — Unify everything to canvas-world
+
+Screen-share windows become canvas objects in 100k space.
+
+- **Pro:** one coord model; cross-device parity for free.
+- **Con:** screen-share windows are conceptually a UI overlay, not a whiteboard primitive. Putting them in the 100k surface means they zoom and pan with the canvas — a participant zooming into a stroke would zoom out of the screen share. That's bad UX. It also means we lose the ability to keep screen share visible during a stroke focus.
+
+### Option B — Normalize the screen-share wire format
+
+Screen-share windows stay viewport overlays *locally*, but the wire format is normalized 0..1 of "lounge interactive viewport". Sender divides by their `_interactiveViewportSize`; receiver multiplies by their own `_interactiveViewportSize`.
+
+- **Pro:** cross-device parity. Screen-share keeps overlay semantics (no zoom-with-canvas). Minimal new code — a translation layer in `canvas_provider.dart` send/receive paths plus a viewport-size sentinel on each end.
+- **Con:** the receiver might have a wildly different aspect ratio. A window pinned to the top-right on a 1920×1080 desktop will appear top-right on a phone too — but proportionally taller/narrower. Acceptable for overlay UX; can be refined per-aspect-ratio later if needed.
+
+### Option C — Keep hybrid; document the divergence as deliberate
+
+Each device's screen-share window position is intentionally local. Wire format goes away entirely; positions are not synchronized.
+
+- **Pro:** simplest. Each user arranges their own view.
+- **Con:** kills shared-pointing UX ("look at this thing in the upper-left of your screen share"). The current `screenshare_move` synchronization exists because that UX was wanted.
+
+## Decision
+
+**Option B**, dated 2026-05-28.
+
+Wire format for `screenshare_move` becomes `{window_id, x_norm, y_norm, w_norm, h_norm}` with values in `[0.0, 1.0]` of the sender's interactive viewport. Receiver multiplies by its own `_interactiveViewportSize` before applying. A `coord_v` field on the event distinguishes the new format from legacy CSS-pixel payloads (legacy continues to be accepted via a translation shim until Phase 4's sunset gate fires).
+
+Avatars and strokes stay in canvas-world coordinates with no changes.
+
+The stroke coord migration heuristic (`_migrateLegacyCoord`) is **not** revisited here; Phase 4 (legacy migration sunset) owns that decision.
+
+## Acceptance criteria
+
+- Any PR that introduces a new canvas entity must place it in one of the two documented coord spaces (canvas-world for whiteboard-like content, normalized-viewport for overlay-like content) and state which in the PR description.
+- Any change to `screenshare_move` payload shape must bump `coord_v` and provide a translation shim for the previous version.
+- No PR may reintroduce raw-CSS-pixel coordinates as a wire format for any entity that synchronizes across devices.
+
+## Open questions
+
+- **Per-aspect-ratio refinement for screen-share overlay placement** — the normalization treats a 16:9 desktop and a 9:19 phone identically, which is good enough for v1 but may want a future "anchor + offset" model (`{anchor: 'top-right', x_offset_norm: 0.05}`). Pickup trigger: tester reports that proportional placement looks wrong on a particular device class.
+- **Whether resize sync uses the same normalization or stays in absolute pixels** — current implementation syncs `w_norm` and `h_norm` per this decision. Open to revisit if windows end up at unreadable sizes on small screens; the simple fix would be to clamp `w_min_px` / `h_min_px` on the receive side.

--- a/docs/voice-lounge/02-input-matrix.md
+++ b/docs/voice-lounge/02-input-matrix.md
@@ -69,6 +69,9 @@ These apply across all device classes; they exist to make gesture-arena behavior
 
 ## Open questions
 
-- **Right-click context menu** — the matrix lists right-click as "tool-cancel / Escape" today, but a real context menu (Cut / Copy / Paste / Bring forward / Send back) would be useful for canvas objects. Pickup trigger: first feature request for canvas-object reordering or copy-paste.
 - **Pen / stylus support** — currently treated as touch. iPad pencil / Wacom may want pressure-sensitive stroke width. Pickup trigger: tester with a stylus reports unsatisfying stroke quality.
-- **Trackpad scroll-wheel zoom without modifier** — some apps treat unmodified trackpad scroll as zoom (Figma) vs pan (most browsers). Today we use modifier-required. Pickup trigger: user feedback prefers unmodified zoom.
+
+## Confirmed by review (2026-05-28)
+
+- **Right-click on canvas = cancel draw / clear selection** (same as Escape). No full context menu in v1; defer Cut/Copy/Paste/z-order until first feature request.
+- **Trackpad scroll-wheel zoom stays modifier-required** (Ctrl/Cmd + scroll). Unmodified two-finger scroll pans. Predictable across web + desktop; revisit if testers report friction.

--- a/docs/voice-lounge/02-input-matrix.md
+++ b/docs/voice-lounge/02-input-matrix.md
@@ -1,0 +1,74 @@
+# 02 — Input matrix
+
+## Status quo
+
+The lounge canvas uses an `InteractiveViewer` for pan/zoom and a `LoungeDrawingCanvas` `GestureDetector` overlay for stroke capture. Recent fixes (#1247, #1257, #1266) tuned gesture-arena handoff but no written contract exists for how each input device class should behave. Implementation decisions have been ad-hoc per-bug.
+
+## Decision matrix
+
+Per device class, per action. Conflict rules at the bottom.
+
+### Touch (phone, tablet)
+
+| Action | Gesture | Notes |
+|---|---|---|
+| Pan | One-finger drag | Only when `selectedTool == CanvasTool.none` (no active draw tool) |
+| Zoom | Pinch (two fingers) | Always available — pinch wins arena over draw via the slop-based `PanGestureRecognizer` handoff (`lounge_drawing_canvas.dart:42`) |
+| Draw | One-finger drag | Only when a draw tool is selected; ~18 px slop before claim |
+| Select an object (avatar, image) | Tap | Tool-agnostic |
+| Double-tap zoom (zoom in 2× at point) | Two quick taps | Only when `selectedTool == CanvasTool.none`. Disabled while a draw tool is active (#1266) |
+| Tool-cancel / exit draw mode | Tap the active tool button again | Currently routed through `_toggleDrawingMode()`; deselects + clears `selectedTool` |
+
+### Mouse (Linux/Windows/macOS desktop, web with mouse)
+
+| Action | Gesture | Notes |
+|---|---|---|
+| Pan | Middle-click drag, OR left-click drag with no tool selected | Same `selectedTool == none` gate as touch |
+| Zoom | `Ctrl/Cmd + scroll wheel` | Wheel without modifier scrolls page / nothing |
+| Draw | Left-click drag | Same slop-based handoff as touch |
+| Select an object | Left-click | |
+| Double-tap zoom | Double-click | Same `selectedTool == none` gate. Double-click while drawing is **explicitly suppressed** (#1266 fix) |
+| Tool-cancel | Right-click OR Escape | Right-click currently has no canvas handler; this is a future addition |
+
+### Trackpad (laptop touchpad)
+
+| Action | Gesture | Notes |
+|---|---|---|
+| Pan | Two-finger drag | Same as scroll; no modifier |
+| Zoom | Pinch-to-zoom (built-in trackpad gesture) OR `Ctrl/Cmd + scroll` | Trackpad pinches arrive as scale events |
+| Draw | One-finger drag | Click-and-drag; same slop handoff |
+| Select | One-finger tap | |
+| Double-tap zoom | Double-tap (one finger) | Same gate |
+
+### Keyboard (all devices with hardware keyboard)
+
+| Action | Keys | Notes |
+|---|---|---|
+| Reset view (fit-to-content) | `0` or `Cmd/Ctrl+0` | Resets to `_centeredPose` |
+| Zoom in | `Cmd/Ctrl + +` | 1.25× current scale |
+| Zoom out | `Cmd/Ctrl + -` | 0.8× current scale |
+| Pan | Arrow keys | 100 canvas-pixels per press; `Shift+Arrow` = 500 |
+| Cancel draw / clear selection | `Escape` | Same as right-click |
+| Cycle tools | `B` (brush) / `E` (eraser) / `T` (text) / `Escape` (none) | Single-letter, no modifier; only active when canvas has focus |
+
+## Conflict rules
+
+These apply across all device classes; they exist to make gesture-arena behavior predictable instead of emergent.
+
+1. **A draw stroke in progress wins all other gestures** — pinch, double-tap, double-click, scroll-wheel zoom are all suppressed for the duration of the stroke (from `onPanStart` to `onPanEnd` / `onPanCancel`). This is the rule that today's #1266 fix encodes.
+2. **A second simultaneous pointer cancels a draw stroke and yields to the pinch/scale recognizer.** Implemented today via the slop-based `PanGestureRecognizer` losing the arena to `ScaleGestureRecognizer` once it sees the second pointer (`lounge_drawing_canvas.dart:42`). This is the rule that today's #1257 fix encodes.
+3. **`selectedTool == CanvasTool.none` means pan/zoom is unrestricted; any tool selected means pan/zoom are still possible but require the gesture to *not* trigger a draw first.** Practically: pinch always pans/zooms; single-pointer drag draws only if a tool is active.
+4. **Tool switching is destructive** — switching from brush to eraser mid-stroke cancels the in-flight stroke (no half-finished strokes get committed). Already implemented via `endStroke` on tool change.
+5. **Focus is required for keyboard shortcuts** — the canvas must have keyboard focus (clicked into) before `B`/`E`/`T`/`Escape` cycle tools. Same model as Figma. Single-letter shortcuts must not fire while the chat input has focus.
+
+## Acceptance criteria
+
+- A PR that adds a new gesture (or changes an existing one) must update the matrix above before the behavior change merges.
+- Any new gesture must declare its arena precedence relative to draw, pinch-zoom, and double-tap. "It just works in testing" is not a precedence declaration.
+- The keyboard shortcuts column is the contract for `Shortcuts`/`Actions` widget keymaps; new shortcuts must not collide with existing single-letter keys without a written justification.
+
+## Open questions
+
+- **Right-click context menu** — the matrix lists right-click as "tool-cancel / Escape" today, but a real context menu (Cut / Copy / Paste / Bring forward / Send back) would be useful for canvas objects. Pickup trigger: first feature request for canvas-object reordering or copy-paste.
+- **Pen / stylus support** — currently treated as touch. iPad pencil / Wacom may want pressure-sensitive stroke width. Pickup trigger: tester with a stylus reports unsatisfying stroke quality.
+- **Trackpad scroll-wheel zoom without modifier** — some apps treat unmodified trackpad scroll as zoom (Figma) vs pan (most browsers). Today we use modifier-required. Pickup trigger: user feedback prefers unmodified zoom.

--- a/docs/voice-lounge/03-multi-device.md
+++ b/docs/voice-lounge/03-multi-device.md
@@ -1,0 +1,78 @@
+# 03 — Multi-device per user
+
+## Status quo
+
+Canvas avatar entries are keyed by `user_id`, **not** by `(user_id, device_id)`. Every device for a user shares one avatar slot.
+
+Citations:
+- `voice_canvas.dart:341` — `key: ValueKey('avatar-${participant.userId}')`
+- `voice_canvas.dart:353` — `.moveAvatar(participant.userId, norm)`
+- `canvas_provider.dart:534` — `void moveAvatar(String userId, CanvasPoint pos)`
+- `canvas_provider.dart:868-870` — incoming `avatar_move` payload keyed by `userId`
+
+### What happens today with two devices
+
+A user on desktop + phone simultaneously in the same lounge:
+
+1. Both devices receive `lounge.join` and add the user's avatar.
+2. Each device computes its own `_defaultAvatarPos` from its local view of `total participants + index`. Because the same user appears once in the participant list (server dedupes by user_id), the position calculation is consistent.
+3. Either device can drag the avatar. The drag broadcasts `avatar_move` with the user_id. Both devices apply it — including the device that **didn't** initiate it.
+4. If both devices drag simultaneously, the two `avatar_move` streams interleave at the server; the receiving canvas state is last-write-wins. The user's avatar visibly fights itself.
+5. Both devices show the same single avatar, even though there are two real call participants associated with this user_id.
+
+### The interactions this breaks
+
+- Simultaneous edits from two of the user's own devices cause avatar jitter.
+- Other participants can't visually distinguish "Nick on desktop" from "Nick on phone" — relevant for voice attribution if one device is muted and the other isn't.
+- A user joining their second device gets dropped into a position calculated as if they were one participant; the avatar position is shared and nothing new gets placed.
+
+This is a latent bug. It hasn't surfaced as a user report yet because multi-device-in-the-same-call is rare in beta.
+
+## Options
+
+### Option A — Keep user_id keying; accept LWW
+
+No change. Document the limitation. Two devices fight; users learn to use one device per call.
+
+- **Pro:** zero work.
+- **Con:** real LWW jitter when a user actually uses two devices. Doesn't scale with adoption.
+
+### Option B — Switch to (user_id, device_id) keying
+
+Each device gets its own avatar slot. Display name shows `username` for the first one and `username (device 2)` for the second.
+
+- **Pro:** clean model; matches the underlying reality.
+- **Con:** confusing — most users don't think of themselves as multiple avatars. Two avatars with the same picture and name might look broken. Also requires server-side multi-device coordination (each device needs a unique session id that survives reconnects).
+
+### Option C — Single avatar slot per user; one device is the "canvas authority"
+
+User_id keying stays. When a user has 2+ devices in a lounge, the **most-recently-active** device is the only one allowed to send canvas events for that user. Other devices are read-only on canvas (they still see and render, just can't send `avatar_move` / `stroke` / `image_*`).
+
+The "most-recently-active" device is whichever sent the most recent canvas event from this user_id, with a fallback rule of "first to join the lounge" on cold start.
+
+- **Pro:** fixes the LWW bug without introducing duplicate-avatar UX. Failure mode (a tester's old device sometimes can't draw) is recoverable by tapping the canvas on the device they want to use.
+- **Con:** silent — a user dragging on phone while desktop is "canvas authority" sees no effect and might think the canvas is broken. Needs a small UI indicator ("Drawing from desktop") to make the state visible.
+
+## Decision
+
+**Option C**, dated 2026-05-28.
+
+Single avatar slot per user. The most-recently-active device is the canvas authority. Other devices are read-only and show a small "Drawing from <device name>" pill in the canvas top-bar so the user understands why their input is ignored. Tapping the canvas on a non-authority device sends a `canvas_authority_claim` event that flips authority to that device after a 1s grace period (the grace stops mash-tapping causing rapid handoff oscillation).
+
+Server-side: `canvas_authority_claim` is a new event kind alongside `avatar_move`. The server tracks `(user_id, voice_channel_id) → device_id` in memory (no DB persistence — the state resets when the user leaves the lounge). All `avatar_move` / `stroke` / `image_*` events from a non-authority device are silently dropped at the server with no error response (drop-not-reject so the rogue device doesn't repeatedly retry).
+
+This is **not** a multi-device E2E protocol change — it's a single-writer-per-lounge policy on top of existing infrastructure.
+
+## Acceptance criteria
+
+- Two devices for the same user join the same lounge. Only one device's gestures move the avatar.
+- The non-authority device displays an indicator naming the authority device.
+- Tapping the canvas on the non-authority device transfers authority within 1-2 seconds.
+- A user with one device sees no behavioral change from today.
+- A user joining their second device sees their existing avatar, not a duplicate.
+
+## Open questions
+
+- **Device-name display** — how do we surface the device name? `device_name` is collected during key upload (per the device-aware server work). Need to confirm it propagates into the lounge presence payload. Pickup: during implementation, if not present, decide between adding to presence vs. inline lookup via `/api/devices/<id>`.
+- **Cross-lounge authority** — does the authority device for lounge A automatically also become authority for lounge B if the user joins B? Default answer: no, authority is per-lounge. Open to revisit if testers find that confusing.
+- **Voice-attribution UX** — currently muting on one device doesn't visually distinguish which device is muted on the avatar. That's a voice-system issue, not a canvas one, and is out of scope here. Captured for future routing to the voice surface.

--- a/docs/voice-lounge/03-multi-device.md
+++ b/docs/voice-lounge/03-multi-device.md
@@ -74,5 +74,8 @@ This is **not** a multi-device E2E protocol change — it's a single-writer-per-
 ## Open questions
 
 - **Device-name display** — how do we surface the device name? `device_name` is collected during key upload (per the device-aware server work). Need to confirm it propagates into the lounge presence payload. Pickup: during implementation, if not present, decide between adding to presence vs. inline lookup via `/api/devices/<id>`.
-- **Cross-lounge authority** — does the authority device for lounge A automatically also become authority for lounge B if the user joins B? Default answer: no, authority is per-lounge. Open to revisit if testers find that confusing.
 - **Voice-attribution UX** — currently muting on one device doesn't visually distinguish which device is muted on the avatar. That's a voice-system issue, not a canvas one, and is out of scope here. Captured for future routing to the voice surface.
+
+## Confirmed by review (2026-05-28)
+
+- **Authority is per-lounge.** Joining lounge B with a desktop that was authority in lounge A starts fresh — whoever draws first in B becomes B's authority. No cross-lounge state to track.

--- a/docs/voice-lounge/04-encrypted-canvas.md
+++ b/docs/voice-lounge/04-encrypted-canvas.md
@@ -50,7 +50,7 @@ Flip canvas off in `is_encrypted == true` groups. Plaintext groups keep the feat
 
 Short-term action (this Phase 1 PR's scope, or a fast follow-up):
 - Add a `Canvas content is not encrypted` section to `docs/PRIVACY.md`.
-- Add a non-blocking notice in the lounge UI for encrypted groups: a small text under the lounge header like "Canvas drawings and shared positions are visible to the server." Dismissible-per-lounge but reappears on each new lounge.
+- Show a **one-time-ever** popup the first time the user enters a voice lounge in an encrypted group: "Canvas drawings and shared positions are currently visible to the server — end-to-end encryption for canvas is tracked at #1268." Dismiss button stores `seen_encrypted_canvas_notice_v1 = true` in SharedPreferences; the popup never appears again for that user (per-device, since SharedPreferences is per-install). Updated 2026-05-28 per review: previous draft called for a per-lounge dismissible notice; reduced to a single global acknowledgement to avoid notice fatigue.
 
 Medium-term action (scheduled after GRP2 message E2E lands):
 - Tracked as #1268 (filed 2026-05-28), linked to the GRP2 design and this doc.
@@ -61,7 +61,7 @@ Option C is rejected because the feature is too useful to remove and the gap is 
 ## Acceptance criteria
 
 - `docs/PRIVACY.md` contains a section titled "Voice-lounge canvas" that states canvas data is server-readable.
-- An encrypted-group lounge displays a one-line privacy notice on first entry.
+- A one-time popup appears the first time the user enters any encrypted-group lounge; after dismissal the popup never appears again on that device.
 - A tracked follow-up issue exists for the GRP2-canvas-encryption work with the documented pickup trigger: "GRP2 message E2E shipped to prod (not just merged)."
 - No PR that adds new canvas event kinds may merge without explicitly stating which side (plaintext or encrypted) it lives on. If plaintext, the PR must also add the kind to the privacy-doc list.
 

--- a/docs/voice-lounge/04-encrypted-canvas.md
+++ b/docs/voice-lounge/04-encrypted-canvas.md
@@ -1,0 +1,72 @@
+# 04 — Encrypted-group canvas
+
+## Status quo
+
+**Canvas events are plaintext on the wire and on disk, regardless of whether the lounge belongs to an encrypted group.**
+
+Citations:
+- `apps/server/src/ws/events/canvas.rs:137` — `handle_canvas_event` takes JWT-authenticated `sender_id`, calls `verify_membership(sender_id, conversation_id)`, then accepts the payload. No encryption check, no per-event signing.
+- `apps/server/src/db/canvas.rs` — persistent kinds (`stroke`, `image_add`, `image_move`, `image_remove`, `clear`) are written to the database as JSON. Server reads them on join to send the current board state to new arrivals.
+- `apps/client/lib/src/providers/canvas_provider.dart` — sender does not consult `is_encrypted` on the group; the payload goes through `_sendCanvasEvent` regardless.
+
+This means: in an encrypted group, where 1:1 and group **messages** are E2E encrypted (per #1131 / GRP2 design), canvas content is still **server-readable**.
+
+This is a real privacy gap. Today it is undocumented. `docs/PRIVACY.md` does not call it out.
+
+## Why this is the way it is
+
+Canvas was added before GRP2 message E2E was specified. The fast path was "WS relay using existing JWT auth"; that worked for plaintext groups (where messages also go plaintext via the relay) and was never revisited when GRP2 was scoped. GRP2 design (`docs/group-e2e-design/`) targets **messages** specifically — canvas isn't in its scope.
+
+## Options
+
+### Option A — Accept the gap; document it explicitly
+
+Update `docs/PRIVACY.md` to call out:
+- Canvas drawings, screen-share window positions, and avatar positions are **not** E2E encrypted, even in groups where messages are.
+- Treat canvas content as visible to the server operator (us, today; the self-hoster when self-hosted).
+
+Keep behavior unchanged.
+
+- **Pro:** zero engineering work. Honest privacy posture.
+- **Con:** users in encrypted groups may incorrectly assume "encrypted" applies to the whole lounge experience. Privacy debt grows the longer it stays.
+
+### Option B — Encrypt canvas payloads with the group's GRP2 sender key (when GRP2 ships)
+
+Once GRP2's sender-key infrastructure is live for messages, reuse the same per-group symmetric key to encrypt canvas event payloads. Server still relays + persists, but the payloads it sees are ciphertext blobs.
+
+- **Pro:** matches the message-encryption posture; no separate trust model.
+- **Con:** depends on GRP2 message E2E landing first. The canvas DB schema needs to accept opaque blobs (it does — JSON columns can hold ciphertext-strings, but server-side replay-from-snapshot semantics change because the server can't introspect). Persisted strokes for late joiners need to be re-encrypted on every key rotation, which is non-trivial state to manage.
+
+### Option C — Disable canvas in encrypted groups until Option B ships
+
+Flip canvas off in `is_encrypted == true` groups. Plaintext groups keep the feature.
+
+- **Pro:** closes the gap immediately. No trust mismatch.
+- **Con:** removes a feature from the group type that's about to become the default (#1131 flipped new groups to encrypted-by-default). Users would lose access to the lounge canvas in most of their groups.
+
+## Decision
+
+**Option A short-term, Option B medium-term.** Dated 2026-05-28.
+
+Short-term action (this Phase 1 PR's scope, or a fast follow-up):
+- Add a `Canvas content is not encrypted` section to `docs/PRIVACY.md`.
+- Add a non-blocking notice in the lounge UI for encrypted groups: a small text under the lounge header like "Canvas drawings and shared positions are visible to the server." Dismissible-per-lounge but reappears on each new lounge.
+
+Medium-term action (scheduled after GRP2 message E2E lands):
+- File a tracked issue with the title "Encrypt canvas events with GRP2 sender key" linked to the GRP2 design and to this doc.
+- Acceptance: server logs no longer contain plaintext canvas payloads in `is_encrypted == true` groups.
+
+Option C is rejected because the feature is too useful to remove and the gap is small enough to disclose-and-defer.
+
+## Acceptance criteria
+
+- `docs/PRIVACY.md` contains a section titled "Voice-lounge canvas" that states canvas data is server-readable.
+- An encrypted-group lounge displays a one-line privacy notice on first entry.
+- A tracked follow-up issue exists for the GRP2-canvas-encryption work with the documented pickup trigger: "GRP2 message E2E shipped to prod (not just merged)."
+- No PR that adds new canvas event kinds may merge without explicitly stating which side (plaintext or encrypted) it lives on. If plaintext, the PR must also add the kind to the privacy-doc list.
+
+## Open questions
+
+- **Server-side metadata even after Option B** — group_id, sender_user_id, timestamp, and event_kind remain visible to the server post-Option-B. That's the metadata floor for any relay-based architecture. Open question for a future doc: do we want a P2P-mesh alternative for canvas that hides metadata too? Unlikely in this product but worth naming.
+- **Existing persisted plaintext strokes after Option B lands** — when GRP2 encryption gets retrofitted to canvas, what happens to drawings already in the DB? Three options: leave them plaintext and let them age out; encrypt-in-place during a one-shot migration; just drop them at cutover. Pickup: during Option B implementation, decide based on how many groups have meaningful canvas content at that time.
+- **Image uploads** — `image_add` events reference media URLs that resolve to files in `./uploads/`. Even with payload encryption (Option B), the image bytes themselves are stored unencrypted. Closing that gap is its own design (likely requires per-group media keys + ciphertext-at-rest, which the existing media pipeline doesn't do). Pickup: same trigger as Option B.

--- a/docs/voice-lounge/04-encrypted-canvas.md
+++ b/docs/voice-lounge/04-encrypted-canvas.md
@@ -53,7 +53,7 @@ Short-term action (this Phase 1 PR's scope, or a fast follow-up):
 - Add a non-blocking notice in the lounge UI for encrypted groups: a small text under the lounge header like "Canvas drawings and shared positions are visible to the server." Dismissible-per-lounge but reappears on each new lounge.
 
 Medium-term action (scheduled after GRP2 message E2E lands):
-- File a tracked issue with the title "Encrypt canvas events with GRP2 sender key" linked to the GRP2 design and to this doc.
+- Tracked as #1268 (filed 2026-05-28), linked to the GRP2 design and this doc.
 - Acceptance: server logs no longer contain plaintext canvas payloads in `is_encrypted == true` groups.
 
 Option C is rejected because the feature is too useful to remove and the gap is small enough to disclose-and-defer.

--- a/docs/voice-lounge/README.md
+++ b/docs/voice-lounge/README.md
@@ -1,0 +1,29 @@
+# Voice-lounge canvas interaction contract
+
+This folder is the **decision-of-record** for how the voice-lounge canvas, its inputs, and its synchronization model behave. It exists because the implementation has acquired enough device-class assumptions, gesture-arena tradeoffs, and per-event wire formats that informal-knowledge approaches were producing avoidable regressions (see PRs #1247 through #1266 for the trail).
+
+Every canvas-behavior PR from this point forward must:
+
+1. Cite the relevant section of these docs in the PR description.
+2. If the PR proposes a change that contradicts a documented decision, the doc gets updated **first**, in its own PR, with the new rationale.
+
+## Contents
+
+- **[01 — Coordinate policy](01-coordinate-policy.md)** — what coordinate space each canvas entity lives in, how those spaces are wire-encoded, and the rule for cross-device translation.
+- **[02 — Input matrix](02-input-matrix.md)** — per-device-class mapping for pan, zoom, draw, select, and double-tap; gesture-arena precedence; conflict rules.
+- **[03 — Multi-device per user](03-multi-device.md)** — how a user with 2+ devices in the same lounge is represented on the canvas, and what's read-only vs write.
+- **[04 — Encrypted-group canvas](04-encrypted-canvas.md)** — current trust posture for canvas events in encrypted groups, the documented gap, and the path to closing it.
+
+## Plan that this contract serves
+
+The contract is **Phase 1 / PR A** of the canvas redesign plan in `canvas_redesign.md`. Phases 2-5 (server geometry validation, gesture + integration tests, legacy-coord sunset, perf budget) all depend on the decisions captured here.
+
+## How decisions are recorded
+
+Each doc follows the same shape:
+
+- **Status quo** — what the code does today, with file:line citations.
+- **Options** — the alternatives considered, each with cost + benefit.
+- **Decision** — the option we picked and **why**, dated.
+- **Acceptance criteria** — the testable rule any future PR must honor.
+- **Open questions** — things deferred to a later decision, with their pickup trigger.


### PR DESCRIPTION
PR B of the canvas redesign plan (`canvas_redesign.md` v2). **Depends on PR #1267 (PR A — contract docs)** — this branch was forked off `feat/canvas-redesign-phase-1-contract` and merges that branch back in. The contract decisions land with PR #1267 and the implementation lands here.

## New

- **Server-side schema validation for every canvas event kind.** Per-event-kind pure validator functions in `apps/server/src/ws/events/canvas_validation.rs`. Rejects NaN/Inf, out-of-range coords, oversized point arrays, malformed UUIDs, absolute-URL leaks in `image_add`, unknown tool names, partial `image_move` width/height (must be both-or-neither), and the dual-format `screenshare_move` shape (legacy CSS pixels vs. new normalized 0..1).
- **`CANVAS_VALIDATION_MODE` env var** for a safe rollout. Three values:
  - `log_only` (default) — validators run, mismatches `warn!` with the structured error code + 256-char payload snippet, event continues unchanged. Zero behavior change for existing clients.
  - `enforce` — mismatches return `send_error` with the code, event dropped. The eventual production default once we've watched `log_only` for a window.
  - `off` — escape hatch.
  Documented in `docs/self-hosting.md`. Default in `.env.example`.
- **One-time popup in encrypted-group voice lounges.** First time the user enters a lounge whose conversation has `isEncrypted: true`, an `AlertDialog` explains canvas content is currently visible to the server, linked to #1268. SharedPreferences key `seen_encrypted_canvas_notice_v1` stores the dismiss state; the popup never appears again on that device.

## Improved

- Error codes follow `canvas.validation.<kind>.<field>.<reason>` so future log-grep is sane.

## Behind the scenes

- 44 unit tests in `canvas_validation.rs` (valid + invalid for every kind).
- 5 mode-parse tests (defaults, case-insensitive, unknown falls back).
- 4 widget tests for the popup (renders on first call, no-op when not encrypted, sets the flag, skips when flag is set).

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p echo-server` ✅ — 755 passed (was 706 before, +49 new)
- `flutter analyze --fatal-infos` ✅
- `flutter test` ✅ — 2442 passed, 9 skipped (was 2438 before, +4 new)
- Pre-commit + pre-push hooks ran clean on every commit; no `--no-verify`.

## Contract compliance

Per `docs/voice-lounge/04-encrypted-canvas.md` acceptance: "*No PR that adds new canvas event kinds may merge without explicitly stating which side (plaintext or encrypted) it lives on.*" — **This PR adds no new event kinds**; it validates the existing allowlist (`stroke`, `stroke_partial`, `clear`, `image_add`, `image_move`, `image_remove`, `avatar_move`, `screenshare_move`). All existing kinds are plaintext-side; the encrypted-side gate doesn't apply.

The `screenshare_move` validator already accepts the new normalized `coord_v: 2` format described in `docs/voice-lounge/01-coordinate-policy.md` (alongside the legacy CSS-pixel format), so PR C / the client-side coord-policy implementation doesn't need to also touch the server.

## Test plan

- [ ] CI gates pass on this PR.
- [ ] Smoke: enter a voice lounge in an encrypted group; popup appears. Dismiss; never returns.
- [ ] Smoke: enter a voice lounge in a plaintext group; popup does NOT appear.
- [ ] Smoke: after deploying to prod with `CANVAS_VALIDATION_MODE=log_only`, watch server logs for `canvas.validation.*` warnings to see what real clients send before flipping to `enforce`.

**Leaving unmerged for review per session convention.**