### PR TITLE
Fix voice-lounge canvas: drawings now pan/zoom with the grid + restore scroll-wheel zoom

### DIFF
--- a/apps/client/lib/src/widgets/voice_lounge/lounge_canvas_gestures.dart
+++ b/apps/client/lib/src/widgets/voice_lounge/lounge_canvas_gestures.dart
@@ -18,6 +18,7 @@
 // lands. The widget compiles standalone.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'canvas_gesture_state.dart';
@@ -297,6 +298,25 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
     _handleLift(event.pointer, cancelled: true);
   }
 
+  /// Desktop zoom: mouse wheel / trackpad scroll zooms around the cursor.
+  /// The pre-rewrite `InteractiveViewer` did this for free; the raw-Listener
+  /// rewrite dropped it, so desktop users had no zoom affordance besides
+  /// double-tap. Scroll up zooms in, scroll down zooms out (~10% per notch),
+  /// clamped to [widget.minScale]/[widget.maxScale].
+  void _onPointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) return;
+    final currentScale = _transform.getMaxScaleOnAxis();
+    final factor = event.scrollDelta.dy < 0 ? 1.1 : 1 / 1.1;
+    final target = (currentScale * factor).clamp(
+      widget.minScale,
+      widget.maxScale,
+    );
+    if ((target - currentScale).abs() < 1e-9) return;
+    _transform = _zoomAround(_transform, event.localPosition, target);
+    _emitTransform();
+    if (mounted) setState(() {});
+  }
+
   void _handleLift(int pointerId, {required bool cancelled}) {
     if (!_pointers.containsKey(pointerId)) return;
     _pointers.remove(pointerId);
@@ -377,6 +397,12 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
     _transform = Matrix4.copy(_transform)
       ..setTranslationRaw(t.x + delta.dx, t.y + delta.dy, t.z);
     _emitTransform();
+    // Rebuild so the Transform in build() re-applies the new matrix to the
+    // canvas child. Without this, pan only moved the grid (which re-projects
+    // from onTransformChanged) while the strokes/avatars stayed put — they
+    // decoupled. _handleDoubleTap / resetToTransform already setState; pan +
+    // pinch were the two transform mutators that didn't.
+    if (mounted) setState(() {});
   }
 
   void _seedPinch() {
@@ -431,6 +457,10 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
     // analyzer doesn't drop the clamp branch — and it documents intent.
     assert(clampedRatio > 0);
     _emitTransform();
+    // Rebuild so the Transform re-applies the new scale/translate to the
+    // canvas child (see _applyPanDelta). Without it pinch zoomed only the
+    // grid, never the strokes/avatars.
+    if (mounted) setState(() {});
   }
 
   void _emitTransform() {
@@ -484,6 +514,7 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
           onPointerMove: _onPointerMove,
           onPointerUp: _onPointerUp,
           onPointerCancel: _onPointerCancel,
+          onPointerSignal: _onPointerSignal,
           child: Transform(transform: _transform, child: widget.child),
         ),
       ),

--- a/apps/client/test/widgets/voice_lounge/lounge_canvas_gestures_test.dart
+++ b/apps/client/test/widgets/voice_lounge/lounge_canvas_gestures_test.dart
@@ -101,6 +101,32 @@ Future<void> _pointerCancel(
   await tester.pump();
 }
 
+Future<void> _scroll(
+  WidgetTester tester, {
+  required Offset at,
+  required double dy,
+}) async {
+  final hitTest = HitTestResult();
+  WidgetsBinding.instance.hitTestInView(hitTest, at, tester.view.viewId);
+  WidgetsBinding.instance.dispatchEvent(
+    PointerScrollEvent(position: at, scrollDelta: Offset(0, dy)),
+    hitTest,
+  );
+  await tester.pump();
+}
+
+/// The matrix actually applied to the canvas child — i.e. the `Transform`
+/// widget rendered by the gesture surface. Distinct from `state.transform`
+/// (the field): a regression where pan/pinch mutate the field but never
+/// rebuild only shows up here.
+Matrix4 _renderedTransform(WidgetTester tester, Key key) => tester
+    .widget<Transform>(
+      find
+          .descendant(of: find.byKey(key), matching: find.byType(Transform))
+          .first,
+    )
+    .transform;
+
 void main() {
   group('resolveTransition (pure state machine)', () {
     test('idle + down with tool → drawing + startStroke', () {
@@ -603,6 +629,68 @@ void main() {
         state.debugTransform.getMaxScaleOnAxis(),
         closeTo(1.0, 0.01),
         reason: 'a double-tap zoom must not fire from the 2nd pan finger',
+      );
+    });
+
+    // Regression (canvas-rewrite #1278): pan mutated `_transform` and emitted
+    // it to the grid, but never setState, so the Transform wrapping the canvas
+    // child kept the old matrix — the grid moved while strokes/avatars stayed
+    // put. Assert the RENDERED transform follows the pan, not just the field.
+    testWidgets('pan moves the rendered canvas transform, not just the field', (
+      tester,
+    ) async {
+      final rec = _Recorder();
+      const key = ValueKey('pan-render');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _harness(rec: rec, isToolSelected: false, key: key),
+        ),
+      );
+
+      await _pointerDown(
+        tester,
+        () => null,
+        at: const Offset(400, 300),
+        pointer: 1,
+      );
+      await _pointerMove(tester, to: const Offset(460, 340), pointer: 1);
+
+      final rendered = _renderedTransform(tester, key);
+      final field = _stateOf(tester, key).debugTransform;
+      expect(
+        rendered.getTranslation().x,
+        closeTo(field.getTranslation().x, 0.01),
+      );
+      expect(
+        rendered.getTranslation().y,
+        closeTo(field.getTranslation().y, 0.01),
+      );
+      // A 60x40 drag must actually have moved the rendered transform.
+      expect(rendered.getTranslation().x, closeTo(60, 0.01));
+      expect(rendered.getTranslation().y, closeTo(40, 0.01));
+    });
+
+    // Regression (canvas-rewrite #1278): desktop scroll-wheel zoom was lost
+    // when InteractiveViewer was replaced by the raw Listener. Scroll up must
+    // zoom in around the cursor and update the rendered transform.
+    testWidgets('mouse-wheel scroll zooms the canvas', (tester) async {
+      final rec = _Recorder();
+      const key = ValueKey('scroll-zoom');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _harness(rec: rec, isToolSelected: false, key: key),
+        ),
+      );
+
+      final before = _stateOf(tester, key).debugTransform.getMaxScaleOnAxis();
+      await _scroll(tester, at: const Offset(400, 300), dy: -120); // scroll up
+      final after = _stateOf(tester, key).debugTransform.getMaxScaleOnAxis();
+
+      expect(after, greaterThan(before), reason: 'scroll up should zoom in');
+      expect(
+        _renderedTransform(tester, key).getMaxScaleOnAxis(),
+        closeTo(after, 0.01),
+        reason: 'the rendered transform must reflect the scroll zoom',
       );
     });
   });


### PR DESCRIPTION
Two regressions from the canvas rewrite (#1278), reported on live test:

## Fixed
- **Drawings now move with the background.** Panning and pinch-zoom updated the grid but left the strokes/avatars behind — they only redrew on double-tap or reset-view. The whole canvas now transforms together.
- **Scroll-wheel / trackpad zoom works again on desktop.** It was lost when `InteractiveViewer` (which zoomed on wheel for free) was replaced by the raw gesture `Listener`. Restored via `onPointerSignal`, zooming around the cursor.

## Behind the scenes
Root cause: `_applyPanDelta` / `_applyPinch` mutated the transform field and re-projected the grid via the `onTransformChanged` callback, but never `setState`, so the `Transform` wrapping the canvas child kept its old matrix (`_handleDoubleTap` / `resetToTransform` did setState, which is why those worked). Added the missing rebuilds + an `onPointerSignal` scroll handler.

New regression tests assert the **rendered** transform (not just the internal field — which always updated, masking the bug) follows a pan, and that scrolling zooms.

## Verification
- Gesture suite + canvas/voice-lounge suite green (160 tests); analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)