### PR TITLE
Fix voice-lounge fullscreen + rejoin crash and stop Linux notification spam crash

### DIFF
--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -330,7 +330,16 @@ mixin _HomeScreenDesktopLayoutMixin
                       _buildDesktopSidebar(sidebarWidth, animatedSidebarWidth),
                       _buildResizeHandle(),
                     ],
-                    Expanded(child: rightPanel),
+                    // Stable key so toggling fullscreen (which adds/removes
+                    // the leading sidebar + trailing members siblings) REORDERS
+                    // this slot instead of re-inflating it. Without it the
+                    // VoiceLoungeScreen State was torn down + rebuilt on every
+                    // fullscreen toggle — which broke fullscreen (dispose
+                    // clears the flag) and thrashed canvas/LiveKit state.
+                    Expanded(
+                      key: const ValueKey('home-right-panel'),
+                      child: rightPanel,
+                    ),
                     if (!loungeFullscreen) ..._buildMembersPanel(),
                   ],
                 ),

--- a/apps/client/lib/src/screens/home_screen/parts/wide_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/wide_layout.dart
@@ -79,7 +79,14 @@ mixin _HomeScreenWideLayoutMixin
                         SizedBox(width: 300, child: _buildConversationPanel()),
                       Container(width: 1, color: context.border),
                     ],
-                    Expanded(child: rightPanel),
+                    // Stable key so toggling fullscreen (removes the leading
+                    // sidebar siblings) reorders this slot instead of
+                    // re-inflating it — preserves the VoiceLoungeScreen State
+                    // (see desktop_layout for the full rationale).
+                    Expanded(
+                      key: const ValueKey('home-right-panel'),
+                      child: rightPanel,
+                    ),
                   ],
                 ),
                 if (_self._whatsNewNotes != null)

--- a/apps/client/lib/src/services/notification_service_stub.dart
+++ b/apps/client/lib/src/services/notification_service_stub.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/foundation.dart'
+    show debugPrint, defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -33,6 +34,23 @@ class _NativeNotificationService implements NotificationService {
   /// that were queued while offline still trigger local notifications.
   static DateTime _lastForeground = DateTime.now();
   static int _fallbackId = 100000;
+
+  /// Serializes notification shows so a burst (e.g. an undelivered-message
+  /// backlog draining on reconnect) can't fire dozens of `_plugin.show()`
+  /// calls in the same tick. Each show awaits the previous; errors are
+  /// swallowed so one failed toast never escapes as an unhandled async
+  /// exception.
+  static Future<void> _showChain = Future<void>.value();
+
+  /// Timestamp of the last actual `_plugin.show()` — drives the Linux
+  /// min-spacing below.
+  static DateTime? _lastShowAt;
+
+  /// freedesktop notification daemons reject rapid bursts with
+  /// `org.freedesktop.Notifications.Error.ExcessNotificationGeneration`
+  /// (~3/sec). Space successive Linux shows out so a backlog trickles
+  /// instead of crashing. Other platforms have no such limit → no delay.
+  static const Duration _kLinuxMinShowInterval = Duration(milliseconds: 400);
 
   // Cached notification preferences (loaded from SharedPreferences).
   static bool _notificationsEnabled = true;
@@ -235,8 +253,31 @@ class _NativeNotificationService implements NotificationService {
     bool isGroup,
     String? conversationName,
   ) {
-    _ensureInitialized().then((_) {
+    // Enqueue on the serialized chain so concurrent calls don't burst the
+    // platform's notification daemon. `.catchError` keeps the chain alive if
+    // a single dispatch throws.
+    _showChain = _showChain.then(
+      (_) => _dispatchNotification(
+        conversationId,
+        senderUsername,
+        body,
+        isGroup,
+        conversationName,
+      ),
+    );
+  }
+
+  Future<void> _dispatchNotification(
+    String? conversationId,
+    String senderUsername,
+    String body,
+    bool isGroup,
+    String? conversationName,
+  ) async {
+    try {
+      await _ensureInitialized();
       if (!_initialized) return;
+      await _throttleLinuxShow();
 
       final notificationId = _idForConversation(conversationId);
       final androidDetails = isGroup ? _groupChannel : _dmChannel;
@@ -250,7 +291,7 @@ class _NativeNotificationService implements NotificationService {
         presentSound: true,
       );
 
-      _plugin.show(
+      await _plugin.show(
         id: notificationId,
         title: senderUsername,
         body: body,
@@ -261,7 +302,30 @@ class _NativeNotificationService implements NotificationService {
         ),
         payload: conversationId,
       );
-    });
+    } catch (e) {
+      // Swallow + log. The Linux DBus daemon can still reject a show with
+      // ExcessNotificationGeneration under a heavy burst even with spacing;
+      // a dropped toast must never crash the app.
+      DebugLogService.instance.log(
+        LogLevel.warning,
+        'Notifications',
+        'show dropped: $e',
+      );
+    }
+  }
+
+  /// On Linux, sleep until at least [_kLinuxMinShowInterval] has elapsed since
+  /// the previous show. No-op on web and non-Linux platforms.
+  Future<void> _throttleLinuxShow() async {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.linux) return;
+    final last = _lastShowAt;
+    if (last != null) {
+      final elapsed = DateTime.now().difference(last);
+      if (elapsed < _kLinuxMinShowInterval) {
+        await Future<void>.delayed(_kLinuxMinShowInterval - elapsed);
+      }
+    }
+    _lastShowAt = DateTime.now();
   }
 
   @override


### PR DESCRIPTION
Three reported issues, two root causes.

## Fixed
- **Fullscreen voice lounge works again, and rejoining no longer thrashes.** The home layout's right-panel slot had no key, so toggling fullscreen (which adds/removes the sidebar + members panels) shifted its position and re-inflated the whole lounge subtree — destroying and rebuilding `VoiceLoungeScreen` every time. That both cleared the fullscreen flag instantly (so fullscreen never stuck) and churned the canvas/LiveKit state on rejoin. A stable key makes the layout reorder the slot instead.
- **Linux desktop no longer crashes on a burst of notifications.** Draining an undelivered-message backlog on reconnect fired many notifications in one tick; the desktop notification daemon rejected the burst (`ExcessNotificationGeneration`) and it surfaced as an unhandled crash. Notifications are now serialized, spaced ~400ms apart on Linux, and a dropped toast can never crash the app.

## Verification
- Screen + voice-lounge widget suites green (225 tests); analyze clean.

Note: the LiveKit `Signal request timed out` on rejoin (seen in the same log) is a separate SFU connect timeout; the churn fix removes the state-thrash that aggravated it. Will keep an eye on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)