### PR TITLE
Show stored accounts on launch when you're signed out

### DIFF
--- a/apps/client/lib/src/router/app_router.dart
+++ b/apps/client/lib/src/router/app_router.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/context_menu/context_menu_testbed.dart';
 import '../screens/admin/admin_dashboard_screen.dart';
+import '../screens/auth/account_picker_screen.dart';
 import '../screens/contacts_screen.dart';
 import '../screens/create_group_screen.dart';
 import '../screens/discover_groups_screen.dart';
@@ -29,6 +30,7 @@ import '../screens/user_profile_screen.dart';
 const _routeHome = '/home';
 const _routeLogin = '/login';
 const _routeSplash = '/splash';
+const _routeAccountPicker = '/auth/pick-account';
 
 // ---------------------------------------------------------------------------
 // Pending Deep Link State Management
@@ -96,7 +98,8 @@ String? _authRedirect(Ref ref, GoRouterState state) {
       state.matchedLocation == _routeLogin ||
       state.matchedLocation == '/register' ||
       state.matchedLocation == '/forgot-password' ||
-      state.matchedLocation == '/reset-password';
+      state.matchedLocation == '/reset-password' ||
+      state.matchedLocation == _routeAccountPicker;
   final isOnboarding = state.matchedLocation == '/onboarding';
   final isJoinRoute =
       state.matchedLocation.startsWith('/join') ||
@@ -198,6 +201,11 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: _routeLogin,
         pageBuilder: (context, state) =>
             _fadePage(key: state.pageKey, child: const LoginScreen()),
+      ),
+      GoRoute(
+        path: _routeAccountPicker,
+        pageBuilder: (context, state) =>
+            _fadePage(key: state.pageKey, child: const AccountPickerScreen()),
       ),
       GoRoute(
         path: '/register',

--- a/apps/client/lib/src/screens/auth/account_picker_screen.dart
+++ b/apps/client/lib/src/screens/auth/account_picker_screen.dart
@@ -1,0 +1,325 @@
+/// Launch-time account picker.
+///
+/// Shown after the splash when `tryAutoLogin` fails AND the device has at
+/// least one persisted account in [AccountsStorage]. Replaces the bare
+/// "go straight to Login" fallback with a Discord/Slack-style "Welcome back"
+/// screen so the user can tap-to-resume a stored session without re-entering
+/// credentials.
+///
+/// The Settings → Account → "Switch account" entry continues to open the
+/// bottom-sheet variant (`AccountSwitcherSheet`); the picker here is a
+/// separate full-screen route consumed only by the splash flow.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../providers/auth_provider.dart';
+import '../../providers/chat_provider.dart';
+import '../../providers/crypto_provider.dart';
+import '../../providers/websocket_provider.dart';
+import '../../services/accounts_storage.dart';
+import '../../theme/echo_theme.dart';
+import '../../widgets/account_list_row.dart';
+import '../../widgets/echo_logo_icon.dart';
+
+const String _kRouteLogin = '/login';
+const String _kRouteHome = '/home';
+const String _kTitleWelcomeBack = 'Welcome back';
+const String _kAddAccountLabel = 'Add another account';
+const String _kSignOutLabel = 'Not your account? Sign out';
+const String _kSwitchFailedMessage =
+    "Couldn't refresh session — please sign in again";
+
+/// Full-screen route shown by the splash flow when stored accounts exist but
+/// the user is not logged in.
+class AccountPickerScreen extends ConsumerStatefulWidget {
+  const AccountPickerScreen({super.key});
+
+  @override
+  ConsumerState<AccountPickerScreen> createState() =>
+      _AccountPickerScreenState();
+}
+
+class _AccountPickerScreenState extends ConsumerState<AccountPickerScreen> {
+  late Future<AccountsSnapshot> _snapshotFuture;
+
+  /// Stable identifier of the row currently mid-switch. While set, every row's
+  /// tap handler is disabled and the matching row shows a spinner in place of
+  /// its trailing slot. Cleared on failure so the user can retry.
+  String? _busyAccountId;
+
+  @override
+  void initState() {
+    super.initState();
+    _snapshotFuture = ref.read(authProvider.notifier).listAccounts();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.mainBg,
+      body: SafeArea(
+        child: FutureBuilder<AccountsSnapshot>(
+          future: _snapshotFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final data =
+                snapshot.data ??
+                const AccountsSnapshot(accounts: [], activeAccountId: null);
+            return _buildBody(data);
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(AccountsSnapshot snap) {
+    final accounts = [...snap.accounts]
+      ..sort((a, b) => b.lastUsed.compareTo(a.lastUsed));
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 440),
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(20, 32, 20, 24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const _BrandHeader(),
+                  const SizedBox(height: 24),
+                  _buildAccountList(accounts),
+                  const SizedBox(height: 4),
+                  Divider(height: 1, color: context.border),
+                  _AddAccountRow(
+                    onTap: _busyAccountId == null ? _onTapAddAccount : null,
+                  ),
+                  const SizedBox(height: 16),
+                  _SignOutFooter(
+                    onTap: _busyAccountId == null ? _onTapSignOut : null,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildAccountList(List<StoredAccount> accounts) {
+    if (accounts.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Text(
+          'No saved accounts.',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: context.textSecondary, fontSize: 13),
+        ),
+      );
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final account in accounts)
+          AccountListRow(
+            account: account,
+            isActive: false,
+            subtitle: _subtitleFor(account),
+            onTap: _busyAccountId == null ? () => _onTapAccount(account) : null,
+            trailing: _trailingFor(account),
+          ),
+      ],
+    );
+  }
+
+  Widget? _trailingFor(StoredAccount account) {
+    if (_busyAccountId != account.id) return null;
+    return const SizedBox(
+      width: 20,
+      height: 20,
+      child: CircularProgressIndicator(strokeWidth: 2),
+    );
+  }
+
+  String _subtitleFor(StoredAccount account) {
+    final host = accountRowHostLabel(account.serverUrl);
+    final lastUsed = _formatLastUsed(account.lastUsed);
+    if (lastUsed == null) return host;
+    return '$host  ·  Last used $lastUsed';
+  }
+
+  Future<void> _onTapAccount(StoredAccount account) async {
+    setState(() => _busyAccountId = account.id);
+
+    // Tear down per-user state before swapping identities. Mirrors the home
+    // screen's _logout sequence so a half-initialised provider doesn't leak
+    // across the identity boundary.
+    ref.read(websocketProvider.notifier).disconnect();
+    ref.read(chatProvider.notifier).clear();
+    await ref.read(cryptoProvider.notifier).resetState();
+
+    final ok = await ref
+        .read(authProvider.notifier)
+        .switchToAccount(account.id);
+    if (!mounted) return;
+
+    if (ok) {
+      context.go(_kRouteHome);
+      return;
+    }
+
+    setState(() => _busyAccountId = null);
+    _showSwitchFailedSnackbar();
+    // Send the user to the login screen so they can re-enter credentials.
+    // The login screen's existing knownServers pre-fill picks up the
+    // matching username when the server URL matches.
+    context.go(_kRouteLogin);
+  }
+
+  void _onTapAddAccount() {
+    context.go(_kRouteLogin);
+  }
+
+  Future<void> _onTapSignOut() async {
+    final auth = ref.read(authProvider.notifier);
+    await auth.accountsStorage.clear();
+    if (!mounted) return;
+    context.go(_kRouteLogin);
+  }
+
+  void _showSwitchFailedSnackbar() {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    messenger?.showSnackBar(
+      const SnackBar(content: Text(_kSwitchFailedMessage)),
+    );
+  }
+
+  /// Compact "5m" / "3h" / "2d" / "Jan 14" descriptor. Returns null when the
+  /// stored stamp is the zero epoch (i.e. the row was added before the
+  /// `lastUsed` field shipped).
+  String? _formatLastUsed(DateTime when) {
+    if (when.millisecondsSinceEpoch <= 0) return null;
+    final diff = DateTime.now().difference(when);
+    if (diff.isNegative) return 'just now';
+    if (diff.inMinutes < 1) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    if (diff.inDays < 7) return '${diff.inDays}d ago';
+    final months = const [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return '${months[when.month - 1]} ${when.day}';
+  }
+}
+
+class _BrandHeader extends StatelessWidget {
+  const _BrandHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const EchoLogoIcon(size: 64),
+        const SizedBox(height: 16),
+        Text(
+          'Echo',
+          style: TextStyle(
+            fontSize: 24,
+            fontWeight: FontWeight.w700,
+            letterSpacing: -0.5,
+            color: context.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          _kTitleWelcomeBack,
+          style: TextStyle(fontSize: 14, color: context.textSecondary),
+        ),
+      ],
+    );
+  }
+}
+
+class _AddAccountRow extends StatelessWidget {
+  final VoidCallback? onTap;
+
+  const _AddAccountRow({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: _kAddAccountLabel,
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 20,
+                backgroundColor: context.cardRowBg,
+                child: Icon(Icons.add, size: 20, color: context.textPrimary),
+              ),
+              const SizedBox(width: 14),
+              Text(
+                _kAddAccountLabel,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                  color: context.textPrimary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SignOutFooter extends StatelessWidget {
+  final VoidCallback? onTap;
+
+  const _SignOutFooter({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: _kSignOutLabel,
+      button: true,
+      child: Center(
+        child: TextButton(
+          onPressed: onTap,
+          child: Text(
+            _kSignOutLabel,
+            style: TextStyle(
+              fontSize: 13,
+              color: context.textMuted,
+              decoration: TextDecoration.underline,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/screens/splash_screen.dart
+++ b/apps/client/lib/src/screens/splash_screen.dart
@@ -205,7 +205,26 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
       return;
     }
 
-    context.go('/login');
+    // Auto-login failed. When the device has at least one persisted account,
+    // route to the launch-time picker so the user can tap-to-resume without
+    // re-typing credentials. Falls back to plain /login when no accounts are
+    // stored or the storage read errors out (treated as "no accounts").
+    unawaited(_routeToPickerOrLogin());
+  }
+
+  /// Pick between the launch-time account picker and the plain login screen
+  /// based on whether [AccountsStorage] has any rows.
+  Future<void> _routeToPickerOrLogin() async {
+    final auth = ref.read(authProvider.notifier);
+    var hasAccounts = false;
+    try {
+      final snap = await auth.listAccounts();
+      hasAccounts = snap.accounts.isNotEmpty;
+    } catch (_) {
+      hasAccounts = false;
+    }
+    if (!mounted) return;
+    context.go(hasAccounts ? '/auth/pick-account' : '/login');
   }
 
   /// Navigate home, setting onboarding flag and showing crypto notice.

--- a/apps/client/lib/src/widgets/account_list_row.dart
+++ b/apps/client/lib/src/widgets/account_list_row.dart
@@ -1,0 +1,139 @@
+/// Shared visual primitive for the account-switcher surfaces.
+///
+/// One row = avatar + username + (server-host | optional subtitle) + optional
+/// trailing widget (check mark on the bottom-sheet's active row; spinner on the
+/// launch picker's in-flight row).
+///
+/// Two callers consume it today:
+///   * `AccountSwitcherSheet` — bottom sheet entry from Settings.
+///   * `AccountPickerScreen` — launch-time fallback when auto-login fails and
+///     stored accounts exist.
+///
+/// Centralising the row visuals here means a future tweak (e.g. swapping the
+/// host text for a server-name pill, or adding a presence dot to the avatar)
+/// lands on both surfaces in one edit instead of drifting between two
+/// hand-rolled copies.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../services/accounts_storage.dart';
+import '../theme/echo_theme.dart';
+import 'user_avatar.dart';
+
+/// Strip the scheme + path off [url] so the row's secondary line shows a
+/// compact "host.example.com" instead of the full origin. Falls back to the
+/// raw string when the URL fails to parse.
+String accountRowHostLabel(String url) {
+  final host = Uri.tryParse(url)?.host;
+  if (host == null || host.isEmpty) return url;
+  return host;
+}
+
+/// Single row in either the account-switcher sheet or the launch-time picker.
+class AccountListRow extends StatelessWidget {
+  /// Account being rendered.
+  final StoredAccount account;
+
+  /// When true, render a check icon on the trailing edge. Mutually exclusive
+  /// with [trailing] (check wins so the active-row marker can't be overridden
+  /// by accident).
+  final bool isActive;
+
+  /// Optional second line under the username. Defaults to the account's
+  /// server host. Pass an empty string to suppress the subtitle line entirely
+  /// (rare — most callers want a non-empty descriptor).
+  final String? subtitle;
+
+  /// Tap handler. Null disables the row's ink ripple (used while a switch is
+  /// in flight to prevent double-taps).
+  final VoidCallback? onTap;
+
+  /// Custom trailing widget for the row (e.g. a small CircularProgressIndicator
+  /// during a switch). Ignored when [isActive] is true.
+  final Widget? trailing;
+
+  /// Accessibility label override. Defaults to a sensible "switch to X" /
+  /// "account X active" label derived from [account] + [isActive].
+  final String? semanticLabel;
+
+  const AccountListRow({
+    super.key,
+    required this.account,
+    required this.isActive,
+    this.subtitle,
+    this.onTap,
+    this.trailing,
+    this.semanticLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final label =
+        semanticLabel ??
+        (isActive
+            ? 'account ${account.username} active'
+            : 'switch to ${account.username}');
+    final secondary = subtitle ?? accountRowHostLabel(account.serverUrl);
+    return Semantics(
+      label: label,
+      button: onTap != null,
+      selected: isActive,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Row(
+            children: [
+              UserAvatar(
+                userId: account.userId,
+                username: account.username,
+                avatarUrl: account.avatarUrl,
+                radius: 20,
+                openProfileOnTap: false,
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      account.username,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: context.textPrimary,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (secondary.isNotEmpty) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        secondary,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: context.textSecondary,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              _buildTrailing(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTrailing(BuildContext context) {
+    if (isActive) {
+      return Icon(Icons.check_circle, size: 20, color: context.accent);
+    }
+    return trailing ?? const SizedBox.shrink();
+  }
+}

--- a/apps/client/lib/src/widgets/account_switcher_sheet.dart
+++ b/apps/client/lib/src/widgets/account_switcher_sheet.dart
@@ -22,8 +22,8 @@ import '../providers/crypto_provider.dart';
 import '../providers/websocket_provider.dart';
 import '../services/accounts_storage.dart';
 import '../theme/echo_theme.dart';
+import 'account_list_row.dart';
 import 'echo_bottom_sheet.dart';
-import 'user_avatar.dart';
 
 const String _kSwitchAccountTitle = 'Switch account';
 const String _kAddAccountLabel = 'Add another account';
@@ -104,7 +104,7 @@ class _AccountSwitcherSheetState extends ConsumerState<AccountSwitcherSheet> {
           ),
         ),
         for (final account in accounts)
-          _AccountRow(
+          AccountListRow(
             account: account,
             isActive: account.id == snap.activeAccountId,
             onTap: _switching ? null : () => _onTapAccount(account),
@@ -161,80 +161,6 @@ class _AccountSwitcherSheetState extends ConsumerState<AccountSwitcherSheet> {
     ref.read(cryptoProvider.notifier).resetState();
     ref.read(authProvider.notifier).logout(forgetAccount: false);
     context.go('/login');
-  }
-}
-
-class _AccountRow extends StatelessWidget {
-  final StoredAccount account;
-  final bool isActive;
-  final VoidCallback? onTap;
-
-  const _AccountRow({
-    required this.account,
-    required this.isActive,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      label: isActive
-          ? 'account ${account.username} active'
-          : 'switch to ${account.username}',
-      button: true,
-      selected: isActive,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-          child: Row(
-            children: [
-              UserAvatar(
-                userId: account.userId,
-                username: account.username,
-                avatarUrl: account.avatarUrl,
-                radius: 20,
-                openProfileOnTap: false,
-              ),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      account.username,
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: context.textPrimary,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      _hostLabel(account.serverUrl),
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: context.textSecondary,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
-              ),
-              if (isActive)
-                Icon(Icons.check_circle, size: 20, color: context.accent),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  String _hostLabel(String url) {
-    final host = Uri.tryParse(url)?.host;
-    if (host == null || host.isEmpty) return url;
-    return host;
   }
 }
 

--- a/apps/client/test/screens/auth/account_picker_screen_test.dart
+++ b/apps/client/test/screens/auth/account_picker_screen_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:echo_app/src/providers/auth_provider.dart';
+import 'package:echo_app/src/providers/chat_provider.dart';
+import 'package:echo_app/src/screens/auth/account_picker_screen.dart';
+import 'package:echo_app/src/services/accounts_storage.dart';
+import 'package:echo_app/src/services/secure_key_store.dart';
+import 'package:echo_app/src/theme/echo_theme.dart';
+
+import '../../helpers/fake_secure_key_store.dart';
+import '../../helpers/mock_providers.dart';
+
+/// Track `switchToAccount` calls so tests can assert that tapping a row
+/// dispatches the right id. Returns [resultByAccountId] when present, else
+/// falls back to true (success).
+class _RecordingAuthNotifier extends AuthNotifier {
+  _RecordingAuthNotifier({
+    required this.storage,
+    this.resultByAccountId = const <String, bool>{},
+  });
+
+  final AccountsStorage storage;
+  final Map<String, bool> resultByAccountId;
+  final List<String> switchCalls = <String>[];
+
+  @override
+  AuthState build() => const AuthState();
+
+  @override
+  AccountsStorage get accountsStorage => storage;
+
+  @override
+  Future<AccountsSnapshot> listAccounts() => storage.load();
+
+  @override
+  Future<bool> switchToAccount(String accountId) async {
+    switchCalls.add(accountId);
+    return resultByAccountId[accountId] ?? true;
+  }
+}
+
+/// Helper to count `clear()` invocations.
+class _CountingStorage extends AccountsStorage {
+  _CountingStorage({super.secureStore});
+  int clearCalls = 0;
+
+  @override
+  Future<void> clear() async {
+    clearCalls++;
+    await super.clear();
+  }
+}
+
+/// Stub Chat notifier so the picker's `chatProvider.notifier.clear()` call
+/// doesn't pull in the real provider's group-crypto + timer setup.
+class _FakeChat extends Chat {
+  @override
+  ChatState build() => const ChatState();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AccountPickerScreen', () {
+    late FakeSecureKeyStore fakeKeyStore;
+    late AccountsStorage storage;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      fakeKeyStore = FakeSecureKeyStore();
+      SecureKeyStore.instance = fakeKeyStore;
+      storage = AccountsStorage(secureStore: fakeKeyStore);
+    });
+
+    /// Mount the picker inside a GoRouter so `context.go('/home')` resolves
+    /// to a routable page. Tracks the location in [locations] so tests can
+    /// assert post-tap navigation without scraping widgets.
+    Future<List<String>> pumpPicker(
+      WidgetTester tester, {
+      _RecordingAuthNotifier? authNotifier,
+      AccountsStorage? overrideStorage,
+    }) async {
+      final locations = <String>[];
+      final activeStorage = overrideStorage ?? storage;
+      final router = GoRouter(
+        initialLocation: '/auth/pick-account',
+        observers: [_LocationObserver(onPush: (loc) => locations.add(loc))],
+        routes: [
+          GoRoute(
+            path: '/auth/pick-account',
+            builder: (_, _) => const AccountPickerScreen(),
+          ),
+          GoRoute(
+            path: '/login',
+            builder: (_, _) => const Scaffold(body: Text('LOGIN_SCREEN')),
+          ),
+          GoRoute(
+            path: '/home',
+            builder: (_, _) => const Scaffold(body: Text('HOME_SCREEN')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authProvider.overrideWith(
+              () =>
+                  authNotifier ??
+                  _RecordingAuthNotifier(storage: activeStorage),
+            ),
+            serverUrlOverride('http://localhost:8080'),
+            // Picker tears down per-user state before swapping identities.
+            // Override the side-effecting providers so the test doesn't open
+            // real sockets or touch crypto state.
+            webSocketOverride(),
+            cryptoOverride(),
+            chatProvider.overrideWith(_FakeChat.new),
+          ],
+          child: MaterialApp.router(
+            theme: EchoTheme.darkTheme,
+            darkTheme: EchoTheme.darkTheme,
+            themeMode: ThemeMode.dark,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return locations;
+    }
+
+    StoredAccount aliceFixture() => StoredAccount(
+      userId: 'u-alice',
+      username: 'alice',
+      serverUrl: 'http://localhost:8080',
+      refreshToken: 'r-a',
+      lastUsed: DateTime.utc(2026, 1, 1),
+    );
+
+    StoredAccount bobFixture() => StoredAccount(
+      userId: 'u-bob',
+      username: 'bob',
+      serverUrl: 'http://localhost:8080',
+      refreshToken: 'r-b',
+      lastUsed: DateTime.utc(2026, 1, 2),
+    );
+
+    testWidgets('renders one row per stored account with username and host', (
+      tester,
+    ) async {
+      await storage.upsertAccount(aliceFixture());
+      await storage.upsertAccount(bobFixture());
+
+      await pumpPicker(tester);
+
+      expect(find.text('alice'), findsOneWidget);
+      expect(find.text('bob'), findsOneWidget);
+      // Brand header + welcome copy.
+      expect(find.text('Welcome back'), findsOneWidget);
+      // Add-account row and sign-out footer are present.
+      expect(find.text('Add another account'), findsOneWidget);
+      expect(find.text('Not your account? Sign out'), findsOneWidget);
+    });
+
+    testWidgets('tapping a row calls switchToAccount with that id', (
+      tester,
+    ) async {
+      await storage.upsertAccount(aliceFixture());
+      await storage.upsertAccount(bobFixture());
+
+      final notifier = _RecordingAuthNotifier(storage: storage);
+      await pumpPicker(tester, authNotifier: notifier);
+
+      await tester.tap(find.text('alice'));
+      await tester.pumpAndSettle();
+
+      // The persisted id is "{userId}@{serverUrl}".
+      expect(notifier.switchCalls.single, 'u-alice@http://localhost:8080');
+    });
+
+    testWidgets('successful switch navigates to /home', (tester) async {
+      await storage.upsertAccount(aliceFixture());
+
+      final notifier = _RecordingAuthNotifier(
+        storage: storage,
+        resultByAccountId: const {'u-alice@http://localhost:8080': true},
+      );
+      await pumpPicker(tester, authNotifier: notifier);
+
+      await tester.tap(find.text('alice'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('HOME_SCREEN'), findsOneWidget);
+    });
+
+    testWidgets('failed switch shows snackbar and routes to /login', (
+      tester,
+    ) async {
+      await storage.upsertAccount(aliceFixture());
+
+      final notifier = _RecordingAuthNotifier(
+        storage: storage,
+        resultByAccountId: const {'u-alice@http://localhost:8080': false},
+      );
+      await pumpPicker(tester, authNotifier: notifier);
+
+      await tester.tap(find.text('alice'));
+      // Pump enough frames for the snackbar to mount before routing.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.textContaining("Couldn't refresh session"), findsOneWidget);
+      await tester.pumpAndSettle();
+      expect(find.text('LOGIN_SCREEN'), findsOneWidget);
+    });
+
+    testWidgets('tapping "Add another account" routes to /login', (
+      tester,
+    ) async {
+      await storage.upsertAccount(aliceFixture());
+
+      await pumpPicker(tester);
+
+      await tester.tap(find.text('Add another account'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('LOGIN_SCREEN'), findsOneWidget);
+    });
+
+    testWidgets(
+      'tapping "Sign out" clears the accounts storage and routes to /login',
+      (tester) async {
+        final countingStorage = _CountingStorage(secureStore: fakeKeyStore);
+        await countingStorage.upsertAccount(aliceFixture());
+
+        final notifier = _RecordingAuthNotifier(storage: countingStorage);
+        await pumpPicker(
+          tester,
+          authNotifier: notifier,
+          overrideStorage: countingStorage,
+        );
+
+        await tester.tap(find.text('Not your account? Sign out'));
+        await tester.pumpAndSettle();
+
+        expect(countingStorage.clearCalls, 1);
+        expect(find.text('LOGIN_SCREEN'), findsOneWidget);
+      },
+    );
+  });
+}
+
+/// Tiny [NavigatorObserver] that records pushed routes' names so tests can
+/// assert nav order. Kept private to the test file.
+class _LocationObserver extends NavigatorObserver {
+  _LocationObserver({required this.onPush});
+
+  final void Function(String location) onPush;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    final name = route.settings.name;
+    if (name != null) onPush(name);
+  }
+}

--- a/apps/client/test/screens/splash_screen_test.dart
+++ b/apps/client/test/screens/splash_screen_test.dart
@@ -4,10 +4,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:echo_app/src/providers/auth_provider.dart';
 import 'package:echo_app/src/providers/update_provider.dart';
 import 'package:echo_app/src/screens/splash_screen.dart';
+import 'package:echo_app/src/services/accounts_storage.dart';
+import 'package:echo_app/src/services/secure_key_store.dart';
 import 'package:echo_app/src/theme/echo_theme.dart';
 
+import '../helpers/fake_secure_key_store.dart';
 import '../helpers/mock_providers.dart';
 
 class _FakeUpdate extends Update {
@@ -30,8 +34,30 @@ GoRouter _router() => GoRouter(
       path: '/home',
       builder: (_, _) => const Scaffold(body: Text('HOME')),
     ),
+    GoRoute(
+      path: '/auth/pick-account',
+      builder: (_, _) => const Scaffold(body: Text('PICK_ACCOUNT')),
+    ),
   ],
 );
+
+/// Auth notifier whose `listAccounts` returns a fixed snapshot. Used in the
+/// post-auto-login routing tests to flip the splash between the launch-time
+/// account picker and the plain login screen.
+class _SnapshotAuthNotifier extends AuthNotifier {
+  _SnapshotAuthNotifier(this._snapshot);
+
+  final AccountsSnapshot _snapshot;
+
+  @override
+  AuthState build() => const AuthState();
+
+  @override
+  Future<bool> tryAutoLogin() async => false;
+
+  @override
+  Future<AccountsSnapshot> listAccounts() async => _snapshot;
+}
 
 Future<void> _pump(
   WidgetTester tester, {
@@ -90,6 +116,81 @@ void main() {
       // The version footer uses the `v` prefix; we don't assert the exact
       // number so the test survives version bumps.
       expect(find.textContaining('v'), findsWidgets);
+    });
+  });
+
+  /// Launch-time routing: with auto-login failing, splash falls back to the
+  /// account picker when stored accounts exist and to the plain login screen
+  /// otherwise.
+  group('SplashScreen launch routing', () {
+    setUp(() {
+      SecureKeyStore.instance = FakeSecureKeyStore();
+    });
+
+    Future<void> pumpWithSnapshot(
+      WidgetTester tester, {
+      required AccountsSnapshot snapshot,
+    }) async {
+      // Mark first launch completed so the 1500ms brand hold drops to 400ms.
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'splash.first_launch_completed': true,
+      });
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authProvider.overrideWith(() => _SnapshotAuthNotifier(snapshot)),
+            serverUrlOverride(),
+            accessibilityOverride(),
+            updateProvider.overrideWith(_FakeUpdate.new),
+          ],
+          child: MaterialApp.router(
+            theme: EchoTheme.darkTheme,
+            darkTheme: EchoTheme.darkTheme,
+            themeMode: ThemeMode.dark,
+            routerConfig: _router(),
+          ),
+        ),
+      );
+      // post-frame → enterSplash → tryAutoLogin → updateProvider.check →
+      // 400ms Future.delayed → _navigateAfterInit → listAccounts → context.go.
+      // tester.runAsync lets real microtasks settle (the awaited Futures in
+      // _init() depend on actual event-loop turns, not just pumped timers).
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 800));
+      });
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    testWidgets(
+      'auto-login fails AND stored accounts exist → routes to picker',
+      (tester) async {
+        final stored = StoredAccount(
+          userId: 'u-alice',
+          username: 'alice',
+          serverUrl: 'http://localhost:8080',
+          refreshToken: 'r',
+          lastUsed: DateTime.utc(2026, 1, 1),
+        );
+        await pumpWithSnapshot(
+          tester,
+          snapshot: AccountsSnapshot(
+            accounts: [stored],
+            activeAccountId: stored.id,
+          ),
+        );
+        expect(find.text('PICK_ACCOUNT'), findsOneWidget);
+      },
+    );
+
+    testWidgets('auto-login fails AND no stored accounts → routes to /login', (
+      tester,
+    ) async {
+      await pumpWithSnapshot(
+        tester,
+        snapshot: const AccountsSnapshot(accounts: [], activeAccountId: null),
+      );
+      expect(find.text('LOGIN'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

When auto-login fails on app start, Echo previously dropped users straight on the Login screen — even when they'd already signed in to one or more accounts on the device. This adds a Discord/Slack-style "Welcome back" picker so they can tap a stored account to resume without retyping credentials, add a new account, or sign out and start fresh.

## New
- Launch-time account picker (`/auth/pick-account`) showing one row per saved account with username, server host, and "Last used" hint
- Splash now branches to the picker when stored accounts exist, or to plain Login when there are none

## Improved
- Settings → Account → "Switch account" sheet now shares its row visuals with the launch picker via a single `AccountListRow` widget, so future tweaks land on both surfaces

## Behind the scenes
- Extracted `AccountListRow` from `AccountSwitcherSheet` so both surfaces render the same avatar / username / host composition
- Added 6 picker widget tests + 2 splash routing tests; full client suite (~2500 tests) green
- Picker handles failed `switchToAccount` by surfacing a snackbar and bouncing the user to Login with their last-used server's username pre-filled (existing `knownServers` behaviour)

## Test plan
- [ ] Cold-launch on a device with one stored account: lands on picker, tap row → home
- [ ] Cold-launch on a device with no stored accounts: lands on Login (unchanged)
- [ ] Cold-launch with a stale refresh token: tap row → snackbar + Login
- [ ] "Add another account" → Login, sign in → new account joins the list
- [ ] "Not your account? Sign out" → list clears, Login screen shown
- [ ] Settings → "Switch account" sheet still works as before