### PR TITLE
Fix profile photo staying stale after upload

### DIFF
--- a/apps/client/lib/src/screens/onboarding_wizard.dart
+++ b/apps/client/lib/src/screens/onboarding_wizard.dart
@@ -11,6 +11,7 @@ import '../providers/accessibility_provider.dart';
 import '../providers/auth_provider.dart';
 import '../providers/server_url_provider.dart';
 import '../providers/theme_provider.dart';
+import '../services/media_cache_service.dart';
 import '../services/notification_service.dart';
 import '../services/sound_service.dart';
 import '../services/toast_service.dart';
@@ -271,6 +272,14 @@ class _OnboardingWizardState extends ConsumerState<OnboardingWizard> {
 
       if (result.ok) {
         if (result.url != null) {
+          // The server reuses the same URL path on re-upload, so the disk cache
+          // would keep serving the old photo without an explicit eviction.
+          final serverUrl = ref.read(serverUrlProvider);
+          final fullUrl = result.url!.startsWith('http')
+              ? result.url!
+              : '$serverUrl${result.url!}';
+          await evictAvatarFromCache(fullUrl);
+          if (!mounted) return;
           ref.read(authProvider.notifier).updateAvatarUrl(result.url!);
         }
         ToastService.show(context, 'Avatar uploaded', type: ToastType.success);

--- a/apps/client/lib/src/screens/settings/account_section.dart
+++ b/apps/client/lib/src/screens/settings/account_section.dart
@@ -10,6 +10,7 @@ import 'package:qr_flutter/qr_flutter.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/server_url_provider.dart';
 import '../../services/clipboard_service.dart';
+import '../../services/media_cache_service.dart';
 import '../../services/toast_service.dart';
 import '../../services/upload_client.dart';
 import '../../theme/echo_theme.dart';
@@ -288,6 +289,14 @@ class _AccountSectionState extends ConsumerState<AccountSection> {
     if (!mounted) return false;
     if (result.ok) {
       if (result.url != null) {
+        // The server reuses the same URL path on re-upload, so the disk cache
+        // would keep serving the old photo without an explicit eviction.
+        final serverUrl = ref.read(serverUrlProvider);
+        final fullUrl = result.url!.startsWith('http')
+            ? result.url!
+            : '$serverUrl${result.url!}';
+        await evictAvatarFromCache(fullUrl);
+        if (!mounted) return false;
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) {
             ref.read(authProvider.notifier).updateAvatarUrl(result.url!);

--- a/apps/client/lib/src/services/media_cache_service.dart
+++ b/apps/client/lib/src/services/media_cache_service.dart
@@ -1,3 +1,5 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
 /// Single named disk cache shared by all chat image and avatar widgets.
@@ -24,5 +26,38 @@ final chatMediaCacheManager = CacheManager(
 String stableMediaCacheKey(String url) {
   final uri = Uri.tryParse(url);
   if (uri == null) return url;
-  return uri.replace(queryParameters: {}).toString();
+  // Reconstruct without query or fragment to get a clean path-only key.
+  // Passing `queryParameters: {}` to uri.replace() adds a trailing "?",
+  // so we build a new Uri from its structural parts instead.
+  return Uri(
+    scheme: uri.scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    path: uri.path,
+  ).toString();
+}
+
+/// Evicts [fullUrl] from both the disk cache ([chatMediaCacheManager]) and
+/// Flutter's in-memory [ImageCache].
+///
+/// Call this whenever an image at a stable URL is re-uploaded so that the
+/// next render fetches fresh bytes instead of serving stale cached content.
+/// The server reuses the same URL for avatar replacements
+/// (e.g. `/api/users/<id>/avatar`), so without explicit eviction
+/// [CachedNetworkImage] would continue to display the old photo indefinitely.
+Future<void> evictAvatarFromCache(String fullUrl) async {
+  // 1. Remove from disk cache (flutter_cache_manager).
+  final cacheKey = stableMediaCacheKey(fullUrl);
+  await chatMediaCacheManager.removeFile(cacheKey);
+
+  // 2. Remove from Flutter's in-memory ImageCache so any in-flight decode
+  //    is also discarded.
+  final provider = CachedNetworkImageProvider(fullUrl, cacheKey: cacheKey);
+  await provider.evict();
+
+  // 3. Belt-and-suspenders: also clear the image from the global imageCache
+  //    keyed by the bare URL (without query params) in case any widget built
+  //    an Image.network or NetworkImage with the same URL directly.
+  final networkProvider = NetworkImage(fullUrl);
+  imageCache.evict(networkProvider);
 }

--- a/apps/client/test/services/media_cache_service_test.dart
+++ b/apps/client/test/services/media_cache_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:echo_app/src/services/media_cache_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('stableMediaCacheKey', () {
+    test('strips query params so auth tokens do not cause cache misses', () {
+      const url =
+          'https://us-east.echo-messenger.us/api/users/42/avatar?ticket=abc123';
+      expect(
+        stableMediaCacheKey(url),
+        'https://us-east.echo-messenger.us/api/users/42/avatar',
+      );
+    });
+
+    test('leaves URLs without query params unchanged', () {
+      const url = 'https://us-east.echo-messenger.us/api/users/42/avatar';
+      expect(stableMediaCacheKey(url), url);
+    });
+
+    test('does not leave a trailing ? on query-stripped URLs', () {
+      const url =
+          'https://us-east.echo-messenger.us/api/users/42/avatar?v=12345';
+      final key = stableMediaCacheKey(url);
+      expect(key.endsWith('?'), isFalse);
+      expect(key, 'https://us-east.echo-messenger.us/api/users/42/avatar');
+    });
+
+    test('strips multiple query params', () {
+      const url =
+          'https://us-east.echo-messenger.us/api/users/42/avatar?v=1&size=lg';
+      expect(
+        stableMediaCacheKey(url),
+        'https://us-east.echo-messenger.us/api/users/42/avatar',
+      );
+    });
+
+    test('returns the input unchanged for non-parseable strings', () {
+      const bad = 'not a url :::';
+      expect(stableMediaCacheKey(bad), bad);
+    });
+
+    test('is stable: same output for repeated calls', () {
+      const url = 'https://us-east.echo-messenger.us/api/users/42/avatar';
+      expect(stableMediaCacheKey(url), stableMediaCacheKey(url));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- The sidebar self-avatar (bottom-left corner of the conversation panel) kept showing the old photo after a successful re-upload.
- Root cause: the server always returns the same URL path (`/api/users/<id>/avatar`) on every re-upload. `CachedNetworkImage` with a 30-day disk-cache TTL served the old bytes indefinitely — no eviction happened.
- Fix: call `evictAvatarFromCache` immediately after a successful upload in both Settings → Account and the onboarding avatar picker. This removes the old entry from `chatMediaCacheManager` (disk) and Flutter's `ImageCache` (memory) so the next render re-fetches the new photo.

## Widget located

`_buildUserAvatar` in `apps/client/lib/src/widgets/conversation_panel/parts/header.dart` (line 435) — rendered by `_buildUserStatusBar` which is called from `ConversationPanel.build` (line 213 of `conversation_panel.dart`) watching `authProvider.select((s) => s.avatarUrl)`.

## Root cause

`stableMediaCacheKey` strips query parameters so auth tokens don't cause cache misses. This is correct for reads. The problem is the same stable key is used for writes: when the same URL is re-uploaded the key never changes, so `CachedNetworkImage` never re-fetches. A bug in the implementation also caused `stableMediaCacheKey` to append a trailing `?` on query-stripped URLs — that is fixed too.

## Changes

- `media_cache_service.dart` — add `evictAvatarFromCache(fullUrl)` helper; fix trailing-`?` in `stableMediaCacheKey`
- `account_section.dart` — call `evictAvatarFromCache` before `updateAvatarUrl` on upload success
- `onboarding_wizard.dart` — same eviction on the onboarding avatar upload path
- `test/services/media_cache_service_test.dart` — 6 unit tests for `stableMediaCacheKey` (covers the trailing-`?` regression)

## Test plan

- [ ] Change avatar in Settings → account — sidebar photo updates immediately without needing to restart
- [ ] Upload avatar during onboarding — same
- [ ] `flutter test test/services/media_cache_service_test.dart` — all 6 pass
- [ ] `flutter analyze --fatal-infos` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)