### PR TITLE
Fix message text spacing out weirdly in compact mode and with markdown

### DIFF
--- a/apps/client/lib/src/theme/echo_theme.dart
+++ b/apps/client/lib/src/theme/echo_theme.dart
@@ -1,6 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+/// Emoji font fallback chain for any text style that may contain emoji.
+///
+/// Platform-native emoji fonts come FIRST: 'Apple Color Emoji' (macOS/iOS)
+/// and 'Segoe UI Emoji' (Windows) both ship the GSUB ligature table that
+/// combines regional-indicator pairs into flag glyphs (#917). 'Twemoji
+/// Mozilla' covers Linux distros that ship Twemoji. The bundled CBDT
+/// 'NotoEmoji' (NotoColorEmoji.ttf) is LAST so AppImage builds without a
+/// system emoji font still render tofu-free.
+///
+/// IMPORTANT: only ever use this as a *fallback* on a style whose primary
+/// `fontFamily` is a real text font (Inter). NotoColorEmoji has huge advance
+/// widths for space + ASCII punctuation, so putting it on a family-less style
+/// makes Skia resolve spaces to the emoji font and blows up word spacing.
+const List<String> kEmojiFontFallback = [
+  'Apple Color Emoji',
+  'Segoe UI Emoji',
+  'Twemoji Mozilla',
+  'NotoEmoji',
+];
+
 class EchoTheme {
   // shadcn-inspired dark palette
   static const mainBg = Color(0xFF0A0A0B);
@@ -69,23 +89,11 @@ class EchoTheme {
         ? ThemeData.dark().textTheme
         : ThemeData.light().textTheme;
     final baseTextTheme = GoogleFonts.interTextTheme(base);
-    // Route any glyph not present in Inter (notably emoji codepoints) to a
-    // fallback chain. Platform-native emoji fonts come FIRST: 'Apple Color
-    // Emoji' (macOS/iOS) and 'Segoe UI Emoji' (Windows) both ship with the
-    // GSUB ligature table that combines regional-indicator pairs into the
-    // expected flag glyph (#917). 'Twemoji Mozilla' covers Linux distros
-    // that ship Twemoji. NotoEmoji is kept at the end as the last-resort
-    // fallback so AppImage builds without system emoji fonts still render
-    // tofu-free for most codepoints -- the bundled CBDT NotoColorEmoji
-    // does not include flag ligatures, so Linux desktops without a system
-    // emoji font will still show regional-indicator letter pairs for
-    // flags. Tracked as a follow-up to ship a COLRv1 build.
-    const emojiFallback = [
-      'Apple Color Emoji',
-      'Segoe UI Emoji',
-      'Twemoji Mozilla',
-      'NotoEmoji',
-    ];
+    // Route any glyph not present in Inter (notably emoji codepoints) to the
+    // shared [kEmojiFontFallback] chain. (Bundled NotoColorEmoji has no flag
+    // ligatures, so Linux desktops without a system emoji font still show
+    // regional-indicator letter pairs for flags — tracked as a COLRv1 follow-up.)
+    const emojiFallback = kEmojiFontFallback;
     return baseTextTheme.copyWith(
       headlineLarge: baseTextTheme.headlineLarge?.copyWith(
         fontSize: 24,

--- a/apps/client/lib/src/widgets/message/rich_text_content.dart
+++ b/apps/client/lib/src/widgets/message/rich_text_content.dart
@@ -4,9 +4,11 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../providers/theme_provider.dart' show UIDensity;
+import '../../theme/echo_theme.dart' show kEmojiFontFallback;
 import 'markdown_patterns.dart';
 
 // Re-export urlRegex for callers that imported it from this file.
@@ -124,15 +126,19 @@ class _RichTextContentState extends State<RichTextContent> {
   }
 
   /// Base text style used throughout message rendering.
-  /// Ligatures are disabled ("calt" 0) so user text reads without code ligatures.
-  /// NotoEmoji font fallback ensures emoji render in color on all platforms.
-  TextStyle _baseStyle() => TextStyle(
+  ///
+  /// Inter is the explicit primary family (matching the app text theme) with
+  /// [kEmojiFontFallback] only as a fallback. The primary family is essential:
+  /// without it, Skia resolves spaces and ASCII punctuation to the bundled
+  /// NotoColorEmoji font, whose enormous advance widths blow up word spacing
+  /// (the "s p a c e d   o u t" compact/markdown bug). Ligatures are disabled
+  /// ("calt" 0) so user text reads without code ligatures.
+  TextStyle _baseStyle() => GoogleFonts.inter(
     fontSize: _bodyFontSize,
     color: widget.textColor,
     height: _bodyLineHeight,
     fontFeatures: const [FontFeature.disable('calt')],
-    fontFamilyFallback: const ['NotoEmoji'],
-  );
+  ).copyWith(fontFamilyFallback: kEmojiFontFallback);
 
   TapGestureRecognizer _createLinkRecognizer(String url) {
     final recognizer = TapGestureRecognizer()
@@ -167,11 +173,9 @@ class _RichTextContentState extends State<RichTextContent> {
       spans.add(
         TextSpan(
           text: match.group(0),
-          style: TextStyle(
-            fontSize: _bodyFontSize,
+          style: _baseStyle().copyWith(
             color: widget.accentHoverColor,
             fontWeight: FontWeight.w600,
-            height: _bodyLineHeight,
           ),
         ),
       );
@@ -567,10 +571,10 @@ class _RichTextContentState extends State<RichTextContent> {
           !hasSpoiler &&
           !hasMaskedLink) {
         if (widget.leadingSpans == null) {
-          return Text(
-            text,
-            style: TextStyle(fontSize: 15, color: textColor, height: 1.47),
-          );
+          // Use the same Inter + emoji-fallback base style as every other
+          // path so plain messages render identically (and pick up bundled
+          // emoji + the correct density font size).
+          return Text(text, style: _baseStyle());
         }
         return RichText(
           text: TextSpan(

--- a/apps/client/test/widgets/message/rich_text_content_test.dart
+++ b/apps/client/test/widgets/message/rich_text_content_test.dart
@@ -1,0 +1,87 @@
+import 'package:echo_app/src/widgets/message/rich_text_content.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Collect every [TextSpan] (with non-empty text) under [root].
+List<TextSpan> _textSpans(InlineSpan root) {
+  final out = <TextSpan>[];
+  void visit(InlineSpan s) {
+    if (s is TextSpan) {
+      if ((s.text ?? '').isNotEmpty) out.add(s);
+      for (final child in s.children ?? const <InlineSpan>[]) {
+        visit(child);
+      }
+    }
+  }
+
+  visit(root);
+  return out;
+}
+
+Future<void> _pump(WidgetTester tester, String text) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: RichTextContent(
+          text: text,
+          textColor: const Color(0xFFEDEDEF),
+          accentHoverColor: const Color(0xFF818CF8),
+          textSecondaryColor: const Color(0xFFABABB0),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('RichTextContent message-body styling', () {
+    // Regression guard for the "spaced-out words" bug: NotoColorEmoji in
+    // fontFamilyFallback with NO primary family makes Skia resolve spaces +
+    // ASCII punctuation to the emoji font's huge advance widths. Every
+    // rendered body span must therefore carry an explicit primary fontFamily
+    // (Inter) so the emoji fonts only ever catch real emoji codepoints.
+    testWidgets('markdown body spans set an explicit primary font family', (
+      tester,
+    ) async {
+      await _pump(tester, 'normal message, but then **bold**');
+
+      final richTexts = tester.widgetList<RichText>(find.byType(RichText));
+      expect(richTexts, isNotEmpty);
+
+      var checkedSpans = 0;
+      for (final rt in richTexts) {
+        for (final span in _textSpans(rt.text)) {
+          checkedSpans++;
+          expect(
+            span.style?.fontFamily,
+            isNotNull,
+            reason:
+                'Body span "${span.text}" must have a primary fontFamily so '
+                'the emoji fallback cannot widen spaces/punctuation.',
+          );
+          expect(
+            span.style?.fontFamilyFallback,
+            contains('NotoEmoji'),
+            reason: 'Emoji fallback should still be present for emoji glyphs.',
+          );
+        }
+      }
+      expect(checkedSpans, greaterThan(0));
+    });
+
+    testWidgets('punctuation-heavy text still sets a primary font family', (
+      tester,
+    ) async {
+      // The asterisk/punctuation case from the bug report: "* * * * *".
+      await _pump(tester, r'* * * * *  @ # $ _ & - + ( ) / ');
+
+      final richTexts = tester.widgetList<RichText>(find.byType(RichText));
+      for (final rt in richTexts) {
+        for (final span in _textSpans(rt.text)) {
+          expect(span.style?.fontFamily, isNotNull);
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
In compact density (and with any markdown, at any density) message text rendered with huge gaps between words and even between individual punctuation marks — e.g. `* * * * *` and `@ # $ _ ...` spread right across the row. Plain messages in normal density looked fine, which is what made it confusing.

### Root cause
The message renderer's base text style set `fontFamilyFallback: ['NotoEmoji']` (the bundled NotoColorEmoji) but **no primary font family**. NotoColorEmoji has enormous advance widths for the space character and ASCII punctuation, so with no primary font to claim those glyphs, Skia resolved them to the emoji font — blowing up the spacing. The one path that looked correct (plain text, normal density) happened to skip that fallback entirely, which is why only compact + markdown broke.

### Fixed
- The message body style now uses **Inter as the explicit primary family** (matching the app's text theme) with the emoji fonts only as a fallback — so emoji still render, but spaces and punctuation always use the real text font.
- Extracted the emoji fallback chain into a single shared `kEmojiFontFallback` constant so the theme and the message renderer can't drift apart again, and documented why a primary family is mandatory.
- Unified the plain-text fast path and @mention spans onto the same base style for consistent rendering.

### Behind the scenes
- Added `rich_text_content_test.dart` asserting every rendered body span carries a primary `fontFamily` (the regression guard) while keeping the emoji fallback. Message + density + theme tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)