### PR TITLE
Fix canvas minimap overshooting on mobile and PNG export crash on Android

### DIFF
--- a/apps/client/lib/src/services/canvas_export_service.dart
+++ b/apps/client/lib/src/services/canvas_export_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -21,6 +22,30 @@ class CanvasExportService {
   /// it's reading an incompatible payload.
   static const int snapshotFormatVersion = 1;
 
+  /// Maximum pixel dimension safe on mobile GPUs (most cap at 4096–8192).
+  /// Using 4096 keeps us inside even the most conservative Android devices.
+  static const double _kMaxTextureDim = 4096;
+
+  /// Minimum pixel ratio to keep the output legible even on tiny boundaries.
+  static const double _kMinPixelRatio = 0.5;
+
+  /// Clamp [pixelRatio] so that neither dimension of the rendered image
+  /// exceeds [maxDim] pixels. Protects against "invalid arguments" on Android
+  /// when the boundary size × ratio overflows the GPU texture limit.
+  ///
+  /// This is a pure helper exposed for testing.
+  static double clampPixelRatio(
+    Size boundarySize, {
+    double pixelRatio = 2.0,
+    double maxDim = _kMaxTextureDim,
+    double minRatio = _kMinPixelRatio,
+  }) {
+    final longest = math.max(boundarySize.width, boundarySize.height);
+    if (longest <= 0) return minRatio;
+    final clamped = math.min(pixelRatio, maxDim / longest);
+    return math.max(clamped, minRatio);
+  }
+
   /// Capture the active canvas as a PNG. Returns the PNG bytes ready to be
   /// written to disk. Caller is responsible for picking a destination path
   /// — most surfaces will use `file_picker.saveFile`.
@@ -32,7 +57,8 @@ class CanvasExportService {
     if (object is! RenderRepaintBoundary) {
       throw StateError('Voice canvas repaint boundary is not mounted yet.');
     }
-    final image = await object.toImage(pixelRatio: pixelRatio);
+    final effectiveRatio = clampPixelRatio(object.size, pixelRatio: pixelRatio);
+    final image = await object.toImage(pixelRatio: effectiveRatio);
     try {
       final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
       if (byteData == null) {

--- a/apps/client/lib/src/widgets/voice_lounge/canvas_minimap.dart
+++ b/apps/client/lib/src/widgets/voice_lounge/canvas_minimap.dart
@@ -62,10 +62,25 @@ class CanvasMinimap extends ConsumerWidget {
         void recenterFrom(Offset boxPoint) =>
             onRecenter(proj.boxToWorld(boxPoint));
 
+        // Incremental pan: translate the viewport by the minimap delta scaled
+        // to world space. Absolute snap-to-touch on every event overshoots on
+        // mobile because coarse-touch deltas jump the viewport centre rather
+        // than nudging it.
+        void recenterDelta(Offset delta) {
+          final worldDelta = delta / proj.fit;
+          final current = proj.boxToWorld(
+            Offset(
+              proj.offset.dx + (viewportRect.width * proj.fit) / 2,
+              proj.offset.dy + (viewportRect.height * proj.fit) / 2,
+            ),
+          );
+          onRecenter(current + worldDelta);
+        }
+
         final scheme = Theme.of(context).colorScheme;
         return GestureDetector(
           onTapDown: (d) => recenterFrom(d.localPosition),
-          onPanUpdate: (d) => recenterFrom(d.localPosition),
+          onPanUpdate: (d) => recenterDelta(d.delta),
           child: Container(
             width: width,
             height: height,

--- a/apps/client/test/services/canvas_export_service_test.dart
+++ b/apps/client/test/services/canvas_export_service_test.dart
@@ -1,8 +1,62 @@
 import 'package:echo_app/src/models/canvas_models.dart';
 import 'package:echo_app/src/services/canvas_export_service.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('CanvasExportService.clampPixelRatio', () {
+    test('returns requested ratio when image fits within maxDim', () {
+      // 200x100 boundary at 2.0 → max dimension 400, well under 4096.
+      final ratio = CanvasExportService.clampPixelRatio(
+        const Size(200, 100),
+        pixelRatio: 2.0,
+        maxDim: 4096,
+      );
+      expect(ratio, closeTo(2.0, 0.0001));
+    });
+
+    test('clamps ratio so the longest side stays at maxDim', () {
+      // 3000x2000 boundary at 2.0 → longest side would be 6000 > 4096.
+      // Expected: 4096 / 3000 ≈ 1.3653.
+      final ratio = CanvasExportService.clampPixelRatio(
+        const Size(3000, 2000),
+        pixelRatio: 2.0,
+        maxDim: 4096,
+      );
+      expect(ratio, closeTo(4096 / 3000, 0.0001));
+    });
+
+    test('never returns below minRatio', () {
+      // Boundary larger than maxDim itself (e.g. 10000px logical).
+      final ratio = CanvasExportService.clampPixelRatio(
+        const Size(10000, 10000),
+        pixelRatio: 2.0,
+        maxDim: 4096,
+        minRatio: 0.5,
+      );
+      expect(ratio, greaterThanOrEqualTo(0.5));
+    });
+
+    test('handles zero-size boundary without throwing', () {
+      final ratio = CanvasExportService.clampPixelRatio(
+        Size.zero,
+        pixelRatio: 2.0,
+      );
+      expect(ratio, equals(0.5)); // minRatio floor
+    });
+
+    test('portrait boundary clamps on height', () {
+      // 1000x4000 boundary at 2.0 → longest side is 4000, result 8000 > 4096.
+      // Expected: 4096 / 4000 = 1.024.
+      final ratio = CanvasExportService.clampPixelRatio(
+        const Size(1000, 4000),
+        pixelRatio: 2.0,
+        maxDim: 4096,
+      );
+      expect(ratio, closeTo(4096 / 4000, 0.0001));
+    });
+  });
+
   group('CanvasExportService', () {
     test('encodes + decodes a snapshot losslessly', () {
       // Coords are in absolute canvas-space pixels (kCanvasWidth × kCanvasHeight).


### PR DESCRIPTION
Two small voice-lounge canvas fixes from an audit pass.

## Fixed

- **Minimap drag overshoots on mobile** — touching the minimap and dragging previously snapped the viewport centre to the exact touch point on every frame, causing coarse mobile deltas to overshoot wildly. `onPanUpdate` now applies incremental world-space deltas (`delta / fit`) so the viewport nudges by the same distance the finger moved. `onTapDown` (tap-to-jump) is unchanged so desktop behaviour is unaffected.

- **PNG export crashes on Android with "invalid arguments"** — `toImage(pixelRatio: 2.0)` on a large boundary can produce pixel dimensions that exceed the GPU texture limit (~4096 px on many Android devices). A new `clampPixelRatio` pure helper caps the effective ratio so neither output dimension exceeds 4096 px, floored at 0.5× to keep output legible. Desktop export stays at full quality on normal-sized boundaries.

## Behind the scenes

- Added `dart:math` import to `canvas_export_service.dart` for the clamp.
- Extracted `CanvasExportService.clampPixelRatio` as a testable static; 5 new unit tests cover the pass-through, landscape clamp, portrait clamp, zero-size guard, and minRatio-floor cases.
- All 12 canvas-export + minimap tests pass; `dart format` + `flutter analyze --fatal-infos` clean; lefthook pre-commit and pre-push gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)