### PR TITLE
fix(server): stabilize chunked-upload CI test against parallel sweep race

### DIFF
--- a/apps/server/src/db/upload_sessions.rs
+++ b/apps/server/src/db/upload_sessions.rs
@@ -129,17 +129,29 @@ pub async fn mark_aborted(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
 /// Return every pending session that has been idle longer than
 /// `idle_seconds`.  The cleanup task feeds these into [`mark_aborted`] and
 /// unlinks each `temp_path`.
+///
+/// `user_id` optionally scopes the sweep to a single user; production
+/// background sweeps pass `None` to sweep globally, while the integration
+/// test that exercises the sweep passes its own `user_id` so that parallel
+/// tests' in-flight uploads aren't reaped underneath them (the global
+/// sweep with `idle_seconds = 0` matches every pending session in the DB,
+/// which races the happy-path test's finalize and yields a flaky 500
+/// when the temp file is unlinked between mime-sniff and `fs::rename`).
 pub async fn list_stale_pending(
     pool: &PgPool,
     idle_seconds: i64,
+    user_id: Option<Uuid>,
 ) -> Result<Vec<UploadSessionRow>, sqlx::Error> {
     sqlx::query_as::<_, UploadSessionRow>(
         "SELECT id, user_id, filename, mime_type, total_size, bytes_received, \
                 conversation_id, temp_path, status, created_at, updated_at \
          FROM upload_sessions \
-         WHERE status = 'pending' AND updated_at < now() - make_interval(secs => $1)",
+         WHERE status = 'pending' \
+           AND updated_at < now() - make_interval(secs => $1) \
+           AND ($2::uuid IS NULL OR user_id = $2)",
     )
     .bind(idle_seconds)
+    .bind(user_id)
     .fetch_all(pool)
     .await
 }

--- a/apps/server/src/routes/media_chunked.rs
+++ b/apps/server/src/routes/media_chunked.rs
@@ -382,18 +382,63 @@ pub async fn finalize(
         );
     }
 
-    let mime_type = detect_mime_from_file(&session.temp_path, &session.mime_type).await?;
+    let mime_type = detect_mime_from_file(&session.temp_path, &session.mime_type)
+        .await
+        .map_err(|e| log_finalize_step(id, "detect_mime", &session.temp_path, e))?;
     let ext = media::extension_for_mime(&mime_type);
     let file_uuid = Uuid::new_v4();
     let disk_path = format!("./uploads/{file_uuid}.{ext}");
 
-    fs::create_dir_all("./uploads")
-        .await
-        .map_err(|e| AppError::internal(format!("Failed to create uploads directory: {e}")))?;
+    fs::create_dir_all("./uploads").await.map_err(|e| {
+        log_finalize_io(
+            id,
+            "create_uploads_dir",
+            &session.temp_path,
+            "./uploads",
+            &e,
+        )
+    })?;
+
+    // Pre-rename sanity check: the temp file must exist and its on-disk
+    // size must match `total_size`.  If it doesn't, surface a structured
+    // message instead of relying on `fs::rename` to fail with a generic
+    // IO error.  This is the diagnostic hook for the chronic CI flake --
+    // the most likely race is the background cleanup sweep unlinking the
+    // file between mime-sniff and rename, in which case `metadata` reports
+    // ENOENT here with a clear log line naming the upload.
+    match fs::metadata(&session.temp_path).await {
+        Ok(meta) => {
+            if meta.len() as i64 != session.total_size {
+                tracing::error!(
+                    upload_id = %id,
+                    temp_path = %session.temp_path,
+                    on_disk = meta.len(),
+                    expected = session.total_size,
+                    "chunked_upload/finalize: temp file size mismatch before rename",
+                );
+                return Err(AppError::internal(format!(
+                    "Temp upload size mismatch: on_disk={} expected={}",
+                    meta.len(),
+                    session.total_size
+                )));
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                upload_id = %id,
+                temp_path = %session.temp_path,
+                error = %e,
+                "chunked_upload/finalize: temp file missing before rename (likely cleanup race)",
+            );
+            return Err(AppError::internal(format!(
+                "Temp upload file missing before rename: {e}"
+            )));
+        }
+    }
 
     fs::rename(&session.temp_path, &disk_path)
         .await
-        .map_err(|e| AppError::internal(format!("Failed to move temp upload into place: {e}")))?;
+        .map_err(|e| log_finalize_io(id, "rename", &session.temp_path, &disk_path, &e))?;
 
     let safe_filename = sanitize_filename(&session.filename);
     let (img_w, img_h) = if mime_type.starts_with("image/") {
@@ -438,6 +483,53 @@ pub async fn finalize(
     Ok((
         StatusCode::CREATED,
         Json(media::build_upload_response(&row, thumb_url)),
+    ))
+}
+
+/// Annotate a finalize-step error with the upload id + step name so the
+/// 500 returned to the client and the server log line both point at the
+/// exact failing operation.  Used to make the chronic CI flake
+/// (`chunks_append_in_order_and_finalize_returns_media_url`) diagnostic
+/// instead of opaque -- the original code wrapped each `?` in a generic
+/// "internal error" message that didn't say which step failed.
+fn log_finalize_step(id: Uuid, step: &'static str, temp_path: &str, err: AppError) -> AppError {
+    tracing::error!(
+        upload_id = %id,
+        step,
+        temp_path,
+        message = %err.message,
+        "chunked_upload/finalize: step failed"
+    );
+    AppError {
+        status: err.status,
+        message: format!("finalize step {step} failed: {}", err.message),
+        code: err.code,
+        body: err.body,
+    }
+}
+
+/// Same idea as [`log_finalize_step`] but for raw `std::io::Error` returns
+/// from filesystem operations -- formats the error with its source path so
+/// flakes that depend on a cleanup race show the unlink in the log next to
+/// the failing rename.
+fn log_finalize_io(
+    id: Uuid,
+    step: &'static str,
+    src: &str,
+    dst: &str,
+    err: &std::io::Error,
+) -> AppError {
+    tracing::error!(
+        upload_id = %id,
+        step,
+        src,
+        dst,
+        kind = ?err.kind(),
+        error = %err,
+        "chunked_upload/finalize: io step failed"
+    );
+    AppError::internal(format!(
+        "finalize step {step} failed (src={src}, dst={dst}): {err}"
     ))
 }
 
@@ -563,7 +655,18 @@ pub async fn get_state(
 /// Spawned from `main.rs` on the same `spawn_periodic` cadence used by
 /// the other cleanup loops.
 pub async fn cleanup_stale_uploads(pool: &sqlx::PgPool, idle_seconds: i64) {
-    let rows = match db::upload_sessions::list_stale_pending(pool, idle_seconds).await {
+    cleanup_stale_uploads_scoped(pool, idle_seconds, None).await;
+}
+
+/// Variant of [`cleanup_stale_uploads`] scoped to a single `user_id` so
+/// integration tests can exercise the sweep without reaping in-flight
+/// uploads belonging to parallel tests sharing the same database.
+pub async fn cleanup_stale_uploads_scoped(
+    pool: &sqlx::PgPool,
+    idle_seconds: i64,
+    user_id: Option<Uuid>,
+) {
+    let rows = match db::upload_sessions::list_stale_pending(pool, idle_seconds, user_id).await {
         Ok(r) => r,
         Err(e) => {
             tracing::warn!("chunked upload cleanup: list_stale_pending failed: {e}");

--- a/apps/server/tests/api_media_chunked.rs
+++ b/apps/server/tests/api_media_chunked.rs
@@ -274,7 +274,7 @@ async fn other_user_cannot_see_or_chunk_my_session() {
 async fn cleanup_sweep_aborts_stale_pending_session() {
     let base = common::spawn_server().await;
     let client = Client::new();
-    let (token, _, _) = common::register_and_login(&client, &base, "chunked_sweep").await;
+    let (token, user_id_str, _) = common::register_and_login(&client, &base, "chunked_sweep").await;
 
     let (upload_id, _) = init_upload(&client, &base, &token, 1024).await;
 
@@ -286,7 +286,14 @@ async fn cleanup_sweep_aborts_stale_pending_session() {
         .expect("TEST_DATABASE_URL or DATABASE_URL must be set");
     let pool: PgPool = sqlx::PgPool::connect(&database_url).await.unwrap();
 
-    echo_server::routes::media_chunked::cleanup_stale_uploads(&pool, 0).await;
+    // Scope the sweep to this test's user so parallel tests sharing the
+    // same DB don't get their in-flight uploads reaped underneath them.
+    // The unscoped variant with `idle_seconds = 0` was the root cause of
+    // the chronic flake in `chunks_append_in_order_and_finalize_returns_media_url`:
+    // it deleted the happy-path test's temp file between its mime-sniff
+    // and its `fs::rename` step, surfacing as an opaque 500.
+    let user_id = Uuid::parse_str(&user_id_str).unwrap();
+    echo_server::routes::media_chunked::cleanup_stale_uploads_scoped(&pool, 0, Some(user_id)).await;
 
     let resp = client
         .get(format!("{base}/api/media/upload/{upload_id}"))


### PR DESCRIPTION
## Summary

The Rust CI flake `chunks_append_in_order_and_finalize_returns_media_url`
(intermittent 500 on finalize, roughly every other CI run) is caused by
the integration test `cleanup_sweep_aborts_stale_pending_session`
calling `cleanup_stale_uploads(&pool, 0)` -- which selects **every**
pending upload row in the shared test database whose `updated_at < now()`
and unlinks its temp file. When that test runs in parallel with the
happy-path test, the sweep's `fs::remove_file` can land between
finalize's mime-sniff and `fs::rename`, surfacing as an opaque 500
("Failed to move temp upload into place") from finalize's generic
`map_err`.

## Root cause

`db::upload_sessions::list_stale_pending` has no user-scope filter.
With `idle_seconds = 0`, every pending session across every parallel
test worker is eligible for unlink. The test only "owns" one session
but the sweep affects all of them.

## Fix

- `list_stale_pending` now takes an `Option<Uuid>` user-scope filter; the
  production cleanup loop continues to pass `None` (global sweep), while
  the integration test passes its own `user_id` via a new
  `cleanup_stale_uploads_scoped` helper.
- Finalize now logs the failing IO step (with `upload_id`, `src`, `dst`,
  `kind`) and includes the step name in the 500 response body, so any
  future flake immediately names the failing operation instead of saying
  "internal error".
- Finalize pre-renames `fs::metadata(temp_path)` to surface "temp file
  missing" / "size mismatch" as structured errors before `fs::rename`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p echo-server --test api_media_chunked` (all 8 pass)
- [x] 50x loop locally: 50/50 pass
- [ ] CI Rust run on this PR stays green

## Behind the scenes

Local 50x and 30x-with-8-test-threads loops did not reproduce the
failure pre-fix (dev machine has fewer parallel workers than GHA + faster
tmpfs), so the bg-sweep hypothesis is inferred from code reading, not
a local repro. If CI somehow still flakes, the new structured logs in
finalize will name the exact failing step in the next failure.