### PR TITLE
Fix the voice lounge staying highlighted after a failed join

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
+++ b/apps/client/lib/src/providers/livekit_voice/livekit_voice_provider.dart
@@ -293,12 +293,20 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
 
   /// Join a voice channel by requesting a LiveKit token from the server and
   /// connecting to the LiveKit SFU room.
-  Future<void> joinChannel({
+  ///
+  /// Returns `true` only when the LiveKit room is actually connected and the
+  /// session is active. Returns `false` on any failure (timeout, track-publish
+  /// error, denied permission) — callers MUST gate their success side-effects
+  /// (highlighting the chip, showing the lounge, announcing "call started") on
+  /// this result. The method swallows its own exceptions, so a `false` return
+  /// is the only failure signal; treating a completed Future as "joined" leaves
+  /// the chip highlighted after a failed join (the stuck-lounge bug).
+  Future<bool> joinChannel({
     required String conversationId,
     required String channelId,
     bool startMuted = false,
   }) async {
-    if (_disposed) return;
+    if (_disposed) return false;
 
     // Prevent concurrent join sequences from racing (tap new lounge mid-join).
     if (_isJoining) {
@@ -307,14 +315,14 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         'LiveKitVoice',
         'joinChannel: ignored — join already in progress for $channelId',
       );
-      return;
+      return false;
     }
 
     // Already in this exact channel -- nothing to do.
     if (state.isActive &&
         state.conversationId == conversationId &&
         state.channelId == channelId) {
-      return;
+      return true;
     }
 
     _isJoining = true;
@@ -385,6 +393,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         'LiveKitVoice',
         'joinChannel: successfully joined channel $channelId',
       );
+      return true;
     } catch (e) {
       // Surface URL on failure so a 404/DNS error points ops at the right subdomain.
       final tried = attemptedUrl ?? '<token-fetch>';
@@ -400,6 +409,7 @@ class LiveKitVoiceNotifier extends _$LiveKitVoiceNotifier
         isActive: false,
         error: 'Failed to join voice channel',
       );
+      return false;
     } finally {
       _isJoining = false;
     }

--- a/apps/client/lib/src/screens/user_profile_screen.dart
+++ b/apps/client/lib/src/screens/user_profile_screen.dart
@@ -773,14 +773,25 @@ class _UserProfileScreenState extends ConsumerState<UserProfileScreen> {
           .read(conversationsProvider.notifier)
           .getOrCreateDm(widget.userId, _username);
       if (!mounted) return;
-      await ref
+      final joined = await ref
           .read(livekitVoiceProvider.notifier)
           .joinChannel(conversationId: conv.id, channelId: conv.id);
-      ref.read(websocketProvider.notifier).sendCallStarted(conv.id);
-      ref
-          .read(chatProvider.notifier)
-          .addSystemEvent(conv.id, 'Voice call started');
       if (!mounted) return;
+      if (joined) {
+        // Only announce the call when the room actually connected.
+        ref.read(websocketProvider.notifier).sendCallStarted(conv.id);
+        ref
+            .read(chatProvider.notifier)
+            .addSystemEvent(conv.id, 'Voice call started');
+      } else {
+        ToastService.show(
+          context,
+          'Could not start voice call',
+          type: ToastType.error,
+        );
+      }
+      // Land the user in the conversation either way (the call simply didn't
+      // connect; the chat is still useful).
       if (Navigator.canPop(context)) Navigator.pop(context);
       context.go('/home?conversation=${conv.id}');
     } on DmException catch (e) {

--- a/apps/client/lib/src/widgets/channel_bar.dart
+++ b/apps/client/lib/src/widgets/channel_bar.dart
@@ -325,7 +325,7 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
         );
         DebugLogService.instance.forceFlushSync();
 
-        await ref
+        final joined = await ref
             .read(livekitVoiceProvider.notifier)
             .joinChannel(
               conversationId: widget.conversationId,
@@ -333,7 +333,10 @@ class _ChannelBarState extends ConsumerState<ChannelBar> {
               startMuted: voiceSettings.selfMuted || voiceSettings.selfDeafened,
             );
         if (!mounted) return;
-        widget.onVoiceChannelChanged(channel.id);
+        // Only mark the chip active when the LiveKit room actually connected.
+        // On failure clear it so a timed-out join can't leave the lounge chip
+        // stuck highlighted while the error toast says it failed.
+        widget.onVoiceChannelChanged(joined ? channel.id : null);
         // The voice dock + auto-show-lounge already give the user clear visual
         // feedback that the join succeeded; the snackbar was redundant noise.
       }

--- a/apps/client/lib/src/widgets/channel_column.dart
+++ b/apps/client/lib/src/widgets/channel_column.dart
@@ -197,13 +197,15 @@ class _ChannelColumnState extends ConsumerState<ChannelColumn> {
     if (!success) return;
 
     final voiceSettings = ref.read(voiceSettingsProvider);
-    await ref
+    final joined = await ref
         .read(livekitVoiceProvider.notifier)
         .joinChannel(
           conversationId: widget.conversation.id,
           channelId: channel.id,
           startMuted: voiceSettings.selfMuted || voiceSettings.selfDeafened,
         );
+    // Don't open the lounge for a join that failed to connect.
+    if (!joined || !mounted) return;
     widget.onShowLounge?.call();
   }
 

--- a/apps/client/lib/src/widgets/chat_header_bar.dart
+++ b/apps/client/lib/src/widgets/chat_header_bar.dart
@@ -538,7 +538,11 @@ class ChatHeaderBar extends ConsumerWidget {
     );
   }
 
-  void _startVoiceCall(BuildContext context, WidgetRef ref, Conversation conv) {
+  Future<void> _startVoiceCall(
+    BuildContext context,
+    WidgetRef ref,
+    Conversation conv,
+  ) async {
     final voiceState = ref.read(livekitVoiceProvider);
     if (voiceState.isActive) {
       // Already in a call — show info
@@ -550,11 +554,21 @@ class ChatHeaderBar extends ConsumerWidget {
       return;
     }
 
-    ref
+    final joined = await ref
         .read(livekitVoiceProvider.notifier)
         .joinChannel(conversationId: conv.id, channelId: conv.id);
+    if (!context.mounted) return;
+    if (!joined) {
+      ToastService.show(
+        context,
+        'Couldn\'t start the voice call.',
+        type: ToastType.error,
+      );
+      return;
+    }
 
-    // Notify peers and add system event to chat timeline
+    // Only announce the call once we're actually connected — otherwise peers
+    // get a "Voice call started" event for a call that never connected.
     ref.read(websocketProvider.notifier).sendCallStarted(conv.id);
     ref
         .read(chatProvider.notifier)

--- a/apps/client/test/screens/home_screen_test.dart
+++ b/apps/client/test/screens/home_screen_test.dart
@@ -116,11 +116,11 @@ class _FakeLiveKit extends LiveKitVoiceNotifier {
   Future<void> leaveChannel() async {}
 
   @override
-  Future<void> joinChannel({
+  Future<bool> joinChannel({
     required String conversationId,
     required String channelId,
     bool startMuted = false,
-  }) async {}
+  }) async => true;
 }
 
 // `standardOverrides()` covers auth, server URL, conversations, contacts,

--- a/apps/client/test/widgets/channel_bar_test.dart
+++ b/apps/client/test/widgets/channel_bar_test.dart
@@ -81,7 +81,7 @@ class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
   int leaveCalls = 0;
 
   @override
-  Future<void> joinChannel({
+  Future<bool> joinChannel({
     required String conversationId,
     required String channelId,
     bool startMuted = false,
@@ -93,6 +93,7 @@ class _FakeVoiceRtcNotifier extends LiveKitVoiceNotifier {
       conversationId: conversationId,
       channelId: channelId,
     );
+    return true;
   }
 
   @override
@@ -120,17 +121,39 @@ class _FakeVoiceSettingsConfirm extends VoiceSettings {
 class _SlowVoiceRtcNotifier extends LiveKitVoiceNotifier {
   _SlowVoiceRtcNotifier();
 
-  final _joinCompleter = Completer<void>();
+  final _joinCompleter = Completer<bool>();
 
   @override
   LiveKitVoiceState build() => LiveKitVoiceState.empty;
 
   @override
-  Future<void> joinChannel({
+  Future<bool> joinChannel({
     required String conversationId,
     required String channelId,
     bool startMuted = false,
   }) => _joinCompleter.future;
+
+  @override
+  Future<void> leaveChannel() async {}
+}
+
+/// Fake whose join always fails (returns false) without ever going active —
+/// mirrors a LiveKit signal timeout / track-publish failure.
+class _FailingVoiceRtcNotifier extends LiveKitVoiceNotifier {
+  int joinCalls = 0;
+
+  @override
+  LiveKitVoiceState build() => LiveKitVoiceState.empty;
+
+  @override
+  Future<bool> joinChannel({
+    required String conversationId,
+    required String channelId,
+    bool startMuted = false,
+  }) async {
+    joinCalls++;
+    return false;
+  }
 
   @override
   Future<void> leaveChannel() async {}
@@ -226,6 +249,45 @@ void main() {
       expect(fakeChannels.joinCalls, 1);
       expect(fakeVoiceRtc.joinCalls, 1);
       expect(activeVoice, 'voice-1');
+    });
+
+    testWidgets('failed join does not leave the voice chip highlighted', (
+      tester,
+    ) async {
+      late _FailingVoiceRtcNotifier failingVoiceRtc;
+      String? activeVoice;
+
+      await tester.pumpApp(
+        StatefulBuilder(
+          builder: (context, setState) => ChannelBar(
+            conversationId: 'conv-1',
+            activeVoiceChannelId: activeVoice,
+            onTextChannelChanged: (_) {},
+            onVoiceChannelChanged: (channelId) {
+              setState(() => activeVoice = channelId);
+            },
+          ),
+        ),
+        overrides: [
+          authOverride(loggedInAuthState),
+          webSocketOverride(),
+          channelsProvider.overrideWith(_FakeChannelsNotifier.new),
+          voiceRtcProvider.overrideWith(() {
+            failingVoiceRtc = _FailingVoiceRtcNotifier();
+            return failingVoiceRtc;
+          }),
+          voiceSettingsProvider.overrideWith(_FakeVoiceSettings.new),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('lounge').first);
+      await tester.pumpAndSettle();
+
+      expect(failingVoiceRtc.joinCalls, 1);
+      // Join returned false → the parent active-channel id must stay null so
+      // the chip can't remain highlighted while the toast reports a failure.
+      expect(activeVoice, isNull);
     });
 
     // -------------------------------------------------------------
@@ -360,7 +422,7 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
       // Release the join future and let the widget settle.
-      slowVoiceRtc._joinCompleter.complete();
+      slowVoiceRtc._joinCompleter.complete(true);
       await tester.pumpAndSettle();
 
       // Spinner is gone after join completes.

--- a/apps/client/test/widgets/voice_dock_test.dart
+++ b/apps/client/test/widgets/voice_dock_test.dart
@@ -27,11 +27,11 @@ class _FakeLiveKitNotifier extends LiveKitVoiceNotifier {
   }
 
   @override
-  Future<void> joinChannel({
+  Future<bool> joinChannel({
     required String conversationId,
     required String channelId,
     bool startMuted = false,
-  }) async {}
+  }) async => true;
 }
 
 class _FakeChannelsNotifier extends Channels {

--- a/apps/client/test/widgets/voice_footer_test.dart
+++ b/apps/client/test/widgets/voice_footer_test.dart
@@ -31,11 +31,11 @@ class _FakeLiveKitNotifier extends LiveKitVoiceNotifier {
   }
 
   @override
-  Future<void> joinChannel({
+  Future<bool> joinChannel({
     required String conversationId,
     required String channelId,
     bool startMuted = false,
-  }) async {}
+  }) async => true;
 }
 
 class _FakeChannelsNotifier extends Channels {


### PR DESCRIPTION
When a voice join failed to connect (LiveKit signal timeout / "failed to publish track"), the lounge chip stayed highlighted as if you were in the call — even though a toast said the join failed. Tapping again could then wedge.

### Root cause
`LiveKitVoiceNotifier.joinChannel` caught its own exceptions internally and returned a plain `Future<void>`, so every caller treated a *completed* future as "joined" and fired its success side-effects regardless of the real outcome:
- the channel bar highlighted the chip,
- the channel column opened the lounge,
- the chat header + profile screen announced "Voice call started" to peers and navigated.

### Fixed
- `joinChannel` now returns `Future<bool>` — `true` only when the LiveKit room actually connects. All four call sites gate their success side-effects on it:
  - **Channel bar:** the lounge chip is only marked active on a real connect; a failed join clears it so it can't stay highlighted.
  - **Channel column:** won't open the lounge for a join that didn't connect.
  - **Chat header / profile:** only send the "Voice call started" event and announce the call once connected; otherwise show a clear error.

### Behind the scenes
- Added a regression test asserting a failed join leaves the chip un-highlighted; updated the voice-notifier test fakes to the new `Future<bool>` signature. Full suite (2609 tests) green.

Note: this fixes the **state desync** (stuck chip / phantom "call started"). The underlying LiveKit *"Signal request timed out"* and the UI hitch during connect/camera-enable are a separate native/infra issue still under investigation — this change makes their fallout recoverable instead of leaving the UI lying about call state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)