### PR TITLE
Voice & Video settings no longer crashes on mobile when device enumeration fails

### DIFF
--- a/apps/client/lib/src/screens/settings/voice_section.dart
+++ b/apps/client/lib/src/screens/settings/voice_section.dart
@@ -38,6 +38,10 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
   ];
   bool _devicesLoaded = false;
 
+  /// Set to true when [_loadAudioDevices] catches an exception so the UI can
+  /// offer a Retry button rather than silently showing stale defaults.
+  bool _deviceEnumerationFailed = false;
+
   // Mic test state
   bool _isMicTesting = false;
   double _micLevel = 0.0;
@@ -73,8 +77,31 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    // Kick off device enumeration exactly once, safely outside build.
+    // unawaited is intentional: the async result is handled inside
+    // _loadAudioDevices via setState / _deviceEnumerationFailed.
+    unawaited(_loadAudioDevices());
+  }
+
+  @override
   void dispose() {
-    _stopMicTest();
+    // Cancel the timer and release native resources without calling setState —
+    // setState during dispose triggers a _lifecycleState assertion because the
+    // element is already being torn down.
+    _micTestTimer?.cancel();
+    _micTestTimer = null;
+    _audioLevelAnalyzer?.dispose();
+    _audioLevelAnalyzer = null;
+    final stream = _micTestStream;
+    _micTestStream = null;
+    if (stream != null) {
+      for (final track in stream.getTracks()) {
+        track.stop();
+      }
+      stream.dispose();
+    }
     super.dispose();
   }
 
@@ -313,6 +340,14 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
         'VoiceSettings',
         '_loadAudioDevices threw: $e\n$st',
       );
+      // Mark failure so the UI can show a note + Retry button instead of
+      // silently displaying stale defaults. _devicesLoaded is already true
+      // (set above the try), so a rebuild will never retry automatically.
+      if (mounted) {
+        setState(() {
+          _deviceEnumerationFailed = true;
+        });
+      }
     }
   }
 
@@ -352,9 +387,6 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
   Widget build(BuildContext context) {
     final voice = ref.watch(voiceSettingsProvider);
     final notifier = ref.read(voiceSettingsProvider.notifier);
-
-    // Load real devices on first build
-    _loadAudioDevices();
 
     final inputDevices = _audioInputDevices;
     final outputDevices = _audioOutputDevices;
@@ -400,6 +432,18 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
           currentId: voice.cameraDeviceId,
           onChanged: notifier.setCameraDevice,
         ),
+        if (_deviceEnumerationFailed) ...[
+          const SizedBox(height: 8),
+          _DeviceEnumerationErrorNote(
+            onRetry: () {
+              setState(() {
+                _devicesLoaded = false;
+                _deviceEnumerationFailed = false;
+              });
+              unawaited(_loadAudioDevices());
+            },
+          ),
+        ],
         const SizedBox(height: 12),
         _CameraPreview(deviceId: voice.cameraDeviceId),
         const SizedBox(height: 16),
@@ -601,6 +645,45 @@ class _VoiceVideoSectionState extends ConsumerState<VoiceVideoSection> {
           ),
           value: voice.confirmBeforeJoinVoice,
           onChanged: notifier.setConfirmBeforeJoinVoice,
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Device enumeration error note
+// ---------------------------------------------------------------------------
+
+/// Shown below the device pickers when [_VoiceVideoSectionState._loadAudioDevices]
+/// throws (e.g. WebRTC not ready, permission not granted, unsupported platform).
+/// Keeps the defaults visible so the rest of the settings screen remains usable.
+class _DeviceEnumerationErrorNote extends StatelessWidget {
+  const _DeviceEnumerationErrorNote({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(Icons.warning_amber_rounded, size: 14, color: context.textMuted),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            "Couldn't list audio/video devices — showing defaults.",
+            style: TextStyle(color: context.textMuted, fontSize: 12),
+          ),
+        ),
+        const SizedBox(width: 8),
+        TextButton(
+          onPressed: onRetry,
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: const Text('Retry', style: TextStyle(fontSize: 12)),
         ),
       ],
     );

--- a/apps/client/test/screens/settings/voice_section_test.dart
+++ b/apps/client/test/screens/settings/voice_section_test.dart
@@ -1,28 +1,117 @@
 // Tests for Voice & Video settings screen device enumeration.
 //
-// Bug: On Linux, flutter_webrtc's enumerateDevices returns PulseAudio devices
-// with deviceId='default'. The original _loadAudioDevices loop filtered them
-// out with `d.deviceId != 'default'`, leaving the dropdown empty despite the
-// provider log saying "applied 1 in / 1 out".
+// Bug 1 (Linux, original): flutter_webrtc's enumerateDevices returns PulseAudio
+// devices with deviceId='default'. The original _loadAudioDevices loop filtered
+// them out with `d.deviceId != 'default'`, leaving the dropdown empty despite
+// the provider log saying "applied 1 in / 1 out".
+//
+// Bug 2 (Mobile, this fix): _loadAudioDevices() was called from build(). On
+// Android/iOS, enumerateDevices() can throw a PlatformException (WebRTC not
+// ready / permission not granted). Calling it from build caused a crash and
+// could produce rebuild loops. Fixed by moving the call to initState and
+// wrapping it in unawaited() with a try/catch that sets _deviceEnumerationFailed.
 //
 // Repro (manual):
 //   1. Run the Linux build (flutter run -d linux or the AppImage).
 //   2. Log in, open Settings → Voice & Video.
 //   3. Observe both input and output dropdowns are empty even though
 //      the system has working audio.
-//
-// The widget test below is skipped because it requires the flutter_webrtc
-// native plugin (Linux platform channels) to intercept enumerateDevices.
-// The unit tests in the second group exercise the equivalent classification
-// logic in isolation and are the canonical regression guard.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:echo_app/src/screens/settings/voice_section.dart';
 import 'package:echo_app/src/theme/echo_theme.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers for stubbing the flutter_webrtc platform channel in tests.
+// ---------------------------------------------------------------------------
+
+/// Fake texture id used by the [_stubWebRtcBase] renderer stub.
+const int _kFakeTextureId = 42;
+
+/// Installs a base stub for the FlutterWebRTC.Method channel that handles
+/// `createVideoRenderer` (needed by [_CameraPreview]) and any `getUserMedia`
+/// or renderer teardown calls so the test host doesn't crash.
+///
+/// Set [sourcesThrows] to simulate the mobile crash: `getSources` (which backs
+/// `enumerateDevices`) throws a [PlatformException].
+void _stubWebRtcBase({bool sourcesThrows = false}) {
+  const channel = MethodChannel('FlutterWebRTC.Method');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+        switch (call.method) {
+          case 'createVideoRenderer':
+            // RTCVideoRenderer.initialize() reads response['textureId'].
+            return {'textureId': _kFakeTextureId};
+          case 'videoRendererDispose':
+          case 'setVolume':
+            return null;
+          case 'getUserMedia':
+            // Stub mic/camera as unavailable for these tests.
+            throw PlatformException(
+              code: 'NOT_AVAILABLE',
+              message: 'getUserMedia stubbed',
+            );
+          case 'getSources':
+            // enumerateDevices() → getSources() via MediaDeviceNative.
+            if (sourcesThrows) {
+              throw PlatformException(
+                code: 'PERMISSION_DENIED',
+                message: 'WebRTC media device enumeration failed',
+              );
+            }
+            // Return empty list — triggers the sentinel-default path.
+            return {'sources': <dynamic>[]};
+          default:
+            return null;
+        }
+      });
+}
+
+/// Variant: first `getSources` call throws, subsequent calls succeed with an
+/// empty source list — simulating WebRTC becoming ready after a retry.
+void _stubWebRtcFirstCallThrowsThenSucceeds() {
+  var sourcesCallCount = 0;
+  const channel = MethodChannel('FlutterWebRTC.Method');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+        switch (call.method) {
+          case 'createVideoRenderer':
+            return {'textureId': _kFakeTextureId};
+          case 'videoRendererDispose':
+          case 'setVolume':
+            return null;
+          case 'getUserMedia':
+            throw PlatformException(
+              code: 'NOT_AVAILABLE',
+              message: 'getUserMedia stubbed',
+            );
+          case 'getSources':
+            sourcesCallCount++;
+            if (sourcesCallCount == 1) {
+              throw PlatformException(
+                code: 'NOT_READY',
+                message: 'WebRTC not initialised',
+              );
+            }
+            // Second call succeeds with empty sources.
+            return {'sources': <dynamic>[]};
+          default:
+            return null;
+        }
+      });
+}
+
+/// Clears the mock handler so it doesn't bleed into later tests.
+void _clearWebRtcStub() {
+  const channel = MethodChannel('FlutterWebRTC.Method');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, null);
+}
 
 // ---------------------------------------------------------------------------
 // Lightweight stand-in for flutter_webrtc MediaDeviceInfo – mirrors the three
@@ -123,6 +212,8 @@ void main() {
       SharedPreferences.setMockInitialValues({});
     });
 
+    tearDown(_clearWebRtcStub);
+
     testWidgets(
       'Linux: input and output dropdowns are not empty after enumerateDevices '
       'returns a device with deviceId=default',
@@ -147,6 +238,88 @@ void main() {
       // which can't be mocked from a headless test runner. The unit tests
       // below cover the classification logic that was actually broken.
       skip: true,
+    );
+
+    testWidgets(
+      'mobile crash fix: section builds without throwing when enumerateDevices '
+      'throws a PlatformException',
+      (tester) async {
+        // Regression test for the mobile crash: _loadAudioDevices() used to be
+        // called directly from build(). On Android/iOS, enumerateDevices() can
+        // throw synchronously or via an unguarded PlatformException. The fix
+        // moves the call to initState() and wraps it in a try/catch that sets
+        // _deviceEnumerationFailed instead of rethrowing.
+        _stubWebRtcBase(sourcesThrows: true);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              theme: EchoTheme.darkTheme,
+              home: const Scaffold(body: VoiceVideoSection()),
+            ),
+          ),
+        );
+
+        // Initial frame — build must not throw. Device list shows defaults.
+        await tester.pump();
+
+        // Flush the async _loadAudioDevices() microtask so the catch block
+        // (which sets _deviceEnumerationFailed) runs and the error note renders.
+        // Also advance past the DebugLogService debounce timer (50 ms).
+        await tester.pump(const Duration(milliseconds: 100));
+
+        // The section must still be on screen and the three dropdowns visible.
+        expect(find.byType(VoiceVideoSection), findsOneWidget);
+        expect(find.byType(DropdownButtonFormField<String>), findsWidgets);
+
+        // The graceful error note must be visible.
+        expect(
+          find.textContaining("Couldn't list audio/video devices"),
+          findsOneWidget,
+        );
+        expect(find.text('Retry'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'mobile crash fix: Retry button re-triggers enumeration and clears the '
+      'error note on success',
+      (tester) async {
+        // First attempt fails; second attempt (after Retry) succeeds with an
+        // empty device list — triggers the sentinel-default path.
+        _stubWebRtcFirstCallThrowsThenSucceeds();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MaterialApp(
+              theme: EchoTheme.darkTheme,
+              home: const Scaffold(body: VoiceVideoSection()),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        // Error note visible after first (failed) enumeration.
+        expect(
+          find.textContaining("Couldn't list audio/video devices"),
+          findsOneWidget,
+        );
+
+        // Tap Retry — triggers second enumeration which succeeds.
+        await tester.tap(find.text('Retry'));
+        await tester.pump();
+        // Flush the DebugLogService info-log debounce timer (500 ms) as well
+        // as the _loadAudioDevices async microtask.
+        await tester.pump(const Duration(milliseconds: 600));
+
+        // Error note must be gone; dropdowns still present with defaults.
+        expect(
+          find.textContaining("Couldn't list audio/video devices"),
+          findsNothing,
+        );
+        expect(find.byType(DropdownButtonFormField<String>), findsWidgets);
+      },
     );
   });
 


### PR DESCRIPTION
## Summary

Voice & Video settings crashed on Android and iOS whenever the screen was opened and device enumeration threw a PlatformException (WebRTC not yet initialised, permission not granted, or API not supported).

## Fixed

- **Crash on open**: `_loadAudioDevices()` was called directly from `build()`. On mobile, `enumerateDevices()` (via `getSources()`) can throw before any async suspension, propagating the exception into the build call stack. Moved the call to `initState()` with `unawaited()` so it runs exactly once, safely outside of `build`.
- **Silent failure with no user feedback**: the original catch block only logged the error. Now `_deviceEnumerationFailed` is set so the UI shows a "Couldn't list audio/video devices — showing defaults" note with a Retry button below the device pickers.
- **setState during dispose assertion**: `_stopMicTest()` called `setState()` inside `dispose()`, which triggers a `_lifecycleState != _ElementLifecycle.defunct` assertion. Fixed `dispose()` to release native resources directly without calling `setState`.

## Behind the scenes

- Added two new widget tests (platform-channel stubs for `FlutterWebRTC.Method`):
  - section builds without throwing when enumerateDevices throws a PlatformException — regression guard for the crash
  - Retry button re-triggers enumeration and clears the error note on success
- All 16 settings tests pass (1 skipped: existing native-plugin test that was already intentionally skipped).
- `dart format`, `flutter analyze --fatal-infos`, and lefthook pre-push all green.

## Changed files

- `apps/client/lib/src/screens/settings/voice_section.dart`
- `apps/client/test/screens/settings/voice_section_test.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)