### PR TITLE
Add a voice-lounge canvas minimap

### DIFF
--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -45,6 +45,7 @@ import '../widgets/confirm_dialog.dart';
 import '../widgets/echo_bottom_sheet.dart';
 import '../widgets/voice_lounge/canvas_debug_overlay.dart';
 import '../widgets/voice_lounge/canvas_loading_banner.dart';
+import '../widgets/voice_lounge/canvas_minimap.dart';
 import '../widgets/voice_lounge/encrypted_canvas_notice.dart';
 import '../widgets/voice_lounge/lounge_canvas_gestures.dart';
 import '../widgets/voice_lounge/lounge_canvas_strokes.dart';
@@ -1588,7 +1589,22 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         ),
       ),
     );
-    if (!_kDebugCanvas) return gestures;
+    // Minimap overlay (bottom-left, clear of the bottom-centre dock and the
+    // top-right view controls) so the user can see where they are on the
+    // 100k surface and tap/drag to jump there (#4, #5).
+    final minimap = Positioned(
+      left: 12,
+      bottom: 12,
+      child: CanvasMinimap(
+        transform: _canvasTransform,
+        viewportSize: viewportSize,
+        onRecenter: _recenterViewportOn,
+      ),
+    );
+
+    if (!_kDebugCanvas) {
+      return Stack(fit: StackFit.expand, children: [gestures, minimap]);
+    }
     // Dev-only on-canvas debug HUD. The painter + counts sit in
     // viewport coordinate space (outside the Transform) so values stay
     // readable regardless of pan / zoom. Wrapped in IgnorePointer
@@ -1597,6 +1613,7 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
       fit: StackFit.expand,
       children: [
         gestures,
+        minimap,
         CanvasDebugOverlay(
           gesturesKey: _canvasGesturesKey,
           canvas: canvas,
@@ -1605,6 +1622,23 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         ),
       ],
     );
+  }
+
+  /// Recenter the main canvas viewport on [canvasPoint] (keeping the current
+  /// zoom). Driven by taps/drags on the [CanvasMinimap].
+  void _recenterViewportOn(Offset canvasPoint) {
+    final size = _interactiveViewportSize;
+    if (size == null) return;
+    final scale = _canvasTransform.value.getMaxScaleOnAxis();
+    if (scale <= 0 || !scale.isFinite) return;
+    final next = Matrix4.identity()
+      ..scaleByDouble(scale, scale, scale, 1)
+      ..setTranslationRaw(
+        size.width / 2 - canvasPoint.dx * scale,
+        size.height / 2 - canvasPoint.dy * scale,
+        0,
+      );
+    _canvasGesturesKey.currentState?.resetToTransform(next);
   }
 
   /// Persist the latest LayoutBuilder constraints so the reset-view

--- a/apps/client/lib/src/widgets/voice_lounge/canvas_minimap.dart
+++ b/apps/client/lib/src/widgets/voice_lounge/canvas_minimap.dart
@@ -1,0 +1,258 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../models/canvas_models.dart';
+import '../../providers/canvas_provider.dart';
+
+/// Small overview map of the voice-lounge canvas, shown in a corner while in
+/// canvas view. It draws every piece of placed content (strokes, images,
+/// screen-share windows, dragged avatars) plus the current viewport rectangle,
+/// scaled to fit — so the user can see where they are on the otherwise vast
+/// 100k×100k surface and tap/drag to jump there (#4, #5).
+///
+/// The "world" the minimap shows is the union of all content and the current
+/// viewport, so the viewport indicator is always visible even when you've
+/// panned far into empty space.
+class CanvasMinimap extends ConsumerWidget {
+  const CanvasMinimap({
+    super.key,
+    required this.transform,
+    required this.viewportSize,
+    required this.onRecenter,
+    this.width = 168,
+    this.height = 116,
+  });
+
+  /// Live canvas transform (viewport ← canvas). Drives the viewport rectangle.
+  final ValueListenable<Matrix4> transform;
+
+  /// Size of the main canvas viewport in logical pixels.
+  final Size viewportSize;
+
+  /// Called with the canvas-space point the user tapped/dragged on the map.
+  /// The lounge recenters the main view on it (keeping the current zoom).
+  final void Function(Offset canvasPoint) onRecenter;
+
+  final double width;
+  final double height;
+
+  static const double _pad = 8;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final canvas = ref.watch(canvasProvider);
+    return ValueListenableBuilder<Matrix4>(
+      valueListenable: transform,
+      builder: (context, matrix, _) {
+        final viewportRect = _viewportInCanvas(matrix, viewportSize);
+        final world = _worldRect(canvas, viewportRect);
+        if (world == null) return const SizedBox.shrink();
+
+        final inner = Rect.fromLTWH(
+          _pad,
+          _pad,
+          width - _pad * 2,
+          height - _pad * 2,
+        );
+        final proj = _MinimapProjection.fit(world, inner);
+
+        void recenterFrom(Offset boxPoint) =>
+            onRecenter(proj.boxToWorld(boxPoint));
+
+        final scheme = Theme.of(context).colorScheme;
+        return GestureDetector(
+          onTapDown: (d) => recenterFrom(d.localPosition),
+          onPanUpdate: (d) => recenterFrom(d.localPosition),
+          child: Container(
+            width: width,
+            height: height,
+            decoration: BoxDecoration(
+              color: scheme.surface.withValues(alpha: 0.85),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: scheme.outlineVariant),
+              boxShadow: const [
+                BoxShadow(blurRadius: 6, color: Color(0x33000000)),
+              ],
+            ),
+            child: CustomPaint(
+              painter: _MinimapPainter(
+                canvas: canvas,
+                viewportRect: viewportRect,
+                proj: proj,
+                accent: scheme.primary,
+                content: scheme.onSurfaceVariant,
+                share: scheme.tertiary,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// The viewport's footprint in canvas space (unproject the screen corners).
+  static Rect _viewportInCanvas(Matrix4 matrix, Size viewport) {
+    final inv = Matrix4.copy(matrix)..invert();
+    final tl = MatrixUtils.transformPoint(inv, Offset.zero);
+    final br = MatrixUtils.transformPoint(
+      inv,
+      Offset(viewport.width, viewport.height),
+    );
+    return Rect.fromPoints(tl, br);
+  }
+
+  /// Union of all placed content and the viewport, padded 8% so nothing
+  /// touches the minimap edge. Returns null only if there is genuinely
+  /// nothing finite to show.
+  static Rect? _worldRect(CanvasState canvas, Rect viewportRect) {
+    Rect? bounds = _finiteRect(viewportRect);
+    Rect grow(Rect? acc, Rect r) => acc == null ? r : acc.expandToInclude(r);
+
+    for (final s in canvas.strokes) {
+      for (final p in s.points) {
+        bounds = grow(bounds, Rect.fromLTWH(p.x, p.y, 0, 0));
+      }
+    }
+    for (final img in canvas.images) {
+      bounds = grow(bounds, Rect.fromLTWH(img.x, img.y, img.width, img.height));
+    }
+    for (final w in canvas.screenSharePositions.values) {
+      bounds = grow(bounds, Rect.fromLTWH(w.x, w.y, w.width, w.height));
+    }
+    for (final a in canvas.avatarPositions.values) {
+      bounds = grow(bounds, Rect.fromLTWH(a.x, a.y, 0, 0));
+    }
+    final result = bounds;
+    if (result == null) return null;
+    final pad = math.max(result.width, result.height) * 0.08 + 1;
+    return result.inflate(pad);
+  }
+
+  static Rect? _finiteRect(Rect r) {
+    if (!r.left.isFinite ||
+        !r.top.isFinite ||
+        !r.right.isFinite ||
+        !r.bottom.isFinite) {
+      return null;
+    }
+    return r;
+  }
+}
+
+/// Linear map between canvas-world space and the minimap box.
+class _MinimapProjection {
+  const _MinimapProjection(this.world, this.fit, this.offset);
+
+  final Rect world;
+  final double fit;
+  final Offset offset; // box-space position of world.topLeft
+
+  factory _MinimapProjection.fit(Rect world, Rect inner) {
+    final w = world.width <= 0 ? 1.0 : world.width;
+    final h = world.height <= 0 ? 1.0 : world.height;
+    final fit = math.min(inner.width / w, inner.height / h);
+    final drawnW = w * fit;
+    final drawnH = h * fit;
+    final offset = Offset(
+      inner.left + (inner.width - drawnW) / 2,
+      inner.top + (inner.height - drawnH) / 2,
+    );
+    return _MinimapProjection(world, fit, offset);
+  }
+
+  Offset worldToBox(double x, double y) => Offset(
+    offset.dx + (x - world.left) * fit,
+    offset.dy + (y - world.top) * fit,
+  );
+
+  Rect rectToBox(Rect r) =>
+      Rect.fromPoints(worldToBox(r.left, r.top), worldToBox(r.right, r.bottom));
+
+  Offset boxToWorld(Offset b) => Offset(
+    (b.dx - offset.dx) / fit + world.left,
+    (b.dy - offset.dy) / fit + world.top,
+  );
+}
+
+class _MinimapPainter extends CustomPainter {
+  _MinimapPainter({
+    required this.canvas,
+    required this.viewportRect,
+    required this.proj,
+    required this.accent,
+    required this.content,
+    required this.share,
+  });
+
+  final CanvasState canvas;
+  final Rect viewportRect;
+  final _MinimapProjection proj;
+  final Color accent;
+  final Color content;
+  final Color share;
+
+  @override
+  void paint(Canvas c, Size size) {
+    // Strokes: one faint dot per stroke origin (cheap; conveys spread).
+    final strokePaint = Paint()..color = content.withValues(alpha: 0.55);
+    for (final s in canvas.strokes) {
+      if (s.points.isEmpty) continue;
+      final p = proj.worldToBox(s.points.first.x, s.points.first.y);
+      c.drawCircle(p, 1.2, strokePaint);
+    }
+
+    // Images: small filled rects.
+    final imgPaint = Paint()..color = content.withValues(alpha: 0.5);
+    for (final img in canvas.images) {
+      c.drawRect(
+        proj.rectToBox(Rect.fromLTWH(img.x, img.y, img.width, img.height)),
+        imgPaint,
+      );
+    }
+
+    // Screen-share windows: distinct accent rects so they stand out.
+    final sharePaint = Paint()..color = share.withValues(alpha: 0.8);
+    for (final w in canvas.screenSharePositions.values) {
+      c.drawRect(
+        proj.rectToBox(Rect.fromLTWH(w.x, w.y, w.width, w.height)),
+        sharePaint,
+      );
+    }
+
+    // Dragged avatars: dots.
+    final avatarPaint = Paint()..color = accent.withValues(alpha: 0.9);
+    for (final a in canvas.avatarPositions.values) {
+      c.drawCircle(proj.worldToBox(a.x, a.y), 2.0, avatarPaint);
+    }
+
+    // The current viewport rectangle.
+    final viewBox = proj.rectToBox(viewportRect);
+    c.drawRect(
+      viewBox,
+      Paint()
+        ..color = accent.withValues(alpha: 0.12)
+        ..style = PaintingStyle.fill,
+    );
+    c.drawRect(
+      viewBox,
+      Paint()
+        ..color = accent
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.5,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_MinimapPainter old) =>
+      old.viewportRect != viewportRect ||
+      !identical(old.canvas.strokes, canvas.strokes) ||
+      !identical(old.canvas.images, canvas.images) ||
+      !identical(
+        old.canvas.screenSharePositions,
+        canvas.screenSharePositions,
+      ) ||
+      !identical(old.canvas.avatarPositions, canvas.avatarPositions);
+}

--- a/apps/client/test/widgets/voice_lounge/canvas_minimap_test.dart
+++ b/apps/client/test/widgets/voice_lounge/canvas_minimap_test.dart
@@ -1,0 +1,87 @@
+import 'package:echo_app/src/widgets/voice_lounge/canvas_minimap.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<Offset?> _pumpAndTap(
+  WidgetTester tester, {
+  required Matrix4 transform,
+  required Size viewportSize,
+  Offset? tapAt,
+}) async {
+  Offset? recentered;
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: CanvasMinimap(
+              transform: ValueNotifier<Matrix4>(transform),
+              viewportSize: viewportSize,
+              onRecenter: (p) => recentered = p,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  if (tapAt == null) {
+    await tester.tap(find.byType(CanvasMinimap));
+  } else {
+    await tester.tapAt(tapAt);
+  }
+  await tester.pump();
+  return recentered;
+}
+
+void main() {
+  group('CanvasMinimap', () {
+    testWidgets('renders without content', (tester) async {
+      await _pumpAndTap(
+        tester,
+        transform: Matrix4.identity(),
+        viewportSize: const Size(400, 300),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CanvasMinimap), findsOneWidget);
+    });
+
+    testWidgets('tapping the centre recenters on the viewport centre', (
+      tester,
+    ) async {
+      // Identity transform + 400x300 viewport → the visible canvas region is
+      // (0,0)-(400,300), so its centre is (200,150). Tapping the minimap
+      // centre must recenter the main view there.
+      final recentered = await _pumpAndTap(
+        tester,
+        transform: Matrix4.identity(),
+        viewportSize: const Size(400, 300),
+      );
+      final r = recentered;
+      expect(r, isNotNull);
+      expect(r!.dx, closeTo(200, 2));
+      expect(r.dy, closeTo(150, 2));
+    });
+
+    testWidgets('recenter point follows a panned/zoomed transform', (
+      tester,
+    ) async {
+      // Zoomed 2x and translated so the visible region is offset into the
+      // canvas. Visible canvas region = unproject of the screen corners:
+      // with scale 2 and translation (-1000,-800), screen (0,0)→canvas
+      // (500,400) and screen (400,300)→canvas (700,550); centre (600,475).
+      final t = Matrix4.identity()
+        ..scaleByDouble(2, 2, 2, 1)
+        ..setTranslationRaw(-1000, -800, 0);
+      final recentered = await _pumpAndTap(
+        tester,
+        transform: t,
+        viewportSize: const Size(400, 300),
+      );
+      final r = recentered;
+      expect(r, isNotNull);
+      expect(r!.dx, closeTo(600, 3));
+      expect(r.dy, closeTo(475, 3));
+    });
+  });
+}


### PR DESCRIPTION
The orientation aid requested for the canvas (#4's "minimap sort of thing", and helps with #5 "find the avatar / screen-share").

## New
- A small overview map in the bottom-left of the canvas view. It draws everything placed on the canvas — strokes, images, screen-share windows, dragged avatars — plus an outline of your current viewport, all scaled to fit. So you can see where you are on the 100k surface and what's out there.
- **Tap or drag the minimap to jump there** — the main view recenters on that point, keeping your current zoom.
- Hidden in spotlight mode and when there's nothing to show.

## Verification
- New widget tests cover the tap-to-recenter projection at identity and under a panned/zoomed transform; voice-lounge suite green (128 tests); analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)