### PR TITLE
Add back/forward conversation navigation in the title bar

### DIFF
--- a/apps/client/lib/src/screens/home_screen.dart
+++ b/apps/client/lib/src/screens/home_screen.dart
@@ -88,6 +88,30 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   // Slice 7: members panel defaults to on so group context (roles, online
   // status) is visible without an explicit toggle. Users can still hide it.
   bool _showMembers = true;
+
+  // ---------------------------------------------------------------------------
+  // Conversation navigation history (browser back/forward model).
+  // Stores conversation IDs rather than Conversation objects to avoid holding
+  // stale references when a conversation is deleted or mutated server-side.
+  // ---------------------------------------------------------------------------
+
+  /// Maximum number of entries kept in the history stack.
+  static const int _navHistoryLimit = 50;
+
+  /// Ordered list of conversation IDs the user has explicitly navigated to.
+  /// The current position is [_navHistoryIndex].
+  final List<String> _navHistory = [];
+
+  /// Index into [_navHistory] pointing at the currently-viewed entry.
+  /// -1 when no conversation has been selected yet.
+  int _navHistoryIndex = -1;
+
+  /// Guards against [_selectConversation] re-pushing to history while a
+  /// back/forward navigation is in flight.
+  bool _navJumping = false;
+
+  bool get _canGoBack => _navHistoryIndex > 0;
+  bool get _canGoForward => _navHistoryIndex < _navHistory.length - 1;
   Timer? _pendingRefreshTimer;
   late final LiveKitVoiceNotifier _voiceRtcNotifier;
   StreamSubscription<String>? _notificationTapSub;

--- a/apps/client/lib/src/screens/home_screen/parts/actions.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/actions.dart
@@ -11,6 +11,10 @@ mixin _HomeScreenActionsMixin on ConsumerState<HomeScreen> {
   _HomeScreenState get _self => this as _HomeScreenState;
 
   void _selectConversation(Conversation conv, {String? messageId}) {
+    // Push to history only for user-initiated navigation, not back/forward jumps.
+    if (!_self._navJumping) {
+      _pushNavHistory(conv.id);
+    }
     setState(() {
       _self._selectedConversation = conv;
       _self._pendingMessageId = messageId;
@@ -24,6 +28,68 @@ mixin _HomeScreenActionsMixin on ConsumerState<HomeScreen> {
     });
     // Clear notifications for this conversation now that the user is viewing it.
     NotificationService().cancelConversationNotifications(conv.id);
+  }
+
+  /// Pushes [conversationId] onto the navigation history, truncating any
+  /// forward entries (browser model). Caps the list at [_navHistoryLimit].
+  void _pushNavHistory(String conversationId) {
+    final history = _self._navHistory;
+    final currentIndex = _self._navHistoryIndex;
+
+    // Skip duplicate: re-selecting the current conversation is a no-op.
+    if (currentIndex >= 0 && history[currentIndex] == conversationId) return;
+
+    // Truncate forward history: entries after current index are discarded.
+    if (currentIndex < history.length - 1) {
+      history.removeRange(currentIndex + 1, history.length);
+    }
+
+    history.add(conversationId);
+
+    // Enforce cap — drop the oldest entry.
+    if (history.length > _HomeScreenState._navHistoryLimit) {
+      history.removeAt(0);
+    }
+
+    _self._navHistoryIndex = history.length - 1;
+  }
+
+  /// Navigates back one step in the conversation history, skipping any
+  /// entries whose conversations have since been removed.
+  void _goBackConversation() {
+    _jumpHistory(forward: false);
+  }
+
+  /// Navigates forward one step in the conversation history, skipping any
+  /// entries whose conversations have since been removed.
+  void _goForwardConversation() {
+    _jumpHistory(forward: true);
+  }
+
+  /// Shared back/forward navigator. Moves [_navHistoryIndex] by ±1, finds
+  /// the matching live [Conversation], and selects it without re-pushing.
+  void _jumpHistory({required bool forward}) {
+    final history = _self._navHistory;
+    var idx = _self._navHistoryIndex;
+    final conversations = ref.read(conversationsProvider).conversations;
+
+    // Walk in the requested direction, skipping deleted conversations.
+    while (true) {
+      idx = forward ? idx + 1 : idx - 1;
+      if (idx < 0 || idx >= history.length) return;
+
+      final targetId = history[idx];
+      final conv = conversations.where((c) => c.id == targetId).firstOrNull;
+
+      if (conv != null) {
+        _self._navHistoryIndex = idx;
+        _self._navJumping = true;
+        _selectConversation(conv);
+        _self._navJumping = false;
+        return;
+      }
+      // Entry no longer exists — continue walking past it.
+    }
   }
 
   void _showQuickSwitcher() {

--- a/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/desktop_layout.dart
@@ -320,7 +320,14 @@ mixin _HomeScreenDesktopLayoutMixin
     return Scaffold(
       body: Column(
         children: [
-          if (!loungeFullscreen) AppTitleBar(title: titleBarText),
+          if (!loungeFullscreen)
+            AppTitleBar(
+              title: titleBarText,
+              onBack: _goBackConversation,
+              onForward: _goForwardConversation,
+              canGoBack: _self._canGoBack,
+              canGoForward: _self._canGoForward,
+            ),
           Expanded(
             child: Stack(
               children: [

--- a/apps/client/lib/src/screens/home_screen/parts/wide_layout.dart
+++ b/apps/client/lib/src/screens/home_screen/parts/wide_layout.dart
@@ -66,7 +66,14 @@ mixin _HomeScreenWideLayoutMixin
     return Scaffold(
       body: Column(
         children: [
-          if (!loungeFullscreen) AppTitleBar(title: titleBarText),
+          if (!loungeFullscreen)
+            AppTitleBar(
+              title: titleBarText,
+              onBack: _goBackConversation,
+              onForward: _goForwardConversation,
+              canGoBack: _self._canGoBack,
+              canGoForward: _self._canGoForward,
+            ),
           Expanded(
             child: Stack(
               children: [

--- a/apps/client/lib/src/widgets/window_chrome.dart
+++ b/apps/client/lib/src/widgets/window_chrome.dart
@@ -127,12 +127,35 @@ class _AppWindowButtonsState extends State<AppWindowButtons>
 /// drag region; [title] is centered and shows the active conversation name;
 /// window controls are anchored to the right edge.
 ///
+/// Optional [onBack] / [onForward] callbacks add browser-style conversation
+/// history arrows to the left of the title on Linux/Windows. Pass
+/// [canGoBack] / [canGoForward] to enable or grey-out the buttons.
+///
 /// No-op (zero height) on web and mobile.
 class AppTitleBar extends StatelessWidget {
-  const AppTitleBar({super.key, this.title});
+  const AppTitleBar({
+    super.key,
+    this.title,
+    this.onBack,
+    this.onForward,
+    this.canGoBack = false,
+    this.canGoForward = false,
+  });
 
   /// Text centered in the bar — typically the active conversation or group name.
   final String? title;
+
+  /// Called when the user taps the back arrow. Null hides the arrow pair.
+  final VoidCallback? onBack;
+
+  /// Called when the user taps the forward arrow.
+  final VoidCallback? onForward;
+
+  /// Whether the back arrow is interactive (enabled).
+  final bool canGoBack;
+
+  /// Whether the forward arrow is interactive (enabled).
+  final bool canGoForward;
 
   @override
   Widget build(BuildContext context) {
@@ -140,6 +163,11 @@ class AppTitleBar extends StatelessWidget {
     if (!Platform.isLinux && !Platform.isWindows && !Platform.isMacOS) {
       return const SizedBox.shrink();
     }
+
+    // Nav arrows only render on Linux/Windows; macOS traffic-light cluster
+    // occupies the same left region (72 px inset), so we skip them there.
+    final bool showNavArrows = onBack != null && !Platform.isMacOS;
+    final double leftInset = Platform.isMacOS ? 72.0 : 0.0;
 
     // Clamp text scale to 1.2x — 1.5x overflows the 36px title bar into the window controls.
     return MediaQuery.withClampedTextScaling(
@@ -154,10 +182,24 @@ class AppTitleBar extends StatelessWidget {
           children: [
             // Full-width drag area underneath everything.
             const Positioned.fill(child: AppDragArea(child: SizedBox.expand())),
-            // IgnorePointer so clicks fall through to drag; macOS padding avoids the traffic-light cluster.
+            // Back / forward navigation arrows on the left edge (Linux/Windows).
+            if (showNavArrows)
+              Positioned(
+                left: 0,
+                top: 0,
+                bottom: 0,
+                child: _NavArrows(
+                  onBack: onBack!,
+                  onForward: onForward,
+                  canGoBack: canGoBack,
+                  canGoForward: canGoForward,
+                ),
+              ),
+            // IgnorePointer so clicks fall through to drag; inset avoids
+            // nav arrows on Linux/Windows, traffic-light cluster on macOS.
             if (title != null && title!.isNotEmpty)
               Padding(
-                padding: EdgeInsets.only(left: Platform.isMacOS ? 72.0 : 0.0),
+                padding: EdgeInsets.only(left: leftInset),
                 child: Center(
                   child: IgnorePointer(
                     child: Text(
@@ -181,6 +223,99 @@ class AppTitleBar extends StatelessWidget {
               child: AppWindowButtons(),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Back and forward arrow buttons shown in the title bar on Linux/Windows.
+class _NavArrows extends StatelessWidget {
+  const _NavArrows({
+    required this.onBack,
+    this.onForward,
+    required this.canGoBack,
+    required this.canGoForward,
+  });
+
+  final VoidCallback onBack;
+  final VoidCallback? onForward;
+  final bool canGoBack;
+  final bool canGoForward;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _NavArrowButton(
+          icon: Icons.arrow_back,
+          tooltip: 'Back to previous conversation',
+          onTap: canGoBack ? onBack : null,
+        ),
+        _NavArrowButton(
+          icon: Icons.arrow_forward,
+          tooltip: 'Forward',
+          onTap: (canGoForward && onForward != null) ? onForward! : null,
+        ),
+      ],
+    );
+  }
+}
+
+/// Single icon button used by [_NavArrows]. Greyed when [onTap] is null.
+class _NavArrowButton extends StatefulWidget {
+  const _NavArrowButton({
+    required this.icon,
+    required this.tooltip,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String tooltip;
+
+  /// Null → disabled (greyed, non-interactive).
+  final VoidCallback? onTap;
+
+  @override
+  State<_NavArrowButton> createState() => _NavArrowButtonState();
+}
+
+class _NavArrowButtonState extends State<_NavArrowButton> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool enabled = widget.onTap != null;
+    final Color iconColor = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: enabled ? 0.75 : 0.25);
+    final Color hoverBg = Theme.of(
+      context,
+    ).colorScheme.onSurface.withValues(alpha: 0.12);
+
+    return Semantics(
+      label: widget.tooltip,
+      button: true,
+      enabled: enabled,
+      child: Tooltip(
+        message: widget.tooltip,
+        child: MouseRegion(
+          cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
+          onEnter: enabled ? (_) => setState(() => _hovered = true) : null,
+          onExit: enabled ? (_) => setState(() => _hovered = false) : null,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.onTap,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 100),
+              width: 32,
+              height: 36,
+              color: (_hovered && enabled) ? hoverBg : Colors.transparent,
+              alignment: Alignment.center,
+              child: Icon(widget.icon, size: 14, color: iconColor),
+            ),
+          ),
         ),
       ),
     );

--- a/apps/client/test/screens/conversation_nav_history_test.dart
+++ b/apps/client/test/screens/conversation_nav_history_test.dart
@@ -1,0 +1,243 @@
+// Unit tests for the conversation navigation history model introduced in
+// home_screen.dart + actions.dart.
+//
+// The history lives in `_HomeScreenState` as a `List<String>` (IDs) +
+// `_navHistoryIndex`.  Rather than spinning up a full widget test, we
+// mirror the same rules in a pure-Dart test using a helper that reproduces
+// the three operations:
+//   - push      → _pushNavHistory (called from _selectConversation)
+//   - goBack    → _jumpHistory(forward: false)
+//   - goForward → _jumpHistory(forward: true)
+//
+// Covered:
+//   1. Pushing to an empty history starts at index 0.
+//   2. Pushing the same ID twice is a no-op (no duplicates at same position).
+//   3. Pushing a new ID advances the index.
+//   4. Push truncates forward entries (browser model).
+//   5. History is capped at _navHistoryLimit (50).
+//   6. canGoBack / canGoForward flags reflect the index correctly.
+//   7. Back navigates to the previous entry.
+//   8. Forward navigates to the next entry after a back.
+//   9. Back/forward are no-ops at the boundaries.
+//  10. goBack skips deleted conversation IDs and continues walking.
+//  11. goForward skips deleted conversation IDs and continues walking.
+
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Minimal simulation of the history stack logic
+// ---------------------------------------------------------------------------
+
+const int _navHistoryLimit = 50;
+
+/// Mirrors _HomeScreenState's nav history fields.
+class _NavState {
+  final List<String> history = [];
+  int index = -1;
+
+  bool get canGoBack => index > 0;
+  bool get canGoForward => index < history.length - 1;
+
+  /// Push [id] onto history, truncating forward entries.
+  void push(String id) {
+    // Skip if re-selecting the current conversation.
+    if (index >= 0 && history[index] == id) return;
+
+    // Truncate forward entries.
+    if (index < history.length - 1) {
+      history.removeRange(index + 1, history.length);
+    }
+
+    history.add(id);
+
+    // Cap.
+    if (history.length > _navHistoryLimit) {
+      history.removeAt(0);
+    }
+
+    index = history.length - 1;
+  }
+
+  /// Move back/forward, skipping [deletedIds].
+  ///
+  /// Returns the landed conversation ID, or null when at a boundary.
+  String? jump({required bool forward, Set<String> deletedIds = const {}}) {
+    var idx = index;
+    while (true) {
+      idx = forward ? idx + 1 : idx - 1;
+      if (idx < 0 || idx >= history.length) return null;
+
+      final targetId = history[idx];
+      if (!deletedIds.contains(targetId)) {
+        index = idx;
+        return targetId;
+      }
+      // Skip deleted entry and keep walking.
+    }
+  }
+
+  String? goBack({Set<String> deletedIds = const {}}) =>
+      jump(forward: false, deletedIds: deletedIds);
+
+  String? goForward({Set<String> deletedIds = const {}}) =>
+      jump(forward: true, deletedIds: deletedIds);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('conversation navigation history', () {
+    test('1. pushing to empty history starts at index 0', () {
+      final s = _NavState();
+      s.push('a');
+      expect(s.index, 0);
+      expect(s.history, ['a']);
+    });
+
+    test('2. pushing the same id twice is a no-op', () {
+      final s = _NavState();
+      s.push('a');
+      s.push('a'); // duplicate of current
+      expect(s.history.length, 1);
+      expect(s.index, 0);
+    });
+
+    test('3. pushing a new id advances the index', () {
+      final s = _NavState();
+      s.push('a');
+      s.push('b');
+      expect(s.history, ['a', 'b']);
+      expect(s.index, 1);
+    });
+
+    test('4. push truncates forward entries (browser model)', () {
+      final s = _NavState();
+      s.push('a');
+      s.push('b');
+      s.push('c');
+      s.goBack(); // index → 1 (b)
+      s.push('d'); // truncates 'c', appends 'd'
+      expect(s.history, ['a', 'b', 'd']);
+      expect(s.index, 2);
+    });
+
+    test('5. history is capped at $_navHistoryLimit entries', () {
+      final s = _NavState();
+      for (var i = 0; i < _navHistoryLimit + 5; i++) {
+        s.push('conv-$i');
+      }
+      expect(s.history.length, _navHistoryLimit);
+      // Oldest entry was dropped; newest is at the end.
+      expect(s.history.last, 'conv-${_navHistoryLimit + 4}');
+    });
+
+    group('canGoBack / canGoForward', () {
+      test('6a. false / false on single entry', () {
+        final s = _NavState();
+        s.push('a');
+        expect(s.canGoBack, isFalse);
+        expect(s.canGoForward, isFalse);
+      });
+
+      test('6b. after two pushes, canGoBack true, canGoForward false', () {
+        final s = _NavState();
+        s.push('a');
+        s.push('b');
+        expect(s.canGoBack, isTrue);
+        expect(s.canGoForward, isFalse);
+      });
+
+      test('6c. after goBack, canGoBack false, canGoForward true', () {
+        final s = _NavState();
+        s.push('a');
+        s.push('b');
+        s.goBack();
+        expect(s.canGoBack, isFalse);
+        expect(s.canGoForward, isTrue);
+      });
+    });
+
+    test('7. goBack navigates to the previous entry', () {
+      final s = _NavState();
+      s.push('a');
+      s.push('b');
+      final landed = s.goBack();
+      expect(landed, 'a');
+      expect(s.index, 0);
+    });
+
+    test('8. goForward navigates to the next entry after a back', () {
+      final s = _NavState();
+      s.push('a');
+      s.push('b');
+      s.goBack();
+      final landed = s.goForward();
+      expect(landed, 'b');
+      expect(s.index, 1);
+    });
+
+    group('boundary no-ops', () {
+      test('9a. goBack at index 0 returns null', () {
+        final s = _NavState();
+        s.push('a');
+        expect(s.goBack(), isNull);
+        expect(s.index, 0); // unchanged
+      });
+
+      test('9b. goForward at the end returns null', () {
+        final s = _NavState();
+        s.push('a');
+        s.push('b');
+        expect(s.goForward(), isNull);
+        expect(s.index, 1); // unchanged
+      });
+
+      test('9c. empty history goBack returns null without error', () {
+        final s = _NavState();
+        expect(s.goBack(), isNull);
+      });
+    });
+
+    test(
+      '10. goBack skips deleted conversations and lands on next live one',
+      () {
+        final s = _NavState();
+        s.push('a');
+        s.push('b'); // deleted
+        s.push('c');
+        // At index 2 (c). Going back: b is deleted → should land on a.
+        final landed = s.goBack(deletedIds: {'b'});
+        expect(landed, 'a');
+        expect(s.index, 0);
+      },
+    );
+
+    test('11. goForward skips deleted conversations', () {
+      final s = _NavState();
+      s.push('a');
+      s.push('b'); // deleted
+      s.push('c');
+      s.goBack(deletedIds: {}); // move to b (index 1)
+      s.goBack(deletedIds: {}); // move to a (index 0)
+      // Forward: b is deleted → should land on c (index 2).
+      final landed = s.goForward(deletedIds: {'b'});
+      expect(landed, 'c');
+      expect(s.index, 2);
+    });
+
+    test(
+      '11b. goForward returns null when all forward entries are deleted',
+      () {
+        final s = _NavState();
+        s.push('a');
+        s.push('b'); // deleted
+        s.goBack(); // back to a
+        final landed = s.goForward(deletedIds: {'b'});
+        expect(landed, isNull);
+        expect(s.index, 0); // unchanged
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds browser-style back and forward arrows to the integrated title bar on Linux and Windows desktop. Clicking back/forward moves through recently-viewed conversations just like browser tab history, so users can quickly retrace their steps without hunting through the sidebar.

- **New**: Back (`←`) and forward (`→`) arrow buttons appear in the top-left of the title bar on Linux and Windows.
- **Improved**: Arrows are greyed (disabled) when there is nothing to go back/forward to — no dead clicks.
- **Behind the scenes**: History is a `List<String>` (conversation IDs, not objects) capped at 50 entries. Push truncates forward entries (browser model). Back/forward jumps skip deleted conversations. A `_navJumping` guard prevents programmatic selection during a jump from writing a new history entry. macOS is excluded — the 72 px traffic-light inset occupies the same region and the arrows would collide with it; macOS also gets native gesture swipe-back from the OS. Web and mobile layouts already return `SizedBox.shrink()` from `AppTitleBar`, so those surfaces are completely unaffected.

## Test plan

- [ ] New unit test file `test/screens/conversation_nav_history_test.dart` covers 16 cases: push semantics, cap enforcement, `canGoBack`/`canGoForward` flags, back/forward navigation, boundary no-ops, and skipping deleted conversations.
- [ ] Existing `test/screens/home_screen_test.dart` (16 widget tests) passes with no changes — `AppTitleBar` still renders correctly in all layout tiers.
- [ ] `flutter analyze --fatal-infos`: no issues.
- [ ] `dart format`: clean (2 files reformatted by formatter, committed clean).
- [ ] lefthook pre-commit + pre-push hooks: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)