### PR TITLE
Messages you send now appear instantly on your other devices in group chats

### DIFF
--- a/apps/server/src/ws/hub.rs
+++ b/apps/server/src/ws/hub.rs
@@ -164,6 +164,38 @@ impl Hub {
         self.send_to_user(user_id, msg)
     }
 
+    /// Send a message to all connected devices of a user **except** one specific device.
+    /// Returns the device IDs whose outbound queues accepted the message.
+    ///
+    /// Used by the group-fanout path to deliver `new_message` to the sender's sibling
+    /// devices without re-delivering to the originating device (same device-id-vs-user-id
+    /// class as VL-19: exclude by device, not by user).
+    pub fn send_to_user_except_device(
+        &self,
+        user_id: &Uuid,
+        exclude_device_id: i32,
+        msg: WsMessage,
+    ) -> SmallVec<[i32; 4]> {
+        let device_ids: SmallVec<[(i32, WsTx); 4]> = {
+            let Some(devices) = self.inner.connections.get(user_id) else {
+                return SmallVec::new();
+            };
+            devices
+                .iter()
+                .filter(|e| *e.key() != exclude_device_id)
+                .map(|e| (*e.key(), e.value().clone()))
+                .collect()
+        };
+
+        let mut accepted: SmallVec<[i32; 4]> = SmallVec::with_capacity(device_ids.len());
+        for (device_id, tx) in device_ids {
+            if self.try_send_tracked(*user_id, device_id, &tx, msg.clone()) {
+                accepted.push(device_id);
+            }
+        }
+        accepted
+    }
+
     /// Broadcast a JSON event to all members of a conversation, optionally excluding one user.
     ///
     /// The JSON string is converted to a `WsMessage` once. Subsequent sends clone the

--- a/apps/server/src/ws/message_service/fanout.rs
+++ b/apps/server/src/ws/message_service/fanout.rs
@@ -302,6 +302,52 @@ async fn filter_revoked_devices(
     rdc
 }
 
+// ── Sender sibling-device delivery ───────────────────────────────────────────
+
+/// Deliver `new_message` to the sender's OTHER connected devices when no per-device
+/// self-slice was included in `recipient_device_contents`.
+///
+/// Background: `deliver_self_messages` (in `storage.rs`) only runs when the sender
+/// included their own devices in `recipient_device_contents`. For plaintext groups (and
+/// any encrypted group where the sender omits a self-slice), device B of the sender
+/// never receives the message because the main fanout loop excludes ALL of the sender's
+/// connections (`id != sender_id`). This function covers that gap by delivering the
+/// public `new_message` frame — the same frame every other group member receives —
+/// directly to the sender's sibling devices using device-id exclusion instead of
+/// user-id exclusion.
+///
+/// The originating device (device A) is explicitly excluded so it cannot double-render:
+/// it already has an optimistic local echo and uses `message_id` dedup. The client's
+/// `addMessage` call on `new_message` is idempotent on duplicate IDs, providing a
+/// second safety net.
+///
+/// DMs are unaffected: the DM sender always includes themselves in
+/// `recipient_device_contents` so `deliver_self_messages` handles their sibling
+/// devices, and `per_recipient_json` will contain the sender's user ID in that case.
+pub(in crate::ws::message_service) fn deliver_to_sender_other_devices(
+    hub: &crate::ws::hub::Hub,
+    sender_id: Uuid,
+    sender_device_id: i32,
+    per_recipient_json: Option<&HashMap<Uuid, Vec<(i32, WsMessage)>>>,
+    legacy_msg: Option<&WsMessage>,
+) {
+    // If the sender's own devices are already in per_recipient_json, then
+    // deliver_self_messages already sent per-device ciphertext frames to each of
+    // them. Skip the fallback so we don't double-deliver.
+    if per_recipient_json
+        .map(|m| m.contains_key(&sender_id))
+        .unwrap_or(false)
+    {
+        return;
+    }
+
+    let Some(msg) = legacy_msg else {
+        return;
+    };
+
+    hub.send_to_user_except_device(&sender_id, sender_device_id, msg.clone());
+}
+
 // ── @here suppression ────────────────────────────────────────────────────────
 
 /// Decide whether offline push should be suppressed for this message.
@@ -427,6 +473,18 @@ pub(in crate::ws::message_service) async fn fanout_message(
             "failed to populate per-device delivery ledger on fanout: {e:?}"
         );
     }
+
+    // Deliver new_message to the sender's sibling devices when no per-device self-slice
+    // was provided. Covers plaintext groups and any group send that omits a self-slice
+    // in recipient_device_contents. DMs are handled by deliver_self_messages (storage.rs)
+    // and are skipped here because per_recipient_json will contain the sender's user ID.
+    deliver_to_sender_other_devices(
+        &state.hub,
+        sender_id,
+        sender_device_id,
+        per_recipient_json.as_ref(),
+        legacy_msg.as_ref(),
+    );
 
     if any_delivered {
         send_delivery_confirmation(state, sender_id, sender_device_id, stored_id, conv_id).await;

--- a/apps/server/tests/ws_fanout.rs
+++ b/apps/server/tests/ws_fanout.rs
@@ -470,6 +470,118 @@ async fn at_everyone_does_not_suppress_offline_replay() {
 }
 
 // ---------------------------------------------------------------------------
+// Group multi-device sender sync: device B sees messages sent from device A
+// ---------------------------------------------------------------------------
+
+/// Regression for the group sender-sync bug: when Alice sends a plaintext group
+/// message from device 1, her other device (device 2) must receive the
+/// `new_message` frame live. Before the fix, `fanout_message` filtered ALL of
+/// the sender's connections (`id != sender_id`), so device 2 saw nothing until
+/// it re-opened the conversation.
+///
+/// Assertions:
+///   1. Alice device 2 receives `new_message` with the correct content and
+///      conversation ID.
+///   2. Alice device 1 (the originating device) does NOT receive a duplicate
+///      `new_message` within 300 ms — it already has an optimistic local echo.
+///   3. Bob and Charlie each receive their own `new_message` (basic sanity that
+///      the normal fanout path is unaffected).
+#[tokio::test]
+async fn group_sender_other_device_receives_new_message_live() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+
+    let (alice_token, _alice_id, alice_name) =
+        common::register_and_login(&client, &base, "gsync_alice").await;
+    let (bob_token, bob_id, _) = common::register_and_login(&client, &base, "gsync_bob").await;
+    let (charlie_token, charlie_id, _) =
+        common::register_and_login(&client, &base, "gsync_charlie").await;
+
+    let group_id =
+        common::create_plaintext_group(&client, &base, &alice_token, "SenderSyncGroup").await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &bob_id).await;
+    common::add_member_to_group(&client, &base, &alice_token, &group_id, &charlie_id).await;
+
+    // Alice on two devices: device 1 sends, device 2 should receive the live update.
+    let alice_d1_ticket = common::get_ws_ticket_for_device(&client, &base, &alice_token, 1).await;
+    let alice_d2_ticket = common::get_ws_ticket_for_device(&client, &base, &alice_token, 2).await;
+    let bob_ticket = common::get_ws_ticket(&client, &base, &bob_token).await;
+    let charlie_ticket = common::get_ws_ticket(&client, &base, &charlie_token).await;
+
+    let mut alice_d1_ws = connect_ws(&base, &alice_d1_ticket).await;
+    let mut alice_d2_ws = connect_ws(&base, &alice_d2_ticket).await;
+    let mut bob_ws = connect_ws(&base, &bob_ticket).await;
+    let mut charlie_ws = connect_ws(&base, &charlie_ticket).await;
+
+    common::drain_pending(&mut alice_d1_ws).await;
+    common::drain_pending(&mut alice_d2_ws).await;
+    common::drain_pending(&mut bob_ws).await;
+    common::drain_pending(&mut charlie_ws).await;
+
+    let send_msg = serde_json::json!({
+        "type": "send_message",
+        "conversation_id": group_id,
+        "content": "hello from device 1",
+    });
+    alice_d1_ws
+        .send(Message::Text(send_msg.to_string().into()))
+        .await
+        .expect("Alice d1 send failed");
+
+    // Alice device 1 — should get message_sent (send confirmation), not new_message.
+    let ack = common::recv_until_event(&mut alice_d1_ws, &["message_sent"]).await;
+    assert_eq!(
+        ack["type"], "message_sent",
+        "originating device must get message_sent"
+    );
+
+    // Alice device 2 — must receive new_message live (the bug: previously received nothing).
+    let d2_event = common::recv_until_event(&mut alice_d2_ws, &["new_message"]).await;
+    assert_eq!(
+        d2_event["type"], "new_message",
+        "sender's sibling device must receive new_message"
+    );
+    assert_eq!(
+        d2_event["content"], "hello from device 1",
+        "sibling device must receive correct content"
+    );
+    assert_eq!(
+        d2_event["conversation_id"], group_id,
+        "sibling device must receive correct conversation_id"
+    );
+    assert_eq!(
+        d2_event["from_username"],
+        alice_name.as_str(),
+        "sibling device must see correct sender username"
+    );
+
+    // Alice device 1 — must NOT receive a duplicate new_message within 300 ms.
+    let dup_result = tokio::time::timeout(
+        std::time::Duration::from_millis(300),
+        recv_new_message(&mut alice_d1_ws),
+    )
+    .await;
+    assert!(
+        dup_result.is_err(),
+        "originating device must not receive a duplicate new_message; got: {dup_result:?}"
+    );
+
+    // Bob and Charlie must still receive new_message (regression guard).
+    let bob_event = common::recv_until_event(&mut bob_ws, &["new_message"]).await;
+    assert_eq!(bob_event["type"], "new_message");
+    assert_eq!(bob_event["content"], "hello from device 1");
+
+    let charlie_event = common::recv_until_event(&mut charlie_ws, &["new_message"]).await;
+    assert_eq!(charlie_event["type"], "new_message");
+    assert_eq!(charlie_event["content"], "hello from device 1");
+
+    let _ = alice_d1_ws.close(None).await;
+    let _ = alice_d2_ws.close(None).await;
+    let _ = bob_ws.close(None).await;
+    let _ = charlie_ws.close(None).await;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

When you sent a message to a group from one device, your other devices (e.g. phone + desktop open at the same time) never saw it live — you had to leave and reopen the conversation to see it. This fixes that.

## Fixed

- **Group messages now appear instantly on all of the sender's devices.** The server now delivers `new_message` to every connected device of the sender except the originating one, so device B sees the message at the same time as the group peers.
- The originating device (device A) is excluded by device ID, not user ID, so it cannot double-render its optimistic local echo.
- 1:1 DMs are unaffected — they use a separate `SelfMessage` path via per-device ciphertext that was already working correctly.
- Group members (Bob, Charlie, etc.) are unaffected — their fanout path is unchanged.

## Root cause

`fanout_message` filtered **all** of the sender's connected sessions (`id != sender_id`), leaving device B with nothing. The existing `deliver_self_messages` path in `storage.rs` only fires when `recipient_device_contents` carries a sender self-slice — which plaintext groups (and encrypted groups that omit a self-slice) never include. Same device-id-vs-user-id exclusion class as VL-19.

## Behind the scenes

- Added `Hub::send_to_user_except_device` — delivers to all connections of a user except one specific device ID.
- Added `deliver_to_sender_other_devices` helper in `fanout.rs` — called after the main member loop; skipped when the sender's per-device ciphertext slice is already handled by `deliver_self_messages`.
- New integration test `group_sender_other_device_receives_new_message_live` in `ws_fanout.rs` asserts device B receives `new_message`, device A receives no duplicate within 300 ms, and Bob/Charlie still receive their copies normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)