### PR TITLE
docs: add coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://github.com/NC1107/echo-messenger/actions/workflows/release.yml/badge.svg)](https://github.com/NC1107/echo-messenger/actions/workflows/release.yml)
 [![Rust CI](https://github.com/NC1107/echo-messenger/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/NC1107/echo-messenger/actions/workflows/rust-ci.yml)
 [![Flutter CI](https://github.com/NC1107/echo-messenger/actions/workflows/flutter-ci.yml/badge.svg)](https://github.com/NC1107/echo-messenger/actions/workflows/flutter-ci.yml)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=NC1107_echo-messenger&metric=coverage)](https://sonarcloud.io/summary/new_code?id=NC1107_echo-messenger)
 [![License](https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue)](LICENSE)
 
 A lightweight, cross-platform messaging app with end-to-end encryption. I'm not a fan of the direction Discord is moving, and I don't think most people can set up Matrix, so this is my attempt at a replacement. It runs centralized by default, but you can always host the server yourself.


### PR DESCRIPTION
Adds a SonarCloud coverage badge alongside the existing Release / Rust CI / Flutter CI badges.

Source: `https://sonarcloud.io/api/project_badges/measure?project=NC1107_echo-messenger&metric=coverage` (uses the existing SonarCloud project key from `sonar-project.properties`).

Note on the Rust CI badge: it's currently still showing the last failure (the chronic `api_media_chunked` flake hit the last main commit). The badge will refresh once the current Rust CI run on `743a7695` completes — that run is in progress right now and is expected to pass since we ran the full server suite locally before merging #1274. The flake itself (finalize returning 500 intermittently on CI tmpfs) is worth a separate diagnostic pass.