### PR TITLE
Stop chat from jumping when images load and add a scroll-to-bottom button

### DIFF
--- a/apps/client/lib/src/widgets/chat_panel.dart
+++ b/apps/client/lib/src/widgets/chat_panel.dart
@@ -23,6 +23,7 @@ import 'chat_input_bar.dart';
 import 'chat_panel_controller.dart';
 import 'chat_panel/chat_panel_body.dart';
 import 'chat_panel/deleted_for_me_storage.dart';
+import 'chat_panel/scroll_to_bottom_button.dart' show kScrollToBottomThreshold;
 import 'chat_panel/drop_handler.dart';
 import 'chat_panel/history_loaders.dart' as history;
 import 'chat_panel/message_actions.dart' as actions;
@@ -151,6 +152,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
   set _hasNewMessagesBelow(bool v) => _controller.hasNewMessagesBelow = v;
   int get _newMessagesBelowCount => _controller.newMessagesBelowCount;
   set _newMessagesBelowCount(int v) => _controller.newMessagesBelowCount = v;
+
+  /// True when the user has scrolled far enough up to show the jump-to-bottom
+  /// button — i.e. more than [kScrollToBottomThreshold] pixels from the end.
+  bool _scrollFarFromBottom = false;
   // Hidden Semantics live-region label (#495). Cleared ~3s after each
   // announcement so a window-focus event doesn't replay the stale label.
   String _liveRegionAnnouncement = '';
@@ -223,6 +228,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
     _pendingInitialMessageId = widget.initialMessageId;
     _hasNewMessagesBelow = false;
     _newMessagesBelowCount = 0;
+    _scrollFarFromBottom = false;
     _unreadBoundaryMessageId = null;
     _unreadBoundaryCount = 0;
     _initialScrollPending = false;
@@ -303,7 +309,19 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         });
       }
     }
+    // Show jump-to-bottom button when scrolled far up (#3/N3).
+    _updateScrollFarFromBottom();
     _updateFloatingDate();
+  }
+
+  void _updateScrollFarFromBottom() {
+    if (!_scrollController.hasClients) return;
+    final pos = _scrollController.position;
+    final distFromBottom = pos.maxScrollExtent - pos.pixels;
+    final farFromBottom = distFromBottom > kScrollToBottomThreshold;
+    if (farFromBottom != _scrollFarFromBottom) {
+      setState(() => _scrollFarFromBottom = farFromBottom);
+    }
   }
 
   void _updateFloatingDate() {
@@ -952,6 +970,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel>
         floatingDateVisible: _floatingDateVisible,
         hasNewMessagesBelow: _hasNewMessagesBelow,
         newMessagesBannerText: _newMessagesBannerText(),
+        scrollFarFromBottom: _scrollFarFromBottom,
         liveRegionAnnouncement: _liveRegionAnnouncement,
         hideVoiceDock: widget.hideVoiceDock,
         typingUsers: input.typingUsers,

--- a/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
+++ b/apps/client/lib/src/widgets/chat_panel/chat_panel_body.dart
@@ -20,6 +20,7 @@ import 'chat_message_list.dart';
 import 'drop_overlay.dart';
 import 'floating_date_pill.dart';
 import 'new_messages_pill.dart';
+import 'scroll_to_bottom_button.dart';
 
 /// Build the inner `chatContentBox` Stack for `ChatPanel.build` — the
 /// header bar, channel bar, banners, message list, floating pills, input
@@ -50,6 +51,7 @@ class ChatPanelBodyParams {
     required this.floatingDateVisible,
     required this.hasNewMessagesBelow,
     required this.newMessagesBannerText,
+    required this.scrollFarFromBottom,
     required this.liveRegionAnnouncement,
     required this.hideVoiceDock,
     required this.typingUsers,
@@ -105,6 +107,11 @@ class ChatPanelBodyParams {
   final bool floatingDateVisible;
   final bool hasNewMessagesBelow;
   final String newMessagesBannerText;
+
+  /// True when the user has scrolled far enough up that the button should
+  /// appear. Driven by the scroll listener in [ChatPanel].
+  final bool scrollFarFromBottom;
+
   final String liveRegionAnnouncement;
   final bool hideVoiceDock;
   final List<String> typingUsers;
@@ -364,6 +371,12 @@ Widget _buildMessageListStack(
           text: p.newMessagesBannerText,
           onTap: p.onScrollToBottom,
         ),
+      // Always keep the widget in the tree so its AnimationController
+      // can drive the fade/scale transition smoothly (#3/N3).
+      ScrollToBottomButton(
+        visible: p.scrollFarFromBottom && !p.hasNewMessagesBelow,
+        onTap: p.onScrollToBottom,
+      ),
       // Live region moved to the outer Stack so its index
       // in the tree is stable across pill toggles (#630).
     ],

--- a/apps/client/lib/src/widgets/chat_panel/scroll_to_bottom_button.dart
+++ b/apps/client/lib/src/widgets/chat_panel/scroll_to_bottom_button.dart
@@ -1,0 +1,121 @@
+// Floating "scroll to latest messages" FAB shown when the user has scrolled
+// far enough up that new/recent messages are out of view.
+import 'package:flutter/material.dart';
+
+import '../../theme/echo_theme.dart';
+
+/// Threshold in pixels beyond which the button appears. One-and-a-half
+/// typical viewport heights keeps it hidden for minor scroll-backs but
+/// surfaces it whenever the user navigates significantly up the history.
+const double kScrollToBottomThreshold = 900.0;
+
+/// A small circular floating button that animates in when the user has
+/// scrolled [kScrollToBottomThreshold] pixels above the bottom of the list.
+///
+/// Tapping it calls [onTap], which should invoke the panel's existing
+/// scroll-to-bottom helper. The button hides automatically via [visible];
+/// the caller drives visibility from the scroll listener.
+class ScrollToBottomButton extends StatefulWidget {
+  final bool visible;
+  final VoidCallback onTap;
+
+  const ScrollToBottomButton({
+    super.key,
+    required this.visible,
+    required this.onTap,
+  });
+
+  @override
+  State<ScrollToBottomButton> createState() => _ScrollToBottomButtonState();
+}
+
+class _ScrollToBottomButtonState extends State<ScrollToBottomButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 200),
+  );
+  late final Animation<double> _fade = CurvedAnimation(
+    parent: _ctrl,
+    curve: Curves.easeOut,
+  );
+  late final Animation<double> _scale = Tween<double>(
+    begin: 0.7,
+    end: 1.0,
+  ).animate(CurvedAnimation(parent: _ctrl, curve: Curves.easeOut));
+
+  @override
+  void initState() {
+    super.initState();
+    // If the button is initially visible (e.g. restored scroll state), skip
+    // the entrance animation and jump straight to fully visible.
+    if (widget.visible) {
+      _ctrl.value = 1.0;
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant ScrollToBottomButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.visible != oldWidget.visible) {
+      if (widget.visible) {
+        _ctrl.forward();
+      } else {
+        _ctrl.reverse();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      // Sit above the new-messages pill position when both are shown; the pill
+      // occupies bottom: EchoSpacing.md (≈12) so we use bottom: 56 here.
+      bottom: 56,
+      right: EchoSpacing.xl,
+      child: FadeTransition(
+        opacity: _fade,
+        child: ScaleTransition(
+          scale: _scale,
+          child: Semantics(
+            label: 'Jump to latest messages',
+            button: true,
+            child: GestureDetector(
+              onTap: widget.onTap,
+              child: Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: context.surface,
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: context.accent.withValues(alpha: 0.35),
+                    width: 1,
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.18),
+                      blurRadius: 6,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Icon(
+                  Icons.keyboard_arrow_down_rounded,
+                  size: 22,
+                  color: context.accent,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/client/lib/src/widgets/message/image_attachment.dart
+++ b/apps/client/lib/src/widgets/message/image_attachment.dart
@@ -137,7 +137,13 @@ class ImageAttachment extends StatelessWidget {
       );
     }
 
-    return cachedImage;
+    // Unknown dimensions: reserve a stable fixed-height box so the message
+    // row does not reflow when the image finishes decoding (#13).
+    return SizedBox(
+      width: kImageBubbleMaxWidth,
+      height: kImageBubbleFallbackHeight,
+      child: cachedImage,
+    );
   }
 
   /// Builds the loading skeleton. When [w] and [h] are known the height is

--- a/apps/client/test/widgets/chat_panel/scroll_to_bottom_button_test.dart
+++ b/apps/client/test/widgets/chat_panel/scroll_to_bottom_button_test.dart
@@ -1,0 +1,144 @@
+// Widget tests for ScrollToBottomButton — visibility driven by [visible] flag.
+//
+// ScrollToBottomButton contains a Positioned widget, so every test wraps it
+// in a Stack (matching the production placement inside _buildMessageListStack).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/widgets/chat_panel/scroll_to_bottom_button.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// Pumps a Stack containing [ScrollToBottomButton] with [visible].
+Future<void> _pump(
+  WidgetTester tester, {
+  required bool visible,
+  VoidCallback? onTap,
+}) async {
+  await tester.pumpApp(
+    Stack(
+      children: [ScrollToBottomButton(visible: visible, onTap: onTap ?? () {})],
+    ),
+  );
+}
+
+/// Returns the first FadeTransition that is a descendant of ScrollToBottomButton.
+FadeTransition _buttonFade(WidgetTester tester) => tester
+    .widgetList<FadeTransition>(
+      find.descendant(
+        of: find.byType(ScrollToBottomButton),
+        matching: find.byType(FadeTransition),
+      ),
+    )
+    .first;
+
+void main() {
+  group('ScrollToBottomButton', () {
+    testWidgets('is hidden (opacity 0) when visible is false', (tester) async {
+      await _pump(tester, visible: false);
+      // Animation has not been forwarded — opacity should be 0.
+      expect(_buttonFade(tester).opacity.value, closeTo(0.0, 0.01));
+    });
+
+    testWidgets('appears (opacity 1) when visible becomes true', (
+      tester,
+    ) async {
+      bool isVisible = false;
+
+      await tester.pumpApp(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return Stack(
+              children: [
+                ScrollToBottomButton(visible: isVisible, onTap: () {}),
+                Positioned(
+                  bottom: 120,
+                  left: 0,
+                  right: 0,
+                  child: Center(
+                    child: ElevatedButton(
+                      onPressed: () => setState(() => isVisible = true),
+                      child: const Text('show'),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      );
+
+      // Initially hidden.
+      expect(_buttonFade(tester).opacity.value, closeTo(0.0, 0.01));
+
+      // Toggle visible = true and let the 200 ms animation settle.
+      await tester.tap(find.text('show'));
+      await tester.pumpAndSettle();
+
+      expect(_buttonFade(tester).opacity.value, closeTo(1.0, 0.01));
+    });
+
+    testWidgets('hides again (opacity 0) when visible goes back to false', (
+      tester,
+    ) async {
+      bool isVisible = true;
+
+      await tester.pumpApp(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return Stack(
+              children: [
+                ScrollToBottomButton(visible: isVisible, onTap: () {}),
+                Positioned(
+                  bottom: 120,
+                  left: 0,
+                  right: 0,
+                  child: Center(
+                    child: ElevatedButton(
+                      onPressed: () => setState(() => isVisible = false),
+                      child: const Text('hide'),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      );
+
+      // Let the entrance animation finish.
+      await tester.pumpAndSettle();
+      expect(_buttonFade(tester).opacity.value, closeTo(1.0, 0.01));
+
+      // Toggle visible = false and let the exit animation finish.
+      await tester.tap(find.text('hide'));
+      await tester.pumpAndSettle();
+
+      expect(_buttonFade(tester).opacity.value, closeTo(0.0, 0.01));
+    });
+
+    testWidgets('carries the a11y label "Jump to latest messages"', (
+      tester,
+    ) async {
+      await _pump(tester, visible: true);
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Jump to latest messages'), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      int taps = 0;
+      await _pump(tester, visible: true, onTap: () => taps++);
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(ScrollToBottomButton),
+          matching: find.byType(GestureDetector),
+        ),
+      );
+      expect(taps, 1);
+    });
+  });
+}

--- a/apps/client/test/widgets/image_attachment_test.dart
+++ b/apps/client/test/widgets/image_attachment_test.dart
@@ -4,7 +4,8 @@
 // These tests verify that:
 //   1. When width + height are provided, the rendered widget tree contains an
 //      AspectRatio with the correct ratio before any image bytes arrive.
-//   2. When dimensions are absent (legacy messages), no AspectRatio is added.
+//   2. When dimensions are absent (legacy messages), the widget uses a
+//      fixed-height SizedBox so the row height is stable before and after load.
 //   3. cacheImageDimensions() pre-populates the session cache so a subsequent
 //      ImageAttachment with the same URL uses the cached ratio automatically.
 
@@ -39,7 +40,7 @@ void main() {
       expect(aspectRatio.aspectRatio, closeTo(2.0, 0.001));
     });
 
-    testWidgets('does not add AspectRatio when dimensions are absent', (
+    testWidgets('uses a stable SizedBox when dimensions are absent', (
       tester,
     ) async {
       await tester.pumpApp(
@@ -49,7 +50,17 @@ void main() {
           // No imageWidth / imageHeight — legacy message.
         ),
       );
+      // No AspectRatio — falls back to fixed-height SizedBox so the row
+      // does not reflow when the image finishes decoding (#13).
       expect(find.byType(AspectRatio), findsNothing);
+
+      // A SizedBox at the fallback height must be in the tree.
+      final boxes = tester.widgetList<SizedBox>(find.byType(SizedBox));
+      expect(
+        boxes.any((b) => b.height == kImageBubbleFallbackHeight),
+        isTrue,
+        reason: 'Expect SizedBox with height=$kImageBubbleFallbackHeight',
+      );
     });
 
     testWidgets('uses session cache when no explicit dimensions are passed', (


### PR DESCRIPTION
Two related chat-list fixes that improve scroll stability and navigation.

## Fixed
- **Chat no longer jumps** when images load below or above the viewport (#13). Images with known dimensions already reserved space via `AspectRatio`; this closes the gap for legacy/non-standard-format images by wrapping them in a fixed-height `SizedBox(height: 200)` so the message row's vertical extent never changes when bytes arrive.
- **Jump-to-bottom button** (#3/N3): a small circular FAB (down-arrow icon) now floats over the message list when the user has scrolled more than ~900 px above the bottom. It fades and scales in/out with a 200 ms animation. Tapping it invokes the existing scroll-to-bottom helper. It hides automatically when near the bottom or when the "new messages" pill is already showing.

## New
- `apps/client/lib/src/widgets/chat_panel/scroll_to_bottom_button.dart` — new `ScrollToBottomButton` widget with `Semantics(label: 'Jump to latest messages')`.

## Behind the scenes
- `_scrollFarFromBottom` state field added to `_ChatPanelState`; updated in `_onScroll` → `_updateScrollFarFromBottom()` and reset on conversation switch.
- `scrollFarFromBottom` field added to `ChatPanelBodyParams` and threaded through `_buildBodyParams`.
- 5 new widget tests for `ScrollToBottomButton` (visibility transitions, a11y label, tap callback); image-attachment test updated to assert the fixed-height `SizedBox` is present when dims are unknown.
- Note: `chat_panel.dart` touches the same file as held PR #1310 — integrate via `dev` branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)