### PR TITLE
Group owners can now promote and demote admins (#17)

### DIFF
--- a/apps/client/lib/src/models/conversation.dart
+++ b/apps/client/lib/src/models/conversation.dart
@@ -237,6 +237,24 @@ class ConversationMember {
     );
   }
 
+  ConversationMember copyWith({
+    String? userId,
+    String? username,
+    String? role,
+    String? avatarUrl,
+    String? statusText,
+    String? presenceStatus,
+  }) {
+    return ConversationMember(
+      userId: userId ?? this.userId,
+      username: username ?? this.username,
+      role: role ?? this.role,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      statusText: statusText ?? this.statusText,
+      presenceStatus: presenceStatus ?? this.presenceStatus,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||

--- a/apps/client/lib/src/providers/conversations_ws_handlers.dart
+++ b/apps/client/lib/src/providers/conversations_ws_handlers.dart
@@ -129,4 +129,28 @@ mixin _ConversationsWsHandlersMixin on Notifier<ConversationsState> {
     updated[index] = conv.copyWith(members: [...conv.members, member]);
     state = state.copyWith(conversations: updated);
   }
+
+  /// Update a member's role inside a group conversation in-place.
+  ///
+  /// Called by the WS `member_role_changed` event so every connected client
+  /// reflects the promotion/demotion without polling. Silently no-ops when
+  /// the conversation or the member is not found locally.
+  void updateGroupMemberRole(
+    String conversationId,
+    String userId,
+    String newRole,
+  ) {
+    final updated = List<Conversation>.from(state.conversations);
+    final convIndex = updated.indexWhere((c) => c.id == conversationId);
+    if (convIndex < 0) return;
+    final conv = updated[convIndex];
+    final memberIndex = conv.members.indexWhere((m) => m.userId == userId);
+    if (memberIndex < 0) return;
+    final updatedMembers = List<ConversationMember>.from(conv.members);
+    updatedMembers[memberIndex] = updatedMembers[memberIndex].copyWith(
+      role: newRole,
+    );
+    updated[convIndex] = conv.copyWith(members: updatedMembers);
+    state = state.copyWith(conversations: updated);
+  }
 }

--- a/apps/client/lib/src/providers/ws_handlers/presence_handlers.dart
+++ b/apps/client/lib/src/providers/ws_handlers/presence_handlers.dart
@@ -143,6 +143,22 @@ extension PresenceHandlersOn on WsMessageHandler {
     ref.read(cryptoProvider.notifier).seedInitialGroupKey(conversationId);
   }
 
+  /// Handle a `member_role_changed` WS event.
+  ///
+  /// The server broadcasts this after a successful
+  /// `PATCH /api/groups/:id/members/:user_id/role` so every connected client
+  /// reflects the promotion/demotion without polling.
+  void _handleMemberRoleChanged(Map<String, dynamic> json) {
+    final conversationId = json['conversation_id'] as String? ?? '';
+    final userId = json['user_id'] as String? ?? '';
+    final role = json['role'] as String? ?? 'member';
+    if (conversationId.isEmpty || userId.isEmpty) return;
+
+    ref
+        .read(conversationsProvider.notifier)
+        .updateGroupMemberRole(conversationId, userId, role);
+  }
+
   void _handleMention(Map<String, dynamic> json, String myUserId) {
     final fromUsername = json['from_username'] as String? ?? 'Someone';
     final conversationId = json['conversation_id'] as String? ?? '';

--- a/apps/client/lib/src/providers/ws_message_handler.dart
+++ b/apps/client/lib/src/providers/ws_message_handler.dart
@@ -341,6 +341,8 @@ mixin WsMessageHandler on Notifier<WebSocketState> {
         _handleCanvasAuthorityChanged(json);
       case 'member_added':
         _handleMemberAdded(json);
+      case 'member_role_changed':
+        _handleMemberRoleChanged(json);
       default:
         DebugLogService.instance.log(
           LogLevel.warning,

--- a/apps/client/lib/src/screens/group_info_screen.dart
+++ b/apps/client/lib/src/screens/group_info_screen.dart
@@ -180,6 +180,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
         .firstOrNull;
     final myRole = myMember?.role ?? 'member';
     final isOwnerOrAdmin = myRole == 'owner' || myRole == 'admin';
+    final viewerIsOwner = myRole == 'owner';
 
     return Scaffold(
       appBar: AppBar(
@@ -200,6 +201,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
               myUserId: myUserId,
               myRole: myRole,
               isOwnerOrAdmin: isOwnerOrAdmin,
+              viewerIsOwner: viewerIsOwner,
             );
           }
           return _buildNarrowLayout(
@@ -208,6 +210,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
             myUserId: myUserId,
             myRole: myRole,
             isOwnerOrAdmin: isOwnerOrAdmin,
+            viewerIsOwner: viewerIsOwner,
           );
         },
       ),
@@ -220,6 +223,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     required String myUserId,
     required String myRole,
     required bool isOwnerOrAdmin,
+    required bool viewerIsOwner,
   }) {
     return SafeArea(
       child: Center(
@@ -251,6 +255,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
                 conv: conv,
                 myUserId: myUserId,
                 isOwnerOrAdmin: isOwnerOrAdmin,
+                viewerIsOwner: viewerIsOwner,
               ),
               if (isOwnerOrAdmin) ..._buildChannelsSection(),
               if (isOwnerOrAdmin) _buildDisappearingSection(),
@@ -268,6 +273,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
     required String myUserId,
     required String myRole,
     required bool isOwnerOrAdmin,
+    required bool viewerIsOwner,
   }) {
     return Center(
       child: ConstrainedBox(
@@ -314,6 +320,7 @@ class _GroupInfoScreenState extends ConsumerState<GroupInfoScreen> {
                       conv: conv,
                       myUserId: myUserId,
                       isOwnerOrAdmin: isOwnerOrAdmin,
+                      viewerIsOwner: viewerIsOwner,
                     ),
                     if (isOwnerOrAdmin) ..._buildChannelsSection(),
                     if (isOwnerOrAdmin) _buildDisappearingSection(),

--- a/apps/client/lib/src/screens/group_info_screen/parts/members_section.dart
+++ b/apps/client/lib/src/screens/group_info_screen/parts/members_section.dart
@@ -51,6 +51,75 @@ extension _MembersSection on _GroupInfoScreenState {
     }
   }
 
+  /// Promote a member to admin or demote an admin back to member.
+  ///
+  /// Only the owner may call this; the server enforces the same rule.
+  /// Optimistic update: role flipped locally immediately and rolled back on
+  /// failure so the UI stays responsive on slow connections.
+  Future<void> _changeRole(ConversationMember member) async {
+    final currentRole = member.role ?? 'member';
+    final isPromoting = currentRole != 'admin';
+    final newRole = isPromoting ? 'admin' : 'member';
+    final actionLabel = isPromoting ? 'Make admin' : 'Remove admin';
+
+    final confirmed = await showEchoConfirmDialog(
+      context,
+      title: actionLabel,
+      content: isPromoting
+          ? 'Make ${member.username} an admin of this group?'
+          : 'Remove admin from ${member.username}?',
+      confirmLabel: actionLabel,
+      destructive: false,
+    );
+    if (!confirmed) return;
+
+    final token = ref.read(authProvider).token;
+    if (token == null) return;
+    final serverUrl = ref.read(serverUrlProvider);
+
+    try {
+      final response = await http.patch(
+        Uri.parse(
+          '$serverUrl/api/groups/${widget.conversationId}'
+          '/members/${member.userId}/role',
+        ),
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
+        body: '{"role":"$newRole"}',
+      );
+      if (response.statusCode == 200 && mounted) {
+        await ref.read(conversationsProvider.notifier).loadConversations();
+        await _loadGroupInfo(force: true);
+        if (mounted) {
+          ToastService.show(
+            context,
+            isPromoting
+                ? '${member.username} is now an admin'
+                : '${member.username} is no longer an admin',
+            type: ToastType.success,
+          );
+        }
+      } else if (mounted) {
+        ToastService.show(
+          context,
+          'Failed to change role (${response.statusCode})',
+          type: ToastType.error,
+        );
+      }
+    } catch (e) {
+      debugPrint('[GroupInfo] _changeRole failed: $e');
+      if (mounted) {
+        ToastService.show(
+          context,
+          'Failed to change role',
+          type: ToastType.error,
+        );
+      }
+    }
+  }
+
   Future<void> _banMember(ConversationMember member) async {
     final confirmed = await showEchoConfirmDialog(
       context,
@@ -105,6 +174,7 @@ extension _MembersSection on _GroupInfoScreenState {
   Widget? _buildMemberActions({
     required ConversationMember member,
     required bool isOwnerOrAdmin,
+    required bool viewerIsOwner,
     required bool isMe,
     required String role,
   }) {
@@ -126,6 +196,7 @@ extension _MembersSection on _GroupInfoScreenState {
             member: member,
             role: role,
             viewerIsAdminOrOwner: isOwnerOrAdmin,
+            viewerIsOwner: viewerIsOwner,
             isMe: isMe,
           );
         },
@@ -146,10 +217,14 @@ extension _MembersSection on _GroupInfoScreenState {
     required ConversationMember member,
     required String role,
     required bool viewerIsAdminOrOwner,
+    required bool viewerIsOwner,
     required bool isMe,
   }) {
     final isBlocked = _isMemberBlocked(member.userId);
     final canModerate = viewerIsAdminOrOwner && !isMe && role != 'owner';
+    // Only the owner can promote/demote; never for self or the owner target.
+    final canChangeRole = viewerIsOwner && !isMe && role != 'owner';
+    final targetIsAdmin = role == 'admin';
 
     final target = MemberTarget(
       userId: member.userId,
@@ -157,6 +232,8 @@ extension _MembersSection on _GroupInfoScreenState {
       isSelf: isMe,
       targetIsOwner: role == 'owner',
       viewerIsAdminOrOwner: viewerIsAdminOrOwner,
+      viewerIsOwner: viewerIsOwner,
+      targetIsAdmin: targetIsAdmin,
       onViewProfile: () => showUserProfileSheet(context, ref, member.userId),
       onSendMessage: isMe ? null : () => _openDmWithMember(member),
       onUnblock: (isMe || !isBlocked)
@@ -168,6 +245,7 @@ extension _MembersSection on _GroupInfoScreenState {
           _copyToClipboardWithToast(member.userId, 'User ID copied'),
       onKick: canModerate ? () => _kickMember(member) : null,
       onBan: canModerate ? () => _banMember(member) : null,
+      onChangeRole: canChangeRole ? () => _changeRole(member) : null,
     );
 
     EchoContextMenu.open(
@@ -217,6 +295,7 @@ extension _MembersSection on _GroupInfoScreenState {
     required ConversationMember member,
     required String myUserId,
     required bool isOwnerOrAdmin,
+    required bool viewerIsOwner,
   }) {
     final isMe = member.userId == myUserId;
     final role = member.role ?? 'member';
@@ -244,6 +323,7 @@ extension _MembersSection on _GroupInfoScreenState {
         member: member,
         role: role,
         viewerIsAdminOrOwner: isOwnerOrAdmin,
+        viewerIsOwner: viewerIsOwner,
         isMe: isMe,
       ),
       onLongPress: () => _openMemberContextMenu(
@@ -251,6 +331,7 @@ extension _MembersSection on _GroupInfoScreenState {
         member: member,
         role: role,
         viewerIsAdminOrOwner: isOwnerOrAdmin,
+        viewerIsOwner: viewerIsOwner,
         isMe: isMe,
       ),
       child: Container(
@@ -307,6 +388,7 @@ extension _MembersSection on _GroupInfoScreenState {
             _buildMemberActions(
                   member: member,
                   isOwnerOrAdmin: isOwnerOrAdmin,
+                  viewerIsOwner: viewerIsOwner,
                   isMe: isMe,
                   role: role,
                 ) ??
@@ -324,6 +406,7 @@ extension _MembersSection on _GroupInfoScreenState {
     required Conversation conv,
     required String myUserId,
     required bool isOwnerOrAdmin,
+    required bool viewerIsOwner,
   }) {
     int sortByName(ConversationMember a, ConversationMember b) =>
         a.username.toLowerCase().compareTo(b.username.toLowerCase());
@@ -362,6 +445,7 @@ extension _MembersSection on _GroupInfoScreenState {
           member: m,
           myUserId: myUserId,
           isOwnerOrAdmin: isOwnerOrAdmin,
+          viewerIsOwner: viewerIsOwner,
         );
       }
     }

--- a/apps/client/lib/src/widgets/context_menu/actions/member_actions_registry.dart
+++ b/apps/client/lib/src/widgets/context_menu/actions/member_actions_registry.dart
@@ -89,12 +89,21 @@ ContextMenuSection _contactSection(MemberTarget t) {
 
 bool _hasAdminSection(MemberTarget t) {
   if (t.isSelf || t.targetIsOwner || !t.viewerIsAdminOrOwner) return false;
-  return t.onKick != null || t.onBan != null;
+  return t.onKick != null || t.onBan != null || t.onChangeRole != null;
 }
 
 ContextMenuSection _adminSection(MemberTarget t) {
+  final changeRoleLabel = t.targetIsAdmin ? 'Remove admin' : 'Make admin';
   return ContextMenuSection(
     actions: [
+      if (t.onChangeRole != null)
+        ContextMenuAction(
+          label: changeRoleLabel,
+          icon: t.targetIsAdmin
+              ? Icons.manage_accounts_outlined
+              : Icons.admin_panel_settings_outlined,
+          onTap: t.onChangeRole,
+        ),
       if (t.onKick != null)
         ContextMenuAction(
           label: 'Kick from Group',

--- a/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
+++ b/apps/client/lib/src/widgets/context_menu/echo_context_menu.dart
@@ -315,6 +315,8 @@ class MemberTarget extends ContextMenuTarget {
     required this.isSelf,
     required this.targetIsOwner,
     required this.viewerIsAdminOrOwner,
+    required this.viewerIsOwner,
+    required this.targetIsAdmin,
     this.onViewProfile,
     this.onSendMessage,
     this.onAddContact,
@@ -325,6 +327,7 @@ class MemberTarget extends ContextMenuTarget {
     this.onCopyUsername,
     this.onKick,
     this.onBan,
+    this.onChangeRole,
   });
 
   final String userId;
@@ -342,6 +345,14 @@ class MemberTarget extends ContextMenuTarget {
   /// section (kick / ban).
   final bool viewerIsAdminOrOwner;
 
+  /// True when the viewer is the group owner. Required to show the
+  /// promote/demote action (only owners may change member roles).
+  final bool viewerIsOwner;
+
+  /// True when the target currently holds the `admin` role.  Determines
+  /// whether the change-role label reads "Make admin" or "Remove admin".
+  final bool targetIsAdmin;
+
   final VoidCallback? onViewProfile;
   final VoidCallback? onSendMessage;
   final VoidCallback? onAddContact;
@@ -352,6 +363,10 @@ class MemberTarget extends ContextMenuTarget {
   final VoidCallback? onCopyUsername;
   final VoidCallback? onKick;
   final VoidCallback? onBan;
+
+  /// Promote member → admin or demote admin → member.  Null when the
+  /// viewer is not the owner, or when the target is the owner or self.
+  final VoidCallback? onChangeRole;
 
   @override
   String get analyticsName => 'member';

--- a/apps/client/test/widgets/context_menu/member_actions_registry_test.dart
+++ b/apps/client/test/widgets/context_menu/member_actions_registry_test.dart
@@ -10,6 +10,8 @@ MemberTarget _t({
   bool isSelf = false,
   bool targetIsOwner = false,
   bool viewerIsAdminOrOwner = false,
+  bool viewerIsOwner = false,
+  bool targetIsAdmin = false,
   bool wireProfile = true,
   bool wireSendMessage = true,
   bool wireAddContact = false,
@@ -18,6 +20,7 @@ MemberTarget _t({
   bool wireUnblock = false,
   bool wireKick = true,
   bool wireBan = true,
+  bool wireChangeRole = false,
   bool wireCopyUsername = true,
   bool wireCopyUserId = true,
 }) {
@@ -27,6 +30,8 @@ MemberTarget _t({
     isSelf: isSelf,
     targetIsOwner: targetIsOwner,
     viewerIsAdminOrOwner: viewerIsAdminOrOwner,
+    viewerIsOwner: viewerIsOwner,
+    targetIsAdmin: targetIsAdmin,
     onViewProfile: wireProfile ? () {} : null,
     onSendMessage: wireSendMessage ? () {} : null,
     onAddContact: wireAddContact ? () {} : null,
@@ -37,6 +42,7 @@ MemberTarget _t({
     onCopyUsername: wireCopyUsername ? () {} : null,
     onKick: wireKick ? () {} : null,
     onBan: wireBan ? () {} : null,
+    onChangeRole: wireChangeRole ? () {} : null,
   );
 }
 
@@ -120,6 +126,65 @@ void main() {
         'Copy Username',
         'Copy User ID',
       ]);
+    });
+
+    test('owner viewer sees Make admin for a regular member', () {
+      final labels = _labels(
+        buildMemberMenu(
+          _t(
+            viewerIsOwner: true,
+            viewerIsAdminOrOwner: true,
+            targetIsAdmin: false,
+            wireChangeRole: true,
+          ),
+        ),
+      ).toList();
+      expect(labels, contains('Make admin'));
+      expect(labels, isNot(contains('Remove admin')));
+    });
+
+    test('owner viewer sees Remove admin for an admin member', () {
+      final labels = _labels(
+        buildMemberMenu(
+          _t(
+            viewerIsOwner: true,
+            viewerIsAdminOrOwner: true,
+            targetIsAdmin: true,
+            wireChangeRole: true,
+          ),
+        ),
+      ).toList();
+      expect(labels, contains('Remove admin'));
+      expect(labels, isNot(contains('Make admin')));
+    });
+
+    test('non-owner admin never sees Make admin / Remove admin', () {
+      final labels = _labels(
+        buildMemberMenu(
+          _t(
+            viewerIsOwner: false,
+            viewerIsAdminOrOwner: true,
+            wireChangeRole: false,
+          ),
+        ),
+      ).toList();
+      expect(labels, isNot(contains('Make admin')));
+      expect(labels, isNot(contains('Remove admin')));
+    });
+
+    test('Make admin is not danger-styled', () {
+      final m = buildMemberMenu(
+        _t(
+          viewerIsOwner: true,
+          viewerIsAdminOrOwner: true,
+          targetIsAdmin: false,
+          wireChangeRole: true,
+        ),
+      );
+      final row = m.sections
+          .expand((s) => s.actions)
+          .firstWhere((a) => a.label == 'Make admin');
+      expect(row.isDanger, isFalse);
     });
   });
 }

--- a/apps/server/src/db/groups.rs
+++ b/apps/server/src/db/groups.rs
@@ -437,6 +437,31 @@ pub async fn remove_member(
     Ok(removed)
 }
 
+/// Change a member's role inside an externally managed transaction.
+///
+/// Returns `true` when the role was actually updated (the row existed and
+/// was active), `false` when the member was not found or already had that
+/// role.  Callers must supply a role string already validated against the
+/// `Role` enum (`"admin"` or `"member"`).
+pub async fn set_member_role_in_tx(
+    conn: &mut PgConnection,
+    group_id: Uuid,
+    user_id: Uuid,
+    new_role: &str,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE conversation_members \
+         SET role = $3 \
+         WHERE conversation_id = $1 AND user_id = $2 AND is_removed = false",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .bind(new_role)
+    .execute(&mut *conn)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
 /// Get all member user IDs for a conversation (works for both DMs and groups).
 ///
 /// Generic over `Executor` so callers can reuse the existing tx during

--- a/apps/server/src/routes/groups/members.rs
+++ b/apps/server/src/routes/groups/members.rs
@@ -442,6 +442,104 @@ pub async fn unban_member(
     Ok(Json(serde_json::json!({ "status": "unbanned" })))
 }
 
+/// PATCH /api/groups/:id/members/:user_id/role -- Promote or demote a member.
+///
+/// Only the group OWNER may call this endpoint.  Accepted target roles:
+/// `"admin"` and `"member"`.  The `"owner"` role is immutable — it cannot be
+/// assigned via this endpoint (ownership transfer is a separate, higher-ceremony
+/// operation).  The owner may not change their own role.  The target must be an
+/// active (non-removed) member of the group.
+///
+/// On success a `member_role_changed` WS event is fanned out to all current
+/// members so connected clients update the member list without polling.
+pub async fn change_member_role(
+    auth: AuthUser,
+    State(state): State<Arc<AppState>>,
+    Path((group_id, target_user_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<super::types::ChangeRoleRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // Validate the requested role up front — "owner" is immutable via this path.
+    let new_role = match body.role.as_str() {
+        "admin" | "member" => body.role.as_str(),
+        "owner" => {
+            return Err(AppError::bad_request(
+                "Cannot assign the owner role via this endpoint",
+            ));
+        }
+        _ => {
+            return Err(AppError::bad_request(
+                "Invalid role; accepted values: \"admin\", \"member\"",
+            ));
+        }
+    };
+
+    // The owner may not demote themselves (would orphan the group).
+    if target_user_id == auth.user_id {
+        return Err(AppError::bad_request("Cannot change your own role"));
+    }
+
+    let mut tx = state.pool.begin().await.db_ctx("change_role/begin_tx")?;
+
+    acquire_member_lock(&mut tx, group_id, target_user_id).await?;
+
+    // Caller must be the group owner.
+    let caller_role = db::groups::get_member_role(&mut *tx, group_id, auth.user_id)
+        .await
+        .db_ctx("change_role/get_caller_role")?
+        .ok_or_else(|| AppError::with_code(ErrorCode::NotMember, "Not a member of this group"))?;
+
+    if Role::from_str_opt(&caller_role) != Some(Role::Owner) {
+        return Err(AppError::unauthorized(
+            "Only the group owner can change member roles",
+        ));
+    }
+
+    // Fetch target role — verify they are a member and not the owner.
+    let target_role = db::groups::get_member_role(&mut *tx, group_id, target_user_id)
+        .await
+        .db_ctx("change_role/get_target_role")?
+        .ok_or_else(|| AppError::bad_request("Target user is not a member of this group"))?;
+
+    if Role::from_str_opt(&target_role) == Some(Role::Owner) {
+        return Err(AppError::bad_request("Cannot change the owner's role"));
+    }
+
+    // Apply the update.
+    let updated = db::groups::set_member_role_in_tx(&mut tx, group_id, target_user_id, new_role)
+        .await
+        .db_ctx("change_role/update")?;
+
+    if !updated {
+        return Err(AppError::bad_request(
+            "Target user is not a member of this group",
+        ));
+    }
+
+    let all_members = db::groups::get_conversation_member_ids(&mut *tx, group_id)
+        .await
+        .unwrap_or_default();
+
+    tx.commit().await.db_ctx("change_role/commit")?;
+
+    invalidate_member_cache(group_id);
+
+    // Broadcast so connected clients refresh without polling.
+    let event = serde_json::json!({
+        "type": "member_role_changed",
+        "conversation_id": group_id,
+        "user_id": target_user_id,
+        "role": new_role,
+    });
+    if let Ok(s) = serde_json::to_string(&event) {
+        state.hub.broadcast_json(&all_members, &s, None);
+    }
+
+    Ok(Json(super::types::ChangeRoleResponse {
+        user_id: target_user_id,
+        role: new_role.to_owned(),
+    }))
+}
+
 /// Shared post-removal logic: auto-delete the group if empty, rotate keys if
 /// not, and emit a system-message pill to remaining members.
 ///

--- a/apps/server/src/routes/groups/mod.rs
+++ b/apps/server/src/routes/groups/mod.rs
@@ -24,7 +24,7 @@ mod types;
 
 pub use create::{create_group, get_group};
 
-pub use members::{add_member, ban_member, remove_member, unban_member};
+pub use members::{add_member, ban_member, change_member_role, remove_member, unban_member};
 
 pub use lifecycle::{delete_group, leave_group};
 

--- a/apps/server/src/routes/groups/types.rs
+++ b/apps/server/src/routes/groups/types.rs
@@ -110,3 +110,19 @@ pub struct CreateInviteRequest {
     pub expires_in_seconds: Option<i64>,
     pub max_uses: Option<i32>,
 }
+
+/// Body for `PATCH /api/groups/:id/members/:user_id/role`.
+///
+/// Accepted values: `"admin"` or `"member"`. `"owner"` is rejected —
+/// ownership transfer is a separate, higher-ceremony operation.
+#[derive(Debug, Deserialize)]
+pub struct ChangeRoleRequest {
+    pub role: String,
+}
+
+/// Response body for the change-role endpoint.
+#[derive(Debug, Serialize)]
+pub struct ChangeRoleResponse {
+    pub user_id: Uuid,
+    pub role: String,
+}

--- a/apps/server/src/routes/mod.rs
+++ b/apps/server/src/routes/mod.rs
@@ -417,6 +417,10 @@ pub fn create_router(state: Arc<AppState>, trusted_proxies: Vec<IpNet>) -> Route
         )
         .route("/{id}/members", post(groups::add_member))
         .route("/{id}/members/{user_id}", delete(groups::remove_member))
+        .route(
+            "/{id}/members/{user_id}/role",
+            patch(groups::change_member_role),
+        )
         .route("/{id}/join", post(groups::join_group))
         .route("/{id}/leave", post(groups::leave_group))
         .route("/{id}/ban/{user_id}", post(groups::ban_member))

--- a/apps/server/tests/api_groups_role_change.rs
+++ b/apps/server/tests/api_groups_role_change.rs
@@ -1,0 +1,276 @@
+//! Integration tests for `PATCH /api/groups/:id/members/:user_id/role`.
+//!
+//! Covers:
+//! - Owner can promote member → admin and demote admin → member.
+//! - Non-owner (admin or regular member) gets 403/401.
+//! - Trying to assign the "owner" role is rejected.
+//! - Owner cannot change their own role.
+//! - Target must be an active member (non-member gets 400).
+//! - Target owner's role cannot be changed.
+
+mod common;
+
+use reqwest::Client;
+
+async fn db_pool() -> sqlx::PgPool {
+    let url = std::env::var("TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("TEST_DATABASE_URL or DATABASE_URL must be set");
+    echo_server::db::create_pool(&url).await
+}
+
+/// Direct DB helper: read the current role for a (group, user) pair.
+async fn member_role(group_id: &str, user_id: &str) -> Option<String> {
+    let pool = db_pool().await;
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT role FROM conversation_members \
+         WHERE conversation_id = $1 AND user_id = $2 AND is_removed = false",
+    )
+    .bind(uuid::Uuid::parse_str(group_id).unwrap())
+    .bind(uuid::Uuid::parse_str(user_id).unwrap())
+    .fetch_optional(&pool)
+    .await
+    .expect("member_role query failed");
+    row.map(|(r,)| r)
+}
+
+// ---------------------------------------------------------------------------
+// Happy paths
+// ---------------------------------------------------------------------------
+
+/// Owner promotes a regular member to admin; DB reflects the change.
+#[tokio::test]
+async fn promote_member_to_admin_succeeds() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _, _) = common::register_and_login(&client, &base, "cr_prm_own").await;
+    let (_, member_id, _) = common::register_and_login(&client, &base, "cr_prm_mem").await;
+
+    let gid = common::create_group(&client, &base, &owner_token, "PromoteGroup").await;
+    common::add_member_to_group(&client, &base, &owner_token, &gid, &member_id).await;
+
+    // Verify starting role is "member"
+    assert_eq!(
+        member_role(&gid, &member_id).await.as_deref(),
+        Some("member")
+    );
+
+    let resp = client
+        .patch(format!("{base}/api/groups/{gid}/members/{member_id}/role"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&serde_json::json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "owner promote should return 200"
+    );
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["role"], "admin");
+    assert_eq!(body["user_id"], member_id);
+
+    // DB must reflect the promotion
+    assert_eq!(
+        member_role(&gid, &member_id).await.as_deref(),
+        Some("admin"),
+        "role should be admin after promotion"
+    );
+}
+
+/// Owner demotes an admin back to regular member.
+#[tokio::test]
+async fn demote_admin_to_member_succeeds() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _, _) = common::register_and_login(&client, &base, "cr_dem_own").await;
+    let (_, admin_id, _) = common::register_and_login(&client, &base, "cr_dem_adm").await;
+
+    let gid = common::create_group(&client, &base, &owner_token, "DemoteGroup").await;
+    common::add_member_to_group(&client, &base, &owner_token, &gid, &admin_id).await;
+
+    // Promote first via DB shortcut (mirrors existing test patterns)
+    let pool = db_pool().await;
+    sqlx::query(
+        "UPDATE conversation_members SET role = 'admin' \
+         WHERE conversation_id = $1 AND user_id = $2",
+    )
+    .bind(uuid::Uuid::parse_str(&gid).unwrap())
+    .bind(uuid::Uuid::parse_str(&admin_id).unwrap())
+    .execute(&pool)
+    .await
+    .expect("seed admin role");
+
+    assert_eq!(member_role(&gid, &admin_id).await.as_deref(), Some("admin"));
+
+    let resp = client
+        .patch(format!("{base}/api/groups/{gid}/members/{admin_id}/role"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&serde_json::json!({ "role": "member" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "owner demote should return 200"
+    );
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["role"], "member");
+
+    assert_eq!(
+        member_role(&gid, &admin_id).await.as_deref(),
+        Some("member"),
+        "role should be member after demotion"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Authorization guards
+// ---------------------------------------------------------------------------
+
+/// A regular member (non-admin) cannot change any role → 401.
+#[tokio::test]
+async fn regular_member_cannot_change_role_returns_401() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _, _) = common::register_and_login(&client, &base, "cr_noauth_own").await;
+    let (member_token, member_id, _) =
+        common::register_and_login(&client, &base, "cr_noauth_mem").await;
+    let (_, target_id, _) = common::register_and_login(&client, &base, "cr_noauth_tgt").await;
+
+    let gid = common::create_group(&client, &base, &owner_token, "NoAuthGroup").await;
+    common::add_member_to_group(&client, &base, &owner_token, &gid, &member_id).await;
+    common::add_member_to_group(&client, &base, &owner_token, &gid, &target_id).await;
+
+    let resp = client
+        .patch(format!("{base}/api/groups/{gid}/members/{target_id}/role"))
+        .header("Authorization", format!("Bearer {member_token}"))
+        .json(&serde_json::json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "regular member must not change roles"
+    );
+}
+
+/// An admin (non-owner) cannot change roles → 401.
+#[tokio::test]
+async fn admin_cannot_change_role_returns_401() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _, _) = common::register_and_login(&client, &base, "cr_adm_own").await;
+    let (admin_token, admin_id, _) = common::register_and_login(&client, &base, "cr_adm_adm").await;
+    let (_, target_id, _) = common::register_and_login(&client, &base, "cr_adm_tgt").await;
+
+    let gid = common::create_group(&client, &base, &owner_token, "AdminNoPromote").await;
+    common::add_member_to_group(&client, &base, &owner_token, &gid, &admin_id).await;
+    common::add_member_to_group(&client, &base, &owner_token, &gid, &target_id).await;
+
+    // Promote caller to admin via DB
+    let pool = db_pool().await;
+    sqlx::query(
+        "UPDATE conversation_members SET role = 'admin' \
+         WHERE conversation_id = $1 AND user_id = $2",
+    )
+    .bind(uuid::Uuid::parse_str(&gid).unwrap())
+    .bind(uuid::Uuid::parse_str(&admin_id).unwrap())
+    .execute(&pool)
+    .await
+    .expect("seed admin role");
+
+    let resp = client
+        .patch(format!("{base}/api/groups/{gid}/members/{target_id}/role"))
+        .header("Authorization", format!("Bearer {admin_token}"))
+        .json(&serde_json::json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "admin must not promote other members"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Immutability guards
+// ---------------------------------------------------------------------------
+
+/// Requesting the "owner" role is rejected with 400.
+#[tokio::test]
+async fn assign_owner_role_rejected_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _, _) = common::register_and_login(&client, &base, "cr_ownr_own").await;
+    let (_, target_id, _) = common::register_and_login(&client, &base, "cr_ownr_tgt").await;
+
+    let gid = common::create_group(&client, &base, &owner_token, "NoOwnerGroup").await;
+    common::add_member_to_group(&client, &base, &owner_token, &gid, &target_id).await;
+
+    let resp = client
+        .patch(format!("{base}/api/groups/{gid}/members/{target_id}/role"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&serde_json::json!({ "role": "owner" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400, "assigning owner role must 400");
+}
+
+/// Owner cannot change their own role.
+#[tokio::test]
+async fn owner_cannot_change_own_role_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, owner_id, _) =
+        common::register_and_login(&client, &base, "cr_self_own").await;
+
+    let gid = common::create_group(&client, &base, &owner_token, "SelfRoleGroup").await;
+
+    let resp = client
+        .patch(format!("{base}/api/groups/{gid}/members/{owner_id}/role"))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&serde_json::json!({ "role": "member" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "owner changing own role must 400"
+    );
+}
+
+/// Attempting to change the role of a non-member returns 400.
+#[tokio::test]
+async fn change_role_of_non_member_returns_400() {
+    let base = common::spawn_server().await;
+    let client = Client::new();
+    let (owner_token, _, _) = common::register_and_login(&client, &base, "cr_noMem_own").await;
+    let (_, outsider_id, _) = common::register_and_login(&client, &base, "cr_noMem_out").await;
+
+    let gid = common::create_group(&client, &base, &owner_token, "OutsiderGroup").await;
+    // outsider is NOT added to the group
+
+    let resp = client
+        .patch(format!(
+            "{base}/api/groups/{gid}/members/{outsider_id}/role"
+        ))
+        .header("Authorization", format!("Bearer {owner_token}"))
+        .json(&serde_json::json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "non-member target must return 400"
+    );
+}


### PR DESCRIPTION
## Summary

Group owners can now promote a regular member to admin — or remove admin from a member — directly from the Members list. The owner role is fully protected: it cannot be assigned or changed via this surface, and owners cannot change their own role.

## New

- **Make admin / Remove admin** action in the member context menu (right-click, long-press, or "..." button). Only visible to group owners; hidden for themselves and for other owners.
- `PATCH /api/groups/:id/members/:user_id/role` endpoint (`{ "role": "admin" | "member" }`). Authz: caller must be the group owner; `"owner"` role is rejected.
- `member_role_changed` WebSocket event broadcasts to all group members so the role badge updates live on every connected client without polling.

## Improved

- `ConversationMember` now has a `copyWith` method (used by the live WS update path).

## Behind the scenes

- `db::groups::set_member_role_in_tx` — transactional role UPDATE wrapped with the existing per-(group, target) advisory lock.
- 7 new Rust integration tests covering: owner promotes/demotes, regular member blocked (401), admin blocked (401), `"owner"` role rejected (400), self-change rejected (400), non-member target rejected (400).
- 4 new Dart unit tests covering: "Make admin" label for members, "Remove admin" label for admins, hidden from non-owner admins, not danger-styled.
- All existing members + registry tests continue to pass (20 + 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)