### PR TITLE
Android Play Store auto-publish: AAB build + internal-testing upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -707,22 +707,19 @@ jobs:
           retention-days: 3
 
   build-android:
-    name: Build Android APK
+    name: Build Android APK + AAB
     runs-on: ubuntu-latest
     needs: [paths, version, lint-test-flutter]
-    # Disabled until ANDROID_KEYSTORE_BASE64 + ANDROID_KEY_PROPERTIES repo
-    # secrets are configured (#357). The fail-fast guard below would otherwise
-    # block every release on a missing keystore. Re-enable by replacing the
-    # `false` gate with the original predicate:
-    #   always() && needs.version.result == 'success'
-    #   && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
-    if: false
+    if: |
+      always()
+      && needs.version.result == 'success'
+      && (needs.lint-test-flutter.result == 'success' || needs.lint-test-flutter.result == 'skipped')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version-file: .flutter-version
@@ -772,16 +769,51 @@ jobs:
       - name: Build APK
         working-directory: apps/client
         run: flutter build apk --release --dart-define=APP_VERSION=${{ needs.version.outputs.version }}
-      - name: Rename APK
+      - name: Build AAB
+        # The AAB is what Play Store accepts; APK stays for GitHub Release
+        # side-loaders. Two separate `flutter build` invocations because each
+        # produces a different artifact and there's no `--all` flag.
+        working-directory: apps/client
+        run: flutter build appbundle --release --dart-define=APP_VERSION=${{ needs.version.outputs.version }}
+      - name: Rename artifacts
         run: |
           cp apps/client/build/app/outputs/flutter-apk/app-release.apk \
              echo-android-${{ needs.version.outputs.version }}.apk
+          cp apps/client/build/app/outputs/bundle/release/app-release.aab \
+             echo-android-${{ needs.version.outputs.version }}.aab
       - name: Upload Android artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-android
-          path: echo-android-*.apk
+          path: |
+            echo-android-*.apk
+            echo-android-*.aab
           retention-days: 3
+      - name: Publish to Play Console Internal testing
+        # Only on direct main pushes (not workflow_dispatch / not PR builds).
+        # Internal testing publishes are instant and don't require Google review,
+        # so this fires on every release. Skipped silently if PLAY_SERVICE_ACCOUNT_JSON
+        # isn't set so contributors building locally / dispatching manually don't
+        # need the secret.
+        if: |
+          github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+          && env.PLAY_JSON != ''
+        env:
+          PLAY_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.echo_messenger
+          releaseFiles: apps/client/build/app/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
+          # Release-notes source: pull from the GitHub release that this workflow
+          # publishes later in the pipeline. To avoid a chicken-and-egg dep on
+          # the release job, we hand-craft a one-line note here pointing at the
+          # version. Operators can edit the notes in Play Console after upload
+          # if they want the full GH release body.
+          releaseName: ${{ needs.version.outputs.version }}
 
   build-ios:
     name: Build iOS IPA

--- a/apps/client/android/app/build.gradle
+++ b/apps/client/android/app/build.gradle
@@ -11,7 +11,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace = "us.echomessenger.echo_app"
+    namespace = "com.echo_messenger"
     compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
@@ -26,7 +26,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "us.echomessenger.echo_app"
+        applicationId = "com.echo_messenger"
         minSdk = 24
         targetSdk = 35
         versionCode = flutter.versionCode

--- a/apps/client/android/app/src/main/kotlin/com/echo_messenger/EchoForegroundService.kt
+++ b/apps/client/android/app/src/main/kotlin/com/echo_messenger/EchoForegroundService.kt
@@ -1,4 +1,4 @@
-package us.echomessenger.echo_app
+package com.echo_messenger
 
 import android.app.Notification
 import android.app.NotificationChannel

--- a/apps/client/android/app/src/main/kotlin/com/echo_messenger/MainActivity.kt
+++ b/apps/client/android/app/src/main/kotlin/com/echo_messenger/MainActivity.kt
@@ -1,4 +1,4 @@
-package us.echomessenger.echo_app
+package com.echo_messenger
 
 import android.app.PictureInPictureParams
 import android.content.Intent

--- a/apps/client/android/app/src/main/kotlin/com/echo_messenger/VoiceNotificationReceiver.kt
+++ b/apps/client/android/app/src/main/kotlin/com/echo_messenger/VoiceNotificationReceiver.kt
@@ -1,4 +1,4 @@
-package us.echomessenger.echo_app
+package com.echo_messenger
 
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -15,8 +15,8 @@ import android.content.Intent
 class VoiceNotificationReceiver : BroadcastReceiver() {
 
     companion object {
-        const val ACTION_TOGGLE_MUTE = "us.echomessenger.echo_app.action.TOGGLE_MUTE"
-        const val ACTION_LEAVE = "us.echomessenger.echo_app.action.LEAVE"
+        const val ACTION_TOGGLE_MUTE = "com.echo_messenger.action.TOGGLE_MUTE"
+        const val ACTION_LEAVE = "com.echo_messenger.action.LEAVE"
         const val EXTRA_NEW_MUTED = "new_muted"
     }
 


### PR DESCRIPTION
Enables the previously-disabled Android job in `release.yml`, switches it to JDK 21, adds an AAB build step alongside the existing APK, and adds an automatic upload to **Play Console Internal testing** on every push to `main`.

Also: the Android applicationId moves from `us.echomessenger.echo_app` → `com.echo_messenger` to match the package name registered in Play Console.

## New

- **Every push to `main` publishes a new Echo Messenger build to Play Store Internal testing** within ~10 minutes of the push.
- AAB is what Play accepts (the APK stays for GitHub Release side-loaders).

## What changed

### `apps/client/android/`
- `applicationId` + `namespace` in `app/build.gradle` → `com.echo_messenger`
- Kotlin sources moved from `kotlin/us/echomessenger/echo_app/` → `kotlin/com/echo_messenger/`
- Package declarations + the two `ACTION_*` broadcast intent strings in `VoiceNotificationReceiver.kt` updated

### `.github/workflows/release.yml — build-android job`
- Removed the `if: false` gate that disabled the job
- Bumped Java from 17 → 21 (matches the local dev toolchain + Android Gradle Plugin requirements)
- Renamed job: "Build Android APK" → "Build Android APK + AAB"
- Added a `flutter build appbundle --release` step alongside the existing `flutter build apk --release`
- Artifact upload now includes both `.apk` (for GitHub Release downloads) and `.aab`
- New "Publish to Play Console Internal testing" step using `r0adkll/upload-google-play@v1.1.3`, gated on `push` event + `refs/heads/main` + `PLAY_SERVICE_ACCOUNT_JSON` secret present. Track: `internal`. Status: `completed`. Release-name: the version string from the existing `version` job.

## Secrets required (already set in repo)

| Secret | Purpose |
|---|---|
| `ANDROID_KEYSTORE_BASE64` | base64-encoded upload-key keystore (re-set 2026-05-28 with the Play App Signing upload key) |
| `ANDROID_KEY_PROPERTIES` | `storePassword=… / keyPassword=… / keyAlias=upload / storeFile=echo-release.jks` |
| `PLAY_SERVICE_ACCOUNT_JSON` | Google service-account JSON granted "Release manager" + testing-track permissions in Play Console (set 2026-05-28) |

## Notes

- Internal testing track publishes have **no Google review** and are instant — testers see the update within minutes.
- The Play upload is gated so it **only fires on direct main pushes**, not on `workflow_dispatch` or PR builds. Contributors building from forks won't accidentally try to publish.
- The upload step is **soft-gated on the secret** (`env.PLAY_JSON != ''`) so it silently skips if the secret isn't present, instead of failing the whole release pipeline. The build-android job still runs and produces the APK + AAB artifacts.
- This PR doesn't promote anything to closed/open testing. Beta + production require completing the Play Console "App content" forms first — captured separately, not in this PR's scope.

## First-release lineage

Today's manual upload to Play Console used a self-generated upload key (`~/upload-keystore.jks`). That same keystore is now committed to CI via `ANDROID_KEYSTORE_BASE64`. Play App Signing has been enrolled, so the upload key is replaceable later if needed — production signing happens server-side at Google.

## Test plan

- [ ] PR CI gates pass (yaml lint, flutter analyze, rust clippy).
- [ ] After merge, watch the `Release` workflow on main. The new `Build Android APK + AAB` job should produce both artifacts and the Play upload step should succeed.
- [ ] Within 10 minutes of the post-merge build, the new release should appear under Play Console → Echo Messenger → Test and release → Internal testing → Releases.
- [ ] Internal testers (you, on the registered Gmail) should receive the update in Play Store on Android.

**Leave unmerged for review per session convention** — once you merge, the very next push to main publishes automatically.