### PR TITLE
Fix portrait/vertical videos playing in a tiny letterboxed 16:9 box

### DIFF
--- a/apps/client/lib/src/widgets/message/video_player.dart
+++ b/apps/client/lib/src/widgets/message/video_player.dart
@@ -41,19 +41,44 @@ class InlineVideoPlayer extends StatefulWidget {
   State<InlineVideoPlayer> createState() => _InlineVideoPlayerState();
 }
 
+/// Maximum height (logical pixels) for the inline video bubble. Prevents a
+/// portrait clip from consuming the entire chat timeline vertically.
+const double _kInlineMaxHeight = 400;
+
+/// Clamp factor shared with the fullscreen player so both behave consistently.
+const double _kAspectMin = 0.3;
+const double _kAspectMax = 5.0;
+
+/// Resolves the aspect ratio to use for the inline video surface.
+///
+/// Falls back to 16:9 while the codec hasn't reported real dimensions yet.
+/// Exposed as a top-level function so it can be exercised in unit tests.
+double resolveInlineAspectRatio(int videoWidth, int videoHeight) {
+  if (videoWidth > 0 && videoHeight > 0) {
+    return (videoWidth / videoHeight).clamp(_kAspectMin, _kAspectMax);
+  }
+  return 16 / 9;
+}
+
 class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
   Player? _player;
   VideoController? _videoController;
   bool _started = false;
   bool _initFailed = false;
   bool _isPlaying = false;
+  int _videoWidth = 0;
+  int _videoHeight = 0;
   StreamSubscription<bool>? _playingSub;
   StreamSubscription<String>? _errorSub;
+  StreamSubscription<int?>? _widthSub;
+  StreamSubscription<int?>? _heightSub;
 
   @override
   void dispose() {
     _playingSub?.cancel();
     _errorSub?.cancel();
+    _widthSub?.cancel();
+    _heightSub?.cancel();
     _player?.dispose();
     super.dispose();
   }
@@ -70,6 +95,12 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
       final controller = VideoController(player);
       _playingSub = player.stream.playing.listen((v) {
         if (mounted) setState(() => _isPlaying = v);
+      });
+      _widthSub = player.stream.width.listen((v) {
+        if (mounted && v != null) setState(() => _videoWidth = v);
+      });
+      _heightSub = player.stream.height.listen((v) {
+        if (mounted && v != null) setState(() => _videoHeight = v);
       });
       _errorSub = player.stream.error.listen((e) {
         if (!mounted || e.isEmpty) return;
@@ -121,6 +152,7 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
+    final aspectRatio = resolveInlineAspectRatio(_videoWidth, _videoHeight);
     return Container(
       width: 300,
       padding: const EdgeInsets.all(4),
@@ -131,7 +163,13 @@ class _InlineVideoPlayerState extends State<InlineVideoPlayer> {
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(10),
-        child: AspectRatio(aspectRatio: 16 / 9, child: _buildVideoArea()),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: _kInlineMaxHeight),
+          child: AspectRatio(
+            aspectRatio: aspectRatio,
+            child: _buildVideoArea(),
+          ),
+        ),
       ),
     );
   }
@@ -531,9 +569,7 @@ class _FullscreenVideoPlayerState extends State<FullscreenVideoPlayer> {
         : 0.0;
     // Fall back to 16:9 until the codec reports real dimensions. Clamp wide
     // so a portrait phone clip doesn't take over the screen vertically.
-    final aspectRatio = (_videoWidth > 0 && _videoHeight > 0)
-        ? (_videoWidth / _videoHeight).clamp(0.3, 5.0)
-        : 16 / 9;
+    final aspectRatio = resolveInlineAspectRatio(_videoWidth, _videoHeight);
 
     return Stack(
       children: [

--- a/apps/client/test/widgets/message/video_player_aspect_test.dart
+++ b/apps/client/test/widgets/message/video_player_aspect_test.dart
@@ -1,0 +1,63 @@
+// Unit tests for resolveInlineAspectRatio (#12).
+//
+// The inline video bubble used to hard-code 16:9 regardless of the video's
+// actual dimensions. Portrait/vertical videos were letterboxed and tiny.
+// resolveInlineAspectRatio() now returns the real w/h ratio once the codec
+// reports dimensions, falling back to 16:9 while initialising.
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/message/video_player.dart';
+
+void main() {
+  group('resolveInlineAspectRatio (#12)', () {
+    test('returns 16/9 when dimensions are not yet known (0, 0)', () {
+      final ratio = resolveInlineAspectRatio(0, 0);
+      expect(ratio, closeTo(16 / 9, 0.001));
+    });
+
+    test('returns 16/9 when width is 0 but height is set', () {
+      final ratio = resolveInlineAspectRatio(0, 1080);
+      expect(ratio, closeTo(16 / 9, 0.001));
+    });
+
+    test('returns 16/9 when height is 0 but width is set', () {
+      final ratio = resolveInlineAspectRatio(1920, 0);
+      expect(ratio, closeTo(16 / 9, 0.001));
+    });
+
+    test('returns correct ratio for landscape 1920x1080', () {
+      final ratio = resolveInlineAspectRatio(1920, 1080);
+      expect(ratio, closeTo(16 / 9, 0.001));
+    });
+
+    test('returns correct ratio for portrait 1080x1920 (9:16)', () {
+      final ratio = resolveInlineAspectRatio(1080, 1920);
+      expect(ratio, closeTo(9 / 16, 0.001));
+    });
+
+    test('returns correct ratio for square 1080x1080', () {
+      final ratio = resolveInlineAspectRatio(1080, 1080);
+      expect(ratio, closeTo(1.0, 0.001));
+    });
+
+    test('clamps extremely wide video to max 5.0', () {
+      final ratio = resolveInlineAspectRatio(10000, 100);
+      expect(ratio, equals(5.0));
+    });
+
+    test('clamps extremely tall video to min 0.3', () {
+      final ratio = resolveInlineAspectRatio(100, 10000);
+      expect(ratio, equals(0.3));
+    });
+
+    test('returns correct ratio for 4:3 (1440x1080)', () {
+      final ratio = resolveInlineAspectRatio(1440, 1080);
+      expect(ratio, closeTo(4 / 3, 0.001));
+    });
+
+    test('returns correct ratio for vertical short-form 1080x1350 (4:5)', () {
+      final ratio = resolveInlineAspectRatio(1080, 1350);
+      expect(ratio, closeTo(1080 / 1350, 0.001));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Portrait and vertical videos (9:16, 4:5, 1:1, etc.) now play in their actual aspect ratio instead of being squashed into a hardcoded 16:9 landscape box inline.
- A `ConstrainedBox(maxHeight: 400)` keeps very tall clips from dominating the timeline; landscape videos are unaffected (their height stays ~169 px at the 300 px bubble width).
- The fullscreen player is unchanged in behavior but now calls the shared `resolveInlineAspectRatio` helper instead of duplicating the clamp logic.

## Fixed

- Inline video bubble hard-coded `AspectRatio(16/9)` regardless of the video's real dimensions (#12). The player now subscribes to `player.stream.width` / `player.stream.height` and recomputes the ratio when the codec reports real dimensions, falling back to 16:9 during load — mirroring the fullscreen player's existing approach.

## Behind the scenes

- Extracted `resolveInlineAspectRatio(int w, int h)` as a testable top-level function with 10 focused unit tests covering portrait, landscape, square, 4:3, short-form 4:5, clamping extremes, and the loading-fallback case.
- `dart format` + `flutter analyze --fatal-infos` clean; lefthook pre-commit and pre-push both pass.

Note: this branch targets `main` but will be integrated via `dev` per the project's standard release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)