### PR TITLE
fix(ci): android keystore decode path — gradle resolves relative to app/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -764,7 +764,11 @@ jobs:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEY_PROPERTIES: ${{ secrets.ANDROID_KEY_PROPERTIES }}
         run: |
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > apps/client/android/echo-release.jks
+          # gradle's `file(storeFile)` in app/build.gradle resolves relative to
+          # the `app/` module dir, not the `android/` dir — so the decoded
+          # keystore must land at app/ alongside build.gradle for
+          # `storeFile=echo-release.jks` in key.properties to resolve.
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > apps/client/android/app/echo-release.jks
           echo "$ANDROID_KEY_PROPERTIES" > apps/client/android/key.properties
       - name: Build APK
         working-directory: apps/client


### PR DESCRIPTION
First post-merge attempt of the Android job hit:

\`\`\`
Execution failed for task ':app:validateSigningRelease'.
> Keystore file 'apps/client/android/app/echo-release.jks' not found for signing config 'release'.
\`\`\`

The previous step decoded the keystore to \`apps/client/android/echo-release.jks\` (one level up from where gradle looks).

Gradle's \`file(storeFile)\` in \`app/build.gradle\` resolves relative to the module dir (\`app/\`), not the \`android/\` root. So \`storeFile=echo-release.jks\` in \`key.properties\` resolves to \`app/echo-release.jks\`. Fix is to decode there.

One-line workflow change. Auto-merging.