### PR TITLE
Stream quality presets up to 4K for screen share

### DIFF
--- a/apps/client/lib/src/providers/livekit_voice/stream_quality_preset.dart
+++ b/apps/client/lib/src/providers/livekit_voice/stream_quality_preset.dart
@@ -1,0 +1,76 @@
+/// Named stream-quality presets for camera and screen-share video tracks.
+///
+/// The mapping is the single authoritative source used by
+/// [ScreenShareSubmenuStandalone] to populate the quality picker, by
+/// [VoiceSettings] to persist the chosen preset, and by the quality badge
+/// in the voice dock to derive the displayed label.
+library;
+
+/// Named quality tier for video encoding.
+enum StreamQuality {
+  /// LiveKit adaptive stream manages quality automatically.
+  auto,
+
+  /// SD — 480p-class encoding, minimal bandwidth.
+  sd,
+
+  /// HD — 720p-class encoding, default on join.
+  hd,
+
+  /// Full HD — 1080p-class encoding.
+  fullHd,
+
+  /// Ultra — 4K-class encoding for high-resolution screen shares.
+  ultra,
+}
+
+/// Encoding parameters that correspond to a [StreamQuality] tier.
+class StreamQualityParams {
+  /// Maximum video bitrate in bits per second.
+  final int bitrate;
+
+  /// Maximum frame rate in frames per second.
+  final int fps;
+
+  const StreamQualityParams({required this.bitrate, required this.fps});
+}
+
+/// Maps each [StreamQuality] tier to its encoding parameters.
+///
+/// `auto` has no fixed params — the caller must check [StreamQuality.auto]
+/// before reading from this map and engage LiveKit adaptive stream instead.
+const Map<StreamQuality, StreamQualityParams> kStreamQualityParams = {
+  StreamQuality.sd: StreamQualityParams(bitrate: 500000, fps: 30),
+  StreamQuality.hd: StreamQualityParams(bitrate: 1500000, fps: 30),
+  StreamQuality.fullHd: StreamQualityParams(bitrate: 2500000, fps: 30),
+  StreamQuality.ultra: StreamQualityParams(bitrate: 5000000, fps: 30),
+};
+
+/// Human-readable label shown in the quality picker and dock badge.
+const Map<StreamQuality, String> kStreamQualityLabel = {
+  StreamQuality.auto: 'Auto',
+  StreamQuality.sd: 'SD',
+  StreamQuality.hd: 'HD',
+  StreamQuality.fullHd: 'Full HD',
+  StreamQuality.ultra: '4K Ultra',
+};
+
+/// Short label used for the compact dock badge (max ~6 chars).
+const Map<StreamQuality, String> kStreamQualityShortLabel = {
+  StreamQuality.auto: 'Auto',
+  StreamQuality.sd: 'SD',
+  StreamQuality.hd: 'HD',
+  StreamQuality.fullHd: 'FHD',
+  StreamQuality.ultra: '4K',
+};
+
+/// Parse a persisted string key back to a [StreamQuality].
+///
+/// Falls back to [StreamQuality.auto] for unknown values so old prefs
+/// don't crash after an upgrade.
+StreamQuality streamQualityFromString(String value) {
+  return StreamQuality.values.firstWhere(
+    (q) => q.name == value,
+    orElse: () => StreamQuality.auto,
+  );
+}

--- a/apps/client/lib/src/providers/voice_settings_provider.dart
+++ b/apps/client/lib/src/providers/voice_settings_provider.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'livekit_voice/stream_quality_preset.dart';
+
 part 'voice_settings_provider.g.dart';
 
 class VoiceSettingsState {
@@ -20,6 +22,9 @@ class VoiceSettingsState {
   final bool autoGainControl;
   final bool confirmBeforeJoinVoice;
 
+  /// Persisted quality preset; [StreamQuality.auto] on first launch.
+  final StreamQuality streamQualityPreset;
+
   const VoiceSettingsState({
     this.inputDeviceId = 'default',
     this.outputDeviceId = 'default',
@@ -35,6 +40,7 @@ class VoiceSettingsState {
     this.echoCancellation = true,
     this.autoGainControl = true,
     this.confirmBeforeJoinVoice = false,
+    this.streamQualityPreset = StreamQuality.auto,
   });
 
   VoiceSettingsState copyWith({
@@ -52,6 +58,7 @@ class VoiceSettingsState {
     bool? echoCancellation,
     bool? autoGainControl,
     bool? confirmBeforeJoinVoice,
+    StreamQuality? streamQualityPreset,
   }) {
     return VoiceSettingsState(
       inputDeviceId: inputDeviceId ?? this.inputDeviceId,
@@ -69,6 +76,7 @@ class VoiceSettingsState {
       autoGainControl: autoGainControl ?? this.autoGainControl,
       confirmBeforeJoinVoice:
           confirmBeforeJoinVoice ?? this.confirmBeforeJoinVoice,
+      streamQualityPreset: streamQualityPreset ?? this.streamQualityPreset,
     );
   }
 }
@@ -95,6 +103,7 @@ class VoiceSettings extends _$VoiceSettings {
   static const _keyEchoCancellation = 'voice_echo_cancellation';
   static const _keyAutoGainControl = 'voice_auto_gain_control';
   static const _keyConfirmBeforeJoin = 'confirm_before_join_voice';
+  static const _keyStreamQualityPreset = 'voice_stream_quality_preset';
 
   Future<void> _load() async {
     try {
@@ -114,6 +123,9 @@ class VoiceSettings extends _$VoiceSettings {
         echoCancellation: prefs.getBool(_keyEchoCancellation) ?? true,
         autoGainControl: prefs.getBool(_keyAutoGainControl) ?? true,
         confirmBeforeJoinVoice: prefs.getBool(_keyConfirmBeforeJoin) ?? false,
+        streamQualityPreset: streamQualityFromString(
+          prefs.getString(_keyStreamQualityPreset) ?? StreamQuality.auto.name,
+        ),
       );
     } catch (e) {
       debugPrint('[VoiceSettings] load failed: $e');
@@ -137,6 +149,10 @@ class VoiceSettings extends _$VoiceSettings {
       await prefs.setBool(_keyEchoCancellation, next.echoCancellation);
       await prefs.setBool(_keyAutoGainControl, next.autoGainControl);
       await prefs.setBool(_keyConfirmBeforeJoin, next.confirmBeforeJoinVoice);
+      await prefs.setString(
+        _keyStreamQualityPreset,
+        next.streamQualityPreset.name,
+      );
     } catch (e) {
       debugPrint('[VoiceSettings] persist failed: $e');
     }
@@ -222,6 +238,12 @@ class VoiceSettings extends _$VoiceSettings {
 
   Future<void> setConfirmBeforeJoinVoice(bool value) async {
     final next = state.copyWith(confirmBeforeJoinVoice: value);
+    state = next;
+    await _persist(next);
+  }
+
+  Future<void> setStreamQualityPreset(StreamQuality preset) async {
+    final next = state.copyWith(streamQualityPreset: preset);
     state = next;
     await _persist(next);
   }

--- a/apps/client/lib/src/screens/voice_lounge/dock_submenus.dart
+++ b/apps/client/lib/src/screens/voice_lounge/dock_submenus.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
 import '../../providers/livekit_voice/livekit_voice_provider.dart';
+import '../../providers/livekit_voice/stream_quality_preset.dart';
 import '../../providers/screen_share_provider.dart';
 import '../../providers/voice_settings_provider.dart';
 import '../../theme/echo_theme.dart';
@@ -217,15 +218,37 @@ class ScreenShareSubmenuStandalone extends ConsumerWidget {
 
   const ScreenShareSubmenuStandalone({super.key, required this.onRequestClose});
 
+  // Ordered list of manual preset tiers shown in the picker.
+  static const List<StreamQuality> _manualPresets = [
+    StreamQuality.sd,
+    StreamQuality.hd,
+    StreamQuality.fullHd,
+    StreamQuality.ultra,
+  ];
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ss = ref.watch(screenShareProvider);
     final voice = ref.watch(livekitVoiceProvider);
-    final notifier = ref.read(livekitVoiceProvider.notifier);
+    final voiceNotifier = ref.read(livekitVoiceProvider.notifier);
+    final settingsNotifier = ref.read(voiceSettingsProvider.notifier);
+    final chosenPreset = ref.watch(
+      voiceSettingsProvider.select((s) => s.streamQualityPreset),
+    );
 
-    Future<void> applyPreset({required int bitrate, required int fps}) async {
-      await notifier.setAutoQuality(false);
-      await notifier.setVideoParams(bitrate: bitrate, fps: fps);
+    Future<void> applyPreset(StreamQuality preset) async {
+      await settingsNotifier.setStreamQualityPreset(preset);
+      await voiceNotifier.setAutoQuality(false);
+      final params = kStreamQualityParams[preset]!;
+      await voiceNotifier.setVideoParams(
+        bitrate: params.bitrate,
+        fps: params.fps,
+      );
+    }
+
+    Future<void> enableAuto() async {
+      await settingsNotifier.setStreamQualityPreset(StreamQuality.auto);
+      await voiceNotifier.setAutoQuality(true);
     }
 
     return SizedBox(
@@ -234,118 +257,167 @@ class ScreenShareSubmenuStandalone extends ConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-            child: Text(
-              'Screen Share',
-              style: TextStyle(
-                color: context.textMuted,
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.5,
-              ),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Text(
-              ss.isScreenSharing ? 'Currently sharing' : 'Not sharing',
-              style: TextStyle(
-                color: ss.isScreenSharing
-                    ? EchoTheme.online
-                    : context.textSecondary,
-                fontSize: 13,
-              ),
-            ),
-          ),
+          _buildHeader(context, ss),
           const SizedBox(height: 6),
-          SwitchListTile.adaptive(
-            dense: true,
-            contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-            title: Text(
-              'Auto quality',
-              style: TextStyle(color: context.textPrimary, fontSize: 13),
-            ),
-            value: voice.autoQuality,
-            onChanged: (v) async {
-              await notifier.setAutoQuality(v);
-            },
+          _buildAutoToggle(
+            context,
+            voice,
+            enableAuto,
+            applyPreset,
+            chosenPreset,
           ),
           const Divider(height: 1),
-          _qualityRow(
-            context,
-            label: 'Low (600 kbps, 15 fps)',
-            selected:
-                !voice.autoQuality &&
-                voice.videoBitrate == 600000 &&
-                voice.videoFps == 15,
-            enabled: !voice.autoQuality,
-            onTap: () => applyPreset(bitrate: 600000, fps: 15),
-          ),
-          _qualityRow(
-            context,
-            label: 'Balanced (1200 kbps, 24 fps)',
-            selected:
-                !voice.autoQuality &&
-                voice.videoBitrate == 1200000 &&
-                voice.videoFps == 24,
-            enabled: !voice.autoQuality,
-            onTap: () => applyPreset(bitrate: 1200000, fps: 24),
-          ),
-          _qualityRow(
-            context,
-            label: 'High (2000 kbps, 30 fps)',
-            selected:
-                !voice.autoQuality &&
-                voice.videoBitrate == 2000000 &&
-                voice.videoFps == 30,
-            enabled: !voice.autoQuality,
-            onTap: () => applyPreset(bitrate: 2000000, fps: 30),
-          ),
+          ..._buildPresetRows(context, voice, chosenPreset, applyPreset),
           const SizedBox(height: 8),
         ],
       ),
     );
   }
 
-  Widget _qualityRow(
-    BuildContext context, {
-    required String label,
-    required bool selected,
-    required bool enabled,
-    required VoidCallback onTap,
-  }) {
-    return InkWell(
-      onTap: enabled ? onTap : null,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
-        child: Row(
-          children: [
-            Icon(
-              selected ? Icons.radio_button_checked : Icons.radio_button_off,
-              size: 16,
-              color: _getRadioColor(selected, enabled, context),
+  Widget _buildHeader(BuildContext context, ScreenShareState ss) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Text(
+            'Screen Share',
+            style: TextStyle(
+              color: context.textMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.5,
             ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                label,
-                style: TextStyle(
-                  color: enabled
-                      ? context.textPrimary
-                      : context.textMuted.withValues(alpha: 0.7),
-                  fontSize: 12,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            ss.isScreenSharing ? 'Currently sharing' : 'Not sharing',
+            style: TextStyle(
+              color: ss.isScreenSharing
+                  ? EchoTheme.online
+                  : context.textSecondary,
+              fontSize: 13,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAutoToggle(
+    BuildContext context,
+    LiveKitVoiceState voice,
+    Future<void> Function() enableAuto,
+    Future<void> Function(StreamQuality) applyPreset,
+    StreamQuality chosenPreset,
+  ) {
+    return SwitchListTile.adaptive(
+      dense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+      title: Semantics(
+        label: 'Auto quality toggle',
+        child: Text(
+          'Auto quality',
+          style: TextStyle(color: context.textPrimary, fontSize: 13),
+        ),
+      ),
+      value: voice.autoQuality,
+      onChanged: (v) async {
+        if (v) {
+          await enableAuto();
+        } else {
+          // Re-apply the last manually chosen preset (or HD if none set yet).
+          final target = chosenPreset == StreamQuality.auto
+              ? StreamQuality.hd
+              : chosenPreset;
+          await applyPreset(target);
+        }
+      },
+    );
+  }
+
+  List<Widget> _buildPresetRows(
+    BuildContext context,
+    LiveKitVoiceState voice,
+    StreamQuality chosenPreset,
+    Future<void> Function(StreamQuality) applyPreset,
+  ) {
+    return _manualPresets.map((preset) {
+      final params = kStreamQualityParams[preset]!;
+      final kbps = params.bitrate ~/ 1000;
+      final label =
+          '${kStreamQualityLabel[preset]} ($kbps kbps, ${params.fps} fps)';
+      final isSelected = !voice.autoQuality && chosenPreset == preset;
+      return _QualityRow(
+        label: label,
+        semanticLabel: '${kStreamQualityLabel[preset]} quality preset',
+        selected: isSelected,
+        enabled: !voice.autoQuality,
+        accent: context.accent,
+        onTap: () => applyPreset(preset),
+      );
+    }).toList();
+  }
+}
+
+class _QualityRow extends StatelessWidget {
+  final String label;
+  final String semanticLabel;
+  final bool selected;
+  final bool enabled;
+  final Color accent;
+  final VoidCallback onTap;
+
+  const _QualityRow({
+    required this.label,
+    required this.semanticLabel,
+    required this.selected,
+    required this.enabled,
+    required this.accent,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final radioColor = _radioColor(context);
+    final textColor = enabled
+        ? context.textPrimary
+        : context.textMuted.withValues(alpha: 0.7);
+
+    return Semantics(
+      label: semanticLabel,
+      selected: selected,
+      button: true,
+      child: InkWell(
+        onTap: enabled ? onTap : null,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+          child: Row(
+            children: [
+              Icon(
+                selected ? Icons.radio_button_checked : Icons.radio_button_off,
+                size: 16,
+                color: radioColor,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  label,
+                  style: TextStyle(color: textColor, fontSize: 12),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
   }
 
-  Color _getRadioColor(bool selected, bool enabled, BuildContext context) {
+  Color _radioColor(BuildContext context) {
     if (!enabled) return context.textMuted.withValues(alpha: 0.5);
-    return selected ? context.accent : context.textMuted;
+    return selected ? accent : context.textMuted;
   }
 }

--- a/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
+++ b/apps/client/lib/src/screens/voice_lounge/floating_dock.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/livekit_voice/livekit_voice_provider.dart';
+import '../../providers/livekit_voice/stream_quality_preset.dart';
 import '../../providers/screen_share_provider.dart';
 import '../../providers/voice_settings_provider.dart';
 import '../../theme/echo_theme.dart';
@@ -209,17 +210,46 @@ class _FloatingDockState extends ConsumerState<FloatingDock> {
   }
 
   Widget _buildScreenShareButton(BuildContext context) {
-    return DockButtonWithSubmenu(
-      icon: screenShare.isScreenSharing
-          ? Icons.stop_screen_share
-          : Icons.screen_share,
-      tooltip: screenShare.isScreenSharing ? 'Stop sharing' : 'Share screen',
-      isActive: screenShare.isScreenSharing,
-      activeColor: EchoTheme.online,
-      onPressed: () => toggleScreenShare(context, ref),
-      onSubmenuTap: () => onToggleSubmenu(DockSubmenu.screenShare),
-      submenuActive: activeSubmenu == DockSubmenu.screenShare,
-      submenuLayerLink: screenShareLayerLink,
+    final chosenPreset = ref.watch(
+      voiceSettingsProvider.select((s) => s.streamQualityPreset),
+    );
+    final showBadge =
+        screenShare.isScreenSharing &&
+        !voiceState.autoQuality &&
+        chosenPreset != StreamQuality.auto;
+    final badgeLabel = kStreamQualityShortLabel[chosenPreset] ?? '';
+
+    return Semantics(
+      label: 'Screen share${showBadge ? ", quality: $badgeLabel" : ""}',
+      button: true,
+      child: Stack(
+        clipBehavior: Clip.none,
+        alignment: Alignment.topRight,
+        children: [
+          DockButtonWithSubmenu(
+            icon: screenShare.isScreenSharing
+                ? Icons.stop_screen_share
+                : Icons.screen_share,
+            tooltip: screenShare.isScreenSharing
+                ? 'Stop sharing'
+                : 'Share screen',
+            isActive: screenShare.isScreenSharing,
+            activeColor: EchoTheme.online,
+            onPressed: () => toggleScreenShare(context, ref),
+            onSubmenuTap: () => onToggleSubmenu(DockSubmenu.screenShare),
+            submenuActive: activeSubmenu == DockSubmenu.screenShare,
+            submenuLayerLink: screenShareLayerLink,
+          ),
+          if (showBadge)
+            Positioned(
+              top: -4,
+              right: 14,
+              child: IgnorePointer(
+                child: _StreamQualityBadge(label: badgeLabel),
+              ),
+            ),
+        ],
+      ),
     );
   }
 
@@ -459,6 +489,38 @@ class DrawingToolsPanel extends StatelessWidget {
       ),
       clipBehavior: Clip.antiAlias,
       child: child,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stream quality badge
+// ---------------------------------------------------------------------------
+
+/// Small pill badge overlaid on the screen-share dock button to show the
+/// active quality tier (e.g. "HD", "4K") when adaptive mode is off.
+class _StreamQualityBadge extends StatelessWidget {
+  final String label;
+
+  const _StreamQualityBadge({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+      decoration: BoxDecoration(
+        color: EchoTheme.online,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 8,
+          fontWeight: FontWeight.w700,
+          height: 1.2,
+        ),
+      ),
     );
   }
 }

--- a/apps/client/test/providers/livekit_voice/stream_quality_preset_test.dart
+++ b/apps/client/test/providers/livekit_voice/stream_quality_preset_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:echo_app/src/providers/livekit_voice/stream_quality_preset.dart';
+
+void main() {
+  group('StreamQuality preset mapping', () {
+    test('every manual preset has entries in kStreamQualityParams', () {
+      const manualPresets = [
+        StreamQuality.sd,
+        StreamQuality.hd,
+        StreamQuality.fullHd,
+        StreamQuality.ultra,
+      ];
+      for (final preset in manualPresets) {
+        expect(
+          kStreamQualityParams.containsKey(preset),
+          isTrue,
+          reason: '${preset.name} must have a params entry',
+        );
+      }
+      // auto has no params entry by design
+      expect(kStreamQualityParams.containsKey(StreamQuality.auto), isFalse);
+    });
+
+    test('every preset has a long label', () {
+      for (final preset in StreamQuality.values) {
+        expect(
+          kStreamQualityLabel.containsKey(preset),
+          isTrue,
+          reason: '${preset.name} must have a long label',
+        );
+        expect(kStreamQualityLabel[preset], isNotEmpty);
+      }
+    });
+
+    test('every preset has a short label of at most 6 chars', () {
+      for (final preset in StreamQuality.values) {
+        expect(
+          kStreamQualityShortLabel.containsKey(preset),
+          isTrue,
+          reason: '${preset.name} must have a short label',
+        );
+        final label = kStreamQualityShortLabel[preset]!;
+        expect(
+          label.length,
+          lessThanOrEqualTo(6),
+          reason: 'Short label "$label" for ${preset.name} exceeds 6 chars',
+        );
+      }
+    });
+
+    test('bitrates are ordered SD < HD < Full HD < Ultra', () {
+      final sd = kStreamQualityParams[StreamQuality.sd]!.bitrate;
+      final hd = kStreamQualityParams[StreamQuality.hd]!.bitrate;
+      final fhd = kStreamQualityParams[StreamQuality.fullHd]!.bitrate;
+      final ultra = kStreamQualityParams[StreamQuality.ultra]!.bitrate;
+
+      expect(sd, lessThan(hd));
+      expect(hd, lessThan(fhd));
+      expect(fhd, lessThan(ultra));
+    });
+
+    test('SD bitrate is ~500 kbps', () {
+      expect(kStreamQualityParams[StreamQuality.sd]!.bitrate, 500000);
+    });
+
+    test('HD bitrate is ~1.5 Mbps', () {
+      expect(kStreamQualityParams[StreamQuality.hd]!.bitrate, 1500000);
+    });
+
+    test('Full HD bitrate is ~2.5 Mbps', () {
+      expect(kStreamQualityParams[StreamQuality.fullHd]!.bitrate, 2500000);
+    });
+
+    test('Ultra bitrate is ~5 Mbps', () {
+      expect(kStreamQualityParams[StreamQuality.ultra]!.bitrate, 5000000);
+    });
+
+    test('all manual presets run at 30 fps', () {
+      for (final preset in [
+        StreamQuality.sd,
+        StreamQuality.hd,
+        StreamQuality.fullHd,
+        StreamQuality.ultra,
+      ]) {
+        expect(
+          kStreamQualityParams[preset]!.fps,
+          30,
+          reason: '${preset.name} should run at 30 fps',
+        );
+      }
+    });
+  });
+
+  group('streamQualityFromString', () {
+    test('round-trips every enum value', () {
+      for (final preset in StreamQuality.values) {
+        expect(streamQualityFromString(preset.name), preset);
+      }
+    });
+
+    test('falls back to auto for unknown strings', () {
+      expect(streamQualityFromString(''), StreamQuality.auto);
+      expect(streamQualityFromString('bogus'), StreamQuality.auto);
+      expect(
+        streamQualityFromString('Ultra'),
+        StreamQuality.auto,
+      ); // case-sensitive
+    });
+  });
+}


### PR DESCRIPTION
Screen shares now look sharp on high-DPI and 4K monitors. Pick a named quality tier and the dock shows you what bitrate you're running at while sharing.

## New

- **Four named quality presets** in the Screen Share submenu: SD (500 kbps), HD (1.5 Mbps), Full HD (2.5 Mbps), 4K Ultra (5 Mbps) — all at 30 fps. The previous three unnamed raw-number rows are replaced.
- **Preset persists across calls** via SharedPreferences; the choice survives app restarts.
- **Quality badge on the dock screen-share button** — a small green pill (SD / HD / FHD / 4K) appears while sharing with adaptive mode off, so the active tier is always visible without opening the submenu.

## Improved

- Switching adaptive mode off now re-applies the last manually chosen preset (defaulting to HD) rather than leaving the encoder at an arbitrary rate.
- Preset rows carry Semantics labels and a selected state for screen-reader users.

## Behind the scenes

- New pure file stream_quality_preset.dart owns the enum, bitrate/fps map, short/long label maps, and the streamQualityFromString round-trip helper — single source of truth with no widget dependencies.
- VoiceSettingsState gains a streamQualityPreset field persisted under voice_stream_quality_preset.
- ScreenShareSubmenuStandalone is refactored from hardcoded rows into an enum-driven list; _QualityRow extracted as a StatelessWidget to keep build complexity in budget.
- 11 new unit tests cover bitrate ordering, all label maps, and the string round-trip with fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)