### PR TITLE
Fix the hover timestamp getting crunched in the message gutter

### DIFF
--- a/apps/client/lib/src/widgets/message_item.dart
+++ b/apps/client/lib/src/widgets/message_item.dart
@@ -1216,6 +1216,11 @@ class _MessageItemState extends State<MessageItem>
             child: Text(
               _formatHourMinute(msg.timestamp),
               textAlign: TextAlign.right,
+              // The gutter is only as wide as the avatar slot, so the time
+              // must stay on one line — never wrap into "3:0 / 6 / PM".
+              maxLines: 1,
+              softWrap: false,
+              overflow: TextOverflow.visible,
               style: GoogleFonts.inter(
                 fontSize: fontSize,
                 color: context.textMuted,
@@ -1227,14 +1232,16 @@ class _MessageItemState extends State<MessageItem>
     );
   }
 
-  /// "HH:MM" only — Discord-style compact hover timestamp.
+  /// "h:mm" only — Discord-style compact hover timestamp. No AM/PM suffix:
+  /// the gutter is only as wide as the avatar slot, and "3:06 PM" wraps into
+  /// a crunched 3-line "3:0 / 6 / PM". The full timestamp (with AM/PM) is
+  /// still shown on the group-header row and the below-bubble timestamp.
   String _formatHourMinute(String iso) {
     try {
       final dt = DateTime.parse(iso).toLocal();
       final h = dt.hour;
       final h12 = h == 0 ? 12 : (h > 12 ? h - 12 : h);
-      final am = h < 12 ? 'AM' : 'PM';
-      return '${h12.toString()}:${dt.minute.toString().padLeft(2, '0')} $am';
+      return '$h12:${dt.minute.toString().padLeft(2, '0')}';
     } catch (_) {
       return '';
     }

--- a/apps/client/test/widgets/message_item_hover_test.dart
+++ b/apps/client/test/widgets/message_item_hover_test.dart
@@ -93,6 +93,45 @@ void main() {
   });
 
   testWidgets(
+    'continuation-row hover timestamp stays on one line with no AM/PM',
+    (tester) async {
+      await mockNetworkImagesFor(() async {
+        // showHeader:false => avatar slot becomes the narrow hover-time gutter.
+        await tester.pumpApp(
+          MessageItem(
+            message: _msg(),
+            showHeader: false,
+            isLastInGroup: false,
+            myUserId: 'me',
+          ),
+        );
+        await tester.pump();
+
+        final hhmm = RegExp(r'^\d{1,2}:\d{2}$');
+        final gutterTimes = tester
+            .widgetList<Text>(find.byType(Text))
+            .where((t) => t.data != null && hhmm.hasMatch(t.data!))
+            .toList();
+        expect(
+          gutterTimes,
+          isNotEmpty,
+          reason: 'gutter h:mm timestamp should render on a continuation row',
+        );
+        for (final t in gutterTimes) {
+          expect(t.maxLines, 1, reason: 'gutter time must never wrap');
+          expect(t.softWrap, isFalse);
+        }
+        // The gutter time replaces the below-bubble timestamp on continuation
+        // rows, so there is no AM/PM text to crunch into "3:0 / 6 / PM".
+        final amPm = tester
+            .widgetList<Text>(find.byType(Text))
+            .where((t) => (t.data ?? '').contains(RegExp(r'\b(AM|PM)\b')));
+        expect(amPm, isEmpty);
+      });
+    },
+  );
+
+  testWidgets(
     'hover state is exposed through scoped ValueListenableBuilder subtrees, not setState (#872)',
     (tester) async {
       await mockNetworkImagesFor(() async {


### PR DESCRIPTION
On grouped (continuation) message rows, hovering revealed a timestamp in the narrow left gutter — but it rendered the full "3:06 PM", which is too wide for the avatar-width slot and wrapped into a crunched three-line "3:0 / 6 / PM".

### Fixed
- The gutter hover timestamp now shows a compact `h:mm` (no AM/PM), matching its documented Discord-style intent, and is pinned to a single line so it can never wrap. The full timestamp with AM/PM still appears on the group-header row and the below-bubble timestamp.

### Behind the scenes
- Added a regression test asserting the continuation-row gutter time stays single-line with no AM/PM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)