### PR TITLE
Show canvas loading status so users know why drawing is blocked (#1277)

### DIFF
--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -424,6 +424,18 @@ StrokeKind strokeKindForTool(CanvasTool tool) {
 }
 
 // ---------------------------------------------------------------------------
+// Canvas attach state
+// ---------------------------------------------------------------------------
+
+/// Lifecycle state for the canvas snapshot fetch.
+///
+/// - [idle] — no attach in progress (initial or after detach).
+/// - [loading] — REST snapshot fetch is in flight.
+/// - [loaded] — snapshot fetched and applied; canvas is live.
+/// - [failed] — fetch threw or returned a non-2xx response.
+enum CanvasAttachState { idle, loading, loaded, failed }
+
+// ---------------------------------------------------------------------------
 // Full canvas state
 // ---------------------------------------------------------------------------
 
@@ -457,6 +469,14 @@ class CanvasState {
   /// True once the initial canvas state has been fetched from the server.
   final bool isLoaded;
 
+  /// Lifecycle state of the snapshot fetch. Drives [CanvasLoadingBanner].
+  final CanvasAttachState attachState;
+
+  /// When the most recent [attach] call started. Used by [CanvasLoadingBanner]
+  /// to detect slow connections (> 8 s without transitioning away from
+  /// [CanvasAttachState.loading]).
+  final DateTime? attachStartedAt;
+
   const CanvasState({
     this.strokes = const [],
     this.images = const [],
@@ -467,6 +487,8 @@ class CanvasState {
     this.currentColor = const Color(0xFFFFFFFF),
     this.strokeWidth = 3.0,
     this.isLoaded = false,
+    this.attachState = CanvasAttachState.idle,
+    this.attachStartedAt,
   });
 
   // @S107: API-stable, params are externally fixed by serialization format.
@@ -482,6 +504,8 @@ class CanvasState {
     Color? currentColor,
     double? strokeWidth,
     bool? isLoaded,
+    CanvasAttachState? attachState,
+    DateTime? attachStartedAt,
   }) => CanvasState(
     strokes: strokes ?? this.strokes,
     images: images ?? this.images,
@@ -492,5 +516,7 @@ class CanvasState {
     currentColor: currentColor ?? this.currentColor,
     strokeWidth: strokeWidth ?? this.strokeWidth,
     isLoaded: isLoaded ?? this.isLoaded,
+    attachState: attachState ?? this.attachState,
+    attachStartedAt: attachStartedAt ?? this.attachStartedAt,
   );
 }

--- a/apps/client/lib/src/providers/canvas_provider.dart
+++ b/apps/client/lib/src/providers/canvas_provider.dart
@@ -64,6 +64,12 @@ class CanvasController extends _$CanvasController {
   /// lounge this session, not on every channel switch).
   bool _legacyCoordLogged = false;
 
+  /// Last (conversationId, channelId) pair passed to [attach]. Stored so
+  /// [retryAttach] can re-issue the same request without threading the ids
+  /// back through the call-site.
+  String? _lastConversationId;
+  String? _lastChannelId;
+
   /// Events buffered while [_channelId] is not yet set (attach race window).
   final List<Map<String, dynamic>> _pendingEvents = [];
 
@@ -101,7 +107,14 @@ class CanvasController extends _$CanvasController {
     _attachingChannelId = channelId;
     _channelId = null;
     _pendingEvents.clear();
-    state = const CanvasState(); // reset while loading
+    _lastConversationId = conversationId;
+    _lastChannelId = channelId;
+    // Reset to loading state; record when the fetch started for slow-connection
+    // detection in CanvasLoadingBanner.
+    state = CanvasState(
+      attachState: CanvasAttachState.loading,
+      attachStartedAt: DateTime.now(),
+    );
 
     await _fetchCanvas(conversationId, channelId);
 
@@ -110,6 +123,8 @@ class CanvasController extends _$CanvasController {
     if (_attachingChannelId != channelId) return;
     _channelId = channelId;
     _attachingChannelId = null;
+    // Promote to loaded only after the stale-channel guard passes.
+    state = state.copyWith(attachState: CanvasAttachState.loaded);
 
     // Once per session: log the legacy-coord migration counter so we can
     // track when it is safe to delete _migrateLegacyCoord (see
@@ -167,7 +182,7 @@ class CanvasController extends _$CanvasController {
     _pendingEvents.clear();
     _channelId = null;
     _attachingChannelId = null;
-    state = const CanvasState();
+    state = const CanvasState(); // attachState defaults back to idle
   }
 
   // -------------------------------------------------------------------------
@@ -203,7 +218,7 @@ class CanvasController extends _$CanvasController {
           isLoaded: true,
         );
       } else {
-        // Canvas may not exist yet — treat as empty board.
+        // Canvas may not exist yet — treat as empty board (still valid).
         state = state.copyWith(isLoaded: true);
       }
     } catch (e) {
@@ -212,8 +227,23 @@ class CanvasController extends _$CanvasController {
         'Canvas',
         'Failed to load canvas for channel $channelId: $e',
       );
-      state = state.copyWith(isLoaded: true);
+      // Network error: mark as failed so the UI can offer a retry.
+      state = state.copyWith(
+        isLoaded: false,
+        attachState: CanvasAttachState.failed,
+      );
     }
+  }
+
+  /// Re-attempt [attach] with the last channel IDs. No-op when no prior attach
+  /// has been recorded (e.g. the notifier was just built).
+  Future<void> retryAttach() async {
+    final convId = _lastConversationId;
+    final chanId = _lastChannelId;
+    if (convId == null || chanId == null) return;
+    // Force-reset _channelId so the guard in attach() doesn't bail early.
+    _channelId = null;
+    await attach(convId, chanId);
   }
 
   // -------------------------------------------------------------------------

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -12,7 +12,12 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import '../models/canvas_models.dart'
-    show CanvasState, CanvasTool, kCanvasHeight, kCanvasWidth;
+    show
+        CanvasAttachState,
+        CanvasState,
+        CanvasTool,
+        kCanvasHeight,
+        kCanvasWidth;
 import '../providers/auth_provider.dart';
 import '../providers/canvas_authority_provider.dart';
 import '../providers/canvas_provider.dart';
@@ -34,6 +39,7 @@ import '../utils/canvas_utils.dart';
 import '../widgets/confirm_dialog.dart';
 import '../widgets/echo_bottom_sheet.dart';
 import '../widgets/lounge_drawing_canvas.dart';
+import '../widgets/voice_lounge/canvas_loading_banner.dart';
 import '../widgets/voice_lounge/encrypted_canvas_notice.dart';
 import '../widgets/vertex_mesh_background.dart';
 import '../widgets/voice_canvas.dart';
@@ -1313,6 +1319,22 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
           right: 0,
           child: Center(child: authorityPill),
         ),
+      if (!_spotlightMode)
+        Positioned(
+          top: authorityPill != null ? 96 : 54,
+          left: 0,
+          right: 0,
+          child: Center(
+            child: IgnorePointer(
+              ignoring: ref.watch(
+                canvasProvider.select(
+                  (s) => s.attachState != CanvasAttachState.failed,
+                ),
+              ),
+              child: const CanvasLoadingBanner(),
+            ),
+          ),
+        ),
     ]);
   }
 
@@ -1379,6 +1401,24 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
           left: 0,
           right: 0,
           child: Center(child: authorityPill),
+        ),
+      if (!_spotlightMode)
+        Positioned(
+          top: authorityPill != null
+              ? (isFull ? (MediaQuery.viewPaddingOf(context).top + 54) : 150)
+              : (isFull ? (MediaQuery.viewPaddingOf(context).top + 8) : 108),
+          left: 0,
+          right: 0,
+          child: Center(
+            child: IgnorePointer(
+              ignoring: ref.watch(
+                canvasProvider.select(
+                  (s) => s.attachState != CanvasAttachState.failed,
+                ),
+              ),
+              child: const CanvasLoadingBanner(),
+            ),
+          ),
         ),
     ]);
   }

--- a/apps/client/lib/src/widgets/voice_lounge/canvas_loading_banner.dart
+++ b/apps/client/lib/src/widgets/voice_lounge/canvas_loading_banner.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/canvas_models.dart' show CanvasAttachState;
+import '../../providers/canvas_provider.dart';
+import '../../theme/echo_theme.dart';
+
+const Duration _kSlowConnectionThreshold = Duration(seconds: 8);
+
+/// Non-blocking banner shown at the top of the voice-lounge canvas while the
+/// initial snapshot is being fetched from the server.
+///
+/// States:
+/// - [CanvasAttachState.idle] / [CanvasAttachState.loaded] → hidden.
+/// - [CanvasAttachState.loading] → spinner + "Catching up…". After 8 s
+///   without state change the text updates to "Slow connection — still
+///   loading…".
+/// - [CanvasAttachState.failed] → error message + retry button.
+class CanvasLoadingBanner extends ConsumerStatefulWidget {
+  const CanvasLoadingBanner({super.key});
+
+  @override
+  ConsumerState<CanvasLoadingBanner> createState() =>
+      _CanvasLoadingBannerState();
+}
+
+class _CanvasLoadingBannerState extends ConsumerState<CanvasLoadingBanner> {
+  Timer? _slowTimer;
+  bool _isSlow = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Seed the timer for the initial state (e.g. if the widget is mounted
+    // while loading is already in progress).
+    final s = ref.read(canvasProvider);
+    if (s.attachState == CanvasAttachState.loading) {
+      _armSlowTimer(s.attachStartedAt);
+    }
+  }
+
+  @override
+  void dispose() {
+    _slowTimer?.cancel();
+    super.dispose();
+  }
+
+  /// Arms the slow-connection timer relative to [startedAt].
+  /// Cancels any existing timer first so re-attach cycles start fresh.
+  void _armSlowTimer(DateTime? startedAt) {
+    _slowTimer?.cancel();
+    _isSlow = false;
+
+    if (startedAt == null) return;
+
+    final elapsed = DateTime.now().difference(startedAt);
+    final remaining = _kSlowConnectionThreshold - elapsed;
+
+    if (remaining <= Duration.zero) {
+      _isSlow = true;
+      return;
+    }
+
+    _slowTimer = Timer(remaining, () {
+      if (mounted) setState(() => _isSlow = true);
+    });
+  }
+
+  void _cancelSlowTimer() {
+    _slowTimer?.cancel();
+    _slowTimer = null;
+    _isSlow = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Listen for attach-state transitions to arm / cancel the slow timer as
+    // a side-effect (not inline in build, which would re-arm on every rebuild).
+    ref.listen<CanvasAttachState>(canvasProvider.select((s) => s.attachState), (
+      prev,
+      next,
+    ) {
+      if (next == CanvasAttachState.loading) {
+        final startedAt = ref.read(
+          canvasProvider.select((s) => s.attachStartedAt),
+        );
+        _armSlowTimer(startedAt);
+      } else {
+        _cancelSlowTimer();
+      }
+    });
+
+    final attachState = ref.watch(canvasProvider.select((s) => s.attachState));
+
+    if (attachState == CanvasAttachState.idle ||
+        attachState == CanvasAttachState.loaded) {
+      return const SizedBox.shrink();
+    }
+
+    if (attachState == CanvasAttachState.loading) {
+      return _buildLoading(context);
+    }
+
+    // failed
+    return _buildFailed(context);
+  }
+
+  Widget _buildLoading(BuildContext context) {
+    final label = _isSlow ? 'Slow connection — still loading…' : 'Catching up…';
+
+    return _BannerShell(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(context.accent),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Text(
+            label,
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFailed(BuildContext context) {
+    return _BannerShell(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.warning_amber_rounded, size: 16, color: context.accent),
+          const SizedBox(width: 8),
+          Text(
+            "Couldn't load canvas",
+            style: TextStyle(
+              color: context.textPrimary,
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(width: 10),
+          TextButton(
+            onPressed: () => ref.read(canvasProvider.notifier).retryAttach(),
+            style: TextButton.styleFrom(
+              foregroundColor: context.accent,
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+              minimumSize: const Size(44, 32),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: const Text(
+              'Retry',
+              style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BannerShell extends StatelessWidget {
+  const _BannerShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: context.surface,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: context.border),
+      ),
+      child: child,
+    );
+  }
+}

--- a/apps/client/test/widgets/voice_lounge/canvas_loading_banner_test.dart
+++ b/apps/client/test/widgets/voice_lounge/canvas_loading_banner_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/models/canvas_models.dart'
+    show CanvasAttachState, CanvasState;
+import 'package:echo_app/src/providers/canvas_provider.dart';
+import 'package:echo_app/src/widgets/voice_lounge/canvas_loading_banner.dart';
+
+// ---------------------------------------------------------------------------
+// Minimal override: expose the CanvasController notifier with a preset state
+// so widget tests drive just the banner without needing a full Flutter app
+// or a live HTTP stack.
+// ---------------------------------------------------------------------------
+
+class _FakeCanvasNotifier extends CanvasController {
+  _FakeCanvasNotifier(CanvasState preset) : _preset = preset;
+
+  final CanvasState _preset;
+
+  @override
+  CanvasState build() => _preset;
+
+  @override
+  Future<void> attach(String conversationId, String channelId) async {}
+
+  @override
+  Future<void> retryAttach() async {
+    retryCallCount++;
+  }
+
+  int retryCallCount = 0;
+}
+
+ProviderScope _wrapBanner({
+  required CanvasState canvasState,
+  _FakeCanvasNotifier? notifier,
+}) {
+  final fakeNotifier = notifier ?? _FakeCanvasNotifier(canvasState);
+  return ProviderScope(
+    overrides: [canvasControllerProvider.overrideWith(() => fakeNotifier)],
+    child: const MaterialApp(home: Scaffold(body: CanvasLoadingBanner())),
+  );
+}
+
+void main() {
+  group('CanvasLoadingBanner', () {
+    testWidgets('renders nothing when attachState is idle', (tester) async {
+      await tester.pumpWidget(
+        _wrapBanner(
+          canvasState: const CanvasState(attachState: CanvasAttachState.idle),
+        ),
+      );
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('Catching up…'), findsNothing);
+      expect(find.textContaining("Couldn't load"), findsNothing);
+    });
+
+    testWidgets('renders nothing when attachState is loaded', (tester) async {
+      await tester.pumpWidget(
+        _wrapBanner(
+          canvasState: const CanvasState(attachState: CanvasAttachState.loaded),
+        ),
+      );
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('Catching up…'), findsNothing);
+    });
+
+    testWidgets('shows spinner and "Catching up…" when loading', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrapBanner(
+          canvasState: CanvasState(
+            attachState: CanvasAttachState.loading,
+            attachStartedAt: DateTime.now(),
+          ),
+        ),
+      );
+      await tester.pump(); // let build run
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Catching up…'), findsOneWidget);
+      expect(find.textContaining('Slow connection'), findsNothing);
+    });
+
+    testWidgets('text changes after 8 s to slow-connection message', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrapBanner(
+          canvasState: CanvasState(
+            attachState: CanvasAttachState.loading,
+            attachStartedAt: DateTime.now(),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Catching up…'), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 8));
+      expect(find.textContaining('Slow connection'), findsOneWidget);
+      expect(find.text('Catching up…'), findsNothing);
+    });
+
+    testWidgets('shows error message when attachState is failed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrapBanner(
+          canvasState: const CanvasState(attachState: CanvasAttachState.failed),
+        ),
+      );
+      await tester.pump();
+      expect(find.textContaining("Couldn't load canvas"), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('tapping retry calls retryAttach', (tester) async {
+      final notifier = _FakeCanvasNotifier(
+        const CanvasState(attachState: CanvasAttachState.failed),
+      );
+      await tester.pumpWidget(
+        _wrapBanner(canvasState: notifier.debugState, notifier: notifier),
+      );
+      await tester.pump();
+      expect(find.text('Retry'), findsOneWidget);
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+      expect(notifier.retryCallCount, 1);
+    });
+  });
+}
+
+extension on _FakeCanvasNotifier {
+  CanvasState get debugState => _preset;
+}


### PR DESCRIPTION
Joining a voice lounge with existing canvas content caused a brief frozen period while the snapshot loaded, with no visible feedback explaining why drawing wasn't working.

## New

- A pill-shaped banner ("Catching up…") appears at the top of the canvas area while the snapshot fetch is in flight
- After 8 seconds without resolution the message changes to "Slow connection — still loading…"
- If the fetch fails entirely, the banner shows "Couldn't load canvas" with a Retry button
- Banner disappears the moment the canvas is fully attached and ready to draw

## Behind the scenes

- Added `CanvasAttachState` enum (`idle | loading | loaded | failed`) to `CanvasState` in `canvas_models.dart`
- `CanvasController.attach()` sets `loading` before the REST fetch and `loaded` after promotion; `_fetchCanvas` sets `failed` on network exceptions
- Added `retryAttach()` to the notifier (re-runs `attach` with the last channel IDs)
- `CanvasLoadingBanner` widget in `widgets/voice_lounge/canvas_loading_banner.dart`; 6 widget tests in `test/widgets/voice_lounge/canvas_loading_banner_test.dart`
- `IgnorePointer` wraps the banner while loading (pointer events fall through to the canvas); the retry button is tappable when failed

Closes #1277