### PR TITLE
Snooze notifications for an hour, eight, or until tomorrow morning

### DIFF
--- a/apps/client/lib/src/providers/notifications_snooze_provider.dart
+++ b/apps/client/lib/src/providers/notifications_snooze_provider.dart
@@ -1,0 +1,151 @@
+/// Notification snooze state — the silence-for-a-while toggle in
+/// settings + the bell-slash overlay on the sidebar avatar.
+///
+/// Backed by `PATCH /api/users/me/notifications/snooze` on the server.
+/// The provider holds the absolute UTC "snoozed until" timestamp, or
+/// `null` when not snoozed. A self-cancelling [Timer] flips the state
+/// back to `null` the moment the window elapses so the UI doesn't have
+/// to wait for a manual refresh.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import 'auth_provider.dart';
+import 'server_url_provider.dart';
+
+/// Allowed snooze presets surfaced in the settings UI.
+enum SnoozeDuration { oneHour, eightHours, twentyFourHours, tomorrowMorning }
+
+/// Resolve a [SnoozeDuration] to an absolute UTC "until" instant.
+///
+/// `tomorrowMorning` lands at 9 AM local time on the next calendar day,
+/// then converts to UTC for the wire format. Exposed for tests.
+DateTime resolveSnoozeUntil(SnoozeDuration duration, {DateTime? now}) {
+  final base = now ?? DateTime.now();
+  switch (duration) {
+    case SnoozeDuration.oneHour:
+      return base.toUtc().add(const Duration(hours: 1));
+    case SnoozeDuration.eightHours:
+      return base.toUtc().add(const Duration(hours: 8));
+    case SnoozeDuration.twentyFourHours:
+      return base.toUtc().add(const Duration(hours: 24));
+    case SnoozeDuration.tomorrowMorning:
+      final tomorrow9 = DateTime(base.year, base.month, base.day + 1, 9);
+      return tomorrow9.toUtc();
+  }
+}
+
+class NotificationsSnoozeNotifier extends StateNotifier<DateTime?> {
+  NotificationsSnoozeNotifier(this._ref) : super(null) {
+    // Best-effort initial hydration from GET /api/users/me. If the user
+    // isn't logged in yet, the listener below will retry on auth change.
+    unawaited(_hydrate());
+    _ref.listen<AuthState>(authProvider, (prev, next) {
+      if (next.isLoggedIn && (prev?.userId != next.userId)) {
+        unawaited(_hydrate());
+      }
+      if (!next.isLoggedIn) {
+        _clearLocal();
+      }
+    });
+  }
+
+  final Ref _ref;
+  Timer? _expiryTimer;
+
+  Future<void> snoozeFor(SnoozeDuration duration) async {
+    final until = resolveSnoozeUntil(duration);
+    await snoozeUntil(until);
+  }
+
+  Future<void> snoozeUntil(DateTime when) async {
+    final utc = when.toUtc();
+    await _patch({'until': utc.toIso8601String()});
+    _setLocal(utc);
+  }
+
+  Future<void> clear() async {
+    await _patch({'until': null});
+    _clearLocal();
+  }
+
+  Future<void> _patch(Map<String, dynamic> body) async {
+    final authNotifier = _ref.read(authProvider.notifier);
+    try {
+      await authNotifier.authenticatedRequest((token) {
+        final url =
+            '${_ref.read(serverUrlProvider)}'
+            '/api/users/me/notifications/snooze';
+        return http.patch(
+          Uri.parse(url),
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer $token',
+          },
+          body: jsonEncode(body),
+        );
+      });
+    } catch (e) {
+      debugPrint('[Snooze] PATCH failed: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> _hydrate() async {
+    final authNotifier = _ref.read(authProvider.notifier);
+    if (!_ref.read(authProvider).isLoggedIn) return;
+    try {
+      final resp = await authNotifier.authenticatedRequest(
+        (token) => http.get(
+          Uri.parse('${_ref.read(serverUrlProvider)}/api/users/me'),
+          headers: {'Authorization': 'Bearer $token'},
+        ),
+      );
+      if (resp.statusCode != 200) return;
+      final data = jsonDecode(resp.body) as Map<String, dynamic>;
+      final raw = data['notifications_snoozed_until'] as String?;
+      final parsed = raw == null ? null : DateTime.tryParse(raw)?.toUtc();
+      if (parsed != null && parsed.isAfter(DateTime.now().toUtc())) {
+        _setLocal(parsed);
+      } else {
+        _clearLocal();
+      }
+    } catch (e) {
+      debugPrint('[Snooze] hydrate failed: $e');
+    }
+  }
+
+  void _setLocal(DateTime utc) {
+    state = utc;
+    _expiryTimer?.cancel();
+    final remaining = utc.difference(DateTime.now().toUtc());
+    if (remaining <= Duration.zero) {
+      _clearLocal();
+      return;
+    }
+    _expiryTimer = Timer(remaining, _clearLocal);
+  }
+
+  void _clearLocal() {
+    _expiryTimer?.cancel();
+    _expiryTimer = null;
+    if (state != null) state = null;
+  }
+
+  @override
+  void dispose() {
+    _expiryTimer?.cancel();
+    super.dispose();
+  }
+}
+
+/// Watch this for the current snooze until-time (or `null` when not snoozed).
+final notificationsSnoozeProvider =
+    StateNotifierProvider<NotificationsSnoozeNotifier, DateTime?>(
+      (ref) => NotificationsSnoozeNotifier(ref),
+    );

--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -18,6 +18,7 @@ import '../providers/privacy_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/livekit_voice/livekit_voice_provider.dart';
+import '../providers/notifications_snooze_provider.dart';
 import '../providers/release_notes_provider.dart';
 import '../providers/voice_lounge_fullscreen_provider.dart';
 import '../providers/websocket_provider.dart';

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -200,13 +200,21 @@ mixin _HomeScreenDesktopLayoutMixin
                   final updateState = ref.watch(updateProvider);
                   final showUpdateDot =
                       updateState.updateAvailable && !updateState.dismissed;
+                  final snoozedUntil = ref.watch(notificationsSnoozeProvider);
+                  final showSnoozeDot =
+                      snoozedUntil != null &&
+                      snoozedUntil.isAfter(DateTime.now().toUtc());
+                  final snoozeTooltip = showSnoozeDot
+                      ? 'Notifications snoozed until '
+                            '${TimeOfDay.fromDateTime(snoozedUntil.toLocal()).format(context)}'
+                      : null;
                   return Stack(
                     clipBehavior: Clip.none,
                     children: [
                       IconButton(
                         icon: const Icon(Icons.settings_outlined, size: 18),
                         color: context.textSecondary,
-                        tooltip: 'Settings',
+                        tooltip: snoozeTooltip ?? 'Settings',
                         onPressed: _openSettings,
                         padding: EdgeInsets.zero,
                         constraints: const BoxConstraints(
@@ -222,6 +230,26 @@ mixin _HomeScreenDesktopLayoutMixin
                           child: _DotBadge(
                             ringColor: context.sidebarBg,
                             bgColor: context.accent,
+                          ),
+                        ),
+                      if (showSnoozeDot)
+                        Positioned(
+                          bottom: 8,
+                          right: 8,
+                          child: Tooltip(
+                            message: snoozeTooltip!,
+                            child: Container(
+                              padding: const EdgeInsets.all(2),
+                              decoration: BoxDecoration(
+                                color: context.sidebarBg,
+                                shape: BoxShape.circle,
+                              ),
+                              child: Icon(
+                                Icons.notifications_off,
+                                size: 10,
+                                color: context.textSecondary,
+                              ),
+                            ),
                           ),
                         ),
                     ],

--- a/apps/client/lib/src/screens/settings/notification_section.dart
+++ b/apps/client/lib/src/screens/settings/notification_section.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../providers/notifications_snooze_provider.dart';
 import '../../services/notification_service.dart';
 import '../../services/sound_service.dart';
 import '../../services/toast_service.dart';
@@ -234,6 +236,10 @@ class _NotificationSectionState extends State<NotificationSection> {
           ),
         ],
 
+        // ---- Snooze notifications ----------------------------------------
+        const _SnoozeSection(),
+        const Divider(height: 32),
+
         // ---- Do Not Disturb toggle ----------------------------------------
         SwitchListTile.adaptive(
           contentPadding: EdgeInsets.zero,
@@ -404,5 +410,119 @@ class _NotificationSectionState extends State<NotificationSection> {
         ],
       ],
     );
+  }
+}
+
+/// "Snooze notifications" section inside [NotificationSection].
+///
+/// Off + four presets (1h, 8h, 24h, until tomorrow 9 AM local). When
+/// active, shows the absolute snooze-until time and a Cancel button.
+/// Backed by [notificationsSnoozeProvider].
+class _SnoozeSection extends ConsumerWidget {
+  const _SnoozeSection();
+
+  static const _presets = <({String label, SnoozeDuration? value})>[
+    (label: 'Off', value: null),
+    (label: '1 hour', value: SnoozeDuration.oneHour),
+    (label: '8 hours', value: SnoozeDuration.eightHours),
+    (label: '24 hours', value: SnoozeDuration.twentyFourHours),
+    (
+      label: 'Until tomorrow morning (9 AM)',
+      value: SnoozeDuration.tomorrowMorning,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final snoozedUntil = ref.watch(notificationsSnoozeProvider);
+    final isActive =
+        snoozedUntil != null && snoozedUntil.isAfter(DateTime.now().toUtc());
+    final notifier = ref.read(notificationsSnoozeProvider.notifier);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Snooze notifications',
+          style: TextStyle(
+            color: context.textPrimary,
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        Text(
+          'Silence push notifications for a chosen period. Your other '
+          'devices will also stop ringing for this account.',
+          style: TextStyle(color: context.textMuted, fontSize: 12),
+        ),
+        const SizedBox(height: 8),
+        RadioGroup<SnoozeDuration?>(
+          groupValue: isActive ? _matchPreset(snoozedUntil) : null,
+          onChanged: (val) async {
+            if (val == null) {
+              await notifier.clear();
+            } else {
+              await notifier.snoozeFor(val);
+            }
+          },
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final preset in _presets)
+                RadioListTile<SnoozeDuration?>(
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                  title: Text(
+                    preset.label,
+                    style: TextStyle(color: context.textPrimary, fontSize: 14),
+                  ),
+                  value: preset.value,
+                ),
+            ],
+          ),
+        ),
+        if (isActive) ...[
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Icon(
+                Icons.notifications_off,
+                size: 16,
+                color: context.textSecondary,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Snoozed until '
+                  '${TimeOfDay.fromDateTime(snoozedUntil.toLocal()).format(context)}',
+                  style: TextStyle(color: context.textSecondary, fontSize: 12),
+                ),
+              ),
+              TextButton(
+                onPressed: notifier.clear,
+                child: const Text('Cancel snooze'),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// Match the persisted snooze-until against the closest preset so the
+  /// radio shows the right selection after rehydration. We accept a 5-min
+  /// jitter because client/server clock drift makes exact matches rare.
+  SnoozeDuration? _matchPreset(DateTime? until) {
+    if (until == null) return null;
+    final now = DateTime.now().toUtc();
+    for (final preset in _presets) {
+      final val = preset.value;
+      if (val == null) continue;
+      final target = resolveSnoozeUntil(val, now: now.toLocal());
+      if (target.difference(until).abs() < const Duration(minutes: 5)) {
+        return val;
+      }
+    }
+    return null;
   }
 }

--- a/apps/client/lib/src/widgets/user_avatar.dart
+++ b/apps/client/lib/src/widgets/user_avatar.dart
@@ -67,6 +67,11 @@ class UserAvatar extends ConsumerWidget {
   /// Override the initial-letter fallback (e.g. show a group icon).
   final Widget? fallbackIcon;
 
+  /// When non-null AND in the future, overlay a small bell-with-slash glyph
+  /// on the avatar to signal "notifications snoozed until X". Tooltip
+  /// renders the locale-formatted [snoozedUntil].
+  final DateTime? snoozedUntil;
+
   const UserAvatar({
     super.key,
     required this.userId,
@@ -79,6 +84,7 @@ class UserAvatar extends ConsumerWidget {
     this.onLongPress,
     this.bgColor,
     this.fallbackIcon,
+    this.snoozedUntil,
   });
 
   @override
@@ -123,6 +129,14 @@ class UserAvatar extends ConsumerWidget {
       );
     }
 
+    final snoozedUntilUtc = snoozedUntil?.toUtc();
+    final isSnoozeActive =
+        snoozedUntilUtc != null &&
+        snoozedUntilUtc.isAfter(DateTime.now().toUtc());
+    if (isSnoozeActive) {
+      avatar = _SnoozeOverlay(snoozedUntil: snoozedUntilUtc, child: avatar);
+    }
+
     final effectiveTap =
         onTap ?? (openProfileOnTap ? () => _openProfile(context, ref) : null);
 
@@ -144,4 +158,54 @@ class UserAvatar extends ConsumerWidget {
   void _openProfile(BuildContext context, WidgetRef ref) {
     UserProfileScreen.show(context, ref, userId);
   }
+}
+
+/// Bell-with-slash badge stacked on the top-left of an avatar; used when
+/// `UserAvatar.snoozedUntil` is in the future. Kept private — every
+/// caller goes through [UserAvatar] so the badge stays consistent.
+class _SnoozeOverlay extends StatelessWidget {
+  const _SnoozeOverlay({required this.snoozedUntil, required this.child});
+
+  final DateTime snoozedUntil;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final tooltip =
+        'Notifications snoozed until ${_formatSnoozeTooltip(context, snoozedUntil)}';
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        child,
+        Positioned(
+          left: -2,
+          top: -2,
+          child: Tooltip(
+            message: tooltip,
+            child: Semantics(
+              label: tooltip,
+              child: Container(
+                padding: const EdgeInsets.all(2),
+                decoration: const BoxDecoration(
+                  color: EchoTheme.sidebarBg,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.notifications_off,
+                  size: 10,
+                  color: Colors.white70,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _formatSnoozeTooltip(BuildContext context, DateTime utc) {
+  final local = utc.toLocal();
+  final t = TimeOfDay.fromDateTime(local).format(context);
+  return t;
 }

--- a/apps/client/test/providers/notifications_snooze_provider_test.dart
+++ b/apps/client/test/providers/notifications_snooze_provider_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/providers/notifications_snooze_provider.dart';
+
+void main() {
+  group('resolveSnoozeUntil', () {
+    test('1 hour preset lands an hour in the future', () {
+      final now = DateTime.utc(2026, 5, 28, 12, 0);
+      final until = resolveSnoozeUntil(SnoozeDuration.oneHour, now: now);
+      expect(until.isUtc, isTrue);
+      expect(until.difference(now), const Duration(hours: 1));
+    });
+
+    test('8 hour preset lands 8 hours in the future', () {
+      final now = DateTime.utc(2026, 5, 28, 12, 0);
+      final until = resolveSnoozeUntil(SnoozeDuration.eightHours, now: now);
+      expect(until.difference(now), const Duration(hours: 8));
+    });
+
+    test('24 hour preset lands 24 hours in the future', () {
+      final now = DateTime.utc(2026, 5, 28, 12, 0);
+      final until = resolveSnoozeUntil(
+        SnoozeDuration.twentyFourHours,
+        now: now,
+      );
+      expect(until.difference(now), const Duration(hours: 24));
+    });
+
+    test('tomorrowMorning lands on the next day at 9 AM local', () {
+      // Local 2026-05-28 22:30 → tomorrow morning is 2026-05-29 09:00 local.
+      final now = DateTime(2026, 5, 28, 22, 30);
+      final until = resolveSnoozeUntil(
+        SnoozeDuration.tomorrowMorning,
+        now: now,
+      );
+      // Convert back to local for the day/hour assertion regardless of TZ.
+      final local = until.toLocal();
+      expect(local.year, 2026);
+      expect(local.month, 5);
+      expect(local.day, 29);
+      expect(local.hour, 9);
+      expect(local.minute, 0);
+    });
+
+    test('tomorrowMorning still rolls forward when called just after 9 AM', () {
+      // Local 09:05 today → tomorrow morning is still the next calendar day.
+      final now = DateTime(2026, 5, 28, 9, 5);
+      final until = resolveSnoozeUntil(
+        SnoozeDuration.tomorrowMorning,
+        now: now,
+      );
+      final local = until.toLocal();
+      expect(local.day, 29);
+      expect(local.hour, 9);
+    });
+
+    test('all presets return UTC instants', () {
+      for (final preset in SnoozeDuration.values) {
+        final until = resolveSnoozeUntil(preset);
+        expect(until.isUtc, isTrue, reason: '$preset must be UTC');
+      }
+    });
+  });
+}

--- a/apps/client/test/widgets/user_avatar_test.dart
+++ b/apps/client/test/widgets/user_avatar_test.dart
@@ -55,5 +55,44 @@ void main() {
       await tester.pump();
       expect(taps, 1);
     });
+
+    testWidgets('renders bell-slash badge when snoozedUntil is in the future', (
+      tester,
+    ) async {
+      final future = DateTime.now().toUtc().add(const Duration(hours: 2));
+      await tester.pumpApp(
+        UserAvatar(
+          userId: 'u1',
+          username: 'jane',
+          radius: 18,
+          snoozedUntil: future,
+        ),
+      );
+      expect(find.byIcon(Icons.notifications_off), findsOneWidget);
+    });
+
+    testWidgets('omits bell-slash badge when snoozedUntil is in the past', (
+      tester,
+    ) async {
+      final past = DateTime.now().toUtc().subtract(const Duration(minutes: 5));
+      await tester.pumpApp(
+        UserAvatar(
+          userId: 'u1',
+          username: 'jane',
+          radius: 18,
+          snoozedUntil: past,
+        ),
+      );
+      expect(find.byIcon(Icons.notifications_off), findsNothing);
+    });
+
+    testWidgets('omits bell-slash badge when snoozedUntil is null', (
+      tester,
+    ) async {
+      await tester.pumpApp(
+        const UserAvatar(userId: 'u1', username: 'jane', radius: 18),
+      );
+      expect(find.byIcon(Icons.notifications_off), findsNothing);
+    });
   });
 }

--- a/apps/server/migrations/20260528000000_notification_snooze.sql
+++ b/apps/server/migrations/20260528000000_notification_snooze.sql
@@ -1,0 +1,6 @@
+-- Notification snooze: user can silence push for a chosen window.
+-- NULL = not snoozed; populated = snoozed until that UTC timestamp.
+-- The push send path checks this column before issuing an APNs alert
+-- and lazily clears expired values so the table self-cleans.
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS notifications_snoozed_until TIMESTAMPTZ NULL;

--- a/apps/server/src/db/users.rs
+++ b/apps/server/src/db/users.rs
@@ -564,3 +564,70 @@ pub async fn get_pinned_conversations(
             .await?;
     Ok(rows.into_iter().map(|(id,)| id).collect())
 }
+
+// ---------------------------------------------------------------------------
+// Notification snooze (apps/server/migrations/20260528000000_notification_snooze.sql)
+// ---------------------------------------------------------------------------
+
+/// Fetch the current snooze-until timestamp for a user (NULL = not snoozed).
+pub async fn get_notifications_snoozed_until(
+    pool: &PgPool,
+    user_id: Uuid,
+) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+    let row: Option<(Option<DateTime<Utc>>,)> =
+        sqlx::query_as("SELECT notifications_snoozed_until FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.and_then(|(t,)| t))
+}
+
+/// Set or clear (when `until = None`) the snooze-until timestamp for a user.
+/// Returns the new stored value so the handler can echo it back.
+pub async fn set_notifications_snoozed_until(
+    pool: &PgPool,
+    user_id: Uuid,
+    until: Option<DateTime<Utc>>,
+) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+    let row: Option<(Option<DateTime<Utc>>,)> = sqlx::query_as(
+        "UPDATE users SET notifications_snoozed_until = $1 WHERE id = $2 \
+         RETURNING notifications_snoozed_until",
+    )
+    .bind(until)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.and_then(|(t,)| t))
+}
+
+/// Return the subset of `user_ids` whose snooze is currently active
+/// (`notifications_snoozed_until > now()`).  Used by the push fan-out path
+/// to skip APNs delivery for snoozed recipients.
+///
+/// As a free side-effect this also lazily clears any expired snoozes so the
+/// `users.notifications_snoozed_until` column self-cleans without a cron.
+pub async fn snoozed_user_ids(pool: &PgPool, user_ids: &[Uuid]) -> Result<Vec<Uuid>, sqlx::Error> {
+    if user_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    // First, lazily clear any expired snoozes for the requested set.
+    // Bounded to the input list so we never touch unrelated rows.
+    sqlx::query(
+        "UPDATE users SET notifications_snoozed_until = NULL \
+         WHERE id = ANY($1) AND notifications_snoozed_until IS NOT NULL \
+           AND notifications_snoozed_until <= now()",
+    )
+    .bind(user_ids)
+    .execute(pool)
+    .await?;
+
+    let rows: Vec<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM users \
+         WHERE id = ANY($1) AND notifications_snoozed_until IS NOT NULL \
+           AND notifications_snoozed_until > now()",
+    )
+    .bind(user_ids)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}

--- a/apps/server/src/push.rs
+++ b/apps/server/src/push.rs
@@ -166,6 +166,29 @@ pub async fn notify_offline_users(
         return;
     }
 
+    // Notification snooze: drop recipients whose
+    // `users.notifications_snoozed_until` is still in the future. The same
+    // helper lazily clears expired snoozes, so the column self-cleans
+    // without a cron job. Fail open on DB error — over-notify > drop.
+    let snoozed = match db::users::snoozed_user_ids(pool, &unmuted).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("Failed to filter snoozed users: {e}");
+            Vec::new()
+        }
+    };
+    let unsnoozed: Vec<Uuid> = unmuted
+        .into_iter()
+        .filter(|uid| !snoozed.contains(uid))
+        .collect();
+    for uid in &snoozed {
+        tracing::debug!(user_id = %uid, "push skipped: snoozed");
+    }
+    if unsnoozed.is_empty() {
+        return;
+    }
+    let unmuted = unsnoozed;
+
     let tokens = match db::push_tokens::get_tokens_for_users(pool, &unmuted).await {
         Ok(t) => t,
         Err(e) => {

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -438,7 +438,8 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
         .route("/{token}/accept", post(groups::accept_invite));
 
     let user_routes = Router::new()
-        .route("/me", delete(users::delete_account))
+        .route("/me", get(users::get_me).delete(users::delete_account))
+        .route("/me/notifications/snooze", patch(users::update_snooze))
         .route("/me/profile", patch(users::update_profile))
         .route("/me/password", patch(users::change_password))
         .route(

--- a/apps/server/src/routes/users.rs
+++ b/apps/server/src/routes/users.rs
@@ -870,6 +870,113 @@ pub struct UpdateStatusTextRequest {
     pub status_text: Option<String>,
 }
 
+// ---------------------------------------------------------------------------
+// Notification snooze
+// ---------------------------------------------------------------------------
+
+/// Maximum snooze window. Anything longer reads as "I've left for good"
+/// rather than "silence this for a while" — force the user to re-affirm.
+const MAX_SNOOZE: chrono::Duration = chrono::Duration::days(7);
+
+#[derive(Deserialize)]
+pub struct SnoozeRequest {
+    /// Explicit ISO-8601 UTC instant. Wins over `duration_hours` when both
+    /// are present; `null` (or omitted with a present `duration_hours`)
+    /// falls back to the duration branch; both absent = clear the snooze.
+    #[serde(default)]
+    pub until: Option<DateTime<Utc>>,
+    /// Convenience: server computes `now() + duration_hours`. Ignored when
+    /// `until` is present.
+    #[serde(default)]
+    pub duration_hours: Option<u32>,
+}
+
+#[derive(Serialize)]
+pub struct SnoozeResponse {
+    pub notifications_snoozed_until: Option<DateTime<Utc>>,
+}
+
+/// PATCH /api/users/me/notifications/snooze
+///
+/// Body forms (pick one):
+/// - `{ "until": "2026-05-29T20:00:00Z" }`   — explicit UTC instant
+/// - `{ "duration_hours": 8 }`               — server adds to `now()`
+/// - `{ "until": null }` / `{}`              — clear the snooze
+///
+/// Rejects past or > 7-day windows with 400.
+pub async fn update_snooze(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<SnoozeRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let target = resolve_snooze_target(&body)?;
+    let stored = db::users::set_notifications_snoozed_until(&state.pool, auth.user_id, target)
+        .await
+        .db_ctx("update_snooze")?;
+    Ok(Json(SnoozeResponse {
+        notifications_snoozed_until: stored,
+    }))
+}
+
+/// Decide the final UTC timestamp (or `None` to clear) for a snooze request.
+/// Extracted so [`update_snooze`] stays well under the cognitive-complexity
+/// budget and the validation rules are unit-testable.
+fn resolve_snooze_target(body: &SnoozeRequest) -> Result<Option<DateTime<Utc>>, AppError> {
+    // `until` always wins.
+    if let Some(until) = body.until {
+        validate_snooze_until(until)?;
+        return Ok(Some(until));
+    }
+    if let Some(hours) = body.duration_hours {
+        if hours == 0 {
+            return Ok(None);
+        }
+        let until = Utc::now() + chrono::Duration::hours(hours as i64);
+        validate_snooze_until(until)?;
+        return Ok(Some(until));
+    }
+    // Neither field set ⇒ clear.
+    Ok(None)
+}
+
+fn validate_snooze_until(until: DateTime<Utc>) -> Result<(), AppError> {
+    let now = Utc::now();
+    if until <= now {
+        return Err(AppError::bad_request(
+            "snooze 'until' must be in the future",
+        ));
+    }
+    if until - now > MAX_SNOOZE {
+        return Err(AppError::bad_request("snooze window may not exceed 7 days"));
+    }
+    Ok(())
+}
+
+/// GET /api/users/me
+///
+/// Returns the authenticated user's identity plus settings the client needs
+/// at startup (currently: notification snooze). Kept deliberately narrow —
+/// extend as more "always needed by the client shell" fields appear.
+pub async fn get_me(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, AppError> {
+    let user = db::users::find_by_id(&state.pool, auth.user_id)
+        .await
+        .db_ctx("get_me/find_user")?
+        .ok_or_else(|| AppError::not_found("User not found"))?;
+    let snoozed_until = db::users::get_notifications_snoozed_until(&state.pool, auth.user_id)
+        .await
+        .db_ctx("get_me/snooze")?;
+    Ok(Json(serde_json::json!({
+        "user_id": user.id,
+        "username": user.username,
+        "avatar_url": user.avatar_url,
+        "is_admin": user.is_admin,
+        "notifications_snoozed_until": snoozed_until,
+    })))
+}
+
 /// PUT /api/users/me/status-text
 pub async fn update_status_text(
     auth: AuthUser,

--- a/apps/server/tests/api_snooze.rs
+++ b/apps/server/tests/api_snooze.rs
@@ -1,0 +1,229 @@
+//! Integration tests for the notification-snooze endpoint and its
+//! interaction with the push-skip helper.
+//!
+//! See `apps/server/migrations/20260528000000_notification_snooze.sql`
+//! and `routes::users::update_snooze`.
+
+mod common;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use reqwest::Client;
+use serde_json::Value;
+use uuid::Uuid;
+
+const SNOOZE_PATH: &str = "/api/users/me/notifications/snooze";
+
+async fn setup_user(client: &Client, base: &str, prefix: &str) -> (String, String) {
+    let username = common::unique_username(prefix);
+    common::register(client, base, &username, "password123").await;
+    common::login(client, base, &username, "password123").await
+}
+
+#[tokio::test]
+async fn snooze_with_valid_until_persists_and_returned_by_me() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _user_id) = setup_user(&client, &base, "snzset").await;
+
+    let until = Utc::now() + ChronoDuration::hours(2);
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "until": until.to_rfc3339() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // GET /api/users/me should now include the same timestamp.
+    let me = client
+        .get(format!("{base}/api/users/me"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(me.status().as_u16(), 200);
+    let body: Value = me.json().await.unwrap();
+    let echoed = body["notifications_snoozed_until"]
+        .as_str()
+        .expect("snooze field missing");
+    let parsed = chrono::DateTime::parse_from_rfc3339(echoed).unwrap();
+    // Timestamps round-trip to within a second.
+    assert!((parsed.with_timezone(&Utc) - until).num_seconds().abs() < 2);
+}
+
+#[tokio::test]
+async fn snooze_with_duration_hours_succeeds() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _) = setup_user(&client, &base, "snzhrs").await;
+
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "duration_hours": 8 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["notifications_snoozed_until"].is_string());
+}
+
+#[tokio::test]
+async fn snooze_with_past_until_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _) = setup_user(&client, &base, "snzpast").await;
+
+    let past = Utc::now() - ChronoDuration::minutes(5);
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "until": past.to_rfc3339() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn snooze_with_window_over_seven_days_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _) = setup_user(&client, &base, "snzlong").await;
+
+    let too_far = Utc::now() + ChronoDuration::days(8);
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "until": too_far.to_rfc3339() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+
+    // duration_hours variant — 8 days = 192 hours.
+    let resp2 = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "duration_hours": 192 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp2.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn snooze_with_explicit_null_clears() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token, _) = setup_user(&client, &base, "snzclr").await;
+
+    // First snooze for an hour.
+    let until = Utc::now() + ChronoDuration::hours(1);
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "until": until.to_rfc3339() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // Clear via explicit null.
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({ "until": null }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["notifications_snoozed_until"].is_null());
+}
+
+#[tokio::test]
+async fn snooze_endpoint_requires_auth() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .json(&serde_json::json!({ "duration_hours": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// Push-skip behaviour
+//
+// The push fan-out path calls `db::users::snoozed_user_ids` to decide which
+// recipients to drop. APNs is mocked out by the production code path when
+// `APNS_KEY_ID` is unset (the test env), so we drive the helper directly to
+// prove the skip is correct AND that expired snoozes are lazily cleared.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn snoozed_user_ids_filters_active_snoozes_and_clears_expired() {
+    use sqlx::Row;
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (token_active, active_id) = setup_user(&client, &base, "snzactive").await;
+    let (_token_expired, expired_id) = setup_user(&client, &base, "snzexpired").await;
+    let (_token_clean, clean_id) = setup_user(&client, &base, "snzclean").await;
+
+    // Active user snoozes for 1h.
+    let until = Utc::now() + ChronoDuration::hours(1);
+    let resp = client
+        .patch(format!("{base}{SNOOZE_PATH}"))
+        .header("Authorization", format!("Bearer {token_active}"))
+        .json(&serde_json::json!({ "until": until.to_rfc3339() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // Use the same Postgres the test server uses; mirror common::spawn_server.
+    let database_url = std::env::var("TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("TEST_DATABASE_URL or DATABASE_URL must be set");
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await
+        .expect("connect test pg");
+
+    // Hand-set the "expired" user's snooze to 5 minutes ago, bypassing the
+    // 400 validator — we are simulating a stale snooze the user set days ago.
+    let expired_uuid = Uuid::parse_str(&expired_id).unwrap();
+    let stale = Utc::now() - ChronoDuration::minutes(5);
+    sqlx::query("UPDATE users SET notifications_snoozed_until = $1 WHERE id = $2")
+        .bind(stale)
+        .bind(expired_uuid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let active_uuid = Uuid::parse_str(&active_id).unwrap();
+    let clean_uuid = Uuid::parse_str(&clean_id).unwrap();
+
+    let snoozed =
+        echo_server::db::users::snoozed_user_ids(&pool, &[active_uuid, expired_uuid, clean_uuid])
+            .await
+            .unwrap();
+
+    // Active user is the only one returned. Expired user is dropped AND
+    // their column was lazily cleared as a side-effect.
+    assert_eq!(snoozed, vec![active_uuid]);
+
+    let row = sqlx::query("SELECT notifications_snoozed_until FROM users WHERE id = $1")
+        .bind(expired_uuid)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let cleared: Option<chrono::DateTime<Utc>> = row.get(0);
+    assert!(cleared.is_none(), "expired snooze should be lazily cleared");
+}


### PR DESCRIPTION
Adds a notification snooze toggle so users can silence push for a chosen window without disabling DMs or push entirely. The server skips APNs delivery while the snooze is active and lazily clears expired snoozes on the push path.

## New
- Settings → Notifications gets a Snooze section with four presets: 1 hour, 8 hours, 24 hours, or until tomorrow morning (9 AM local).
- Sidebar settings icon shows a small bell-with-slash badge while snoozed; the tooltip reads "Notifications snoozed until 9:30 PM" so a glance is enough.
- Snooze survives restarts (persisted on the server) and auto-expires the UI when the window elapses.

## Improved
- `GET /api/users/me` now returns `notifications_snoozed_until` so the client doesn't need a second round-trip on startup.

## Behind the scenes
- New `users.notifications_snoozed_until TIMESTAMPTZ` column (migration `20260528000000_notification_snooze.sql`).
- `PATCH /api/users/me/notifications/snooze` accepts either an explicit ISO-8601 `until` or a convenience `duration_hours` (max 7 days; past/oversize windows return 400).
- Push fan-out filters via `db::users::snoozed_user_ids`, which also lazily clears expired snoozes so the column self-cleans.
- 7 new server tests in `apps/server/tests/api_snooze.rs`; 6 new client provider tests + 3 new `UserAvatar` widget tests.