### PR TITLE
Fix group-info dead-end, add-contact access, canvas image insert, and contact-search keyboard

### DIFF
--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -133,16 +133,35 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   // Build
   // ---------------------------------------------------------------------------
 
-  Widget _buildLoadingState() {
+  /// Back affordance. The group-info screen is reached both as a dismissible
+  /// sheet (canPop) AND as a full page via `context.go('/group-info/:id')`
+  /// (which replaces the stack, so there's nothing to pop) — the latter left
+  /// the user stranded with no exit. Pop when we can, else fall back to the
+  /// conversation.
+  Widget _backButton(BuildContext context) => IconButton(
+    icon: const Icon(Icons.arrow_back),
+    tooltip: 'Back',
+    onPressed: () => context.canPop()
+        ? context.pop()
+        : context.go('/home?conversation=${widget.conversationId}'),
+  );
+
+  Widget _buildLoadingState(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text(_kGroupInfoTitle)),
+      appBar: AppBar(
+        title: const Text(_kGroupInfoTitle),
+        leading: _backButton(context),
+      ),
       body: const Center(child: CircularProgressIndicator()),
     );
   }
 
-  Widget _buildErrorState() {
+  Widget _buildErrorState(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text(_kGroupInfoTitle)),
+      appBar: AppBar(
+        title: const Text(_kGroupInfoTitle),
+        leading: _backButton(context),
+      ),
       body: const Center(child: Text('Could not load group information')),
     );
   }
@@ -151,8 +170,8 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
   Widget build(BuildContext context) {
     final myUserId = ref.watch(authProvider).userId ?? '';
 
-    if (_isLoading) return _buildLoadingState();
-    if (_conversation == null) return _buildErrorState();
+    if (_isLoading) return _buildLoadingState(context);
+    if (_conversation == null) return _buildErrorState(context);
 
     final conv = _conversation!;
     final displayName = conv.displayName(myUserId);
@@ -163,7 +182,10 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     final isOwnerOrAdmin = myRole == 'owner' || myRole == 'admin';
 
     return Scaffold(
-      appBar: AppBar(title: const Text(_kGroupInfoTitle)),
+      appBar: AppBar(
+        title: const Text(_kGroupInfoTitle),
+        leading: _backButton(context),
+      ),
       body: LayoutBuilder(
         builder: (context, constraints) {
           // Wide (split-pane / desktop): 2-column layout — avatar+identity

--- a/apps/client/lib/src/screens/new_message_screen.dart
+++ b/apps/client/lib/src/screens/new_message_screen.dart
@@ -38,6 +38,12 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
 
   final _searchController = TextEditingController();
   final _searchFocusNode = FocusNode();
+  // Stable identity for the search field. Each keystroke calls setState, which
+  // rebuilds the surrounding Wrap/Column; without a stable key the field's
+  // EditableText element can't be matched across the rebuild, gets recreated,
+  // and Android tears down the input connection (the soft keyboard closes on
+  // the first letter). A GlobalKey forces element reuse so focus survives.
+  final _searchFieldKey = GlobalKey();
   final _searchLayerLink = LayerLink();
   OverlayEntry? _overlayEntry;
   String _query = '';
@@ -414,6 +420,7 @@ class _NewMessageScreenState extends ConsumerState<NewMessageScreen> {
                       constraints: const BoxConstraints(minWidth: 120),
                       child: IntrinsicWidth(
                         child: TextField(
+                          key: _searchFieldKey,
                           controller: _searchController,
                           focusNode: _searchFocusNode,
                           style: TextStyle(

--- a/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
+++ b/apps/client/lib/src/screens/voice_lounge/drawing_tools_menu.dart
@@ -745,15 +745,18 @@ class _DrawingToolsMenuState extends ConsumerState<DrawingToolsMenu> {
   void _addImageByUrl(String url) {
     if (!mounted) return;
     // Broadcast via canvasProvider only — local _canvas?.addImageFromUrl caused a "stuck twin" (#752).
-    // Spawn dead-centre: the user just confirmed an image; they shouldn't
-    // have to hunt for it in a random off-centre quadrant.
-    const w = 0.25;
-    const h = 0.25;
+    // CanvasImage coords are ABSOLUTE canvas pixels, not 0..1 fractions. The
+    // old normalized 0.375/0.25 values placed a sub-pixel image in the
+    // top-left corner (invisible to the uploader; rescaled by the legacy
+    // migration on remotes) — i.e. "add image did nothing". Spawn a
+    // quarter-board-sized image dead-centre, matching the paste path.
+    const w = kCanvasWidth * 0.25;
+    const h = kCanvasHeight * 0.25;
     final img = CanvasImage(
       id: newCanvasId(),
       url: url,
-      x: 0.5 - w / 2,
-      y: 0.5 - h / 2,
+      x: kCanvasWidth / 2 - w / 2,
+      y: kCanvasHeight / 2 - h / 2,
       width: w,
       height: h,
     );

--- a/apps/client/lib/src/widgets/conversation_panel/parts/header.dart
+++ b/apps/client/lib/src/widgets/conversation_panel/parts/header.dart
@@ -148,6 +148,8 @@ mixin _ConversationPanelHeaderMixin
               switch (value) {
                 case 'chat':
                   widget.onNewChat?.call();
+                case 'contacts':
+                  widget.onShowContacts?.call();
                 case 'group':
                   widget.onNewGroup?.call();
                 case 'discover':
@@ -171,6 +173,25 @@ mixin _ConversationPanelHeaderMixin
                       Flexible(
                         child: Text(
                           'New Chat',
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              PopupMenuItem(
+                value: 'contacts',
+                child: SizedBox(
+                  width: 200,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.contacts_outlined, size: 18),
+                      SizedBox(width: 10),
+                      Flexible(
+                        child: Text(
+                          'Add Contact',
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),


### PR DESCRIPTION
A batch of UI bugs.

## Fixed
- **You can leave the group-info screen again.** Opening it from "Encryption Activity" (or Open Info / Invite People) navigated with no back button and stranded you. Added a back arrow that returns to the conversation.
- **Add a contact any time.** The "New (+)" menu now has an **Add Contact** entry — previously, once you had any conversation, there was no way to add a contact on desktop (only the empty-state placeholder offered it).
- **Adding an image to the lounge canvas works.** It was being placed at a sub-pixel spot in the corner (it used 0–1 fractions where the canvas expects absolute pixels), so it appeared to do nothing. Now it drops a quarter-board image in the center.
- **Typing in contact search no longer hides the keyboard on Android.** The field was losing its input connection on each keystroke; a stable key keeps focus.

## Not in this PR (flagged for follow-up)
- Screen-share window placement on the canvas (it renders in screen-space outside the pan/zoom transform, so it detaches and mis-syncs — needs a small refactor to live in canvas-space).
- The "fake chips" contact picker redesign (subjective — happy to propose options).
- Items 1–3 from the report (account-switch, Linux notification crash, fullscreen) are already fixed in `main` (#1291/#1292) but only reach the **desktop app** with a new desktop build (watchtower only updates web/server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)