### PR TITLE
Bound the voice-lounge canvas for beta and open centered on the group

### DIFF
--- a/apps/client/lib/src/models/canvas_models.dart
+++ b/apps/client/lib/src/models/canvas_models.dart
@@ -4,25 +4,30 @@ import 'dart:ui' show Color;
 // Canvas geometry helpers
 // ---------------------------------------------------------------------------
 
-/// Virtual canvas size. 100k×100k is large enough to feel infinite for any
-/// realistic call (at default 1× zoom you'd have to drag your finger across
-/// the screen ~250 times to cross it) while staying inside the range where
-/// Flutter's transformation math and floating-point precision behave well.
-/// Treat the lounge as a Figma-style pannable surface where the user lands
-/// in a default region (origin, or the bbox of existing content on
-/// rejoin) and can zoom out repeatedly to see more.
+/// Virtual canvas size. For beta this is a *bounded* 6000×6000 board (≈ 3×3
+/// desktop screens at 1× zoom) rather than a near-infinite surface: the
+/// gesture layer clamps pan/zoom to these bounds, so the whole board is
+/// always reachable and you can't get lost in empty space. Avatars cluster
+/// in the centre (the default ring radius is a fraction of this) and the
+/// lounge opens framing the whole board.
 ///
-/// Old call-sites of `kCanvasWidth` from the 4096-era still work as a
-/// "clamp coords to the canvas" guard, but the value is now so large the
-/// clamp is effectively a no-op for any realistic input.
-const double kCanvasWidth = 100000;
-const double kCanvasHeight = 100000;
+/// Going "infinite" later is just raising this constant and dropping the
+/// clamp — everything else (the ring, image spawn, the initial pose, the
+/// coord clamps) is defined relative to it.
+const double kCanvasWidth = 6000;
+const double kCanvasHeight = 6000;
 
-/// Legacy 4096-px canvas size, used by [_migrateLegacyCoord] so old
-/// persisted strokes land where they were drawn (in the top-left 4% of
-/// the new 100k space) instead of being rescaled to fill the new range.
-/// Auto-fit-to-content on join zooms the user to that region naturally,
-/// so users never notice the canvas got bigger underneath them.
+/// Default avatar-ring radius as a fraction of the canvas. Un-dragged
+/// participants sit on a circle of `kDefaultAvatarRingFraction * kCanvasWidth`
+/// around the centre. Kept small so people cluster near the middle and the
+/// lounge can open zoomed-in on the group. Shared by the avatar layout
+/// (`voice_canvas.dart`) and the initial pose (`voice_lounge_screen.dart`).
+const double kDefaultAvatarRingFraction = 0.15;
+
+/// Legacy normalised-coordinate scale, used by [_migrateLegacyCoord] to map
+/// very old strokes persisted as 0..1 fractions into absolute pixels. Kept at
+/// 4096 (the pre-bounded canvas size) for backwards-compatibility; auto-fit
+/// on join frames whatever content exists regardless.
 const double _kLegacyNormalisedScale = 4096;
 
 /// Running count of how many times [_migrateLegacyCoord] has applied the

--- a/apps/client/lib/src/screens/voice_lounge_screen.dart
+++ b/apps/client/lib/src/screens/voice_lounge_screen.dart
@@ -20,6 +20,7 @@ import '../models/canvas_models.dart'
         StrokeKind,
         kCanvasHeight,
         kCanvasWidth,
+        kDefaultAvatarRingFraction,
         strokeKindForTool;
 import '../providers/auth_provider.dart';
 import '../providers/canvas_authority_provider.dart';
@@ -70,18 +71,11 @@ const double _kAvatarTileRadius = 24.0;
 /// Minimum canvas zoom. ~0.02 lets the whole 100k×100k surface fit a typical
 /// viewport (viewport / kCanvasWidth) so the user can zoom all the way out to
 /// see everything and find content that drifted far away (#4).
-const double _kCanvasMinScale = 0.02;
-
-/// Canvas-space radius of the default avatar ring used by
-/// `voice_canvas.dart`'s `_defaultAvatarPos` when no one has dragged
-/// their puck yet. Default positions sit on a circle of this radius
-/// around the canvas centre; the initial-pose fallback zooms out far
-/// enough to frame that entire ring so a fresh joiner sees every
-/// participant (including their own avatar) without panning across
-/// 50 000 canvas-pixels first. Mirrors the `0.3 * kCanvasWidth`
-/// magic number in `_defaultAvatarPos`; kept in sync with that
-/// helper by the `voice_canvas` widget tests.
-const double _kDefaultAvatarRingRadius = 0.3 * kCanvasWidth;
+/// Canvas-space radius of the default avatar ring (shared fraction lives in
+/// `canvas_models.dart`). The initial pose frames this ring so a fresh joiner
+/// lands zoomed-in on the centre cluster.
+const double _kDefaultAvatarRingRadius =
+    kDefaultAvatarRingFraction * kCanvasWidth;
 
 /// On-canvas debug overlay flag. Flip to `true` only when locally
 /// debugging the lounge canvas — it paints a dashed border around the
@@ -289,96 +283,26 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
     _canvasGesturesKey.currentState?.resetToTransform(next);
   }
 
-  /// Compute the matrix that frames the existing canvas content inside
-  /// [viewport]. Auto-fit semantics:
-  ///   - Bounding box of every stroke point + image rect + avatar tile.
-  ///   - +10% padding so content doesn't touch the edges.
-  ///   - Empty canvas (no strokes / images / avatars) → centre on the
-  ///     middle of the canvas at a zoom that frames the default avatar
-  ///     ring so a fresh joiner sees every participant without first
-  ///     panning across the 100k×100k surface (#1265).
-  ///
-  /// Avatars ARE included so a fresh joiner with no drawings still
-  /// frames participants in view; the per-audio-tick avatar jitter
-  /// can't pull the fit pose around because the listener-driven
-  /// helpers only recompute on viewport-transform changes, not on
-  /// canvas-state updates.
-  Matrix4 _computeInitialPose(CanvasState canvas, Size viewport) {
-    final bbox = _contentBbox(canvas);
-    if (bbox == null) {
-      return _centeredPose(viewport);
-    }
-    final contentW = bbox.width;
-    final contentH = bbox.height;
-    // 10% padding around the bbox so strokes don't kiss the edges.
-    final pad = math.max(contentW, contentH) * 0.1;
-    final paddedW = contentW + pad * 2;
-    final paddedH = contentH + pad * 2;
-    final fit = math.min(viewport.width / paddedW, viewport.height / paddedH);
-    // Anchor: bbox top-left lands at (-pad, -pad) of the visible region
-    // so the padding shows on every side.
-    return Matrix4.identity()
-      ..scaleByDouble(fit, fit, fit, 1)
-      ..setTranslationRaw(-(bbox.left - pad) * fit, -(bbox.top - pad) * fit, 0);
-  }
+  /// The lounge always opens at the SAME centred, zoomed-in "home" pose —
+  /// the middle of the bounded board, framed around the default avatar
+  /// cluster with drawing room around it. Deliberately NOT fit-to-content:
+  /// landing in the same place every join is the point (it keeps everyone in
+  /// the centre and nudges drawing toward the middle). "Reset zoom" returns
+  /// here after panning/zooming away.
+  Matrix4 _computeInitialPose(CanvasState canvas, Size viewport) =>
+      _centeredPose(viewport);
 
-  /// Returns the bounding rectangle of every stroke point, image rect,
-  /// and stored avatar position, or null when the canvas has no content
-  /// to fit around. Avatars are inflated by [_kAvatarTileRadius] so the
-  /// tile (not just its centre) fits inside the frame.
-  Rect? _contentBbox(CanvasState canvas) {
-    double minX = double.infinity, minY = double.infinity;
-    double maxX = double.negativeInfinity, maxY = double.negativeInfinity;
-    for (final s in canvas.strokes) {
-      for (final p in s.points) {
-        if (p.x < minX) minX = p.x;
-        if (p.y < minY) minY = p.y;
-        if (p.x > maxX) maxX = p.x;
-        if (p.y > maxY) maxY = p.y;
-      }
-    }
-    for (final img in canvas.images) {
-      if (img.x < minX) minX = img.x;
-      if (img.y < minY) minY = img.y;
-      if (img.x + img.width > maxX) maxX = img.x + img.width;
-      if (img.y + img.height > maxY) maxY = img.y + img.height;
-    }
-    for (final pos in canvas.avatarPositions.values) {
-      final half = _kAvatarTileRadius * pos.scale;
-      if (pos.x - half < minX) minX = pos.x - half;
-      if (pos.y - half < minY) minY = pos.y - half;
-      if (pos.x + half > maxX) maxX = pos.x + half;
-      if (pos.y + half > maxY) maxY = pos.y + half;
-    }
-    // Screen-share windows count as content too — otherwise "fit view" could
-    // never frame a shared screen and the user couldn't find it (#5).
-    for (final win in canvas.screenSharePositions.values) {
-      if (win.x < minX) minX = win.x;
-      if (win.y < minY) minY = win.y;
-      if (win.x + win.width > maxX) maxX = win.x + win.width;
-      if (win.y + win.height > maxY) maxY = win.y + win.height;
-    }
-    if (minX == double.infinity || maxX <= minX || maxY <= minY) {
-      return null;
-    }
-    return Rect.fromLTRB(minX, minY, maxX, maxY);
-  }
-
-  /// Pose used when the canvas is completely empty (no strokes, no
-  /// images, no persisted avatar drags). Centres on the canvas middle
-  /// and zooms OUT just far enough to frame the default avatar ring
-  /// `voice_canvas.dart` lays out for un-dragged participants — so a
-  /// fresh joiner sees every avatar (their own included) without
-  /// hunting across the 100k×100k surface (#1265). A 10% margin keeps
-  /// pucks off the very edge of the viewport.
+  /// The lounge's "home" pose: centre on the middle of the board, zoomed in
+  /// to frame the default avatar cluster with ~30% drawing room around it.
+  /// Everyone lands here on join so the group stays clustered in the centre
+  /// and drawing naturally happens in the middle.
   Matrix4 _centeredPose(Size viewport) {
     const cx = kCanvasWidth / 2;
     const cy = kCanvasHeight / 2;
-    // Frame the full default avatar ring + half an avatar tile so the
-    // outermost puck lands inside the visible region, then a 10%
-    // padding band on top.
+    // Frame the avatar ring + half a tile, with a 30% padding band so there's
+    // room to draw around the group without the pucks hugging the edge.
     const ringExtent = _kDefaultAvatarRingRadius + _kAvatarTileRadius;
-    const framed = ringExtent * 2 * 1.1;
+    const framed = ringExtent * 2 * 1.3;
     final fit = math.min(viewport.width, viewport.height) / framed;
     return Matrix4.identity()
       ..scaleByDouble(fit, fit, fit, 1)
@@ -1545,6 +1469,17 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         canvas.selectedTool != CanvasTool.none &&
         canvas.selectedTool != CanvasTool.text;
 
+    // Zoom-out floor = "fit the whole board with ~10% margin". You can pull
+    // back to see the entire bounded canvas but no further into empty space;
+    // the gesture layer also clamps pan/zoom to the board (see canvasSize).
+    const canvasSize = Size(kCanvasWidth, kCanvasHeight);
+    final fitWhole =
+        math.min(
+          viewportSize.width / kCanvasWidth,
+          viewportSize.height / kCanvasHeight,
+        ) /
+        1.1;
+
     final gestures = GestureDetector(
       key: const Key('canvas-tap-to-claim'),
       behavior: HitTestBehavior.translucent,
@@ -1553,11 +1488,9 @@ class _VoiceLoungeScreenState extends ConsumerState<VoiceLoungeScreen> {
         key: _canvasGesturesKey,
         isToolSelected: isToolSelected,
         initialTransform: initialTransform,
-        // Allow zooming out far enough to frame the whole 100k surface
-        // (viewport / 100k ≈ 0.02) so users can see the entire canvas /
-        // find content that drifted far away (#4). The minimap gives
-        // orientation at that zoom.
-        minScale: _kCanvasMinScale,
+        minScale: fitWhole,
+        viewportSize: viewportSize,
+        canvasSize: canvasSize,
         onStrokeStart: _onStrokeStart,
         onStrokeMove: _onStrokeMove,
         onStrokeEnd: _onStrokeEnd,

--- a/apps/client/lib/src/widgets/voice_canvas.dart
+++ b/apps/client/lib/src/widgets/voice_canvas.dart
@@ -390,9 +390,9 @@ class _VoiceCanvasState extends ConsumerState<VoiceCanvas> {
     const cy = kCanvasHeight / 2;
     if (total <= 1) return AvatarPosition(userId: userId, x: cx, y: cy);
     final angle = (2 * math.pi * index) / total;
-    // Radius = 30% of the shorter canvas axis so all defaults land well
-    // inside the visible region at minScale.
-    const r = 0.3 * kCanvasWidth;
+    // Tight ring near the centre (shared fraction; see canvas_models) so the
+    // group clusters in the middle and the lounge opens zoomed-in on them.
+    const r = kDefaultAvatarRingFraction * kCanvasWidth;
     return AvatarPosition(
       userId: userId,
       x: cx + r * math.cos(angle),

--- a/apps/client/lib/src/widgets/voice_lounge/lounge_canvas_gestures.dart
+++ b/apps/client/lib/src/widgets/voice_lounge/lounge_canvas_gestures.dart
@@ -85,6 +85,13 @@ class LoungeCanvasGestures extends StatefulWidget {
   /// Maximum scale. Clamped against pinch + double-tap zoom.
   final double maxScale;
 
+  /// Visible viewport size and the bounded canvas (child) size. When BOTH are
+  /// provided, pan/zoom is clamped so the bounded board can't be dragged out
+  /// of view (and centres when it's smaller than the viewport). Leave null to
+  /// disable clamping (e.g. unit tests / an unbounded surface).
+  final Size? viewportSize;
+  final Size? canvasSize;
+
   const LoungeCanvasGestures({
     super.key,
     required this.child,
@@ -97,6 +104,8 @@ class LoungeCanvasGestures extends StatefulWidget {
     this.onTransformChanged,
     this.minScale = 0.2,
     this.maxScale = 5.0,
+    this.viewportSize,
+    this.canvasSize,
   });
 
   @override
@@ -217,7 +226,7 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
       _strokeActive = false;
       widget.onStrokeCancel();
     }
-    _transform = Matrix4.copy(next);
+    _transform = _clampTransform(Matrix4.copy(next));
     _pinchStartSpread = null;
     _pinchStartMidpoint = null;
     _pinchStartTransform = null;
@@ -312,7 +321,9 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
       widget.maxScale,
     );
     if ((target - currentScale).abs() < 1e-9) return;
-    _transform = _zoomAround(_transform, event.localPosition, target);
+    _transform = _clampTransform(
+      _zoomAround(_transform, event.localPosition, target),
+    );
     _emitTransform();
     if (mounted) setState(() {});
   }
@@ -394,8 +405,10 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
     final delta = current - last;
     _panLastPosition = current;
     final t = _transform.getTranslation();
-    _transform = Matrix4.copy(_transform)
-      ..setTranslationRaw(t.x + delta.dx, t.y + delta.dy, t.z);
+    _transform = _clampTransform(
+      Matrix4.copy(_transform)
+        ..setTranslationRaw(t.x + delta.dx, t.y + delta.dy, t.z),
+    );
     _emitTransform();
     // Rebuild so the Transform in build() re-applies the new matrix to the
     // canvas child. Without this, pan only moved the grid (which re-projects
@@ -456,6 +469,7 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
     // The intermediate `clampedRatio` is referenced so the static
     // analyzer doesn't drop the clamp branch — and it documents intent.
     assert(clampedRatio > 0);
+    _transform = _clampTransform(_transform);
     _emitTransform();
     // Rebuild so the Transform re-applies the new scale/translate to the
     // canvas child (see _applyPanDelta). Without it pinch zoomed only the
@@ -465,6 +479,30 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
 
   void _emitTransform() {
     widget.onTransformChanged?.call(Matrix4.copy(_transform));
+  }
+
+  /// Clamp the transform so the bounded canvas stays in view: centre it when
+  /// it's smaller than the viewport (gravity toward the middle), and prevent
+  /// empty space at the edges when it's larger. No-op unless both
+  /// [LoungeCanvasGestures.viewportSize] and `canvasSize` are provided.
+  Matrix4 _clampTransform(Matrix4 m) {
+    final vp = widget.viewportSize;
+    final cs = widget.canvasSize;
+    if (vp == null || cs == null) return m;
+    final s = m.getMaxScaleOnAxis();
+    if (s <= 0 || !s.isFinite) return m;
+    final t = m.getTranslation();
+    double axis(double tx, double viewport, double content) {
+      final scaled = content * s;
+      if (scaled <= viewport) return (viewport - scaled) / 2; // centre
+      return tx.clamp(viewport - scaled, 0.0);
+    }
+
+    return Matrix4.copy(m)..setTranslationRaw(
+      axis(t.x, vp.width, cs.width),
+      axis(t.y, vp.height, cs.height),
+      t.z,
+    );
   }
 
   Offset _toCanvasPoint(Offset viewportPoint) {
@@ -488,7 +526,9 @@ class LoungeCanvasGesturesState extends State<LoungeCanvasGestures> {
     final atZoomedIn = (currentScale - _kDoubleTapZoomScale).abs() < 0.01;
     final targetScale = atZoomedIn ? 1.0 : _kDoubleTapZoomScale;
     final clampedTarget = targetScale.clamp(widget.minScale, widget.maxScale);
-    _transform = _zoomAround(_transform, tapPoint, clampedTarget);
+    _transform = _clampTransform(
+      _zoomAround(_transform, tapPoint, clampedTarget),
+    );
     _emitTransform();
     if (mounted) setState(() {});
   }

--- a/apps/client/test/models/canvas_models_test.dart
+++ b/apps/client/test/models/canvas_models_test.dart
@@ -8,13 +8,13 @@ void main() {
   setUp(resetLegacyMigrationCount);
 
   group('CanvasPoint', () {
-    test('canvas dimensions are the 100k-px figma-style surface', () {
-      // The 100k value is the "feels infinite" virtual canvas; in 2026-05
-      // we bumped from the original 4096 to give users true Figma-style
-      // pan/zoom. The auto-fit-on-join logic frames the bbox of existing
-      // content so users never have to find the corner.
-      expect(kCanvasWidth, 100000);
-      expect(kCanvasHeight, 100000);
+    test('canvas is a bounded 6000-px board for beta', () {
+      // Beta uses a bounded board (pan/zoom clamped to it) rather than a
+      // near-infinite surface, so the whole canvas is always reachable and
+      // the group clusters in the centre. Going "infinite" later is just
+      // raising this constant + dropping the clamp.
+      expect(kCanvasWidth, 6000);
+      expect(kCanvasHeight, 6000);
     });
 
     test('round-trips through JSON in canvas-space pixels', () {

--- a/apps/client/test/providers/canvas_provider_test.dart
+++ b/apps/client/test/providers/canvas_provider_test.dart
@@ -214,8 +214,8 @@ void main() {
       const fromUserId = 'user-a';
       const payload = <String, dynamic>{
         'user_id': 'user-b',
-        'x': 40000.0,
-        'y': 60000.0,
+        'x': 4000.0,
+        'y': 5000.0,
         'scale': 1.5,
       };
 
@@ -235,8 +235,8 @@ void main() {
       );
       state = state.copyWith(avatarPositions: updated);
 
-      expect(state.avatarPositions['user-b']?.x, closeTo(40000.0, 1e-10));
-      expect(state.avatarPositions['user-b']?.y, closeTo(60000.0, 1e-10));
+      expect(state.avatarPositions['user-b']?.x, closeTo(4000.0, 1e-10));
+      expect(state.avatarPositions['user-b']?.y, closeTo(5000.0, 1e-10));
       expect(state.avatarPositions['user-b']?.scale, 1.5);
       expect(
         state.avatarPositions.containsKey('user-a'),

--- a/apps/client/test/widgets/voice_lounge/lounge_canvas_gestures_test.dart
+++ b/apps/client/test/widgets/voice_lounge/lounge_canvas_gestures_test.dart
@@ -23,6 +23,8 @@ LoungeCanvasGestures _harness({
   double minScale = 0.2,
   double maxScale = 5.0,
   Key? key,
+  Size? viewportSize,
+  Size? canvasSize,
 }) {
   return LoungeCanvasGestures(
     key: key,
@@ -30,6 +32,8 @@ LoungeCanvasGestures _harness({
     initialTransform: initial ?? Matrix4.identity(),
     minScale: minScale,
     maxScale: maxScale,
+    viewportSize: viewportSize,
+    canvasSize: canvasSize,
     onStrokeStart: rec.strokeStarts.add,
     onStrokeMove: rec.strokeMoves.add,
     onStrokeEnd: () => rec.strokeEnds++,
@@ -692,6 +696,44 @@ void main() {
         closeTo(after, 0.01),
         reason: 'the rendered transform must reflect the scroll zoom',
       );
+    });
+
+    // Beta bounded-canvas: with viewportSize + canvasSize provided, pan is
+    // clamped so the board can't be dragged out of view.
+    testWidgets('pan is clamped to the bounded canvas', (tester) async {
+      final rec = _Recorder();
+      const key = ValueKey('clamp');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _harness(
+            rec: rec,
+            isToolSelected: false,
+            key: key,
+            viewportSize: const Size(800, 600),
+            canvasSize: const Size(1000, 1000),
+          ),
+        ),
+      );
+      // At scale 1 the 1000px board is larger than the 800x600 viewport, so
+      // translation is clamped to [viewport-scaled, 0] = x:[-200,0], y:[-400,0].
+      // Drag up-left (on-screen points): the -600,-400 delta over-shoots the
+      // bounds and clamps to the corner (-200,-400).
+      await _pointerDown(
+        tester,
+        () => null,
+        at: const Offset(700, 500),
+        pointer: 1,
+      );
+      await _pointerMove(tester, to: const Offset(100, 100), pointer: 1);
+      var t = _stateOf(tester, key).debugTransform.getTranslation();
+      expect(t.x, closeTo(-200, 0.01));
+      expect(t.y, closeTo(-400, 0.01));
+
+      // Drag back down-right: clamps to the opposite bound (0,0).
+      await _pointerMove(tester, to: const Offset(700, 500), pointer: 1);
+      t = _stateOf(tester, key).debugTransform.getTranslation();
+      expect(t.x, closeTo(0, 0.01));
+      expect(t.y, closeTo(0, 0.01));
     });
   });
 }

--- a/scripts/canvas_demo.py
+++ b/scripts/canvas_demo.py
@@ -58,7 +58,7 @@ try:
 except ImportError:
     sys.exit("Missing deps. Run:  pip install requests websockets")
 
-CANVAS_CENTER = 50000.0
+CANVAS_CENTER = 3000.0  # centre of the bounded 6000×6000 beta board
 
 
 # --------------------------------------------------------------------------- #
@@ -109,14 +109,14 @@ def build_strokes():
         return p
 
     strokes = [
-        stroke("#3DDC97", 18.0, _circle(31000)),            # outer ring (Echo green)
-        stroke("#FF3DAE", 10.0, _rose(5, 24000)),           # magenta 10-petal rose
-        stroke("#38E1FF", 8.0, _rose(4, 17000, phase=0.4)), # cyan rose
-        stroke("#FFD93B", 6.0, _rose(7, 11000)),            # gold rose
-        stroke("#B388FF", 5.0, _rose(2, 6000)),             # violet inner loop
+        stroke("#3DDC97", 14.0, _circle(2500)),            # outer ring (Echo green)
+        stroke("#FF3DAE", 9.0, _rose(5, 2000)),            # magenta 10-petal rose
+        stroke("#38E1FF", 7.0, _rose(4, 1500, phase=0.4)), # cyan rose
+        stroke("#FFD93B", 5.0, _rose(7, 1000)),            # gold rose
+        stroke("#B388FF", 4.0, _rose(2, 550)),             # violet inner loop
         # A text label (kind="text": single anchor point + text field).
-        stroke("#FFFFFF", 1400.0,
-               [{"x": CANVAS_CENTER - 16000, "y": CANVAS_CENTER + 34000}],
+        stroke("#FFFFFF", 220.0,
+               [{"x": CANVAS_CENTER - 1300, "y": CANVAS_CENTER + 2750}],
                kind="text", text="ECHO canvas demo ✨"),
     ]
     return strokes
@@ -277,8 +277,8 @@ async def run_ws(ws_url, channel_id, user_id, strokes, once, clear):
                   f"{len(sp['points'])} pts, {sp['color']})")
 
         avatar = {"user_id": user_id, "x": CANVAS_CENTER, "y": CANVAS_CENTER, "scale": 1.6}
-        share = {"window_id": "demo-share", "x": CANVAS_CENTER + 22000,
-                 "y": CANVAS_CENTER - 18000, "width": 9000.0, "height": 5200.0}
+        share = {"window_id": "demo-share", "x": CANVAS_CENTER + 1700,
+                 "y": CANVAS_CENTER - 1400, "width": 1200.0, "height": 700.0}
         await send("avatar_move", avatar)
         await send("screenshare_move", share)
         print("  -> placed avatar + screen-share window")


### PR DESCRIPTION
The 100k "infinite" canvas left people zoomed way out in empty space with nothing pulling them to the action. For beta this makes the canvas a **bounded 6000×6000 board** with walls.

## Improved
- **You can't get lost.** Pan/zoom is clamped to the board — it centers when you zoom out past the whole canvas, and the edges stop you from dragging it off-screen.
- **Everyone lands in the same place.** The lounge always opens at a centered, zoomed-in "home" pose; the default avatar ring is a tight cluster near the middle, so the group is together and drawing gravitates to the center. "Reset zoom" returns home.
- Zoom-out floor now = "fit the whole board," not the old 0.02.

Going truly infinite later is just raising `kCanvasWidth` and dropping the clamp — everything (ring, image-spawn, pose, coord clamps) is relative to it.

## Behind the scenes
New tests: bounded-canvas dimension, pan-clamp behavior; updated avatar-move + dimension tests for the new size. Demo script updated to the 6000 space. Full Flutter suite green (2604).

Note: drawings saved in the old 100k space fall outside the new board — fine given the beta data-reset banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)