### PR TITLE
Fix Android voice call cutting out when screen turns off

### DIFF
--- a/apps/client/android/app/src/main/kotlin/com/echo_messenger/EchoForegroundService.kt
+++ b/apps/client/android/app/src/main/kotlin/com/echo_messenger/EchoForegroundService.kt
@@ -7,6 +7,9 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
 import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
@@ -46,6 +49,8 @@ class EchoForegroundService : Service() {
     }
 
     private var wakeLock: PowerManager.WakeLock? = null
+    // Held for the lifetime of a voice session; null outside voice mode.
+    private var audioFocusRequest: AudioFocusRequest? = null
     private var currentMode: String = MODE_KEEPALIVE
     private var voiceChannelName: String = ""
     private var voiceIsMuted: Boolean = false
@@ -67,6 +72,26 @@ class EchoForegroundService : Service() {
             voiceIsMuted = intent?.getBooleanExtra(EXTRA_IS_MUTED, voiceIsMuted) ?: voiceIsMuted
             voiceParticipantCount = intent?.getIntExtra(EXTRA_PARTICIPANT_COUNT, voiceParticipantCount)
                 ?: voiceParticipantCount
+
+            // Request audio focus so Doze / aggressive battery policies cannot
+            // duck or suspend the voice session while the screen is off.
+            // AudioFocusRequest.Builder requires API 26; minSdk is 24.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && audioFocusRequest == null) {
+                val attrs = AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+                val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                    .setAudioAttributes(attrs)
+                    .setAcceptsDelayedFocusGain(false)
+                    .setWillPauseWhenDucked(false)
+                    .build()
+                val am = getSystemService(AudioManager::class.java)
+                if (am != null) {
+                    am.requestAudioFocus(req)
+                    audioFocusRequest = req
+                }
+            }
         }
 
         val notification = buildNotification()
@@ -111,6 +136,12 @@ class EchoForegroundService : Service() {
     override fun onDestroy() {
         wakeLock?.let { if (it.isHeld) it.release() }
         wakeLock = null
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { req ->
+                getSystemService(AudioManager::class.java)?.abandonAudioFocusRequest(req)
+            }
+        }
+        audioFocusRequest = null
         super.onDestroy()
     }
 


### PR DESCRIPTION
## Summary

- Voice calls on Android could be ducked or suspended by Doze / aggressive battery policies when the screen turned off, because the foreground service never claimed audio focus.
- Now requests `AUDIOFOCUS_GAIN` with `USAGE_VOICE_COMMUNICATION` / `CONTENT_TYPE_SPEECH` the moment voice mode starts, and abandons it on service destroy.

## Fixed

- Android voice audio no longer drops out or goes silent in the background / screen-off state (#31)

## Behind the scenes

- Added `AudioFocusRequest.Builder` (API 26+) path in `EchoForegroundService.onStartCommand` inside the `MODE_VOICE` branch, guarded by `Build.VERSION_CODES.O` (minSdk is 24).
- Stored `audioFocusRequest: AudioFocusRequest?` field mirroring the `wakeLock` lifecycle pattern already in the service.
- `abandonAudioFocusRequest` called in `onDestroy` alongside `WakeLock.release()`.
- No Dart files changed; `dart format` and `flutter analyze --fatal-infos` both clean.

## Test plan

- [ ] Join a voice channel on Android, lock the screen — audio should remain live.
- [ ] Leave the voice channel / kill the app — verify the Android CI build passes (path filter: `apps/client/android/**`).
- [ ] On-device verification required before merge (no Android emulator available in CI for audio focus testing).

> **Note:** Needs on-device verification and the Android dev-build CI green before merging. Integrate via `dev` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)